### PR TITLE
Fleet supervision, slice 3: the supervision skeleton — brake, topology, marks, status

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -205,6 +205,32 @@ extension AppState {
         }
     }
 
+    /// Load the supervision fleet brake from the daemon `Config`. Called on
+    /// launch and whenever a config-change delta arrives — same two call
+    /// sites as `loadHibernationConfig()`, kept as its own function rather
+    /// than folded into that one so this feature's wiring stays legible on
+    /// its own diff. Silent on failure — the toggle just shows a stale value
+    /// until the next successful load.
+    func loadSupervisionConfig() async {
+        guard let config = await fetchConfig() else { return }
+        if config.supervisionEnabled != supervisionEnabled {
+            supervisionEnabled = config.supervisionEnabled
+        }
+    }
+
+    /// Persist the supervision fleet brake (design 2026-07-26 §3, §7). Shipped
+    /// OFF; for now inert, since the rest of the supervision subsystem is
+    /// landing in the same series of changes.
+    func setSupervisionEnabled(_ enabled: Bool) async {
+        do {
+            try await daemonClient.setSupervisionEnabled(enabled)
+            supervisionEnabled = enabled
+        } catch {
+            logger.error("Failed to set supervisionEnabled: \(error, privacy: .public)")
+            showAlert("Failed to update supervision setting: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Set the global session-limit auto-resume gate. Turning it OFF also
     /// cancels all pending scheduled resumes daemon-side.
     func setAutoResumeOnLimitReset(_ enabled: Bool) async {

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -205,11 +205,12 @@ extension AppState {
         }
     }
 
-    /// Load the supervision fleet brake from the daemon `Config`. Called on
-    /// launch and whenever a config-change delta arrives — same two call
-    /// sites as `loadHibernationConfig()`, kept as its own function rather
-    /// than folded into that one so this feature's wiring stays legible on
-    /// its own diff. Silent on failure — the toggle just shows a stale value
+    /// Load supervision's fleet-wide authority switch (`true` == enabled ==
+    /// the fleet brake released) from the daemon `Config`. Called on launch
+    /// and whenever a config-change delta arrives — same two call sites as
+    /// `loadHibernationConfig()`, kept as its own function rather than
+    /// folded into that one so this feature's wiring stays legible on its
+    /// own diff. Silent on failure — the toggle just shows a stale value
     /// until the next successful load.
     func loadSupervisionConfig() async {
         guard let config = await fetchConfig() else { return }
@@ -218,9 +219,10 @@ extension AppState {
         }
     }
 
-    /// Persist the supervision fleet brake (design 2026-07-26 §3, §7). Shipped
-    /// OFF; for now inert, since the rest of the supervision subsystem is
-    /// landing in the same series of changes.
+    /// Persist supervision's fleet-wide authority switch (design 2026-07-26
+    /// §3, §7). `enabled: true` releases the fleet brake; `false` engages it.
+    /// Shipped OFF (braked); for now inert, since the rest of the supervision
+    /// subsystem is landing in the same series of changes.
     func setSupervisionEnabled(_ enabled: Bool) async {
         do {
             try await daemonClient.setSupervisionEnabled(enabled)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -739,10 +739,12 @@ final class AppState: ObservableObject {
     @Published var autoHibernateEnabled: Bool = false
     /// Auto-hibernate idle timeout in minutes. Loaded from `Config`.
     @Published var hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes
-    /// The supervision fleet brake (design 2026-07-26 §3, §7) — supervision's
-    /// fleet-wide on/off switch. Shipped OFF; for now inert, since the rest
-    /// of the supervision subsystem is landing in the same series of
-    /// changes. Loaded from the daemon `Config` via `loadSupervisionConfig()`.
+    /// Supervision's fleet-wide authority switch (design 2026-07-26 §3, §7).
+    /// `true` means supervision is enabled — the fleet brake is *released*,
+    /// the opposite sense from the brake's own name. Shipped OFF (braked);
+    /// for now inert, since the rest of the supervision subsystem is landing
+    /// in the same series of changes. Loaded from the daemon `Config` via
+    /// `loadSupervisionConfig()`.
     @Published var supervisionEnabled: Bool = false
     /// Daemon-persisted gate for session-limit auto-resume (default OFF).
     /// Daemon-side (not @AppStorage) because the daemon must act while the

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -739,6 +739,11 @@ final class AppState: ObservableObject {
     @Published var autoHibernateEnabled: Bool = false
     /// Auto-hibernate idle timeout in minutes. Loaded from `Config`.
     @Published var hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes
+    /// The supervision fleet brake (design 2026-07-26 §3, §7) — supervision's
+    /// fleet-wide on/off switch. Shipped OFF; for now inert, since the rest
+    /// of the supervision subsystem is landing in the same series of
+    /// changes. Loaded from the daemon `Config` via `loadSupervisionConfig()`.
+    @Published var supervisionEnabled: Bool = false
     /// Daemon-persisted gate for session-limit auto-resume (default OFF).
     /// Daemon-side (not @AppStorage) because the daemon must act while the
     /// app is closed.
@@ -1914,6 +1919,7 @@ final class AppState: ObservableObject {
             Task { [weak self] in
                 await self?.loadModelProfiles()
                 await self?.loadHibernationConfig()
+                await self?.loadSupervisionConfig()
                 // The daemon reuses this delta for config changes including
                 // the control-mode toggle (handleConfigSetControlMode), so
                 // refresh capabilities too — a toggle from ANOTHER client
@@ -2393,6 +2399,7 @@ final class AppState: ObservableObject {
             }
             await loadModelProfiles()
             await loadHibernationConfig()
+            await loadSupervisionConfig()
             await refreshRemote()
             startSubscription()
             await refreshPRStatuses()

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -942,6 +942,16 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the fleet supervision brake (design 2026-07-26 §3, §7).
+    /// Shipped OFF; for now inert, since the rest of the supervision
+    /// subsystem is landing in the same series of changes.
+    func setSupervisionEnabled(_ enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetSupervisionEnabled,
+            params: ConfigSetSupervisionEnabledParams(enabled: enabled)
+        )
+    }
+
     /// Persist the tmux control-mode opt-in (M5). Applies to newly created
     /// panes; a truthy TBD_TMUX_CONTROL_MODE in the daemon's env still forces
     /// the gate on regardless of this flag.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -942,8 +942,9 @@ actor DaemonClient {
         )
     }
 
-    /// Persist the fleet supervision brake (design 2026-07-26 §3, §7).
-    /// Shipped OFF; for now inert, since the rest of the supervision
+    /// Persist supervision's fleet-wide authority switch (design 2026-07-26
+    /// §3, §7). `enabled: true` releases the fleet brake; `false` engages it.
+    /// Shipped OFF (braked); for now inert, since the rest of the supervision
     /// subsystem is landing in the same series of changes.
     func setSupervisionEnabled(_ enabled: Bool) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -245,6 +245,7 @@ struct GeneralSettingsTab: View {
                 hibernateInputVetoToggle
                 autoCloseSetupToggle
                 queuedPromptToggle
+                supervisionBrakeToggle
             }
         }
         .formStyle(.grouped)
@@ -287,6 +288,22 @@ struct GeneralSettingsTab: View {
             set: { newValue in Task { await appState.setQueuedPromptEnabled(newValue) } }
         ))
         .help("Opens a prompt sheet right after creation starts, and hands the text to the agent whenever it comes up — so you don't wait out a preSession hook before saying what you want. While it's on, the inline rename field no longer opens on create. Off by default (soaking).")
+    }
+
+    /// Supervision's fleet-wide brake (design 2026-07-26 §3, §7). Reads/writes
+    /// straight from `Config` via `loadSupervisionConfig()`/`getConfig()`, not
+    /// `daemon.capabilities` — the one soak flag here that isn't mirrored
+    /// there yet. Off by default, and releasing it does nothing visible on
+    /// its own: nothing in the daemon acts on this column yet, since the rest
+    /// of supervision (which projects are on, what conduct they run) is
+    /// shipping in the same series of changes as this switch.
+    @ViewBuilder
+    private var supervisionBrakeToggle: some View {
+        Toggle("Supervision fleet brake", isOn: Binding(
+            get: { appState.supervisionEnabled },
+            set: { newValue in Task { await appState.setSupervisionEnabled(newValue) } }
+        ))
+        .help("The fleet-wide switch for supervision: released, TBD's autonomous processes may act on sessions it supervises; braked, they may not. Off by default. Releasing it has no visible effect by itself yet — the rest of supervision (turning projects on, choosing their conduct) is shipping in the same series of changes, and nothing acts on this column until that lands.")
     }
 
     /// Pending-input veto for auto-hibernate. Reads the persisted flag from

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -245,7 +245,7 @@ struct GeneralSettingsTab: View {
                 hibernateInputVetoToggle
                 autoCloseSetupToggle
                 queuedPromptToggle
-                supervisionBrakeToggle
+                supervisionEnabledToggle
             }
         }
         .formStyle(.grouped)
@@ -290,20 +290,24 @@ struct GeneralSettingsTab: View {
         .help("Opens a prompt sheet right after creation starts, and hands the text to the agent whenever it comes up — so you don't wait out a preSession hook before saying what you want. While it's on, the inline rename field no longer opens on create. Off by default (soaking).")
     }
 
-    /// Supervision's fleet-wide brake (design 2026-07-26 §3, §7). Reads/writes
-    /// straight from `Config` via `loadSupervisionConfig()`/`getConfig()`, not
-    /// `daemon.capabilities` — the one soak flag here that isn't mirrored
-    /// there yet. Off by default, and releasing it does nothing visible on
-    /// its own: nothing in the daemon acts on this column yet, since the rest
-    /// of supervision (which projects are on, what conduct they run) is
-    /// shipping in the same series of changes as this switch.
+    /// Supervision's fleet-wide authority switch (design 2026-07-26 §3, §7).
+    /// Reads/writes straight from `Config` via `loadSupervisionConfig()`/
+    /// `getConfig()`, not `daemon.capabilities` — the one soak flag here that
+    /// isn't mirrored there yet. Off by default. The toggle's sense matches
+    /// `Config.supervisionEnabled` directly (on == enabled == the fleet brake
+    /// released) rather than reading as the brake itself, so it can't invert
+    /// against the underlying boolean the way a "brake" label switched ON
+    /// would. Turning it on has no visible effect by itself yet: nothing in
+    /// the daemon acts on this column yet, since the rest of supervision
+    /// (which projects are on, what conduct they run) is shipping in the
+    /// same series of changes as this switch.
     @ViewBuilder
-    private var supervisionBrakeToggle: some View {
-        Toggle("Supervision fleet brake", isOn: Binding(
+    private var supervisionEnabledToggle: some View {
+        Toggle("Supervision enabled", isOn: Binding(
             get: { appState.supervisionEnabled },
             set: { newValue in Task { await appState.setSupervisionEnabled(newValue) } }
         ))
-        .help("The fleet-wide switch for supervision: released, TBD's autonomous processes may act on sessions it supervises; braked, they may not. Off by default. Releasing it has no visible effect by itself yet — the rest of supervision (turning projects on, choosing their conduct) is shipping in the same series of changes, and nothing acts on this column until that lands.")
+        .help("The fleet-wide switch for supervision. On releases TBD's autonomous processes to act on sessions it supervises; off engages the fleet brake and pauses that authority, leaving every per-project mark untouched. Off by default. Turning it on has no visible effect by itself yet — the rest of supervision (turning projects on, choosing their conduct) is shipping in the same series of changes, and nothing acts on this column until that lands.")
     }
 
     /// Pending-input veto for auto-hibernate. Reads the persisted flag from

--- a/Sources/TBDCLI/Commands/SuperviseCommands.swift
+++ b/Sources/TBDCLI/Commands/SuperviseCommands.swift
@@ -71,35 +71,42 @@ struct SuperviseOff: AsyncParsableCommand {
 /// named project is that project's mark. The two never mix — the brake writes
 /// no mark, and a mark never moves the brake.
 private func applySupervisionSwitch(project: String?, on: Bool) throws {
+    let client = SocketClient()
     guard let raw = project else {
-        let client = SocketClient()
         try client.callVoid(
             method: RPCMethod.configSetSupervisionEnabled,
             params: ConfigSetSupervisionEnabledParams(enabled: on))
         print(renderSupervisionBrake(on ? .released : .engaged))
-        if on { warnIfReleasingCoversNothing(client: client) }
+        if on { warnAfterSupervisionGesture(client: client) }
         return
     }
     let name = try requireSupervisionProjectName(raw)
-    let result: SuperviseSetProjectMarkResult = try SocketClient().call(
+    let result: SuperviseSetProjectMarkResult = try client.call(
         method: RPCMethod.superviseSetProjectMark,
         params: SuperviseSetProjectMarkParams(project: name, on: on),
         resultType: SuperviseSetProjectMarkResult.self)
     print(renderSupervisionMarkResult(result))
+    if on { warnAfterSupervisionGesture(client: client) }
 }
 
-/// Say so, right at the release, when the brake comes off over a fleet where
-/// nothing is marked on.
+/// Say so, at the gesture, when what the operator just switched on covers
+/// nothing: the brake released over an unmarked fleet, or a mark set while the
+/// brake is engaged.
 ///
-/// Best-effort by construction, and in that order for a reason: the brake is
-/// already released by the time this runs, so a readout that fails must not
+/// Runs only for `on`, never `off`. Turning something off is a deliberate
+/// reduction of coverage — the operator is not forming a mistaken belief, and a
+/// line telling them what they just chose is the noise that teaches people to
+/// stop reading the line.
+///
+/// Best-effort by construction, and in that order for a reason: the switch has
+/// already taken effect by the time this runs, so a readout that fails must not
 /// turn a gesture that succeeded into a nonzero exit. It stays quiet only when
 /// it has read the state and found nothing to say — a readout it could not take
 /// is reported as a readout it could not take, never as a calm night.
 ///
-/// The lines go to stderr because the command's data is the one `brake:` line;
+/// The lines go to stderr because the command's data is its one result line;
 /// under `status` the same lines are part of the readout and belong on stdout.
-private func warnIfReleasingCoversNothing(client: SocketClient) {
+private func warnAfterSupervisionGesture(client: SocketClient) {
     let status: SupervisionStatus
     do {
         status = try client.call(
@@ -107,11 +114,11 @@ private func warnIfReleasingCoversNothing(client: SocketClient) {
             resultType: SupervisionStatus.self)
     } catch {
         printToStandardError(
-            "warning: the brake is released, but supervision state could not be read "
+            "warning: the change took effect, but supervision state could not be read "
                 + "(\(error)) — run 'tbd supervise status'")
         return
     }
-    for line in supervisionBrakeReleaseWarningLines(status) {
+    for line in supervisionGestureWarningLines(status) {
         printToStandardError(line)
     }
 }

--- a/Sources/TBDCLI/Commands/SuperviseCommands.swift
+++ b/Sources/TBDCLI/Commands/SuperviseCommands.swift
@@ -1,0 +1,259 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+/// `tbd supervise` — the operator surface for fleet supervision
+/// (`docs/cli-supervise.md`; `docs/specs/2026-07-26-fleet-supervision-design.md`
+/// §10 is normative for these names).
+///
+/// Every command here routes through the daemon over RPC: the daemon is the
+/// single writer of `~/tbd/supervision/`, so the CLI composes params, renders
+/// results, and refuses what it can refuse honestly on its own.
+struct SuperviseCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "supervise",
+        abstract: "Operate fleet supervision: the brake, per-project coverage, modes, projects",
+        subcommands: [
+            SuperviseOn.self,
+            SuperviseOff.self,
+            SuperviseStatusCommand.self,
+            SuperviseMode.self,
+            SuperviseProject.self,
+        ]
+    )
+}
+
+// MARK: - on / off
+
+struct SuperviseOn: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "on",
+        abstract: "Turn a project's supervision on; bare, release the fleet brake",
+        discussion: """
+            With a project, sets that project's standing mark — every project \
+            starts off, and an untouched project and a turned-off one are the \
+            same state.
+
+            With no project, releases the fleet brake. The brake is one bit \
+            ANDed over every mark: releasing it writes no mark and restores \
+            exactly the coverage that stood.
+            """
+    )
+
+    @Argument(help: "Project name. Omit to release the fleet brake.")
+    var project: String?
+
+    mutating func run() async throws {
+        try applySupervisionSwitch(project: project, on: true)
+    }
+}
+
+struct SuperviseOff: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "off",
+        abstract: "Turn a project's supervision off; bare, engage the fleet brake",
+        discussion: """
+            With a project, clears that project's mark. With no project, \
+            engages the fleet brake — TBD's authority to act pauses \
+            everywhere, and no mark is touched.
+            """
+    )
+
+    @Argument(help: "Project name. Omit to engage the fleet brake.")
+    var project: String?
+
+    mutating func run() async throws {
+        try applySupervisionSwitch(project: project, on: false)
+    }
+}
+
+/// The one implementation behind `on` and `off`: bare is the fleet brake, a
+/// named project is that project's mark. The two never mix — the brake writes
+/// no mark, and a mark never moves the brake.
+private func applySupervisionSwitch(project: String?, on: Bool) throws {
+    guard let raw = project else {
+        try SocketClient().callVoid(
+            method: RPCMethod.configSetSupervisionEnabled,
+            params: ConfigSetSupervisionEnabledParams(enabled: on))
+        print(renderSupervisionBrake(on ? .released : .engaged))
+        return
+    }
+    let name = try requireSupervisionProjectName(raw)
+    let result: SuperviseSetProjectMarkResult = try SocketClient().call(
+        method: RPCMethod.superviseSetProjectMark,
+        params: SuperviseSetProjectMarkParams(project: name, on: on),
+        resultType: SuperviseSetProjectMarkResult.self)
+    print(renderSupervisionMarkResult(result))
+}
+
+// MARK: - status
+
+struct SuperviseStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show the brake and every project's supervision state"
+    )
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let status: SupervisionStatus = try SocketClient().call(
+            method: RPCMethod.superviseStatus,
+            resultType: SupervisionStatus.self)
+        if json {
+            printJSON(status)
+        } else {
+            print(renderSupervisionStatus(status))
+        }
+    }
+}
+
+// MARK: - mode
+
+struct SuperviseMode: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mode",
+        abstract: "Show or select a project's active mode",
+        discussion: """
+            With no mode name, shows the active mode and the declared choices. \
+            A name outside the declared list is refused with the choices \
+            listed; the conduct a name stands for is the playbook's prose.
+            """
+    )
+
+    @Argument(help: "Project name")
+    var project: String
+
+    @Argument(help: "Mode to select. Omit to show the active mode and the choices.")
+    var mode: String?
+
+    mutating func run() async throws {
+        let name = try requireSupervisionProjectName(project)
+        let client = SocketClient()
+        // The declared list rides on the status readout, so a refusal can name
+        // the choices without a second round trip after the write is rejected.
+        let status: SupervisionStatus = try client.call(
+            method: RPCMethod.superviseStatus,
+            resultType: SupervisionStatus.self)
+        guard let entry = status.projects.first(where: { $0.name == name }) else {
+            throw CLIError.invalidArgument(
+                "unknown project \"\(name)\" — run 'tbd supervise project list' to see them")
+        }
+        guard let requested = mode else {
+            print(renderSupervisionMode(
+                project: entry.name, active: entry.mode, declared: entry.declaredModes))
+            return
+        }
+        if let refusal = supervisionModeRefusal(
+            project: entry.name, requested: requested, declared: entry.declaredModes) {
+            throw CLIError.invalidArgument(refusal)
+        }
+        let result: SuperviseSetModeResult = try client.call(
+            method: RPCMethod.superviseSetMode,
+            params: SuperviseSetModeParams(project: name, mode: requested),
+            resultType: SuperviseSetModeResult.self)
+        print(renderSupervisionModeResult(result))
+    }
+}
+
+// MARK: - project
+
+/// The membership vocabulary is deliberately restricted: `move` and no
+/// `add`/`remove` pair, because "every repo belongs to exactly one project" is
+/// enforced by having no verb that can express anything else.
+struct SuperviseProject: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "project",
+        abstract: "Declare and edit multi-repo projects",
+        subcommands: [
+            SuperviseProjectList.self,
+            SuperviseProjectCreate.self,
+            SuperviseProjectDelete.self,
+            SuperviseProjectMove.self,
+        ]
+    )
+}
+
+struct SuperviseProjectList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List projects — declared ones and singletons alike"
+    )
+
+    mutating func run() async throws {
+        let result: SuperviseProjectListResult = try SocketClient().call(
+            method: RPCMethod.superviseProjectList,
+            resultType: SuperviseProjectListResult.self)
+        print(renderSupervisionProjectList(result))
+    }
+}
+
+struct SuperviseProjectCreate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create",
+        abstract: "Declare a project over one or more repos"
+    )
+
+    @Argument(help: "Project name")
+    var name: String
+
+    @Option(name: .long, help: "Comma-separated repo IDs or names")
+    var repos: String
+
+    @Option(name: .long, help: "Playbook policy source: repo:<id> or operator")
+    var policy: String
+
+    mutating func run() async throws {
+        let project = try requireSupervisionProjectName(name)
+        let members = try parseSupervisionRepoList(repos)
+        let policySource = try parseSupervisionPolicy(policy)
+        let result: SuperviseProjectListResult = try SocketClient().call(
+            method: RPCMethod.superviseProjectCreate,
+            params: SuperviseProjectCreateParams(
+                name: project, repos: members, policy: policySource),
+            resultType: SuperviseProjectListResult.self)
+        print(renderSupervisionProjectList(result))
+    }
+}
+
+struct SuperviseProjectDelete: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Delete a declaration, returning its repos to being their own projects"
+    )
+
+    @Argument(help: "Project name")
+    var name: String
+
+    mutating func run() async throws {
+        let project = try requireSupervisionProjectName(name)
+        let result: SuperviseProjectListResult = try SocketClient().call(
+            method: RPCMethod.superviseProjectDelete,
+            params: SuperviseProjectDeleteParams(name: project),
+            resultType: SuperviseProjectListResult.self)
+        print(renderSupervisionProjectList(result))
+    }
+}
+
+struct SuperviseProjectMove: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "move",
+        abstract: "Move a repo into a project, or back to being its own"
+    )
+
+    @Argument(help: "Repo ID or name")
+    var repo: String
+
+    @Option(name: .long, help: "Destination project, or \"singleton\"")
+    var to: String
+
+    mutating func run() async throws {
+        let target = try parseSupervisionMoveTarget(to)
+        let result: SuperviseProjectListResult = try SocketClient().call(
+            method: RPCMethod.superviseProjectMove,
+            params: SuperviseProjectMoveParams(repo: repo, to: target.argument),
+            resultType: SuperviseProjectListResult.self)
+        print(renderSupervisionProjectList(result))
+    }
+}

--- a/Sources/TBDCLI/Commands/SuperviseCommands.swift
+++ b/Sources/TBDCLI/Commands/SuperviseCommands.swift
@@ -72,10 +72,12 @@ struct SuperviseOff: AsyncParsableCommand {
 /// no mark, and a mark never moves the brake.
 private func applySupervisionSwitch(project: String?, on: Bool) throws {
     guard let raw = project else {
-        try SocketClient().callVoid(
+        let client = SocketClient()
+        try client.callVoid(
             method: RPCMethod.configSetSupervisionEnabled,
             params: ConfigSetSupervisionEnabledParams(enabled: on))
         print(renderSupervisionBrake(on ? .released : .engaged))
+        if on { warnIfReleasingCoversNothing(client: client) }
         return
     }
     let name = try requireSupervisionProjectName(raw)
@@ -84,6 +86,38 @@ private func applySupervisionSwitch(project: String?, on: Bool) throws {
         params: SuperviseSetProjectMarkParams(project: name, on: on),
         resultType: SuperviseSetProjectMarkResult.self)
     print(renderSupervisionMarkResult(result))
+}
+
+/// Say so, right at the release, when the brake comes off over a fleet where
+/// nothing is marked on.
+///
+/// Best-effort by construction, and in that order for a reason: the brake is
+/// already released by the time this runs, so a readout that fails must not
+/// turn a gesture that succeeded into a nonzero exit. It stays quiet only when
+/// it has read the state and found nothing to say — a readout it could not take
+/// is reported as a readout it could not take, never as a calm night.
+///
+/// The lines go to stderr because the command's data is the one `brake:` line;
+/// under `status` the same lines are part of the readout and belong on stdout.
+private func warnIfReleasingCoversNothing(client: SocketClient) {
+    let status: SupervisionStatus
+    do {
+        status = try client.call(
+            method: RPCMethod.superviseStatus,
+            resultType: SupervisionStatus.self)
+    } catch {
+        printToStandardError(
+            "warning: the brake is released, but supervision state could not be read "
+                + "(\(error)) — run 'tbd supervise status'")
+        return
+    }
+    for line in supervisionBrakeReleaseWarningLines(status) {
+        printToStandardError(line)
+    }
+}
+
+private func printToStandardError(_ line: String) {
+    FileHandle.standardError.write(Data("\(line)\n".utf8))
 }
 
 // MARK: - status

--- a/Sources/TBDCLI/Commands/SuperviseRendering.swift
+++ b/Sources/TBDCLI/Commands/SuperviseRendering.swift
@@ -21,6 +21,11 @@ import TBDShared
 /// would render as boilerplate instead of as words, which is the quiet failure
 /// this whole surface exists to prevent. The compile error is the forcing
 /// function that makes every new warning get a human sentence.
+///
+/// It has already earned that twice in this subsystem's first day —
+/// `unusableProjectName` and then `ambiguousRepoName` / `brakeEngagedWithProjectsOn`
+/// each stopped the build until an operator-facing sentence existed. Under a
+/// `default` arm all four would have shipped as boilerplate. Keep it exhaustive.
 func supervisionWarningSentence(_ code: SupervisionWarningCode) -> String {
     switch code {
     case .noProjectsOn:
@@ -30,6 +35,18 @@ func supervisionWarningSentence(_ code: SupervisionWarningCode) -> String {
             a project's name cannot be used as a directory name, so nothing can be \
             written beside it — no playbook, journal, proposals or programs. It is \
             supervised like any other project; rename the repo to give it a directory.
+            """
+    case .ambiguousRepoName:
+        return """
+            two or more repos share a display name, so none of them resolves to a \
+            project and none is supervised — a name with two candidates identifies \
+            nothing. Rename one, or declare a project naming them. The rest of the \
+            fleet is unaffected.
+            """
+    case .brakeEngagedWithProjectsOn:
+        return """
+            the brake is engaged while projects are marked on — nothing is watching \
+            them. Release it with `tbd supervise on`.
             """
     }
 }
@@ -44,28 +61,43 @@ func supervisionWarningSentence(_ code: SupervisionWarningCode) -> String {
 /// daemon that forgot to warn render a calm night.
 func supervisionStatusWarningLines(_ status: SupervisionStatus) -> [String] {
     var lines: [String] = []
-    var sawNoProjectsOn = false
+    var seen: Set<SupervisionWarningCode> = []
     for warning in status.warnings {
-        if warning.code == .noProjectsOn { sawNoProjectsOn = true }
+        seen.insert(warning.code)
         let supplied = warning.message.trimmingCharacters(in: .whitespacesAndNewlines)
         let message = supplied.isEmpty ? supervisionWarningSentence(warning.code) : supplied
         lines.append("warning: \(message)")
     }
-    if !sawNoProjectsOn && status.brake == .released && !status.effectivelySupervising {
+    if !seen.contains(.noProjectsOn) && status.brake == .released
+        && !status.effectivelySupervising {
         lines.append("warning: \(supervisionWarningSentence(.noProjectsOn))")
+    }
+    // The mirror, recomputed for the same reason and worth more: here the
+    // operator has performed a gesture and been told it succeeded.
+    // `effectivelySupervising` is false in both states and cannot tell them
+    // apart, so the condition is read from the brake and the marks.
+    if !seen.contains(.brakeEngagedWithProjectsOn) && status.brake == .engaged
+        && status.projects.contains(where: { $0.on }) {
+        lines.append("warning: \(supervisionWarningSentence(.brakeEngagedWithProjectsOn))")
     }
     return lines
 }
 
-/// The lines bare `tbd supervise on` emits after releasing the brake.
+/// The lines a switching gesture emits after it has taken effect — bare
+/// `tbd supervise on` releasing the brake, and `on <project>` setting a mark.
 ///
 /// Deliberately the very same composition `status` renders, not a second
-/// wording: releasing the brake is where an operator forms the belief that
-/// supervision is running, and it is the only gesture that can create the state
-/// the warning describes — so it is the highest-value place to say it. One fact
-/// gets one sentence, and this seam is what stops the two surfaces drifting
-/// into two.
-func supervisionBrakeReleaseWarningLines(_ status: SupervisionStatus) -> [String] {
+/// wording. A gesture is where an operator forms the belief that supervision is
+/// running, and each of these two is the only gesture that can create the state
+/// its warning describes — so they are the highest-value places to say it. One
+/// fact gets one sentence, and this seam is what stops the surfaces drifting
+/// into three.
+///
+/// Nothing is filtered to "the warning about this gesture". A finding true of
+/// supervision is worth saying at the moment an operator is about to rely on
+/// it, and a filter is a rule that can silently drop a warning a later slice
+/// adds — the failure this surface exists to prevent, arriving by omission.
+func supervisionGestureWarningLines(_ status: SupervisionStatus) -> [String] {
     supervisionStatusWarningLines(status)
 }
 

--- a/Sources/TBDCLI/Commands/SuperviseRendering.swift
+++ b/Sources/TBDCLI/Commands/SuperviseRendering.swift
@@ -57,6 +57,18 @@ func supervisionStatusWarningLines(_ status: SupervisionStatus) -> [String] {
     return lines
 }
 
+/// The lines bare `tbd supervise on` emits after releasing the brake.
+///
+/// Deliberately the very same composition `status` renders, not a second
+/// wording: releasing the brake is where an operator forms the belief that
+/// supervision is running, and it is the only gesture that can create the state
+/// the warning describes — so it is the highest-value place to say it. One fact
+/// gets one sentence, and this seam is what stops the two surfaces drifting
+/// into two.
+func supervisionBrakeReleaseWarningLines(_ status: SupervisionStatus) -> [String] {
+    supervisionStatusWarningLines(status)
+}
+
 /// Compose the human-readable `tbd supervise status` readout: the brake, the
 /// loud lines, then one row per project.
 ///
@@ -272,21 +284,37 @@ func parseSupervisionPolicy(_ raw: String) throws -> SupervisionPolicyRequest {
 
 /// Reads `--to <project|singleton>`. `singleton` is the documented sentinel
 /// that returns a repo to being its own project.
+///
+/// The destination is a project name, so it is passed through verbatim for the
+/// same reason `requireSupervisionProjectName` does — `--to " staging "` must be
+/// able to name the project `status` shows as `" staging "`. The sentinel is the
+/// exact word: `--to " singleton "` names a project, not the sentinel, because
+/// a caller who quoted those spaces typed them deliberately.
 func parseSupervisionMoveTarget(_ raw: String) throws -> SupervisionMoveTarget {
-    let value = raw.trimmingCharacters(in: .whitespaces)
-    guard !value.isEmpty else {
+    guard !raw.trimmingCharacters(in: .whitespaces).isEmpty else {
         throw CLIError.invalidArgument(
             "--to must name a project or \"\(SupervisionMoveTarget.singletonArgument)\"")
     }
-    return SupervisionMoveTarget(argument: value)
+    return SupervisionMoveTarget(argument: raw)
 }
 
-/// A project name typed on the command line. Empty is refused rather than
-/// silently read as the bare (fleet-brake) form of `on`/`off`.
+/// A project name typed on the command line, passed to the daemon **verbatim**.
+///
+/// A name of nothing but whitespace is refused, because that is the empty case
+/// — it would otherwise read as the bare (fleet-brake) form of `on`/`off`. Any
+/// other name goes through exactly as typed, surrounding spaces included: a
+/// singleton project's name is its repo's display name, and `isSafeProjectName`
+/// deliberately rejects only genuinely unsafe components (empty, `.`, `..`, a
+/// path separator, NUL) so a repo named `" staging "` keeps its directory. If
+/// the CLI trimmed, that project would appear in `status` and be unaddressable
+/// by every other verb.
+///
+/// The CLI resolves no names: the daemon is the single resolver, so a name that
+/// matches nothing comes back as a refusal naming the condition rather than
+/// being silently repaired into a neighbouring project's.
 func requireSupervisionProjectName(_ raw: String) throws -> String {
-    let value = raw.trimmingCharacters(in: .whitespaces)
-    guard !value.isEmpty else {
+    guard !raw.trimmingCharacters(in: .whitespaces).isEmpty else {
         throw CLIError.invalidArgument("project name must not be empty")
     }
-    return value
+    return raw
 }

--- a/Sources/TBDCLI/Commands/SuperviseRendering.swift
+++ b/Sources/TBDCLI/Commands/SuperviseRendering.swift
@@ -290,7 +290,7 @@ private func supervisionPolicyDescription(
 /// them is the daemon's job; the CLI only refuses an empty list.
 func parseSupervisionRepoList(_ raw: String) throws -> [String] {
     let repos = raw.split(separator: ",")
-        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .filter { !$0.isEmpty }
     guard !repos.isEmpty else {
         throw CLIError.invalidArgument("--repos must name at least one repo (comma-separated)")
@@ -303,11 +303,11 @@ let supervisionPolicyRepoPrefix = "repo:"
 
 /// Reads `--policy repo:<id>|operator`.
 func parseSupervisionPolicy(_ raw: String) throws -> SupervisionPolicyRequest {
-    let value = raw.trimmingCharacters(in: .whitespaces)
+    let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
     if value == "operator" { return .operator }
     if value.hasPrefix(supervisionPolicyRepoPrefix) {
         let repo = String(value.dropFirst(supervisionPolicyRepoPrefix.count))
-            .trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         if !repo.isEmpty { return .repo(repo) }
     }
     throw CLIError.invalidArgument(
@@ -322,8 +322,12 @@ func parseSupervisionPolicy(_ raw: String) throws -> SupervisionPolicyRequest {
 /// able to name the project `status` shows as `" staging "`. The sentinel is the
 /// exact word: `--to " singleton "` names a project, not the sentinel, because
 /// a caller who quoted those spaces typed them deliberately.
+///
+/// The emptiness test is `.whitespacesAndNewlines` for the reason spelled out on
+/// `requireSupervisionProjectName`: these two guards are twins over the same
+/// input class, and they have to move together or one of them is a hole.
 func parseSupervisionMoveTarget(_ raw: String) throws -> SupervisionMoveTarget {
-    guard !raw.trimmingCharacters(in: .whitespaces).isEmpty else {
+    guard !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         throw CLIError.invalidArgument(
             "--to must name a project or \"\(SupervisionMoveTarget.singletonArgument)\"")
     }
@@ -344,8 +348,14 @@ func parseSupervisionMoveTarget(_ raw: String) throws -> SupervisionMoveTarget {
 /// The CLI resolves no names: the daemon is the single resolver, so a name that
 /// matches nothing comes back as a refusal naming the condition rather than
 /// being silently repaired into a neighbouring project's.
+///
+/// **The emptiness test is `.whitespacesAndNewlines`, and the distinction is
+/// load-bearing.** `CharacterSet.whitespaces` holds spaces and tabs but no
+/// newline, so `"\t \n"` trimmed by it is `"\n"` — not empty, guard passed, a
+/// whitespace-only name on its way to the daemon. That is the exact input this
+/// guard exists to stop, and a shell-expanded argument is where it comes from.
 func requireSupervisionProjectName(_ raw: String) throws -> String {
-    guard !raw.trimmingCharacters(in: .whitespaces).isEmpty else {
+    guard !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         throw CLIError.invalidArgument("project name must not be empty")
     }
     return raw

--- a/Sources/TBDCLI/Commands/SuperviseRendering.swift
+++ b/Sources/TBDCLI/Commands/SuperviseRendering.swift
@@ -1,0 +1,292 @@
+import Foundation
+import TBDShared
+
+// Pure composition for the `tbd supervise` surface: every function here takes
+// the DTO the daemon answered with and returns the exact text a human or a
+// program sees. Nothing here talks to the daemon, so the loud cases can be
+// asserted on the composed output rather than on an internal boolean.
+
+// MARK: - status
+
+/// The sentence a warning code gets when the daemon supplied no message of its
+/// own. The CLI carries its own wording so the loud case cannot be silenced by
+/// an empty string arriving over the wire.
+///
+/// The switch is deliberately exhaustive, with no `default` arm. A code this
+/// enum does not know cannot reach here — `SupervisionWarningCode` is one
+/// `TBDShared` type compiled into both the daemon and this CLI, and an
+/// unrecognized raw value fails to decode in `SocketClient` long before
+/// rendering — so a `default` would be unreachable rather than protective. What
+/// it would actually buy is silence when a later slice adds a warning: the code
+/// would render as boilerplate instead of as words, which is the quiet failure
+/// this whole surface exists to prevent. The compile error is the forcing
+/// function that makes every new warning get a human sentence.
+func supervisionWarningSentence(_ code: SupervisionWarningCode) -> String {
+    switch code {
+    case .noProjectsOn:
+        return "the brake is released but no project is on — nothing is being supervised."
+    case .unusableProjectName:
+        return """
+            a project's name cannot be used as a directory name, so nothing can be \
+            written beside it — no playbook, journal, proposals or programs. It is \
+            supervised like any other project; rename the repo to give it a directory.
+            """
+    }
+}
+
+/// The loud lines that precede the per-project rows.
+///
+/// A fleet switched on with nothing marked on is the quiet failure this design
+/// fears: an account that looks peaceful because nothing was watched. So the
+/// line is composed from the facts the status carries — `brake` released with
+/// `effectivelySupervising` false means exactly "nothing is being supervised" —
+/// rather than only from the daemon's `warnings` array, which would let a
+/// daemon that forgot to warn render a calm night.
+func supervisionStatusWarningLines(_ status: SupervisionStatus) -> [String] {
+    var lines: [String] = []
+    var sawNoProjectsOn = false
+    for warning in status.warnings {
+        if warning.code == .noProjectsOn { sawNoProjectsOn = true }
+        let supplied = warning.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let message = supplied.isEmpty ? supervisionWarningSentence(warning.code) : supplied
+        lines.append("warning: \(message)")
+    }
+    if !sawNoProjectsOn && status.brake == .released && !status.effectivelySupervising {
+        lines.append("warning: \(supervisionWarningSentence(.noProjectsOn))")
+    }
+    return lines
+}
+
+/// Compose the human-readable `tbd supervise status` readout: the brake, the
+/// loud lines, then one row per project.
+///
+/// `now` and `timeZone` are seams so the rendering is a pure function of its
+/// inputs — a status rendered in a test reads the same in every timezone.
+func renderSupervisionStatus(
+    _ status: SupervisionStatus,
+    now: Date = Date(),
+    timeZone: TimeZone = .current
+) -> String {
+    var lines = ["brake: \(status.brake.rawValue)"]
+    lines.append(contentsOf: supervisionStatusWarningLines(status))
+
+    guard !status.projects.isEmpty else {
+        lines.append("(no projects)")
+        return lines.joined(separator: "\n")
+    }
+
+    let cells = status.projects.map { project in
+        (
+            name: project.name,
+            state: supervisionStateCell(project, timeZone: timeZone),
+            mode: "mode \(project.mode)",
+            supervisor: supervisionSupervisorCell(project.supervisor),
+            contact: supervisionContactCell(project, now: now),
+            coverage: supervisionCoverageCell(project)
+        )
+    }
+    let nameWidth = cells.map { $0.name.count }.max() ?? 0
+    let stateWidth = cells.map { $0.state.count }.max() ?? 0
+    let modeWidth = cells.map { $0.mode.count }.max() ?? 0
+    let supervisorWidth = cells.map { $0.supervisor.count }.max() ?? 0
+    let contactWidth = cells.map { $0.contact.count }.max() ?? 0
+
+    for cell in cells {
+        lines.append(tableRow([
+            (cell.name, nameWidth),
+            (cell.state, stateWidth),
+            (cell.mode, modeWidth),
+            (cell.supervisor, supervisorWidth),
+            (cell.contact, contactWidth),
+            (cell.coverage, 0),
+        ]))
+    }
+    return lines.joined(separator: "\n")
+}
+
+/// An untouched project and a turned-off one are the same state, so an off
+/// project renders exactly `off` — never a span, never a "was on until" — even
+/// when the record still carries an opening instant. A third rendering would
+/// be a third tier.
+private func supervisionStateCell(
+    _ project: SupervisionStatusProject, timeZone: TimeZone
+) -> String {
+    guard project.on else { return "off" }
+    guard let started = project.spanStartedAt else { return "on" }
+    return "on since \(supervisionClockTime(started.date, timeZone: timeZone))"
+}
+
+private func supervisionSupervisorCell(
+    _ supervisor: SupervisionSupervisorArrangement
+) -> String {
+    switch supervisor.kind {
+    case .hostedDesk:
+        return "supervisor: hosted desk"
+    case .appointed:
+        guard let terminal = supervisor.terminal, !terminal.isEmpty else {
+            return "supervisor: appointed"
+        }
+        return "supervisor: appointed (\(terminal))"
+    }
+}
+
+private func supervisionContactCell(
+    _ project: SupervisionStatusProject, now: Date
+) -> String {
+    guard let contact = project.lastSweepContactAt else {
+        return "last sweep contact: never"
+    }
+    return "last sweep contact: \(supervisionAge(from: contact.date, to: now))"
+}
+
+/// A project with no declared contact window reports `coverage unknown` — the
+/// honest not-yet value. Nothing here invents a coverage claim.
+private func supervisionCoverageCell(_ project: SupervisionStatusProject) -> String {
+    guard let window = project.coverageWindow, !window.isEmpty else {
+        return "coverage unknown"
+    }
+    return "coverage \(window)"
+}
+
+func supervisionClockTime(_ date: Date, timeZone: TimeZone) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = timeZone
+    formatter.dateFormat = "HH:mm"
+    return formatter.string(from: date)
+}
+
+func supervisionAge(from: Date, to now: Date) -> String {
+    let seconds = max(0, Int(now.timeIntervalSince(from).rounded()))
+    if seconds < 60 { return "\(seconds)s ago" }
+    let minutes = seconds / 60
+    if minutes < 60 { return "\(minutes)m ago" }
+    let hours = minutes / 60
+    if hours < 24 { return "\(hours)h ago" }
+    return "\(hours / 24)d ago"
+}
+
+// MARK: - marks and modes
+
+func renderSupervisionMarkResult(_ result: SuperviseSetProjectMarkResult) -> String {
+    let state = result.on ? "on" : "off"
+    return result.changed
+        ? "\(state): \(result.project)"
+        : "\(state): \(result.project) (already \(state))"
+}
+
+func renderSupervisionBrake(_ brake: SupervisionBrakeState) -> String {
+    "brake: \(brake.rawValue)"
+}
+
+func renderSupervisionMode(project: String, active: String, declared: [String]) -> String {
+    let choices = declared.isEmpty ? "(none declared)" : declared.joined(separator: ", ")
+    return "mode: \(project) is \(active)   choices: \(choices)"
+}
+
+func renderSupervisionModeResult(_ result: SuperviseSetModeResult) -> String {
+    let head = result.changed
+        ? "mode: \(result.project) is now \(result.mode)"
+        : "mode: \(result.project) was already \(result.mode)"
+    guard !result.declaredModes.isEmpty else { return head }
+    return head + "   choices: " + result.declaredModes.joined(separator: ", ")
+}
+
+/// The refusal a mode outside the project's declared list gets, or nil when the
+/// name is one of the choices. The choices ride along because a refusal that
+/// does not say what would have worked makes the operator go look.
+func supervisionModeRefusal(
+    project: String, requested: String, declared: [String]
+) -> String? {
+    guard !declared.contains(requested) else { return nil }
+    let choices = declared.isEmpty ? "(none declared)" : declared.joined(separator: ", ")
+    return "mode \"\(requested)\" is not declared for project \"\(project)\" — choices: \(choices)"
+}
+
+// MARK: - projects
+
+func renderSupervisionProjectList(_ result: SuperviseProjectListResult) -> String {
+    guard !result.projects.isEmpty else { return "(no projects)" }
+    let cells = result.projects.map { project in
+        (
+            name: project.name,
+            repos: project.repos.map(\.name).joined(separator: ", "),
+            policy: "policy: \(supervisionPolicyDescription(project.policy, repos: project.repos))",
+            sweep: "sweep: \(project.sweepScript ?? "shipped")"
+        )
+    }
+    let nameWidth = cells.map { $0.name.count }.max() ?? 0
+    let reposWidth = cells.map { $0.repos.count }.max() ?? 0
+    let policyWidth = cells.map { $0.policy.count }.max() ?? 0
+    return cells.map { cell in
+        tableRow([
+            (cell.name, nameWidth),
+            (cell.repos, reposWidth),
+            (cell.policy, policyWidth),
+            (cell.sweep, 0),
+        ])
+    }.joined(separator: "\n")
+}
+
+private func supervisionPolicyDescription(
+    _ policy: SupervisionPolicySource, repos: [SupervisionProjectRepoRef]
+) -> String {
+    switch policy {
+    case .operator:
+        return "operator"
+    case .repo(let id):
+        let name = repos.first(where: { $0.id == id })?.name
+        return "repo:\(name ?? id.uuidString)"
+    }
+}
+
+// MARK: - argument parsing
+
+/// Reads `--repos <id,…>`: repo UUIDs or display names, as typed. Resolving
+/// them is the daemon's job; the CLI only refuses an empty list.
+func parseSupervisionRepoList(_ raw: String) throws -> [String] {
+    let repos = raw.split(separator: ",")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+    guard !repos.isEmpty else {
+        throw CLIError.invalidArgument("--repos must name at least one repo (comma-separated)")
+    }
+    return repos
+}
+
+/// The prefix `--policy repo:<id>` is spelled with.
+let supervisionPolicyRepoPrefix = "repo:"
+
+/// Reads `--policy repo:<id>|operator`.
+func parseSupervisionPolicy(_ raw: String) throws -> SupervisionPolicyRequest {
+    let value = raw.trimmingCharacters(in: .whitespaces)
+    if value == "operator" { return .operator }
+    if value.hasPrefix(supervisionPolicyRepoPrefix) {
+        let repo = String(value.dropFirst(supervisionPolicyRepoPrefix.count))
+            .trimmingCharacters(in: .whitespaces)
+        if !repo.isEmpty { return .repo(repo) }
+    }
+    throw CLIError.invalidArgument(
+        "--policy must be \"repo:<id>\" or \"operator\" (got \"\(raw)\")")
+}
+
+/// Reads `--to <project|singleton>`. `singleton` is the documented sentinel
+/// that returns a repo to being its own project.
+func parseSupervisionMoveTarget(_ raw: String) throws -> SupervisionMoveTarget {
+    let value = raw.trimmingCharacters(in: .whitespaces)
+    guard !value.isEmpty else {
+        throw CLIError.invalidArgument(
+            "--to must name a project or \"\(SupervisionMoveTarget.singletonArgument)\"")
+    }
+    return SupervisionMoveTarget(argument: value)
+}
+
+/// A project name typed on the command line. Empty is refused rather than
+/// silently read as the bare (fleet-brake) form of `on`/`off`.
+func requireSupervisionProjectName(_ raw: String) throws -> String {
+    let value = raw.trimmingCharacters(in: .whitespaces)
+    guard !value.isEmpty else {
+        throw CLIError.invalidArgument("project name must not be empty")
+    }
+    return value
+}

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -26,6 +26,7 @@ struct TBDCommand: AsyncParsableCommand {
             LinkCommand.self,
             DoctorCommand.self,
             NightwatchCommand.self,
+            SuperviseCommand.self,
             GCCommand.self,
             PRCommand.self,
         ]

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -973,7 +973,9 @@ public final class Daemon: Sendable {
                 // effectively on" and never alarms about.
                 let brakeReleased = (try? await database.config.get())?.supervisionEnabled
                     ?? Config.supervisionEnabledDefault
-                await heartbeat.applyBrake(released: brakeReleased)
+                // Sequence 0: boot orders against nothing, and every real
+                // transition the store hands out starts at 1.
+                await heartbeat.applyBrake(released: brakeReleased, sequence: 0)
             }
 
             // 13. Periodic git status refresh (branch sync, conflict detection).

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -631,21 +631,28 @@ public final class Daemon: Sendable {
         // project's coverage span from the ledger. **It writes no ledger line,
         // sends nothing, and starts nothing** — a restart resumes coverage from
         // the two files and never replays a decision.
-        let supervisionStore = SupervisionStore(
-            files: SupervisionFileStore(),
-            ledger: SupervisionLedgerWriter(path: TBDConstants.supervisionLedgerPath),
-            fleet: DatabaseSupervisionFleetReader(db: database))
-        self.supervision = supervisionStore
-        rpcRouter.supervision = supervisionStore
-        do {
-            try await supervisionStore.load()
-        } catch {
-            // A file the operator can hand-edit into an unloadable state must
-            // not stop the daemon from booting. Every supervision gesture will
-            // refuse with the same named condition until it is fixed, and
-            // everything else TBD does is unaffected.
-            daemonLogger.error(
-                "Could not load supervision state: \(String(describing: error), privacy: .public)")
+        // Skipped in mock mode like every other rail: a fixture render must not
+        // read the operator's real supervision file, and `supervise.*` refuses
+        // with a named condition there rather than answering from it.
+        let supervisionStore: SupervisionStore? = mockMode == nil
+            ? SupervisionStore(
+                files: SupervisionFileStore(),
+                ledger: SupervisionLedgerWriter(path: TBDConstants.supervisionLedgerPath),
+                fleet: DatabaseSupervisionFleetReader(db: database))
+            : nil
+        if let supervisionStore {
+            self.supervision = supervisionStore
+            rpcRouter.supervision = supervisionStore
+            do {
+                try await supervisionStore.load()
+            } catch {
+                // A file the operator can hand-edit into an unloadable state
+                // must not stop the daemon from booting. Every supervision
+                // gesture will refuse with the same named condition until it is
+                // fixed, and everything else TBD does is unaffected.
+                let detail = String(describing: error)
+                daemonLogger.error("Could not load supervision state: \(detail, privacy: .public)")
+            }
         }
 
         // 8b. Migrate legacy per-repo claude_settings_overlay column values
@@ -942,16 +949,18 @@ public final class Daemon: Sendable {
             // brake that moved a minute ago. A tick that cannot read the state
             // publishes nothing and lets the file go stale, which is precisely
             // the signal the watchdog exists to notice.
-            let heartbeat = SupervisionHeartbeat(
-                path: TBDConstants.supervisionStatusPath,
-                snapshot: { [database, supervisionStore] in
-                    guard let config = try? await database.config.get() else { return nil }
-                    let brake: SupervisionBrakeState =
-                        config.supervisionEnabled ? .released : .engaged
-                    return try? await supervisionStore.statusFileSnapshot(brake: brake)
-                })
-            self.supervisionHeartbeat = heartbeat
-            await heartbeat.start()
+            if let supervisionStore {
+                let heartbeat = SupervisionHeartbeat(
+                    path: TBDConstants.supervisionStatusPath,
+                    snapshot: { [database, supervisionStore] in
+                        guard let config = try? await database.config.get() else { return nil }
+                        let brake: SupervisionBrakeState =
+                            config.supervisionEnabled ? .released : .engaged
+                        return try? await supervisionStore.statusFileSnapshot(brake: brake)
+                    })
+                self.supervisionHeartbeat = heartbeat
+                await heartbeat.start()
+            }
 
             // 13. Periodic git status refresh (branch sync, conflict detection).
             // 10s foreground, 60s background (GitPollCadence.statusInterval);

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -938,19 +938,19 @@ public final class Daemon: Sendable {
                 reconcileLogger.error("Failed to restore daywatch mode on boot: \(String(describing: error), privacy: .public)")
             }
 
-            // 12f. Out-of-band supervision heartbeat (design §14). Writes
-            // `status.json` on its own cadence **regardless of the brake** — a
-            // watchdog that cannot reach the socket or the DB still needs to
-            // read "engaged" from a fresh file, and a heartbeat that fell
-            // silent under a pause would make a paused fleet
-            // indistinguishable from a dead daemon.
+            // 12f. Out-of-band supervision heartbeat (design §14). Publishes
+            // `status.json` at every brake edge, and runs its periodic timer
+            // only while the brake is released — the brake is the one switch,
+            // and a braked daemon runs no background loop. See the type's own
+            // doc for why that costs the watchdog nothing.
             //
             // The snapshot closure reads the brake per tick rather than
             // capturing it: the app's toggle and the CLI's bare `on`/`off`
             // both write that column, and the file must not go on publishing a
             // brake that moved a minute ago. A tick that cannot read the state
-            // publishes nothing and lets the file go stale, which is precisely
-            // the signal the watchdog exists to notice.
+            // publishes nothing and lets the file go stale — which, while the
+            // brake is released, is precisely the signal the watchdog exists
+            // to notice.
             if let supervisionStore {
                 let heartbeat = SupervisionHeartbeat(
                     path: TBDConstants.supervisionStatusPath,
@@ -965,7 +965,15 @@ public final class Daemon: Sendable {
                         return try await supervisionStore.statusFileSnapshot(brake: brake)
                     })
                 self.supervisionHeartbeat = heartbeat
-                await heartbeat.start()
+                rpcRouter.supervisionHeartbeat = heartbeat
+                // Publish once at boot and arm the timer only if the brake is
+                // already released. A braked daemon therefore starts no loop —
+                // the brake is the switch — and still leaves behind a file
+                // saying `engaged`, which the watchdog reads as "nothing is
+                // effectively on" and never alarms about.
+                let brakeReleased = (try? await database.config.get())?.supervisionEnabled
+                    ?? Config.supervisionEnabledDefault
+                await heartbeat.applyBrake(released: brakeReleased)
             }
 
             // 13. Periodic git status refresh (branch sync, conflict detection).

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -647,9 +647,11 @@ public final class Daemon: Sendable {
                 try await supervisionStore.load()
             } catch {
                 // A file the operator can hand-edit into an unloadable state
-                // must not stop the daemon from booting. Every supervision
-                // gesture will refuse with the same named condition until it is
-                // fixed, and everything else TBD does is unaffected.
+                // must not stop the daemon from booting, and everything else
+                // TBD does is unaffected. The store stays unloaded, so each
+                // later gesture retries the read and refuses with whatever the
+                // file says at that moment — which means fixing the file makes
+                // the next gesture work with no restart.
                 let detail = String(describing: error)
                 daemonLogger.error("Could not load supervision state: \(detail, privacy: .public)")
             }
@@ -953,10 +955,14 @@ public final class Daemon: Sendable {
                 let heartbeat = SupervisionHeartbeat(
                     path: TBDConstants.supervisionStatusPath,
                     snapshot: { [database, supervisionStore] in
-                        guard let config = try? await database.config.get() else { return nil }
+                        // Errors propagate rather than collapsing to "no
+                        // snapshot": a heartbeat that goes quiet looks exactly
+                        // like a dead daemon to the watchdog, so the reason has
+                        // to reach the log even though the tick is skipped.
+                        let config = try await database.config.get()
                         let brake: SupervisionBrakeState =
                             config.supervisionEnabled ? .released : .engaged
-                        return try? await supervisionStore.statusFileSnapshot(brake: brake)
+                        return try await supervisionStore.statusFileSnapshot(brake: brake)
                     })
                 self.supervisionHeartbeat = heartbeat
                 await heartbeat.start()

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -94,6 +94,13 @@ public final class Daemon: Sendable {
     /// on shutdown; `nil` in mock mode.
     public nonisolated(unsafe) var limitResumeScheduler: LimitResumeScheduler?
     public nonisolated(unsafe) var daywatchRunner: DaywatchRunner?
+    /// Fleet supervision's single writer of `~/tbd/supervision/`. Owned here so
+    /// the heartbeat below can read through it; also handed to the router.
+    public nonisolated(unsafe) var supervision: SupervisionStore?
+    /// The out-of-band `status.json` heartbeat (design §14). Owned here so it
+    /// can be stopped on shutdown; `nil` in mock mode, where the daemon must
+    /// not write into the real supervision directory.
+    public nonisolated(unsafe) var supervisionHeartbeat: SupervisionHeartbeat?
     /// Per-daemon tmux control-mode supervisor. Owned here so it can be stopped
     /// on shutdown; the gate (`ControlModeGate.shouldEnable`) keeps it dormant
     /// unless `TBD_TMUX_CONTROL_MODE` is opted in and tmux is ≥ 3.2.
@@ -612,6 +619,35 @@ public final class Daemon: Sendable {
         let appForeground = AppForegroundState()
         rpcRouter.appForegroundState = appForeground
 
+        // 8a-supervision. Fleet supervision's single writer of
+        // `~/tbd/supervision/` (design §7). Wired BEFORE the socket server
+        // starts serving (step 9): a `tbd supervise` call arriving on a router
+        // with no store is refused, and the boot window is exactly when the
+        // operator's first gesture of the day tends to land.
+        //
+        // Reading the two files at boot is deliberate and is only reading. It
+        // makes a malformed `supervision.json` loud here rather than at
+        // whichever gesture happens to hit it first, and it recovers each on
+        // project's coverage span from the ledger. **It writes no ledger line,
+        // sends nothing, and starts nothing** — a restart resumes coverage from
+        // the two files and never replays a decision.
+        let supervisionStore = SupervisionStore(
+            files: SupervisionFileStore(),
+            ledger: SupervisionLedgerWriter(path: TBDConstants.supervisionLedgerPath),
+            fleet: DatabaseSupervisionFleetReader(db: database))
+        self.supervision = supervisionStore
+        rpcRouter.supervision = supervisionStore
+        do {
+            try await supervisionStore.load()
+        } catch {
+            // A file the operator can hand-edit into an unloadable state must
+            // not stop the daemon from booting. Every supervision gesture will
+            // refuse with the same named condition until it is fixed, and
+            // everything else TBD does is unaffected.
+            daemonLogger.error(
+                "Could not load supervision state: \(String(describing: error), privacy: .public)")
+        }
+
         // 8b. Migrate legacy per-repo claude_settings_overlay column values
         // (v53, PR #452) to their file-backed home under
         // `~/tbd/repos/<repoID>/claude-settings.json`. Idempotent; converges
@@ -893,6 +929,30 @@ public final class Daemon: Sendable {
                 reconcileLogger.error("Failed to restore daywatch mode on boot: \(String(describing: error), privacy: .public)")
             }
 
+            // 12f. Out-of-band supervision heartbeat (design §14). Writes
+            // `status.json` on its own cadence **regardless of the brake** — a
+            // watchdog that cannot reach the socket or the DB still needs to
+            // read "engaged" from a fresh file, and a heartbeat that fell
+            // silent under a pause would make a paused fleet
+            // indistinguishable from a dead daemon.
+            //
+            // The snapshot closure reads the brake per tick rather than
+            // capturing it: the app's toggle and the CLI's bare `on`/`off`
+            // both write that column, and the file must not go on publishing a
+            // brake that moved a minute ago. A tick that cannot read the state
+            // publishes nothing and lets the file go stale, which is precisely
+            // the signal the watchdog exists to notice.
+            let heartbeat = SupervisionHeartbeat(
+                path: TBDConstants.supervisionStatusPath,
+                snapshot: { [database, supervisionStore] in
+                    guard let config = try? await database.config.get() else { return nil }
+                    let brake: SupervisionBrakeState =
+                        config.supervisionEnabled ? .released : .engaged
+                    return try? await supervisionStore.statusFileSnapshot(brake: brake)
+                })
+            self.supervisionHeartbeat = heartbeat
+            await heartbeat.start()
+
             // 13. Periodic git status refresh (branch sync, conflict detection).
             // 10s foreground, 60s background (GitPollCadence.statusInterval);
             // per-worktree conflict checks are additionally dirty-gated inside
@@ -1032,6 +1092,13 @@ public final class Daemon: Sendable {
         // Stop the daemon-clock PR poll (no-op when it was never started).
         if let router = self.router {
             await router.prPoller.stop()
+        }
+
+        // Stop the supervision heartbeat. `status.json` is left exactly as the
+        // last tick wrote it: a stopped heartbeat says nothing, and its going
+        // stale is the fact a watchdog reads.
+        if let heartbeat = supervisionHeartbeat {
+            await heartbeat.stop()
         }
 
         // Stop any tmux control-mode connections (no-op when the gate is off).

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -369,9 +369,6 @@ public struct ConfigStore: Sendable {
     /// that leaves the column non-NULL forever after — including `false`,
     /// which is the point: an operator who pulls the brake stays braked when
     /// the shipped default eventually graduates.
-    /// Returns the **resolved** brake as it stood immediately before this write
-    /// — the column when it was set, the shipped default when it was NULL — so
-    /// a caller can tell a real transition from a gesture that changed nothing.
     ///
     /// The read and the write share one transaction on purpose. Read-then-write
     /// across two calls lets two concurrent toggles observe the same previous
@@ -379,9 +376,14 @@ public struct ConfigStore: Sendable {
     /// ledger gets two identical brake lines for one change, and the record
     /// claims something happened twice. Serializing them here is what makes
     /// "did this call move the brake" answerable at all.
+    ///
+    /// - Returns: the **resolved** brake as it stood immediately before this
+    ///   write — the column when it was set, the shipped default when it was
+    ///   NULL — so a caller can tell a real transition from a gesture that
+    ///   changed nothing.
     @discardableResult
     public func setSupervisionEnabled(enabled: Bool) async throws -> Bool {
-        try await writer.write { db in
+        try await writer.write { db -> Bool in
             let previous = try Bool.fetchOne(
                 db, sql: "SELECT supervision_enabled FROM config WHERE id = ?",
                 arguments: [Self.singletonID])

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -369,12 +369,27 @@ public struct ConfigStore: Sendable {
     /// that leaves the column non-NULL forever after — including `false`,
     /// which is the point: an operator who pulls the brake stays braked when
     /// the shipped default eventually graduates.
-    public func setSupervisionEnabled(enabled: Bool) async throws {
+    /// Returns the **resolved** brake as it stood immediately before this write
+    /// — the column when it was set, the shipped default when it was NULL — so
+    /// a caller can tell a real transition from a gesture that changed nothing.
+    ///
+    /// The read and the write share one transaction on purpose. Read-then-write
+    /// across two calls lets two concurrent toggles observe the same previous
+    /// value, and each then believes it caused the transition: the supervision
+    /// ledger gets two identical brake lines for one change, and the record
+    /// claims something happened twice. Serializing them here is what makes
+    /// "did this call move the brake" answerable at all.
+    @discardableResult
+    public func setSupervisionEnabled(enabled: Bool) async throws -> Bool {
         try await writer.write { db in
+            let previous = try Bool.fetchOne(
+                db, sql: "SELECT supervision_enabled FROM config WHERE id = ?",
+                arguments: [Self.singletonID])
             try db.execute(
                 sql: "UPDATE config SET supervision_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
+            return previous ?? Config.supervisionEnabledDefault
         }
     }
 

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -49,12 +49,26 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// default, so `nil` here means "never chose" rather than "off". Resolve it
     /// through `Config.queuedPromptDefault`, never through `?? false`.
     var queued_prompt_enabled: Bool?
+    /// The fleet supervision brake (design 2026-07-26 §3, §7). **Genuinely
+    /// tri-state**, same shape as `queued_prompt_enabled`: the
+    /// `v75_config_supervision_enabled` column carries no SQL default, so
+    /// `nil` here means "never chose" rather than "off". Resolve it through
+    /// `Config.supervisionEnabledDefault`, never through `?? false`.
+    var supervision_enabled: Bool?
 
     /// - Parameter queuedPromptDefault: the shipped default a NULL
     ///   `queued_prompt_enabled` resolves to. Defaulted to the real constant;
     ///   the parameter exists so tests can prove that NULL *follows* a changed
     ///   default while an explicit `false` does not.
-    func toModel(queuedPromptDefault: Bool = Config.queuedPromptDefault) -> Config {
+    /// - Parameter supervisionEnabledDefault: same shape, for
+    ///   `supervision_enabled` — the parameter exists so tests can prove the
+    ///   same NULL-follows/explicit-sticks property for the fleet brake
+    ///   without waiting for the real `Config.supervisionEnabledDefault`
+    ///   constant to change.
+    func toModel(
+        queuedPromptDefault: Bool = Config.queuedPromptDefault,
+        supervisionEnabledDefault: Bool = Config.supervisionEnabledDefault
+    ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
             primaryAgentPreference: primary_agent_preference
@@ -96,7 +110,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // NOT `?? false`. The column has no SQL default, so NULL really
             // means "never chose" and must resolve to the shipped default —
             // that is the whole point of v70_config_queued_prompt.
-            queuedPromptEnabled: queued_prompt_enabled ?? queuedPromptDefault
+            queuedPromptEnabled: queued_prompt_enabled ?? queuedPromptDefault,
+            // Same reasoning, for the fleet supervision brake — NOT `?? false`.
+            supervisionEnabled: supervision_enabled ?? supervisionEnabledDefault
         )
     }
 }
@@ -340,6 +356,23 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET queued_prompt_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the fleet supervision brake (design 2026-07-26 §3, §7). Off is
+    /// the shipped default; releasing it hands TBD's autonomous processes the
+    /// authority to act, but nothing in the daemon reads this column to
+    /// actually act yet — the rest of the supervision subsystem lands in the
+    /// same series of changes. Writing either value is an explicit gesture
+    /// that leaves the column non-NULL forever after — including `false`,
+    /// which is the point: an operator who pulls the brake stays braked when
+    /// the shipped default eventually graduates.
+    public func setSupervisionEnabled(enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET supervision_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1393,6 +1393,21 @@ public final class TBDDatabase: Sendable {
                 table: "worktree", column: "prObservation", type: .text)
         }
 
+        // The fleet supervision brake (design 2026-07-26 §3, §7): one
+        // fleet-wide on/off switch, shipped OFF per the house
+        // default-off-flag rule. Numbered v77 because main took v75 and v76 while this branch
+        // was open; renumbering is safe for the same reason theirs was —
+        // `addColumnIfMissing` re-runs as a no-op on a machine that already
+        // applied it under the old id. Tri-state like `v73_config_queued_prompt`,
+        // not `v69_config_delivery_verification`: no SQL default, so a
+        // pre-migration row reads NULL ("never chose") rather than 0. NULL
+        // resolves through `Config.supervisionEnabledDefault` in
+        // `ConfigRecord.toModel()` — the single place graduation changes.
+        migrator.registerMigration("v77_config_supervision_enabled") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "supervision_enabled", type: .boolean)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -201,17 +201,21 @@ extension RPCRouter {
             try await db.config.setSupervisionEnabled(enabled: params.enabled)
         }
         if let supervision {
-            try await supervision.applyBrakeChange(released: params.enabled, commit: commit)
+            // The transition's ordering token travels with the edge, so the
+            // heartbeat can discard a toggle that lost its race in the gate.
+            // Notifying from out here rather than from inside the gate is
+            // deliberate: publishing performs a file write, and every brake
+            // gesture would otherwise pay for it inside the serialized region.
+            let transition = try await supervision.applyBrakeChange(
+                released: params.enabled, commit: commit)
+            await supervisionHeartbeat?.applyBrake(
+                released: params.enabled, sequence: transition.sequence)
         } else {
             // Nothing to keep in step with, so the column moves on its own. The
             // brake is a daemon-wide switch and must not depend on supervision
             // being wired — see `brakeWorksWithoutAStore`.
             _ = try await commit()
         }
-        // Publish the edge and match the timer to it. Doing this here rather
-        // than inside the store keeps the heartbeat out of the serialized
-        // region: it reads state, it does not decide any.
-        await supervisionHeartbeat?.applyBrake(released: params.enabled)
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -182,7 +182,7 @@ extension RPCRouter {
     /// The change is recorded in the supervision ledger, and **the line carries
     /// no project and no mode**: the brake is one bit over the whole fleet, so
     /// naming a project on its line would be a lie. That holds by construction
-    /// — the factories behind `recordBrakeChange` take no project.
+    /// — the factories behind `applyBrakeChange` take no project.
     ///
     /// The column is written on every call, because writing either value is the
     /// explicit gesture that lifts it out of NULL forever after. The *ledger*
@@ -192,12 +192,26 @@ extension RPCRouter {
     /// nothing is not a decision.
     func handleConfigSetSupervisionEnabled(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ConfigSetSupervisionEnabledParams.self, from: paramsData)
-        // The store reads the previous value inside the same transaction as the
-        // write, so two concurrent toggles cannot both believe they caused the
-        // transition and write two identical brake lines for one change.
-        let wasReleased = try await db.config.setSupervisionEnabled(enabled: params.enabled)
-        await supervision?.recordBrakeChange(
-            engaged: !params.enabled, changed: wasReleased != params.enabled)
+        // One serialized region per transition: the store holds a gate across
+        // the commit *and* the line it justifies, so two overlapping toggles
+        // cannot commit in one order and reach the record in the other. The
+        // transaction inside `commit` makes the column atomic; the gate is what
+        // keeps the record's order from contradicting it.
+        let commit: @Sendable () async throws -> Bool = { [db] in
+            try await db.config.setSupervisionEnabled(enabled: params.enabled)
+        }
+        if let supervision {
+            try await supervision.applyBrakeChange(released: params.enabled, commit: commit)
+        } else {
+            // Nothing to keep in step with, so the column moves on its own. The
+            // brake is a daemon-wide switch and must not depend on supervision
+            // being wired — see `brakeWorksWithoutAStore`.
+            _ = try await commit()
+        }
+        // Publish the edge and match the timer to it. Doing this here rather
+        // than inside the store keeps the heartbeat out of the serialized
+        // region: it reads state, it does not decide any.
+        await supervisionHeartbeat?.applyBrake(released: params.enabled)
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -173,16 +173,29 @@ extension RPCRouter {
     }
 
     /// Persist the fleet supervision brake (design 2026-07-26 §3, §7) — the
-    /// fleet-wide on/off switch for supervision. Shipped OFF and, for now,
-    /// inert: nothing in the daemon reads this column to gate an actuation
-    /// yet, because the rest of the supervision subsystem (per-project marks,
-    /// playbooks, the sweep, actuation preconditions) is landing in the same
-    /// series of changes. This handler exists so the switch itself — settable
-    /// from app and CLI, broadcast on change, surviving restart — is in place
-    /// before anything depends on it.
+    /// fleet-wide on/off switch for supervision. Shipped OFF; nothing in the
+    /// daemon reads this column to gate an actuation yet, because the acting
+    /// half of supervision (the sweep, deliveries, actuation preconditions)
+    /// lands in later slices. What the column already does is decide what
+    /// `supervise.status` reports and what the heartbeat publishes.
+    ///
+    /// The change is recorded in the supervision ledger, and **the line carries
+    /// no project and no mode**: the brake is one bit over the whole fleet, so
+    /// naming a project on its line would be a lie. That holds by construction
+    /// — the factories behind `recordBrakeChange` take no project.
+    ///
+    /// The column is written on every call, because writing either value is the
+    /// explicit gesture that lifts it out of NULL forever after. The *ledger*
+    /// line is written only when the resolved brake actually moved: sending
+    /// `false` while the brake already stands engaged is a gesture on the
+    /// column but no change to what the brake means, and a gesture that changes
+    /// nothing is not a decision.
     func handleConfigSetSupervisionEnabled(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ConfigSetSupervisionEnabledParams.self, from: paramsData)
+        let before = try await supervisionBrake()
         try await db.config.setSupervisionEnabled(enabled: params.enabled)
+        let after: SupervisionBrakeState = params.enabled ? .released : .engaged
+        await supervision?.recordBrakeChange(engaged: !params.enabled, changed: before != after)
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -192,10 +192,12 @@ extension RPCRouter {
     /// nothing is not a decision.
     func handleConfigSetSupervisionEnabled(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ConfigSetSupervisionEnabledParams.self, from: paramsData)
-        let before = try await supervisionBrake()
-        try await db.config.setSupervisionEnabled(enabled: params.enabled)
-        let after: SupervisionBrakeState = params.enabled ? .released : .engaged
-        await supervision?.recordBrakeChange(engaged: !params.enabled, changed: before != after)
+        // The store reads the previous value inside the same transaction as the
+        // write, so two concurrent toggles cannot both believe they caused the
+        // transition and write two identical brake lines for one change.
+        let wasReleased = try await db.config.setSupervisionEnabled(enabled: params.enabled)
+        await supervision?.recordBrakeChange(
+            engaged: !params.enabled, changed: wasReleased != params.enabled)
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -172,6 +172,22 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the fleet supervision brake (design 2026-07-26 §3, §7) — the
+    /// fleet-wide on/off switch for supervision. Shipped OFF and, for now,
+    /// inert: nothing in the daemon reads this column to gate an actuation
+    /// yet, because the rest of the supervision subsystem (per-project marks,
+    /// playbooks, the sweep, actuation preconditions) is landing in the same
+    /// series of changes. This handler exists so the switch itself — settable
+    /// from app and CLI, broadcast on change, surviving restart — is in place
+    /// before anything depends on it.
+    func handleConfigSetSupervisionEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetSupervisionEnabledParams.self, from: paramsData)
+        try await db.config.setSupervisionEnabled(enabled: params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the remote-backends master switch. Takes effect for polling
     /// on the NEXT daemon start — the manager is constructed at boot only
     /// when the flag was already on (see `Daemon.swift`), so flipping this

--- a/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
@@ -1,0 +1,95 @@
+import Foundation
+import TBDShared
+
+/// RPC handlers for the `supervise.*` surface (`docs/cli-supervise.md`,
+/// `docs/specs/2026-07-26-fleet-supervision-design.md` §10).
+///
+/// Every one of them is a thin shell: decode, read the brake, hand the gesture
+/// to `SupervisionStore`, encode what it answered. The daemon is the single
+/// writer of `~/tbd/supervision/`, and the store is where that single writer
+/// lives — a handler that reached for the file itself would be a second writer
+/// with none of the store's ordering.
+///
+/// **Nothing here broadcasts a state delta.** The one supervision fact the app
+/// displays is the brake, and its own config handler already broadcasts. Marks,
+/// modes and topology have no app surface in this slice, so a broadcast would
+/// ask every connected client to reload for a change it cannot see.
+///
+/// The store is `nil` in mock mode and in tests that do not wire it, exactly
+/// like `orphanGC`; these handlers refuse with a named condition rather than
+/// crashing.
+extension RPCRouter {
+
+    /// The brake as it stands, resolved through the shipped default when the
+    /// tri-state column is unset. Read fresh per call — the app's toggle and
+    /// the CLI's bare `on`/`off` both write it, and every surface must see the
+    /// same value immediately after a change.
+    func supervisionBrake() async throws -> SupervisionBrakeState {
+        let config = try await db.config.get()
+        return config.supervisionEnabled ? .released : .engaged
+    }
+
+    private func requireSupervision() throws -> SupervisionStore {
+        guard let supervision else { throw SupervisionUnavailable() }
+        return supervision
+    }
+
+    func handleSuperviseStatus() async throws -> RPCResponse {
+        let store = try requireSupervision()
+        let brake = try await supervisionBrake()
+        return try RPCResponse(result: await store.status(brake: brake))
+    }
+
+    func handleSuperviseSetProjectMark(_ paramsData: Data) async throws -> RPCResponse {
+        let store = try requireSupervision()
+        let params = try decoder.decode(SuperviseSetProjectMarkParams.self, from: paramsData)
+        return try RPCResponse(
+            result: await store.setProjectMark(project: params.project, on: params.on))
+    }
+
+    func handleSuperviseSetMode(_ paramsData: Data) async throws -> RPCResponse {
+        let store = try requireSupervision()
+        let params = try decoder.decode(SuperviseSetModeParams.self, from: paramsData)
+        return try RPCResponse(
+            result: await store.setMode(project: params.project, mode: params.mode))
+    }
+
+    func handleSuperviseProjectList() async throws -> RPCResponse {
+        let store = try requireSupervision()
+        return try RPCResponse(result: await store.projectList())
+    }
+
+    func handleSuperviseProjectCreate(_ paramsData: Data) async throws -> RPCResponse {
+        let store = try requireSupervision()
+        let params = try decoder.decode(SuperviseProjectCreateParams.self, from: paramsData)
+        return try RPCResponse(result: await store.projectCreate(
+            name: params.name, repos: params.repos, policy: params.policy))
+    }
+
+    func handleSuperviseProjectDelete(_ paramsData: Data) async throws -> RPCResponse {
+        let store = try requireSupervision()
+        let params = try decoder.decode(SuperviseProjectDeleteParams.self, from: paramsData)
+        return try RPCResponse(result: await store.projectDelete(name: params.name))
+    }
+
+    func handleSuperviseProjectMove(_ paramsData: Data) async throws -> RPCResponse {
+        let store = try requireSupervision()
+        let params = try decoder.decode(SuperviseProjectMoveParams.self, from: paramsData)
+        return try RPCResponse(result: await store.projectMove(
+            repo: params.repo, to: SupervisionMoveTarget(argument: params.to)))
+    }
+}
+
+/// The refusal a `supervise.*` call gets when the daemon has no supervision
+/// store wired — mock mode, or a unit test that did not attach one. Named
+/// rather than a bare string so the sentence a human reads on stderr says what
+/// is missing and what it means.
+struct SupervisionUnavailable: Error, CustomStringConvertible, LocalizedError {
+    var description: String {
+        "This daemon has no supervision store: nothing is being supervised, and no coverage "
+            + "gesture can be recorded. Restart the daemon; if it is running in mock mode, "
+            + "supervision is deliberately absent."
+    }
+
+    var errorDescription: String? { description }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -563,6 +563,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetAutoTrustWorktrees(request.paramsData)
             case RPCMethod.configSetGCEnabled:
                 return try await handleConfigSetGCEnabled(request.paramsData)
+            case RPCMethod.configSetSupervisionEnabled:
+                return try await handleConfigSetSupervisionEnabled(request.paramsData)
             case RPCMethod.remoteProviders:
                 return try await handleRemoteProviders()
             case RPCMethod.remoteSessions:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -31,6 +31,16 @@ public final class RPCRouter: Sendable {
     /// `nil` in mock mode / unit tests, where a poll simply refreshes statuses
     /// and judges nothing.
     public nonisolated(unsafe) var mergeTrigger: AllResolvedMergeTrigger?
+    /// Fleet supervision's single writer of `~/tbd/supervision/` — the
+    /// operator's file, the ledger beside it, and the coverage decisions that
+    /// connect them. Wired post-construction by `Daemon.swift` (mirrors
+    /// `orphanGC`); `nil` in mock mode / unit tests that don't need it, where
+    /// the `supervise.*` handlers refuse with a named condition rather than
+    /// crashing. Never defaulted to a store built on `TBDConstants`: that
+    /// default is the "helper ignores its caller's injected seam" shape, and
+    /// every router a test constructs would share the developer's real
+    /// `~/tbd/supervision`.
+    public nonisolated(unsafe) var supervision: SupervisionStore?
     /// Orphan-GC actor. `nil` in mock mode / unit tests that don't need it;
     /// set post-construction by `Daemon.swift` (mirrors `claudeUsagePoller`).
     /// The `gc.*` handlers return an error response rather than crashing when
@@ -593,6 +603,20 @@ public final class RPCRouter: Sendable {
                 return try await handleGCRestore(request.paramsData)
             case RPCMethod.gcSweepNow:
                 return try await handleGCSweepNow(request.paramsData)
+            case RPCMethod.superviseStatus:
+                return try await handleSuperviseStatus()
+            case RPCMethod.superviseSetProjectMark:
+                return try await handleSuperviseSetProjectMark(request.paramsData)
+            case RPCMethod.superviseSetMode:
+                return try await handleSuperviseSetMode(request.paramsData)
+            case RPCMethod.superviseProjectList:
+                return try await handleSuperviseProjectList()
+            case RPCMethod.superviseProjectCreate:
+                return try await handleSuperviseProjectCreate(request.paramsData)
+            case RPCMethod.superviseProjectDelete:
+                return try await handleSuperviseProjectDelete(request.paramsData)
+            case RPCMethod.superviseProjectMove:
+                return try await handleSuperviseProjectMove(request.paramsData)
             case RPCMethod.panelGet:
                 return try await handlePanelGet(request.paramsData)
             case RPCMethod.panelApply:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -41,6 +41,13 @@ public final class RPCRouter: Sendable {
     /// every router a test constructs would share the developer's real
     /// `~/tbd/supervision`.
     public nonisolated(unsafe) var supervision: SupervisionStore?
+    /// The out-of-band `status.json` heartbeat. The brake handler publishes an
+    /// edge through it and arms or disarms its timer to match, so the timer's
+    /// lifetime is tied to the brake rather than to daemon boot. Wired
+    /// post-construction by `Daemon.swift` like `supervision`; `nil` in mock
+    /// mode and in tests, where the brake still moves and simply publishes
+    /// nothing.
+    public nonisolated(unsafe) var supervisionHeartbeat: SupervisionHeartbeat?
     /// Orphan-GC actor. `nil` in mock mode / unit tests that don't need it;
     /// set post-construction by `Daemon.swift` (mirrors `claudeUsagePoller`).
     /// The `gc.*` handlers return an error response rather than crashing when

--- a/Sources/TBDDaemon/Supervision/SupervisionFleetReader.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionFleetReader.swift
@@ -1,0 +1,94 @@
+import Foundation
+import TBDShared
+
+/// One agent inside the perimeter, as the roster snapshot records it.
+///
+/// The perimeter is the fleet table: a session TBD did not spawn is invisible
+/// to it, and the record reports that boundary honestly rather than implying
+/// coverage it does not have (design §6).
+public struct SupervisionFleetAgent: Sendable, Equatable {
+    public let worktree: UUID
+    public let terminal: UUID
+    public let repo: UUID
+    /// What TBD launched in this terminal — `claude`, `codex`, or `unknown` for
+    /// a row whose kind was never recorded.
+    public let spawnSource: String
+    /// The agent's transcript, or nil when TBD does not know it.
+    public let transcriptPath: String?
+
+    public init(worktree: UUID, terminal: UUID, repo: UUID,
+                spawnSource: String, transcriptPath: String?) {
+        self.worktree = worktree
+        self.terminal = terminal
+        self.repo = repo
+        self.spawnSource = spawnSource
+        self.transcriptPath = transcriptPath
+    }
+
+    /// The value `spawnSource` takes for a terminal whose kind was never
+    /// recorded. Named rather than spelled inline so the roster and its tests
+    /// agree on the one string.
+    public static let unknownSpawnSource = "unknown"
+}
+
+/// The only fleet facts supervision reads.
+///
+/// Deliberately two methods and two value types wide. Supervision needs the
+/// repo list to resolve topology and a roster of agents to snapshot when a
+/// project turns on; everything else about a session — its activity state, its
+/// work facts, its counters — belongs to the readout that a later slice builds,
+/// and pulling any of it through here now would couple coverage to a surface
+/// that is still moving.
+public protocol SupervisionFleetReading: Sendable {
+    /// Every registered repo, as project resolution sees it.
+    ///
+    /// All of them, including hidden and `.missing` ones: a repo an operator
+    /// hid from the sidebar is still a repo, and resolving it away would make
+    /// its project silently vanish from the topology rather than appear turned
+    /// off — the third state this design refuses.
+    func repos() async throws -> [SupervisionRepo]
+
+    /// The agents whose worktrees belong to any of `repoIDs`, for a roster
+    /// snapshot. Order is not part of the contract; the caller sorts.
+    func agents(inRepos repoIDs: Set<UUID>) async throws -> [SupervisionFleetAgent]
+}
+
+/// The production reader, over TBD's own database.
+public struct DatabaseSupervisionFleetReader: SupervisionFleetReading {
+    private let db: TBDDatabase
+
+    public init(db: TBDDatabase) {
+        self.db = db
+    }
+
+    public func repos() async throws -> [SupervisionRepo] {
+        try await db.repos.list().map(SupervisionRepo.init)
+    }
+
+    /// Archived worktrees are excluded — an archived worktree's sessions are
+    /// gone, so listing them would put agents on the roster that no longer
+    /// exist. A terminal explicitly recorded as a shell is excluded because a
+    /// shell is not an agent; one whose kind was never recorded is **kept**,
+    /// with `spawnSource` reading `unknown`. Dropping it would make the record
+    /// claim it was not there, and "what was under watch" is exactly the
+    /// question this snapshot answers.
+    public func agents(inRepos repoIDs: Set<UUID>) async throws -> [SupervisionFleetAgent] {
+        var agents: [SupervisionFleetAgent] = []
+        for repoID in repoIDs.sorted(by: { $0.uuidString < $1.uuidString }) {
+            let worktrees = try await db.worktrees.list(repoID: repoID, excludeArchived: true)
+            for worktree in worktrees {
+                for terminal in try await db.terminals.list(worktreeID: worktree.id) {
+                    guard terminal.kind != .shell else { continue }
+                    agents.append(SupervisionFleetAgent(
+                        worktree: worktree.id,
+                        terminal: terminal.id,
+                        repo: repoID,
+                        spawnSource: terminal.kind?.rawValue
+                            ?? SupervisionFleetAgent.unknownSpawnSource,
+                        transcriptPath: terminal.transcriptPath))
+                }
+            }
+        }
+        return agents
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SupervisionFleetReader.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionFleetReader.swift
@@ -62,7 +62,10 @@ public struct DatabaseSupervisionFleetReader: SupervisionFleetReading {
     }
 
     public func repos() async throws -> [SupervisionRepo] {
-        try await db.repos.list().map(SupervisionRepo.init)
+        // Spelled out rather than `map(SupervisionRepo.init)`: that type has two
+        // initializers, and naming one by arity alone is the kind of overload
+        // resolution that reads as fine and breaks when a third is added.
+        try await db.repos.list().map { SupervisionRepo($0) }
     }
 
     /// Archived worktrees are excluded — an archived worktree's sessions are

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -69,12 +69,21 @@ public actor SupervisionHeartbeat {
         }
     }
 
-    /// Stop ticking. The file is left exactly as the last tick wrote it — a
-    /// stopped heartbeat says nothing, and its staleness is the fact the
-    /// watchdog reads.
-    public func stop() {
-        loop?.cancel()
-        loop = nil
+    /// Stop ticking, and return only once the loop has actually finished. The
+    /// file is left exactly as the last tick wrote it — a stopped heartbeat
+    /// says nothing, and its staleness is the fact the watchdog reads.
+    ///
+    /// Awaiting the task rather than firing `cancel()` and walking away is what
+    /// makes "stopped" an observable state instead of a request: a shutdown
+    /// that returned with a tick still in flight could leave a write racing the
+    /// process teardown. Awaiting from inside the actor is safe — this
+    /// suspension releases the actor, which is exactly what the loop needs to
+    /// unwind.
+    public func stop() async {
+        guard let loop else { return }
+        loop.cancel()
+        self.loop = nil
+        await loop.value
     }
 
     private func run() async {

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -51,11 +51,21 @@ public actor SupervisionHeartbeat {
     ///     into a state that cannot be resolved at all, where the daemon
     ///     genuinely cannot state coverage; staleness is then the honest signal,
     ///     and the log says which file and why.
+    ///
+    ///     **Throwing is the only way to say "no snapshot", deliberately.** An
+    ///     `Optional` return would add a second, reasonless way to say the same
+    ///     thing, and every caller would then have to handle two flavours of one
+    ///     outcome with the compiler no longer able to tell them apart. There is
+    ///     no legitimately-absent case to model: a fleet with no projects
+    ///     publishes an empty list, which is a true statement about an empty
+    ///     fleet, so the only reason a snapshot does not exist is that composing
+    ///     it failed — and a failure that cannot say why is the thing finding 3
+    ///     of the review was about.
     ///   - clock: the delay seam. `Duration` is behavior; the timestamps in the
     ///     file are data and come from the snapshot's own date seam.
     public init(
         path: String,
-        snapshot: @Sendable @escaping () async -> SupervisionStatusFile?,
+        snapshot: @Sendable @escaping () async throws -> SupervisionStatusFile,
         interval: Duration = SupervisionHeartbeat.defaultInterval,
         clock: any Clock<Duration> = ContinuousClock()
     ) {

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -33,7 +33,7 @@ public actor SupervisionHeartbeat {
     public static let defaultInterval: Duration = .seconds(60)
 
     private let path: String
-    private let snapshot: @Sendable () async -> SupervisionStatusFile?
+    private let snapshot: @Sendable () async throws -> SupervisionStatusFile
     private let interval: Duration
     private let clock: any Clock<Duration>
 
@@ -43,10 +43,14 @@ public actor SupervisionHeartbeat {
     ///   - path: where the heartbeat is written. Injected rather than resolved
     ///     from `TBDConstants` inside, so a test cannot be made to write into
     ///     the developer's real `~/tbd`.
-    ///   - snapshot: the facts to publish, or nil when they could not be read
-    ///     this tick — a malformed `supervision.json`, say. A nil skips the
-    ///     write rather than publishing a half-truth, and the file's mtime
-    ///     going stale is precisely the signal the watchdog is built to notice.
+    ///   - snapshot: the facts to publish. A throw skips this tick's write
+    ///     rather than publishing a half-truth — an empty project list would be
+    ///     a claim, not an absence — and **the thrown error is logged**, so the
+    ///     file going stale is never the only trace of what went wrong. The
+    ///     residual throwing case is a `supervision.json` an operator edited
+    ///     into a state that cannot be resolved at all, where the daemon
+    ///     genuinely cannot state coverage; staleness is then the honest signal,
+    ///     and the log says which file and why.
     ///   - clock: the delay seam. `Duration` is behavior; the timestamps in the
     ///     file are data and come from the snapshot's own date seam.
     public init(
@@ -106,12 +110,16 @@ public actor SupervisionHeartbeat {
     /// Compose and publish one heartbeat. Internal so tests can drive a single
     /// write without arming the loop.
     func tick() async {
-        guard let file = await snapshot() else {
-            heartbeatLogger.warning(
+        let file: SupervisionStatusFile
+        do {
+            file = try await snapshot()
+        } catch {
+            let reason = String(describing: error)
+            heartbeatLogger.error(
                 """
-                Skipped a supervision heartbeat: the current state could not be read. \
+                Skipped a supervision heartbeat: \(reason, privacy: .public). \
                 \(self.path, privacy: .public) keeps its previous contents and will read \
-                as stale.
+                as stale, so a watchdog may report this daemon as down.
                 """)
             return
         }

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -1,0 +1,148 @@
+import Foundation
+import os
+import TBDShared
+
+private let heartbeatLogger = Logger(subsystem: "com.tbd.daemon", category: "supervision.heartbeat")
+
+/// The out-of-band heartbeat (design §14, requirement P3-1): a small
+/// `status.json` under `~/tbd/supervision/`, rewritten atomically on a fixed
+/// cadence with the brake, each project's mark and active mode, and each
+/// project's last sweep contact.
+///
+/// **It writes regardless of the brake.** Observability is never withheld, and
+/// the watchdog's rule — *if any project claims to be effectively on and this
+/// file has not changed in about ten minutes, raise a notification* — needs the
+/// file fresh enough to read `engaged`. A heartbeat that fell silent under the
+/// brake would make a paused fleet indistinguishable from a dead daemon, which
+/// is the one distinction this file exists to draw.
+///
+/// The watchdog reads a file rather than the socket or the DB, so a dead daemon
+/// cannot make it unavailable. That is also why the writer is deliberately dumb:
+/// it composes nothing and judges nothing, it asks for a snapshot and writes it.
+public actor SupervisionHeartbeat {
+    /// How often the file is rewritten.
+    ///
+    /// One minute, against a watchdog rule of about ten. The cadence has to sit
+    /// far enough below the alarm that ordinary jitter cannot trip it — a
+    /// scheduler delay, a slow repo read, a machine that napped — and a factor
+    /// of ten means ten consecutive ticks would have to be lost before a
+    /// healthy daemon looked dead. It also bounds how stale an operator's or a
+    /// watchdog's picture of the fleet can be at one minute, which is the same
+    /// order as the human gestures it reports. The cost is one small atomic
+    /// rewrite a minute, well under the daemon's existing ten-second git poll.
+    public static let defaultInterval: Duration = .seconds(60)
+
+    private let path: String
+    private let snapshot: @Sendable () async -> SupervisionStatusFile?
+    private let interval: Duration
+    private let clock: any Clock<Duration>
+
+    private var loop: Task<Void, Never>?
+
+    /// - Parameters:
+    ///   - path: where the heartbeat is written. Injected rather than resolved
+    ///     from `TBDConstants` inside, so a test cannot be made to write into
+    ///     the developer's real `~/tbd`.
+    ///   - snapshot: the facts to publish, or nil when they could not be read
+    ///     this tick — a malformed `supervision.json`, say. A nil skips the
+    ///     write rather than publishing a half-truth, and the file's mtime
+    ///     going stale is precisely the signal the watchdog is built to notice.
+    ///   - clock: the delay seam. `Duration` is behavior; the timestamps in the
+    ///     file are data and come from the snapshot's own date seam.
+    public init(
+        path: String,
+        snapshot: @Sendable @escaping () async -> SupervisionStatusFile?,
+        interval: Duration = SupervisionHeartbeat.defaultInterval,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.path = path
+        self.snapshot = snapshot
+        self.interval = interval
+        self.clock = clock
+    }
+
+    /// Start ticking. Idempotent: a second call while running does nothing.
+    public func start() {
+        guard loop == nil else { return }
+        loop = Task { [weak self] in
+            await self?.run()
+        }
+    }
+
+    /// Stop ticking. The file is left exactly as the last tick wrote it — a
+    /// stopped heartbeat says nothing, and its staleness is the fact the
+    /// watchdog reads.
+    public func stop() {
+        loop?.cancel()
+        loop = nil
+    }
+
+    private func run() async {
+        // Write once immediately: a daemon that just started should publish
+        // fresh facts rather than leave a whole interval in which the file
+        // still describes the previous run.
+        if !Task.isCancelled { await tick() }
+        while !Task.isCancelled {
+            do {
+                try await clock.sleep(for: interval)
+            } catch {
+                // The only throw from the clocks in use is cancellation.
+                return
+            }
+            if Task.isCancelled { return }
+            await tick()
+        }
+    }
+
+    /// Compose and publish one heartbeat. Internal so tests can drive a single
+    /// write without arming the loop.
+    func tick() async {
+        guard let file = await snapshot() else {
+            heartbeatLogger.warning(
+                """
+                Skipped a supervision heartbeat: the current state could not be read. \
+                \(self.path, privacy: .public) keeps its previous contents and will read \
+                as stale.
+                """)
+            return
+        }
+        do {
+            try write(file)
+        } catch {
+            heartbeatLogger.error(
+                """
+                Could not write the supervision heartbeat to \(self.path, privacy: .public): \
+                \((error as NSError).localizedDescription, privacy: .public)
+                """)
+        }
+    }
+
+    /// Atomically: a fresh temp in the **same directory**, then `rename(2)`.
+    /// The reader is an outside process on its own schedule, so it must never
+    /// be able to see a half-written file — and a temp elsewhere could land on
+    /// another volume, where the rename degrades into a tearable copy.
+    private func write(_ file: SupervisionStatusFile) throws {
+        let url = URL(fileURLWithPath: path)
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(file)
+        data.append(0x0A)
+
+        let temporary = directory.appendingPathComponent(
+            ".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+        do {
+            try data.write(to: temporary)
+        } catch {
+            try? FileManager.default.removeItem(at: temporary)
+            throw error
+        }
+        guard rename(temporary.path, url.path) == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            try? FileManager.default.removeItem(at: temporary)
+            throw POSIXError(code)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -110,7 +110,26 @@ public actor SupervisionHeartbeat {
     /// one the timer ends up matching, whichever order they resume in.
     private var brakeReleased = false
 
-    public func applyBrake(released: Bool) async {
+    /// The highest ordering token seen from the store's gate. An edge carrying
+    /// a lower one lost its race and is discarded.
+    private var lastBrakeSequence: UInt64 = 0
+
+    /// - Parameter sequence: the ordering token from
+    ///   `SupervisionStore.applyBrakeChange`, or `0` at boot where there is no
+    ///   transition to order against.
+    ///
+    /// **Two orderings, and both are needed.** The sequence orders edges
+    /// against the *commits* they describe: the store's gate serializes the
+    /// commit and the ledger line, but the heartbeat is notified after that
+    /// region ends, so two toggles can arrive here in the opposite order to the
+    /// one they committed in. Discarding a lower token is what stops the
+    /// chronologically losing toggle from arming or disarming the timer. The
+    /// `brakeReleased` re-check below orders edges against *each other* inside
+    /// this actor, where the write is an await and a later edge can complete
+    /// entirely within an earlier one's suspension. Neither subsumes the other.
+    public func applyBrake(released: Bool, sequence: UInt64) async {
+        guard sequence >= lastBrakeSequence else { return }
+        lastBrakeSequence = sequence
         brakeReleased = released
         await tick()
         if brakeReleased {

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -5,20 +5,34 @@ import TBDShared
 private let heartbeatLogger = Logger(subsystem: "com.tbd.daemon", category: "supervision.heartbeat")
 
 /// The out-of-band heartbeat (design §14, requirement P3-1): a small
-/// `status.json` under `~/tbd/supervision/`, rewritten atomically on a fixed
-/// cadence with the brake, each project's mark and active mode, and each
-/// project's last sweep contact.
+/// `status.json` under `~/tbd/supervision/`, rewritten atomically with the
+/// brake, each project's mark and active mode, and each project's last sweep
+/// contact.
 ///
-/// **It writes regardless of the brake.** Observability is never withheld, and
-/// the watchdog's rule — *if any project claims to be effectively on and this
-/// file has not changed in about ten minutes, raise a notification* — needs the
-/// file fresh enough to read `engaged`. A heartbeat that fell silent under the
-/// brake would make a paused fleet indistinguishable from a dead daemon, which
-/// is the one distinction this file exists to draw.
+/// **The file is published at every brake edge; the periodic timer runs only
+/// while the brake is released.** So the fleet brake is the one switch that
+/// starts and stops this, and a braked daemon runs no background loop at all —
+/// no second flag hides behind the brake, and nothing here acts before an
+/// operator has released it.
+///
+/// That costs the watchdog nothing, which is the part worth spelling out. Its
+/// rule is *if any project claims to be **effectively on** and this file has
+/// not changed in about ten minutes, raise a notification*, and effectively on
+/// means a standing mark **and** a released brake. A file that says `engaged`
+/// therefore claims nothing is effectively on, and cannot trip the rule however
+/// stale it grows — the freshness requirement only bites while the brake is
+/// released, which is exactly when the timer runs. Publishing at the edges is
+/// what keeps that true across the transition itself: the moment the brake
+/// moves, the file says so, before the timer starts or stops.
 ///
 /// The watchdog reads a file rather than the socket or the DB, so a dead daemon
 /// cannot make it unavailable. That is also why the writer is deliberately dumb:
 /// it composes nothing and judges nothing, it asks for a snapshot and writes it.
+///
+/// Known and accepted: while the brake is engaged, marks and modes an operator
+/// changes are not reflected here until the next edge, because nothing is
+/// ticking. The file's consumer is the watchdog, which is indifferent to both
+/// while braked; `tbd supervise status` is the live surface for a human.
 public actor SupervisionHeartbeat {
     /// How often the file is rewritten.
     ///
@@ -75,12 +89,39 @@ public actor SupervisionHeartbeat {
         self.clock = clock
     }
 
-    /// Start ticking. Idempotent: a second call while running does nothing.
-    public func start() {
+    /// Publish the file now, and match the timer to the brake.
+    ///
+    /// The single entry point, used both at boot and on every brake gesture, so
+    /// there is no way to arm the timer without also publishing the edge that
+    /// justifies it. Idempotent in both directions: calling it twice with the
+    /// same value republishes and leaves the timer as it was.
+    ///
+    /// The edge write happens **first and unconditionally**, including when the
+    /// brake is engaging. That write is what makes gating the timer safe: it
+    /// leaves behind a file that says `engaged`, which the watchdog reads as
+    /// "nothing is effectively on" and therefore never alarms about, no matter
+    /// how long it then sits untouched.
+    public func applyBrake(released: Bool) async {
+        await tick()
+        if released {
+            startTimer()
+        } else {
+            await cancelTimer()
+        }
+    }
+
+    private func startTimer() {
         guard loop == nil else { return }
         loop = Task { [weak self] in
             await self?.run()
         }
+    }
+
+    private func cancelTimer() async {
+        guard let loop else { return }
+        loop.cancel()
+        self.loop = nil
+        await loop.value
     }
 
     /// Stop ticking, and return only once the loop has actually finished. The
@@ -94,17 +135,12 @@ public actor SupervisionHeartbeat {
     /// suspension releases the actor, which is exactly what the loop needs to
     /// unwind.
     public func stop() async {
-        guard let loop else { return }
-        loop.cancel()
-        self.loop = nil
-        await loop.value
+        await cancelTimer()
     }
 
     private func run() async {
-        // Write once immediately: a daemon that just started should publish
-        // fresh facts rather than leave a whole interval in which the file
-        // still describes the previous run.
-        if !Task.isCancelled { await tick() }
+        // No opening tick: `applyBrake` published the edge that armed this loop,
+        // so a tick here would rewrite the same facts a moment later.
         while !Task.isCancelled {
             do {
                 try await clock.sleep(for: interval)

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -101,9 +101,19 @@ public actor SupervisionHeartbeat {
     /// leaves behind a file that says `engaged`, which the watchdog reads as
     /// "nothing is effectively on" and therefore never alarms about, no matter
     /// how long it then sits untouched.
+    /// Two overlapping edges must not leave the timer disagreeing with the
+    /// brake. The edge write is an `await`, so an actor releases itself across
+    /// it and a second edge can run entirely inside the first's suspension —
+    /// after which the first would resume and arm a timer the second had just
+    /// disarmed. Recording the intent before the write and reconciling against
+    /// the **latest** intent afterwards means whichever edge landed last is the
+    /// one the timer ends up matching, whichever order they resume in.
+    private var brakeReleased = false
+
     public func applyBrake(released: Bool) async {
+        brakeReleased = released
         await tick()
-        if released {
+        if brakeReleased {
             startTimer()
         } else {
             await cancelTimer()

--- a/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionHeartbeat.swift
@@ -120,6 +120,17 @@ public actor SupervisionHeartbeat {
         }
     }
 
+    /// Whether the periodic timer is currently armed.
+    ///
+    /// Internal, and a deliberate test seam rather than an accident of access
+    /// control: the timer's *presence* can be observed by waiting on the clock,
+    /// but its **absence** cannot — a clock advance with no sleeper registered
+    /// simply moves time, so "no tick arrived" is equally consistent with a
+    /// disarmed timer and with one that had not yet reached its sleep. Every
+    /// assertion here that matters is an absence, so it needs to be read rather
+    /// than waited for.
+    var isTimerArmed: Bool { loop != nil }
+
     private func startTimer() {
         guard loop == nil else { return }
         loop = Task { [weak self] in

--- a/Sources/TBDDaemon/Supervision/SupervisionLedgerWriter.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionLedgerWriter.swift
@@ -114,7 +114,6 @@ public actor SupervisionLedgerWriter {
 
         var bytes = Data()
         if isolatingFragment || fragmentPendingIsolation { bytes.append(0x0A) }
-        fragmentPendingIsolation = false
         bytes.append(try encoder.encode(line))
         bytes.append(0x0A)
 
@@ -129,6 +128,13 @@ public actor SupervisionLedgerWriter {
         }
         // One `fsync` per row is affordable at coverage-gesture rates.
         guard fsync(descriptor) == 0 else { throw Self.posixError("fsync") }
+        // Cleared here and nowhere earlier: the flag is a debt owed to bytes
+        // still on disk, and only a write that actually landed pays it. Clearing
+        // it up front loses the isolating newline whenever both the attempt and
+        // its retry fail — the fragment survives, the flag does not, and the
+        // *next* append fuses a valid object onto it, turning a junk line into a
+        // permanently unreadable one.
+        fragmentPendingIsolation = false
     }
 
     // MARK: - Reading the record back
@@ -144,6 +150,14 @@ public actor SupervisionLedgerWriter {
     /// A line that does not decode is skipped rather than fatal. A hand-edit or
     /// a crash fragment must not take the whole record's memory offline, and
     /// the count is logged so the damage is visible.
+    ///
+    /// **That count means corruption, and only corruption.** A line of a kind
+    /// this build does not know — a `delivery` or `enrollment` line from a later
+    /// slice, or a lifecycle event added after this one — decodes into
+    /// `.unrecognized` rather than failing, so it passes through here as a line
+    /// that opens and closes nothing. Without that, the first slice to write a
+    /// new kind would have made every restart log its whole record as damaged,
+    /// which is the shape of alarm an operator learns to ignore.
     public func spanStarts() -> [String: SupervisionInstant] {
         guard let data = FileManager.default.contents(atPath: path), !data.isEmpty else {
             return [:]
@@ -162,14 +176,17 @@ public actor SupervisionLedgerWriter {
             switch line.payload {
             case .projectOn: open[project] = line.ts
             case .projectOff: open.removeValue(forKey: project)
-            case .brakeEngaged, .brakeReleased, .modeChanged: break
+            // A line of a kind this build does not recognize neither opens a
+            // span nor closes one. It is somebody else's record, read past.
+            case .brakeEngaged, .brakeReleased, .modeChanged, .unrecognized: break
             }
         }
         if skipped > 0 {
             ledgerLogger.warning(
                 """
-                Skipped \(skipped, privacy: .public) unreadable line(s) in \
-                \(self.path, privacy: .public) while recovering coverage spans.
+                Skipped \(skipped, privacy: .public) corrupt line(s) in \
+                \(self.path, privacy: .public) while recovering coverage spans — \
+                lines of an unrecognized kind are read past and are not counted here.
                 """)
         }
         return open

--- a/Sources/TBDDaemon/Supervision/SupervisionLedgerWriter.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionLedgerWriter.swift
@@ -1,0 +1,220 @@
+import Foundation
+import os
+import TBDShared
+
+private let ledgerLogger = Logger(subsystem: "com.tbd.daemon", category: "supervision.ledger")
+
+/// The append-only supervision record at `~/tbd/supervision/ledger.jsonl`
+/// (design §6, §7): one JSON object per line, written by the daemon at the
+/// moment a coverage decision takes effect.
+///
+/// Shaped after `ActuationLog`, and for the same reasons: actor isolation *is*
+/// the serialization, so one whole-line append runs at a time and interleaved
+/// partial lines are impossible within this process; the handle is `O_APPEND`
+/// and every row is `fsync`ed, so a crash costs at most the row in flight; the
+/// open descriptor's `(device, inode)` is checked against the path before each
+/// append, so a file moved or replaced under the daemon is a failed append
+/// rather than a silent write into a file nobody will read. Timestamps arrive
+/// as `SupervisionInstant` on the line itself, minted by the caller's date
+/// seam — this writer never reaches for `Date()`.
+///
+/// **Appends are best-effort-loud, never fail-closed.** That is the opposite of
+/// `ActuationLog.appendRequest`, and deliberately: an actuation row is written
+/// *before* its act, so refusing to write is refusing to act, while a lifecycle
+/// line is written *after* a decision has already taken effect in
+/// `supervision.json` or the config column. Retroactively refusing a mark that
+/// already stands is impossible, so a failed append is `.fault`-logged and the
+/// gesture still succeeds. What the record then shows is a project whose span
+/// has no opening line — which reads as "start unknown" through
+/// `SupervisionCoverageSummary(spanStartedAt: nil, …)`, honest by construction.
+///
+/// **This writer does not rotate.** `ActuationLog` rotates daily because it
+/// carries every actuation the daemon performs; this file carries coverage
+/// decisions, at a rate of a few lines per operator gesture. When rotation
+/// arrives it must land together with a `spanStarts()` that reads the rotated
+/// segments in name order before the active file — otherwise a span opened
+/// yesterday would read as unknown after the first rotation.
+public actor SupervisionLedgerWriter {
+    /// The active file.
+    public let path: String
+
+    private let encoder: JSONEncoder
+
+    /// Open `O_APPEND` descriptor, or -1 when closed. Dropped on any write
+    /// failure so the single retry gets a fresh one.
+    private var fd: Int32 = -1
+
+    /// Set when a read of the file found it ending mid-line, and consumed by
+    /// the next append: the row goes out behind a newline so the dangling bytes
+    /// terminate as their own junk line instead of fusing with it.
+    private var fragmentPendingIsolation = false
+
+    public init(path: String) {
+        self.path = path
+        let encoder = JSONEncoder()
+        // Sorted keys so a line is stable and diffable; no pretty-printing so
+        // one row is one line.
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        self.encoder = encoder
+    }
+
+    deinit {
+        if fd >= 0 { close(fd) }
+    }
+
+    // MARK: - Appending
+
+    /// Append one line, retrying once through a fresh descriptor.
+    ///
+    /// Never throws: see the type's note on best-effort-loud. The return value
+    /// says whether the line reached the file, for the callers that want to log
+    /// about it; nothing branches on it.
+    ///
+    /// The retry opens with a newline, so a half-written first attempt
+    /// terminates as its own junk line rather than fusing with this one. It can
+    /// therefore duplicate a line whose bytes landed but whose `fsync` failed,
+    /// and that is the accepted trade rather than an oversight: `ActuationLog`
+    /// carries the three-phase resume-from-offset machinery because a
+    /// duplicated actuation row would claim an act happened twice, while a
+    /// duplicated lifecycle line carries the same `id` and the same `ts` and
+    /// therefore claims the same decision once. Span recovery reads it
+    /// idempotently, and the repeated id is what makes the duplicate visible.
+    @discardableResult
+    public func append(_ line: SupervisionLedgerLine) -> Bool {
+        do {
+            try appendOnce(line)
+            return true
+        } catch {
+            closeHandle()
+            do {
+                try appendOnce(line, isolatingFragment: true)
+                return true
+            } catch {
+                ledgerLogger.fault(
+                    """
+                    Could not append a supervision lifecycle line to \
+                    \(self.path, privacy: .public): \
+                    \((error as NSError).localizedDescription, privacy: .public). \
+                    The decision itself took effect; only the record of it is missing, \
+                    so the span it opens or closes will read as start-unknown.
+                    """)
+                return false
+            }
+        }
+    }
+
+    private func appendOnce(_ line: SupervisionLedgerLine, isolatingFragment: Bool = false) throws {
+        // The row must land in the file that is at `path` NOW. An open
+        // descriptor whose inode was replaced under us still accepts writes,
+        // into a file nobody will ever read.
+        if fd >= 0, !handleStillPointsAtPath() {
+            throw Self.pathError("the supervision ledger was moved or removed")
+        }
+        let descriptor = try openHandle()
+
+        var bytes = Data()
+        if isolatingFragment || fragmentPendingIsolation { bytes.append(0x0A) }
+        fragmentPendingIsolation = false
+        bytes.append(try encoder.encode(line))
+        bytes.append(0x0A)
+
+        try bytes.withUnsafeBytes { buffer in
+            var offset = 0
+            while offset < buffer.count {
+                let count = write(
+                    descriptor, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
+                guard count > 0 else { throw Self.posixError("write") }
+                offset += count
+            }
+        }
+        // One `fsync` per row is affordable at coverage-gesture rates.
+        guard fsync(descriptor) == 0 else { throw Self.posixError("fsync") }
+    }
+
+    // MARK: - Reading the record back
+
+    /// The open coverage span for each project: the timestamp of its most
+    /// recent `projectOn` with no `projectOff` after it (design §9).
+    ///
+    /// **A span's start is recovered from the record, never stored as a field**
+    /// — which is what makes "a restart resumes coverage from two files"
+    /// literally true. Reading is not deciding: this walks the file and returns
+    /// values, and writes, sends, and starts nothing.
+    ///
+    /// A line that does not decode is skipped rather than fatal. A hand-edit or
+    /// a crash fragment must not take the whole record's memory offline, and
+    /// the count is logged so the damage is visible.
+    public func spanStarts() -> [String: SupervisionInstant] {
+        guard let data = FileManager.default.contents(atPath: path), !data.isEmpty else {
+            return [:]
+        }
+        if data.last != 0x0A { fragmentPendingIsolation = true }
+
+        let decoder = JSONDecoder()
+        var open: [String: SupervisionInstant] = [:]
+        var skipped = 0
+        for raw in data.split(separator: 0x0A, omittingEmptySubsequences: true) {
+            guard let line = try? decoder.decode(SupervisionLedgerLine.self, from: Data(raw)) else {
+                skipped += 1
+                continue
+            }
+            guard let project = line.project else { continue }
+            switch line.payload {
+            case .projectOn: open[project] = line.ts
+            case .projectOff: open.removeValue(forKey: project)
+            case .brakeEngaged, .brakeReleased, .modeChanged: break
+            }
+        }
+        if skipped > 0 {
+            ledgerLogger.warning(
+                """
+                Skipped \(skipped, privacy: .public) unreadable line(s) in \
+                \(self.path, privacy: .public) while recovering coverage spans.
+                """)
+        }
+        return open
+    }
+
+    // MARK: - Handle
+
+    private func openHandle() throws -> Int32 {
+        if fd >= 0 { return fd }
+        let directory = (path as NSString).deletingLastPathComponent
+        if !directory.isEmpty {
+            try FileManager.default.createDirectory(
+                atPath: directory, withIntermediateDirectories: true)
+        }
+        let descriptor = open(path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+        guard descriptor >= 0 else { throw Self.posixError("open") }
+        fd = descriptor
+        return descriptor
+    }
+
+    private func closeHandle() {
+        if fd >= 0 {
+            close(fd)
+            fd = -1
+        }
+    }
+
+    /// Whether the open descriptor and `path` still name the same file.
+    private func handleStillPointsAtPath() -> Bool {
+        var openFile = stat()
+        var pathFile = stat()
+        guard fstat(fd, &openFile) == 0, stat(path, &pathFile) == 0 else { return false }
+        return openFile.st_dev == pathFile.st_dev && openFile.st_ino == pathFile.st_ino
+    }
+
+    private static func pathError(_ reason: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain, code: Int(ENOENT),
+            userInfo: [NSLocalizedDescriptionKey: reason])
+    }
+
+    private static func posixError(_ operation: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain, code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey:
+                "\(operation) failed: \(String(cString: strerror(errno)))"])
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SupervisionStore.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionStore.swift
@@ -40,6 +40,32 @@ public enum SupervisionStoreError: Error, Equatable, CustomStringConvertible, Lo
     public var errorDescription: String? { description }
 }
 
+/// What one brake transition did, and where it sits in the order they were
+/// committed.
+///
+/// The sequence exists because more than one thing has to react to a brake
+/// change — the ledger, and the heartbeat's timer — and only the store's gate
+/// knows what order the transitions actually landed in. Handing that order out
+/// as a token lets a consumer outside the gate discard an edge that lost its
+/// race, **without** lengthening the serialized region to cover that consumer's
+/// work. It is a number rather than a callback on purpose: the store is the
+/// single writer of the record and must not acquire references to the observers
+/// that read it — the heartbeat's snapshot closure already holds the store, so
+/// injecting the heartbeat back into the store would close a retain cycle
+/// between two actors.
+public struct SupervisionBrakeTransition: Sendable, Equatable {
+    /// Whether the brake actually moved. A gesture that resolved to no change
+    /// still gets a sequence — it is an ordering token, not a change counter.
+    public let changed: Bool
+    /// Monotonic within one store, assigned inside the gate.
+    public let sequence: UInt64
+
+    public init(changed: Bool, sequence: UInt64) {
+        self.changed = changed
+        self.sequence = sequence
+    }
+}
+
 /// The daemon's single writer of `~/tbd/supervision/supervision.json`, and the
 /// one place a coverage decision becomes a ledger line.
 ///
@@ -643,21 +669,30 @@ public actor SupervisionStore {
     /// `SupervisionLedgerLine.brakeEngaged` / `.brakeReleased` take none, which
     /// is what keeps a fleet-wide line from ever naming one project.
     ///
-    /// - Returns: whether the brake actually moved.
+    /// Orders brake transitions for consumers outside this actor. Assigned
+    /// inside the gate, so its order is the commit order by construction.
+    private var brakeSequence: UInt64 = 0
+
+    /// - Returns: whether the brake actually moved, and the ordering token that
+    ///   says where this transition sits relative to every other one.
     @discardableResult
     public func applyBrakeChange(
         released: Bool, commit: @Sendable () async throws -> Bool
-    ) async throws -> Bool {
+    ) async throws -> SupervisionBrakeTransition {
         await acquireBrakeGate()
         defer { releaseBrakeGate() }
 
+        brakeSequence += 1
+        let sequence = brakeSequence
         let wasReleased = try await commit()
-        guard wasReleased != released else { return false }
+        guard wasReleased != released else {
+            return SupervisionBrakeTransition(changed: false, sequence: sequence)
+        }
         let at = now()
         await ledger.append(released
             ? SupervisionLedgerLine.brakeReleased(at: at)
             : SupervisionLedgerLine.brakeEngaged(at: at))
-        return true
+        return SupervisionBrakeTransition(changed: true, sequence: sequence)
     }
 
     // MARK: - Projects

--- a/Sources/TBDDaemon/Supervision/SupervisionStore.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionStore.swift
@@ -1,0 +1,563 @@
+import Foundation
+import os
+import TBDShared
+
+private let storeLogger = Logger(subsystem: "com.tbd.daemon", category: "supervision.store")
+
+/// Why a supervision RPC was refused for a reason the shared types do not
+/// already name. Every case reaches a human on the CLI's stderr, so every
+/// message names the offending value and the way out.
+public enum SupervisionStoreError: Error, Equatable, CustomStringConvertible, LocalizedError {
+    case unknownRepoIdentifier(String)
+    case ambiguousRepoName(String, repos: [UUID])
+    case unknownProject(String)
+    case projectAlreadyDeclared(String)
+    case modeNotDeclared(project: String, requested: String, declared: [String])
+
+    public var description: String {
+        switch self {
+        case .unknownRepoIdentifier(let identifier):
+            return "There is no repo \"\(identifier)\" — name a repo by its id or its display name."
+        case .ambiguousRepoName(let name, let repos):
+            let ids = repos.map(\.uuidString).sorted().joined(separator: ", ")
+            return "\"\(name)\" names \(repos.count) repos (\(ids)). Name the one you mean by its id."
+        case .unknownProject(let project):
+            return "There is no project \"\(project)\" — run \"tbd supervise project list\" to see them."
+        case .projectAlreadyDeclared(let project):
+            return "A project named \"\(project)\" is already declared. "
+                + "Delete it first, or move repos into it."
+        case .modeNotDeclared(let project, let requested, let declared):
+            let choices = declared.isEmpty ? "(none declared)" : declared.joined(separator: ", ")
+            return "Mode \"\(requested)\" is not declared for project \"\(project)\" "
+                + "— choices: \(choices)."
+        }
+    }
+
+    public var errorDescription: String? { description }
+}
+
+/// The daemon's single writer of `~/tbd/supervision/supervision.json`, and the
+/// one place a coverage decision becomes a ledger line.
+///
+/// Holds the operator's file in memory for lookups, resolves topology against
+/// the repo list, rewrites the file atomically after each operator action, and
+/// appends the lifecycle line that records what changed — **file first, then
+/// ledger**. That order is not arbitrary: a line written before the save could
+/// claim a decision the save then failed to apply, which is exactly the false
+/// claim the record exists to forbid, while a save that lands without its line
+/// leaves a span whose start reads as unknown — degraded, but true.
+///
+/// **A no-op is not a decision.** Turning on a project already on, turning off
+/// one already off, or selecting the mode already selected returns
+/// `changed: false`, writes no ledger line, and does not rewrite the file.
+///
+/// **Untouched and turned-off are one state**, all the way down: a mark is
+/// membership in `supervised`, absence is off, and nothing here carries a third
+/// tier.
+///
+/// Every mutation reads the file and writes it back with **no suspension in
+/// between**, so two operators acting at once cannot compute from the same base
+/// and clobber each other. Actor isolation gives that for free only across
+/// synchronous stretches, which is why each method does its awaiting (the repo
+/// list, the roster) before the read-modify-write and not inside it.
+public actor SupervisionStore {
+    private let files: SupervisionFileStore
+    private let ledger: SupervisionLedgerWriter
+    private let fleet: any SupervisionFleetReading
+    private let now: @Sendable () -> Date
+
+    /// The operator's file as last read from disk. Every read goes through
+    /// `freshFile()`, which reloads first when the bytes on disk changed.
+    private var cached = SupervisionFile()
+
+    /// Identity of the bytes `cached` was read from, or nil when the file was
+    /// absent. See `freshFile()`.
+    private var fingerprint: FileFingerprint?
+
+    /// Open coverage spans by project, recovered from the ledger at first use
+    /// and maintained from there. Never persisted beside the mark — a derived
+    /// "covered since" field would drift out of step with the lines that
+    /// actually record coverage (design §9).
+    private var spanStarts: [String: SupervisionInstant] = [:]
+
+    /// Set once the first read of both files has happened.
+    private var loaded = false
+
+    /// Per-project counters the coverage summary reports.
+    ///
+    /// **Nothing increments these in this slice, so zero is accurate rather
+    /// than fabricated** — and they are counters rather than literals so that
+    /// the change which ships briefing delivery has somewhere to feed. Feeding
+    /// them is part of that change, not an optional follow-up: the moment
+    /// briefings exist and these stay at zero, every closing line starts lying.
+    /// In memory rather than persisted because both facts become queries over
+    /// the ledger's own `delivery` lines once those exist.
+    private var sweepContacts: [String: Int] = [:]
+    private var briefingsDelivered: [String: Int] = [:]
+    private var lastSweepContact: [String: SupervisionInstant] = [:]
+
+    public init(
+        files: SupervisionFileStore,
+        ledger: SupervisionLedgerWriter,
+        fleet: any SupervisionFleetReading,
+        now: @Sendable @escaping () -> Date = { Date() }
+    ) {
+        self.files = files
+        self.ledger = ledger
+        self.fleet = fleet
+        self.now = now
+    }
+
+    // MARK: - Loading
+
+    /// The `(device, inode, size, mtime)` of the file `cached` was read from.
+    ///
+    /// Four facts rather than one: an atomic rewrite (this store's own, or an
+    /// editor's `:w`) replaces the inode, while an in-place edit keeps it and
+    /// moves size or mtime.
+    private struct FileFingerprint: Equatable {
+        let device: dev_t
+        let inode: ino_t
+        let size: off_t
+        let modifiedSeconds: Int
+        let modifiedNanoseconds: Int
+
+        init?(path: String) {
+            var info = stat()
+            guard stat(path, &info) == 0 else { return nil }
+            device = info.st_dev
+            inode = info.st_ino
+            size = info.st_size
+            modifiedSeconds = info.st_mtimespec.tv_sec
+            modifiedNanoseconds = info.st_mtimespec.tv_nsec
+        }
+    }
+
+    /// Read both files once, at daemon start, so a malformed `supervision.json`
+    /// is loud at boot rather than at whichever operator gesture happens to hit
+    /// it first.
+    ///
+    /// **Loading writes no ledger line, sends nothing, and starts nothing.**
+    /// Reading state back is not re-deciding: the marks say what is covered
+    /// now, the ledger says since when, and a restart that replayed either
+    /// would be inventing decisions nobody made.
+    public func load() async throws {
+        try await ensureLoaded()
+    }
+
+    private func ensureLoaded() async throws {
+        guard !loaded else { return }
+        let recovered = await ledger.spanStarts()
+        // Set after the await, so a second caller that arrives mid-suspension
+        // repeats the (idempotent, side-effect-free) read rather than
+        // proceeding on half-initialized state.
+        cached = try files.load()
+        fingerprint = FileFingerprint(path: files.fileURL.path)
+        spanStarts = recovered
+        loaded = true
+    }
+
+    /// The file as it is on disk right now, reloading when the bytes changed.
+    ///
+    /// Synchronous on purpose: it is the first step of every read-modify-write,
+    /// and a suspension between the read and the save is what would let two
+    /// operators clobber each other.
+    ///
+    /// **Freshness is checked per operation rather than watched.** The file is
+    /// hand-editable by design, and the daemon is its only programmatic writer,
+    /// which rules a `FileWatcher` out on two counts. A watcher fires on this
+    /// store's own atomic rewrites, so it would need self-write suppression —
+    /// "was that edit mine?" bookkeeping that is wrong in exactly the cases it
+    /// matters. And a watcher is debounced, so an operator who edits the file
+    /// and immediately runs `tbd supervise on <project>` opens a window where
+    /// the daemon computes from stale bytes and then rewrites them, silently
+    /// destroying the edit. A `stat(2)` taken at the moment of the read closes
+    /// that window by construction, at human-gesture rates, with no descriptor
+    /// or dispatch source to keep alive.
+    private func freshFile() throws -> SupervisionFile {
+        let current = FileFingerprint(path: files.fileURL.path)
+        guard current != fingerprint else { return cached }
+        storeLogger.debug(
+            "supervision.json changed on disk; reloading \(self.files.fileURL.path, privacy: .public)")
+        cached = try files.load()
+        fingerprint = current
+        return cached
+    }
+
+    /// Write the file, then adopt it. A throw leaves `cached` and the file
+    /// itself untouched: `SupervisionFileStore.save` validates before it
+    /// touches the disk and writes through a temp-and-rename, so a refused or
+    /// failed save is byte-identical to no save at all.
+    private func persist(_ updated: SupervisionFile) throws {
+        try files.save(updated)
+        cached = updated
+        fingerprint = FileFingerprint(path: files.fileURL.path)
+    }
+
+    // MARK: - Status
+
+    /// The `supervise.status` readout.
+    public func status(brake: SupervisionBrakeState) async throws -> SupervisionStatus {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+        let projects = try SupervisionTopology.resolve(file: try freshFile(), repos: repos)
+        let effectivelySupervising = brake == .released && projects.contains { $0.mark }
+
+        var warnings: [SupervisionWarning] = []
+        if brake == .released && !effectivelySupervising {
+            warnings.append(SupervisionWarning(
+                code: .noProjectsOn,
+                message: "the brake is released but no project is on — nothing is being supervised."))
+        }
+        let unusable = SupervisionTopology.projectsWithoutUsableDirectory(in: projects)
+        if !unusable.isEmpty {
+            warnings.append(SupervisionWarning(
+                code: .unusableProjectName, message: Self.unusableNameSentence(unusable)))
+        }
+
+        return SupervisionStatus(
+            brake: brake,
+            effectivelySupervising: effectivelySupervising,
+            projects: projects.map { project in
+                SupervisionStatusProject(
+                    name: project.name,
+                    on: project.mark,
+                    mode: project.activeMode,
+                    declaredModes: project.declaredModes,
+                    supervisor: project.supervisor,
+                    // An off project renders exactly `off`: no span, and never
+                    // a "was on until". A third rendering would imply a third
+                    // state that does not exist.
+                    spanStartedAt: project.mark ? spanStarts[project.name] : nil,
+                    lastSweepContactAt: lastSweepContact[project.name],
+                    // The declared contact window lives in the project's sweep
+                    // selection, whose vocabulary belongs to the sweep program.
+                    // Nothing here invents one: null is what the readout renders
+                    // as "coverage unknown", the honest not-yet value.
+                    coverageWindow: nil)
+            },
+            warnings: warnings)
+    }
+
+    /// The sentence the `unusableProjectName` warning carries. It names the
+    /// projects — the CLI's own fallback wording cannot, since it sees only the
+    /// code.
+    static func unusableNameSentence(_ names: [String]) -> String {
+        let quoted = names.map { "\"\($0)\"" }.joined(separator: ", ")
+        let subject = names.count == 1 ? "it" : "them"
+        let verb = names.count == 1 ? "is" : "are"
+        return """
+            \(quoted) cannot be used as a directory name, so nothing can be written beside \
+            \(subject) — no playbook, journal, proposals or programs. \
+            \(names.count == 1 ? "It" : "They") \(verb) supervised like any other project; \
+            rename the repo to give \(subject) a directory.
+            """
+    }
+
+    /// The heartbeat's view of the same facts (design §14).
+    public func statusFileSnapshot(brake: SupervisionBrakeState) async throws
+        -> SupervisionStatusFile {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+        let projects = try SupervisionTopology.resolve(file: try freshFile(), repos: repos)
+        return SupervisionStatusFile(
+            writtenAt: SupervisionInstant(now()),
+            brake: brake,
+            projects: projects.map { project in
+                SupervisionStatusFileProject(
+                    name: project.name,
+                    on: project.mark,
+                    mode: project.activeMode,
+                    lastSweepContactAt: lastSweepContact[project.name])
+            })
+    }
+
+    // MARK: - Marks
+
+    /// Set or clear a project's standing mark.
+    ///
+    /// A project name that resolves to nothing is refused rather than recorded.
+    /// The file itself keeps an unknown name in `supervised` verbatim — a hand
+    /// edit may name a project about to be declared — but a *gesture* that
+    /// names one is a typo far more often than a plan, and accepting it would
+    /// buy silent non-coverage, which is the failure this whole surface exists
+    /// to prevent.
+    public func setProjectMark(project: String, on: Bool) async throws
+        -> SuperviseSetProjectMarkResult {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+
+        // Read-modify-write, no suspension inside.
+        let file = try freshFile()
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        guard let resolved = projects.first(where: { $0.name == project }) else {
+            throw SupervisionStoreError.unknownProject(project)
+        }
+        let updated = file.settingMark(project, on: on)
+        guard updated != file else {
+            return SuperviseSetProjectMarkResult(project: project, on: on, changed: false)
+        }
+        try persist(updated)
+
+        let at = now()
+        if on {
+            let roster = try await rosterSnapshot(for: resolved)
+            let recorded = await ledger.append(SupervisionLedgerLine.projectOn(
+                project: project, mode: resolved.activeMode, roster: roster, at: at))
+            // The span start is memory of the record, not a second copy of it:
+            // if the opening line did not land, the span reads as unknown here
+            // exactly as it would after a restart, and the status renders a
+            // bare `on` rather than inventing a start.
+            if recorded { spanStarts[project] = SupervisionInstant(at) }
+        } else {
+            await appendProjectOff(project: project, mode: resolved.activeMode, at: at)
+        }
+        return SuperviseSetProjectMarkResult(project: project, on: on, changed: true)
+    }
+
+    /// The `projectOff` line and the span bookkeeping that goes with it. Shared
+    /// by the explicit `off` gesture and by the two topology edits that end a
+    /// project's life while its mark still stands.
+    private func appendProjectOff(project: String, mode: String, at date: Date) async {
+        let coverage = SupervisionCoverageSummary(
+            spanStartedAt: spanStarts[project],
+            spanEndedAt: SupervisionInstant(date),
+            sweepContacts: sweepContacts[project] ?? 0,
+            briefingsDelivered: briefingsDelivered[project] ?? 0)
+        spanStarts.removeValue(forKey: project)
+        sweepContacts.removeValue(forKey: project)
+        briefingsDelivered.removeValue(forKey: project)
+        await ledger.append(SupervisionLedgerLine.projectOff(
+            project: project, mode: mode, coverage: coverage, at: date))
+    }
+
+    /// One entry per agent already inside the project's perimeter, for the
+    /// `projectOn` line's roster snapshot (design §6).
+    private func rosterSnapshot(for project: SupervisionProject) async throws
+        -> [SupervisionRosterEntry] {
+        let agents = try await fleet.agents(inRepos: Set(project.repos))
+        return agents
+            .map { agent in
+                SupervisionRosterEntry(
+                    worktree: agent.worktree, terminal: agent.terminal, repo: agent.repo,
+                    project: project.name, spawnSource: agent.spawnSource,
+                    transcriptPath: agent.transcriptPath)
+            }
+            .sorted { $0.terminal.uuidString < $1.terminal.uuidString }
+    }
+
+    // MARK: - Modes
+
+    public func setMode(project: String, mode: String) async throws -> SuperviseSetModeResult {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+
+        // Read-modify-write, no suspension inside.
+        let file = try freshFile()
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        guard let resolved = projects.first(where: { $0.name == project }) else {
+            throw SupervisionStoreError.unknownProject(project)
+        }
+        guard resolved.declaredModes.contains(mode) else {
+            throw SupervisionStoreError.modeNotDeclared(
+                project: project, requested: mode, declared: resolved.declaredModes)
+        }
+        let previous = resolved.activeMode
+        guard previous != mode else {
+            return SuperviseSetModeResult(
+                project: project, mode: mode, declaredModes: resolved.declaredModes,
+                changed: false)
+        }
+        try persist(file.settingMode(project, to: mode))
+
+        await ledger.append(SupervisionLedgerLine.modeChanged(
+            project: project, from: previous, to: mode, at: now()))
+        return SuperviseSetModeResult(
+            project: project, mode: mode, declaredModes: resolved.declaredModes, changed: true)
+    }
+
+    // MARK: - The brake
+
+    /// Record a fleet brake change, after the config column already took it.
+    ///
+    /// The line carries no project and no mode, and cannot be given either: the
+    /// brake is one bit over the whole fleet, so naming a project on its line
+    /// would be a lie. `SupervisionLedgerLine.brakeEngaged` / `.brakeReleased`
+    /// take no project, which is what holds this by construction.
+    ///
+    /// `changed` is the caller's comparison of the resolved brake before and
+    /// after: the column is tri-state, so writing `false` over an unset column
+    /// is a real gesture on the column but no change to what the brake means,
+    /// and a gesture that changes nothing writes no line.
+    public func recordBrakeChange(engaged: Bool, changed: Bool) async {
+        guard changed else { return }
+        let at = now()
+        await ledger.append(engaged
+            ? SupervisionLedgerLine.brakeEngaged(at: at)
+            : SupervisionLedgerLine.brakeReleased(at: at))
+    }
+
+    // MARK: - Projects
+
+    public func projectList() async throws -> SuperviseProjectListResult {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+        return try topologyResult(file: try freshFile(), repos: repos)
+    }
+
+    public func projectCreate(
+        name: String, repos identifiers: [String], policy: SupervisionPolicyRequest
+    ) async throws -> SuperviseProjectListResult {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+
+        // Read-modify-write, no suspension inside.
+        let file = try freshFile()
+        guard file.projects[name] == nil else {
+            throw SupervisionStoreError.projectAlreadyDeclared(name)
+        }
+        let members = try identifiers.map { try resolveRepo($0, in: repos) }
+        let resolvedPolicy: SupervisionPolicySource
+        switch policy {
+        case .operator: resolvedPolicy = .operator
+        case .repo(let identifier): resolvedPolicy = .repo(try resolveRepo(identifier, in: repos))
+        }
+
+        var updated = file
+        updated.projects[name] = SupervisionProjectDeclaration(
+            repos: members, policy: resolvedPolicy)
+        // Resolve before saving, not after: it is the check that catches a name
+        // colliding with a repo's own project, and running it first is what
+        // makes a refused create byte-identical to no create at all.
+        let result = try topologyResult(file: updated, repos: repos)
+        try persist(updated)
+        return result
+    }
+
+    /// Delete a declaration, returning its repos to being their own projects.
+    ///
+    /// The vanished project's mark, mode entry and supervisor binding go with
+    /// it — a mark outliving its project would silently turn a later project of
+    /// the same name on without an operator gesture. Where the mark stood, the
+    /// project's coverage genuinely ends here, so its span is closed on the
+    /// record like any other `off`.
+    public func projectDelete(name: String) async throws -> SuperviseProjectListResult {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+
+        // Read-modify-write, no suspension inside.
+        let file = try freshFile()
+        guard file.projects[name] != nil else {
+            throw SupervisionStoreError.unknownProject(name)
+        }
+        let wasMarked = file.isMarked(name)
+        let mode = file.activeMode(for: name)
+
+        var updated = file
+        updated.projects.removeValue(forKey: name)
+        updated.supervised.removeAll { $0 == name }
+        updated.modes.removeValue(forKey: name)
+        updated.supervisors.removeValue(forKey: name)
+
+        let result = try topologyResult(file: updated, repos: repos)
+        try persist(updated)
+
+        if wasMarked { await appendProjectOff(project: name, mode: mode, at: now()) }
+        return result
+    }
+
+    /// Move a repo between projects — the only membership verb.
+    ///
+    /// The transform is `SupervisionTopology.move`, a pure function over the
+    /// file, so a repo can never land in zero or two projects: the input is
+    /// taken by value, a refusal throws before anything is written, and a save
+    /// that fails leaves both the file and this actor's copy exactly as they
+    /// were.
+    public func projectMove(repo identifier: String, to target: SupervisionMoveTarget) async throws
+        -> SuperviseProjectListResult {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+
+        // Read-modify-write, no suspension inside.
+        let file = try freshFile()
+        let repoID = try resolveRepo(identifier, in: repos)
+        let updated = try SupervisionTopology.move(
+            repo: repoID, to: target, in: file, repos: repos)
+        let result = try topologyResult(file: updated, repos: repos)
+        guard updated != file else { return result }
+
+        // A move that empties a declaration deletes it, and takes its mark with
+        // it. Where that mark stood, the span it opened ends here.
+        let vanished = Set(file.supervised.filter { name in
+            file.projects[name] != nil && updated.projects[name] == nil
+        })
+        let modes = Dictionary(
+            vanished.map { ($0, file.activeMode(for: $0)) }, uniquingKeysWith: { first, _ in first })
+
+        try persist(updated)
+
+        for name in vanished.sorted() {
+            await appendProjectOff(
+                project: name, mode: modes[name] ?? SupervisionModeEntry.defaultMode, at: now())
+        }
+        return result
+    }
+
+    private func topologyResult(file: SupervisionFile, repos: [SupervisionRepo]) throws
+        -> SuperviseProjectListResult {
+        let names = Dictionary(
+            repos.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first })
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        return SuperviseProjectListResult(projects: projects.map { project in
+            SupervisionProjectTopologyEntry(
+                name: project.name,
+                repos: project.repos.map { id in
+                    SupervisionProjectRepoRef(id: id, name: names[id] ?? id.uuidString)
+                },
+                policy: project.policy,
+                sweepScript: project.sweep?.script)
+        })
+    }
+
+    /// Resolve a repo id or display name to a repo.
+    ///
+    /// A display name shared by two repos is refused naming the condition,
+    /// never guessed — and that refusal is not a new rule, only an earlier one:
+    /// `SupervisionTopology.resolve` already rejects the whole topology for
+    /// exactly that ambiguity, because both repos' singleton projects would
+    /// carry the same name.
+    private func resolveRepo(_ identifier: String, in repos: [SupervisionRepo]) throws -> UUID {
+        if let id = UUID(uuidString: identifier) {
+            guard repos.contains(where: { $0.id == id }) else {
+                throw SupervisionStoreError.unknownRepoIdentifier(identifier)
+            }
+            return id
+        }
+        let matches = repos.filter { $0.name == identifier }
+        switch matches.count {
+        case 0: throw SupervisionStoreError.unknownRepoIdentifier(identifier)
+        case 1: return matches[0].id
+        default: throw SupervisionStoreError.ambiguousRepoName(identifier, repos: matches.map(\.id))
+        }
+    }
+
+    // MARK: - Counters the coverage summary reports
+
+    /// Record that a sweep program made contact with a project.
+    ///
+    /// Unused in this slice — nothing submits a briefing yet, so every counter
+    /// reads zero and zero is accurate. **The change that ships delivery must
+    /// call this**, or the closing line's `sweepContacts` and the status
+    /// readout's `lastSweepContactAt` start lying the moment briefings exist.
+    public func noteSweepContact(project: String, at date: Date) {
+        sweepContacts[project, default: 0] += 1
+        lastSweepContact[project] = SupervisionInstant(date)
+    }
+
+    /// Record that a briefing was delivered to a project's supervisor. Unused
+    /// in this slice, for the same reason and with the same obligation as
+    /// `noteSweepContact`.
+    public func noteBriefingDelivered(project: String) {
+        briefingsDelivered[project, default: 0] += 1
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SupervisionStore.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionStore.swift
@@ -87,6 +87,12 @@ public actor SupervisionStore {
     /// Set once the first read of both files has happened.
     private var loaded = false
 
+    /// Set when `freshFile()` reloaded bytes this store did not write, and
+    /// cleared by `reconcileExternalEdits(repos:)`. Deliberately not set by the
+    /// **initial** load: recovering state at boot is reading, not observing a
+    /// change, and a restart must write no ledger line.
+    private var sawExternalEdit = false
+
     /// Per-project counters the coverage summary reports.
     ///
     /// **Nothing increments these in this slice, so zero is accurate rather
@@ -152,9 +158,15 @@ public actor SupervisionStore {
     private func ensureLoaded() async throws {
         guard !loaded else { return }
         let recovered = await ledger.spanStarts()
-        // Set after the await, so a second caller that arrives mid-suspension
-        // repeats the (idempotent, side-effect-free) read rather than
-        // proceeding on half-initialized state.
+        // Re-check after the await. Two callers can both pass the guard above
+        // and suspend on the ledger read; if the first finishes and then
+        // completes a whole `on` gesture — including its `spanStarts` entry —
+        // the second's continuation would overwrite `spanStarts` with a
+        // snapshot taken before that opening line existed, and the project
+        // would render a bare `on` with its opening line sitting on disk. The
+        // first completer leaves the actor fully initialized, so returning
+        // here is strictly safe.
+        guard !loaded else { return }
         cached = try files.load()
         fingerprint = FileFingerprint(path: files.fileURL.path)
         spanStarts = recovered
@@ -185,6 +197,11 @@ public actor SupervisionStore {
             "supervision.json changed on disk; reloading \(self.files.fileURL.path, privacy: .public)")
         cached = try files.load()
         fingerprint = current
+        // The reload may have taken coverage away from a project this store is
+        // still holding a span for. Closing that span needs the ledger, which
+        // needs a suspension this method must not take — see
+        // `reconcileExternalEdits(repos:)`, which drains the flag.
+        sawExternalEdit = true
         return cached
     }
 
@@ -198,26 +215,189 @@ public actor SupervisionStore {
         fingerprint = FileFingerprint(path: files.fileURL.path)
     }
 
+    // MARK: - Reconciling what an edit outside this store did
+
+    /// Close the coverage of any project this store holds a span for that the
+    /// file no longer covers, after an edit this store did not make.
+    ///
+    /// The ledger is written from the gesture path, so without this a mark
+    /// cleared by hand — or a repo removed, or a singleton absorbed by a hand
+    /// edit — would leave the span open forever, and the next `on` would append
+    /// a second `projectOn` over it. A reader would then see one span covering
+    /// hours in which the mark was off. The file is hand-editable **by design**,
+    /// so that is a foreseeable state, not abuse.
+    ///
+    /// **The closing line is timestamped when the daemon noticed, not when the
+    /// operator edited**, because the daemon does not know when they edited.
+    /// That overstates the span by the un-noticed interval — bounded by the
+    /// heartbeat's cadence, since the heartbeat reads through here every minute
+    /// — and the alternative overstates it by everything that follows, forever.
+    /// Noticing is an observation the daemon really made; inventing an earlier
+    /// end time would not be.
+    ///
+    /// **This is not the startup path.** `ensureLoaded` never sets the flag this
+    /// drains, so a restart still writes no line: a mark that is off with an
+    /// open span in the record simply renders off, which is what a bare `on`
+    /// with no opening line already means on the readout.
+    ///
+    /// The reverse case is deliberately not handled: a mark *added* by hand
+    /// gets no synthesized `projectOn`. Writing one would make TBD the author
+    /// of a decision the operator made in a text editor, at a time it guessed.
+    private func reconcileExternalEdits(repos: [SupervisionRepo]) {
+        guard sawExternalEdit else { return }
+        sawExternalEdit = false
+        guard !spanStarts.isEmpty else { return }
+
+        let file = cached
+        // A file that will not resolve tells us nothing about which projects
+        // still exist, so close nothing: leaving a span open is recoverable,
+        // and closing one on a guess is not. The reload already ran
+        // `validate()`, so the only condition that reaches here is a declared
+        // name colliding with a repo's own project — a real state, and one
+        // worth saying out loud rather than swallowing.
+        let projects: [SupervisionProject]
+        do {
+            projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        } catch {
+            let reason = String(describing: error)
+            storeLogger.error(
+                """
+                Could not reconcile coverage after an edit to \
+                \(self.files.fileURL.path, privacy: .public): \(reason, privacy: .public). \
+                Open spans are left open rather than closed on a guess.
+                """)
+            return
+        }
+        let covered = Set(projects.filter(\.mark).map(\.name))
+        orphanedSpans = spanStarts.keys
+            .filter { !covered.contains($0) }
+            .sorted()
+            .map { (project: $0, mode: file.activeMode(for: $0)) }
+    }
+
+    /// Projects whose spans `reconcileExternalEdits` found orphaned, waiting for
+    /// the ledger append that closes them. Held between the synchronous
+    /// detection and the asynchronous write so neither has to happen in the
+    /// other's context.
+    private var orphanedSpans: [(project: String, mode: String)] = []
+
+    private func closeOrphanedSpans() async {
+        guard !orphanedSpans.isEmpty else { return }
+        let orphans = orphanedSpans
+        orphanedSpans = []
+        for orphan in orphans {
+            storeLogger.notice(
+                """
+                Coverage of "\(orphan.project, privacy: .public)" ended outside TBD — closing \
+                its span on the record as of now.
+                """)
+            await appendProjectOff(project: orphan.project, mode: orphan.mode, at: now())
+        }
+    }
+
+    /// Everything every entry point does before it touches the file: load once,
+    /// read the repo list, and settle any coverage an outside edit ended.
+    ///
+    /// Returns the repo list, because every caller needs it and resolving
+    /// topology without it is impossible.
+    private func prepare() async throws -> [SupervisionRepo] {
+        try await ensureLoaded()
+        let repos = try await fleet.repos()
+        // `freshFile()` is what notices an outside edit, so this pass primes the
+        // flag that the drain below consumes.
+        _ = try freshFile()
+        reconcileExternalEdits(repos: repos)
+        await closeOrphanedSpans()
+        return repos
+    }
+
+    /// The projects a topology edit stops resolving, and the coverage that has
+    /// to end with them.
+    ///
+    /// **Computed by comparing resolved project sets, not declarations.** A
+    /// singleton has no entry in `projects`, so a rule phrased over declarations
+    /// misses the two edits that make one stop resolving — a `move` absorbing it
+    /// into a declared project, and a `create` that names it as a member — and
+    /// both are ordinary operator gestures. Getting this wrong is not merely a
+    /// missing line: the absorbed project keeps its mark, so dissolving the
+    /// group later brings it back **on**, hours later, with no gesture and no
+    /// opening line. Comparing what resolves before against what resolves after
+    /// covers every way a project can vanish, including ones no verb has yet.
+    private func applyTopologyEdit(
+        from file: SupervisionFile, to proposed: SupervisionFile, repos: [SupervisionRepo]
+    ) async throws -> SuperviseProjectListResult {
+        let before = try SupervisionTopology.resolve(file: file, repos: repos)
+        // Resolving the proposal is also what validates it — a name colliding
+        // with a repo's own project throws here, before anything is written.
+        let after = try SupervisionTopology.resolve(file: proposed, repos: repos)
+        let surviving = Set(after.map(\.name))
+        let vanished = before.filter { !surviving.contains($0.name) }
+
+        // A vanished project leaves nothing behind that could bind a future
+        // project of the same name — the mark above all, but the mode selection
+        // and supervisor binding with it, matching what `SupervisionTopology`
+        // already does for a declaration a move empties.
+        var updated = proposed
+        for project in vanished {
+            updated.supervised.removeAll { $0 == project.name }
+            updated.modes.removeValue(forKey: project.name)
+            updated.supervisors.removeValue(forKey: project.name)
+        }
+
+        let result = try topologyResult(file: updated, repos: repos)
+        try persist(updated)
+
+        for project in vanished where project.mark {
+            await appendProjectOff(
+                project: project.name, mode: project.activeMode, at: now())
+        }
+        return result
+    }
+
     // MARK: - Status
 
     /// The `supervise.status` readout.
     public func status(brake: SupervisionBrakeState) async throws -> SupervisionStatus {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
         let file = try freshFile()
         let projects = try SupervisionTopology.resolve(file: file, repos: repos)
         let effectivelySupervising = brake == .released && projects.contains { $0.mark }
 
+        // The two halves of "nothing is watching" are separate codes because
+        // they call for opposite actions — mark a project, or release the brake
+        // — and `effectivelySupervising` is false in both, so it cannot tell
+        // them apart.
         var warnings: [SupervisionWarning] = []
-        if brake == .released && !effectivelySupervising {
+        let anyMarked = projects.contains(\.mark)
+        if brake == .released && !anyMarked {
             warnings.append(SupervisionWarning(
                 code: .noProjectsOn,
                 message: "the brake is released but no project is on — nothing is being supervised."))
+        }
+        // Only when a mark actually stands. An engaged brake over a fleet with
+        // nothing marked is a deliberately quiet system; warning there would
+        // train an operator to ignore the line.
+        if brake == .engaged && anyMarked {
+            let marked = projects.filter(\.mark).map { "\"\($0.name)\"" }.joined(separator: ", ")
+            warnings.append(SupervisionWarning(
+                code: .brakeEngagedWithProjectsOn,
+                message: """
+                    the fleet brake is engaged, so nothing is being supervised — \(marked) \
+                    \(projects.filter(\.mark).count == 1 ? "is" : "are") marked on and will \
+                    resume the moment the brake is released.
+                    """))
         }
         let unusable = SupervisionTopology.projectsWithoutUsableDirectory(in: projects)
         if !unusable.isEmpty {
             warnings.append(SupervisionWarning(
                 code: .unusableProjectName, message: Self.unusableNameSentence(unusable)))
+        }
+        // These repos resolve to no project at all, so they appear in no row
+        // above — the warning is the only place their absence is visible.
+        let ambiguous = SupervisionTopology.ambiguousRepoNames(file: file, repos: repos)
+        if !ambiguous.isEmpty {
+            warnings.append(SupervisionWarning(
+                code: .ambiguousRepoName, message: Self.ambiguousNameSentence(ambiguous)))
         }
 
         return SupervisionStatus(
@@ -259,11 +439,26 @@ public actor SupervisionStore {
             """
     }
 
+    /// The sentence the `ambiguousRepoName` warning carries. It names both the
+    /// name and the repos holding it, because the operator's fix — rename one,
+    /// or declare a project over them — needs to know which ones.
+    static func ambiguousNameSentence(_ ambiguous: [SupervisionAmbiguousRepoName]) -> String {
+        let clauses = ambiguous.map { entry in
+            "\(entry.repos.count) repos are named \"\(entry.name)\" "
+                + "(\(entry.repos.map(\.uuidString).joined(separator: ", ")))"
+        }
+        return """
+            \(clauses.joined(separator: "; ")). A project is identified by its name, so two \
+            candidates for one name identify nothing: those repos resolve to no project and \
+            are not supervised. The rest of the fleet is unaffected. Rename one, or declare a \
+            project naming them.
+            """
+    }
+
     /// The heartbeat's view of the same facts (design §14).
     public func statusFileSnapshot(brake: SupervisionBrakeState) async throws
         -> SupervisionStatusFile {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
         let file = try freshFile()
         let projects = try SupervisionTopology.resolve(file: file, repos: repos)
         return SupervisionStatusFile(
@@ -290,8 +485,7 @@ public actor SupervisionStore {
     /// to prevent.
     public func setProjectMark(project: String, on: Bool) async throws
         -> SuperviseSetProjectMarkResult {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
 
         // The roster has to be read before the mark is committed — a snapshot
         // taken afterwards could fail, leaving the gesture done and the caller
@@ -365,8 +559,7 @@ public actor SupervisionStore {
     // MARK: - Modes
 
     public func setMode(project: String, mode: String) async throws -> SuperviseSetModeResult {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
 
         // Read-modify-write, no suspension inside.
         let file = try freshFile()
@@ -416,8 +609,7 @@ public actor SupervisionStore {
     // MARK: - Projects
 
     public func projectList() async throws -> SuperviseProjectListResult {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
         let file = try freshFile()
         return try topologyResult(file: file, repos: repos)
     }
@@ -425,8 +617,7 @@ public actor SupervisionStore {
     public func projectCreate(
         name: String, repos identifiers: [String], policy: SupervisionPolicyRequest
     ) async throws -> SuperviseProjectListResult {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
 
         // Read-modify-write, no suspension inside.
         let file = try freshFile()
@@ -443,12 +634,12 @@ public actor SupervisionStore {
         var updated = file
         updated.projects[name] = SupervisionProjectDeclaration(
             repos: members, policy: resolvedPolicy)
-        // Resolve before saving, not after: it is the check that catches a name
-        // colliding with a repo's own project, and running it first is what
-        // makes a refused create byte-identical to no create at all.
-        let result = try topologyResult(file: updated, repos: repos)
-        try persist(updated)
-        return result
+        // Declaring a group over repos that were their own projects makes each
+        // of those stop resolving — and a marked one's coverage ends there,
+        // whether or not the operator was thinking of it that way. Validation
+        // runs inside the same helper, before anything is written, so a refused
+        // create is byte-identical to no create at all.
+        return try await applyTopologyEdit(from: file, to: updated, repos: repos)
     }
 
     /// Delete a declaration, returning its repos to being their own projects.
@@ -459,28 +650,21 @@ public actor SupervisionStore {
     /// project's coverage genuinely ends here, so its span is closed on the
     /// record like any other `off`.
     public func projectDelete(name: String) async throws -> SuperviseProjectListResult {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
 
         // Read-modify-write, no suspension inside.
         let file = try freshFile()
         guard file.projects[name] != nil else {
             throw SupervisionStoreError.unknownProject(name)
         }
-        let wasMarked = file.isMarked(name)
-        let mode = file.activeMode(for: name)
-
         var updated = file
         updated.projects.removeValue(forKey: name)
-        updated.supervised.removeAll { $0 == name }
-        updated.modes.removeValue(forKey: name)
-        updated.supervisors.removeValue(forKey: name)
-
-        let result = try topologyResult(file: updated, repos: repos)
-        try persist(updated)
-
-        if wasMarked { await appendProjectOff(project: name, mode: mode, at: now()) }
-        return result
+        // The mark, mode and binding go with the declaration, and the coverage
+        // ends with it — all of that is `applyTopologyEdit`'s job, which sees
+        // this project stop resolving. Deleting a group also makes its members
+        // resolve again as their own projects, which the same comparison
+        // handles: they appear rather than vanish.
+        return try await applyTopologyEdit(from: file, to: updated, repos: repos)
     }
 
     /// Move a repo between projects — the only membership verb.
@@ -492,32 +676,19 @@ public actor SupervisionStore {
     /// were.
     public func projectMove(repo identifier: String, to target: SupervisionMoveTarget) async throws
         -> SuperviseProjectListResult {
-        try await ensureLoaded()
-        let repos = try await fleet.repos()
+        let repos = try await prepare()
 
         // Read-modify-write, no suspension inside.
         let file = try freshFile()
         let repoID = try resolveRepo(identifier, in: repos)
         let updated = try SupervisionTopology.move(
             repo: repoID, to: target, in: file, repos: repos)
-        let result = try topologyResult(file: updated, repos: repos)
-        guard updated != file else { return result }
+        guard updated != file else { return try topologyResult(file: file, repos: repos) }
 
-        // A move that empties a declaration deletes it, and takes its mark with
-        // it. Where that mark stood, the span it opened ends here.
-        let vanished = Set(file.supervised.filter { name in
-            file.projects[name] != nil && updated.projects[name] == nil
-        })
-        let modes = Dictionary(
-            vanished.map { ($0, file.activeMode(for: $0)) }, uniquingKeysWith: { first, _ in first })
-
-        try persist(updated)
-
-        for name in vanished.sorted() {
-            await appendProjectOff(
-                project: name, mode: modes[name] ?? SupervisionModeEntry.defaultMode, at: now())
-        }
-        return result
+        // Absorbing a repo into a declared project makes that repo's own
+        // project stop resolving — and a singleton has no declaration, so only
+        // comparing what resolves catches it. See `applyTopologyEdit`.
+        return try await applyTopologyEdit(from: file, to: updated, repos: repos)
     }
 
     private func topologyResult(file: SupervisionFile, repos: [SupervisionRepo]) throws

--- a/Sources/TBDDaemon/Supervision/SupervisionStore.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionStore.swift
@@ -595,23 +595,69 @@ public actor SupervisionStore {
 
     // MARK: - The brake
 
-    /// Record a fleet brake change, after the config column already took it.
+    /// Serializes brake transitions. Actor isolation is not enough on its own:
+    /// `commit` is an `await` on the database, and an actor releases itself
+    /// across every suspension, so without this gate a second transition can
+    /// run its whole commit-and-record while the first is still inside its own.
+    private var brakeGateBusy = false
+    private var brakeGateWaiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquireBrakeGate() async {
+        if brakeGateBusy {
+            await withCheckedContinuation { brakeGateWaiters.append($0) }
+            // Resumed by releaseBrakeGate(); `brakeGateBusy` stays true.
+        } else {
+            brakeGateBusy = true
+        }
+    }
+
+    private func releaseBrakeGate() {
+        if brakeGateWaiters.isEmpty {
+            brakeGateBusy = false
+        } else {
+            brakeGateWaiters.removeFirst().resume()
+        }
+    }
+
+    /// Commit a fleet brake change and record it as one indivisible step.
     ///
-    /// The line carries no project and no mode, and cannot be given either: the
-    /// brake is one bit over the whole fleet, so naming a project on its line
-    /// would be a lie. `SupervisionLedgerLine.brakeEngaged` / `.brakeReleased`
-    /// take no project, which is what holds this by construction.
+    /// **The commit and the line it justifies happen inside one serialized
+    /// region, and that is the whole point of this method existing.** Putting
+    /// the column's read-and-write in a single transaction makes the *column*
+    /// atomic, but it says nothing about the order two transitions reach the
+    /// ledger: two overlapping toggles — the CLI racing the app's Settings
+    /// switch — could commit in one order and append in the other, leaving the
+    /// record's last line disagreeing with the database about what the brake
+    /// is now. The ledger is exactly what a watchdog or a person reads to
+    /// answer that question, so a record that can contradict the live state is
+    /// worse than no record.
     ///
-    /// `changed` is the caller's comparison of the resolved brake before and
-    /// after: the column is tri-state, so writing `false` over an unset column
-    /// is a real gesture on the column but no change to what the brake means,
-    /// and a gesture that changes nothing writes no line.
-    public func recordBrakeChange(engaged: Bool, changed: Bool) async {
-        guard changed else { return }
+    /// `commit` performs the database write and returns the **resolved**
+    /// previous brake, so the decision "did this call actually move the brake"
+    /// is made from a value read in the same transaction that wrote it. A call
+    /// that moved nothing writes no line: the column is tri-state, so writing
+    /// `false` over an unset column is a real gesture on the column and no
+    /// change at all to what the brake means.
+    ///
+    /// The line carries no project and no mode, and cannot be given either —
+    /// `SupervisionLedgerLine.brakeEngaged` / `.brakeReleased` take none, which
+    /// is what keeps a fleet-wide line from ever naming one project.
+    ///
+    /// - Returns: whether the brake actually moved.
+    @discardableResult
+    public func applyBrakeChange(
+        released: Bool, commit: @Sendable () async throws -> Bool
+    ) async throws -> Bool {
+        await acquireBrakeGate()
+        defer { releaseBrakeGate() }
+
+        let wasReleased = try await commit()
+        guard wasReleased != released else { return false }
         let at = now()
-        await ledger.append(engaged
-            ? SupervisionLedgerLine.brakeEngaged(at: at)
-            : SupervisionLedgerLine.brakeReleased(at: at))
+        await ledger.append(released
+            ? SupervisionLedgerLine.brakeReleased(at: at)
+            : SupervisionLedgerLine.brakeEngaged(at: at))
+        return true
     }
 
     // MARK: - Projects

--- a/Sources/TBDDaemon/Supervision/SupervisionStore.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionStore.swift
@@ -361,15 +361,15 @@ public actor SupervisionStore {
         let repos = try await prepare()
         let file = try freshFile()
         let projects = try SupervisionTopology.resolve(file: file, repos: repos)
-        let effectivelySupervising = brake == .released && projects.contains { $0.mark }
+        let markedProjects = projects.filter(\.mark)
+        let effectivelySupervising = brake == .released && !markedProjects.isEmpty
 
         // The two halves of "nothing is watching" are separate codes because
         // they call for opposite actions — mark a project, or release the brake
         // — and `effectivelySupervising` is false in both, so it cannot tell
         // them apart.
         var warnings: [SupervisionWarning] = []
-        let anyMarked = projects.contains(\.mark)
-        if brake == .released && !anyMarked {
+        if brake == .released && markedProjects.isEmpty {
             warnings.append(SupervisionWarning(
                 code: .noProjectsOn,
                 message: "the brake is released but no project is on — nothing is being supervised."))
@@ -377,14 +377,14 @@ public actor SupervisionStore {
         // Only when a mark actually stands. An engaged brake over a fleet with
         // nothing marked is a deliberately quiet system; warning there would
         // train an operator to ignore the line.
-        if brake == .engaged && anyMarked {
-            let marked = projects.filter(\.mark).map { "\"\($0.name)\"" }.joined(separator: ", ")
+        if brake == .engaged && !markedProjects.isEmpty {
+            let named = markedProjects.map { "\"\($0.name)\"" }.joined(separator: ", ")
+            let verb = markedProjects.count == 1 ? "is" : "are"
             warnings.append(SupervisionWarning(
                 code: .brakeEngagedWithProjectsOn,
                 message: """
-                    the fleet brake is engaged, so nothing is being supervised — \(marked) \
-                    \(projects.filter(\.mark).count == 1 ? "is" : "are") marked on and will \
-                    resume the moment the brake is released.
+                    the fleet brake is engaged, so nothing is being supervised — \(named) \
+                    \(verb) marked on and will resume the moment the brake is released.
                     """))
         }
         let unusable = SupervisionTopology.projectsWithoutUsableDirectory(in: projects)
@@ -504,7 +504,15 @@ public actor SupervisionStore {
             guard updated != file else {
                 return SuperviseSetProjectMarkResult(project: project, on: on, changed: false)
             }
-            let roster = on ? try await rosterSnapshot(for: resolved) : []
+            // Spelled out rather than as a ternary: `try await` inside one
+            // branch of `?:` sits to the right of a non-assignment operator,
+            // which the grammar does not accept.
+            let roster: [SupervisionRosterEntry]
+            if on {
+                roster = try await rosterSnapshot(for: resolved)
+            } else {
+                roster = []
+            }
             guard try freshFile() == file else { continue }
 
             try persist(updated)
@@ -710,10 +718,15 @@ public actor SupervisionStore {
     /// Resolve a repo id or display name to a repo.
     ///
     /// A display name shared by two repos is refused naming the condition,
-    /// never guessed — and that refusal is not a new rule, only an earlier one:
-    /// `SupervisionTopology.resolve` already rejects the whole topology for
-    /// exactly that ambiguity, because both repos' singleton projects would
-    /// carry the same name.
+    /// never guessed: the operator typed one name and there are two answers, so
+    /// there is nothing to act on.
+    ///
+    /// Refusing here does not contradict `SupervisionTopology.resolve`, which
+    /// *reports* the same ambiguity as a warning and carries on covering the
+    /// rest of the fleet. The two are asymmetric on purpose. Reading is a
+    /// question about everything, and one repo's naming must not take the
+    /// fleet's coverage down; a gesture is a question about one repo, and
+    /// picking either candidate would act on a repo the operator did not name.
     private func resolveRepo(_ identifier: String, in repos: [SupervisionRepo]) throws -> UUID {
         if let id = UUID(uuidString: identifier) {
             guard repos.contains(where: { $0.id == id }) else {

--- a/Sources/TBDDaemon/Supervision/SupervisionStore.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionStore.swift
@@ -13,6 +13,7 @@ public enum SupervisionStoreError: Error, Equatable, CustomStringConvertible, Lo
     case unknownProject(String)
     case projectAlreadyDeclared(String)
     case modeNotDeclared(project: String, requested: String, declared: [String])
+    case concurrentEdit(project: String)
 
     public var description: String {
         switch self {
@@ -30,6 +31,9 @@ public enum SupervisionStoreError: Error, Equatable, CustomStringConvertible, Lo
             let choices = declared.isEmpty ? "(none declared)" : declared.joined(separator: ", ")
             return "Mode \"\(requested)\" is not declared for project \"\(project)\" "
                 + "— choices: \(choices)."
+        case .concurrentEdit(let project):
+            return "The supervision file kept changing while \"\(project)\"'s mark was being "
+                + "set, so nothing was written. Something else is editing it — try again."
         }
     }
 
@@ -200,7 +204,8 @@ public actor SupervisionStore {
     public func status(brake: SupervisionBrakeState) async throws -> SupervisionStatus {
         try await ensureLoaded()
         let repos = try await fleet.repos()
-        let projects = try SupervisionTopology.resolve(file: try freshFile(), repos: repos)
+        let file = try freshFile()
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
         let effectivelySupervising = brake == .released && projects.contains { $0.mark }
 
         var warnings: [SupervisionWarning] = []
@@ -259,7 +264,8 @@ public actor SupervisionStore {
         -> SupervisionStatusFile {
         try await ensureLoaded()
         let repos = try await fleet.repos()
-        let projects = try SupervisionTopology.resolve(file: try freshFile(), repos: repos)
+        let file = try freshFile()
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
         return SupervisionStatusFile(
             writtenAt: SupervisionInstant(now()),
             brake: brake,
@@ -287,32 +293,42 @@ public actor SupervisionStore {
         try await ensureLoaded()
         let repos = try await fleet.repos()
 
-        // Read-modify-write, no suspension inside.
-        let file = try freshFile()
-        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
-        guard let resolved = projects.first(where: { $0.name == project }) else {
-            throw SupervisionStoreError.unknownProject(project)
-        }
-        let updated = file.settingMark(project, on: on)
-        guard updated != file else {
-            return SuperviseSetProjectMarkResult(project: project, on: on, changed: false)
-        }
-        try persist(updated)
+        // The roster has to be read before the mark is committed — a snapshot
+        // taken afterwards could fail, leaving the gesture done and the caller
+        // told it failed — but reading it is a suspension, and a suspension
+        // between the read and the write is what lets two operators clobber
+        // each other. So: decide, snapshot, then commit only if the file has
+        // not moved underneath, and start over if it has. Three attempts is a
+        // bound on a race that human-rate gestures essentially never lose.
+        for _ in 0..<3 {
+            let file = try freshFile()
+            let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+            guard let resolved = projects.first(where: { $0.name == project }) else {
+                throw SupervisionStoreError.unknownProject(project)
+            }
+            let updated = file.settingMark(project, on: on)
+            guard updated != file else {
+                return SuperviseSetProjectMarkResult(project: project, on: on, changed: false)
+            }
+            let roster = on ? try await rosterSnapshot(for: resolved) : []
+            guard try freshFile() == file else { continue }
 
-        let at = now()
-        if on {
-            let roster = try await rosterSnapshot(for: resolved)
-            let recorded = await ledger.append(SupervisionLedgerLine.projectOn(
-                project: project, mode: resolved.activeMode, roster: roster, at: at))
-            // The span start is memory of the record, not a second copy of it:
-            // if the opening line did not land, the span reads as unknown here
-            // exactly as it would after a restart, and the status renders a
-            // bare `on` rather than inventing a start.
-            if recorded { spanStarts[project] = SupervisionInstant(at) }
-        } else {
-            await appendProjectOff(project: project, mode: resolved.activeMode, at: at)
+            try persist(updated)
+            let at = now()
+            if on {
+                let recorded = await ledger.append(SupervisionLedgerLine.projectOn(
+                    project: project, mode: resolved.activeMode, roster: roster, at: at))
+                // The span start is memory of the record, not a second copy of
+                // it: if the opening line did not land, the span reads as
+                // unknown here exactly as it would after a restart, and the
+                // status renders a bare `on` rather than inventing a start.
+                if recorded { spanStarts[project] = SupervisionInstant(at) }
+            } else {
+                await appendProjectOff(project: project, mode: resolved.activeMode, at: at)
+            }
+            return SuperviseSetProjectMarkResult(project: project, on: on, changed: true)
         }
-        return SuperviseSetProjectMarkResult(project: project, on: on, changed: true)
+        throw SupervisionStoreError.concurrentEdit(project: project)
     }
 
     /// The `projectOff` line and the span bookkeeping that goes with it. Shared
@@ -402,7 +418,8 @@ public actor SupervisionStore {
     public func projectList() async throws -> SuperviseProjectListResult {
         try await ensureLoaded()
         let repos = try await fleet.repos()
-        return try topologyResult(file: try freshFile(), repos: repos)
+        let file = try freshFile()
+        return try topologyResult(file: file, repos: repos)
     }
 
     public func projectCreate(

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -315,4 +315,87 @@ public enum TBDConstants {
             return isSafe ? Character(scalar) : "_"
         })
     }
+
+    /// Directory holding everything fleet supervision persists outside the DB:
+    /// the operator's `supervision.json`, the continuous `ledger.jsonl`, the
+    /// out-of-band `status.json` heartbeat, and one directory per declared
+    /// project. Honors `TBD_HOME` like every other derived path — never
+    /// hand-build it from `$HOME`.
+    public static func supervisionDir(environment: [String: String]) -> URL {
+        configDir(environment: environment).appendingPathComponent("supervision")
+    }
+    public static var supervisionDir: URL {
+        supervisionDir(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// The operator's supervision file: `~/tbd/supervision/supervision.json`.
+    /// Project topology, per-project marks, mode declarations and selections,
+    /// supervisor bindings, sweep selection. Hand-editable; the daemon is its
+    /// only programmatic writer.
+    public static func supervisionFilePath(environment: [String: String]) -> String {
+        supervisionDir(environment: environment).appendingPathComponent("supervision.json").path
+    }
+    public static var supervisionFilePath: String {
+        supervisionFilePath(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// The continuous supervision record: `~/tbd/supervision/ledger.jsonl`.
+    /// Append-only, one JSON object per line, whole-line writes.
+    public static func supervisionLedgerPath(environment: [String: String]) -> String {
+        supervisionDir(environment: environment).appendingPathComponent("ledger.jsonl").path
+    }
+    public static var supervisionLedgerPath: String {
+        supervisionLedgerPath(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// The out-of-band heartbeat: `~/tbd/supervision/status.json`, rewritten
+    /// atomically at boot, at every brake edge, and on a fixed cadence while
+    /// the brake is released — so a watchdog that cannot reach the socket or
+    /// the DB can still tell whether the daemon is alive. See
+    /// `SupervisionStatusFile` for the full contract, including why staleness
+    /// under an engaged brake is expected rather than a liveness signal.
+    public static func supervisionStatusPath(environment: [String: String]) -> String {
+        supervisionDir(environment: environment).appendingPathComponent("status.json").path
+    }
+    public static var supervisionStatusPath: String {
+        supervisionStatusPath(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// A project's own directory: `~/tbd/supervision/projects/<name>`. Holds
+    /// the operator-level playbook, the journal, the proposals doc, and any
+    /// customized sweep or transition program.
+    ///
+    /// **Returns nil when the name is not one safe path component, and the
+    /// optional return is the guarantee — do not make it non-optional.** A
+    /// helper that accepts an unvalidated name and hands back a path outside
+    /// its own directory *is* the vulnerability; refusing to compose one is how
+    /// this closes, and it closes for every caller at once, including callers
+    /// not yet written.
+    ///
+    /// Validating at the call site instead would be the same bug with more
+    /// steps: not every project name arrives through `supervision.json`, where
+    /// `SupervisionFile.validate()` already refuses an unusable name. A
+    /// singleton project is named by its repo's **display name**, which an
+    /// operator may edit to anything at all — `acme/web` yields
+    /// `…/supervision/projects/acme/web`, and `..` walks straight out of the
+    /// supervision directory. Those names never pass through the file's
+    /// validation, so the only place that can be relied on to check them is
+    /// here.
+    ///
+    /// A nil is not an error condition to escalate: the project is supervised
+    /// normally and only its directory is unavailable
+    /// (`SupervisionProject.hasUsableDirectory`,
+    /// `SupervisionWarningCode.unusableProjectName`). The operator's fix is to
+    /// rename the repo.
+    public static func supervisionProjectDir(
+        project: String, environment: [String: String]
+    ) -> URL? {
+        guard SupervisionFile.isSafeProjectName(project) else { return nil }
+        return supervisionDir(environment: environment)
+            .appendingPathComponent("projects")
+            .appendingPathComponent(project)
+    }
+    public static func supervisionProjectDir(project: String) -> URL? {
+        supervisionProjectDir(project: project, environment: ProcessInfo.processInfo.environment)
+    }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1166,6 +1166,20 @@ public struct Config: Codable, Sendable, Equatable {
     /// chose" and follows the shipped default wherever it goes; `0`/`1` is an
     /// explicit gesture and is honored forever.
     public var queuedPromptEnabled: Bool
+    /// The fleet brake for supervision
+    /// (`docs/specs/2026-07-26-fleet-supervision-design.md` §3, §8): one bit,
+    /// fleet-wide, ANDed over every project's mark and writing none of them.
+    /// Released (`true`) means TBD may act where a mark stands; engaged
+    /// (`false`, the shipped state) means TBD's authority is paused everywhere,
+    /// with the marks left exactly as they were.
+    ///
+    /// **Resolved, not stored**, like `queuedPromptEnabled`: the backing column
+    /// carries no SQL default and stays NULL until somebody touches the toggle,
+    /// so this property is
+    /// `supervision_enabled ?? Config.supervisionEnabledDefault`. NULL means
+    /// "never chose" and follows the shipped default wherever it goes; `0`/`1`
+    /// is an explicit gesture and is honored forever.
+    public var supervisionEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -1186,6 +1200,11 @@ public struct Config: Codable, Sendable, Equatable {
     /// the feature is a change to this constant — no forcing `UPDATE`
     /// migration, and an explicit opt-out is left alone.
     public static let queuedPromptDefault = false
+    /// The shipped default for `supervisionEnabled`, and the single place it
+    /// lives. Supervision ships with the brake engaged; graduating it is a
+    /// change to this constant — no forcing `UPDATE` migration, and an explicit
+    /// opt-out is left alone.
+    public static let supervisionEnabledDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1212,7 +1231,8 @@ public struct Config: Codable, Sendable, Equatable {
                 agentPanelControlEnabled: Bool = false,
                 remoteBackendsEnabled: Bool = false,
                 deliveryVerificationEnabled: Bool = false,
-                queuedPromptEnabled: Bool = Config.queuedPromptDefault) {
+                queuedPromptEnabled: Bool = Config.queuedPromptDefault,
+                supervisionEnabled: Bool = Config.supervisionEnabledDefault) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -1239,6 +1259,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.remoteBackendsEnabled = remoteBackendsEnabled
         self.deliveryVerificationEnabled = deliveryVerificationEnabled
         self.queuedPromptEnabled = queuedPromptEnabled
+        self.supervisionEnabled = supervisionEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1297,6 +1318,11 @@ public struct Config: Codable, Sendable, Equatable {
         // fall through to the shipped default rather than hardcoding `false`.
         queuedPromptEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .queuedPromptEnabled) ?? Config.queuedPromptDefault
+        // Same tri-state as above: absent means the sender knew nothing about
+        // the flag, which is the NULL column's situation — follow the shipped
+        // default rather than hardcoding `false` here as well.
+        supervisionEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .supervisionEnabled) ?? Config.supervisionEnabledDefault
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -2088,6 +2088,28 @@ public enum SupervisionWarningCode: String, Codable, Sendable {
     /// Supervision covers them regardless; the fix is renaming the repo, and
     /// the message names which ones.
     case unusableProjectName
+    /// Two or more repos share a display name, so none of them resolves to a
+    /// project and none is supervised — a project is identified by its name,
+    /// and two candidates for one name identify nothing
+    /// (`SupervisionTopology.ambiguousRepoNames(file:repos:)`). The rest of the
+    /// fleet is unaffected. The message names the repos; the operator's fix is
+    /// to rename one, or to declare a project naming them.
+    case ambiguousRepoName
+    /// The brake is engaged while at least one project's mark stands — the
+    /// exact mirror of `noProjectsOn`. An operator who runs
+    /// `tbd supervise on acme` against an engaged brake sees `on: acme` and
+    /// forms the belief that supervision is running; nothing is watching.
+    ///
+    /// **Emitted only when a mark actually stands.** An engaged brake over a
+    /// fleet with nothing marked is a deliberately quiet system, not a warning,
+    /// and warning there would train an operator to ignore the line — which
+    /// costs more than it buys.
+    ///
+    /// `SupervisionStatus.effectivelySupervising` is false in this state and in
+    /// `noProjectsOn` alike, and cannot tell them apart; they call for opposite
+    /// actions — release the brake, or mark a project — so the code is what a
+    /// program branches on.
+    case brakeEngagedWithProjectsOn
 }
 
 /// One warning on the status readout: a stable code, and the sentence a human

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -260,6 +260,14 @@ public enum RPCMethod {
     public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
     public static let configSetDeliveryVerification = "config.setDeliveryVerification"
     public static let configSetQueuedPrompt = "config.setQueuedPrompt"
+    public static let configSetSupervisionEnabled = "config.setSupervisionEnabled"
+    public static let superviseStatus = "supervise.status"
+    public static let superviseSetProjectMark = "supervise.setProjectMark"
+    public static let superviseSetMode = "supervise.setMode"
+    public static let superviseProjectList = "supervise.projectList"
+    public static let superviseProjectCreate = "supervise.projectCreate"
+    public static let superviseProjectDelete = "supervise.projectDelete"
+    public static let superviseProjectMove = "supervise.projectMove"
     public static let worktreeSetPendingPrompt = "worktree.setPendingPrompt"
     public static let configSetAutoCloseSetup = "config.setAutoCloseSetup"
     public static let configSetAutoTrustWorktrees = "config.setAutoTrustWorktrees"
@@ -2051,6 +2059,304 @@ public struct ConfigSetDeliveryVerificationParams: Codable, Sendable {
 public struct ConfigSetQueuedPromptParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
+}
+
+// MARK: - Supervision
+
+/// Params for `config.setSupervisionEnabled` — the fleet brake
+/// (`docs/specs/2026-07-26-fleet-supervision-design.md` §3, §8). `true`
+/// releases the brake, `false` engages it; either way the per-project marks are
+/// untouched, so releasing restores exactly the coverage that stood.
+///
+/// Sending either value is an explicit gesture: the backing column is NULL
+/// until this verb writes to it, and a written `false` stays engaged even after
+/// the shipped default graduates.
+public struct ConfigSetSupervisionEnabledParams: Codable, Sendable, Equatable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// A stable code a program may branch on, carried in `SupervisionStatus`.
+public enum SupervisionWarningCode: String, Codable, Sendable {
+    /// The brake is released and not one project is marked on — supervision is
+    /// on but nothing is being supervised. The loud case: the CLI says so in
+    /// words a human reads, and this code is the same fact for a program.
+    case noProjectsOn
+}
+
+/// One warning on the status readout: a stable code, and the sentence a human
+/// gets.
+public struct SupervisionWarning: Codable, Sendable, Equatable {
+    public let code: SupervisionWarningCode
+    public let message: String
+    public init(code: SupervisionWarningCode, message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+/// Result of `supervise.status`: the brake, then one entry per resolved project
+/// (declared and singleton alike — nothing here distinguishes them).
+public struct SupervisionStatus: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let brake: SupervisionBrakeState
+    /// Whether TBD's own attention actually covers anything right now: the
+    /// brake released AND at least one project marked on.
+    public let effectivelySupervising: Bool
+    public let projects: [SupervisionStatusProject]
+    public let warnings: [SupervisionWarning]
+
+    public init(brake: SupervisionBrakeState, effectivelySupervising: Bool,
+                projects: [SupervisionStatusProject], warnings: [SupervisionWarning],
+                schemaVersion: Int = SupervisionStatus.currentSchemaVersion) {
+        self.schemaVersion = schemaVersion
+        self.brake = brake
+        self.effectivelySupervising = effectivelySupervising
+        self.projects = projects
+        self.warnings = warnings
+    }
+}
+
+/// One project's row on the status readout.
+public struct SupervisionStatusProject: Codable, Sendable, Equatable {
+    public let name: String
+    /// The project's mark. Effectively on is this AND a released brake.
+    public let on: Bool
+    public let mode: String
+    public let declaredModes: [String]
+    public let supervisor: SupervisionSupervisorArrangement
+    /// When the current coverage span opened, or null when the project is off
+    /// or the record holds no opening line.
+    public let spanStartedAt: SupervisionInstant?
+    /// When a sweep program last made contact, or null when it never has.
+    public let lastSweepContactAt: SupervisionInstant?
+    /// The project's declared contact window, or null when it declares none —
+    /// which is what the readout's "coverage unknown" reports. Null is the
+    /// honest not-yet value; nothing here invents a coverage claim.
+    public let coverageWindow: String?
+
+    public init(name: String, on: Bool, mode: String, declaredModes: [String],
+                supervisor: SupervisionSupervisorArrangement,
+                spanStartedAt: SupervisionInstant?, lastSweepContactAt: SupervisionInstant?,
+                coverageWindow: String?) {
+        self.name = name
+        self.on = on
+        self.mode = mode
+        self.declaredModes = declaredModes
+        self.supervisor = supervisor
+        self.spanStartedAt = spanStartedAt
+        self.lastSweepContactAt = lastSweepContactAt
+        self.coverageWindow = coverageWindow
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, on, mode, declaredModes, supervisor
+        case spanStartedAt, lastSweepContactAt, coverageWindow
+    }
+
+    /// Written by hand because synthesized `Codable` *omits* a nil optional.
+    /// The honest not-yet values are the point of these three fields, so they
+    /// are present and null rather than absent.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(on, forKey: .on)
+        try container.encode(mode, forKey: .mode)
+        try container.encode(declaredModes, forKey: .declaredModes)
+        try container.encode(supervisor, forKey: .supervisor)
+        try container.encode(spanStartedAt, forKey: .spanStartedAt)
+        try container.encode(lastSweepContactAt, forKey: .lastSweepContactAt)
+        try container.encode(coverageWindow, forKey: .coverageWindow)
+    }
+}
+
+/// Params for `supervise.setProjectMark` — `tbd supervise on|off <project>`.
+/// The mark is coverage, never protection: it binds TBD's own hand and builds
+/// no wall around a terminal.
+public struct SuperviseSetProjectMarkParams: Codable, Sendable, Equatable {
+    public let project: String
+    public let on: Bool
+    public init(project: String, on: Bool) {
+        self.project = project
+        self.on = on
+    }
+}
+
+/// Result of `supervise.setProjectMark`. `changed` is false when the mark
+/// already stood as asked — a no-op is not a decision, and no ledger line is
+/// written for one.
+public struct SuperviseSetProjectMarkResult: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let project: String
+    public let on: Bool
+    public let changed: Bool
+
+    public init(project: String, on: Bool, changed: Bool,
+                schemaVersion: Int = SuperviseSetProjectMarkResult.currentSchemaVersion) {
+        self.schemaVersion = schemaVersion
+        self.project = project
+        self.on = on
+        self.changed = changed
+    }
+}
+
+/// Params for `supervise.setMode` — the per-project selection, validated
+/// against the project's declared list (a lookup within `supervision.json`;
+/// TBD never parses the playbook to derive one).
+public struct SuperviseSetModeParams: Codable, Sendable, Equatable {
+    public let project: String
+    public let mode: String
+    public init(project: String, mode: String) {
+        self.project = project
+        self.mode = mode
+    }
+}
+
+/// Result of `supervise.setMode`, carrying the choices so the CLI can show them
+/// without a second call. `changed` is false when the mode already stood.
+public struct SuperviseSetModeResult: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let project: String
+    public let mode: String
+    public let declaredModes: [String]
+    public let changed: Bool
+
+    public init(project: String, mode: String, declaredModes: [String], changed: Bool,
+                schemaVersion: Int = SuperviseSetModeResult.currentSchemaVersion) {
+        self.schemaVersion = schemaVersion
+        self.project = project
+        self.mode = mode
+        self.declaredModes = declaredModes
+        self.changed = changed
+    }
+}
+
+/// A member repo on the topology readout: the id the file holds, and the name a
+/// human typed or reads.
+public struct SupervisionProjectRepoRef: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let name: String
+    public init(id: UUID, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+/// One project on the topology readout.
+///
+/// Declared projects and singletons appear alike, and no field distinguishes
+/// them: a reader sees a project with its repos and its policy, which is all
+/// there is to see (design §5).
+public struct SupervisionProjectTopologyEntry: Codable, Sendable, Equatable {
+    public let name: String
+    public let repos: [SupervisionProjectRepoRef]
+    public let policy: SupervisionPolicySource
+    /// The project's own sweep program, when one has been customized.
+    public let sweepScript: String?
+
+    public init(name: String, repos: [SupervisionProjectRepoRef],
+                policy: SupervisionPolicySource, sweepScript: String?) {
+        self.name = name
+        self.repos = repos
+        self.policy = policy
+        self.sweepScript = sweepScript
+    }
+}
+
+/// Result of `supervise.projectList`, and of every project mutation — a
+/// mutation answers with the topology it produced.
+public struct SuperviseProjectListResult: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let projects: [SupervisionProjectTopologyEntry]
+
+    public init(projects: [SupervisionProjectTopologyEntry],
+                schemaVersion: Int = SuperviseProjectListResult.currentSchemaVersion) {
+        self.schemaVersion = schemaVersion
+        self.projects = projects
+    }
+}
+
+/// The policy source as a caller names it: `--policy repo:<id>` or
+/// `--policy operator`. The repo arrives as a string because the CLI accepts a
+/// repo UUID or a repo display name; resolving it to a `UUID` is the daemon's
+/// job.
+public enum SupervisionPolicyRequest: Codable, Sendable, Equatable {
+    case repo(String)
+    case `operator`
+
+    private enum CodingKeys: String, CodingKey {
+        case repo
+        case `operator`
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let repo = try container.decodeIfPresent(String.self, forKey: .repo) {
+            self = .repo(repo)
+            return
+        }
+        if let isOperator = try container.decodeIfPresent(Bool.self, forKey: .operator), isOperator {
+            self = .operator
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            forKey: .repo, in: container,
+            debugDescription: "a policy must be {\"repo\": \"<repo>\"} or {\"operator\": true}")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .repo(let repo): try container.encode(repo, forKey: .repo)
+        case .operator: try container.encode(true, forKey: .operator)
+        }
+    }
+}
+
+/// Params for `supervise.projectCreate`. `repos` entries are repo UUIDs or repo
+/// display names, as typed.
+public struct SuperviseProjectCreateParams: Codable, Sendable, Equatable {
+    public let name: String
+    public let repos: [String]
+    public let policy: SupervisionPolicyRequest
+
+    public init(name: String, repos: [String], policy: SupervisionPolicyRequest) {
+        self.name = name
+        self.repos = repos
+        self.policy = policy
+    }
+}
+
+/// Params for `supervise.projectDelete`. Deleting a declaration returns its
+/// member repos to being their own projects.
+public struct SuperviseProjectDeleteParams: Codable, Sendable, Equatable {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+/// Params for `supervise.projectMove` — the only membership verb, because an
+/// add/remove pair can express states the "exactly one project" model forbids.
+/// `repo` is a repo UUID or display name; `to` is a project name or the
+/// documented `"singleton"` sentinel.
+public struct SuperviseProjectMoveParams: Codable, Sendable, Equatable {
+    /// The value of `to` that returns a repo to being its own project.
+    public static let singletonTarget = SupervisionMoveTarget.singletonArgument
+
+    public let repo: String
+    public let to: String
+
+    public init(repo: String, to: String) {
+        self.repo = repo
+        self.to = to
+    }
 }
 
 /// Params for `worktree.setPendingPrompt` — park the text the operator composed

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -2082,6 +2082,12 @@ public enum SupervisionWarningCode: String, Codable, Sendable {
     /// on but nothing is being supervised. The loud case: the CLI says so in
     /// words a human reads, and this code is the same fact for a program.
     case noProjectsOn
+    /// One or more projects have a name that cannot be a directory, so nothing
+    /// can be written beside them — no playbook, journal, proposals, or
+    /// programs (`SupervisionTopology.projectsWithoutUsableDirectory(in:)`).
+    /// Supervision covers them regardless; the fix is renaming the repo, and
+    /// the message names which ones.
+    case unusableProjectName
 }
 
 /// One warning on the status readout: a stable code, and the sentence a human

--- a/Sources/TBDShared/Supervision/SupervisionFile.swift
+++ b/Sources/TBDShared/Supervision/SupervisionFile.swift
@@ -1,0 +1,546 @@
+import Foundation
+
+// MARK: - Timestamps
+
+/// A moment on the wire, encoded as ISO-8601 with fractional seconds in UTC
+/// (`2026-08-14T02:13:12.482Z`).
+///
+/// Supervision carries its own instant type rather than a bare `Date` because
+/// every one of its surfaces is read by something outside this process — a
+/// watchdog reading `status.json`, a sweep program reading `ledger.jsonl`, a
+/// human hand-editing a file — so the wire format has to be a property of the
+/// value, not of whichever encoder happens to touch it. (`JSONEncoder`'s
+/// `.iso8601` strategy also drops fractional seconds, which the ledger needs.)
+///
+/// It is data, never behavior: producing one is the caller's date seam
+/// (`now: @Sendable () -> Date`), never `Date()` inline.
+public struct SupervisionInstant: Codable, Sendable, Equatable, Hashable, Comparable {
+    public let date: Date
+
+    /// Rounded to the millisecond the wire format carries. An instant holds the
+    /// precision it can persist, so a value and its reloaded self are the same
+    /// value rather than two that differ by a few microseconds — the drift that
+    /// makes "did this line survive a round trip" unanswerable.
+    public init(_ date: Date) {
+        let milliseconds = (date.timeIntervalSince1970 * 1000).rounded()
+        self.date = Date(timeIntervalSince1970: milliseconds / 1000)
+    }
+
+    public static func < (lhs: SupervisionInstant, rhs: SupervisionInstant) -> Bool {
+        lhs.date < rhs.date
+    }
+
+    /// Identity is the wire form, not the `Date`'s full precision: an instant
+    /// means the millisecond it records, so one that survived a round trip
+    /// equals the one that was written. Comparing raw `Date`s would make every
+    /// value unequal to its own reloaded self by a few microseconds.
+    public static func == (lhs: SupervisionInstant, rhs: SupervisionInstant) -> Bool {
+        lhs.wireValue == rhs.wireValue
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wireValue)
+    }
+
+    private static let style = Date.ISO8601FormatStyle(
+        includingFractionalSeconds: true, timeZone: TimeZone(identifier: "UTC")!)
+
+    /// The wire representation, e.g. `2026-08-14T02:13:12.482Z`.
+    public var wireValue: String { Self.style.format(date) }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let text = try container.decode(String.self)
+        guard let parsed = try? Self.style.parse(text) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "not an ISO-8601 UTC timestamp with fractional seconds: \(text)")
+        }
+        self.init(parsed)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(wireValue)
+    }
+}
+
+// MARK: - Preserved JSON
+
+/// A JSON value carried through `supervision.json` verbatim.
+///
+/// Used for the per-project `sweep` selection, whose vocabulary belongs to the
+/// sweep program (`docs/specs/2026-08-01-fleet-supervision-sweep-program-design.md`)
+/// rather than to this loader. Modeling it as preserved JSON means a rewrite
+/// after an unrelated edit cannot drop a key this version does not know about,
+/// and it keeps this file from inventing fields it does not own.
+public enum SupervisionJSONValue: Codable, Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case integer(Int)
+    case number(Double)
+    case string(String)
+    case array([SupervisionJSONValue])
+    case object([String: SupervisionJSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null; return }
+        if let value = try? container.decode(Bool.self) { self = .bool(value); return }
+        if let value = try? container.decode(Int.self) { self = .integer(value); return }
+        if let value = try? container.decode(Double.self) { self = .number(value); return }
+        if let value = try? container.decode(String.self) { self = .string(value); return }
+        if let value = try? container.decode([SupervisionJSONValue].self) { self = .array(value); return }
+        if let value = try? container.decode([String: SupervisionJSONValue].self) {
+            self = .object(value)
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            in: container, debugDescription: "unsupported JSON value")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let value): try container.encode(value)
+        case .integer(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+
+    /// The value as a string, when it is one.
+    public var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+}
+
+// MARK: - Policy source
+
+/// Which playbook a project's supervisor stands on: a member repo's
+/// `.agents/supervision.md`, or the operator-level file beside the project's
+/// definition. Encodes as `{"repo":"<repo-id>"}` or `{"operator":true}`.
+public enum SupervisionPolicySource: Codable, Sendable, Equatable {
+    case repo(UUID)
+    case `operator`
+
+    private enum CodingKeys: String, CodingKey {
+        case repo
+        case `operator`
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let repo = try container.decodeIfPresent(UUID.self, forKey: .repo) {
+            self = .repo(repo)
+            return
+        }
+        if let isOperator = try container.decodeIfPresent(Bool.self, forKey: .operator) {
+            guard isOperator else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .operator, in: container,
+                    debugDescription: "a policy of {\"operator\": false} names no policy source")
+            }
+            self = .operator
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            forKey: .repo, in: container,
+            debugDescription: "a policy must be {\"repo\": \"<repo-id>\"} or {\"operator\": true}")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .repo(let id): try container.encode(id, forKey: .repo)
+        case .operator: try container.encode(true, forKey: .operator)
+        }
+    }
+}
+
+// MARK: - Sweep selection
+
+/// A project's sweep selection — the schedule, the declared contact window, and
+/// the custom-program pointer. Preserved verbatim (see `SupervisionJSONValue`);
+/// this slice reads only `script` and writes nothing.
+public struct SupervisionSweepSelection: Codable, Sendable, Equatable {
+    public var fields: [String: SupervisionJSONValue]
+
+    public init(fields: [String: SupervisionJSONValue]) { self.fields = fields }
+
+    /// The project's own sweep program, when the "Customize sweep…" gesture has
+    /// pointed at one.
+    public var script: String? { fields["script"]?.stringValue }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        fields = try container.decode([String: SupervisionJSONValue].self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(fields)
+    }
+}
+
+// MARK: - Supervisor binding
+
+/// The operator-appointed supervisor for a project: the TBD-managed terminal
+/// bound into the role. Absence means the shipped default, the hosted desk.
+///
+/// The terminal is held as a string rather than a `UUID` deliberately. A
+/// binding is made real by the appointment relaunch, not by the registry write,
+/// so a hand-edited binding — including one naming something that is not a
+/// terminal id at all — is an anomaly for the daemon to report, never a reason
+/// to reject the whole file and take supervision offline.
+public struct SupervisionSupervisorBinding: Codable, Sendable, Equatable {
+    public var terminal: String
+
+    public init(terminal: String) { self.terminal = terminal }
+    public init(terminalID: UUID) { self.terminal = terminalID.uuidString }
+
+    /// The bound terminal as an id, or nil when the binding does not name one.
+    public var terminalID: UUID? { UUID(uuidString: terminal) }
+}
+
+// MARK: - Mode entry
+
+/// A project's entry in `modes`: the declared mode names an operator may
+/// select, and the selection among them.
+///
+/// Polymorphic on the wire (design §8): a bare string is a selection against
+/// the built-in list, an object carries `declared` (complete when present) and
+/// `selected`. The shape a value arrived in is carried on the value and
+/// reproduced on rewrite, so an unrelated edit never rewrites an operator's
+/// bare `"autonomous"` into an object.
+public struct SupervisionModeEntry: Codable, Sendable, Equatable {
+    /// The two shapes design §8 gives this value.
+    public enum WireShape: Sendable, Equatable {
+        /// `"autonomous"` — a selection against the built-in list.
+        case bareSelection
+        /// `{"selected": …, "declared": […]}`.
+        case object
+    }
+
+    /// The names an operator may select for this project, or nil when the entry
+    /// declares none and the built-in pair stands.
+    public let declared: [String]?
+    /// The operator's selection, or nil when the entry carries none and the
+    /// default stands.
+    public let selected: String?
+    public let wireShape: WireShape
+
+    /// The two modes the shipped playbook defines, available to every project
+    /// without authoring anything (design §3, §8).
+    public static let builtInModes = ["attended", "autonomous"]
+    /// The selection when an entry names none (design §8).
+    public static let defaultMode = "attended"
+
+    private init(declared: [String]?, selected: String?, wireShape: WireShape) {
+        self.declared = declared
+        self.selected = selected
+        self.wireShape = wireShape
+    }
+
+    /// A bare selection against the built-in list — the common case.
+    public static func bare(_ selected: String) -> SupervisionModeEntry {
+        SupervisionModeEntry(declared: nil, selected: selected, wireShape: .bareSelection)
+    }
+
+    /// An object entry. Either half may be absent; the defaults chain fills it.
+    public static func declaring(
+        declared: [String]? = nil, selected: String? = nil
+    ) -> SupervisionModeEntry {
+        SupervisionModeEntry(declared: declared, selected: selected, wireShape: .object)
+    }
+
+    /// The names selectable for this project — the declared list when present,
+    /// the built-in pair when absent.
+    public var declaredModes: [String] { declared ?? Self.builtInModes }
+
+    /// The project's active mode — the selection when present, `attended` when
+    /// absent.
+    public var activeMode: String { selected ?? Self.defaultMode }
+
+    /// The same entry with a different selection, keeping the wire shape a bare
+    /// entry arrived in.
+    public func selecting(_ mode: String) -> SupervisionModeEntry {
+        SupervisionModeEntry(declared: declared, selected: mode, wireShape: wireShape)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case selected
+        case declared
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(), let name = try? single.decode(String.self) {
+            self = .bare(name)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        declared = try container.decodeIfPresent([String].self, forKey: .declared)
+        selected = try container.decodeIfPresent(String.self, forKey: .selected)
+        wireShape = .object
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch wireShape {
+        case .bareSelection:
+            var container = encoder.singleValueContainer()
+            try container.encode(activeMode)
+        case .object:
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(selected, forKey: .selected)
+            try container.encodeIfPresent(declared, forKey: .declared)
+        }
+    }
+}
+
+// MARK: - Project declaration
+
+/// One declared multi-repo project. Singletons are declared nowhere — see
+/// `SupervisionTopology.resolve(file:repos:)`.
+public struct SupervisionProjectDeclaration: Codable, Sendable, Equatable {
+    /// The member repos, in the order the operator declared them.
+    public var repos: [UUID]
+    /// The one playbook source the project designates.
+    public var policy: SupervisionPolicySource
+    /// The project's sweep selection, preserved verbatim.
+    public var sweep: SupervisionSweepSelection?
+
+    public init(repos: [UUID], policy: SupervisionPolicySource,
+                sweep: SupervisionSweepSelection? = nil) {
+        self.repos = repos
+        self.policy = policy
+        self.sweep = sweep
+    }
+}
+
+// MARK: - The file
+
+/// `~/tbd/supervision/supervision.json` — the operator's selections, and
+/// nothing a machine evaluates (design §8). Topology, the per-project marks,
+/// mode declarations and selections, supervisor bindings, sweep selection.
+///
+/// **Untouched and turned-off are one state.** A mark is membership in
+/// `supervised`; absence is off. There is no "never configured" third tier
+/// anywhere in this type, and an absent file loads as the value
+/// `SupervisionFile()` returns rather than as an error or an optional.
+public struct SupervisionFile: Codable, Sendable, Equatable {
+    /// The only version this build reads and writes.
+    public static let currentVersion = 1
+
+    public var version: Int
+    /// Declared multi-repo projects, keyed by project name. Absent or empty is
+    /// the normal state — an installation that groups nothing declares nothing.
+    public var projects: [String: SupervisionProjectDeclaration]
+    /// The projects turned on. Unknown names are kept verbatim (a project may
+    /// be declared later); they resolve to nothing.
+    public var supervised: [String]
+    public var modes: [String: SupervisionModeEntry]
+    public var supervisors: [String: SupervisionSupervisorBinding]
+
+    public init(version: Int = SupervisionFile.currentVersion,
+                projects: [String: SupervisionProjectDeclaration] = [:],
+                supervised: [String] = [],
+                modes: [String: SupervisionModeEntry] = [:],
+                supervisors: [String: SupervisionSupervisorBinding] = [:]) {
+        self.version = version
+        self.projects = projects
+        self.supervised = supervised
+        self.modes = modes
+        self.supervisors = supervisors
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case projects
+        case supervised
+        case modes
+        case supervisors
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? Self.currentVersion
+        projects = try container.decodeIfPresent(
+            [String: SupervisionProjectDeclaration].self, forKey: .projects) ?? [:]
+        supervised = try container.decodeIfPresent([String].self, forKey: .supervised) ?? []
+        modes = try container.decodeIfPresent(
+            [String: SupervisionModeEntry].self, forKey: .modes) ?? [:]
+        supervisors = try container.decodeIfPresent(
+            [String: SupervisionSupervisorBinding].self, forKey: .supervisors) ?? [:]
+    }
+
+    /// Empty collections are omitted, so a fleet that declared nothing keeps a
+    /// one-line file rather than accumulating empty scaffolding it never asked
+    /// for.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        if !projects.isEmpty { try container.encode(projects, forKey: .projects) }
+        if !supervised.isEmpty { try container.encode(supervised, forKey: .supervised) }
+        if !modes.isEmpty { try container.encode(modes, forKey: .modes) }
+        if !supervisors.isEmpty { try container.encode(supervisors, forKey: .supervisors) }
+    }
+
+    // MARK: Marks and modes
+
+    /// Whether the project's mark is set. Absent is off; there is no third
+    /// state to distinguish.
+    public func isMarked(_ project: String) -> Bool { supervised.contains(project) }
+
+    /// The same file with a project's mark set or cleared. Setting a mark that
+    /// already stands, or clearing one that does not, returns an equal value —
+    /// a no-op is not a decision, and callers use that to decline writing a
+    /// ledger line.
+    public func settingMark(_ project: String, on: Bool) -> SupervisionFile {
+        var copy = self
+        if on {
+            guard !copy.supervised.contains(project) else { return self }
+            copy.supervised.append(project)
+        } else {
+            guard copy.supervised.contains(project) else { return self }
+            copy.supervised.removeAll { $0 == project }
+        }
+        return copy
+    }
+
+    /// The declared mode names for a project, defaults chain applied.
+    public func declaredModes(for project: String) -> [String] {
+        modes[project]?.declaredModes ?? SupervisionModeEntry.builtInModes
+    }
+
+    /// A project's active mode, defaults chain applied.
+    public func activeMode(for project: String) -> String {
+        modes[project]?.activeMode ?? SupervisionModeEntry.defaultMode
+    }
+
+    /// The same file with a project's selection changed, keeping an existing
+    /// entry's wire shape. A project with no entry gains a bare one.
+    public func settingMode(_ project: String, to mode: String) -> SupervisionFile {
+        var copy = self
+        if let existing = modes[project] {
+            copy.modes[project] = existing.selecting(mode)
+        } else {
+            copy.modes[project] = .bare(mode)
+        }
+        return copy
+    }
+
+    // MARK: Validation
+
+    /// Rejects a file no consumer should act on, naming the offending repo,
+    /// project, or condition.
+    ///
+    /// Every rejection here is loud and whole-file: nothing is repaired and
+    /// nothing is partially loaded, because "every repo belongs to exactly one
+    /// project" is the property the whole grouping rests on (design §5, §8).
+    public func validate() throws {
+        guard version == Self.currentVersion else {
+            throw SupervisionFileError.unsupportedVersion(
+                found: version, supported: Self.currentVersion)
+        }
+
+        var ownerOfRepo: [UUID: String] = [:]
+        for name in projects.keys.sorted() {
+            guard let declaration = projects[name] else { continue }
+            guard Self.isSafeProjectName(name) else {
+                throw SupervisionFileError.invalidProjectName(project: name)
+            }
+            guard !declaration.repos.isEmpty else {
+                throw SupervisionFileError.projectHasNoRepos(project: name)
+            }
+            var seenHere: Set<UUID> = []
+            for repo in declaration.repos {
+                guard seenHere.insert(repo).inserted else {
+                    throw SupervisionFileError.repoListedTwice(repo: repo, project: name)
+                }
+                if let owner = ownerOfRepo[repo], owner != name {
+                    let (first, second) = owner < name ? (owner, name) : (name, owner)
+                    throw SupervisionFileError.repoInTwoProjects(
+                        repo: repo, first: first, second: second)
+                }
+                ownerOfRepo[repo] = name
+            }
+            if case .repo(let policyRepo) = declaration.policy,
+               !declaration.repos.contains(policyRepo) {
+                throw SupervisionFileError.policyRepoNotAMember(
+                    project: name, repo: policyRepo)
+            }
+        }
+
+        for project in modes.keys.sorted() {
+            guard let entry = modes[project] else { continue }
+            if let declared = entry.declared, declared.isEmpty {
+                throw SupervisionFileError.emptyDeclaredModeList(project: project)
+            }
+            guard entry.declaredModes.contains(entry.activeMode) else {
+                throw SupervisionFileError.selectedModeNotDeclared(
+                    project: project, selected: entry.activeMode,
+                    declared: entry.declaredModes)
+            }
+        }
+    }
+
+    /// A declared project name has to be one safe path component: it names a
+    /// directory under `~/tbd/supervision/projects/` holding the project's
+    /// playbook, journal, and programs.
+    public static func isSafeProjectName(_ name: String) -> Bool {
+        guard !name.isEmpty, name != ".", name != ".." else { return false }
+        guard !name.contains("/"), !name.contains("\0") else { return false }
+        guard !name.hasPrefix(" "), !name.hasSuffix(" ") else { return false }
+        return true
+    }
+}
+
+// MARK: - Errors
+
+/// Why a supervision file was refused. Every message names the offending repo,
+/// project, or condition — these reach a human on stderr.
+public enum SupervisionFileError: Error, Equatable, CustomStringConvertible, LocalizedError {
+    case unsupportedVersion(found: Int, supported: Int)
+    case repoInTwoProjects(repo: UUID, first: String, second: String)
+    case repoListedTwice(repo: UUID, project: String)
+    case policyRepoNotAMember(project: String, repo: UUID)
+    case projectHasNoRepos(project: String)
+    case invalidProjectName(project: String)
+    case emptyDeclaredModeList(project: String)
+    case selectedModeNotDeclared(project: String, selected: String, declared: [String])
+    case malformed(path: String, detail: String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedVersion(let found, let supported):
+            return "The supervision file is version \(found); this build reads version \(supported)."
+        case .repoInTwoProjects(let repo, let first, let second):
+            return "Repo \(repo.uuidString) is a member of both \"\(first)\" and \"\(second)\". "
+                + "Every repo belongs to exactly one project, so the supervision file was rejected "
+                + "whole; move the repo with \"tbd supervise project move\" or remove one membership by hand."
+        case .repoListedTwice(let repo, let project):
+            return "Repo \(repo.uuidString) is listed twice in project \"\(project)\"."
+        case .policyRepoNotAMember(let project, let repo):
+            return "Project \"\(project)\" designates repo \(repo.uuidString) as its policy source, "
+                + "but that repo is not one of its members."
+        case .projectHasNoRepos(let project):
+            return "Project \"\(project)\" declares no member repos."
+        case .invalidProjectName(let project):
+            return "Project name \"\(project)\" is not usable: a name must be a single path "
+                + "component with no slashes and no leading or trailing spaces."
+        case .emptyDeclaredModeList(let project):
+            return "Project \"\(project)\" declares an empty mode list, so no mode could be selected."
+        case .selectedModeNotDeclared(let project, let selected, let declared):
+            return "Project \"\(project)\" selects mode \"\(selected)\", which is not one of its "
+                + "declared modes (\(declared.joined(separator: ", ")))."
+        case .malformed(let path, let detail):
+            return "The supervision file at \(path) could not be read: \(detail)"
+        }
+    }
+
+    public var errorDescription: String? { description }
+}

--- a/Sources/TBDShared/Supervision/SupervisionFile.swift
+++ b/Sources/TBDShared/Supervision/SupervisionFile.swift
@@ -488,14 +488,18 @@ public struct SupervisionFile: Codable, Sendable, Equatable {
         }
     }
 
-    /// A declared project name has to be one safe path component: it names a
-    /// directory under `~/tbd/supervision/projects/` holding the project's
-    /// playbook, journal, and programs.
+    /// Whether a project name can be one path component — the name of the
+    /// directory under `~/tbd/supervision/projects/` that holds the project's
+    /// playbook, journal, proposals, and programs.
+    ///
+    /// Deliberately a path-safety test and nothing more. A singleton project is
+    /// named by its repo's display name, so anything this rejects is a repo an
+    /// operator cannot give a supervision directory; an over-tight rule would
+    /// start refusing ordinary names for taste. Spaces, dots inside the name,
+    /// leading dots, and non-ASCII are all fine.
     public static func isSafeProjectName(_ name: String) -> Bool {
         guard !name.isEmpty, name != ".", name != ".." else { return false }
-        guard !name.contains("/"), !name.contains("\0") else { return false }
-        guard !name.hasPrefix(" "), !name.hasSuffix(" ") else { return false }
-        return true
+        return !name.contains("/") && !name.contains("\0")
     }
 }
 

--- a/Sources/TBDShared/Supervision/SupervisionFile.swift
+++ b/Sources/TBDShared/Supervision/SupervisionFile.swift
@@ -67,13 +67,21 @@ public struct SupervisionInstant: Codable, Sendable, Equatable, Hashable, Compar
 
 // MARK: - Preserved JSON
 
-/// A JSON value carried through `supervision.json` verbatim.
+/// A JSON value carried through `supervision.json` as a *value*.
 ///
 /// Used for the per-project `sweep` selection, whose vocabulary belongs to the
 /// sweep program (`docs/specs/2026-08-01-fleet-supervision-sweep-program-design.md`)
-/// rather than to this loader. Modeling it as preserved JSON means a rewrite
-/// after an unrelated edit cannot drop a key this version does not know about,
-/// and it keeps this file from inventing fields it does not own.
+/// rather than to this loader. Modeling it this way means a rewrite after an
+/// unrelated edit cannot drop a key this version does not know about, and it
+/// keeps this file from inventing fields it does not own.
+///
+/// **What is preserved is the value, not the text.** Every key, every nesting,
+/// and every value survives a round trip; the *spelling* of a number does not,
+/// because `JSONDecoder` hands over a parsed `Int` or `Double` and the original
+/// token is gone by then. A hand-written `15.0` comes back as `15`, and `1e3`
+/// as `1000`. Those are the same JSON value to every consumer, so nothing a
+/// sweep program reads changes — but do not describe this type as byte-faithful,
+/// and do not use it where the literal text carries meaning.
 public enum SupervisionJSONValue: Codable, Sendable, Equatable {
     case null
     case bool(Bool)
@@ -165,8 +173,9 @@ public enum SupervisionPolicySource: Codable, Sendable, Equatable {
 // MARK: - Sweep selection
 
 /// A project's sweep selection — the schedule, the declared contact window, and
-/// the custom-program pointer. Preserved verbatim (see `SupervisionJSONValue`);
-/// this slice reads only `script` and writes nothing.
+/// the custom-program pointer. Carried through as values rather than as text
+/// (see `SupervisionJSONValue`), so no key is lost on rewrite; this slice reads
+/// only `script` and writes nothing.
 public struct SupervisionSweepSelection: Codable, Sendable, Equatable {
     public var fields: [String: SupervisionJSONValue]
 
@@ -453,6 +462,13 @@ public struct SupervisionFile: Codable, Sendable, Equatable {
             guard Self.isSafeProjectName(name) else {
                 throw SupervisionFileError.invalidProjectName(project: name)
             }
+            // `--to singleton` resolves the word before it looks for a project,
+            // so a declared project of that name could be created and then
+            // never targeted. Refusing the name is what keeps the sentinel
+            // safe.
+            guard name != SupervisionMoveTarget.singletonArgument else {
+                throw SupervisionFileError.reservedProjectName(project: name)
+            }
             guard !declaration.repos.isEmpty else {
                 throw SupervisionFileError.projectHasNoRepos(project: name)
             }
@@ -514,6 +530,7 @@ public enum SupervisionFileError: Error, Equatable, CustomStringConvertible, Loc
     case policyRepoNotAMember(project: String, repo: UUID)
     case projectHasNoRepos(project: String)
     case invalidProjectName(project: String)
+    case reservedProjectName(project: String)
     case emptyDeclaredModeList(project: String)
     case selectedModeNotDeclared(project: String, selected: String, declared: [String])
     case malformed(path: String, detail: String)
@@ -534,8 +551,12 @@ public enum SupervisionFileError: Error, Equatable, CustomStringConvertible, Loc
         case .projectHasNoRepos(let project):
             return "Project \"\(project)\" declares no member repos."
         case .invalidProjectName(let project):
-            return "Project name \"\(project)\" is not usable: a name must be a single path "
-                + "component with no slashes and no leading or trailing spaces."
+            return "Project name \"\(project)\" is not usable: a name must be one path "
+                + "component — not empty, not \".\" or \"..\", and containing no \"/\"."
+        case .reservedProjectName(let project):
+            return "Project name \"\(project)\" is reserved: it is the word "
+                + "\"tbd supervise project move --to\" takes to mean \"back to being its own "
+                + "project\", so a project of that name could never be a move destination."
         case .emptyDeclaredModeList(let project):
             return "Project \"\(project)\" declares an empty mode list, so no mode could be selected."
         case .selectedModeNotDeclared(let project, let selected, let declared):

--- a/Sources/TBDShared/Supervision/SupervisionFileStore.swift
+++ b/Sources/TBDShared/Supervision/SupervisionFileStore.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Reads and writes `supervision.json`.
+///
+/// The store holds the file URL it was given. There is deliberately **no static
+/// helper that builds its own path**: a static twin added "for convenience"
+/// makes every caller's injected seam decorative, which is exactly how a test
+/// suite ends up writing into the developer's real `~/tbd` (root `CLAUDE.md`,
+/// "Tests must not touch ~/tbd"). Path resolution happens once, in
+/// `init(environment:)`, through `TBDConstants`.
+public struct SupervisionFileStore: Sendable {
+    public let fileURL: URL
+
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// Resolves `~/tbd/supervision/supervision.json` through `TBDConstants`,
+    /// honoring `TBD_HOME`.
+    public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.init(fileURL: URL(
+            fileURLWithPath: TBDConstants.supervisionFilePath(environment: environment)))
+    }
+
+    /// The directory the file and its write-temp live in.
+    public var directoryURL: URL { fileURL.deletingLastPathComponent() }
+
+    // MARK: - Load
+
+    /// The operator's file, or the empty value when there is none.
+    ///
+    /// An absent file is not an error and not a distinguishable state: a fleet
+    /// that never touched supervision and a fleet that turned everything off
+    /// load as the same value.
+    public func load() throws -> SupervisionFile {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return SupervisionFile()
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch {
+            throw SupervisionFileError.malformed(
+                path: fileURL.path, detail: error.localizedDescription)
+        }
+        let file: SupervisionFile
+        do {
+            file = try JSONDecoder().decode(SupervisionFile.self, from: data)
+        } catch let error as DecodingError {
+            throw SupervisionFileError.malformed(
+                path: fileURL.path, detail: Self.describe(error))
+        }
+        try file.validate()
+        return file
+    }
+
+    // MARK: - Save
+
+    /// Writes the file atomically: a fresh temporary in the **same directory**,
+    /// then `rename(2)` over the target.
+    ///
+    /// Two consequences a caller may rely on. A crash mid-write leaves the
+    /// previous bytes in place — never a half-written file the loader would
+    /// reject on next start. And a file that would not load is refused before
+    /// anything touches the disk, so `save` can never produce a file `load`
+    /// rejects.
+    public func save(_ file: SupervisionFile) throws {
+        try file.validate()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(file)
+        data.append(0x0A)  // a trailing newline; this file is hand-edited
+
+        try FileManager.default.createDirectory(
+            at: directoryURL, withIntermediateDirectories: true)
+
+        let temporary = temporaryURL()
+        do {
+            try data.write(to: temporary)
+        } catch {
+            try? FileManager.default.removeItem(at: temporary)
+            throw error
+        }
+        guard rename(temporary.path, fileURL.path) == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            try? FileManager.default.removeItem(at: temporary)
+            throw POSIXError(code)
+        }
+    }
+
+    /// The write-temp for one save. Its directory is the target's directory:
+    /// `rename(2)` is atomic only within a filesystem, and a temp under
+    /// `/tmp` (or `NSTemporaryDirectory()`) can land on another volume, where
+    /// the "rename" degrades into a copy that a crash can tear in half.
+    func temporaryURL() -> URL {
+        directoryURL.appendingPathComponent(
+            ".\(fileURL.lastPathComponent).\(UUID().uuidString).tmp")
+    }
+
+    private static func describe(_ error: DecodingError) -> String {
+        switch error {
+        case .keyNotFound(let key, let context):
+            return "missing key \"\(key.stringValue)\" at \(path(of: context))"
+        case .typeMismatch(_, let context), .valueNotFound(_, let context),
+             .dataCorrupted(let context):
+            return "\(context.debugDescription) at \(path(of: context))"
+        @unknown default:
+            return error.localizedDescription
+        }
+    }
+
+    private static func path(of context: DecodingError.Context) -> String {
+        let joined = context.codingPath.map(\.stringValue).joined(separator: ".")
+        return joined.isEmpty ? "the top level" : joined
+    }
+}

--- a/Sources/TBDShared/Supervision/SupervisionFileStore.swift
+++ b/Sources/TBDShared/Supervision/SupervisionFileStore.swift
@@ -56,14 +56,23 @@ public struct SupervisionFileStore: Sendable {
 
     // MARK: - Save
 
-    /// Writes the file atomically: a fresh temporary in the **same directory**,
-    /// then `rename(2)` over the target.
+    /// Writes the file durably: a fresh temporary in the **same directory**,
+    /// flushed to the platter, then `rename(2)` over the target, then the
+    /// directory itself flushed.
     ///
-    /// Two consequences a caller may rely on. A crash mid-write leaves the
+    /// Three consequences a caller may rely on. A crash mid-write leaves the
     /// previous bytes in place — never a half-written file the loader would
-    /// reject on next start. And a file that would not load is refused before
-    /// anything touches the disk, so `save` can never produce a file `load`
-    /// rejects.
+    /// reject on next start. **Power loss** after the rename leaves either the
+    /// previous file or the complete new one, never an empty file where the
+    /// topology used to be: `rename(2)` orders the metadata, but only the two
+    /// `fsync`s order the *data*, and without them the renamed file can surface
+    /// with its blocks unwritten. And a file that would not load is refused
+    /// before anything touches the disk, so `save` can never produce a file
+    /// `load` rejects.
+    ///
+    /// The cost is two `fsync`s per operator gesture — `on`, `off`, `mode`, a
+    /// project mutation. Nothing writes this file in a loop, and losing it
+    /// silently loses the fleet's topology and every mark with it.
     public func save(_ file: SupervisionFile) throws {
         try file.validate()
 
@@ -77,15 +86,35 @@ public struct SupervisionFileStore: Sendable {
 
         let temporary = temporaryURL()
         do {
-            try data.write(to: temporary)
+            guard FileManager.default.createFile(atPath: temporary.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            let handle = try FileHandle(forWritingTo: temporary)
+            do {
+                try handle.write(contentsOf: data)
+                try handle.synchronize()  // the bytes, before the name points at them
+                try handle.close()
+            } catch {
+                try? handle.close()
+                throw error
+            }
         } catch {
             try? FileManager.default.removeItem(at: temporary)
             throw error
         }
+
         guard rename(temporary.path, fileURL.path) == 0 else {
             let code = POSIXErrorCode(rawValue: errno) ?? .EIO
             try? FileManager.default.removeItem(at: temporary)
             throw POSIXError(code)
+        }
+
+        // The rename itself is a directory change, and it needs flushing too —
+        // otherwise power loss can lose the new name and leave the old one.
+        let directory = open(directoryURL.path, O_RDONLY)
+        if directory >= 0 {
+            fsync(directory)
+            close(directory)
         }
     }
 

--- a/Sources/TBDShared/Supervision/SupervisionLedger.swift
+++ b/Sources/TBDShared/Supervision/SupervisionLedger.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+/// The kinds of line `ledger.jsonl` carries (design §6). This slice writes
+/// `lifecycle` only.
+public enum SupervisionLedgerKind: String, Codable, Sendable {
+    case lifecycle
+    case delivery
+    case enrollment
+    case anomaly
+}
+
+/// The lifecycle events a line can carry.
+public enum SupervisionLifecycleEvent: String, Codable, Sendable {
+    case projectOn
+    case projectOff
+    case brakeEngaged
+    case brakeReleased
+    case modeChanged
+}
+
+/// One agent inside a project's perimeter, as the `projectOn` roster snapshot
+/// records it. Mechanical facts only.
+public struct SupervisionRosterEntry: Codable, Sendable, Equatable {
+    public let worktree: UUID
+    public let terminal: UUID
+    public let repo: UUID
+    /// The project the agent's repo resolved to.
+    public let project: String
+    public let spawnSource: String
+    /// The agent's transcript, or null when TBD does not know it. Null is the
+    /// accurate answer; the key is always present.
+    public let transcriptPath: String?
+
+    public init(worktree: UUID, terminal: UUID, repo: UUID, project: String,
+                spawnSource: String, transcriptPath: String?) {
+        self.worktree = worktree
+        self.terminal = terminal
+        self.repo = repo
+        self.project = project
+        self.spawnSource = spawnSource
+        self.transcriptPath = transcriptPath
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case worktree, terminal, repo, project, spawnSource, transcriptPath
+    }
+
+    /// Written by hand because synthesized `Codable` *omits* a nil optional,
+    /// and an unknown transcript has to read as an explicit null: a missing key
+    /// leaves a reader guessing whether the field was unknown or the writer was
+    /// an older build.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(worktree, forKey: .worktree)
+        try container.encode(terminal, forKey: .terminal)
+        try container.encode(repo, forKey: .repo)
+        try container.encode(project, forKey: .project)
+        try container.encode(spawnSource, forKey: .spawnSource)
+        try container.encode(transcriptPath, forKey: .transcriptPath)
+    }
+}
+
+/// The coverage summary the line ending a span carries (design §6).
+///
+/// The counters are real fields fed by counters this slice never increments, so
+/// zero is accurate rather than fabricated. `spanStartedAt` is null when the
+/// record holds no `projectOn` to pair with — a daemon that was not running
+/// when the span opened cannot invent one.
+public struct SupervisionCoverageSummary: Codable, Sendable, Equatable {
+    public let spanStartedAt: SupervisionInstant?
+    public let spanEndedAt: SupervisionInstant
+    public let durationSeconds: Int?
+    public let sweepContacts: Int
+    public let briefingsDelivered: Int
+
+    public init(spanStartedAt: SupervisionInstant?, spanEndedAt: SupervisionInstant,
+                sweepContacts: Int, briefingsDelivered: Int) {
+        self.spanStartedAt = spanStartedAt
+        self.spanEndedAt = spanEndedAt
+        self.durationSeconds = spanStartedAt.map {
+            Int(spanEndedAt.date.timeIntervalSince($0.date).rounded())
+        }
+        self.sweepContacts = sweepContacts
+        self.briefingsDelivered = briefingsDelivered
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case spanStartedAt, spanEndedAt, durationSeconds, sweepContacts, briefingsDelivered
+    }
+
+    /// Explicit nulls, for the same reason as `SupervisionRosterEntry`: an
+    /// unpaired span says so rather than leaving the key out.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(spanStartedAt, forKey: .spanStartedAt)
+        try container.encode(spanEndedAt, forKey: .spanEndedAt)
+        try container.encode(durationSeconds, forKey: .durationSeconds)
+        try container.encode(sweepContacts, forKey: .sweepContacts)
+        try container.encode(briefingsDelivered, forKey: .briefingsDelivered)
+    }
+}
+
+/// What a lifecycle line carries beyond its envelope.
+public enum SupervisionLedgerPayload: Sendable, Equatable {
+    case projectOn(roster: [SupervisionRosterEntry])
+    case projectOff(coverage: SupervisionCoverageSummary)
+    case brakeEngaged
+    case brakeReleased
+    case modeChanged(from: String, to: String)
+
+    public var event: SupervisionLifecycleEvent {
+        switch self {
+        case .projectOn: return .projectOn
+        case .projectOff: return .projectOff
+        case .brakeEngaged: return .brakeEngaged
+        case .brakeReleased: return .brakeReleased
+        case .modeChanged: return .modeChanged
+        }
+    }
+}
+
+/// One line of `ledger.jsonl`: the envelope `{id, ts, mode, project, kind}`
+/// with the payload's fields beside it in the same object.
+///
+/// **A line is built by the factory for its event, never by a free-form
+/// initializer.** `project` and `mode` are null on the lines the daemon writes
+/// on its own behalf — the brake's — and null there is the accurate answer, not
+/// a gap. Making the brake factories take no project is what keeps a caller
+/// from synthesizing one onto a fleet-wide line.
+public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
+    /// An opaque unique id: a lowercased UUID with the dashes removed.
+    public let id: String
+    public let ts: SupervisionInstant
+    /// The project's active mode at write time; null on fleet-wide lines.
+    public let mode: String?
+    /// The acting project; null on fleet-wide lines.
+    public let project: String?
+    public let kind: SupervisionLedgerKind
+    public let payload: SupervisionLedgerPayload
+
+    private init(id: String, ts: SupervisionInstant, mode: String?, project: String?,
+                 kind: SupervisionLedgerKind, payload: SupervisionLedgerPayload) {
+        self.id = id
+        self.ts = ts
+        self.mode = mode
+        self.project = project
+        self.kind = kind
+        self.payload = payload
+    }
+
+    /// A fresh opaque line id.
+    public static func newID() -> String {
+        UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+    }
+
+    // MARK: Factories
+    //
+    // `at:` is required rather than defaulted so no call site can reach for
+    // `Date()` inline: persisted timestamps come from the writer's date seam.
+
+    public static func projectOn(
+        project: String, mode: String, roster: [SupervisionRosterEntry],
+        at date: Date, id: String = SupervisionLedgerLine.newID()
+    ) -> SupervisionLedgerLine {
+        SupervisionLedgerLine(
+            id: id, ts: SupervisionInstant(date), mode: mode, project: project,
+            kind: .lifecycle, payload: .projectOn(roster: roster))
+    }
+
+    public static func projectOff(
+        project: String, mode: String, coverage: SupervisionCoverageSummary,
+        at date: Date, id: String = SupervisionLedgerLine.newID()
+    ) -> SupervisionLedgerLine {
+        SupervisionLedgerLine(
+            id: id, ts: SupervisionInstant(date), mode: mode, project: project,
+            kind: .lifecycle, payload: .projectOff(coverage: coverage))
+    }
+
+    public static func modeChanged(
+        project: String, from: String, to: String,
+        at date: Date, id: String = SupervisionLedgerLine.newID()
+    ) -> SupervisionLedgerLine {
+        SupervisionLedgerLine(
+            id: id, ts: SupervisionInstant(date), mode: to, project: project,
+            kind: .lifecycle, payload: .modeChanged(from: from, to: to))
+    }
+
+    /// Fleet-wide: takes no project and no mode, because the brake has neither.
+    public static func brakeEngaged(
+        at date: Date, id: String = SupervisionLedgerLine.newID()
+    ) -> SupervisionLedgerLine {
+        SupervisionLedgerLine(
+            id: id, ts: SupervisionInstant(date), mode: nil, project: nil,
+            kind: .lifecycle, payload: .brakeEngaged)
+    }
+
+    /// Fleet-wide: takes no project and no mode, because the brake has neither.
+    public static func brakeReleased(
+        at date: Date, id: String = SupervisionLedgerLine.newID()
+    ) -> SupervisionLedgerLine {
+        SupervisionLedgerLine(
+            id: id, ts: SupervisionInstant(date), mode: nil, project: nil,
+            kind: .lifecycle, payload: .brakeReleased)
+    }
+
+    // MARK: Wire form
+
+    private enum CodingKeys: String, CodingKey {
+        case id, ts, mode, project, kind
+        case event, roster, coverage, from, to
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(ts, forKey: .ts)
+        // `encode`, not `encodeIfPresent`: a fleet-wide line says null rather
+        // than leaving the reader to guess why a key is missing.
+        try container.encode(mode, forKey: .mode)
+        try container.encode(project, forKey: .project)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(payload.event, forKey: .event)
+        switch payload {
+        case .projectOn(let roster):
+            try container.encode(roster, forKey: .roster)
+        case .projectOff(let coverage):
+            try container.encode(coverage, forKey: .coverage)
+        case .brakeEngaged, .brakeReleased:
+            break
+        case .modeChanged(let from, let to):
+            try container.encode(from, forKey: .from)
+            try container.encode(to, forKey: .to)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        ts = try container.decode(SupervisionInstant.self, forKey: .ts)
+        mode = try container.decodeIfPresent(String.self, forKey: .mode)
+        project = try container.decodeIfPresent(String.self, forKey: .project)
+        kind = try container.decode(SupervisionLedgerKind.self, forKey: .kind)
+        let event = try container.decode(SupervisionLifecycleEvent.self, forKey: .event)
+        switch event {
+        case .projectOn:
+            payload = .projectOn(
+                roster: try container.decodeIfPresent(
+                    [SupervisionRosterEntry].self, forKey: .roster) ?? [])
+        case .projectOff:
+            payload = .projectOff(
+                coverage: try container.decode(
+                    SupervisionCoverageSummary.self, forKey: .coverage))
+        case .brakeEngaged:
+            payload = .brakeEngaged
+        case .brakeReleased:
+            payload = .brakeReleased
+        case .modeChanged:
+            payload = .modeChanged(
+                from: try container.decode(String.self, forKey: .from),
+                to: try container.decode(String.self, forKey: .to))
+        }
+    }
+}

--- a/Sources/TBDShared/Supervision/SupervisionLedger.swift
+++ b/Sources/TBDShared/Supervision/SupervisionLedger.swift
@@ -107,14 +107,27 @@ public enum SupervisionLedgerPayload: Sendable, Equatable {
     case brakeEngaged
     case brakeReleased
     case modeChanged(from: String, to: String)
+    /// A line whose envelope this build understands and whose body it does
+    /// not — a `delivery`, `enrollment` or `anomaly` line, or a lifecycle event
+    /// a later build writes.
+    ///
+    /// **The record is append-only and documented, so a reader will meet lines
+    /// it did not write.** Failing to decode them would report a healthy record
+    /// as damaged — `Skipped N unreadable line(s)` on every boot, with real
+    /// corruption buried in the false alarm. The envelope (`id`, `ts`, `mode`,
+    /// `project`, `kind`) is still read, which is all a windowing or grouping
+    /// query needs; only the body is skipped.
+    case unrecognized
 
-    public var event: SupervisionLifecycleEvent {
+    /// The lifecycle event, or nil for a line this build does not model.
+    public var event: SupervisionLifecycleEvent? {
         switch self {
         case .projectOn: return .projectOn
         case .projectOff: return .projectOff
         case .brakeEngaged: return .brakeEngaged
         case .brakeReleased: return .brakeReleased
         case .modeChanged: return .modeChanged
+        case .unrecognized: return nil
         }
     }
 }
@@ -210,6 +223,11 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
         case event, roster, coverage, from, to
     }
 
+    /// Encoding a `.unrecognized` line throws rather than writing a line whose
+    /// body was never parsed: this build only ever writes lines it composed
+    /// itself, and re-emitting a half-understood one would silently truncate
+    /// somebody else's record. A reader that must reproduce such a line copies
+    /// its original bytes.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
@@ -219,20 +237,34 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
         try container.encode(mode, forKey: .mode)
         try container.encode(project, forKey: .project)
         try container.encode(kind, forKey: .kind)
-        try container.encode(payload.event, forKey: .event)
         switch payload {
         case .projectOn(let roster):
+            try container.encode(SupervisionLifecycleEvent.projectOn, forKey: .event)
             try container.encode(roster, forKey: .roster)
         case .projectOff(let coverage):
+            try container.encode(SupervisionLifecycleEvent.projectOff, forKey: .event)
             try container.encode(coverage, forKey: .coverage)
-        case .brakeEngaged, .brakeReleased:
-            break
+        case .brakeEngaged:
+            try container.encode(SupervisionLifecycleEvent.brakeEngaged, forKey: .event)
+        case .brakeReleased:
+            try container.encode(SupervisionLifecycleEvent.brakeReleased, forKey: .event)
         case .modeChanged(let from, let to):
+            try container.encode(SupervisionLifecycleEvent.modeChanged, forKey: .event)
             try container.encode(from, forKey: .from)
             try container.encode(to, forKey: .to)
+        case .unrecognized:
+            throw EncodingError.invalidValue(payload, EncodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "a ledger line this build did not parse cannot be re-encoded; "
+                    + "copy its original bytes instead"))
         }
     }
 
+    /// Reads the envelope first and the body only for the kinds and events this
+    /// build models. A `delivery`, `enrollment` or `anomaly` line — or a
+    /// lifecycle event added by a later build — decodes as `.unrecognized`
+    /// rather than throwing, because throwing would report an intact
+    /// append-only record as corrupt.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)
@@ -240,8 +272,13 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
         mode = try container.decodeIfPresent(String.self, forKey: .mode)
         project = try container.decodeIfPresent(String.self, forKey: .project)
         kind = try container.decode(SupervisionLedgerKind.self, forKey: .kind)
-        let event = try container.decode(SupervisionLifecycleEvent.self, forKey: .event)
-        switch event {
+
+        guard kind == .lifecycle else {
+            payload = .unrecognized
+            return
+        }
+        let name = try container.decodeIfPresent(String.self, forKey: .event)
+        switch name.flatMap(SupervisionLifecycleEvent.init(rawValue:)) {
         case .projectOn:
             payload = .projectOn(
                 roster: try container.decodeIfPresent(
@@ -258,6 +295,8 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
             payload = .modeChanged(
                 from: try container.decode(String.self, forKey: .from),
                 to: try container.decode(String.self, forKey: .to))
+        case nil:
+            payload = .unrecognized
         }
     }
 }

--- a/Sources/TBDShared/Supervision/SupervisionStatusFile.swift
+++ b/Sources/TBDShared/Supervision/SupervisionStatusFile.swift
@@ -10,12 +10,30 @@ public enum SupervisionBrakeState: String, Codable, Sendable {
 
 /// `~/tbd/supervision/status.json` — the out-of-band heartbeat (design §14).
 ///
-/// Written on a fixed cadence, atomically, **regardless of the brake**:
-/// observability is never withheld, and the watchdog's rule ("if any project
-/// claims to be effectively on and this file has not changed in about ten
-/// minutes, raise a notification") needs the file fresh enough to read
-/// "engaged". `writtenAt` changes every tick so that rule works on content as
-/// well as on mtime.
+/// Always written atomically, and `writtenAt` changes on every write, so a
+/// reader can work on content as well as on mtime and never sees a torn file.
+///
+/// **When it is written, in full — this is the whole contract a watchdog needs:**
+///
+/// - at daemon start, once;
+/// - at every fleet brake edge, before the timer below is armed or disarmed;
+/// - and then on a fixed cadence **only while the brake is released**.
+///
+/// **Staleness is therefore a liveness signal only while `brake` reads
+/// `released`.** Under an engaged brake the daemon runs no periodic write at
+/// all, and a file that has not changed for hours means the fleet is paused,
+/// not that the daemon is gone. Reading it the other way produces exactly the
+/// false alarm this arrangement exists to prevent.
+///
+/// That costs the watchdog nothing, because its rule is *if any project claims
+/// to be **effectively on** and this file has not changed in about ten minutes,
+/// raise a notification* — and effectively on means a project's `on` **and** a
+/// released `brake`. A file saying `engaged` claims nothing is effectively on,
+/// so it cannot trip the rule however old it is. The freshness requirement
+/// binds precisely when the timer runs.
+///
+/// The brake is the only switch over this: there is no separate flag, and
+/// nothing here writes before an operator has released it.
 public struct SupervisionStatusFile: Codable, Sendable, Equatable {
     public static let currentSchemaVersion = 1
 

--- a/Sources/TBDShared/Supervision/SupervisionStatusFile.swift
+++ b/Sources/TBDShared/Supervision/SupervisionStatusFile.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// The fleet brake: one bit, ANDed over every project's mark (design §3, §8).
+public enum SupervisionBrakeState: String, Codable, Sendable {
+    /// TBD's authority is paused. The shipped state.
+    case engaged
+    /// TBD may act, subject to each project's mark.
+    case released
+}
+
+/// `~/tbd/supervision/status.json` — the out-of-band heartbeat (design §14).
+///
+/// Written on a fixed cadence, atomically, **regardless of the brake**:
+/// observability is never withheld, and the watchdog's rule ("if any project
+/// claims to be effectively on and this file has not changed in about ten
+/// minutes, raise a notification") needs the file fresh enough to read
+/// "engaged". `writtenAt` changes every tick so that rule works on content as
+/// well as on mtime.
+public struct SupervisionStatusFile: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let writtenAt: SupervisionInstant
+    public let brake: SupervisionBrakeState
+    public let projects: [SupervisionStatusFileProject]
+
+    public init(writtenAt: SupervisionInstant, brake: SupervisionBrakeState,
+                projects: [SupervisionStatusFileProject],
+                schemaVersion: Int = SupervisionStatusFile.currentSchemaVersion) {
+        self.schemaVersion = schemaVersion
+        self.writtenAt = writtenAt
+        self.brake = brake
+        self.projects = projects
+    }
+}
+
+/// One project's line in the heartbeat.
+public struct SupervisionStatusFileProject: Codable, Sendable, Equatable {
+    public let name: String
+    /// The project's mark. Effectively on is this AND a released brake.
+    public let on: Bool
+    public let mode: String
+    /// When a sweep program last made contact, or null when it never has.
+    public let lastSweepContactAt: SupervisionInstant?
+
+    public init(name: String, on: Bool, mode: String,
+                lastSweepContactAt: SupervisionInstant?) {
+        self.name = name
+        self.on = on
+        self.mode = mode
+        self.lastSweepContactAt = lastSweepContactAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, on, mode, lastSweepContactAt
+    }
+
+    /// Explicit null for "never contacted": the watchdog reads this file
+    /// without the daemon's help, so a missing key would be one more thing for
+    /// it to guess about.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(on, forKey: .on)
+        try container.encode(mode, forKey: .mode)
+        try container.encode(lastSweepContactAt, forKey: .lastSweepContactAt)
+    }
+}

--- a/Sources/TBDShared/Supervision/SupervisionTopology.swift
+++ b/Sources/TBDShared/Supervision/SupervisionTopology.swift
@@ -121,10 +121,23 @@ public enum SupervisionMoveTarget: Sendable, Equatable {
     }
 }
 
+/// A display name two or more undeclared repos share, and the repos that share
+/// it. None of them resolves to a project until one is renamed or a declaration
+/// names them.
+public struct SupervisionAmbiguousRepoName: Sendable, Equatable {
+    public let name: String
+    /// The repos sharing the name, in a stable order.
+    public let repos: [UUID]
+
+    public init(name: String, repos: [UUID]) {
+        self.name = name
+        self.repos = repos
+    }
+}
+
 /// Why a topology operation was refused.
 public enum SupervisionTopologyError: Error, Equatable, CustomStringConvertible, LocalizedError {
     case projectNameCollidesWithRepo(project: String, repo: UUID, repoName: String)
-    case duplicateRepoName(name: String, repos: [UUID])
     case unknownRepo(repo: UUID)
     case unknownProject(project: String)
     case policySourceWouldLeaveProject(project: String, repo: UUID)
@@ -135,10 +148,6 @@ public enum SupervisionTopologyError: Error, Equatable, CustomStringConvertible,
             return "Declared project \"\(project)\" has the same name as repo \(repoName) "
                 + "(\(repo.uuidString)), which is not one of its members — that repo's own "
                 + "project would have the same name. Rename the project or move the repo into it."
-        case .duplicateRepoName(let name, let repos):
-            let ids = repos.map(\.uuidString).joined(separator: ", ")
-            return "Two repos are both named \"\(name)\" (\(ids)), so each would be its own "
-                + "project under the same name. Rename one, or declare a project for them."
         case .unknownRepo(let repo):
             return "There is no repo \(repo.uuidString)."
         case .unknownProject(let project):
@@ -163,35 +172,27 @@ public enum SupervisionTopology {
     /// can tell it from a one-repo declared project — its policy source is
     /// `.repo(thatRepo)`, precisely what such a declaration resolves to.
     ///
-    /// Reports rather than repairs: a name collision is refused whole and no
-    /// partial resolution is served.
+    /// **A declared** name that collides is refused whole, and no partial
+    /// resolution is served: that name is the operator's own edit, in a file
+    /// they can fix. An **undeclared** repo whose display name is not unique is
+    /// reported instead — see `ambiguousRepoNames(file:repos:)`.
     public static func resolve(
         file: SupervisionFile, repos: [SupervisionRepo]
     ) throws -> [SupervisionProject] {
         try file.validate()
 
-        var declaredOwner: [UUID: String] = [:]
-        for (name, declaration) in file.projects {
-            for repo in declaration.repos { declaredOwner[repo] = name }
-        }
+        let declaredOwner = declaredOwners(file: file)
+        let implicitOwner = implicitOwners(file: file, repos: repos)
 
-        // Implicit names first, so a collision is reported before anything is
+        // The declared collision first, so it is reported before anything is
         // built.
-        var implicitOwner: [String: [UUID]] = [:]
-        for repo in repos where declaredOwner[repo.id] == nil {
-            implicitOwner[repo.name, default: []].append(repo.id)
-        }
         for name in implicitOwner.keys.sorted() {
-            let owners = implicitOwner[name] ?? []
-            if owners.count > 1 {
-                throw SupervisionTopologyError.duplicateRepoName(
-                    name: name, repos: owners.sorted { $0.uuidString < $1.uuidString })
-            }
-            if file.projects[name] != nil, let repo = owners.first {
+            if file.projects[name] != nil, let repo = implicitOwner[name]?.first {
                 throw SupervisionTopologyError.projectNameCollidesWithRepo(
                     project: name, repo: repo, repoName: name)
             }
         }
+        let ambiguous = Set(implicitOwner.filter { $0.value.count > 1 }.keys)
 
         var projects: [SupervisionProject] = []
         for (name, declaration) in file.projects {
@@ -199,12 +200,59 @@ public enum SupervisionTopology {
                 named: name, repos: declaration.repos, policy: declaration.policy,
                 sweep: declaration.sweep, file: file))
         }
-        for repo in repos where declaredOwner[repo.id] == nil {
+        for repo in repos
+        where declaredOwner[repo.id] == nil && !ambiguous.contains(repo.name) {
             projects.append(project(
                 named: repo.name, repos: [repo.id], policy: .repo(repo.id),
                 sweep: nil, file: file))
         }
         return projects.sorted { $0.name < $1.name }
+    }
+
+    /// The display names shared by two or more repos that no declaration
+    /// names, each with its repos, sorted.
+    ///
+    /// Those repos resolve to **no project**: a project is identified by its
+    /// name, so two candidates for one name identify nothing. The rest of the
+    /// fleet resolves normally, which is the whole point — display names carry
+    /// no uniqueness constraint anywhere in TBD (`RepoStore.addRepo` defaults
+    /// to the path's last component and rename accepts anything), so two
+    /// clones of `api` under different parents is an ordinary state, and it
+    /// must not take `status`, `project list`, every mark and mode gesture, and
+    /// the `status.json` heartbeat down together. A fleet whose heartbeat stops
+    /// is indistinguishable from a dead daemon to the watchdog, which is the
+    /// one distinction that file exists to draw.
+    ///
+    /// Reported as `SupervisionWarningCode.ambiguousRepoName`. The operator's
+    /// fix is to rename one repo, or to declare a project naming them.
+    public static func ambiguousRepoNames(
+        file: SupervisionFile, repos: [SupervisionRepo]
+    ) -> [SupervisionAmbiguousRepoName] {
+        implicitOwners(file: file, repos: repos)
+            .filter { $0.value.count > 1 }
+            .map { SupervisionAmbiguousRepoName(name: $0.key, repos: $0.value) }
+            .sorted { $0.name < $1.name }
+    }
+
+    private static func declaredOwners(file: SupervisionFile) -> [UUID: String] {
+        var owners: [UUID: String] = [:]
+        for (name, declaration) in file.projects {
+            for repo in declaration.repos { owners[repo] = name }
+        }
+        return owners
+    }
+
+    /// Repos no declaration names, grouped by the project name they would take,
+    /// each group in a stable order.
+    private static func implicitOwners(
+        file: SupervisionFile, repos: [SupervisionRepo]
+    ) -> [String: [UUID]] {
+        let declaredOwner = declaredOwners(file: file)
+        var implicitOwner: [String: [UUID]] = [:]
+        for repo in repos where declaredOwner[repo.id] == nil {
+            implicitOwner[repo.name, default: []].append(repo.id)
+        }
+        return implicitOwner.mapValues { $0.sorted { $0.uuidString < $1.uuidString } }
     }
 
     /// The resolved projects that cannot have a directory of their own, by

--- a/Sources/TBDShared/Supervision/SupervisionTopology.swift
+++ b/Sources/TBDShared/Supervision/SupervisionTopology.swift
@@ -68,6 +68,22 @@ public struct SupervisionProject: Sendable, Equatable, Identifiable {
 
     public var id: String { name }
 
+    /// Whether this project can have a directory of its own under
+    /// `~/tbd/supervision/projects/` — where its playbook, journal, proposals,
+    /// and programs would live.
+    ///
+    /// False only for a name that is not one path component. Resolution keeps
+    /// such a project whole: it has its mark, its mode, and its line in the
+    /// readout, and only the directory is unavailable until the repo is
+    /// renamed. Refusing to resolve it would take the whole fleet's coverage
+    /// offline over one repo's display name, in a file the operator never
+    /// edited.
+    ///
+    /// This is a function of the name and nothing else, so a declared project
+    /// and a singleton with the same name answer identically: a validity
+    /// condition, not a declared-ness flag.
+    public var hasUsableDirectory: Bool { SupervisionFile.isSafeProjectName(name) }
+
     public init(name: String, repos: [UUID], policy: SupervisionPolicySource,
                 sweep: SupervisionSweepSelection?, mark: Bool,
                 declaredModes: [String], activeMode: String,
@@ -189,6 +205,17 @@ public enum SupervisionTopology {
                 sweep: nil, file: file))
         }
         return projects.sorted { $0.name < $1.name }
+    }
+
+    /// The resolved projects that cannot have a directory of their own, by
+    /// name, sorted. What the daemon reports as
+    /// `SupervisionWarningCode.unusableProjectName`: the projects are supervised
+    /// like any other, but nothing can be written beside them until the repo is
+    /// renamed.
+    public static func projectsWithoutUsableDirectory(
+        in projects: [SupervisionProject]
+    ) -> [String] {
+        projects.filter { !$0.hasUsableDirectory }.map(\.name).sorted()
     }
 
     private static func project(

--- a/Sources/TBDShared/Supervision/SupervisionTopology.swift
+++ b/Sources/TBDShared/Supervision/SupervisionTopology.swift
@@ -1,0 +1,277 @@
+import Foundation
+
+/// A repo as project resolution sees it: an id and the display name a
+/// singleton project takes.
+public struct SupervisionRepo: Sendable, Equatable, Hashable, Identifiable {
+    public let id: UUID
+    public let name: String
+
+    public init(id: UUID, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    public init(_ repo: Repo) {
+        self.init(id: repo.id, name: repo.displayName)
+    }
+}
+
+/// The supervisor arrangement standing for a project: the shipped hosted desk,
+/// or a session the operator appointed.
+public struct SupervisionSupervisorArrangement: Codable, Sendable, Equatable {
+    public enum Kind: String, Codable, Sendable {
+        case hostedDesk
+        case appointed
+    }
+
+    public let kind: Kind
+    /// The bound terminal, when one is bound.
+    public let terminal: String?
+
+    public init(kind: Kind, terminal: String?) {
+        self.kind = kind
+        self.terminal = terminal
+    }
+
+    public static let hostedDesk = SupervisionSupervisorArrangement(
+        kind: .hostedDesk, terminal: nil)
+
+    public static func appointed(terminal: String) -> SupervisionSupervisorArrangement {
+        SupervisionSupervisorArrangement(kind: .appointed, terminal: terminal)
+    }
+}
+
+/// A resolved supervision project: one policy, one supervisor, one mark.
+///
+/// **There is no `isSingleton` or `isDeclared` field, and there never will be.**
+/// A repo declared nowhere is its own project, and the collapse is a property
+/// rather than a branch: a fresh install with no `supervision.json` and an
+/// install whose file declares one single-repo project per repo resolve to
+/// equal values, down to the policy source. Any consumer able to tell the two
+/// apart would be able to behave differently between them, which design §5
+/// calls a bug and not a feature.
+public struct SupervisionProject: Sendable, Equatable, Identifiable {
+    /// The project's name — the declared key, or the repo's display name for a
+    /// repo declared nowhere.
+    public let name: String
+    /// The member repos, in the order the topology gives them.
+    public let repos: [UUID]
+    /// Where this project's playbook comes from.
+    public let policy: SupervisionPolicySource
+    /// The project's sweep selection, when it has one.
+    public let sweep: SupervisionSweepSelection?
+    /// Whether the project's mark is set. Coverage, never protection (§8).
+    public let mark: Bool
+    public let declaredModes: [String]
+    public let activeMode: String
+    public let supervisor: SupervisionSupervisorArrangement
+
+    public var id: String { name }
+
+    public init(name: String, repos: [UUID], policy: SupervisionPolicySource,
+                sweep: SupervisionSweepSelection?, mark: Bool,
+                declaredModes: [String], activeMode: String,
+                supervisor: SupervisionSupervisorArrangement) {
+        self.name = name
+        self.repos = repos
+        self.policy = policy
+        self.sweep = sweep
+        self.mark = mark
+        self.declaredModes = declaredModes
+        self.activeMode = activeMode
+        self.supervisor = supervisor
+    }
+}
+
+/// Where a `move` puts a repo.
+public enum SupervisionMoveTarget: Sendable, Equatable {
+    case project(String)
+    /// Back to being its own project — the default arrangement.
+    case singleton
+
+    /// The word the CLI accepts for `--to singleton`.
+    public static let singletonArgument = "singleton"
+
+    /// Reads `--to <project|singleton>`.
+    public init(argument: String) {
+        self = argument == Self.singletonArgument ? .singleton : .project(argument)
+    }
+
+    public var argument: String {
+        switch self {
+        case .singleton: return Self.singletonArgument
+        case .project(let name): return name
+        }
+    }
+}
+
+/// Why a topology operation was refused.
+public enum SupervisionTopologyError: Error, Equatable, CustomStringConvertible, LocalizedError {
+    case projectNameCollidesWithRepo(project: String, repo: UUID, repoName: String)
+    case duplicateRepoName(name: String, repos: [UUID])
+    case unknownRepo(repo: UUID)
+    case unknownProject(project: String)
+    case policySourceWouldLeaveProject(project: String, repo: UUID)
+
+    public var description: String {
+        switch self {
+        case .projectNameCollidesWithRepo(let project, let repo, let repoName):
+            return "Declared project \"\(project)\" has the same name as repo \(repoName) "
+                + "(\(repo.uuidString)), which is not one of its members — that repo's own "
+                + "project would have the same name. Rename the project or move the repo into it."
+        case .duplicateRepoName(let name, let repos):
+            let ids = repos.map(\.uuidString).joined(separator: ", ")
+            return "Two repos are both named \"\(name)\" (\(ids)), so each would be its own "
+                + "project under the same name. Rename one, or declare a project for them."
+        case .unknownRepo(let repo):
+            return "There is no repo \(repo.uuidString)."
+        case .unknownProject(let project):
+            return "There is no declared project \"\(project)\"."
+        case .policySourceWouldLeaveProject(let project, let repo):
+            return "Repo \(repo.uuidString) is project \"\(project)\"'s policy source, so moving "
+                + "it out would leave the project with no playbook. Designate another member's "
+                + "policy first."
+        }
+    }
+
+    public var errorDescription: String? { description }
+}
+
+/// Project resolution and the one membership transform.
+public enum SupervisionTopology {
+
+    /// The full project set: the declared projects, plus one project per repo
+    /// that no declaration names.
+    ///
+    /// A singleton's implicit values are filled in so that nothing downstream
+    /// can tell it from a one-repo declared project — its policy source is
+    /// `.repo(thatRepo)`, precisely what such a declaration resolves to.
+    ///
+    /// Reports rather than repairs: a name collision is refused whole and no
+    /// partial resolution is served.
+    public static func resolve(
+        file: SupervisionFile, repos: [SupervisionRepo]
+    ) throws -> [SupervisionProject] {
+        try file.validate()
+
+        var declaredOwner: [UUID: String] = [:]
+        for (name, declaration) in file.projects {
+            for repo in declaration.repos { declaredOwner[repo] = name }
+        }
+
+        // Implicit names first, so a collision is reported before anything is
+        // built.
+        var implicitOwner: [String: [UUID]] = [:]
+        for repo in repos where declaredOwner[repo.id] == nil {
+            implicitOwner[repo.name, default: []].append(repo.id)
+        }
+        for name in implicitOwner.keys.sorted() {
+            let owners = implicitOwner[name] ?? []
+            if owners.count > 1 {
+                throw SupervisionTopologyError.duplicateRepoName(
+                    name: name, repos: owners.sorted { $0.uuidString < $1.uuidString })
+            }
+            if file.projects[name] != nil, let repo = owners.first {
+                throw SupervisionTopologyError.projectNameCollidesWithRepo(
+                    project: name, repo: repo, repoName: name)
+            }
+        }
+
+        var projects: [SupervisionProject] = []
+        for (name, declaration) in file.projects {
+            projects.append(project(
+                named: name, repos: declaration.repos, policy: declaration.policy,
+                sweep: declaration.sweep, file: file))
+        }
+        for repo in repos where declaredOwner[repo.id] == nil {
+            projects.append(project(
+                named: repo.name, repos: [repo.id], policy: .repo(repo.id),
+                sweep: nil, file: file))
+        }
+        return projects.sorted { $0.name < $1.name }
+    }
+
+    private static func project(
+        named name: String, repos: [UUID], policy: SupervisionPolicySource,
+        sweep: SupervisionSweepSelection?, file: SupervisionFile
+    ) -> SupervisionProject {
+        SupervisionProject(
+            name: name,
+            repos: repos,
+            policy: policy,
+            sweep: sweep,
+            mark: file.isMarked(name),
+            declaredModes: file.declaredModes(for: name),
+            activeMode: file.activeMode(for: name),
+            supervisor: file.supervisors[name].map { .appointed(terminal: $0.terminal) }
+                ?? .hostedDesk)
+    }
+
+    /// Moves a repo between projects, returning the new file.
+    ///
+    /// This is the only membership verb. There is deliberately no `add`/`remove`
+    /// pair: `remove` could leave a repo belonging to nothing and `add` could
+    /// put it in a second place, so the pair can express states the model
+    /// forbids while `move` cannot express them at all (design §5).
+    ///
+    /// - `--to singleton` takes the repo out of its declared project, and
+    ///   **deletes a declaration the move empties**, along with that vanished
+    ///   project's mark, mode entry, and supervisor binding. A stale mark left
+    ///   behind would silently turn a later project of the same name on without
+    ///   an operator gesture.
+    /// - Moving a repo that is a project's designated policy source out of a
+    ///   project that would survive is refused: the project would be left with
+    ///   no playbook.
+    /// - A move that changes nothing (already there, already singleton) returns
+    ///   an equal value.
+    ///
+    /// A move that cannot complete throws, and the input is untouched — this
+    /// takes the file by value and never mutates through the caller's copy.
+    public static func move(
+        repo: UUID, to target: SupervisionMoveTarget, in file: SupervisionFile,
+        repos: [SupervisionRepo]
+    ) throws -> SupervisionFile {
+        try file.validate()
+        guard repos.contains(where: { $0.id == repo }) else {
+            throw SupervisionTopologyError.unknownRepo(repo: repo)
+        }
+
+        let currentOwner = file.projects.first { $0.value.repos.contains(repo) }?.key
+
+        switch target {
+        case .project(let name):
+            guard file.projects[name] != nil else {
+                throw SupervisionTopologyError.unknownProject(project: name)
+            }
+            if currentOwner == name { return file }
+        case .singleton:
+            if currentOwner == nil { return file }
+        }
+
+        var updated = file
+        if let owner = currentOwner, var declaration = updated.projects[owner] {
+            let survives = declaration.repos.count > 1
+            if survives, case .repo(let policyRepo) = declaration.policy, policyRepo == repo {
+                throw SupervisionTopologyError.policySourceWouldLeaveProject(
+                    project: owner, repo: repo)
+            }
+            declaration.repos.removeAll { $0 == repo }
+            if declaration.repos.isEmpty {
+                updated.projects.removeValue(forKey: owner)
+                updated.supervised.removeAll { $0 == owner }
+                updated.modes.removeValue(forKey: owner)
+                updated.supervisors.removeValue(forKey: owner)
+            } else {
+                updated.projects[owner] = declaration
+            }
+        }
+
+        if case .project(let name) = target, var declaration = updated.projects[name] {
+            declaration.repos.append(repo)
+            updated.projects[name] = declaration
+        }
+
+        try updated.validate()
+        return updated
+    }
+}

--- a/Tests/TBDCLITests/SuperviseCommandParsingTests.swift
+++ b/Tests/TBDCLITests/SuperviseCommandParsingTests.swift
@@ -160,9 +160,22 @@ struct SuperviseArgumentValueTests {
     }
 
     @Test func reposRefusesAnEmptyList() {
-        for bad in ["", "   ", ",", " , "] {
+        for bad in ["", "   ", ",", " , ", "\n", "\t \n", ",\n,"] {
             #expect(throws: CLIError.self) { _ = try parseSupervisionRepoList(bad) }
         }
+    }
+
+    /// A shell-expanded `--repos "$(…)"` arrives with a trailing newline far
+    /// more often than with a trailing space.
+    @Test func reposStripsTrailingNewlinesFromShellExpandedValues() throws {
+        #expect(try parseSupervisionRepoList("acme-web\n") == ["acme-web"])
+        #expect(try parseSupervisionRepoList("acme-web,\nacme-api\n") == ["acme-web", "acme-api"])
+    }
+
+    @Test func policyToleratesAShellExpandedTrailingNewline() throws {
+        #expect(try parseSupervisionPolicy("operator\n") == .operator)
+        #expect(try parseSupervisionPolicy("repo:acme-web\n") == .repo("acme-web"))
+        #expect(throws: CLIError.self) { _ = try parseSupervisionPolicy("repo:\n") }
     }
 
     // MARK: to flag
@@ -191,9 +204,15 @@ struct SuperviseArgumentValueTests {
         #expect(try parseSupervisionMoveTarget(" singleton ") == .project(" singleton "))
     }
 
-    @Test func moveTargetRefusesAnEmptyDestination() {
+    /// The twin of `emptyProjectNameIsRefusedRatherThanReadAsTheBareForm`, and
+    /// it covers the newline for the same reason: `CharacterSet.whitespaces`
+    /// excludes newlines, so a guard written with it lets `"\t \n"` through as a
+    /// name. The two guards are one input class and must be proven together.
+    @Test func moveTargetRefusesAnEmptyDestinationIncludingNewlineOnlyWhitespace() {
         #expect(throws: CLIError.self) { _ = try parseSupervisionMoveTarget("") }
         #expect(throws: CLIError.self) { _ = try parseSupervisionMoveTarget("   ") }
+        #expect(throws: CLIError.self) { _ = try parseSupervisionMoveTarget("\n") }
+        #expect(throws: CLIError.self) { _ = try parseSupervisionMoveTarget("\t \n") }
     }
 
     // MARK: project names

--- a/Tests/TBDCLITests/SuperviseCommandParsingTests.swift
+++ b/Tests/TBDCLITests/SuperviseCommandParsingTests.swift
@@ -1,0 +1,196 @@
+import ArgumentParser
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDCLI
+
+@Suite("tbd supervise command registration and parsing")
+struct SuperviseCommandParsingTests {
+    // MARK: registration
+
+    @Test func groupIsRegisteredOnTheRootCommandUnderItsNormativeName() {
+        let names = TBDCommand.configuration.subcommands.map { $0._commandName }
+        #expect(names.contains("supervise"))
+        // The name is `supervise`, not `supervision` (design §10 is normative).
+        #expect(!names.contains("supervision"))
+        #expect(SuperviseCommand.configuration.commandName == "supervise")
+    }
+
+    @Test func groupRegistersEverySubcommand() {
+        let names = SuperviseCommand.configuration.subcommands.map { $0._commandName }
+        #expect(names.sorted() == ["mode", "off", "on", "project", "status"])
+    }
+
+    @Test func projectGroupRegistersOnlyTheRestrictedVocabulary() {
+        let names = SuperviseProject.configuration.subcommands.map { $0._commandName }
+        #expect(names.sorted() == ["create", "delete", "list", "move"])
+        // There is deliberately no add/remove pair: "every repo belongs to
+        // exactly one project" is enforced by having no verb for anything else.
+        #expect(!names.contains("add"))
+        #expect(!names.contains("remove"))
+    }
+
+    // MARK: on / off
+
+    @Test func bareOnAndOffParseWithNoProject() throws {
+        #expect(try SuperviseOn.parse([]).project == nil)
+        #expect(try SuperviseOff.parse([]).project == nil)
+    }
+
+    @Test func onAndOffParseAProjectArgument() throws {
+        #expect(try SuperviseOn.parse(["acme-checkout"]).project == "acme-checkout")
+        #expect(try SuperviseOff.parse(["acme-checkout"]).project == "acme-checkout")
+    }
+
+    @Test func rootRoutesBareOnAndProjectOnToTheSameCommand() throws {
+        let bare = try TBDCommand.parseAsRoot(["supervise", "on"])
+        #expect((bare as? SuperviseOn)?.project == nil)
+        let named = try TBDCommand.parseAsRoot(["supervise", "on", "acme-checkout"])
+        #expect((named as? SuperviseOn)?.project == "acme-checkout")
+        let off = try TBDCommand.parseAsRoot(["supervise", "off", "acme-checkout"])
+        #expect((off as? SuperviseOff)?.project == "acme-checkout")
+    }
+
+    // MARK: status
+
+    @Test func statusParsesBareAndWithJSONFlag() throws {
+        #expect(try SuperviseStatusCommand.parse([]).json == false)
+        #expect(try SuperviseStatusCommand.parse(["--json"]).json == true)
+        let root = try TBDCommand.parseAsRoot(["supervise", "status", "--json"])
+        #expect((root as? SuperviseStatusCommand)?.json == true)
+    }
+
+    // MARK: mode
+
+    @Test func modeParsesShowAndSelectForms() throws {
+        let show = try SuperviseMode.parse(["acme-checkout"])
+        #expect(show.project == "acme-checkout")
+        #expect(show.mode == nil)
+
+        let select = try SuperviseMode.parse(["acme-checkout", "autonomous"])
+        #expect(select.project == "acme-checkout")
+        #expect(select.mode == "autonomous")
+    }
+
+    @Test func modeRequiresAProject() {
+        #expect(throws: (any Error).self) { _ = try SuperviseMode.parse([]) }
+    }
+
+    // MARK: project
+
+    @Test func projectListParses() throws {
+        let root = try TBDCommand.parseAsRoot(["supervise", "project", "list"])
+        #expect(root is SuperviseProjectList)
+    }
+
+    @Test func projectCreateParsesReposAndPolicyFlags() throws {
+        let cmd = try SuperviseProjectCreate.parse([
+            "acme-platform", "--repos", "acme-web,acme-api", "--policy", "repo:acme-web",
+        ])
+        #expect(cmd.name == "acme-platform")
+        #expect(cmd.repos == "acme-web,acme-api")
+        #expect(cmd.policy == "repo:acme-web")
+    }
+
+    @Test func projectCreateRequiresBothFlags() {
+        #expect(throws: (any Error).self) {
+            _ = try SuperviseProjectCreate.parse(["acme-platform", "--repos", "acme-web"])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try SuperviseProjectCreate.parse(["acme-platform", "--policy", "operator"])
+        }
+    }
+
+    @Test func projectDeleteParsesAName() throws {
+        #expect(try SuperviseProjectDelete.parse(["acme-platform"]).name == "acme-platform")
+    }
+
+    @Test func projectMoveParsesRepoAndDestination() throws {
+        let cmd = try SuperviseProjectMove.parse(["acme-web", "--to", "acme-platform"])
+        #expect(cmd.repo == "acme-web")
+        #expect(cmd.to == "acme-platform")
+
+        let root = try TBDCommand.parseAsRoot([
+            "supervise", "project", "move", "acme-web", "--to", "singleton",
+        ])
+        #expect((root as? SuperviseProjectMove)?.to == "singleton")
+    }
+
+    @Test func projectMoveRequiresADestination() {
+        #expect(throws: (any Error).self) { _ = try SuperviseProjectMove.parse(["acme-web"]) }
+    }
+}
+
+@Suite("tbd supervise argument value parsing")
+struct SuperviseArgumentValueTests {
+    // MARK: policy flag
+
+    @Test func policyOperatorParses() throws {
+        #expect(try parseSupervisionPolicy("operator") == .operator)
+    }
+
+    @Test func policyRepoParsesTheIdentifierAsTyped() throws {
+        let id = UUID().uuidString
+        #expect(try parseSupervisionPolicy("repo:\(id)") == .repo(id))
+        #expect(try parseSupervisionPolicy("repo:acme-web") == .repo("acme-web"))
+    }
+
+    @Test func policyWithoutTheRepoPrefixIsRefusedNamingTheForms() {
+        for bad in ["acme-web", "", "repo:", "repo", "owner"] {
+            #expect(throws: CLIError.self) { _ = try parseSupervisionPolicy(bad) }
+        }
+        do {
+            _ = try parseSupervisionPolicy("acme-web")
+            Issue.record("expected a refusal")
+        } catch let error as CLIError {
+            #expect(error.description.contains("repo:<id>"))
+            #expect(error.description.contains("operator"))
+        } catch {
+            Issue.record("expected CLIError, got \(error)")
+        }
+    }
+
+    // MARK: repos flag
+
+    @Test func reposSplitsOnCommasAndTrims() throws {
+        #expect(try parseSupervisionRepoList("acme-web,acme-api") == ["acme-web", "acme-api"])
+        #expect(try parseSupervisionRepoList(" acme-web , acme-api ") == ["acme-web", "acme-api"])
+        #expect(try parseSupervisionRepoList("acme-web") == ["acme-web"])
+    }
+
+    @Test func reposRefusesAnEmptyList() {
+        for bad in ["", "   ", ",", " , "] {
+            #expect(throws: CLIError.self) { _ = try parseSupervisionRepoList(bad) }
+        }
+    }
+
+    // MARK: to flag
+
+    @Test func moveTargetReadsTheSingletonSentinel() throws {
+        #expect(try parseSupervisionMoveTarget("singleton") == .singleton)
+        #expect(try parseSupervisionMoveTarget(" singleton ") == .singleton)
+        #expect(SupervisionMoveTarget.singletonArgument == "singleton")
+    }
+
+    @Test func moveTargetReadsAProjectName() throws {
+        #expect(try parseSupervisionMoveTarget("acme-platform") == .project("acme-platform"))
+        // A project literally named `singleton` is unreachable by design — the
+        // word is the sentinel, and the round trip proves what gets sent.
+        #expect(try parseSupervisionMoveTarget("acme-platform").argument == "acme-platform")
+        #expect(try parseSupervisionMoveTarget("singleton").argument == "singleton")
+    }
+
+    @Test func moveTargetRefusesAnEmptyDestination() {
+        #expect(throws: CLIError.self) { _ = try parseSupervisionMoveTarget("") }
+        #expect(throws: CLIError.self) { _ = try parseSupervisionMoveTarget("   ") }
+    }
+
+    // MARK: project names
+
+    @Test func emptyProjectNameIsRefusedRatherThanReadAsTheBareForm() {
+        #expect(throws: CLIError.self) { _ = try requireSupervisionProjectName("") }
+        #expect(throws: CLIError.self) { _ = try requireSupervisionProjectName("   ") }
+        #expect((try? requireSupervisionProjectName(" acme-checkout ")) == "acme-checkout")
+    }
+}

--- a/Tests/TBDCLITests/SuperviseCommandParsingTests.swift
+++ b/Tests/TBDCLITests/SuperviseCommandParsingTests.swift
@@ -169,7 +169,6 @@ struct SuperviseArgumentValueTests {
 
     @Test func moveTargetReadsTheSingletonSentinel() throws {
         #expect(try parseSupervisionMoveTarget("singleton") == .singleton)
-        #expect(try parseSupervisionMoveTarget(" singleton ") == .singleton)
         #expect(SupervisionMoveTarget.singletonArgument == "singleton")
     }
 
@@ -179,6 +178,17 @@ struct SuperviseArgumentValueTests {
         // word is the sentinel, and the round trip proves what gets sent.
         #expect(try parseSupervisionMoveTarget("acme-platform").argument == "acme-platform")
         #expect(try parseSupervisionMoveTarget("singleton").argument == "singleton")
+    }
+
+    /// The destination is a project name, and a repo display name may carry
+    /// surrounding spaces — `isSafeProjectName` permits them. Trimming here
+    /// would make `" staging "` visible in `status` and unreachable by `move`.
+    @Test func moveTargetKeepsSurroundingSpacesSoSuchProjectsStayAddressable() throws {
+        #expect(try parseSupervisionMoveTarget(" staging ") == .project(" staging "))
+        #expect(try parseSupervisionMoveTarget(" staging ").argument == " staging ")
+        // Quoted spaces around the sentinel were typed deliberately, so they
+        // name a project rather than the sentinel.
+        #expect(try parseSupervisionMoveTarget(" singleton ") == .project(" singleton "))
     }
 
     @Test func moveTargetRefusesAnEmptyDestination() {
@@ -191,6 +201,17 @@ struct SuperviseArgumentValueTests {
     @Test func emptyProjectNameIsRefusedRatherThanReadAsTheBareForm() {
         #expect(throws: CLIError.self) { _ = try requireSupervisionProjectName("") }
         #expect(throws: CLIError.self) { _ = try requireSupervisionProjectName("   ") }
-        #expect((try? requireSupervisionProjectName(" acme-checkout ")) == "acme-checkout")
+        #expect(throws: CLIError.self) { _ = try requireSupervisionProjectName("\t \n") }
+    }
+
+    /// A singleton's name is its repo's display name, and `isSafeProjectName`
+    /// rejects only genuinely unsafe components — so `" api "` is a project the
+    /// operator can see in `status`. Trimming it here would send `api` and earn
+    /// an `unknownProject` refusal for a project plainly on screen.
+    @Test func projectNameReachesTheDaemonVerbatimIncludingSurroundingSpaces() throws {
+        #expect(try requireSupervisionProjectName(" api ") == " api ")
+        #expect(try requireSupervisionProjectName("acme-checkout") == "acme-checkout")
+        #expect(try requireSupervisionProjectName(" leading") == " leading")
+        #expect(try requireSupervisionProjectName("trailing ") == "trailing ")
     }
 }

--- a/Tests/TBDCLITests/SuperviseStatusRenderingTests.swift
+++ b/Tests/TBDCLITests/SuperviseStatusRenderingTests.swift
@@ -147,7 +147,7 @@ struct SupervisionStatusLoudCaseTests {
     /// supervision is running, and the only gesture that can create the state
     /// the warning describes — so bare `on` says it too.
     @Test func releasingTheBrakeOverNothingWarnsAtTheRelease() {
-        let lines = supervisionBrakeReleaseWarningLines(
+        let lines = supervisionGestureWarningLines(
             SuperviseFixture.status(
                 brake: .released, effectivelySupervising: false,
                 projects: [SuperviseFixture.project(name: "acme-checkout", on: false)]))
@@ -156,9 +156,38 @@ struct SupervisionStatusLoudCaseTests {
         #expect(lines.first?.contains("nothing is being supervised") == true)
     }
 
-    /// One fact, one sentence: `on` and `status` must not drift into two
-    /// wordings for the same condition.
-    @Test func theReleaseWarningIsTheSameCompositionStatusRenders() {
+    /// The mirror, and the worse of the two: the operator ran `on acme`, was
+    /// told `on: acme`, and nothing is watching it.
+    @Test func markingAProjectOnUnderAnEngagedBrakeSaysNothingIsWatching() {
+        let lines = supervisionGestureWarningLines(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false,
+                projects: [SuperviseFixture.project(name: "acme-checkout", on: true)]))
+        #expect(lines.count == 1)
+        #expect(lines.first?.contains("brake is engaged") == true)
+        #expect(lines.first?.contains("nothing is watching") == true)
+        #expect(lines.first?.contains("tbd supervise on") == true)
+        // Not the other half of the pair: these two states are both
+        // `effectivelySupervising == false` and call for opposite actions.
+        #expect(lines.first?.contains("no project is on") == false)
+    }
+
+    /// An engaged brake over a fleet with no marks is a deliberately quiet
+    /// system. Warning there would train an operator to ignore the line.
+    @Test func anEngagedBrakeWithNoMarksStandingIsQuiet() {
+        let lines = supervisionGestureWarningLines(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false,
+                projects: [
+                    SuperviseFixture.project(name: "acme-checkout", on: false),
+                    SuperviseFixture.project(name: "tbd", on: false),
+                ]))
+        #expect(lines.isEmpty)
+    }
+
+    /// One fact, one sentence: the gesture surfaces and `status` must not drift
+    /// into separate wordings for the same condition.
+    @Test func theGestureWarningIsTheSameCompositionStatusRenders() {
         for status in [
             SuperviseFixture.status(
                 brake: .released, effectivelySupervising: false, projects: []),
@@ -166,22 +195,52 @@ struct SupervisionStatusLoudCaseTests {
                 brake: .released, effectivelySupervising: false, projects: [],
                 warnings: [SupervisionWarning(code: .unusableProjectName, message: "")]),
             SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false,
+                projects: [SuperviseFixture.project(name: "acme", on: true)]),
+            SuperviseFixture.status(
                 brake: .released, effectivelySupervising: true,
                 projects: [SuperviseFixture.project(name: "acme", on: true)]),
         ] {
-            #expect(supervisionBrakeReleaseWarningLines(status)
+            #expect(supervisionGestureWarningLines(status)
                 == supervisionStatusWarningLines(status))
         }
     }
 
-    /// A release that covers something is quiet — the warning is a finding, not
+    /// A gesture that covers something is quiet — the warning is a finding, not
     /// a ceremony printed on every gesture.
     @Test func releasingTheBrakeOverASupervisedFleetIsQuiet() {
-        let lines = supervisionBrakeReleaseWarningLines(
+        let lines = supervisionGestureWarningLines(
             SuperviseFixture.status(
                 brake: .released, effectivelySupervising: true,
                 projects: [SuperviseFixture.project(name: "acme-checkout", on: true)]))
         #expect(lines.isEmpty)
+    }
+
+    /// The daemon's own line wins over the recomputed one — never both.
+    @Test func theDaemonsEngagedBrakeWarningIsNotDuplicatedByTheRecomputation() {
+        let lines = supervisionGestureWarningLines(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false,
+                projects: [SuperviseFixture.project(name: "acme", on: true)],
+                warnings: [
+                    SupervisionWarning(
+                        code: .brakeEngagedWithProjectsOn,
+                        message: "the brake is engaged; acme is marked on."),
+                ]))
+        #expect(lines == ["warning: the brake is engaged; acme is marked on."])
+    }
+
+    /// Two repos answering to one name resolve to nothing, so neither is
+    /// covered — a coverage loss, stated as one.
+    @Test func anAmbiguousRepoNameWarnsThatNeitherRepoIsSupervised() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme", on: true)],
+                warnings: [SupervisionWarning(code: .ambiguousRepoName, message: "")]))
+        #expect(text.contains("share a display name"))
+        #expect(text.contains("none is supervised"))
+        #expect(text.contains("Rename one"))
     }
 
     @Test func aSupervisedFleetGetsNoWarning() {

--- a/Tests/TBDCLITests/SuperviseStatusRenderingTests.swift
+++ b/Tests/TBDCLITests/SuperviseStatusRenderingTests.swift
@@ -1,0 +1,392 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDCLI
+
+private enum SuperviseFixtureError: Error {
+    case encodedStatusWasNotUTF8
+}
+
+/// Fixtures and the two shapes every assertion here is made against: the text a
+/// human reads, and the JSON a program branches on.
+private enum SuperviseFixture {
+    static let zone = TimeZone(identifier: "UTC")!
+    /// 2026-08-14T22:10:00Z — the rows below sit a few minutes on either side.
+    static let now = Date(timeIntervalSince1970: 1_786_745_400)
+
+    static func project(
+        name: String,
+        on: Bool,
+        mode: String = "attended",
+        declaredModes: [String] = ["attended", "autonomous"],
+        supervisor: SupervisionSupervisorArrangement = .hostedDesk,
+        spanStartedAt: Date? = nil,
+        lastSweepContactAt: Date? = nil,
+        coverageWindow: String? = nil
+    ) -> SupervisionStatusProject {
+        SupervisionStatusProject(
+            name: name, on: on, mode: mode, declaredModes: declaredModes,
+            supervisor: supervisor,
+            spanStartedAt: spanStartedAt.map { SupervisionInstant($0) },
+            lastSweepContactAt: lastSweepContactAt.map { SupervisionInstant($0) },
+            coverageWindow: coverageWindow)
+    }
+
+    static func status(
+        brake: SupervisionBrakeState,
+        effectivelySupervising: Bool,
+        projects: [SupervisionStatusProject],
+        warnings: [SupervisionWarning] = []
+    ) -> SupervisionStatus {
+        SupervisionStatus(
+            brake: brake, effectivelySupervising: effectivelySupervising,
+            projects: projects, warnings: warnings)
+    }
+
+    static func render(_ status: SupervisionStatus) -> String {
+        renderSupervisionStatus(status, now: now, timeZone: zone)
+    }
+
+    /// The `--json` form as a program sees it, encoded exactly the way
+    /// `printJSON` encodes it.
+    static func json(_ status: SupervisionStatus) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(status)
+        guard let text = String(bytes: data, encoding: .utf8) else {
+            throw SuperviseFixtureError.encodedStatusWasNotUTF8
+        }
+        return text
+    }
+}
+
+@Suite("tbd supervise status — the loud case")
+struct SupervisionStatusLoudCaseTests {
+    /// The property this whole design fears losing: a fleet switched on with
+    /// nothing marked on must not render a calm night.
+    @Test func fleetOnWithNoProjectOnSaysSoInWords() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false,
+                projects: [
+                    SuperviseFixture.project(name: "acme-checkout", on: false),
+                    SuperviseFixture.project(name: "tbd", on: false),
+                ]))
+        #expect(text.contains("brake: released"))
+        #expect(text.contains("warning:"))
+        #expect(text.contains("no project is on"))
+        #expect(text.contains("nothing is being supervised"))
+    }
+
+    @Test func fleetOnWithNoProjectsAtAllSaysSoToo() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false, projects: []))
+        #expect(text.contains("nothing is being supervised"))
+    }
+
+    /// The same fact as a field a program branches on.
+    @Test func jsonCarriesTheSameFactAsFields() throws {
+        let status = SuperviseFixture.status(
+            brake: .released, effectivelySupervising: false,
+            projects: [SuperviseFixture.project(name: "acme-checkout", on: false)],
+            warnings: [
+                SupervisionWarning(
+                    code: .noProjectsOn,
+                    message: "the brake is released but no project is on."),
+            ])
+        let json = try SuperviseFixture.json(status)
+        #expect(json.contains("\"schemaVersion\" : 1"))
+        #expect(json.contains("\"effectivelySupervising\" : false"))
+        #expect(json.contains("\"noProjectsOn\""))
+    }
+
+    @Test func daemonSuppliedWarningTextIsWhatGetsPrinted() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false, projects: [],
+                warnings: [
+                    SupervisionWarning(code: .noProjectsOn, message: "nobody is watching acme."),
+                ]))
+        #expect(text.contains("warning: nobody is watching acme."))
+        // The daemon's sentence replaces the built-in one rather than doubling it.
+        #expect(!text.contains("nothing is being supervised"))
+    }
+
+    /// A daemon that sends the code with no sentence must still be loud.
+    @Test func emptyWarningMessageFallsBackToTheBuiltInSentence() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false, projects: [],
+                warnings: [SupervisionWarning(code: .noProjectsOn, message: "   ")]))
+        #expect(text.contains("warning: the brake is released but no project is on"))
+    }
+
+    /// A project whose name cannot be a directory is still supervised — the
+    /// warning must say what is missing and how to fix it without reading as a
+    /// stopped fleet.
+    @Test func anUnusableProjectNameWarnsWithoutClaimingSupervisionStopped() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme/web", on: true)],
+                warnings: [SupervisionWarning(code: .unusableProjectName, message: "")]))
+        #expect(text.contains("warning:"))
+        #expect(text.contains("cannot be used as a directory name"))
+        #expect(text.contains("rename the repo"))
+        #expect(text.contains("supervised like any other project"))
+        #expect(!text.contains("nothing is being supervised"))
+        // The project keeps its row, its mark and its mode.
+        #expect(text.contains("acme/web"))
+        #expect(text.contains("mode attended"))
+    }
+
+    @Test func aSupervisedFleetGetsNoWarning() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme-checkout", on: true)]))
+        #expect(!text.contains("warning"))
+        #expect(!text.contains("nothing is being supervised"))
+    }
+
+    /// An engaged brake is a deliberately quiet fleet: the brake line already
+    /// says so, and warning on top of it would cry wolf on every paused fleet.
+    @Test func anEngagedBrakeWithNothingOnDoesNotWarn() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false,
+                projects: [SuperviseFixture.project(name: "acme-checkout", on: false)]))
+        #expect(text.contains("brake: engaged"))
+        #expect(!text.contains("warning"))
+    }
+}
+
+@Suite("tbd supervise status — rendered rows")
+struct SupervisionStatusRowRenderingTests {
+    @Test func bothBrakeBranchesRenderTheirOwnWord() {
+        let released = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme-checkout", on: true)]))
+        let engaged = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false,
+                projects: [SuperviseFixture.project(name: "acme-checkout", on: true)]))
+        #expect(released.hasPrefix("brake: released\n"))
+        #expect(engaged.hasPrefix("brake: engaged\n"))
+        #expect(released != engaged)
+    }
+
+    @Test func anOnProjectRendersItsSpanAndAnOffProjectDoesNot() throws {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [
+                    SuperviseFixture.project(
+                        name: "acme-checkout", on: true, mode: "autonomous",
+                        spanStartedAt: SuperviseFixture.now.addingTimeInterval(-6 * 60)),
+                    SuperviseFixture.project(name: "tbd", on: false),
+                ]))
+        #expect(text.contains("on since 22:04"))
+        #expect(text.contains("mode autonomous"))
+        let rows = text.split(separator: "\n").map(String.init)
+        let offRow = try #require(rows.first(where: { $0.hasPrefix("tbd") }))
+        #expect(offRow.contains("off"))
+        #expect(!offRow.contains("since"))
+    }
+
+    /// An untouched project and a turned-off one are the same state — there is
+    /// no third tier, so the record's leftover span must not leak one into the
+    /// rendering.
+    @Test func untouchedAndTurnedOffRenderIdentically() {
+        let untouched = SuperviseFixture.project(name: "acme", on: false)
+        let turnedOff = SuperviseFixture.project(
+            name: "acme", on: false,
+            spanStartedAt: SuperviseFixture.now.addingTimeInterval(-3600))
+        let a = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false, projects: [untouched]))
+        let b = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false, projects: [turnedOff]))
+        #expect(a == b)
+    }
+
+    @Test func markedOnAndMarkedOffRenderDifferently() {
+        let on = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme", on: true)]))
+        let off = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false,
+                projects: [SuperviseFixture.project(name: "acme", on: false)]))
+        #expect(on.contains("acme  on"))
+        #expect(off.contains("acme  off"))
+        #expect(on != off)
+    }
+
+    /// This slice fills none of these honestly, and says so rather than
+    /// printing a plausible-looking measurement.
+    @Test func unfilledFactsRenderAsTheirHonestNotYetValues() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme", on: true)]))
+        #expect(text.contains("supervisor: hosted desk"))
+        #expect(text.contains("last sweep contact: never"))
+        #expect(text.contains("coverage unknown"))
+    }
+
+    @Test func declaredFactsReplaceTheNotYetValuesWhenPresent() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [
+                    SuperviseFixture.project(
+                        name: "acme", on: true,
+                        supervisor: .appointed(terminal: "t42"),
+                        lastSweepContactAt: SuperviseFixture.now.addingTimeInterval(-120),
+                        coverageWindow: "22:00-08:00"),
+                ]))
+        #expect(text.contains("supervisor: appointed (t42)"))
+        #expect(text.contains("last sweep contact: 2m ago"))
+        #expect(text.contains("coverage 22:00-08:00"))
+        #expect(!text.contains("coverage unknown"))
+    }
+
+    @Test func rowsAlignOnTheWidestNameAndState() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false,
+                projects: [
+                    SuperviseFixture.project(name: "acme-checkout", on: false),
+                    SuperviseFixture.project(name: "tbd", on: false),
+                ]))
+        let rows = text.split(separator: "\n").map(String.init).filter { $0.contains("mode ") }
+        #expect(rows.count == 2)
+        let offsets = rows.compactMap { row in
+            row.range(of: "mode ").map { row.distance(from: row.startIndex, to: $0.lowerBound) }
+        }
+        #expect(offsets.count == 2)
+        #expect(offsets[0] == offsets[1])
+    }
+
+    @Test func anEmptyFleetSaysItHasNoProjects() {
+        let text = SuperviseFixture.render(
+            SuperviseFixture.status(
+                brake: .engaged, effectivelySupervising: false, projects: []))
+        #expect(text.contains("(no projects)"))
+    }
+
+    @Test func agesRenderInTheLargestWholeUnit() {
+        let now = SuperviseFixture.now
+        #expect(supervisionAge(from: now.addingTimeInterval(-30), to: now) == "30s ago")
+        #expect(supervisionAge(from: now.addingTimeInterval(-90), to: now) == "1m ago")
+        #expect(supervisionAge(from: now.addingTimeInterval(-7200), to: now) == "2h ago")
+        #expect(supervisionAge(from: now.addingTimeInterval(-3 * 86400), to: now) == "3d ago")
+        // A clock that ran backwards reads as "now", never as a negative age.
+        #expect(supervisionAge(from: now.addingTimeInterval(60), to: now) == "0s ago")
+    }
+}
+
+@Suite("tbd supervise mode and mark rendering")
+struct SupervisionModeRenderingTests {
+    @Test func aModeOutsideTheDeclaredListIsRefusedWithTheChoicesListed() throws {
+        let refusal = try #require(
+            supervisionModeRefusal(
+                project: "acme-checkout", requested: "turbo",
+                declared: ["attended", "autonomous"]))
+        #expect(refusal.contains("turbo"))
+        #expect(refusal.contains("not declared"))
+        #expect(refusal.contains("acme-checkout"))
+        #expect(refusal.contains("choices: attended, autonomous"))
+    }
+
+    @Test func aDeclaredModeIsNotRefused() {
+        #expect(
+            supervisionModeRefusal(
+                project: "acme", requested: "autonomous",
+                declared: ["attended", "autonomous"]) == nil)
+        #expect(
+            supervisionModeRefusal(
+                project: "acme", requested: "attended",
+                declared: ["attended", "autonomous"]) == nil)
+    }
+
+    @Test func aProjectDeclaringNoModesRefusesEveryNameAndSaysSo() throws {
+        let refusal = try #require(
+            supervisionModeRefusal(project: "acme", requested: "attended", declared: []))
+        #expect(refusal.contains("(none declared)"))
+    }
+
+    @Test func showFormPrintsTheActiveModeAndTheChoices() {
+        let text = renderSupervisionMode(
+            project: "acme", active: "attended", declared: ["attended", "autonomous"])
+        #expect(text.contains("acme"))
+        #expect(text.contains("is attended"))
+        #expect(text.contains("choices: attended, autonomous"))
+    }
+
+    @Test func selectionResultDistinguishesAChangeFromANoOp() {
+        let changed = renderSupervisionModeResult(
+            SuperviseSetModeResult(
+                project: "acme", mode: "autonomous",
+                declaredModes: ["attended", "autonomous"], changed: true))
+        let unchanged = renderSupervisionModeResult(
+            SuperviseSetModeResult(
+                project: "acme", mode: "autonomous",
+                declaredModes: ["attended", "autonomous"], changed: false))
+        #expect(changed.contains("is now autonomous"))
+        #expect(unchanged.contains("was already autonomous"))
+        #expect(changed != unchanged)
+    }
+
+    @Test func markResultRendersBothBranchesAndTheNoOp() {
+        let on = renderSupervisionMarkResult(
+            SuperviseSetProjectMarkResult(project: "acme", on: true, changed: true))
+        let off = renderSupervisionMarkResult(
+            SuperviseSetProjectMarkResult(project: "acme", on: false, changed: true))
+        let alreadyOn = renderSupervisionMarkResult(
+            SuperviseSetProjectMarkResult(project: "acme", on: true, changed: false))
+        #expect(on == "on: acme")
+        #expect(off == "off: acme")
+        #expect(alreadyOn == "on: acme (already on)")
+    }
+
+    @Test func brakeRendersBothBranches() {
+        #expect(renderSupervisionBrake(.released) == "brake: released")
+        #expect(renderSupervisionBrake(.engaged) == "brake: engaged")
+    }
+}
+
+@Suite("tbd supervise project list rendering")
+struct SupervisionProjectListRenderingTests {
+    @Test func emptyTopologySaysSo() {
+        #expect(renderSupervisionProjectList(SuperviseProjectListResult(projects: [])) == "(no projects)")
+    }
+
+    @Test func rowsCarryReposPolicyAndSweep() {
+        let web = SupervisionProjectRepoRef(id: UUID(), name: "acme-web")
+        let api = SupervisionProjectRepoRef(id: UUID(), name: "acme-api")
+        let text = renderSupervisionProjectList(
+            SuperviseProjectListResult(projects: [
+                SupervisionProjectTopologyEntry(
+                    name: "acme-platform", repos: [web, api],
+                    policy: .repo(web.id), sweepScript: nil),
+                SupervisionProjectTopologyEntry(
+                    name: "tbd", repos: [SupervisionProjectRepoRef(id: UUID(), name: "tbd")],
+                    policy: .operator, sweepScript: "/tmp/sweep.py"),
+            ]))
+        #expect(text.contains("acme-web, acme-api"))
+        // The policy repo is shown by the name a human typed, not its UUID.
+        #expect(text.contains("policy: repo:acme-web"))
+        #expect(!text.contains(web.id.uuidString))
+        #expect(text.contains("policy: operator"))
+        #expect(text.contains("sweep: shipped"))
+        #expect(text.contains("sweep: /tmp/sweep.py"))
+    }
+}

--- a/Tests/TBDCLITests/SuperviseStatusRenderingTests.swift
+++ b/Tests/TBDCLITests/SuperviseStatusRenderingTests.swift
@@ -143,6 +143,47 @@ struct SupervisionStatusLoudCaseTests {
         #expect(text.contains("mode attended"))
     }
 
+    /// Releasing the brake is the moment an operator forms the belief that
+    /// supervision is running, and the only gesture that can create the state
+    /// the warning describes — so bare `on` says it too.
+    @Test func releasingTheBrakeOverNothingWarnsAtTheRelease() {
+        let lines = supervisionBrakeReleaseWarningLines(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false,
+                projects: [SuperviseFixture.project(name: "acme-checkout", on: false)]))
+        #expect(lines.count == 1)
+        #expect(lines.first?.contains("no project is on") == true)
+        #expect(lines.first?.contains("nothing is being supervised") == true)
+    }
+
+    /// One fact, one sentence: `on` and `status` must not drift into two
+    /// wordings for the same condition.
+    @Test func theReleaseWarningIsTheSameCompositionStatusRenders() {
+        for status in [
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false, projects: []),
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: false, projects: [],
+                warnings: [SupervisionWarning(code: .unusableProjectName, message: "")]),
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme", on: true)]),
+        ] {
+            #expect(supervisionBrakeReleaseWarningLines(status)
+                == supervisionStatusWarningLines(status))
+        }
+    }
+
+    /// A release that covers something is quiet — the warning is a finding, not
+    /// a ceremony printed on every gesture.
+    @Test func releasingTheBrakeOverASupervisedFleetIsQuiet() {
+        let lines = supervisionBrakeReleaseWarningLines(
+            SuperviseFixture.status(
+                brake: .released, effectivelySupervising: true,
+                projects: [SuperviseFixture.project(name: "acme-checkout", on: true)]))
+        #expect(lines.isEmpty)
+    }
+
     @Test func aSupervisedFleetGetsNoWarning() {
         let text = SuperviseFixture.render(
             SuperviseFixture.status(

--- a/Tests/TBDDaemonTests/SupervisionBrakeRPCTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionBrakeRPCTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// Thread-safe collector for broadcast StateDeltas, mirroring the pattern in
+/// `GCHandlersTests` / `RPCRouterWorktreeCreateBroadcastTests`.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}
+
+/// RPC surface for the supervision fleet brake (design 2026-07-26 §3, §7):
+/// the `config.setSupervisionEnabled` verb, its round-trip through
+/// `config.get`, and its broadcast so every other client sees the same value
+/// immediately (§7: "all surfaces must see the same value immediately after
+/// a change").
+@Suite("Supervision brake RPC")
+struct SupervisionBrakeRPCTests {
+
+    private func makeRouter(db: TBDDatabase, subscriptions: StateSubscriptionManager = StateSubscriptionManager())
+        -> RPCRouter
+    {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subscriptions,
+            actuationLog: makeTestActuationLog()
+        )
+    }
+
+    private func setSupervisionEnabled(_ router: RPCRouter, enabled: Bool) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetSupervisionEnabled,
+            params: ConfigSetSupervisionEnabledParams(enabled: enabled))
+        let response = await router.handle(request)
+        #expect(response.success)
+    }
+
+    // MARK: - config.setSupervisionEnabled
+
+    @Test("config.setSupervisionEnabled persists the release")
+    func setEnabledPersists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+        try await setSupervisionEnabled(router, enabled: true)
+        #expect(try await db.config.get().supervisionEnabled == true)
+    }
+
+    @Test("config.setSupervisionEnabled persists an explicit brake")
+    func setDisabledPersists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+        try await setSupervisionEnabled(router, enabled: false)
+        #expect(try await db.config.get().supervisionEnabled == false)
+        // …and it is a real 0, not a NULL that merely resolves to the default.
+        let stored = try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)?.supervision_enabled
+        }
+        #expect(stored == false)
+    }
+
+    @Test("config.get reports the brake OFF by default")
+    func defaultsOff() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+        let response = await router.handle(RPCRequest(method: RPCMethod.configGet))
+        let result = try response.decodeResult(Config.self)
+        #expect(result.supervisionEnabled == false)
+    }
+
+    // MARK: - Broadcast (§7: "all surfaces must see the same value immediately")
+
+    @Test("config.setSupervisionEnabled flips the config and broadcasts")
+    func setSupervisionEnabledFlipsConfigAndBroadcasts() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let deltas = BroadcastDeltas()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let router = makeRouter(db: db, subscriptions: subs)
+
+        #expect(try await db.config.get().supervisionEnabled == false, "default is braked")
+
+        try await setSupervisionEnabled(router, enabled: true)
+
+        #expect(try await db.config.get().supervisionEnabled == true)
+        let modelProfilesChangedCount = deltas.snapshot().filter {
+            if case .modelProfilesChanged = $0 { return true }; return false
+        }.count
+        #expect(modelProfilesChangedCount == 1)
+    }
+
+    // MARK: - Codable back-compat
+
+    @Test("Config JSON without supervisionEnabled decodes to the shipped default")
+    func configDecodeBackCompat() throws {
+        let result = try JSONDecoder().decode(Config.self, from: Data("{}".utf8))
+        #expect(result.supervisionEnabled == Config.supervisionEnabledDefault)
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionBrakeSchemaTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionBrakeSchemaTests.swift
@@ -1,0 +1,178 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema-level guards for the supervision fleet brake
+/// (`docs/specs/2026-07-26-fleet-supervision-design.md` §3, §7).
+///
+/// The whole reason this suite exists is the tri-state on
+/// `config.supervision_enabled`: like `queued_prompt_enabled` before it, that
+/// column is added with **no SQL default**, so "never chose" (NULL) stays
+/// distinguishable from "explicitly off" (0). If someone re-adds
+/// `defaults: false` to `v75_config_supervision_enabled`,
+/// `supervisionEnabledIsNullBeforeAnyGesture` goes red — that is its only job.
+@Suite("SupervisionBrakeSchema")
+struct SupervisionBrakeSchemaTests {
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    // MARK: - v75: the flag is genuinely NULL until somebody touches the toggle
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by
+    /// v1, so every install — fresh or years old — has a row that predates
+    /// v75. After v75 that row's `supervision_enabled` must read NULL, not
+    /// `0`. A SQL default would backfill it to `0` and make "never chose"
+    /// indistinguishable from a deliberate opt-out, which is exactly what the
+    /// no-default convention exists to prevent. (Cautionary precedent:
+    /// `auto_hibernate_enabled` shipped WITH a SQL default and needed a
+    /// forcing migration later — this test is what would have caught that
+    /// defect before it shipped.)
+    @Test func supervisionEnabledIsNullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.supervision_enabled == nil,
+            """
+            config.supervision_enabled must be NULL until the toggle is \
+            touched — read back \(String(describing: record.supervision_enabled)). \
+            A non-nil value here means v75_config_supervision_enabled grew a \
+            `defaults:` argument; remove it.
+            """
+        )
+    }
+
+    /// The same guard against a row written by a real pre-v75 daemon: migrate
+    /// only through v74, write to the config row, then finish migrating.
+    @Test func rowWrittenBeforeV75StillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v74_worktree_pending_prompt")
+
+        // A pre-v75 daemon touching config: the row exists and has been
+        // written to, but knows nothing about the new column.
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET delivery_verification_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID]
+            )
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["supervision_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before v75 must read NULL, not \(raw)"
+            )
+            // The pre-existing write survived — v75 is purely additive.
+            #expect(row["delivery_verification_enabled"] == true)
+        }
+    }
+
+    // MARK: - The three states are distinguishable
+
+    /// NULL follows `Config.supervisionEnabledDefault` wherever it goes; an
+    /// explicit `false` does not. This is the property that makes graduation
+    /// a one-line constant change with no forcing `UPDATE` migration.
+    /// Exercised against BOTH possible default values, not just today's
+    /// constant, so this test would fail if the tri-state resolution were
+    /// wired as `?? false` instead of `?? supervisionEnabledDefault`.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.supervision_enabled == nil)
+        #expect(untouched.toModel(supervisionEnabledDefault: false).supervisionEnabled == false)
+        #expect(
+            untouched.toModel(supervisionEnabledDefault: true).supervisionEnabled == true,
+            "a never-chosen row must pick up a changed shipped default"
+        )
+
+        try await db.config.setSupervisionEnabled(enabled: false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.supervision_enabled == false)
+        #expect(explicitlyOff.toModel(supervisionEnabledDefault: false).supervisionEnabled == false)
+        #expect(
+            explicitlyOff.toModel(supervisionEnabledDefault: true).supervisionEnabled == false,
+            "an explicit opt-out (pulling the brake) must be honored forever, whatever the shipped default becomes"
+        )
+    }
+
+    /// Same property, mirrored for an explicit `true` — an operator who
+    /// releases the brake stays released even if the shipped default were
+    /// ever flipped back to off.
+    @Test func explicitTrueSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        try await db.config.setSupervisionEnabled(enabled: true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.supervision_enabled == true)
+        #expect(explicitlyOn.toModel(supervisionEnabledDefault: false).supervisionEnabled == true)
+        #expect(explicitlyOn.toModel(supervisionEnabledDefault: true).supervisionEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard (`toModel()`'s `?? supervisionEnabledDefault`)
+    /// from the STORAGE guard (the migration's no-SQL-default) by constructing
+    /// a `ConfigRecord` directly — no database, no migration involved. If
+    /// `toModel()` were ever hardened from `supervision_enabled ??
+    /// supervisionEnabledDefault` into `supervision_enabled ?? false`, this is
+    /// the test that would catch it, and it would catch it even if the
+    /// migration guard above were *also* broken at the same time — the two
+    /// failures can't be mistaken for each other because this one never reads
+    /// the database.
+    @Test func toModelResolvesNullThroughTheInjectedDefaultRegardlessOfStorage() {
+        let record = ConfigRecord(id: "unstored", supervision_enabled: nil)
+        #expect(record.toModel(supervisionEnabledDefault: false).supervisionEnabled == false)
+        #expect(
+            record.toModel(supervisionEnabledDefault: true).supervisionEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false"
+        )
+    }
+
+    /// The shipped default today. Graduation edits this constant and nothing
+    /// else.
+    @Test func shippedDefaultIsOff() async throws {
+        #expect(Config.supervisionEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().supervisionEnabled == false)
+    }
+
+    @Test func setSupervisionEnabledRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setSupervisionEnabled(enabled: true)
+        #expect(try await db.config.get().supervisionEnabled == true)
+        try await db.config.setSupervisionEnabled(enabled: false)
+        #expect(try await db.config.get().supervisionEnabled == false)
+    }
+
+    /// Restart-equivalent: reopening the store against the same on-disk file
+    /// and reading back must return the persisted value, not the in-memory
+    /// default.
+    @Test func setSupervisionEnabledSurvivesReopeningTheStore() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("supervision-brake-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let dbPath = dir.appendingPathComponent("state.db").path
+
+        do {
+            let db = try TBDDatabase(path: dbPath)
+            try await db.config.setSupervisionEnabled(enabled: true)
+            #expect(try await db.config.get().supervisionEnabled == true)
+        }
+
+        // Reopen — simulates a daemon restart reading the same file back.
+        let reopened = try TBDDatabase(path: dbPath)
+        #expect(try await reopened.config.get().supervisionEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -307,7 +307,12 @@ struct SupervisionHeartbeatTests {
         #expect(snapshots.calls == 1, "and the stale edge publishes nothing either")
     }
 
-    @Test("The heartbeat publishes an engaged brake — observability is never withheld")
+    // "Never withheld" would overstate it now: under an engaged brake there is
+    // no cadence, so what this pins is that a *write* — an edge, or boot —
+    // publishes the engaged state rather than declining to describe a paused
+    // fleet. The cadence's absence is pinned by
+    // `engagedBrakePublishesOnceAndArmsNoTimer`.
+    @Test("A write under an engaged brake publishes the engaged state, marks and all")
     func writesWhileTheBrakeIsEngaged() async throws {
         let path = try Self.path()
         let snapshots = Snapshots(Self.statusFile(

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -145,7 +145,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.applyBrake(released: true)
+        await heartbeat.applyBrake(released: true, sequence: 1)
         // The first advance proves the loop reached its sleep, which it can
         // only do after the immediate tick. The second waits for the sleep that
         // follows the *second* tick — so its returning is the evidence that a
@@ -167,7 +167,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.applyBrake(released: true)
+        await heartbeat.applyBrake(released: true, sequence: 1)
         // Parking on the clock is the loop's first act after its immediate
         // write, so a registered sleeper with no file on disk would mean the
         // daemon published nothing for a whole interval after boot.
@@ -185,7 +185,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.applyBrake(released: true)
+        await heartbeat.applyBrake(released: true, sequence: 1)
         await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
         // `stop()` returns only once the loop has unwound, so what follows is
         // an assertion about a settled state rather than a race.
@@ -206,7 +206,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.applyBrake(released: false)
+        await heartbeat.applyBrake(released: false, sequence: 2)
         #expect(snapshots.calls == 1, "the edge is published even while braked")
         #expect(try read(path)?.brake == .engaged)
 
@@ -228,7 +228,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.applyBrake(released: true)
+        await heartbeat.applyBrake(released: true, sequence: 1)
         // Each advance waits for a registered sleeper first, so returning at
         // all is the evidence the timer is armed and re-arming.
         await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
@@ -236,7 +236,7 @@ struct SupervisionHeartbeatTests {
         #expect(snapshots.calls >= 2, "the timer runs while the brake is released")
 
         snapshots.set(Self.statusFile(brake: .engaged))
-        await heartbeat.applyBrake(released: false)
+        await heartbeat.applyBrake(released: false, sequence: 2)
         #expect(try read(path)?.brake == .engaged, "the engaging edge is published")
 
         // `applyBrake` awaits the loop's unwind before returning, so no tick
@@ -259,7 +259,12 @@ struct SupervisionHeartbeatTests {
         // actor — exactly the window in which a second edge can run start to
         // finish. Without the intent re-check, the parked call would resume and
         // arm a timer the engaging edge had just decided against.
-        let releasing = Task { await heartbeat.applyBrake(released: true) }
+        // Whatever happens below, the park is lifted on the way out, so a
+        // failed assertion degrades to one red test rather than a task parked
+        // for the rest of the run. `release()` is idempotent.
+        defer { snapshots.release() }
+
+        let releasing = Task { await heartbeat.applyBrake(released: true, sequence: 1) }
         await snapshots.waitForFirstCall()
 
         // Deterministic, and this is why: the engaging edge does not depend on
@@ -267,7 +272,7 @@ struct SupervisionHeartbeatTests {
         // released. No yields, no polling, no timing — unlike its sibling at
         // the store layer, where the guard's whole purpose is that the second
         // caller *cannot* proceed and so cannot be awaited.
-        let engaging = Task { await heartbeat.applyBrake(released: false) }
+        let engaging = Task { await heartbeat.applyBrake(released: false, sequence: 2) }
         await engaging.value
 
         snapshots.release()
@@ -278,6 +283,28 @@ struct SupervisionHeartbeatTests {
             one here is a loop ticking under a brake the operator pulled
             """)
         #expect(snapshots.calls == 2, "both edges published; neither was skipped")
+    }
+
+    @Test("A brake edge that lost its ordering in the store's gate cannot move the timer")
+    func staleBrakeEdgeIsDiscarded() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .engaged))
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider,
+            interval: SupervisionHeartbeat.defaultInterval, clock: TestClock())
+
+        // The store's gate committed `engaged` second, so it holds the higher
+        // token. The notifications reach the heartbeat in the other order —
+        // which is the whole race, since the notification happens after the
+        // serialized region ends.
+        await heartbeat.applyBrake(released: false, sequence: 2)
+        await heartbeat.applyBrake(released: true, sequence: 1)
+
+        #expect(await heartbeat.isTimerArmed == false, """
+            the losing toggle must not arm a timer under a brake the winning \
+            one engaged — a stale edge is discarded, not applied
+            """)
+        #expect(snapshots.calls == 1, "and the stale edge publishes nothing either")
     }
 
     @Test("The heartbeat publishes an engaged brake — observability is never withheld")

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -1,0 +1,180 @@
+import Clocks
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 1 for the cadence — virtual time only, never a real sleep — and tier 2
+/// for the bytes it writes.
+///
+/// The path is injected, so nothing here can reach `~/tbd/supervision`.
+@Suite("Supervision heartbeat", .clockDriven)
+struct SupervisionHeartbeatTests {
+
+    /// Counts ticks and hands back whatever the test wants published.
+    private final class Snapshots: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: SupervisionStatusFile?
+        private var callCount = 0
+
+        init(_ value: SupervisionStatusFile?) { self.value = value }
+
+        func set(_ value: SupervisionStatusFile?) { lock.withLock { self.value = value } }
+
+        var calls: Int { lock.withLock { callCount } }
+
+        var provider: @Sendable () async -> SupervisionStatusFile? {
+            { [self] in
+                lock.withLock {
+                    callCount += 1
+                    return value
+                }
+            }
+        }
+    }
+
+    private static func path() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-heartbeat-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("status.json").path
+    }
+
+    private static func statusFile(
+        brake: SupervisionBrakeState, at seconds: TimeInterval = 1_700_000_000,
+        projects: [SupervisionStatusFileProject] = []
+    ) -> SupervisionStatusFile {
+        SupervisionStatusFile(
+            writtenAt: SupervisionInstant(Date(timeIntervalSince1970: seconds)),
+            brake: brake, projects: projects)
+    }
+
+    private func read(_ path: String) throws -> SupervisionStatusFile? {
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
+        return try JSONDecoder().decode(SupervisionStatusFile.self, from: data)
+    }
+
+    @Test("The first tick is immediate, then one per interval")
+    func writesImmediatelyThenOnCadence() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .released))
+        let clock = TestClock()
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider,
+            interval: SupervisionHeartbeat.defaultInterval, clock: clock)
+
+        await heartbeat.start()
+        // The first advance proves the loop reached its sleep, which it can
+        // only do after the immediate tick. The second waits for the sleep that
+        // follows the *second* tick — so its returning is the evidence that a
+        // tick happened per elapsed interval, not merely once at start.
+        await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
+        await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
+        await heartbeat.stop()
+
+        #expect(snapshots.calls >= 2, "one immediate write plus one per interval elapsed")
+        #expect(try read(path)?.brake == .released)
+    }
+
+    @Test("Stopping ends the cadence")
+    func stopEndsTheCadence() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .released))
+        let clock = TestClock()
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider,
+            interval: SupervisionHeartbeat.defaultInterval, clock: clock)
+
+        await heartbeat.start()
+        await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
+        // `stop()` returns only once the loop has unwound, so what follows is
+        // an assertion about a settled state rather than a race.
+        await heartbeat.stop()
+        let afterStop = snapshots.calls
+
+        await clock.advance(by: SupervisionHeartbeat.defaultInterval * 5)
+        #expect(snapshots.calls == afterStop)
+        #expect(try read(path) != nil, "the last tick's file is left exactly as it was")
+    }
+
+    @Test("The heartbeat publishes an engaged brake — observability is never withheld")
+    func writesWhileTheBrakeIsEngaged() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(
+            brake: .engaged,
+            projects: [SupervisionStatusFileProject(
+                name: "acme-web", on: true, mode: "autonomous", lastSweepContactAt: nil)]))
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider, clock: TestClock())
+
+        await heartbeat.tick()
+
+        let published = try #require(try read(path))
+        #expect(published.brake == .engaged)
+        #expect(published.projects.first?.on == true,
+                "the mark is published beside the brake that suppresses it")
+    }
+
+    @Test("A never-contacted project publishes an explicit null, not a missing key")
+    func neverContactedPublishesNull() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(
+            brake: .released,
+            projects: [SupervisionStatusFileProject(
+                name: "acme-web", on: true, mode: "attended", lastSweepContactAt: nil)]))
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider, clock: TestClock())
+
+        await heartbeat.tick()
+
+        let data = try #require(FileManager.default.contents(atPath: path))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let projects = try #require(object["projects"] as? [[String: Any]])
+        #expect(projects.first?["lastSweepContactAt"] is NSNull)
+    }
+
+    @Test("A tick that cannot read the state writes nothing and lets the file go stale")
+    func unreadableStateSkipsTheWrite() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .released, at: 1_700_000_000))
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider, clock: TestClock())
+
+        await heartbeat.tick()
+        let first = try #require(FileManager.default.contents(atPath: path))
+
+        snapshots.set(nil)
+        await heartbeat.tick()
+
+        #expect(FileManager.default.contents(atPath: path) == first,
+                "staleness is the signal the watchdog reads; a half-truth is not")
+    }
+
+    @Test("Each tick republishes, so the file's content changes and not only its mtime")
+    func everyTickRestampsWrittenAt() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .released, at: 1_700_000_000))
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider, clock: TestClock())
+
+        await heartbeat.tick()
+        let first = try #require(try read(path))
+
+        snapshots.set(Self.statusFile(brake: .released, at: 1_700_000_060))
+        await heartbeat.tick()
+        let second = try #require(try read(path))
+
+        #expect(first.writtenAt != second.writtenAt)
+    }
+
+    @Test("The published cadence sits an order of magnitude under the watchdog's rule")
+    func cadenceLeavesRoomForLostTicks() {
+        // The watchdog raises when a file claiming coverage has not changed in
+        // about ten minutes. A shipped cadence that did not leave several
+        // missed ticks of headroom would page on ordinary jitter, and a page
+        // nobody trusts is a page nobody reads.
+        #expect(SupervisionHeartbeat.defaultInterval <= .seconds(120))
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -13,6 +13,10 @@ import Testing
 struct SupervisionHeartbeatTests {
 
     /// Counts ticks and hands back whatever the test wants published.
+    /// The reason a snapshot could not be composed, so a test can assert the
+    /// heartbeat skips rather than publishes.
+    private struct Unreadable: Error {}
+
     private final class Snapshots: @unchecked Sendable {
         private let lock = NSLock()
         private var value: SupervisionStatusFile?
@@ -24,12 +28,14 @@ struct SupervisionHeartbeatTests {
 
         var calls: Int { lock.withLock { callCount } }
 
-        var provider: @Sendable () async -> SupervisionStatusFile? {
+        var provider: @Sendable () async throws -> SupervisionStatusFile {
             { [self] in
-                lock.withLock {
+                let value = lock.withLock { () -> SupervisionStatusFile? in
                     callCount += 1
-                    return value
+                    return self.value
                 }
+                guard let value else { throw Unreadable() }
+                return value
             }
         }
     }

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -12,11 +12,15 @@ import Testing
 @Suite("Supervision heartbeat", .clockDriven)
 struct SupervisionHeartbeatTests {
 
-    /// Counts ticks and hands back whatever the test wants published.
     /// The reason a snapshot could not be composed, so a test can assert the
     /// heartbeat skips rather than publishes.
     private struct Unreadable: Error {}
 
+    /// Counts ticks and hands back whatever the test wants published.
+    ///
+    /// Holding `nil` means **the next call throws**, not that it publishes
+    /// nothing: the production seam has exactly one way to say "no snapshot",
+    /// and this stub speaks it rather than inventing a second.
     private final class Snapshots: @unchecked Sendable {
         private let lock = NSLock()
         private var value: SupervisionStatusFile?

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -77,6 +77,24 @@ struct SupervisionHeartbeatTests {
         #expect(try read(path)?.brake == .released)
     }
 
+    @Test("The file exists before a single interval has elapsed")
+    func firstTickPrecedesTheFirstInterval() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .released))
+        let clock = TestClock()
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider,
+            interval: SupervisionHeartbeat.defaultInterval, clock: clock)
+
+        await heartbeat.start()
+        // Parking on the clock is the loop's first act after its immediate
+        // write, so a registered sleeper with no file on disk would mean the
+        // daemon published nothing for a whole interval after boot.
+        await clock.waitForSuspension()
+        #expect(FileManager.default.fileExists(atPath: path))
+        await heartbeat.stop()
+    }
+
     @Test("Stopping ends the cadence")
     func stopEndsTheCadence() async throws {
         let path = try Self.path()

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -161,6 +161,12 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider, clock: TestClock())
 
         await heartbeat.tick()
+        // `#require` is the right form here and must stay: a tick with a
+        // readable snapshot was supposed to write, so absence is a real
+        // failure. Capturing this as an optional instead would let a heartbeat
+        // that never wrote at all pass vacuously on `nil == nil`. The opposite
+        // reasoning applies where absence is a legitimate state — see
+        // `SupervisionStoreTests.fileBytes`.
         let first = try #require(FileManager.default.contents(atPath: path))
 
         snapshots.set(nil)

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -44,6 +44,77 @@ struct SupervisionHeartbeatTests {
         }
     }
 
+    /// A snapshot source whose **first** call parks until the test releases it,
+    /// so one `applyBrake` can be held inside its edge write while another runs
+    /// to completion.
+    ///
+    /// Lock-guarded rather than an actor, deliberately: an actor that parked
+    /// inside its own isolated method would still be holding itself, so the
+    /// second call could not get in and the test would deadlock instead of
+    /// interleaving. The lock is only ever held across bookkeeping, never
+    /// across the suspension.
+    private final class ParkingSnapshots: @unchecked Sendable {
+        private let lock = NSLock()
+        private let value: SupervisionStatusFile
+        private var callCount = 0
+        private var sawFirstCall = false
+        private var firstCallWaiters: [CheckedContinuation<Void, Never>] = []
+        private var isReleased = false
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        init(_ value: SupervisionStatusFile) { self.value = value }
+
+        var calls: Int { lock.withLock { callCount } }
+
+        var provider: @Sendable () async throws -> SupervisionStatusFile {
+            { [self] in
+                let shouldPark = lock.withLock { () -> Bool in
+                    callCount += 1
+                    guard !sawFirstCall else { return false }
+                    sawFirstCall = true
+                    return true
+                }
+                guard shouldPark else { return value }
+
+                let arrivals = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+                    defer { firstCallWaiters = [] }
+                    return firstCallWaiters
+                }
+                for waiter in arrivals { waiter.resume() }
+
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    let alreadyReleased = lock.withLock { () -> Bool in
+                        guard !isReleased else { return true }
+                        releaseWaiters.append(continuation)
+                        return false
+                    }
+                    if alreadyReleased { continuation.resume() }
+                }
+                return value
+            }
+        }
+
+        func waitForFirstCall() async {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                let alreadyArrived = lock.withLock { () -> Bool in
+                    guard !sawFirstCall else { return true }
+                    firstCallWaiters.append(continuation)
+                    return false
+                }
+                if alreadyArrived { continuation.resume() }
+            }
+        }
+
+        func release() {
+            let waiters = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+                isReleased = true
+                defer { releaseWaiters = [] }
+                return releaseWaiters
+            }
+            for waiter in waiters { waiter.resume() }
+        }
+    }
+
     private static func path() throws -> String {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-heartbeat-\(UUID().uuidString)", isDirectory: true)
@@ -174,6 +245,39 @@ struct SupervisionHeartbeatTests {
         await clock.advance(by: SupervisionHeartbeat.defaultInterval * 5)
         for _ in 0..<20 { await Task.yield() }
         #expect(snapshots.calls == afterEngaging, "and the timer is disarmed behind it")
+    }
+
+    @Test("Overlapping brake edges leave the timer matching the edge that landed last")
+    func overlappingBrakeEdgesSettleOnTheLastOne() async throws {
+        let path = try Self.path()
+        let snapshots = ParkingSnapshots(Self.statusFile(brake: .released))
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider,
+            interval: SupervisionHeartbeat.defaultInterval, clock: TestClock())
+
+        // The releasing edge parks inside its own write, which releases the
+        // actor — exactly the window in which a second edge can run start to
+        // finish. Without the intent re-check, the parked call would resume and
+        // arm a timer the engaging edge had just decided against.
+        let releasing = Task { await heartbeat.applyBrake(released: true) }
+        await snapshots.waitForFirstCall()
+
+        // Deterministic, and this is why: the engaging edge does not depend on
+        // the parked one, so it can be awaited to completion before the park is
+        // released. No yields, no polling, no timing — unlike its sibling at
+        // the store layer, where the guard's whole purpose is that the second
+        // caller *cannot* proceed and so cannot be awaited.
+        let engaging = Task { await heartbeat.applyBrake(released: false) }
+        await engaging.value
+
+        snapshots.release()
+        await releasing.value
+
+        #expect(await heartbeat.isTimerArmed == false, """
+            the engaging edge landed last, so no timer may be running — an armed \
+            one here is a loop ticking under a brake the operator pulled
+            """)
+        #expect(snapshots.calls == 2, "both edges published; neither was skipped")
     }
 
     @Test("The heartbeat publishes an engaged brake — observability is never withheld")

--- a/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionHeartbeatTests.swift
@@ -74,7 +74,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.start()
+        await heartbeat.applyBrake(released: true)
         // The first advance proves the loop reached its sleep, which it can
         // only do after the immediate tick. The second waits for the sleep that
         // follows the *second* tick — so its returning is the evidence that a
@@ -96,7 +96,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.start()
+        await heartbeat.applyBrake(released: true)
         // Parking on the clock is the loop's first act after its immediate
         // write, so a registered sleeper with no file on disk would mean the
         // daemon published nothing for a whole interval after boot.
@@ -114,7 +114,7 @@ struct SupervisionHeartbeatTests {
             path: path, snapshot: snapshots.provider,
             interval: SupervisionHeartbeat.defaultInterval, clock: clock)
 
-        await heartbeat.start()
+        await heartbeat.applyBrake(released: true)
         await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
         // `stop()` returns only once the loop has unwound, so what follows is
         // an assertion about a settled state rather than a race.
@@ -124,6 +124,56 @@ struct SupervisionHeartbeatTests {
         await clock.advance(by: SupervisionHeartbeat.defaultInterval * 5)
         #expect(snapshots.calls == afterStop)
         #expect(try read(path) != nil, "the last tick's file is left exactly as it was")
+    }
+
+    @Test("An engaged brake publishes the edge and arms no timer")
+    func engagedBrakePublishesOnceAndArmsNoTimer() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .engaged))
+        let clock = TestClock()
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider,
+            interval: SupervisionHeartbeat.defaultInterval, clock: clock)
+
+        await heartbeat.applyBrake(released: false)
+        #expect(snapshots.calls == 1, "the edge is published even while braked")
+        #expect(try read(path)?.brake == .engaged)
+
+        // Nothing is registered on the clock, so this advance moves virtual
+        // time past five intervals and releases nobody. A braked daemon runs no
+        // background loop at all — the brake is the switch.
+        await clock.advance(by: SupervisionHeartbeat.defaultInterval * 5)
+        for _ in 0..<20 { await Task.yield() }
+        #expect(snapshots.calls == 1)
+        await heartbeat.stop()
+    }
+
+    @Test("Releasing the brake arms the timer; engaging it publishes and disarms")
+    func brakeEdgesArmAndDisarmTheTimer() async throws {
+        let path = try Self.path()
+        let snapshots = Snapshots(Self.statusFile(brake: .released))
+        let clock = TestClock()
+        let heartbeat = SupervisionHeartbeat(
+            path: path, snapshot: snapshots.provider,
+            interval: SupervisionHeartbeat.defaultInterval, clock: clock)
+
+        await heartbeat.applyBrake(released: true)
+        // Each advance waits for a registered sleeper first, so returning at
+        // all is the evidence the timer is armed and re-arming.
+        await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
+        await clock.advanceWhenSuspended(by: SupervisionHeartbeat.defaultInterval)
+        #expect(snapshots.calls >= 2, "the timer runs while the brake is released")
+
+        snapshots.set(Self.statusFile(brake: .engaged))
+        await heartbeat.applyBrake(released: false)
+        #expect(try read(path)?.brake == .engaged, "the engaging edge is published")
+
+        // `applyBrake` awaits the loop's unwind before returning, so no tick
+        // can still be in flight and this count is settled.
+        let afterEngaging = snapshots.calls
+        await clock.advance(by: SupervisionHeartbeat.defaultInterval * 5)
+        for _ in 0..<20 { await Task.yield() }
+        #expect(snapshots.calls == afterEngaging, "and the timer is disarmed behind it")
     }
 
     @Test("The heartbeat publishes an engaged brake — observability is never withheld")

--- a/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
@@ -17,6 +17,59 @@ struct SupervisionLedgerWriterTests {
 
     private static let epoch = Date(timeIntervalSince1970: 1_700_000_000)
 
+    /// Every project named by a line in the file, in order — enough to say
+    /// which line landed where.
+    private func projects(at path: String) throws -> [String?] {
+        guard let data = FileManager.default.contents(atPath: path) else { return [] }
+        return try data.split(separator: 0x0A, omittingEmptySubsequences: true).map { raw in
+            try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(raw)).project
+        }
+    }
+
+    private static func line(_ project: String) -> SupervisionLedgerLine {
+        .projectOn(project: project, mode: "attended", roster: [], at: epoch)
+    }
+
+    // MARK: - The file the handle points at
+
+    @Test("A ledger removed between appends is noticed and recreated, not written into a ghost")
+    func removedFileIsRecreated() async throws {
+        let path = try Self.makePath()
+        let directory = URL(fileURLWithPath: path).deletingLastPathComponent()
+        let writer = SupervisionLedgerWriter(path: path)
+
+        #expect(await writer.append(Self.line("acme-web")))
+        // Someone moved the whole directory aside. The still-open `O_APPEND`
+        // descriptor would happily accept writes into the unlinked inode —
+        // into a file nobody will ever read — so the identity check has to
+        // fail the append and let the reopen-retry recreate the path.
+        try FileManager.default.removeItem(at: directory)
+
+        #expect(await writer.append(Self.line("acme-api")),
+                "the retry recreates the file rather than reporting the line lost")
+        #expect(try projects(at: path) == ["acme-api"])
+    }
+
+    @Test("A ledger replaced between appends is followed, not written past")
+    func replacedFileIsFollowed() async throws {
+        let path = try Self.makePath()
+        let directory = URL(fileURLWithPath: path).deletingLastPathComponent()
+        let archived = directory.appendingPathComponent("archived.jsonl").path
+        let writer = SupervisionLedgerWriter(path: path)
+
+        #expect(await writer.append(Self.line("acme-web")))
+        // An external rotation: the segment is moved aside and a fresh file
+        // takes its place at the same path. The line must land in the file
+        // that is at `path` *now*.
+        try FileManager.default.moveItem(atPath: path, toPath: archived)
+        FileManager.default.createFile(atPath: path, contents: Data())
+
+        #expect(await writer.append(Self.line("acme-api")))
+        #expect(try projects(at: path) == ["acme-api"], "the new line follows the path")
+        #expect(try projects(at: archived) == ["acme-web"],
+                "and the rotated segment keeps only what it already held")
+    }
+
     @Test("Each append is one whole line, and a line survives the round trip")
     func appendsWholeLines() async throws {
         let path = try Self.makePath()

--- a/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
@@ -32,6 +32,16 @@ struct SupervisionLedgerWriterTests {
 
     // MARK: - The file the handle points at
 
+    // These two are a pair, and the pair is the evidence — neither alone is.
+    //
+    // Removal is caught by any check that looks at the path at all, because
+    // `stat` fails on a deleted file whether the guard compares inode identity
+    // or merely asks "does something exist here". So a guard weakened to
+    // path-existence still passes the removal test and fails only the
+    // replacement one, where a *different* file now sits at the path and the
+    // open descriptor still points at the old inode. Delete the replacement
+    // test and the guard can silently decay into a weaker one that the doc
+    // comment no longer describes.
     @Test("A ledger removed between appends is noticed and recreated, not written into a ghost")
     func removedFileIsRecreated() async throws {
         let path = try Self.makePath()

--- a/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
@@ -103,29 +103,60 @@ struct SupervisionLedgerWriterTests {
             SupervisionLedgerLine.self, from: Data(rows[1].utf8)).project == "acme-web")
     }
 
+    /// A `delivery` line, as a later slice will write it.
+    ///
+    /// Its timestamp is deliberately **not** `epoch`: a fixture whose
+    /// unrecognized line shares a timestamp with the span it sits beside cannot
+    /// tell "read past" from "opened a span at the same instant", and the whole
+    /// point of this fixture is to tell those apart.
+    private static func deliveryLine(project: String) -> String {
+        // epoch + 300s = 2023-11-14T22:18:20Z. Built by concatenation rather
+        // than a multiline literal: a `\` continuation inside `"""` is one
+        // keystroke away from producing JSON that silently fails to parse, and
+        // a fixture that does not decode makes every assertion below vacuous.
+        "{\"id\":\"deadbeef\",\"ts\":\"2023-11-14T22:18:20.000Z\",\"mode\":\"attended\","
+            + "\"project\":\"\(project)\",\"kind\":\"delivery\",\"hash\":\"abc123\"}\n"
+    }
+
+    private static func appendRaw(_ text: String, to path: String) throws {
+        if !FileManager.default.fileExists(atPath: path) {
+            FileManager.default.createFile(atPath: path, contents: nil)
+        }
+        let handle = try #require(FileHandle(forWritingAtPath: path))
+        _ = try handle.seekToEnd()
+        try handle.write(contentsOf: Data(text.utf8))
+        try handle.close()
+    }
+
     @Test("A line of a kind this build does not model opens and closes nothing")
     func unrecognizedKindsAreReadPast() async throws {
-        let path = try Self.makePath()
-        let writer = SupervisionLedgerWriter(path: path)
+        let raw = Self.deliveryLine(project: "acme-web")
+
+        // Pinned first, and on its own. Span recovery's read-past behavior is
+        // defined against a line that actually *decodes* as `.unrecognized`; a
+        // fixture that fails to decode is counted as corruption instead and
+        // never reaches the arm under test, which would make both assertions
+        // below pass for the wrong reason. If this fixture ever stops
+        // decoding, the failure should say so by name.
+        let decoded = try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(raw.utf8))
+        #expect(decoded.payload == .unrecognized)
+        #expect(decoded.project == "acme-web")
+
+        // It must not close a span that stands …
+        let beside = try Self.makePath()
+        let writer = SupervisionLedgerWriter(path: beside)
         await writer.append(.projectOn(
             project: "acme-web", mode: "attended", roster: [], at: Self.epoch))
+        try Self.appendRaw(raw, to: beside)
+        #expect(await SupervisionLedgerWriter(path: beside).spanStarts()
+            == ["acme-web": SupervisionInstant(Self.epoch)],
+                "an unrecognized line neither closes the span nor restamps it")
 
-        // A `delivery` line, as a later slice will write it. It must not close
-        // the span above, and it must not be counted as damage — a record that
-        // reports itself corrupt the first time somebody adds a kind is an
-        // alarm nobody will keep reading.
-        let delivery = """
-            {"id":"deadbeef","ts":"2023-11-14T22:13:20.000Z","mode":"attended",\
-            "project":"acme-web","kind":"delivery","hash":"abc123"}
-
-            """
-        let handle = try #require(FileHandle(forWritingAtPath: path))
-        try handle.seekToEnd()
-        try handle.write(contentsOf: Data(delivery.utf8))
-        try handle.close()
-
-        let spans = await SupervisionLedgerWriter(path: path).spanStarts()
-        #expect(spans == ["acme-web": SupervisionInstant(Self.epoch)])
+        // … and must not open one where none does.
+        let alone = try Self.makePath()
+        try Self.appendRaw(raw, to: alone)
+        #expect(await SupervisionLedgerWriter(path: alone).spanStarts().isEmpty,
+                "coverage starts from a projectOn line and nothing else")
     }
 
     @Test("An empty or absent file recovers no spans")

--- a/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
@@ -103,6 +103,31 @@ struct SupervisionLedgerWriterTests {
             SupervisionLedgerLine.self, from: Data(rows[1].utf8)).project == "acme-web")
     }
 
+    @Test("A line of a kind this build does not model opens and closes nothing")
+    func unrecognizedKindsAreReadPast() async throws {
+        let path = try Self.makePath()
+        let writer = SupervisionLedgerWriter(path: path)
+        await writer.append(.projectOn(
+            project: "acme-web", mode: "attended", roster: [], at: Self.epoch))
+
+        // A `delivery` line, as a later slice will write it. It must not close
+        // the span above, and it must not be counted as damage — a record that
+        // reports itself corrupt the first time somebody adds a kind is an
+        // alarm nobody will keep reading.
+        let delivery = """
+            {"id":"deadbeef","ts":"2023-11-14T22:13:20.000Z","mode":"attended",\
+            "project":"acme-web","kind":"delivery","hash":"abc123"}
+
+            """
+        let handle = try #require(FileHandle(forWritingAtPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(delivery.utf8))
+        try handle.close()
+
+        let spans = await SupervisionLedgerWriter(path: path).spanStarts()
+        #expect(spans == ["acme-web": SupervisionInstant(Self.epoch)])
+    }
+
     @Test("An empty or absent file recovers no spans")
     func absentFileRecoversNothing() async throws {
         let path = try Self.makePath()

--- a/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionLedgerWriterTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — real filesystem, no clocks, no subprocesses. The path is injected;
+/// nothing here can reach `~/tbd/supervision`.
+@Suite("Supervision ledger writer")
+struct SupervisionLedgerWriterTests {
+
+    private static func makePath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-supervision-ledger-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("ledger.jsonl").path
+    }
+
+    private static let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("Each append is one whole line, and a line survives the round trip")
+    func appendsWholeLines() async throws {
+        let path = try Self.makePath()
+        let writer = SupervisionLedgerWriter(path: path)
+        let line = SupervisionLedgerLine.projectOn(
+            project: "acme-web", mode: "attended", roster: [], at: Self.epoch)
+
+        #expect(await writer.append(line))
+        #expect(await writer.append(SupervisionLedgerLine.brakeEngaged(at: Self.epoch)))
+
+        let contents = try String(contentsOfFile: path, encoding: .utf8)
+        let rows = contents.split(separator: "\n", omittingEmptySubsequences: true)
+        #expect(rows.count == 2)
+        let first = try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(rows[0].utf8))
+        #expect(first == line, "a line equals its reloaded self")
+    }
+
+    @Test("Span recovery reports the most recent open span and nothing closed")
+    func spanRecoveryPairsOnWithOff() async throws {
+        let path = try Self.makePath()
+        let writer = SupervisionLedgerWriter(path: path)
+        let opened = Self.epoch
+        let closed = Self.epoch.addingTimeInterval(60)
+        let reopened = Self.epoch.addingTimeInterval(120)
+
+        await writer.append(.projectOn(project: "acme-web", mode: "attended", roster: [], at: opened))
+        await writer.append(.projectOff(
+            project: "acme-web", mode: "attended",
+            coverage: SupervisionCoverageSummary(
+                spanStartedAt: SupervisionInstant(opened),
+                spanEndedAt: SupervisionInstant(closed),
+                sweepContacts: 0, briefingsDelivered: 0),
+            at: closed))
+        await writer.append(.projectOn(project: "acme-web", mode: "attended", roster: [], at: reopened))
+        await writer.append(.projectOn(project: "acme-api", mode: "attended", roster: [], at: opened))
+        await writer.append(.projectOff(
+            project: "acme-api", mode: "attended",
+            coverage: SupervisionCoverageSummary(
+                spanStartedAt: SupervisionInstant(opened),
+                spanEndedAt: SupervisionInstant(closed),
+                sweepContacts: 0, briefingsDelivered: 0),
+            at: closed))
+
+        let spans = await SupervisionLedgerWriter(path: path).spanStarts()
+        #expect(spans == ["acme-web": SupervisionInstant(reopened)],
+                "the most recent `on` with no `off` after it, and nothing for a closed span")
+    }
+
+    @Test("Fleet-wide lines open no span")
+    func brakeLinesOpenNoSpan() async throws {
+        let path = try Self.makePath()
+        let writer = SupervisionLedgerWriter(path: path)
+        await writer.append(.brakeReleased(at: Self.epoch))
+        await writer.append(.brakeEngaged(at: Self.epoch))
+        #expect(await SupervisionLedgerWriter(path: path).spanStarts().isEmpty)
+    }
+
+    @Test("A line nobody can read is skipped, not fatal")
+    func unreadableLineDoesNotTakeTheRecordOffline() async throws {
+        let path = try Self.makePath()
+        try "{ this is not json\n".write(toFile: path, atomically: true, encoding: .utf8)
+        let writer = SupervisionLedgerWriter(path: path)
+        await writer.append(.projectOn(
+            project: "acme-web", mode: "attended", roster: [], at: Self.epoch))
+
+        let spans = await SupervisionLedgerWriter(path: path).spanStarts()
+        #expect(spans == ["acme-web": SupervisionInstant(Self.epoch)],
+                "a hand edit costs the edited line, never the record's memory")
+    }
+
+    @Test("A file ending mid-line does not fuse with the next append")
+    func danglingFragmentIsIsolated() async throws {
+        let path = try Self.makePath()
+        try "{\"id\":\"abc\",\"ts\"".write(toFile: path, atomically: true, encoding: .utf8)
+        let writer = SupervisionLedgerWriter(path: path)
+        _ = await writer.spanStarts()  // notices the fragment
+        await writer.append(.projectOn(
+            project: "acme-web", mode: "attended", roster: [], at: Self.epoch))
+
+        let contents = try String(contentsOfFile: path, encoding: .utf8)
+        let rows = contents.split(separator: "\n", omittingEmptySubsequences: true)
+        #expect(rows.count == 2, "the fragment terminates as its own junk line")
+        #expect(try JSONDecoder().decode(
+            SupervisionLedgerLine.self, from: Data(rows[1].utf8)).project == "acme-web")
+    }
+
+    @Test("An empty or absent file recovers no spans")
+    func absentFileRecoversNothing() async throws {
+        let path = try Self.makePath()
+        #expect(await SupervisionLedgerWriter(path: path).spanStarts().isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionRPCTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionRPCTests.swift
@@ -88,6 +88,23 @@ struct SupervisionRPCTests {
         #expect(try lines(at: fixture.ledgerPath).isEmpty)
     }
 
+    @Test("The brake write reports the resolved value it replaced")
+    func brakeWriteReportsWhatItReplaced() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        // The column starts unset, so the value being replaced is the shipped
+        // default rather than a written one — the distinction that stops an
+        // opening `off` from being recorded as a transition.
+        let firstPrevious = try await db.config.setSupervisionEnabled(enabled: false)
+        #expect(firstPrevious == Config.supervisionEnabledDefault)
+
+        let secondPrevious = try await db.config.setSupervisionEnabled(enabled: true)
+        #expect(secondPrevious == false, "now reading the written value, not the default")
+
+        let thirdPrevious = try await db.config.setSupervisionEnabled(enabled: true)
+        #expect(thirdPrevious == true, "a repeat reports no transition")
+    }
+
     @Test("A released brake with no projects reports the loud case through RPC")
     func statusReportsTheLoudCase() async throws {
         let fixture = try makeFixture()

--- a/Tests/TBDDaemonTests/SupervisionRPCTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionRPCTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The `supervise.*` surface as the CLI reaches it, plus the brake's ledger
+/// lines.
+///
+/// The store is injected with temp paths, so nothing here writes into
+/// `~/tbd/supervision` — and the router deliberately has no default store for
+/// exactly that reason.
+@Suite("Supervision RPC")
+struct SupervisionRPCTests {
+
+    private struct EmptyFleet: SupervisionFleetReading {
+        func repos() async throws -> [SupervisionRepo] { [] }
+        func agents(inRepos repoIDs: Set<UUID>) async throws -> [SupervisionFleetAgent] { [] }
+    }
+
+    private struct Fixture {
+        let router: RPCRouter
+        let db: TBDDatabase
+        let ledgerPath: String
+    }
+
+    private func makeFixture(wireSupervision: Bool = true) throws -> Fixture {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-supervision-rpc-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let ledgerPath = directory.appendingPathComponent("ledger.jsonl").path
+        if wireSupervision {
+            router.supervision = SupervisionStore(
+                files: SupervisionFileStore(
+                    fileURL: directory.appendingPathComponent("supervision.json")),
+                ledger: SupervisionLedgerWriter(path: ledgerPath),
+                fleet: EmptyFleet())
+        }
+        return Fixture(router: router, db: db, ledgerPath: ledgerPath)
+    }
+
+    private func setBrake(_ fixture: Fixture, enabled: Bool) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetSupervisionEnabled,
+            params: ConfigSetSupervisionEnabledParams(enabled: enabled))
+        let response = await fixture.router.handle(request)
+        #expect(response.success, "\(response.error ?? "")")
+    }
+
+    private func lines(at path: String) throws -> [SupervisionLedgerLine] {
+        guard let data = FileManager.default.contents(atPath: path) else { return [] }
+        return try data.split(separator: 0x0A, omittingEmptySubsequences: true).map { raw in
+            try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(raw))
+        }
+    }
+
+    // MARK: - The brake
+
+    @Test("Releasing and re-engaging the brake each write one fleet-wide line")
+    func brakeGesturesAreRecorded() async throws {
+        let fixture = try makeFixture()
+        try await setBrake(fixture, enabled: true)
+        try await setBrake(fixture, enabled: false)
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.map(\.payload) == [.brakeReleased, .brakeEngaged])
+        #expect(decoded.allSatisfy { $0.project == nil && $0.mode == nil })
+    }
+
+    @Test("Engaging a brake that already stands engaged writes the column but no line")
+    func unchangedBrakeWritesNoLine() async throws {
+        let fixture = try makeFixture()
+        // The shipped default is engaged, and the column starts unset. Sending
+        // `false` is a real gesture on the column — it lifts it out of NULL —
+        // and no change at all to what the brake means.
+        try await setBrake(fixture, enabled: false)
+
+        #expect(try await fixture.db.config.get().supervisionEnabled == false)
+        #expect(try lines(at: fixture.ledgerPath).isEmpty)
+    }
+
+    @Test("A released brake with no projects reports the loud case through RPC")
+    func statusReportsTheLoudCase() async throws {
+        let fixture = try makeFixture()
+        try await setBrake(fixture, enabled: true)
+
+        let response = await fixture.router.handle(
+            RPCRequest(method: RPCMethod.superviseStatus))
+        #expect(response.success, "\(response.error ?? "")")
+        let status = try response.decodeResult(SupervisionStatus.self)
+        #expect(status.brake == .released)
+        #expect(status.effectivelySupervising == false)
+        #expect(status.warnings.map(\.code) == [.noProjectsOn])
+        #expect(status.projects.isEmpty)
+    }
+
+    @Test("The status readout follows the brake column")
+    func statusFollowsTheBrakeColumn() async throws {
+        let fixture = try makeFixture()
+
+        let engaged = try await fixture.router.handle(
+            RPCRequest(method: RPCMethod.superviseStatus))
+            .decodeResult(SupervisionStatus.self)
+        #expect(engaged.brake == .engaged, "shipped default, with the column unset")
+
+        try await setBrake(fixture, enabled: true)
+        let released = try await fixture.router.handle(
+            RPCRequest(method: RPCMethod.superviseStatus))
+            .decodeResult(SupervisionStatus.self)
+        #expect(released.brake == .released)
+    }
+
+    // MARK: - Refusals
+
+    @Test("A daemon with no supervision store refuses rather than crashing")
+    func unwiredSupervisionRefuses() async throws {
+        let fixture = try makeFixture(wireSupervision: false)
+        let response = await fixture.router.handle(
+            RPCRequest(method: RPCMethod.superviseStatus))
+        #expect(response.success == false)
+        #expect(response.error?.contains("no supervision store") == true)
+    }
+
+    @Test("The brake still moves when no supervision store is wired")
+    func brakeWorksWithoutAStore() async throws {
+        let fixture = try makeFixture(wireSupervision: false)
+        try await setBrake(fixture, enabled: true)
+        #expect(try await fixture.db.config.get().supervisionEnabled == true)
+    }
+
+    @Test("An unknown project is refused by name, and the topology still lists")
+    func unknownProjectIsRefused() async throws {
+        let fixture = try makeFixture()
+        let request = try RPCRequest(
+            method: RPCMethod.superviseSetProjectMark,
+            params: SuperviseSetProjectMarkParams(project: "acme-platform", on: true))
+        let response = await fixture.router.handle(request)
+        #expect(response.success == false)
+        #expect(response.error?.contains("acme-platform") == true)
+
+        let listed = try await fixture.router.handle(
+            RPCRequest(method: RPCMethod.superviseProjectList))
+            .decodeResult(SuperviseProjectListResult.self)
+        #expect(listed.projects.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -30,6 +30,43 @@ struct SupervisionStoreTests {
         }
     }
 
+    /// Counts roster reads and gives each one a distinct value to write.
+    private final class EditCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+        func next() -> Int { lock.withLock { value += 1; return value } }
+        var count: Int { lock.withLock { value } }
+    }
+
+    /// A fleet whose roster read edits `supervision.json` underneath the
+    /// gesture that asked for it.
+    ///
+    /// The roster read is the *only* suspension inside `setProjectMark`'s
+    /// read-modify-write, so an edit landing here is a competing writer at the
+    /// worst possible moment — and doing it on every read is that writer
+    /// winning the race three times running, which is what the retry bound
+    /// exists for.
+    private struct EditingFleet: SupervisionFleetReading {
+        let repoList: [SupervisionRepo]
+        let fileURL: URL
+        let counter: EditCounter
+
+        func repos() async throws -> [SupervisionRepo] { repoList }
+
+        func agents(inRepos repoIDs: Set<UUID>) async throws -> [SupervisionFleetAgent] {
+            // A distinct binding each time, so the file the gesture re-reads
+            // never matches the one it started from. Supervisor bindings are
+            // not validated and do not affect resolution, so this changes the
+            // bytes without changing what the project *is*.
+            let edit = counter.next()
+            try SupervisionFileStore(fileURL: fileURL).save(
+                SupervisionFile(supervisors: [
+                    "acme-web": SupervisionSupervisorBinding(terminal: "t\(edit)")
+                ]))
+            return []
+        }
+    }
+
     private struct Fixture {
         let directory: URL
         let filePath: String
@@ -744,6 +781,33 @@ struct SupervisionStoreTests {
         #expect(status.projects.map(\.name) == ["acme-platform"])
         #expect(status.effectivelySupervising == false,
                 "the group is off until someone turns it on")
+    }
+
+    @Test("A gesture that keeps losing to an outside editor refuses by name, and writes nothing")
+    func repeatedExternalEditsExhaustTheRetries() async throws {
+        let web = Self.repo("acme-web")
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-supervision-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("supervision.json")
+        let ledgerPath = directory.appendingPathComponent("ledger.jsonl").path
+        let counter = EditCounter()
+        let store = SupervisionStore(
+            files: SupervisionFileStore(fileURL: fileURL),
+            ledger: SupervisionLedgerWriter(path: ledgerPath),
+            fleet: EditingFleet(repoList: [web], fileURL: fileURL, counter: counter))
+
+        await #expect(throws: SupervisionStoreError.concurrentEdit(project: "acme-web")) {
+            _ = try await store.setProjectMark(project: "acme-web", on: true)
+        }
+
+        #expect(counter.count == 3, "bounded at three attempts rather than retrying forever")
+        // The refusal is the whole point: losing the race must not degrade into
+        // writing the mark against a file the gesture never read, nor into
+        // reporting success for something that did not happen.
+        let onDisk = try SupervisionFileStore(fileURL: fileURL).load()
+        #expect(onDisk.isMarked("acme-web") == false)
+        #expect(try lines(at: ledgerPath).isEmpty, "and nothing reaches the record")
     }
 
     // MARK: - An edit made outside this store

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -85,6 +85,50 @@ struct SupervisionStoreTests {
         FileManager.default.contents(atPath: fixture.filePath)
     }
 
+    /// Lets a test park inside a `commit` closure and observe what a second,
+    /// overlapping toggle can see while it is parked. Every wait is a
+    /// continuation rather than a sleep, so the handshake is exact rather than
+    /// timed.
+    private actor CommitGate {
+        /// The ledger line count each commit saw, in commit order.
+        private(set) var observed: [Int] = []
+        private var sawFirstCommit = false
+        private var firstCommitWaiters: [CheckedContinuation<Void, Never>] = []
+        private var isReleased = false
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func noteCommit(linesOnDisk: Int) {
+            observed.append(linesOnDisk)
+            guard !sawFirstCommit else { return }
+            sawFirstCommit = true
+            for waiter in firstCommitWaiters { waiter.resume() }
+            firstCommitWaiters = []
+        }
+
+        func waitForFirstCommit() async {
+            guard !sawFirstCommit else { return }
+            await withCheckedContinuation { firstCommitWaiters.append($0) }
+        }
+
+        func waitForRelease() async {
+            guard !isReleased else { return }
+            await withCheckedContinuation { releaseWaiters.append($0) }
+        }
+
+        func release() {
+            isReleased = true
+            for waiter in releaseWaiters { waiter.resume() }
+            releaseWaiters = []
+        }
+    }
+
+    /// How many lines the ledger holds right now. Non-throwing so it can be
+    /// read from inside a `commit` closure without `try` noise.
+    private static func lineCount(at path: String) -> Int {
+        guard let data = FileManager.default.contents(atPath: path) else { return 0 }
+        return data.split(separator: 0x0A, omittingEmptySubsequences: true).count
+    }
+
     /// Every ledger line, decoded, in order.
     private func lines(at path: String) throws -> [SupervisionLedgerLine] {
         guard let data = FileManager.default.contents(atPath: path) else { return [] }
@@ -127,9 +171,11 @@ struct SupervisionStoreTests {
     func brakeChangeWritesAFleetWideLine() async throws {
         let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
 
-        await fixture.store.recordBrakeChange(engaged: true, changed: true)
+        // `commit` stands in for the transaction, returning the resolved brake
+        // it replaced — engaged, then released.
+        try await fixture.store.applyBrakeChange(released: false) { true }
         fixture.dates.advance(by: 60)
-        await fixture.store.recordBrakeChange(engaged: false, changed: true)
+        try await fixture.store.applyBrakeChange(released: true) { false }
 
         let decoded = try lines(at: fixture.ledgerPath)
         #expect(decoded.map(\.payload) == [.brakeEngaged, .brakeReleased])
@@ -144,9 +190,53 @@ struct SupervisionStoreTests {
     @Test("A brake gesture that changes nothing writes no line")
     func unchangedBrakeWritesNoLine() async throws {
         let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
-        await fixture.store.recordBrakeChange(engaged: true, changed: false)
-        await fixture.store.recordBrakeChange(engaged: false, changed: false)
+        // The column moved in both cases; what it resolved to did not.
+        let engagedAgain = try await fixture.store.applyBrakeChange(released: false) { false }
+        let releasedAgain = try await fixture.store.applyBrakeChange(released: true) { true }
+        #expect(engagedAgain == false)
+        #expect(releasedAgain == false)
         #expect(try lines(at: fixture.ledgerPath).isEmpty)
+    }
+
+    @Test("Overlapping brake toggles cannot reach the record out of step with the column")
+    func concurrentBrakeTogglesStayOrdered() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+        let ledgerPath = fixture.ledgerPath
+        let store = fixture.store
+        let gate = CommitGate()
+
+        // The first toggle's commit parks inside the serialized region, holding
+        // it open. Whatever the second toggle does, it must not be able to
+        // commit while the first has not yet written its line.
+        let first = Task {
+            try await store.applyBrakeChange(released: true) {
+                await gate.noteCommit(linesOnDisk: Self.lineCount(at: ledgerPath))
+                await gate.waitForRelease()
+                return false
+            }
+        }
+        await gate.waitForFirstCommit()
+
+        let second = Task {
+            try await store.applyBrakeChange(released: false) {
+                await gate.noteCommit(linesOnDisk: Self.lineCount(at: ledgerPath))
+                return true
+            }
+        }
+        // Give the second toggle every chance to reach the gate before the
+        // first is let go; if it slips past the region, the counts below say so.
+        for _ in 0..<20 { await Task.yield() }
+        await gate.release()
+        _ = try await first.value
+        _ = try await second.value
+
+        #expect(await gate.observed == [0, 1], """
+            the second commit must see the first toggle's line already on the \
+            record — [0, 0] means the two overlapped and their order can diverge
+            """)
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.map(\.payload) == [.brakeReleased, .brakeEngaged],
+                "the record's order is the commit order")
     }
 
     // MARK: - The per-project mark, both branches

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -1,0 +1,511 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — real filesystem, no clocks, no subprocesses.
+///
+/// Every test injects its own `supervision.json` and `ledger.jsonl` paths
+/// rather than touching `TBD_HOME`: the seams exist precisely so this suite
+/// never needs the process-global env, which only `TBDHomeSerialized` may
+/// mutate.
+@Suite("Supervision store")
+struct SupervisionStoreTests {
+
+    // MARK: - Fixture
+
+    /// A fleet the store reads through the narrow injected seam. Deliberately
+    /// not the database: supervision needs a repo list and a roster, and
+    /// nothing about these tests should depend on how session facts are
+    /// stored.
+    private struct StubFleet: SupervisionFleetReading {
+        var repoList: [SupervisionRepo] = []
+        var agentList: [SupervisionFleetAgent] = []
+
+        func repos() async throws -> [SupervisionRepo] { repoList }
+
+        func agents(inRepos repoIDs: Set<UUID>) async throws -> [SupervisionFleetAgent] {
+            agentList.filter { repoIDs.contains($0.repo) }
+        }
+    }
+
+    private struct Fixture {
+        let directory: URL
+        let filePath: String
+        let ledgerPath: String
+        let dates: TestDateSource
+        let store: SupervisionStore
+    }
+
+    private static func makeFixture(
+        fleet: StubFleet, seed: SupervisionFile? = nil
+    ) throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-supervision-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("supervision.json")
+        let files = SupervisionFileStore(fileURL: fileURL)
+        if let seed { try files.save(seed) }
+        let ledgerPath = directory.appendingPathComponent("ledger.jsonl").path
+        let dates = TestDateSource()
+        return Fixture(
+            directory: directory,
+            filePath: fileURL.path,
+            ledgerPath: ledgerPath,
+            dates: dates,
+            store: SupervisionStore(
+                files: files,
+                ledger: SupervisionLedgerWriter(path: ledgerPath),
+                fleet: fleet,
+                now: dates.provider))
+    }
+
+    /// A second store over the same two files — what a daemon restart is.
+    private static func reopen(_ fixture: Fixture, fleet: StubFleet) -> SupervisionStore {
+        SupervisionStore(
+            files: SupervisionFileStore(fileURL: URL(fileURLWithPath: fixture.filePath)),
+            ledger: SupervisionLedgerWriter(path: fixture.ledgerPath),
+            fleet: fleet,
+            now: fixture.dates.provider)
+    }
+
+    /// Every ledger line, decoded, in order.
+    private func lines(at path: String) throws -> [SupervisionLedgerLine] {
+        guard let data = FileManager.default.contents(atPath: path) else { return [] }
+        return try data.split(separator: 0x0A, omittingEmptySubsequences: true).map { raw in
+            try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(raw))
+        }
+    }
+
+    /// Every ledger line as raw JSON, for the assertions about explicit nulls.
+    private func rawLines(at path: String) throws -> [[String: Any]] {
+        guard let data = FileManager.default.contents(atPath: path) else { return [] }
+        return try data.split(separator: 0x0A, omittingEmptySubsequences: true).map { raw in
+            try #require(try JSONSerialization.jsonObject(with: Data(raw)) as? [String: Any])
+        }
+    }
+
+    private static func repo(_ name: String) -> SupervisionRepo {
+        SupervisionRepo(id: UUID(), name: name)
+    }
+
+    // MARK: - The brake, both branches
+
+    @Test("An engaged brake means nothing is effectively supervised, marks intact")
+    func engagedBrakeSuppressesCoverageWithoutClearingMarks() async throws {
+        let web = Self.repo("acme-web")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web]),
+            seed: SupervisionFile(supervised: ["acme-web"]))
+
+        let engaged = try await fixture.store.status(brake: .engaged)
+        #expect(engaged.effectivelySupervising == false)
+        #expect(engaged.projects.first?.on == true, "the mark survives the brake")
+
+        let released = try await fixture.store.status(brake: .released)
+        #expect(released.effectivelySupervising == true)
+        #expect(released.projects.first?.on == true)
+    }
+
+    @Test("Each brake direction writes one fleet-wide line carrying no project")
+    func brakeChangeWritesAFleetWideLine() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+
+        await fixture.store.recordBrakeChange(engaged: true, changed: true)
+        fixture.dates.advance(by: 60)
+        await fixture.store.recordBrakeChange(engaged: false, changed: true)
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.map(\.payload) == [.brakeEngaged, .brakeReleased])
+        #expect(decoded.allSatisfy { $0.project == nil && $0.mode == nil })
+
+        for raw in try rawLines(at: fixture.ledgerPath) {
+            #expect(raw["project"] is NSNull, "a fleet-wide line says null, never omits the key")
+            #expect(raw["mode"] is NSNull)
+        }
+    }
+
+    @Test("A brake gesture that changes nothing writes no line")
+    func unchangedBrakeWritesNoLine() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+        await fixture.store.recordBrakeChange(engaged: true, changed: false)
+        await fixture.store.recordBrakeChange(engaged: false, changed: false)
+        #expect(try lines(at: fixture.ledgerPath).isEmpty)
+    }
+
+    // MARK: - The per-project mark, both branches
+
+    @Test("Turning a project on writes an opening line with the roster already present")
+    func markOnWritesRosterSnapshot() async throws {
+        let web = Self.repo("acme-web")
+        let worktree = UUID()
+        let terminal = UUID()
+        let fleet = StubFleet(
+            repoList: [web],
+            agentList: [SupervisionFleetAgent(
+                worktree: worktree, terminal: terminal, repo: web.id,
+                spawnSource: "claude", transcriptPath: "/tmp/transcript.jsonl")])
+        let fixture = try Self.makeFixture(fleet: fleet)
+
+        let result = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        #expect(result.changed)
+        #expect(result.on)
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.count == 1)
+        let line = try #require(decoded.first)
+        #expect(line.project == "acme-web")
+        #expect(line.mode == "attended")
+        guard case .projectOn(let roster) = line.payload else {
+            Issue.record("expected a projectOn payload, got \(line.payload)")
+            return
+        }
+        #expect(roster == [SupervisionRosterEntry(
+            worktree: worktree, terminal: terminal, repo: web.id, project: "acme-web",
+            spawnSource: "claude", transcriptPath: "/tmp/transcript.jsonl")])
+    }
+
+    @Test("Turning a project off closes the span the opening line started")
+    func markOffWritesCoverageSummary() async throws {
+        let web = Self.repo("acme-web")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
+
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        let openedAt = fixture.dates.now
+        fixture.dates.advance(by: 3600)
+        // A counter the delivery slice will feed; the summary must report it
+        // rather than a literal.
+        await fixture.store.noteSweepContact(project: "acme-web", at: fixture.dates.now)
+        let result = try await fixture.store.setProjectMark(project: "acme-web", on: false)
+        #expect(result.changed)
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.count == 2)
+        guard case .projectOff(let coverage) = try #require(decoded.last).payload else {
+            Issue.record("expected a projectOff payload")
+            return
+        }
+        #expect(coverage.spanStartedAt == SupervisionInstant(openedAt))
+        #expect(coverage.durationSeconds == 3600)
+        #expect(coverage.sweepContacts == 1)
+        #expect(coverage.briefingsDelivered == 0)
+    }
+
+    @Test("An unknown project name is refused rather than marked")
+    func markingAnUnknownProjectIsRefused() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+        await #expect(throws: SupervisionStoreError.unknownProject("acme-platform")) {
+            _ = try await fixture.store.setProjectMark(project: "acme-platform", on: true)
+        }
+        #expect(try lines(at: fixture.ledgerPath).isEmpty)
+    }
+
+    // MARK: - Idempotence
+
+    @Test("A mark that already stands as asked writes nothing and reports changed: false")
+    func idempotentMarkGestures() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+
+        // Off when already off — the untouched state.
+        let offAgain = try await fixture.store.setProjectMark(project: "acme-web", on: false)
+        #expect(offAgain.changed == false)
+        #expect(try lines(at: fixture.ledgerPath).isEmpty)
+
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        let onAgain = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        #expect(onAgain.changed == false)
+        #expect(try lines(at: fixture.ledgerPath).count == 1, "only the first `on` is a decision")
+    }
+
+    @Test("Selecting the mode already selected writes nothing; a real change writes one line")
+    func idempotentModeGestures() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+
+        let same = try await fixture.store.setMode(project: "acme-web", mode: "attended")
+        #expect(same.changed == false)
+        #expect(same.declaredModes == SupervisionModeEntry.builtInModes)
+        #expect(try lines(at: fixture.ledgerPath).isEmpty)
+
+        let changed = try await fixture.store.setMode(project: "acme-web", mode: "autonomous")
+        #expect(changed.changed)
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.count == 1)
+        #expect(decoded.first?.payload == .modeChanged(from: "attended", to: "autonomous"))
+        #expect(decoded.first?.mode == "autonomous", "the line's mode is the one now in force")
+    }
+
+    @Test("A mode outside the declared list is refused, naming the choices")
+    func undeclaredModeIsRefused() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+        await #expect(throws: SupervisionStoreError.modeNotDeclared(
+            project: "acme-web", requested: "friday-freeze",
+            declared: SupervisionModeEntry.builtInModes)) {
+            _ = try await fixture.store.setMode(project: "acme-web", mode: "friday-freeze")
+        }
+        #expect(try lines(at: fixture.ledgerPath).isEmpty)
+    }
+
+    // MARK: - The loud case
+
+    @Test("A released brake with nothing marked on warns, in words and in a code")
+    func releasedBrakeWithNoProjectsOnWarns() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+        let status = try await fixture.store.status(brake: .released)
+
+        #expect(status.effectivelySupervising == false)
+        #expect(status.warnings.map(\.code) == [.noProjectsOn])
+        #expect(status.warnings.first?.message
+            == "the brake is released but no project is on — nothing is being supervised.")
+    }
+
+    @Test("A marked project silences the loud line")
+    func markedProjectSilencesTheWarning() async throws {
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [Self.repo("acme-web")]),
+            seed: SupervisionFile(supervised: ["acme-web"]))
+        let status = try await fixture.store.status(brake: .released)
+        #expect(status.effectivelySupervising)
+        #expect(status.warnings.isEmpty)
+    }
+
+    @Test("An engaged brake is not the noProjectsOn warning")
+    func engagedBrakeDoesNotWarnAboutProjects() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+        let status = try await fixture.store.status(brake: .engaged)
+        #expect(status.warnings.isEmpty, "a paused fleet is a stated choice, not a quiet failure")
+    }
+
+    @Test("A project whose name cannot be a directory warns and is supervised anyway")
+    func unusableProjectNameWarns() async throws {
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [Self.repo("acme/web")]),
+            seed: SupervisionFile(supervised: ["acme/web"]))
+        let status = try await fixture.store.status(brake: .released)
+
+        #expect(status.warnings.map(\.code) == [.unusableProjectName])
+        #expect(status.warnings.first?.message.contains("\"acme/web\"") == true,
+                "the message names which ones")
+        #expect(status.projects.map(\.name) == ["acme/web"])
+        #expect(status.projects.first?.on == true)
+        #expect(status.effectivelySupervising, "coverage is not withheld over a display name")
+    }
+
+    // MARK: - Untouched and turned-off are one state
+
+    @Test("A project never touched and one turned back off are indistinguishable")
+    func untouchedAndTurnedOffRenderIdentically() async throws {
+        let web = Self.repo("acme-web")
+        let untouched = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
+        let turnedOff = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
+        _ = try await turnedOff.store.setProjectMark(project: "acme-web", on: true)
+        _ = try await turnedOff.store.setProjectMark(project: "acme-web", on: false)
+
+        let a = try await untouched.store.status(brake: .released)
+        let b = try await turnedOff.store.status(brake: .released)
+        #expect(a.projects == b.projects,
+                "a third tier would show up here as a leftover span or a differing flag")
+        #expect(b.projects.first?.spanStartedAt == nil)
+    }
+
+    // MARK: - Restart
+
+    @Test("A restart resumes the span from the two files and replays no decision")
+    func restartRecoversSpanAndWritesNothing() async throws {
+        let web = Self.repo("acme-web")
+        let fleet = StubFleet(repoList: [web])
+        let fixture = try Self.makeFixture(fleet: fleet)
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        let openedAt = fixture.dates.now
+        let afterFirstRun = try lines(at: fixture.ledgerPath)
+        #expect(afterFirstRun.count == 1)
+
+        fixture.dates.advance(by: 7200)
+        let restarted = Self.reopen(fixture, fleet: fleet)
+        try await restarted.load()
+
+        #expect(try lines(at: fixture.ledgerPath).map(\.id) == afterFirstRun.map(\.id),
+                "loading writes no line — reading state back is not re-deciding")
+        let status = try await restarted.status(brake: .released)
+        #expect(status.projects.first?.on == true)
+        #expect(status.projects.first?.spanStartedAt == SupervisionInstant(openedAt))
+        #expect(status.effectivelySupervising)
+    }
+
+    @Test("A span closed before the restart is not resurrected as open")
+    func restartDoesNotReopenAClosedSpan() async throws {
+        let web = Self.repo("acme-web")
+        let fleet = StubFleet(repoList: [web])
+        let fixture = try Self.makeFixture(fleet: fleet)
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        fixture.dates.advance(by: 60)
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: false)
+
+        let restarted = Self.reopen(fixture, fleet: fleet)
+        try await restarted.load()
+        let status = try await restarted.status(brake: .released)
+        #expect(status.projects.first?.on == false)
+        #expect(status.projects.first?.spanStartedAt == nil)
+    }
+
+    // MARK: - Reload after a hand edit
+
+    @Test("A hand edit between gestures is picked up, not overwritten")
+    func handEditIsReloadedBeforeTheNextGesture() async throws {
+        let web = Self.repo("acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web, api]))
+        _ = try await fixture.store.projectList()  // populate the in-memory copy
+
+        // The operator edits the file directly — the whole surface beyond the
+        // CLI, by design.
+        let edited = SupervisionFile(
+            projects: ["acme-platform": SupervisionProjectDeclaration(
+                repos: [web.id, api.id], policy: .repo(web.id))])
+        try SupervisionFileStore(fileURL: URL(fileURLWithPath: fixture.filePath)).save(edited)
+
+        let listed = try await fixture.store.projectList()
+        #expect(listed.projects.map(\.name) == ["acme-platform"])
+
+        // And the next write preserves the edit rather than rewriting it away.
+        _ = try await fixture.store.setProjectMark(project: "acme-platform", on: true)
+        let onDisk = try SupervisionFileStore(
+            fileURL: URL(fileURLWithPath: fixture.filePath)).load()
+        #expect(onDisk.projects["acme-platform"]?.repos == [web.id, api.id])
+        #expect(onDisk.supervised == ["acme-platform"])
+    }
+
+    // MARK: - Projects and moves
+
+    @Test("A declared project and its repos survive a round trip through the file")
+    func projectCreateDeclaresAndLists() async throws {
+        let web = Self.repo("acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web, api]))
+
+        let result = try await fixture.store.projectCreate(
+            name: "acme-platform", repos: ["acme-web", api.id.uuidString],
+            policy: .repo("acme-web"))
+        #expect(result.projects.map(\.name) == ["acme-platform"])
+        #expect(result.projects.first?.repos.map(\.name) == ["acme-web", "acme-api"])
+        #expect(result.projects.first?.policy == .repo(web.id))
+    }
+
+    @Test("A display name two repos share is refused, never guessed")
+    func ambiguousRepoNameIsRefused() async throws {
+        let first = Self.repo("acme-web")
+        let second = SupervisionRepo(id: UUID(), name: "acme-web")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [first, second]))
+
+        await #expect(throws: SupervisionStoreError.ambiguousRepoName(
+            "acme-web", repos: [first.id, second.id])) {
+            _ = try await fixture.store.projectCreate(
+                name: "acme-platform", repos: ["acme-web"], policy: .operator)
+        }
+    }
+
+    @Test("Moving a project's policy source out is refused and changes nothing")
+    func refusedMoveLeavesFileAndMemoryUntouched() async throws {
+        let web = Self.repo("acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web, api]),
+            seed: SupervisionFile(projects: ["acme-platform": SupervisionProjectDeclaration(
+                repos: [web.id, api.id], policy: .repo(web.id))]))
+        let before = try #require(FileManager.default.contents(atPath: fixture.filePath))
+        let listedBefore = try await fixture.store.projectList()
+
+        await #expect(throws: SupervisionTopologyError.policySourceWouldLeaveProject(
+            project: "acme-platform", repo: web.id)) {
+            _ = try await fixture.store.projectMove(repo: "acme-web", to: .singleton)
+        }
+
+        #expect(FileManager.default.contents(atPath: fixture.filePath) == before,
+                "a refused move leaves the file byte-identical")
+        #expect(try await fixture.store.projectList() == listedBefore)
+        #expect(try lines(at: fixture.ledgerPath).isEmpty)
+    }
+
+    @Test("Moving to a project that does not exist is refused and changes nothing")
+    func moveToUnknownProjectLeavesStateUntouched() async throws {
+        let web = Self.repo("acme-web")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
+        let before = try #require(FileManager.default.contents(atPath: fixture.filePath))
+
+        await #expect(throws: SupervisionTopologyError.unknownProject(project: "acme-platform")) {
+            _ = try await fixture.store.projectMove(repo: "acme-web", to: .project("acme-platform"))
+        }
+        #expect(FileManager.default.contents(atPath: fixture.filePath) == before)
+    }
+
+    @Test("A repo lands in exactly one project across a move, and the emptied one is closed")
+    func moveEmptyingAProjectClosesItsSpan() async throws {
+        let web = Self.repo("acme-web")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web]),
+            seed: SupervisionFile(
+                projects: ["acme-platform": SupervisionProjectDeclaration(
+                    repos: [web.id], policy: .repo(web.id))],
+                supervised: ["acme-platform"]))
+
+        let result = try await fixture.store.projectMove(repo: "acme-web", to: .singleton)
+        #expect(result.projects.map(\.name) == ["acme-web"], "exactly one project holds the repo")
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.count == 1)
+        #expect(decoded.first?.project == "acme-platform")
+        guard case .projectOff = try #require(decoded.first).payload else {
+            Issue.record("a vanished project's coverage must be closed on the record")
+            return
+        }
+        let onDisk = try SupervisionFileStore(
+            fileURL: URL(fileURLWithPath: fixture.filePath)).load()
+        #expect(onDisk.supervised.isEmpty, "a mark must not outlive its project")
+    }
+
+    @Test("Deleting a declaration returns its repos to being their own projects")
+    func projectDeleteReturnsReposToSingletons() async throws {
+        let web = Self.repo("acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web, api]),
+            seed: SupervisionFile(projects: ["acme-platform": SupervisionProjectDeclaration(
+                repos: [web.id, api.id], policy: .repo(web.id))]))
+
+        let result = try await fixture.store.projectDelete(name: "acme-platform")
+        #expect(result.projects.map(\.name) == ["acme-api", "acme-web"])
+    }
+
+    // MARK: - A failed save
+
+    @Test("A save that cannot be written leaves the file and the store unchanged")
+    func failedSaveChangesNothing() async throws {
+        let web = Self.repo("acme-web")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web]),
+            seed: SupervisionFile(supervised: ["acme-web"]))
+        _ = try await fixture.store.projectList()
+        let before = try #require(FileManager.default.contents(atPath: fixture.filePath))
+
+        // Read and traverse but never write: the temp the atomic save needs
+        // cannot be created.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o500], ofItemAtPath: fixture.directory.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: fixture.directory.path)
+        }
+
+        await #expect(throws: (any Error).self) {
+            _ = try await fixture.store.setProjectMark(project: "acme-web", on: false)
+        }
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: fixture.directory.path)
+        #expect(FileManager.default.contents(atPath: fixture.filePath) == before)
+        let status = try await fixture.store.status(brake: .released)
+        #expect(status.projects.first?.on == true, "the in-memory mark did not move either")
+        #expect(try lines(at: fixture.ledgerPath).isEmpty,
+                "no line for a decision that never took effect")
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -284,11 +284,43 @@ struct SupervisionStoreTests {
         #expect(status.warnings.isEmpty)
     }
 
-    @Test("An engaged brake is not the noProjectsOn warning")
-    func engagedBrakeDoesNotWarnAboutProjects() async throws {
-        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
-        let status = try await fixture.store.status(brake: .engaged)
-        #expect(status.warnings.isEmpty, "a paused fleet is a stated choice, not a quiet failure")
+    @Test("An engaged brake over a standing mark warns; over an unmarked fleet it does not")
+    func engagedBrakeWarnsOnlyWhenAMarkStands() async throws {
+        let web = Self.repo("acme-web")
+        let quiet = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
+        #expect(try await quiet.store.status(brake: .engaged).warnings.isEmpty,
+                "a paused fleet with nothing marked is a stated choice, not a quiet failure")
+
+        let marked = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web]),
+            seed: SupervisionFile(supervised: ["acme-web"]))
+        let status = try await marked.store.status(brake: .engaged)
+        #expect(status.warnings.map(\.code) == [.brakeEngagedWithProjectsOn])
+        #expect(status.warnings.first?.message.contains("\"acme-web\"") == true)
+        #expect(status.effectivelySupervising == false)
+        #expect(status.warnings.contains { $0.code == .noProjectsOn } == false,
+                "the two halves of \"nothing is watching\" are never both true")
+    }
+
+    @Test("A shared display name costs those repos their projects, not the fleet's coverage")
+    func ambiguousRepoNamesAreReportedNotFatal() async throws {
+        let first = SupervisionRepo(id: UUID(), name: "acme-web")
+        let second = SupervisionRepo(id: UUID(), name: "acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [first, second, api]),
+            seed: SupervisionFile(supervised: ["acme-api"]))
+
+        let status = try await fixture.store.status(brake: .released)
+
+        #expect(status.projects.map(\.name) == ["acme-api"],
+                "the colliding repos resolve to no project; the rest of the fleet is unaffected")
+        #expect(status.effectivelySupervising, "one repo's naming does not take coverage down")
+        #expect(status.warnings.map(\.code) == [.ambiguousRepoName])
+        let message = try #require(status.warnings.first?.message)
+        #expect(message.contains("\"acme-web\""))
+        #expect(message.contains(first.id.uuidString))
+        #expect(message.contains(second.id.uuidString))
     }
 
     @Test("A project whose name cannot be a directory warns and is supervised anyway")
@@ -501,6 +533,135 @@ struct SupervisionStoreTests {
         let onDisk = try SupervisionFileStore(
             fileURL: URL(fileURLWithPath: fixture.filePath)).load()
         #expect(onDisk.supervised.isEmpty, "a mark must not outlive its project")
+    }
+
+    // MARK: - A project that stops resolving
+
+    @Test("Absorbing a marked singleton by move closes its coverage and clears its mark")
+    func moveAbsorbingAMarkedSingletonClosesItsCoverage() async throws {
+        let web = Self.repo("acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web, api]),
+            seed: SupervisionFile(projects: ["acme-platform": SupervisionProjectDeclaration(
+                repos: [web.id], policy: .repo(web.id))]))
+        // `acme-api` is its own project — declared nowhere — and it is on.
+        _ = try await fixture.store.setProjectMark(project: "acme-api", on: true)
+        fixture.dates.advance(by: 600)
+
+        _ = try await fixture.store.projectMove(repo: "acme-api", to: .project("acme-platform"))
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.count == 2, "the absorbed project's coverage ends on the record")
+        let closing = try #require(decoded.last)
+        #expect(closing.project == "acme-api")
+        guard case .projectOff(let coverage) = closing.payload else {
+            Issue.record("a project that stops resolving must have its span closed")
+            return
+        }
+        #expect(coverage.durationSeconds == 600)
+
+        let onDisk = try SupervisionFileStore(
+            fileURL: URL(fileURLWithPath: fixture.filePath)).load()
+        #expect(onDisk.supervised.isEmpty,
+                "a mark that outlived its project would resurrect it without a gesture")
+    }
+
+    @Test("A dissolved group does not resurrect an absorbed project's coverage")
+    func absorbedProjectDoesNotComeBackOn() async throws {
+        let web = Self.repo("acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(
+            fleet: StubFleet(repoList: [web, api]),
+            seed: SupervisionFile(projects: ["acme-platform": SupervisionProjectDeclaration(
+                repos: [web.id], policy: .repo(web.id))]))
+        _ = try await fixture.store.setProjectMark(project: "acme-api", on: true)
+        _ = try await fixture.store.projectMove(repo: "acme-api", to: .project("acme-platform"))
+        let afterAbsorption = try lines(at: fixture.ledgerPath).count
+
+        // Hours later the group is dissolved and `acme-api` is its own project
+        // again. Nobody has turned it on since.
+        fixture.dates.advance(by: 6 * 3600)
+        _ = try await fixture.store.projectMove(repo: "acme-api", to: .singleton)
+
+        let status = try await fixture.store.status(brake: .released)
+        let resurrected = try #require(status.projects.first { $0.name == "acme-api" })
+        #expect(resurrected.on == false, "coverage may only start from an operator gesture")
+        #expect(resurrected.spanStartedAt == nil)
+        #expect(status.effectivelySupervising == false)
+        #expect(try lines(at: fixture.ledgerPath).count == afterAbsorption,
+                "coming back into existence is not a decision and writes no line")
+    }
+
+    @Test("Declaring a group over a marked singleton closes its coverage too")
+    func projectCreateAbsorbingAMarkedSingletonClosesItsCoverage() async throws {
+        let web = Self.repo("acme-web")
+        let api = Self.repo("acme-api")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web, api]))
+        _ = try await fixture.store.setProjectMark(project: "acme-api", on: true)
+
+        _ = try await fixture.store.projectCreate(
+            name: "acme-platform", repos: ["acme-web", "acme-api"], policy: .repo("acme-web"))
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.count == 2)
+        #expect(decoded.last?.project == "acme-api")
+        guard case .projectOff = try #require(decoded.last).payload else {
+            Issue.record("declaring a group over a marked singleton ends that project")
+            return
+        }
+        let status = try await fixture.store.status(brake: .released)
+        #expect(status.projects.map(\.name) == ["acme-platform"])
+        #expect(status.effectivelySupervising == false,
+                "the group is off until someone turns it on")
+    }
+
+    // MARK: - An edit made outside this store
+
+    @Test("A mark cleared by hand closes its span on the next read")
+    func markClearedByHandIsReconciled() async throws {
+        let web = Self.repo("acme-web")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        fixture.dates.advance(by: 900)
+
+        // The operator clears the mark in the file. The same running store then
+        // reads it — this is an observation it really made, unlike a restart,
+        // which only recovers state and must write nothing.
+        try SupervisionFileStore(fileURL: URL(fileURLWithPath: fixture.filePath))
+            .save(SupervisionFile())
+        let status = try await fixture.store.status(brake: .released)
+        #expect(status.projects.first?.on == false)
+
+        let decoded = try lines(at: fixture.ledgerPath)
+        #expect(decoded.count == 2, "the span left open by the edit is closed as of now")
+        guard case .projectOff(let coverage) = try #require(decoded.last).payload else {
+            Issue.record("expected the orphaned span to be closed")
+            return
+        }
+        #expect(coverage.durationSeconds == 900)
+
+        // And the next `on` opens a fresh span rather than a second one over
+        // the first.
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+        #expect(try lines(at: fixture.ledgerPath).count == 3)
+    }
+
+    @Test("A mark added by hand is not turned into a decision TBD authored")
+    func markAddedByHandWritesNoOpeningLine() async throws {
+        let web = Self.repo("acme-web")
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
+        _ = try await fixture.store.projectList()
+
+        try SupervisionFileStore(fileURL: URL(fileURLWithPath: fixture.filePath))
+            .save(SupervisionFile(supervised: ["acme-web"]))
+        let status = try await fixture.store.status(brake: .released)
+
+        #expect(status.projects.first?.on == true)
+        #expect(status.projects.first?.spanStartedAt == nil,
+                "a bare `on` is what the readout shows when the record holds no opening line")
+        #expect(try lines(at: fixture.ledgerPath).isEmpty,
+                "TBD does not author a decision an operator made in a text editor")
     }
 
     @Test("Deleting a declaration returns its repos to being their own projects")

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -308,6 +308,28 @@ struct SupervisionStoreTests {
         #expect(b.projects.first?.spanStartedAt == nil)
     }
 
+    @Test("A project turned off by hand still renders exactly off, span or no span")
+    func handClearedMarkRendersBareOffDespiteAnOpenLine() async throws {
+        let web = Self.repo("acme-web")
+        let fleet = StubFleet(repoList: [web])
+        let fixture = try Self.makeFixture(fleet: fleet)
+        _ = try await fixture.store.setProjectMark(project: "acme-web", on: true)
+
+        // The operator clears the mark in the file itself, so the ledger keeps
+        // an opening line with no `off` after it. A restart therefore recovers
+        // an open span for a project whose mark is gone — the one arrangement
+        // where "off" and "has a span" meet.
+        try SupervisionFileStore(fileURL: URL(fileURLWithPath: fixture.filePath))
+            .save(SupervisionFile())
+        let restarted = Self.reopen(fixture, fleet: fleet)
+        try await restarted.load()
+
+        let status = try await restarted.status(brake: .released)
+        #expect(status.projects.first?.on == false)
+        #expect(status.projects.first?.spanStartedAt == nil,
+                "an off project renders exactly off — a span here would be a third state")
+    }
+
     // MARK: - Restart
 
     @Test("A restart resumes the span from the two files and replays no decision")

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -193,9 +193,25 @@ struct SupervisionStoreTests {
         // The column moved in both cases; what it resolved to did not.
         let engagedAgain = try await fixture.store.applyBrakeChange(released: false) { false }
         let releasedAgain = try await fixture.store.applyBrakeChange(released: true) { true }
-        #expect(engagedAgain == false)
-        #expect(releasedAgain == false)
+        #expect(engagedAgain.changed == false)
+        #expect(releasedAgain.changed == false)
         #expect(try lines(at: fixture.ledgerPath).isEmpty)
+        // A gesture that moved nothing still takes an ordering token: the
+        // sequence says where a transition sits, not whether it mattered.
+        #expect(engagedAgain.sequence < releasedAgain.sequence)
+    }
+
+    @Test("Every transition takes a token, and the tokens follow commit order")
+    func brakeTransitionsAreOrdered() async throws {
+        let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [Self.repo("acme-web")]))
+
+        let first = try await fixture.store.applyBrakeChange(released: true) { false }
+        let second = try await fixture.store.applyBrakeChange(released: false) { true }
+        let third = try await fixture.store.applyBrakeChange(released: true) { false }
+
+        #expect(first.sequence < second.sequence)
+        #expect(second.sequence < third.sequence)
+        #expect([first, second, third].allSatisfy(\.changed))
     }
 
     @Test("Overlapping brake toggles cannot reach the record out of step with the column")

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -211,10 +211,22 @@ struct SupervisionStoreTests {
 
         #expect(first.sequence < second.sequence)
         #expect(second.sequence < third.sequence)
-        // Spelled as a conjunction rather than `allSatisfy(\.changed)`:
-        // `allSatisfy` is `rethrows`, and inside `#expect`'s expansion the
-        // key-path-as-function conversion stops reading as non-throwing, so the
-        // macro demands a `try` for a call that cannot throw.
+        // **Inside `#expect`, avoid any `rethrows` call whose non-throwing-ness
+        // depends on an implicit conversion.** `allSatisfy(\.changed)` reads as
+        // non-throwing in ordinary code because the key path converts to a
+        // non-throwing closure, but `#expect` re-evaluates the expression and
+        // that conversion stops carrying its throwing-ness through the
+        // expansion — so the macro demands a `try` for a call that cannot
+        // throw, and the error points at the expansion rather than at this
+        // line, which makes it a slow one to place.
+        //
+        // It is the *implicit conversion* that trips, not `allSatisfy`: the two
+        // sites in this suite that pass an explicit closure literal
+        // (`allSatisfy { $0.project == nil ... }`) have compiled since the day
+        // they were written. So the fix is to spell the predicate out, hoist it
+        // to a `let` above the macro, or — as here, for three values — drop the
+        // call entirely. The same caution applies to `contains(where:)`,
+        // `first(where:)` and friends given a key path or a bare function name.
         #expect(first.changed && second.changed && third.changed)
     }
 

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -368,6 +368,7 @@ struct SupervisionStoreTests {
         // where "off" and "has a span" meet.
         try SupervisionFileStore(fileURL: URL(fileURLWithPath: fixture.filePath))
             .save(SupervisionFile())
+        let beforeRestart = try lines(at: fixture.ledgerPath).map(\.id)
         let restarted = Self.reopen(fixture, fleet: fleet)
         try await restarted.load()
 
@@ -375,6 +376,13 @@ struct SupervisionStoreTests {
         #expect(status.projects.first?.on == false)
         #expect(status.projects.first?.spanStartedAt == nil,
                 "an off project renders exactly off — a span here would be a third state")
+        // Startup recovers state; it does not settle it. Reconciling here would
+        // close the span with an end time nobody observed, and it is the one
+        // arrangement where a load *could* — the mark is gone and the span is
+        // open, exactly what an outside edit leaves behind. Asserted on ids so
+        // a rewrite fails it as well as an extra append.
+        #expect(try lines(at: fixture.ledgerPath).map(\.id) == beforeRestart,
+                "loading writes no ledger line, even with a span to settle")
     }
 
     // MARK: - Restart

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -211,7 +211,11 @@ struct SupervisionStoreTests {
 
         #expect(first.sequence < second.sequence)
         #expect(second.sequence < third.sequence)
-        #expect([first, second, third].allSatisfy(\.changed))
+        // Spelled as a conjunction rather than `allSatisfy(\.changed)`:
+        // `allSatisfy` is `rethrows`, and inside `#expect`'s expansion the
+        // key-path-as-function conversion stops reading as non-throwing, so the
+        // macro demands a `try` for a call that cannot throw.
+        #expect(first.changed && second.changed && third.changed)
     }
 
     @Test("Overlapping brake toggles cannot reach the record out of step with the column")

--- a/Tests/TBDDaemonTests/SupervisionStoreTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStoreTests.swift
@@ -70,6 +70,21 @@ struct SupervisionStoreTests {
             now: fixture.dates.provider)
     }
 
+    /// The supervision file's bytes, or nil when there is no file.
+    ///
+    /// **Optional on purpose, and compared as an optional.** An absent file is
+    /// not a missing baseline — it is the empty state, the one every fresh
+    /// install is in, and `SupervisionFileStore.load()` reads it as exactly the
+    /// value an empty file would produce. So "unchanged" has to include "there
+    /// were no bytes and there still are none"; unwrapping the baseline with
+    /// `#require` instead would demand bytes that ought not to exist and fail
+    /// before the refusal under test was even attempted. Comparing optionals
+    /// keeps the assertion discriminating in both directions: a refusal that
+    /// wrote a file moves nil to non-nil and reddens.
+    private func fileBytes(_ fixture: Fixture) -> Data? {
+        FileManager.default.contents(atPath: fixture.filePath)
+    }
+
     /// Every ledger line, decoded, in order.
     private func lines(at path: String) throws -> [SupervisionLedgerLine] {
         guard let data = FileManager.default.contents(atPath: path) else { return [] }
@@ -434,7 +449,7 @@ struct SupervisionStoreTests {
             fleet: StubFleet(repoList: [web, api]),
             seed: SupervisionFile(projects: ["acme-platform": SupervisionProjectDeclaration(
                 repos: [web.id, api.id], policy: .repo(web.id))]))
-        let before = try #require(FileManager.default.contents(atPath: fixture.filePath))
+        let before = fileBytes(fixture)
         let listedBefore = try await fixture.store.projectList()
 
         await #expect(throws: SupervisionTopologyError.policySourceWouldLeaveProject(
@@ -442,8 +457,7 @@ struct SupervisionStoreTests {
             _ = try await fixture.store.projectMove(repo: "acme-web", to: .singleton)
         }
 
-        #expect(FileManager.default.contents(atPath: fixture.filePath) == before,
-                "a refused move leaves the file byte-identical")
+        #expect(fileBytes(fixture) == before, "a refused move leaves the file byte-identical")
         #expect(try await fixture.store.projectList() == listedBefore)
         #expect(try lines(at: fixture.ledgerPath).isEmpty)
     }
@@ -452,12 +466,16 @@ struct SupervisionStoreTests {
     func moveToUnknownProjectLeavesStateUntouched() async throws {
         let web = Self.repo("acme-web")
         let fixture = try Self.makeFixture(fleet: StubFleet(repoList: [web]))
-        let before = try #require(FileManager.default.contents(atPath: fixture.filePath))
+        // Nothing has been declared, so there is no file — and a refused move
+        // must leave it that way. `nil == nil` is the assertion, and a store
+        // that wrote anything on the way to refusing moves it off nil.
+        let before = fileBytes(fixture)
+        #expect(before == nil, "the fixture starts from the empty state, which is an absent file")
 
         await #expect(throws: SupervisionTopologyError.unknownProject(project: "acme-platform")) {
             _ = try await fixture.store.projectMove(repo: "acme-web", to: .project("acme-platform"))
         }
-        #expect(FileManager.default.contents(atPath: fixture.filePath) == before)
+        #expect(fileBytes(fixture) == before)
     }
 
     @Test("A repo lands in exactly one project across a move, and the emptied one is closed")
@@ -507,7 +525,7 @@ struct SupervisionStoreTests {
             fleet: StubFleet(repoList: [web]),
             seed: SupervisionFile(supervised: ["acme-web"]))
         _ = try await fixture.store.projectList()
-        let before = try #require(FileManager.default.contents(atPath: fixture.filePath))
+        let before = fileBytes(fixture)
 
         // Read and traverse but never write: the temp the atomic save needs
         // cannot be created.
@@ -524,7 +542,7 @@ struct SupervisionStoreTests {
 
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o700], ofItemAtPath: fixture.directory.path)
-        #expect(FileManager.default.contents(atPath: fixture.filePath) == before)
+        #expect(fileBytes(fixture) == before)
         let status = try await fixture.store.status(brake: .released)
         #expect(status.projects.first?.on == true, "the in-memory mark did not move either")
         #expect(try lines(at: fixture.ledgerPath).isEmpty,

--- a/Tests/TBDDaemonTests/TmuxControlSupervisorTeardownTests.swift
+++ b/Tests/TBDDaemonTests/TmuxControlSupervisorTeardownTests.swift
@@ -53,7 +53,7 @@ struct TmuxControlSupervisorTeardownTests {
         // teardown. (Reachable in production from any untolerated %error too.)
         await client.handle(.commandSucceeded(number: 1, fromClient: true, lines: []))
         #expect(await waitUntil(
-            { stopStarted.count == 1 }, timeout: .seconds(60)), "teardown never reached stop()")
+            { stopStarted.count == 1 }, timeout: ciSafeDeadline), "teardown never reached stop()")
 
         // While the stop is STILL blocked, unrelated supervisor calls must
         // complete. Bounded by a generous CI-safe deadline: pre-fix, the
@@ -65,7 +65,7 @@ struct TmuxControlSupervisorTeardownTests {
             _ = await supervisor.command(server: "srv-unrelated")
             unrelatedDone.increment()
         }
-        let unrelatedCompleted = await waitUntil({ unrelatedDone.count == 1 }, timeout: .seconds(60))
+        let unrelatedCompleted = await waitUntil({ unrelatedDone.count == 1 }, timeout: ciSafeDeadline)
         #expect(unrelatedCompleted, "supervisor actor is blocked by a mid-stop teardown")
         // Pre-fix the actor stays wedged until the gate opens — unwedge so the
         // remaining assertions (and cleanup) can run instead of hanging.
@@ -118,7 +118,7 @@ struct TmuxControlSupervisorTeardownTests {
         // Fatal correlator violation → teardown; eviction runs, stop is held.
         await client.handle(.commandSucceeded(number: 1, fromClient: true, lines: []))
         #expect(await waitUntil(
-            { stopStarted.count == 1 }, timeout: .seconds(60)), "teardown never reached stop()")
+            { stopStarted.count == 1 }, timeout: ciSafeDeadline), "teardown never reached stop()")
 
         // A re-attach's ensureConnection lands while the old tmux client
         // process is still dying. It must SUSPEND: `PaneFanout.route` keys by
@@ -139,7 +139,7 @@ struct TmuxControlSupervisorTeardownTests {
         // The held stop completes → the parked ensureConnection resumes and
         // creates exactly one successor.
         stopGate.signal()
-        #expect(await waitUntil({ ensured.count == 1 }, timeout: .seconds(60)),
+        #expect(await waitUntil({ ensured.count == 1 }, timeout: ciSafeDeadline),
                 "ensureConnection must resume once the stop completed")
         #expect(stopFinished.count == 1)
         #expect(created.count == 2, "exactly one successor after the teardown finished")
@@ -176,7 +176,7 @@ struct TmuxControlSupervisorTeardownTests {
         // stopAll must route through the injectable stop seam (pre-fix it
         // called connection.stop() directly ON the actor).
         #expect(await waitUntil(
-            { stopStarted.count == 2 }, timeout: .seconds(60)), "stopAll never reached the stop seam")
+            { stopStarted.count == 2 }, timeout: ciSafeDeadline), "stopAll never reached the stop seam")
 
         // While BOTH stops are still held open, an unrelated actor call must
         // complete promptly — pre-fix the actor is wedged inside the stops.
@@ -186,7 +186,7 @@ struct TmuxControlSupervisorTeardownTests {
             _ = await supervisor.command(server: "srv-third")
             unrelatedDone.increment()
         }
-        #expect(await waitUntil({ unrelatedDone.count == 1 }, timeout: .seconds(60)),
+        #expect(await waitUntil({ unrelatedDone.count == 1 }, timeout: ciSafeDeadline),
                 "supervisor actor is blocked by a mid-stop stopAll")
 
         // Bookkeeping ran BEFORE the stops: both clients already evicted.
@@ -207,12 +207,12 @@ struct TmuxControlSupervisorTeardownTests {
 
         stopGate.signal()
         stopGate.signal()
-        #expect(await waitUntil({ stopAllDone.count == 1 }, timeout: .seconds(60)),
+        #expect(await waitUntil({ stopAllDone.count == 1 }, timeout: ciSafeDeadline),
                 "stopAll must return once its stops complete")
         // The parked ensureConnection resumes and creates a fresh connection:
         // the supervisor stays usable after stopAll (the reconnect-after-
         // stopAll contract in TmuxControlCommandClientIntegrationTests).
-        #expect(await waitUntil({ ensured.count == 1 }, timeout: .seconds(60)),
+        #expect(await waitUntil({ ensured.count == 1 }, timeout: ciSafeDeadline),
                 "parked ensureConnection must resume after stopAll finishes")
         #expect(await supervisor.command(server: "srv-a") != nil)
 
@@ -244,7 +244,7 @@ struct TmuxControlSupervisorTeardownTests {
         let client = try #require(await supervisor.command(server: "srv-pool"))
         await client.handle(.commandSucceeded(number: 1, fromClient: true, lines: []))
 
-        #expect(await waitUntil({ stopSeen.count >= 1 }, timeout: .seconds(60)),
+        #expect(await waitUntil({ stopSeen.count >= 1 }, timeout: ciSafeDeadline),
                 "fatal teardown never reached stop()")
         let label = labelBox.get() ?? ""
         #expect(!label.contains("cooperative"),
@@ -275,7 +275,7 @@ struct TmuxControlSupervisorTeardownTests {
             })
 
         await supervisor.ensureConnection(serverName: "srv-natural")
-        #expect(await waitUntil({ stopSeen.count == 1 }, timeout: .seconds(60)),
+        #expect(await waitUntil({ stopSeen.count == 1 }, timeout: ciSafeDeadline),
                 "natural stream end must stop() the connection to release its pty fd")
         // The map entry is gone too (drain owned it at stream end).
         #expect(await supervisor.command(server: "srv-natural") == nil)

--- a/Tests/TBDSharedTests/SupervisionFileStoreTests.swift
+++ b/Tests/TBDSharedTests/SupervisionFileStoreTests.swift
@@ -1,0 +1,174 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+/// Runs `body` against a fresh temporary directory, removed afterwards. Nothing
+/// here touches `~/tbd`: the store is constructed with an explicit file URL,
+/// and the `environment:` seam is exercised with a dictionary.
+private func withTemporaryDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-supervision-store-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    return try body(directory)
+}
+
+@Suite struct SupervisionFileStoreTests {
+    private let repoA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000000")!
+    private let repoB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000000")!
+
+    @Test func anAbsentFileLoadsAsTheEmptyValue() throws {
+        try withTemporaryDirectory { directory in
+            let store = SupervisionFileStore(
+                fileURL: directory.appendingPathComponent("supervision.json"))
+            let loaded = try store.load()
+            #expect(loaded == SupervisionFile())
+        }
+    }
+
+    @Test func untouchedAndTurnedOffAreIndistinguishable() throws {
+        try withTemporaryDirectory { directory in
+            let store = SupervisionFileStore(
+                fileURL: directory.appendingPathComponent("supervision.json"))
+            let untouched = try store.load()
+
+            try store.save(untouched.settingMark("acme-checkout", on: true))
+            let on = try store.load()
+            #expect(on.isMarked("acme-checkout"))
+
+            try store.save(on.settingMark("acme-checkout", on: false))
+            let reloaded = try store.load()
+            #expect(reloaded == untouched)
+        }
+    }
+
+    @Test func theEnvironmentSeamResolvesThroughTBDConstants() {
+        let store = SupervisionFileStore(environment: ["TBD_HOME": "/tmp/tbd-store-seam"])
+        #expect(store.fileURL.path == "/tmp/tbd-store-seam/supervision/supervision.json")
+    }
+
+    @Test func saveCreatesTheDirectory() throws {
+        try withTemporaryDirectory { directory in
+            let nested = directory.appendingPathComponent("supervision", isDirectory: true)
+            let store = SupervisionFileStore(
+                fileURL: nested.appendingPathComponent("supervision.json"))
+            try store.save(SupervisionFile().settingMark("acme-checkout", on: true))
+            let loaded = try store.load()
+            #expect(loaded.isMarked("acme-checkout"))
+        }
+    }
+
+    @Test func savedFileRoundTripsThroughLoad() throws {
+        try withTemporaryDirectory { directory in
+            let store = SupervisionFileStore(
+                fileURL: directory.appendingPathComponent("supervision.json"))
+            let file = SupervisionFile(
+                projects: ["acme-checkout": .init(
+                    repos: [repoA, repoB], policy: .repo(repoA),
+                    sweep: .init(fields: ["script": .string("/tmp/sweep.py")]))],
+                supervised: ["acme-checkout"],
+                modes: ["acme-checkout": .bare("autonomous")],
+                supervisors: ["acme-checkout": .init(terminal: "t42")])
+            try store.save(file)
+            let loaded = try store.load()
+            #expect(loaded == file)
+        }
+    }
+
+    @Test func loaderRefusesARepoInTwoProjectsOnDisk() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent("supervision.json")
+            let json = """
+                {"version": 1,
+                 "projects": {
+                   "acme-checkout": {"repos": ["\(repoA.uuidString)"], "policy": {"operator": true}},
+                   "acme-hooks": {"repos": ["\(repoA.uuidString)"], "policy": {"operator": true}}}}
+                """
+            try Data(json.utf8).write(to: url)
+            let thrown = #expect(throws: SupervisionFileError.self) {
+                try SupervisionFileStore(fileURL: url).load()
+            }
+            #expect(thrown?.description.contains(repoA.uuidString) == true)
+        }
+    }
+
+    @Test func malformedJSONNamesTheFile() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent("supervision.json")
+            try Data("{ not json".utf8).write(to: url)
+            let thrown = #expect(throws: SupervisionFileError.self) {
+                try SupervisionFileStore(fileURL: url).load()
+            }
+            #expect(thrown?.description.contains(url.path) == true)
+        }
+    }
+
+    // MARK: Atomicity
+
+    @Test func theWriteTempSitsInTheTargetsOwnDirectory() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent("supervision.json")
+            let store = SupervisionFileStore(fileURL: url)
+            // rename(2) is atomic only within one filesystem: a temp under
+            // NSTemporaryDirectory() can land on another volume, where the
+            // rename degrades into a tearable copy.
+            #expect(store.temporaryURL().deletingLastPathComponent().path == directory.path)
+        }
+    }
+
+    @Test func aSaveReplacesTheFileRatherThanTruncatingItInPlace() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent("supervision.json")
+            let store = SupervisionFileStore(fileURL: url)
+            try store.save(SupervisionFile().settingMark("acme-checkout", on: true))
+            let before = try Data(contentsOf: url)
+
+            // An open handle keeps reading the bytes it opened as long as the
+            // writer renames a new file over the name. A writer that truncated
+            // and rewrote in place would show this handle the new content — and
+            // would leave a torn file behind on a crash.
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+
+            try store.save(SupervisionFile().settingMark("acme-hooks", on: true))
+            let seenThroughTheOldHandle = try handle.readToEnd() ?? Data()
+            #expect(seenThroughTheOldHandle == before)
+            let after = try Data(contentsOf: url)
+            #expect(after != before)
+        }
+    }
+
+    @Test func aSuccessfulSaveLeavesNoTemporaryBehind() throws {
+        try withTemporaryDirectory { directory in
+            let store = SupervisionFileStore(
+                fileURL: directory.appendingPathComponent("supervision.json"))
+            try store.save(SupervisionFile().settingMark("acme-checkout", on: true))
+            try store.save(SupervisionFile().settingMark("acme-hooks", on: true))
+            let entries = try FileManager.default
+                .contentsOfDirectory(atPath: directory.path).sorted()
+            #expect(entries == ["supervision.json"])
+        }
+    }
+
+    @Test func aRefusedSaveLeavesThePreviousBytesByteIdentical() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent("supervision.json")
+            let store = SupervisionFileStore(fileURL: url)
+            try store.save(SupervisionFile().settingMark("acme-checkout", on: true))
+            let before = try Data(contentsOf: url)
+
+            // A file the loader would reject never reaches the disk at all.
+            let unloadable = SupervisionFile(projects: [
+                "acme-checkout": .init(repos: [repoA], policy: .repo(repoB)),
+            ])
+            #expect(throws: SupervisionFileError.self) { try store.save(unloadable) }
+
+            let after = try Data(contentsOf: url)
+            #expect(after == before)
+            let entries = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            #expect(entries == ["supervision.json"])
+            let reloaded = try store.load()
+            #expect(reloaded.isMarked("acme-checkout"))
+        }
+    }
+}

--- a/Tests/TBDSharedTests/SupervisionFileTests.swift
+++ b/Tests/TBDSharedTests/SupervisionFileTests.swift
@@ -1,0 +1,332 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+// Path helpers are exercised through the `environment:` injection seam, and
+// every file test uses an explicit temporary directory. This target does not
+// link TestSupport and may not call `setenv("TBD_HOME", …)` — that is permitted
+// only in suites nested under `TBDHomeSerialized` in `Tests/TBDDaemonTests`.
+
+@Suite struct SupervisionPathTests {
+    private let env = ["TBD_HOME": "/tmp/tbd-supervision-paths"]
+
+    @Test func supervisionDirHangsOffConfigDir() {
+        #expect(TBDConstants.supervisionDir(environment: env).path
+            == "/tmp/tbd-supervision-paths/supervision")
+    }
+
+    @Test func fileLedgerAndStatusSitInTheSupervisionDir() {
+        #expect(TBDConstants.supervisionFilePath(environment: env)
+            == "/tmp/tbd-supervision-paths/supervision/supervision.json")
+        #expect(TBDConstants.supervisionLedgerPath(environment: env)
+            == "/tmp/tbd-supervision-paths/supervision/ledger.jsonl")
+        #expect(TBDConstants.supervisionStatusPath(environment: env)
+            == "/tmp/tbd-supervision-paths/supervision/status.json")
+    }
+
+    @Test func projectDirIsNamedByTheProject() {
+        #expect(TBDConstants.supervisionProjectDir(project: "acme-checkout", environment: env).path
+            == "/tmp/tbd-supervision-paths/supervision/projects/acme-checkout")
+    }
+
+    @Test func pathsFallBackToHomeTbdWithoutTBDHome() {
+        let path = TBDConstants.supervisionFilePath(environment: [:])
+        #expect(path.hasSuffix("/tbd/supervision/supervision.json"))
+        #expect(path.hasPrefix(FileManager.default.homeDirectoryForCurrentUser.path))
+    }
+}
+
+// MARK: - The on-disk shape
+
+@Suite struct SupervisionFileCodingTests {
+    /// The design spec §8 file, verbatim.
+    static let specFixture = """
+        {
+          "version": 1,
+          "projects": {
+            "acme-checkout": {
+              "repos": ["11111111-1111-1111-1111-111111111111",
+                        "22222222-2222-2222-2222-222222222222"],
+              "policy": { "repo": "11111111-1111-1111-1111-111111111111" },
+              "sweep": { "script": "~/tbd/supervision/projects/acme-checkout/sweep.py" }
+            }
+          },
+          "supervised": ["acme-checkout"],
+          "modes": {
+            "acme-checkout": "autonomous",
+            "acme-hooks": { "selected": "friday-freeze",
+                            "declared": ["attended", "autonomous", "friday-freeze"] }
+          },
+          "supervisors": { "acme-checkout": { "terminal": "t42" } }
+        }
+        """
+
+    private func decodeFixture() throws -> SupervisionFile {
+        try JSONDecoder().decode(SupervisionFile.self, from: Data(Self.specFixture.utf8))
+    }
+
+    @Test func decodesTheSpecShape() throws {
+        let file = try decodeFixture()
+        try file.validate()
+        #expect(file.version == 1)
+        #expect(file.projects["acme-checkout"]?.repos.count == 2)
+        #expect(file.projects["acme-checkout"]?.policy
+            == .repo(UUID(uuidString: "11111111-1111-1111-1111-111111111111")!))
+        #expect(file.projects["acme-checkout"]?.sweep?.script
+            == "~/tbd/supervision/projects/acme-checkout/sweep.py")
+        #expect(file.supervised == ["acme-checkout"])
+        #expect(file.supervisors["acme-checkout"]?.terminal == "t42")
+    }
+
+    @Test func roundTripKeepsSweepSupervisorsAndModeShapes() throws {
+        let file = try decodeFixture()
+        let encoded = try JSONEncoder().encode(file)
+        let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let projects = object?["projects"] as? [String: Any]
+        let checkout = projects?["acme-checkout"] as? [String: Any]
+        #expect((checkout?["sweep"] as? [String: Any])?["script"] as? String
+            == "~/tbd/supervision/projects/acme-checkout/sweep.py")
+        #expect((object?["supervisors"] as? [String: Any])?["acme-checkout"] != nil)
+
+        let modes = object?["modes"] as? [String: Any]
+        // A bare selection stays bare; an object entry stays an object.
+        #expect(modes?["acme-checkout"] as? String == "autonomous")
+        #expect((modes?["acme-hooks"] as? [String: Any])?["selected"] as? String == "friday-freeze")
+
+        let reloaded = try JSONDecoder().decode(SupervisionFile.self, from: encoded)
+        #expect(reloaded == file)
+    }
+
+    @Test func unknownSweepKeysSurviveARewrite() throws {
+        let json = """
+            {"version": 1,
+             "projects": {"acme-checkout": {"repos": ["11111111-1111-1111-1111-111111111111"],
+                                            "policy": {"operator": true},
+                                            "sweep": {"schedule": "external",
+                                                      "contactWindowMinutes": 15,
+                                                      "somethingLaterVersionsAdd": [1, 2]}}}}
+            """
+        let file = try JSONDecoder().decode(SupervisionFile.self, from: Data(json.utf8))
+        let encoded = try JSONEncoder().encode(file)
+        let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let sweep = ((object?["projects"] as? [String: Any])?["acme-checkout"]
+            as? [String: Any])?["sweep"] as? [String: Any]
+        #expect(sweep?["schedule"] as? String == "external")
+        #expect(sweep?["contactWindowMinutes"] as? Int == 15)
+        #expect((sweep?["somethingLaterVersionsAdd"] as? [Int]) == [1, 2])
+    }
+
+    @Test func emptyFileEncodesWithoutEmptyScaffolding() throws {
+        let encoded = try JSONEncoder().encode(SupervisionFile())
+        let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        #expect(object?.keys.sorted() == ["version"])
+    }
+
+    @Test func operatorPolicyRoundTrips() throws {
+        let source = SupervisionPolicySource.operator
+        let encoded = try JSONEncoder().encode(source)
+        #expect(String(bytes: encoded, encoding: .utf8) == "{\"operator\":true}")
+        #expect(try JSONDecoder().decode(SupervisionPolicySource.self, from: encoded) == source)
+    }
+
+    @Test func operatorFalseIsNotAPolicySource() {
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(
+                SupervisionPolicySource.self, from: Data("{\"operator\":false}".utf8))
+        }
+    }
+}
+
+// MARK: - Modes
+
+@Suite struct SupervisionModeEntryTests {
+    @Test func bareStringDecodesAsASelectionAgainstTheBuiltInList() throws {
+        let entry = try JSONDecoder().decode(
+            SupervisionModeEntry.self, from: Data("\"autonomous\"".utf8))
+        #expect(entry.activeMode == "autonomous")
+        #expect(entry.declaredModes == ["attended", "autonomous"])
+        #expect(entry.wireShape == .bareSelection)
+    }
+
+    @Test func bareEntryReEncodesBare() throws {
+        let entry = try JSONDecoder().decode(
+            SupervisionModeEntry.self, from: Data("\"autonomous\"".utf8))
+        let encoded = try JSONEncoder().encode(entry)
+        #expect(String(bytes: encoded, encoding: .utf8) == "\"autonomous\"")
+    }
+
+    @Test func objectEntryReEncodesAsAnObject() throws {
+        let json = "{\"selected\":\"friday-freeze\",\"declared\":[\"attended\",\"friday-freeze\"]}"
+        let entry = try JSONDecoder().decode(SupervisionModeEntry.self, from: Data(json.utf8))
+        #expect(entry.wireShape == .object)
+        #expect(entry.activeMode == "friday-freeze")
+        #expect(entry.declaredModes == ["attended", "friday-freeze"])
+        let reencoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(entry)) as? [String: Any]
+        #expect(reencoded?["selected"] as? String == "friday-freeze")
+        #expect(reencoded?["declared"] as? [String] == ["attended", "friday-freeze"])
+    }
+
+    @Test func absentDeclaredListFallsBackToTheBuiltInPair() throws {
+        let entry = try JSONDecoder().decode(
+            SupervisionModeEntry.self, from: Data("{\"selected\":\"autonomous\"}".utf8))
+        #expect(entry.declaredModes == ["attended", "autonomous"])
+        #expect(entry.activeMode == "autonomous")
+    }
+
+    @Test func absentSelectionFallsBackToAttended() throws {
+        let entry = try JSONDecoder().decode(
+            SupervisionModeEntry.self,
+            from: Data("{\"declared\":[\"attended\",\"autonomous\",\"friday-freeze\"]}".utf8))
+        #expect(entry.activeMode == "attended")
+    }
+
+    @Test func absentEntryEntirelyIsAttendedAgainstTheBuiltInPair() {
+        let file = SupervisionFile()
+        #expect(file.activeMode(for: "acme-checkout") == "attended")
+        #expect(file.declaredModes(for: "acme-checkout") == ["attended", "autonomous"])
+    }
+
+    @Test func selectingKeepsTheWireShape() throws {
+        let bare = SupervisionModeEntry.bare("attended").selecting("autonomous")
+        #expect(try String(bytes: JSONEncoder().encode(bare), encoding: .utf8) == "\"autonomous\"")
+
+        let object = SupervisionModeEntry
+            .declaring(declared: ["attended", "autonomous"], selected: "attended")
+            .selecting("autonomous")
+        let encoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(object)) as? [String: Any]
+        #expect(encoded?["selected"] as? String == "autonomous")
+        #expect(encoded?["declared"] as? [String] == ["attended", "autonomous"])
+    }
+
+    @Test func settingAModeOnAProjectWithNoEntryWritesABareOne() throws {
+        let file = SupervisionFile().settingMode("acme-checkout", to: "autonomous")
+        #expect(file.modes["acme-checkout"]?.wireShape == .bareSelection)
+        #expect(file.activeMode(for: "acme-checkout") == "autonomous")
+    }
+}
+
+// MARK: - What the loader refuses
+
+@Suite struct SupervisionFileValidationTests {
+    private let repoA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000000")!
+    private let repoB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000000")!
+
+    @Test func aRepoInTwoProjectsIsRejectedAndTheErrorNamesIt() {
+        let file = SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA, repoB], policy: .operator),
+            "acme-hooks": .init(repos: [repoA], policy: .operator),
+        ])
+        let thrown = #expect(throws: SupervisionFileError.self) { try file.validate() }
+        #expect(thrown == SupervisionFileError.repoInTwoProjects(
+            repo: repoA, first: "acme-checkout", second: "acme-hooks"))
+        let message = thrown?.description ?? ""
+        #expect(message.contains(repoA.uuidString))
+        #expect(message.contains("acme-checkout"))
+        #expect(message.contains("acme-hooks"))
+    }
+
+    @Test func aRepoListedTwiceInOneProjectIsRejected() {
+        let file = SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA, repoA], policy: .operator),
+        ])
+        #expect(throws: SupervisionFileError.repoListedTwice(repo: repoA, project: "acme-checkout")) {
+            try file.validate()
+        }
+    }
+
+    @Test func aPolicyRepoOutsideTheProjectIsRejected() {
+        let file = SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA], policy: .repo(repoB)),
+        ])
+        #expect(throws: SupervisionFileError.policyRepoNotAMember(
+            project: "acme-checkout", repo: repoB)) {
+            try file.validate()
+        }
+    }
+
+    @Test func anUnsupportedVersionIsRejected() {
+        let file = SupervisionFile(version: 2)
+        #expect(throws: SupervisionFileError.unsupportedVersion(found: 2, supported: 1)) {
+            try file.validate()
+        }
+    }
+
+    @Test func aProjectWithNoReposIsRejected() {
+        let file = SupervisionFile(projects: ["acme-checkout": .init(repos: [], policy: .operator)])
+        #expect(throws: SupervisionFileError.projectHasNoRepos(project: "acme-checkout")) {
+            try file.validate()
+        }
+    }
+
+    @Test(arguments: ["", ".", "..", "acme/checkout", " acme"])
+    func anUnusableProjectNameIsRejected(_ name: String) {
+        let file = SupervisionFile(projects: [name: .init(repos: [repoA], policy: .operator)])
+        #expect(throws: SupervisionFileError.invalidProjectName(project: name)) {
+            try file.validate()
+        }
+    }
+
+    @Test func aSelectionOutsideTheDeclaredListIsRejected() {
+        let file = SupervisionFile(modes: [
+            "acme-hooks": .declaring(declared: ["attended", "autonomous"], selected: "friday-freeze"),
+        ])
+        #expect(throws: SupervisionFileError.selectedModeNotDeclared(
+            project: "acme-hooks", selected: "friday-freeze",
+            declared: ["attended", "autonomous"])) {
+            try file.validate()
+        }
+    }
+
+    @Test func aDeclaredListWithoutTheDefaultSelectionIsRejected() {
+        // No selection means "attended", so a list that omits it leaves the
+        // project with a selection it cannot make.
+        let file = SupervisionFile(modes: ["acme-hooks": .declaring(declared: ["friday-freeze"])])
+        #expect(throws: SupervisionFileError.selectedModeNotDeclared(
+            project: "acme-hooks", selected: "attended", declared: ["friday-freeze"])) {
+            try file.validate()
+        }
+    }
+
+    @Test func markingIsMembershipWithNoThirdState() {
+        let untouched = SupervisionFile()
+        let turnedOff = SupervisionFile().settingMark("acme-checkout", on: true)
+            .settingMark("acme-checkout", on: false)
+        #expect(untouched == turnedOff)
+        #expect(!untouched.isMarked("acme-checkout"))
+        #expect(!turnedOff.isMarked("acme-checkout"))
+    }
+
+    @Test func aMarkThatAlreadyStandsChangesNothing() {
+        let on = SupervisionFile().settingMark("acme-checkout", on: true)
+        #expect(on.settingMark("acme-checkout", on: true) == on)
+        #expect(on.supervised == ["acme-checkout"])
+    }
+}
+
+// MARK: - The fleet brake's shared model field
+
+@Suite struct SupervisionConfigFlagTests {
+    @Test func shippedDefaultIsOff() {
+        #expect(Config.supervisionEnabledDefault == false)
+        #expect(Config().supervisionEnabled == Config.supervisionEnabledDefault)
+    }
+
+    @Test func absentKeyFollowsTheShippedDefault() throws {
+        let config = try JSONDecoder().decode(Config.self, from: Data("{}".utf8))
+        // Asserted against the constant, not against `false`: an absent key is
+        // the NULL column's situation and must follow the default wherever it
+        // goes.
+        #expect(config.supervisionEnabled == Config.supervisionEnabledDefault)
+    }
+
+    @Test func anExplicitChoiceIsHonored() throws {
+        let released = try JSONDecoder().decode(
+            Config.self, from: Data("{\"supervisionEnabled\":true}".utf8))
+        #expect(released.supervisionEnabled)
+        let engaged = try JSONDecoder().decode(
+            Config.self, from: Data("{\"supervisionEnabled\":false}".utf8))
+        #expect(!engaged.supervisionEnabled)
+    }
+}

--- a/Tests/TBDSharedTests/SupervisionFileTests.swift
+++ b/Tests/TBDSharedTests/SupervisionFileTests.swift
@@ -149,6 +149,35 @@ import Foundation
         #expect((sweep?["somethingLaterVersionsAdd"] as? [Int]) == [1, 2])
     }
 
+    /// The narrowed contract, pinned: every key and value survives a rewrite,
+    /// but the *spelling* of a number does not — `JSONDecoder` hands over a
+    /// parsed number and the original token is gone. Same JSON value to every
+    /// consumer; not byte-faithful, and the doc comment must not claim it is.
+    @Test func numbersSurviveAsValuesNotAsText() throws {
+        let json = """
+            {"version": 1,
+             "projects": {"acme-checkout": {"repos": ["11111111-1111-1111-1111-111111111111"],
+                                            "policy": {"operator": true},
+                                            "sweep": {"everyMinutes": 15.0, "ratio": 0.5,
+                                                      "count": 3}}}}
+            """
+        let file = try JSONDecoder().decode(SupervisionFile.self, from: Data(json.utf8))
+        let sweep = try #require(file.projects["acme-checkout"]?.sweep)
+        // Preserved as values: every key is still there, and the numbers are
+        // equal to what was written.
+        #expect(sweep.fields.keys.sorted() == ["count", "everyMinutes", "ratio"])
+        #expect(sweep.fields["everyMinutes"] == .integer(15))
+        #expect(sweep.fields["ratio"] == .number(0.5))
+        #expect(sweep.fields["count"] == .integer(3))
+
+        let reencoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(file)) as? [String: Any]
+        let rewritten = ((reencoded?["projects"] as? [String: Any])?["acme-checkout"]
+            as? [String: Any])?["sweep"] as? [String: Any]
+        #expect(rewritten?["everyMinutes"] as? Double == 15)
+        #expect(rewritten?["ratio"] as? Double == 0.5)
+    }
+
     @Test func emptyFileEncodesWithoutEmptyScaffolding() throws {
         let encoded = try JSONEncoder().encode(SupervisionFile())
         let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
@@ -311,6 +340,32 @@ import Foundation
         let file = SupervisionFile(projects: [name: .init(repos: [repoA], policy: .operator)])
         try file.validate()
         #expect(SupervisionFile.isSafeProjectName(name))
+    }
+
+    /// `--to singleton` resolves the word before it looks for a project, so a
+    /// declared project of that name could be created and never targeted.
+    @Test func theSingletonSentinelCannotBeTakenAsAProjectName() {
+        let file = SupervisionFile(projects: ["singleton": .init(repos: [repoA], policy: .operator)])
+        #expect(throws: SupervisionFileError.reservedProjectName(project: "singleton")) {
+            try file.validate()
+        }
+    }
+
+    @Test func aNameMerelyContainingSingletonIsFine() throws {
+        let file = SupervisionFile(projects: [
+            "singleton-web": .init(repos: [repoA], policy: .operator),
+        ])
+        try file.validate()
+    }
+
+    /// The refusal message has to describe the rule the predicate actually
+    /// applies — it once claimed to reject leading and trailing spaces, which
+    /// `isSafeProjectName` permits.
+    @Test func theInvalidNameMessageMatchesThePredicate() {
+        let message = SupervisionFileError.invalidProjectName(project: "acme/web").description
+        #expect(message.contains("acme/web"))
+        #expect(!message.contains("space"))
+        #expect(SupervisionFile.isSafeProjectName(" acme "))
     }
 
     @Test func aSelectionOutsideTheDeclaredListIsRejected() {

--- a/Tests/TBDSharedTests/SupervisionFileTests.swift
+++ b/Tests/TBDSharedTests/SupervisionFileTests.swift
@@ -25,8 +25,41 @@ import Foundation
     }
 
     @Test func projectDirIsNamedByTheProject() {
-        #expect(TBDConstants.supervisionProjectDir(project: "acme-checkout", environment: env).path
+        #expect(TBDConstants.supervisionProjectDir(project: "acme-checkout", environment: env)?.path
             == "/tmp/tbd-supervision-paths/supervision/projects/acme-checkout")
+    }
+
+    /// A singleton project is named by its repo's display name, which nothing
+    /// in TBD constrains. The helper must be incapable of composing a path out
+    /// of one that traverses.
+    @Test(arguments: ["acme/web", "..", ".", "", "../../etc", "acme/../../etc"])
+    func projectDirRefusesANameThatIsNotOnePathComponent(_ name: String) {
+        #expect(TBDConstants.supervisionProjectDir(project: name, environment: env) == nil)
+    }
+
+    @Test(arguments: ["acme.web", "acme..web", ".hidden", "acme web", " acme ",
+                      "café-ünïcode", "acme-web."])
+    func projectDirAcceptsUnusualButSafeNames(_ name: String) {
+        let url = TBDConstants.supervisionProjectDir(project: name, environment: env)
+        #expect(url?.deletingLastPathComponent().path
+            == "/tmp/tbd-supervision-paths/supervision/projects")
+        #expect(url?.lastPathComponent == name)
+    }
+
+    /// The guarantee stated as a property rather than as a list of bad inputs:
+    /// whatever the name, the composed path never leaves the projects
+    /// directory.
+    @Test func aComposedProjectDirNeverEscapesTheSupervisionDirectory() {
+        let names = ["acme/web", "..", ".", "", "acme-checkout", " acme ", "acme..web",
+                     "../..", "a/b/c", "\u{0}bad", "café"]
+        let root = TBDConstants.supervisionDir(environment: env)
+            .appendingPathComponent("projects").standardizedFileURL.path
+        for name in names {
+            guard let url = TBDConstants.supervisionProjectDir(project: name, environment: env)
+            else { continue }
+            #expect(url.standardizedFileURL.path.hasPrefix(root + "/"))
+            #expect(url.standardizedFileURL.deletingLastPathComponent().path == root)
+        }
     }
 
     @Test func pathsFallBackToHomeTbdWithoutTBDHome() {
@@ -260,12 +293,24 @@ import Foundation
         }
     }
 
-    @Test(arguments: ["", ".", "..", "acme/checkout", " acme"])
-    func anUnusableProjectNameIsRejected(_ name: String) {
+    /// A declared name came from the file, so refusing it refuses the
+    /// operator's own edit — the loud rejection is right here.
+    @Test(arguments: ["", ".", "..", "acme/checkout"])
+    func anUnusableDeclaredProjectNameIsRejected(_ name: String) {
         let file = SupervisionFile(projects: [name: .init(repos: [repoA], policy: .operator)])
         #expect(throws: SupervisionFileError.invalidProjectName(project: name)) {
             try file.validate()
         }
+    }
+
+    /// The guard is path safety, not taste: an over-tight rule would start
+    /// refusing ordinary repo names, since a singleton's name is a repo's
+    /// display name.
+    @Test(arguments: [" acme ", "acme.web", "acme..web", ".hidden", "acme web", "café-ünïcode"])
+    func anUnusualButSafeProjectNameIsAccepted(_ name: String) throws {
+        let file = SupervisionFile(projects: [name: .init(repos: [repoA], policy: .operator)])
+        try file.validate()
+        #expect(SupervisionFile.isSafeProjectName(name))
     }
 
     @Test func aSelectionOutsideTheDeclaredListIsRejected() {

--- a/Tests/TBDSharedTests/SupervisionLedgerTests.swift
+++ b/Tests/TBDSharedTests/SupervisionLedgerTests.swift
@@ -141,6 +141,52 @@ import Foundation
         }
     }
 
+    /// The record is append-only and documented, so a reader meets lines it did
+    /// not write. A `delivery`, `enrollment` or `anomaly` line must read as an
+    /// envelope, not as damage: counting them as unreadable would report a
+    /// healthy record as corrupt on every boot and bury real corruption in the
+    /// false alarm.
+    @Test(arguments: ["delivery", "enrollment", "anomaly"])
+    func aLineOfAnotherKindReadsAsAnEnvelopeRatherThanDamage(_ kind: String) throws {
+        let json = """
+            {"id":"abc123","ts":"2026-08-14T02:13:12.482Z","mode":"autonomous",
+             "project":"acme-checkout","kind":"\(kind)",
+             "textHash":"deadbeef","conductHash":"cafe"}
+            """
+        let line = try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(json.utf8))
+        #expect(line.id == "abc123")
+        #expect(line.project == "acme-checkout")
+        #expect(line.mode == "autonomous")
+        #expect(line.kind.rawValue == kind)
+        #expect(line.payload == .unrecognized)
+        #expect(line.payload.event == nil)
+    }
+
+    /// The same protection one level down: a lifecycle event a later build
+    /// writes — a desk recycle, an appointment — is an envelope, not damage.
+    @Test func aLifecycleEventFromALaterBuildReadsAsAnEnvelope() throws {
+        let json = """
+            {"id":"abc123","ts":"2026-08-14T02:13:12.482Z","mode":"attended",
+             "project":"acme-checkout","kind":"lifecycle","event":"deskRecycled",
+             "reason":"contextFull"}
+            """
+        let line = try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(json.utf8))
+        #expect(line.kind == .lifecycle)
+        #expect(line.project == "acme-checkout")
+        #expect(line.payload == .unrecognized)
+    }
+
+    /// Re-encoding a line whose body was never parsed would silently truncate
+    /// somebody else's record, so it is refused instead.
+    @Test func anUnparsedLineCannotBeReEncoded() throws {
+        let json = """
+            {"id":"abc123","ts":"2026-08-14T02:13:12.482Z","mode":null,
+             "project":null,"kind":"anomaly","detail":"something"}
+            """
+        let line = try JSONDecoder().decode(SupervisionLedgerLine.self, from: Data(json.utf8))
+        #expect(throws: (any Error).self) { try JSONEncoder().encode(line) }
+    }
+
     @Test func lineIdsAreOpaqueAndUnique() {
         let first = SupervisionLedgerLine.newID()
         let second = SupervisionLedgerLine.newID()
@@ -213,9 +259,36 @@ import Foundation
     @Test func warningCodesAreTheDocumentedStrings() throws {
         #expect(SupervisionWarningCode.noProjectsOn.rawValue == "noProjectsOn")
         #expect(SupervisionWarningCode.unusableProjectName.rawValue == "unusableProjectName")
+        #expect(SupervisionWarningCode.ambiguousRepoName.rawValue == "ambiguousRepoName")
+        #expect(SupervisionWarningCode.brakeEngagedWithProjectsOn.rawValue
+            == "brakeEngagedWithProjectsOn")
         let decoded = try JSONDecoder().decode(
             SupervisionWarningCode.self, from: Data("\"unusableProjectName\"".utf8))
         #expect(decoded == .unusableProjectName)
+    }
+
+    /// The two quiet failures are opposite states that `effectivelySupervising`
+    /// alone reports identically — released with nothing marked, and marks
+    /// standing under an engaged brake. They call for opposite actions (mark a
+    /// project, or release the brake), so the enumerated code is the thing a
+    /// program branches on.
+    @Test func theTwoQuietFailuresAreDistinguishableBeyondOneBit() throws {
+        let nothingMarked = SupervisionStatus(
+            brake: .released, effectivelySupervising: false, projects: [],
+            warnings: [.init(code: .noProjectsOn, message: "nothing is being supervised")])
+        let markedButBraked = SupervisionStatus(
+            brake: .engaged, effectivelySupervising: false, projects: [],
+            warnings: [.init(code: .brakeEngagedWithProjectsOn,
+                             message: "the brake is engaged; nothing is being supervised")])
+
+        #expect(nothingMarked.effectivelySupervising == markedButBraked.effectivelySupervising)
+        #expect(nothingMarked.warnings.map(\.code) != markedButBraked.warnings.map(\.code))
+
+        for status in [nothingMarked, markedButBraked] {
+            let decoded = try JSONDecoder().decode(
+                SupervisionStatus.self, from: try JSONEncoder().encode(status))
+            #expect(decoded == status)
+        }
     }
 
     @Test func everyResultDTOCarriesASchemaVersion() throws {

--- a/Tests/TBDSharedTests/SupervisionLedgerTests.swift
+++ b/Tests/TBDSharedTests/SupervisionLedgerTests.swift
@@ -210,6 +210,14 @@ import Foundation
         #expect(warning?["code"] as? String == "noProjectsOn")
     }
 
+    @Test func warningCodesAreTheDocumentedStrings() throws {
+        #expect(SupervisionWarningCode.noProjectsOn.rawValue == "noProjectsOn")
+        #expect(SupervisionWarningCode.unusableProjectName.rawValue == "unusableProjectName")
+        let decoded = try JSONDecoder().decode(
+            SupervisionWarningCode.self, from: Data("\"unusableProjectName\"".utf8))
+        #expect(decoded == .unusableProjectName)
+    }
+
     @Test func everyResultDTOCarriesASchemaVersion() throws {
         let payloads: [any Encodable] = [
             SupervisionStatus(brake: .engaged, effectivelySupervising: false,

--- a/Tests/TBDSharedTests/SupervisionLedgerTests.swift
+++ b/Tests/TBDSharedTests/SupervisionLedgerTests.swift
@@ -1,0 +1,276 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct SupervisionInstantTests {
+    @Test func encodesISO8601WithFractionalSecondsInUTC() throws {
+        let instant = SupervisionInstant(Date(timeIntervalSince1970: 1_786_000_392.482))
+        #expect(instant.wireValue.hasSuffix("Z"))
+        #expect(instant.wireValue.contains("."))
+        let encoded = try JSONEncoder().encode(instant)
+        #expect(String(bytes: encoded, encoding: .utf8) == "\"\(instant.wireValue)\"")
+    }
+
+    @Test func roundTripsToTheMillisecond() throws {
+        let instant = SupervisionInstant(Date(timeIntervalSince1970: 1_786_000_392.482))
+        let decoded = try JSONDecoder().decode(
+            SupervisionInstant.self, from: try JSONEncoder().encode(instant))
+        #expect(abs(decoded.date.timeIntervalSince(instant.date)) < 0.001)
+        // The stronger claim, and the one the ledger needs: a line that made a
+        // round trip is the same value, not a near neighbour.
+        #expect(decoded.wireValue == instant.wireValue)
+        #expect(decoded == instant)
+    }
+
+    @Test func subMillisecondPrecisionIsDroppedAtConstruction() {
+        // An instant holds the precision it can persist. Two `Date`s inside one
+        // millisecond of each other are one instant.
+        let base = Date(timeIntervalSince1970: 1_786_000_392.4821)
+        #expect(SupervisionInstant(base) == SupervisionInstant(base.addingTimeInterval(0.0002)))
+        #expect(SupervisionInstant(base) != SupervisionInstant(base.addingTimeInterval(0.01)))
+    }
+
+    @Test func refusesAValueThatIsNotATimestamp() {
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(SupervisionInstant.self, from: Data("\"soon\"".utf8))
+        }
+    }
+}
+
+@Suite struct SupervisionLedgerLineTests {
+    private let writtenAt = Date(timeIntervalSince1970: 1_786_000_392.482)
+
+    private func object(_ line: SupervisionLedgerLine) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(line)
+        return try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+    }
+
+    @Test func aBrakeLineCarriesAnExplicitNullProjectAndMode() throws {
+        // The brake acts fleet-wide, so null is the accurate answer, not a gap:
+        // the keys are present and null rather than omitted. And there is no
+        // API by which a caller could name a project here — `brakeEngaged` and
+        // `brakeReleased` take none, and the memberwise initializer is private.
+        for line in [SupervisionLedgerLine.brakeEngaged(at: writtenAt),
+                     SupervisionLedgerLine.brakeReleased(at: writtenAt)] {
+            let encoded = try object(line)
+            #expect(encoded.keys.contains("project"))
+            #expect(encoded["project"] is NSNull)
+            #expect(encoded.keys.contains("mode"))
+            #expect(encoded["mode"] is NSNull)
+            #expect(encoded["kind"] as? String == "lifecycle")
+            #expect(line.project == nil)
+            #expect(line.mode == nil)
+        }
+        #expect(try object(.brakeEngaged(at: writtenAt))["event"] as? String == "brakeEngaged")
+        #expect(try object(.brakeReleased(at: writtenAt))["event"] as? String == "brakeReleased")
+    }
+
+    @Test func aProjectLineCarriesTheEnvelopeAndItsPayload() throws {
+        let roster = [SupervisionRosterEntry(
+            worktree: UUID(), terminal: UUID(), repo: UUID(), project: "acme-checkout",
+            spawnSource: "tbd", transcriptPath: nil)]
+        let line = SupervisionLedgerLine.projectOn(
+            project: "acme-checkout", mode: "autonomous", roster: roster,
+            at: writtenAt, id: "abc123")
+        let encoded = try object(line)
+        #expect(encoded["id"] as? String == "abc123")
+        #expect(encoded["project"] as? String == "acme-checkout")
+        #expect(encoded["mode"] as? String == "autonomous")
+        #expect(encoded["kind"] as? String == "lifecycle")
+        #expect(encoded["event"] as? String == "projectOn")
+        #expect((encoded["roster"] as? [[String: Any]])?.count == 1)
+        // An unknown transcript is null, never a missing key or a guess.
+        let entry = (encoded["roster"] as? [[String: Any]])?.first
+        #expect(entry?.keys.contains("transcriptPath") == true)
+        #expect(entry?["transcriptPath"] is NSNull)
+    }
+
+    @Test func theSpanEndCarriesItsCoverageSummary() throws {
+        let summary = SupervisionCoverageSummary(
+            spanStartedAt: SupervisionInstant(writtenAt.addingTimeInterval(-3600)),
+            spanEndedAt: SupervisionInstant(writtenAt),
+            sweepContacts: 0, briefingsDelivered: 0)
+        #expect(summary.durationSeconds == 3600)
+        let line = SupervisionLedgerLine.projectOff(
+            project: "acme-checkout", mode: "attended", coverage: summary, at: writtenAt)
+        let coverage = try object(line)["coverage"] as? [String: Any]
+        #expect(coverage?["sweepContacts"] as? Int == 0)
+        #expect(coverage?["briefingsDelivered"] as? Int == 0)
+        #expect(coverage?["durationSeconds"] as? Int == 3600)
+    }
+
+    @Test func anUnpairedSpanEndSaysSoRatherThanInventingAStart() throws {
+        let summary = SupervisionCoverageSummary(
+            spanStartedAt: nil, spanEndedAt: SupervisionInstant(writtenAt),
+            sweepContacts: 0, briefingsDelivered: 0)
+        #expect(summary.durationSeconds == nil)
+        let line = SupervisionLedgerLine.projectOff(
+            project: "acme-checkout", mode: "attended", coverage: summary, at: writtenAt)
+        let coverage = try object(line)["coverage"] as? [String: Any]
+        #expect(coverage?["spanStartedAt"] is NSNull)
+        #expect(coverage?["durationSeconds"] is NSNull)
+    }
+
+    @Test func aModeChangeNamesBothEnds() throws {
+        let line = SupervisionLedgerLine.modeChanged(
+            project: "acme-checkout", from: "attended", to: "autonomous", at: writtenAt)
+        let encoded = try object(line)
+        #expect(encoded["from"] as? String == "attended")
+        #expect(encoded["to"] as? String == "autonomous")
+        // The envelope's mode is the mode in force after the change.
+        #expect(encoded["mode"] as? String == "autonomous")
+    }
+
+    @Test func everyLineShapeSurvivesARoundTrip() throws {
+        let lines: [SupervisionLedgerLine] = [
+            .brakeEngaged(at: writtenAt),
+            .brakeReleased(at: writtenAt),
+            .projectOn(project: "acme-checkout", mode: "autonomous", roster: [], at: writtenAt),
+            .projectOff(project: "acme-checkout", mode: "attended",
+                        coverage: .init(spanStartedAt: nil,
+                                        spanEndedAt: SupervisionInstant(writtenAt),
+                                        sweepContacts: 0, briefingsDelivered: 0),
+                        at: writtenAt),
+            .modeChanged(project: "acme-checkout", from: "attended", to: "autonomous",
+                         at: writtenAt),
+        ]
+        for line in lines {
+            let decoded = try JSONDecoder().decode(
+                SupervisionLedgerLine.self, from: try JSONEncoder().encode(line))
+            #expect(decoded == line)
+        }
+    }
+
+    @Test func lineIdsAreOpaqueAndUnique() {
+        let first = SupervisionLedgerLine.newID()
+        let second = SupervisionLedgerLine.newID()
+        #expect(first != second)
+        #expect(!first.contains("-"))
+        #expect(first == first.lowercased())
+    }
+
+    @Test func aWholeLineIsOneJSONLRow() throws {
+        let data = try JSONEncoder().encode(SupervisionLedgerLine.brakeEngaged(at: writtenAt))
+        #expect(String(bytes: data, encoding: .utf8)?.contains("\n") == false)
+    }
+}
+
+@Suite struct SupervisionStatusFileTests {
+    @Test func theHeartbeatCarriesSchemaVersionBrakeAndProjects() throws {
+        let file = SupervisionStatusFile(
+            writtenAt: SupervisionInstant(Date(timeIntervalSince1970: 1_786_000_392.482)),
+            brake: .released,
+            projects: [.init(name: "acme-checkout", on: true, mode: "autonomous",
+                             lastSweepContactAt: nil)])
+        let encoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(file)) as? [String: Any]
+        #expect(encoded?["schemaVersion"] as? Int == 1)
+        #expect(encoded?["brake"] as? String == "released")
+        #expect((encoded?["writtenAt"] as? String)?.hasSuffix("Z") == true)
+        let project = (encoded?["projects"] as? [[String: Any]])?.first
+        #expect(project?["on"] as? Bool == true)
+        // Never contacted is null, not a fabricated time.
+        #expect(project?.keys.contains("lastSweepContactAt") == true)
+        #expect(project?["lastSweepContactAt"] is NSNull)
+    }
+
+    @Test func theHeartbeatRoundTrips() throws {
+        let file = SupervisionStatusFile(
+            writtenAt: SupervisionInstant(Date(timeIntervalSince1970: 1_786_000_392.482)),
+            brake: .engaged, projects: [])
+        let decoded = try JSONDecoder().decode(
+            SupervisionStatusFile.self, from: try JSONEncoder().encode(file))
+        #expect(decoded == file)
+    }
+}
+
+@Suite struct SupervisionRPCVocabularyTests {
+    @Test func methodNamesAreTheDocumentedOnes() {
+        #expect(RPCMethod.configSetSupervisionEnabled == "config.setSupervisionEnabled")
+        #expect(RPCMethod.superviseStatus == "supervise.status")
+        #expect(RPCMethod.superviseSetProjectMark == "supervise.setProjectMark")
+        #expect(RPCMethod.superviseSetMode == "supervise.setMode")
+        #expect(RPCMethod.superviseProjectList == "supervise.projectList")
+        #expect(RPCMethod.superviseProjectCreate == "supervise.projectCreate")
+        #expect(RPCMethod.superviseProjectDelete == "supervise.projectDelete")
+        #expect(RPCMethod.superviseProjectMove == "supervise.projectMove")
+    }
+
+    @Test func statusCarriesASchemaVersionAndTheLoudWarning() throws {
+        let status = SupervisionStatus(
+            brake: .released, effectivelySupervising: false, projects: [],
+            warnings: [.init(code: .noProjectsOn,
+                             message: "supervision is on but no project is on — "
+                                + "nothing is being supervised")])
+        let encoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(status)) as? [String: Any]
+        #expect(encoded?["schemaVersion"] as? Int == 1)
+        #expect(encoded?["effectivelySupervising"] as? Bool == false)
+        let warning = (encoded?["warnings"] as? [[String: Any]])?.first
+        #expect(warning?["code"] as? String == "noProjectsOn")
+    }
+
+    @Test func everyResultDTOCarriesASchemaVersion() throws {
+        let payloads: [any Encodable] = [
+            SupervisionStatus(brake: .engaged, effectivelySupervising: false,
+                              projects: [], warnings: []),
+            SuperviseProjectListResult(projects: []),
+            SuperviseSetProjectMarkResult(project: "acme-checkout", on: true, changed: true),
+            SuperviseSetModeResult(project: "acme-checkout", mode: "autonomous",
+                                   declaredModes: ["attended", "autonomous"], changed: true),
+        ]
+        for payload in payloads {
+            let data = try JSONEncoder().encode(payload)
+            let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            #expect(object?["schemaVersion"] as? Int == 1)
+        }
+    }
+
+    @Test func aStatusProjectRowLeavesUnknowableFieldsNull() throws {
+        let row = SupervisionStatusProject(
+            name: "tbd", on: false, mode: "attended",
+            declaredModes: ["attended", "autonomous"], supervisor: .hostedDesk,
+            spanStartedAt: nil, lastSweepContactAt: nil, coverageWindow: nil)
+        let encoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(row)) as? [String: Any]
+        #expect(encoded?["spanStartedAt"] is NSNull)
+        #expect(encoded?["lastSweepContactAt"] is NSNull)
+        #expect(encoded?["coverageWindow"] is NSNull)
+        #expect((encoded?["supervisor"] as? [String: Any])?["kind"] as? String == "hostedDesk")
+    }
+
+    @Test func policyRequestsCarryTheRepoAsTypedText() throws {
+        let byRepo = SupervisionPolicyRequest.repo("acme-web")
+        let encoded = try JSONEncoder().encode(byRepo)
+        #expect(String(bytes: encoded, encoding: .utf8) == "{\"repo\":\"acme-web\"}")
+        #expect(try JSONDecoder().decode(SupervisionPolicyRequest.self, from: encoded) == byRepo)
+        let byOperator = try JSONEncoder().encode(SupervisionPolicyRequest.operator)
+        #expect(try JSONDecoder().decode(
+            SupervisionPolicyRequest.self, from: byOperator) == .operator)
+    }
+
+    @Test func paramsRoundTrip() throws {
+        let create = SuperviseProjectCreateParams(
+            name: "acme-checkout", repos: ["acme-web", "acme-api"], policy: .repo("acme-web"))
+        #expect(try JSONDecoder().decode(
+            SuperviseProjectCreateParams.self,
+            from: try JSONEncoder().encode(create)) == create)
+
+        let move = SuperviseProjectMoveParams(repo: "acme-web", to: "singleton")
+        #expect(try JSONDecoder().decode(
+            SuperviseProjectMoveParams.self, from: try JSONEncoder().encode(move)) == move)
+
+        let mark = SuperviseSetProjectMarkParams(project: "acme-checkout", on: true)
+        #expect(try JSONDecoder().decode(
+            SuperviseSetProjectMarkParams.self, from: try JSONEncoder().encode(mark)) == mark)
+
+        let mode = SuperviseSetModeParams(project: "acme-checkout", mode: "autonomous")
+        #expect(try JSONDecoder().decode(
+            SuperviseSetModeParams.self, from: try JSONEncoder().encode(mode)) == mode)
+
+        let brake = ConfigSetSupervisionEnabledParams(enabled: true)
+        #expect(try JSONDecoder().decode(
+            ConfigSetSupervisionEnabledParams.self,
+            from: try JSONEncoder().encode(brake)) == brake)
+    }
+}

--- a/Tests/TBDSharedTests/SupervisionTopologyTests.swift
+++ b/Tests/TBDSharedTests/SupervisionTopologyTests.swift
@@ -135,13 +135,71 @@ private func generatedRepos(count: Int, using generator: inout SplitMix64) -> [S
         #expect(projects.map(\.name) == ["acme-api", "tbd"])
     }
 
-    @Test func twoReposWithOneNameAreReportedRatherThanCollapsed() {
-        let twins = [SupervisionRepo(id: repoA, name: "acme-web"),
-                     SupervisionRepo(id: repoB, name: "acme-web")]
-        let thrown = #expect(throws: SupervisionTopologyError.self) {
-            try SupervisionTopology.resolve(file: SupervisionFile(), repos: twins)
+    /// Display names carry no uniqueness constraint, so two clones of `api`
+    /// under different parents is an ordinary state. Neither resolves to a
+    /// project — two candidates for one name identify nothing — but the rest of
+    /// the fleet resolves, and `resolve` does not throw.
+    @Test func twoReposWithOneNameResolveToNoProjectAndTakeNothingElseDown() throws {
+        let twins = [SupervisionRepo(id: repoA, name: "api"),
+                     SupervisionRepo(id: repoB, name: "api"),
+                     SupervisionRepo(id: repoC, name: "tbd")]
+        let projects = try SupervisionTopology.resolve(file: SupervisionFile(), repos: twins)
+
+        #expect(projects.map(\.name) == ["tbd"])
+        #expect(projects.flatMap(\.repos) == [repoC])
+
+        let ambiguous = SupervisionTopology.ambiguousRepoNames(
+            file: SupervisionFile(), repos: twins)
+        #expect(ambiguous == [SupervisionAmbiguousRepoName(
+            name: "api", repos: [repoA, repoB].sorted { $0.uuidString < $1.uuidString })])
+    }
+
+    /// The compounding failure the throw used to cause: every supervision
+    /// surface, the `status.json` heartbeat included, went down together — and
+    /// a fleet with no heartbeat is indistinguishable from a dead daemon to the
+    /// watchdog. Resolution must survive so the heartbeat can be written.
+    @Test func anAmbiguousNameDoesNotStopTheRestOfTheFleetResolving() throws {
+        let repos = [SupervisionRepo(id: repoA, name: "api"),
+                     SupervisionRepo(id: repoB, name: "api"),
+                     SupervisionRepo(id: repoC, name: "tbd")]
+        let file = SupervisionFile(
+            supervised: ["tbd"], modes: ["tbd": .bare("autonomous")])
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        let survivor = try #require(projects.first { $0.name == "tbd" })
+        #expect(survivor.mark)
+        #expect(survivor.activeMode == "autonomous")
+    }
+
+    /// A declaration naming the shared repos resolves them — the second fix
+    /// the warning suggests.
+    @Test func declaringAProjectResolvesTheSharedName() throws {
+        let twins = [SupervisionRepo(id: repoA, name: "api"),
+                     SupervisionRepo(id: repoB, name: "api")]
+        let file = SupervisionFile(projects: [
+            "acme-api": .init(repos: [repoA, repoB], policy: .repo(repoA)),
+        ])
+        let projects = try SupervisionTopology.resolve(file: file, repos: twins)
+        #expect(projects.map(\.name) == ["acme-api"])
+        #expect(SupervisionTopology.ambiguousRepoNames(file: file, repos: twins).isEmpty)
+    }
+
+    /// A name from the operator's own file still refuses loudly, even when the
+    /// repos sharing it are ambiguous among themselves.
+    @Test func aDeclaredNameCollidingWithSharedRepoNamesStillThrows() {
+        let twins = [SupervisionRepo(id: repoA, name: "api"),
+                     SupervisionRepo(id: repoB, name: "api"),
+                     SupervisionRepo(id: repoC, name: "tbd")]
+        let file = SupervisionFile(projects: [
+            "api": .init(repos: [repoC], policy: .repo(repoC)),
+        ])
+        #expect(throws: SupervisionTopologyError.self) {
+            try SupervisionTopology.resolve(file: file, repos: twins)
         }
-        #expect(thrown?.description.contains("acme-web") == true)
+    }
+
+    @Test func aFleetOfDistinctNamesReportsNoAmbiguity() {
+        #expect(SupervisionTopology.ambiguousRepoNames(
+            file: SupervisionFile(), repos: repos).isEmpty)
     }
 
     /// A repo displayed as `acme/web` is a project whose name cannot be a

--- a/Tests/TBDSharedTests/SupervisionTopologyTests.swift
+++ b/Tests/TBDSharedTests/SupervisionTopologyTests.swift
@@ -1,0 +1,277 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+/// A deterministic generator, so a failing case is reproducible from the seed
+/// rather than being a coin flip in CI.
+private struct SplitMix64: RandomNumberGenerator {
+    var state: UInt64
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+private func generatedRepos(count: Int, using generator: inout SplitMix64) -> [SupervisionRepo] {
+    let words = ["acme", "checkout", "hooks", "platform", "ledger", "atlas", "harbor", "meadow"]
+    return (0..<count).map { index in
+        let name = "\(words[Int(generator.next() % UInt64(words.count))])-\(index)"
+        return SupervisionRepo(id: UUID(), name: name)
+    }
+}
+
+@Suite struct SupervisionCollapseTests {
+    /// The singleton collapse is a property, not a branch: for any repo set, an
+    /// absent `supervision.json` and a file declaring one single-repo project
+    /// per repo resolve to *equal* values — same names, same repos, same policy
+    /// source, same marks, same modes, same supervisor arrangement.
+    ///
+    /// Any field that could tell the two apart would let a consumer behave
+    /// differently between them, which design §5 calls a bug.
+    @Test(arguments: [1, 2, 3, 5, 8, 13])
+    func nothingDeclaredResolvesLikeOneProjectPerRepo(count: Int) throws {
+        var generator = SplitMix64(state: UInt64(count) &* 0x1234_5678)
+        for _ in 0..<8 {
+            let repos = generatedRepos(count: count, using: &generator)
+            guard Set(repos.map(\.name)).count == repos.count else { continue }
+
+            let declaredPerRepo = SupervisionFile(
+                projects: Dictionary(uniqueKeysWithValues: repos.map { repo in
+                    (repo.name, SupervisionProjectDeclaration(
+                        repos: [repo.id], policy: .repo(repo.id)))
+                }))
+
+            let implicit = try SupervisionTopology.resolve(file: SupervisionFile(), repos: repos)
+            let declared = try SupervisionTopology.resolve(file: declaredPerRepo, repos: repos)
+            #expect(implicit == declared)
+            #expect(implicit.count == repos.count)
+        }
+    }
+
+    /// The same property with marks and modes in play — the state an operator
+    /// actually accumulates.
+    @Test(arguments: [1, 4, 7])
+    func collapseHoldsWithMarksAndModes(count: Int) throws {
+        var generator = SplitMix64(state: UInt64(count) &* 0x9999)
+        let repos = generatedRepos(count: count, using: &generator)
+        guard Set(repos.map(\.name)).count == repos.count else { return }
+        let marked = repos.first!.name
+
+        let implicitFile = SupervisionFile(
+            supervised: [marked], modes: [marked: .bare("autonomous")])
+        var declaredFile = implicitFile
+        declaredFile.projects = Dictionary(uniqueKeysWithValues: repos.map { repo in
+            (repo.name, SupervisionProjectDeclaration(repos: [repo.id], policy: .repo(repo.id)))
+        })
+
+        let implicit = try SupervisionTopology.resolve(file: implicitFile, repos: repos)
+        let declared = try SupervisionTopology.resolve(file: declaredFile, repos: repos)
+        #expect(implicit == declared)
+        #expect(implicit.first { $0.name == marked }?.mark == true)
+        #expect(implicit.first { $0.name == marked }?.activeMode == "autonomous")
+    }
+}
+
+@Suite struct SupervisionResolutionTests {
+    private let repoA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000000")!
+    private let repoB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000000")!
+    private let repoC = UUID(uuidString: "CCCCCCCC-0000-0000-0000-000000000000")!
+
+    private var repos: [SupervisionRepo] {
+        [SupervisionRepo(id: repoA, name: "acme-web"),
+         SupervisionRepo(id: repoB, name: "acme-api"),
+         SupervisionRepo(id: repoC, name: "tbd")]
+    }
+
+    @Test func declaredMembersJoinTheirProjectAndTheRestAreTheirOwn() throws {
+        let file = SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA, repoB], policy: .repo(repoA)),
+        ])
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        #expect(projects.map(\.name) == ["acme-checkout", "tbd"])
+        #expect(projects[0].repos == [repoA, repoB])
+        #expect(projects[1].repos == [repoC])
+        #expect(projects[1].policy == .repo(repoC))
+        #expect(projects[1].supervisor == .hostedDesk)
+    }
+
+    @Test func everyRepoLandsInExactlyOneProject() throws {
+        let file = SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA, repoB], policy: .repo(repoA)),
+        ])
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        let memberships = projects.flatMap(\.repos)
+        #expect(memberships.sorted { $0.uuidString < $1.uuidString }
+            == [repoA, repoB, repoC].sorted { $0.uuidString < $1.uuidString })
+        #expect(Set(memberships).count == memberships.count)
+    }
+
+    @Test func anAppointedSupervisorShowsAsTheArrangement() throws {
+        let file = SupervisionFile(supervisors: ["tbd": .init(terminal: "t42")])
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        #expect(projects.first { $0.name == "tbd" }?.supervisor == .appointed(terminal: "t42"))
+    }
+
+    @Test func aProjectNameCollidingWithANonMemberRepoIsReported() {
+        let file = SupervisionFile(projects: [
+            "tbd": .init(repos: [repoA], policy: .repo(repoA)),
+        ])
+        let thrown = #expect(throws: SupervisionTopologyError.self) {
+            try SupervisionTopology.resolve(file: file, repos: repos)
+        }
+        #expect(thrown == SupervisionTopologyError.projectNameCollidesWithRepo(
+            project: "tbd", repo: repoC, repoName: "tbd"))
+        #expect(thrown?.description.contains("tbd") == true)
+    }
+
+    @Test func aProjectMayShareItsNameWithOneOfItsOwnMembers() throws {
+        let file = SupervisionFile(projects: [
+            "tbd": .init(repos: [repoC, repoA], policy: .repo(repoC)),
+        ])
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        #expect(projects.map(\.name) == ["acme-api", "tbd"])
+    }
+
+    @Test func twoReposWithOneNameAreReportedRatherThanCollapsed() {
+        let twins = [SupervisionRepo(id: repoA, name: "acme-web"),
+                     SupervisionRepo(id: repoB, name: "acme-web")]
+        let thrown = #expect(throws: SupervisionTopologyError.self) {
+            try SupervisionTopology.resolve(file: SupervisionFile(), repos: twins)
+        }
+        #expect(thrown?.description.contains("acme-web") == true)
+    }
+
+    @Test func aRejectedFileServesNoPartialResolution() {
+        let file = SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA], policy: .repo(repoA)),
+            "acme-hooks": .init(repos: [repoA], policy: .repo(repoA)),
+        ])
+        #expect(throws: SupervisionFileError.self) {
+            try SupervisionTopology.resolve(file: file, repos: repos)
+        }
+    }
+}
+
+@Suite struct SupervisionMoveTests {
+    private let repoA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000000")!
+    private let repoB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000000")!
+    private let repoC = UUID(uuidString: "CCCCCCCC-0000-0000-0000-000000000000")!
+    private let unknownRepo = UUID(uuidString: "DDDDDDDD-0000-0000-0000-000000000000")!
+
+    private var repos: [SupervisionRepo] {
+        [SupervisionRepo(id: repoA, name: "acme-web"),
+         SupervisionRepo(id: repoB, name: "acme-api"),
+         SupervisionRepo(id: repoC, name: "tbd")]
+    }
+
+    private var grouped: SupervisionFile {
+        SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA, repoB], policy: .repo(repoA)),
+        ])
+    }
+
+    /// The invariant every move must preserve, checked through resolution
+    /// rather than through the file's internals.
+    private func expectExactlyOneProjectPerRepo(
+        _ file: SupervisionFile, sourceLocation: SourceLocation = #_sourceLocation
+    ) throws {
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        let memberships = projects.flatMap(\.repos)
+        #expect(memberships.count == repos.count, sourceLocation: sourceLocation)
+        #expect(Set(memberships) == Set(repos.map(\.id)), sourceLocation: sourceLocation)
+    }
+
+    @Test func movingIntoAProjectAddsExactlyOneMembership() throws {
+        let moved = try SupervisionTopology.move(
+            repo: repoC, to: .project("acme-checkout"), in: grouped, repos: repos)
+        #expect(moved.projects["acme-checkout"]?.repos == [repoA, repoB, repoC])
+        try expectExactlyOneProjectPerRepo(moved)
+    }
+
+    @Test func movingToSingletonLeavesTheRepoItsOwnProject() throws {
+        let moved = try SupervisionTopology.move(
+            repo: repoB, to: .singleton, in: grouped, repos: repos)
+        #expect(moved.projects["acme-checkout"]?.repos == [repoA])
+        let projects = try SupervisionTopology.resolve(file: moved, repos: repos)
+        #expect(projects.first { $0.name == "acme-api" }?.repos == [repoB])
+        try expectExactlyOneProjectPerRepo(moved)
+    }
+
+    @Test func emptyingAProjectDeletesItAndItsSelections() throws {
+        let file = SupervisionFile(
+            projects: ["acme-checkout": .init(repos: [repoA], policy: .repo(repoA))],
+            supervised: ["acme-checkout"],
+            modes: ["acme-checkout": .bare("autonomous")],
+            supervisors: ["acme-checkout": .init(terminal: "t42")])
+        let moved = try SupervisionTopology.move(
+            repo: repoA, to: .singleton, in: file, repos: repos)
+        #expect(moved.projects.isEmpty)
+        // A mark left behind would turn a later project of the same name on
+        // without an operator gesture.
+        #expect(moved.supervised.isEmpty)
+        #expect(moved.modes.isEmpty)
+        #expect(moved.supervisors.isEmpty)
+        try expectExactlyOneProjectPerRepo(moved)
+    }
+
+    @Test func aMoveThatChangesNothingReturnsAnEqualValue() throws {
+        let alreadyThere = try SupervisionTopology.move(
+            repo: repoA, to: .project("acme-checkout"), in: grouped, repos: repos)
+        #expect(alreadyThere == grouped)
+        let alreadySingleton = try SupervisionTopology.move(
+            repo: repoC, to: .singleton, in: grouped, repos: repos)
+        #expect(alreadySingleton == grouped)
+    }
+
+    @Test func anUnknownRepoIsRefusedAndTheFileIsUntouched() throws {
+        let before = grouped
+        #expect(throws: SupervisionTopologyError.unknownRepo(repo: unknownRepo)) {
+            try SupervisionTopology.move(
+                repo: unknownRepo, to: .project("acme-checkout"), in: before, repos: repos)
+        }
+        #expect(before == grouped)
+        try expectExactlyOneProjectPerRepo(before)
+    }
+
+    @Test func anUnknownTargetProjectIsRefusedAndTheFileIsUntouched() throws {
+        let before = grouped
+        #expect(throws: SupervisionTopologyError.unknownProject(project: "acme-platform")) {
+            try SupervisionTopology.move(
+                repo: repoC, to: .project("acme-platform"), in: before, repos: repos)
+        }
+        #expect(before == grouped)
+        try expectExactlyOneProjectPerRepo(before)
+    }
+
+    @Test func movingOutTheSurvivingProjectsPolicySourceIsRefused() throws {
+        let before = grouped
+        #expect(throws: SupervisionTopologyError.policySourceWouldLeaveProject(
+            project: "acme-checkout", repo: repoA)) {
+            try SupervisionTopology.move(repo: repoA, to: .singleton, in: before, repos: repos)
+        }
+        #expect(before == grouped)
+        try expectExactlyOneProjectPerRepo(before)
+    }
+
+    @Test func aRejectedFileIsRefusedBeforeAnyMove() throws {
+        let broken = SupervisionFile(projects: [
+            "acme-checkout": .init(repos: [repoA], policy: .repo(repoA)),
+            "acme-hooks": .init(repos: [repoA], policy: .repo(repoA)),
+        ])
+        let before = broken
+        #expect(throws: SupervisionFileError.self) {
+            try SupervisionTopology.move(repo: repoA, to: .singleton, in: before, repos: repos)
+        }
+        #expect(before == broken)
+    }
+
+    @Test func theSingletonSentinelIsTheDocumentedWord() {
+        #expect(SupervisionMoveTarget(argument: "singleton") == .singleton)
+        #expect(SupervisionMoveTarget(argument: "acme-checkout") == .project("acme-checkout"))
+        #expect(SupervisionMoveTarget.singleton.argument == "singleton")
+        #expect(SuperviseProjectMoveParams.singletonTarget == "singleton")
+    }
+}

--- a/Tests/TBDSharedTests/SupervisionTopologyTests.swift
+++ b/Tests/TBDSharedTests/SupervisionTopologyTests.swift
@@ -144,6 +144,70 @@ private func generatedRepos(count: Int, using generator: inout SplitMix64) -> [S
         #expect(thrown?.description.contains("acme-web") == true)
     }
 
+    /// A repo displayed as `acme/web` is a project whose name cannot be a
+    /// directory. It is still supervised — mark, mode, policy, supervisor all
+    /// intact — because the name never came from `supervision.json` and taking
+    /// the fleet's coverage offline over one repo's display name would be the
+    /// wrong trade. What it loses is only the directory.
+    @Test func aSingletonWithAnUnusableNameStillResolves() throws {
+        let awkward = [SupervisionRepo(id: repoA, name: "acme/web"),
+                       SupervisionRepo(id: repoB, name: "acme-api")]
+        let file = SupervisionFile(
+            supervised: ["acme/web"], modes: ["acme/web": .bare("autonomous")])
+        let projects = try SupervisionTopology.resolve(file: file, repos: awkward)
+
+        let escaping = try #require(projects.first { $0.name == "acme/web" })
+        #expect(escaping.mark)
+        #expect(escaping.activeMode == "autonomous")
+        #expect(escaping.repos == [repoA])
+        #expect(escaping.policy == .repo(repoA))
+        #expect(escaping.supervisor == .hostedDesk)
+        // …and the one thing it cannot have.
+        #expect(!escaping.hasUsableDirectory)
+        #expect(projects.first { $0.name == "acme-api" }?.hasUsableDirectory == true)
+        #expect(SupervisionTopology.projectsWithoutUsableDirectory(in: projects) == ["acme/web"])
+    }
+
+    /// The other half of the same fact, kept in its own test so that breaking
+    /// the path helper and breaking the usability condition redden different
+    /// tests instead of the same one.
+    @Test func anUnusableProjectNameYieldsNoDirectoryPath() {
+        #expect(TBDConstants.supervisionProjectDir(
+            project: "acme/web", environment: ["TBD_HOME": "/tmp/tbd-unusable"]) == nil)
+    }
+
+    /// One repo's display name never takes the rest of the fleet's coverage
+    /// offline — the same trade that keeps a phantom member rather than
+    /// failing resolution.
+    @Test func anUnusableNameLeavesTheRestOfTheFleetResolved() throws {
+        let awkward = [SupervisionRepo(id: repoA, name: "acme/web"),
+                       SupervisionRepo(id: repoB, name: "acme-api"),
+                       SupervisionRepo(id: repoC, name: "tbd")]
+        let projects = try SupervisionTopology.resolve(file: SupervisionFile(), repos: awkward)
+        #expect(projects.count == 3)
+        #expect(Set(projects.map(\.name)) == ["acme/web", "acme-api", "tbd"])
+        #expect(Set(projects.flatMap(\.repos)) == Set(awkward.map(\.id)))
+    }
+
+    /// Directory usability is a function of the name alone, so it cannot become
+    /// a declared-ness flag by another route: the same name answers the same
+    /// whether the project was declared or fell out of the collapse.
+    @Test func directoryUsabilityDoesNotDistinguishDeclaredFromSingleton() throws {
+        let repos = [SupervisionRepo(id: repoA, name: "acme-web")]
+        let implicit = try SupervisionTopology.resolve(file: SupervisionFile(), repos: repos)
+        let declared = try SupervisionTopology.resolve(
+            file: SupervisionFile(projects: [
+                "acme-web": .init(repos: [repoA], policy: .repo(repoA)),
+            ]), repos: repos)
+        #expect(implicit == declared)
+        #expect(implicit.map(\.hasUsableDirectory) == declared.map(\.hasUsableDirectory))
+    }
+
+    @Test func aFleetOfUsableNamesReportsNothing() throws {
+        let projects = try SupervisionTopology.resolve(file: SupervisionFile(), repos: repos)
+        #expect(SupervisionTopology.projectsWithoutUsableDirectory(in: projects).isEmpty)
+    }
+
     @Test func aRejectedFileServesNoPartialResolution() {
         let file = SupervisionFile(projects: [
             "acme-checkout": .init(repos: [repoA], policy: .repo(repoA)),

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -13,12 +13,15 @@ Status: documents the `tbd supervise` surface specified by
 Part of that surface exists and part of it is specification the rest of this
 document describes ahead of the code:
 
-- **Built** – `on`, `off`, `status`, `mode`, `project`.
+- **Built** – `on`, `off`, `status`, `mode`, `project`. These are what
+  `tbd supervise --help` lists, and their output is quoted here exactly.
 - **Specified, not yet built** – `appoint`, `relieve`, `sweep customize`,
-  `readout`, `brief`, `ledger`.
+  `readout`, `brief`, `ledger`. Their sections below carry the same marker,
+  and any output they show is the specified shape rather than a transcript.
 
 The migration from the current implementation is planned separately. JSON
-output shown here is illustrative of the schema family until the schemas ship.
+output for the unbuilt commands is illustrative of the schema family until
+their schemas ship.
 
 ## Synopsis
 
@@ -102,23 +105,23 @@ narrative" below.
 ```
 # Hand a project over for the night
 $ tbd supervise on acme-platform
-on: acme-platform (mode autonomous, hosted desk ready)
+on: acme-platform
 
 # What is supervision doing right now?
 $ tbd supervise status
 brake: released
-acme-platform   on since 22:04   mode autonomous   supervisor: hosted desk   last sweep report 2m ago
-tbd             on since 21:40   mode attended     supervisor: appointed (⌁ main session)   last sweep report 4m ago
+acme-platform  on since 22:04  mode autonomous  supervisor: hosted desk      last sweep contact: never  coverage unknown
+acme-hooks     on since 21:40  mode attended    supervisor: appointed (t42)  last sweep contact: never  coverage unknown
 
-# Read the facts the way the sweep program does
+# Read the facts the way the sweep program does (not yet built)
 $ tbd supervise readout --project acme-platform
 
-# Answer "what did supervision actually do overnight?"
+# Answer "what did supervision actually do overnight?" (not yet built)
 $ tbd supervise ledger --project acme-platform --since 22:00
 
-# Make your current pairing session the project's supervisor for the day
-$ tbd supervise appoint tbd --terminal t42
-appointed: session t42 supervises "tbd" (relaunched with playbook layer)
+# Make your current pairing session the project's supervisor for the day (not yet built)
+$ tbd supervise appoint acme-hooks --terminal t42
+appointed: session t42 supervises "acme-hooks" (relaunched with playbook layer)
 ```
 
 ## tbd supervise on / off
@@ -153,6 +156,20 @@ summary of the span; on `on`, nothing — or the project's own script at
 delivered to the supervisor verbatim. A failing hook is recorded as an
 anomaly and never blocks the transition.
 
+A per-project call prints the resulting state and whether it changed anything
+— `on: acme-platform`, or `on: acme-platform (already on)` when the mark
+already stood. A gesture that changes nothing is not a decision: it writes no
+ledger line, and the parenthetical is how you can tell. The bare form prints
+the brake instead, `brake: engaged` or `brake: released`. The result carries
+the mark and nothing more: no mode, no supervisor state, nothing about a desk
+— reporting a fact the command did not establish is exactly the invented
+measurement this design refuses.
+
+What these gestures do today is the mark, the ledger line, and that result.
+The supervisor half described above — ensuring a hosted desk live, standing
+one down — and the transition hook belong with the not-yet-built commands,
+and arrive with them.
+
 Bare: the fleet brake. `off` pauses TBD's authority to act everywhere —
 briefings refused, identified supervisor sends refused from that instant —
 without disposing any supervisor or touching the per-project marks, so
@@ -168,10 +185,52 @@ continuous, and views over it are windowed.
 tbd supervise status [--json]
 ```
 
-One line of global state (the brake), then one line per project: on/off
-with the span's start, active
-mode, supervisor arrangement, last sweep contact age, and coverage — a
-project with no declared contact window and no tick shows `coverage unknown`.
+One line of global state (the brake), then any warning lines, then one line
+per project. A project's line carries its name, its state — `on since HH:mm`,
+or bare `on` where the record holds no opening line, or `off` — then
+`mode <name>`, the supervisor arrangement (`supervisor: hosted desk`, or
+`supervisor: appointed (<terminal>)`, which names the bound terminal rather
+than its display string), `last sweep contact: <age>` or
+`last sweep contact: never`, and coverage: the project's declared contact
+window, or `coverage unknown` where it declares none. Unknown is the honest
+not-yet value; nothing here invents a coverage claim. A fleet with no
+projects at all prints `(no projects)` where the rows would be.
+
+An off project renders exactly `off`, never a span and never a "was on
+until" — an untouched project and a turned-off one are the same state, and a
+third rendering would imply a third state that does not exist.
+
+**Warnings are stdout, and they are not errors.** A fleet state that would
+otherwise render as a calm night gets its own `warning:` line, between the
+brake and the project rows. The line is data on stdout and the exit code
+stays 0: a state worth saying out loud is not a failure of the command that
+reported it. Two conditions warn:
+
+- **`noProjectsOn`** – the brake is released and no project is on, so nothing
+  is being supervised. This is the quiet failure the whole surface exists to
+  prevent, so the line is composed from the facts the status carries — a
+  released brake with nothing effectively supervised — and appears whether or
+  not the daemon named it.
+- **`unusableProjectName`** – one or more projects have a name that cannot be
+  a directory name, so nothing can be written beside them: no playbook,
+  journal, proposals or programs. They are supervised like any other project,
+  and the message names which ones; renaming the repo gives them a directory.
+
+`--json` carries the same facts for a program. `effectivelySupervising` — the
+brake released *and* at least one project on — is the authoritative bit, and
+`warnings` is an array whose entries pair a stable `code`
+(`noProjectsOn`, `unusableProjectName`) with the sentence a human would have
+read. Branch on `effectivelySupervising` and on `code`; never on the rendered
+line. Each project entry carries `spanStartedAt`, `lastSweepContactAt` and
+`coverageWindow` as explicit nulls when unknown, so a missing value is
+readable as one rather than as an absent key.
+
+```
+$ tbd supervise status
+brake: released
+warning: the brake is released but no project is on — nothing is being supervised.
+(no projects)
+```
 
 ## tbd supervise mode
 
@@ -184,6 +243,29 @@ Selects the project's active mode, or with no mode name, shows the active
 mode and the declared choices. Names are validated against the declared mode
 list in `supervision.json`; the conduct a name stands for is the playbook's
 prose. Selection takes effect on the next briefing — no restart.
+
+Every form prints the choices beside the answer, so an operator never has to
+go looking for what would have worked — including the refusal, which names
+the condition on stderr and exits nonzero.
+
+```
+$ tbd supervise mode acme-platform
+mode: acme-platform is autonomous   choices: attended, autonomous
+
+$ tbd supervise mode acme-platform attended
+mode: acme-platform is now attended   choices: attended, autonomous
+
+$ tbd supervise mode acme-platform attended
+mode: acme-platform was already attended   choices: attended, autonomous
+
+$ tbd supervise mode acme-platform friday-freeze
+mode "friday-freeze" is not declared for project "acme-platform" — choices: attended, autonomous
+```
+
+`was already` is the same distinction the `on`/`off` parenthetical draws: a
+selection that changes nothing is not a decision and writes no ledger line. A
+project whose declared list is somehow empty renders `choices: (none
+declared)` rather than an empty space.
 
 ## tbd supervise project
 
@@ -198,7 +280,27 @@ Declares multi-repo projects and moves repos between them. A repo in no
 declared project is its own singleton project with its repo name — most
 fleets never need these commands.
 
+`list` prints one row per project: its name, its member repos, the playbook
+source it designates (`policy: repo:<repo>` or `policy: operator`), and its
+sweep program (`sweep: shipped`, or the path of the copy `sweep customize`
+wrote). An installation that has declared nothing prints `(no projects)`.
+There is no `--json` here; `status` is the machine surface.
+
+```
+$ tbd supervise project list
+acme-checkout  acme-web, acme-api  policy: repo:acme-web  sweep: shipped
+```
+
+`move --to singleton` takes a repo back to being its own project, and where
+that empties a declaration it deletes the declaration outright, along with
+that project's mark, its mode selection and any supervisor binding — a mark
+outliving its project would silently turn a later project of the same name
+on. A move that would take a surviving project's designated policy repo away
+is refused, naming the condition: designate another member's policy first.
+
 ## tbd supervise appoint / relieve
+
+*Specified, not yet built.*
 
 ```
 tbd supervise appoint  <project> --terminal <id>
@@ -225,6 +327,8 @@ than touching your session.
 
 ## tbd supervise sweep customize
 
+*Specified, not yet built.*
+
 ```
 tbd supervise sweep customize <project>
 ```
@@ -236,6 +340,8 @@ touched by TBD again. Until then, the shipped program runs on the default
 tick with no setup.
 
 ## tbd supervise readout
+
+*Specified, not yet built.*
 
 ```
 tbd supervise readout --project <name>
@@ -287,6 +393,8 @@ $ tbd supervise readout --project tbd | jq '.agents[] | {terminal, state}'
 
 ## tbd supervise brief
 
+*Specified, not yet built.*
+
 ```
 tbd supervise brief --project <name>    # briefing text on stdin
 ```
@@ -331,6 +439,8 @@ $ tbd supervise brief --project acme-platform < /dev/null
 ```
 
 ## tbd supervise ledger
+
+*Specified, not yet built.*
 
 ```
 tbd supervise ledger --project <name> --since <t>

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -246,7 +246,10 @@ section.) Four conditions warn:
 - **`ambiguousRepoName`** – two or more repos share a display name, so none of
   them resolves to a project and none is supervised: a name with two
   candidates identifies nothing. Rename one, or declare a project naming them.
-  The message names the repos, and the rest of the fleet is unaffected.
+  The message names the repos, and the rest of the fleet is unaffected. Those
+  repos have **no rows at all** below, so if you marked one on and cannot find
+  its row, this line is the explanation — the repo is still in TBD, it is the
+  project that has stopped resolving.
 - **`unusableProjectName`** – one or more projects have a name that cannot be
   a directory name, so nothing can be written beside them: no playbook,
   journal, proposals or programs. They are supervised like any other project,

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -9,9 +9,16 @@ and narrative" below).
 Status: documents the `tbd supervise` surface specified by
 [`docs/specs/2026-07-26-fleet-supervision-design.md`](specs/2026-07-26-fleet-supervision-design.md)
 (§10 is normative for names and shapes) and the
-[sweep-program sub-document](specs/2026-08-01-fleet-supervision-sweep-program-design.md);
-the migration from the current implementation is planned separately. JSON output
-shown here is illustrative of the schema family until the schemas ship.
+[sweep-program sub-document](specs/2026-08-01-fleet-supervision-sweep-program-design.md).
+Part of that surface exists and part of it is specification the rest of this
+document describes ahead of the code:
+
+- **Built** – `on`, `off`, `status`, `mode`, `project`.
+- **Specified, not yet built** – `appoint`, `relieve`, `sweep customize`,
+  `readout`, `brief`, `ledger`.
+
+The migration from the current implementation is planned separately. JSON
+output shown here is illustrative of the schema family until the schemas ship.
 
 ## Synopsis
 

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -64,7 +64,12 @@ that reads the `readout`, checks the `ledger` for what TBD already did, and
 submits composed briefings to `brief`. Those three commands are the program's
 entire contract with TBD.
 
-Conventions: data goes to stdout, messages to stderr. JSON output carries a
+Conventions: data goes to stdout, messages to stderr. **Project names are
+taken verbatim** — a `<project>` argument reaches the daemon exactly as typed,
+surrounding spaces included, because a singleton's name is its repo's display
+name and TBD lets a repo be called ` api `. A name of nothing but whitespace
+is refused: that is the empty case, and it would otherwise read as the bare
+fleet-brake form of `on`/`off`. JSON output carries a
 top-level `schemaVersion`; changes within a version are additive only.
 Commands exit 0 on success and nonzero with the refusing condition named on
 stderr; exit codes called out below as stable are a contract scripts may
@@ -165,10 +170,30 @@ the mark and nothing more: no mode, no supervisor state, nothing about a desk
 — reporting a fact the command did not establish is exactly the invented
 measurement this design refuses.
 
-What these gestures do today is the mark, the ledger line, and that result.
-The supervisor half described above — ensuring a hosted desk live, standing
-one down — and the transition hook belong with the not-yet-built commands,
-and arrive with them.
+**`on` warns; `off` deliberately does not.** After the switch has taken
+effect, both forms of `on` — releasing the brake, and marking a project —
+print the same warning composition `status` renders, unfiltered. The gesture
+is where an operator forms the belief that supervision is running, and each
+of the two is the only gesture that can create the state its warning
+describes: release the brake over an unmarked fleet and you get
+`noProjectsOn`; mark a project while the brake is engaged and you get
+`brakeEngagedWithProjectsOn`, having just been told `on: acme-platform`.
+Turning something off is a deliberate reduction of coverage rather than a
+mistaken belief, so it says nothing extra.
+
+**The streams split, so the command stays scriptable.** The one result line —
+`on: acme-platform`, or `brake: released` — is stdout; the warnings are
+stderr; the exit code is unchanged by either. `$(tbd supervise on acme-web)`
+captures the result and nothing else, and a terminal shows both. The check is
+best-effort in one direction only: it runs after the switch, so a readout it
+cannot take never turns a gesture that succeeded into a nonzero exit — but it
+says on stderr that it could not read the state, rather than falling silent
+and letting silence read as a calm night.
+
+What these gestures do today is the mark, the ledger line, the result and
+that warning. The supervisor half described above — ensuring a hosted desk
+live, standing one down — and the transition hook belong with the
+not-yet-built commands, and arrive with them.
 
 Bare: the fleet brake. `off` pauses TBD's authority to act everywhere —
 briefings refused, identified supervisor sends refused from that instant —
@@ -200,28 +225,40 @@ An off project renders exactly `off`, never a span and never a "was on
 until" — an untouched project and a turned-off one are the same state, and a
 third rendering would imply a third state that does not exist.
 
-**Warnings are stdout, and they are not errors.** A fleet state that would
-otherwise render as a calm night gets its own `warning:` line, between the
-brake and the project rows. The line is data on stdout and the exit code
-stays 0: a state worth saying out loud is not a failure of the command that
-reported it. Two conditions warn:
+**Here warnings are stdout, and they are not errors.** A fleet state that
+would otherwise render as a calm night gets its own `warning:` line, between
+the brake and the project rows. Under `status` the lines are part of the
+readout, so they go to stdout; the exit code stays 0 either way, because a
+state worth saying out loud is not a failure of the command that reported it.
+(The same lines appear under `on`, where they go to stderr instead — see that
+section.) Four conditions warn:
 
 - **`noProjectsOn`** – the brake is released and no project is on, so nothing
-  is being supervised. This is the quiet failure the whole surface exists to
-  prevent, so the line is composed from the facts the status carries — a
-  released brake with nothing effectively supervised — and appears whether or
-  not the daemon named it.
+  is being supervised. The quiet failure the whole surface exists to prevent,
+  so the line is composed from the facts the status carries — a released brake
+  with nothing effectively supervised — and appears whether or not the daemon
+  named it.
+- **`brakeEngagedWithProjectsOn`** – the mirror: the brake is engaged while
+  projects are marked on, so nothing is watching projects you believe are
+  covered. Release it with `tbd supervise on`. It appears only while a mark
+  actually stands — an engaged brake over an unmarked fleet is a deliberately
+  quiet system, and a line there would teach you to stop reading the line.
+- **`ambiguousRepoName`** – two or more repos share a display name, so none of
+  them resolves to a project and none is supervised: a name with two
+  candidates identifies nothing. Rename one, or declare a project naming them.
+  The message names the repos, and the rest of the fleet is unaffected.
 - **`unusableProjectName`** – one or more projects have a name that cannot be
   a directory name, so nothing can be written beside them: no playbook,
   journal, proposals or programs. They are supervised like any other project,
   and the message names which ones; renaming the repo gives them a directory.
 
-`--json` carries the same facts for a program. `effectivelySupervising` — the
-brake released *and* at least one project on — is the authoritative bit, and
-`warnings` is an array whose entries pair a stable `code`
-(`noProjectsOn`, `unusableProjectName`) with the sentence a human would have
-read. Branch on `effectivelySupervising` and on `code`; never on the rendered
-line. Each project entry carries `spanStartedAt`, `lastSweepContactAt` and
+`--json` carries the same facts for a program. `warnings` is an array whose
+entries pair a stable `code` — the four above — with the sentence a human
+would have read. `effectivelySupervising` (the brake released *and* at least
+one project on) is a useful bit but not a diagnosis: it is false for
+`noProjectsOn` and `brakeEngagedWithProjectsOn` alike, and those call for
+opposite gestures, so branch on `code`. Never branch on the rendered line.
+Each project entry carries `spanStartedAt`, `lastSweepContactAt` and
 `coverageWindow` as explicit nulls when unknown, so a missing value is
 readable as one rather than as an absent key.
 
@@ -297,6 +334,16 @@ that project's mark, its mode selection and any supervisor binding — a mark
 outliving its project would silently turn a later project of the same name
 on. A move that would take a surviving project's designated policy repo away
 is refused, naming the condition: designate another member's policy first.
+
+`singleton` is a reserved name: `create` refuses it, because it is the word
+`--to` takes to mean "back to being its own project" and a project holding it
+could never be a move destination. `--to` is otherwise verbatim like every
+other project name, so the sentinel is the exact word — `--to " singleton "`
+names a project whose name has spaces around it, on the reading that whoever
+quoted those spaces typed them deliberately. `--repos` is the one place that
+still trims: it splits on commas and trims each element, so a repo whose
+display name carries surrounding spaces cannot be named there. `project move`
+reaches it.
 
 ## tbd supervise appoint / relieve
 

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -3054,9 +3054,10 @@ overrides (§15).
 
 ## 14. Out-of-band heartbeat (P3-1)
 
-On a fixed cadence of its own, the daemon writes a small `status.json` file
-under `~/tbd/supervision/`. It contains the brake, each project's mark and
-active mode, and each project's last sweep contact. The watchdog is an
+The daemon writes a small `status.json` file under `~/tbd/supervision/` at
+start, at every fleet brake edge, and then on a fixed cadence of its own **for
+as long as the brake is released**. It contains the brake, each project's mark
+and active mode, and each project's last sweep contact. The watchdog is an
 optional `launchd` job with one rule: *if any project claims to be
 effectively on and the
 status file has not changed in about 10 minutes, raise a notification.* It
@@ -3065,6 +3066,19 @@ watchdog unavailable. The watchdog never acts on the fleet. It can only alert
 the operator; it cannot pretend to be the supervisor. A down daemon therefore
 means silence plus an alarm. This applies the rule that uncertainty must lead
 to inaction at the largest scale.
+
+Gating the cadence on the brake costs the watchdog nothing, which is what
+makes the brake the single switch here rather than something the heartbeat
+sits outside of. Effectively on means a project's mark **and** a released
+brake, so a status file reading `engaged` claims that nothing is effectively
+on and cannot trip the rule however old it grows; the freshness requirement
+binds exactly while the brake is released, which is exactly when the cadence
+runs. Writing at the edges is what carries that across the transition itself —
+the moment the brake moves, the file says so, before the cadence starts or
+stops. The consequence to state plainly for whoever builds the watchdog:
+**staleness is a liveness signal only while the file reads `released`.** Under
+an engaged brake a file untouched for hours means a paused fleet, not a dead
+daemon.
 
 ## 15. Deliberately not built
 

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -1128,7 +1128,9 @@ came from decides what happens:
   each, reported as a warning, while the rest of the fleet resolves normally.
   A name with two candidates identifies nothing, so neither repo can be
   addressed — but nothing about a coincidence between those two says anything
-  about the others.
+  about the others. A mark previously set for that name is not cleared: it
+  stops applying while the name is ambiguous and applies again if the
+  ambiguity is resolved, which is the boundary §9 states plainly.
 
 The second is not leniency, and the asymmetry is the point: nothing in TBD
 constrains repo display names, so two clones of one upstream under different
@@ -1861,7 +1863,10 @@ most one project; the loader rejects the file if one appears twice, because
 `supervised` is the list of projects turned on — TBD's own attention covers
 exactly these, and an absent name is off (below). A name here matching no
 current project is kept rather than pruned, because a project may be declared
-later; until one is, the name resolves to nothing. `modes` holds two things on the default-props chain: the **declared
+later; until one is, the name resolves to nothing. That is also how a mark
+survives its project ceasing to resolve for a reason no supervision gesture
+caused — a repo renamed or unregistered — and how it can apply again if the
+name resolves once more (§5, §9). `modes` holds two things on the default-props chain: the **declared
 mode list** — the names a project's operator may select, defaulting to the
 built-in pair `attended`/`autonomous` when absent — and the operator's
 **selection** per project, defaulting to `attended` (§3). The map's value
@@ -2081,15 +2086,28 @@ coverage. A span opened while nothing was recording has no `projectOn` to pair
 with, and its closing line reports the start as unknown rather than inventing
 one.
 
-**A project that stops resolving has its coverage closed.** Whatever made it
-stop — a declared project deleted, one emptied by a `move`, a marked singleton
-absorbed into a declared project — the record sees one event: the span ends
-with that project's `projectOff` line, and its mark, mode selection and
-supervisor binding go with it. Stating it as an invariant rather than as a
-property of any one gesture is what keeps it true of gestures added later. A
-mark outliving its project would silently turn a later project of the same
-name on with no operator gesture — coverage nobody asked for, which is the
-failure per-project marks exist to prevent (§5, §8).
+**A topology gesture that ends a project closes its coverage.** Deleting a
+declared project, emptying one by a `move`, absorbing a marked singleton into
+a declared project: whichever gesture it was, the record sees one event — the
+span ends with that project's `projectOff` line, and its mark, mode selection
+and supervisor binding go with it. Binding this to the gestures as a class,
+rather than to each verb separately, is what keeps it true of topology
+gestures added later. A mark outliving its project would silently turn a
+later project of the same name on with no operator gesture — coverage nobody
+asked for, which is the failure per-project marks exist to prevent (§5, §8).
+
+**Coverage is not closed when a project stops resolving because the repo
+table changed underneath it.** Supervision reconciles resolution against edits
+to its own file; a repo renamed or unregistered is not a supervision gesture,
+so nothing notices. The consequence is a mark that outlives the resolution it
+was set against, and that can take effect again later: mark a singleton on,
+let a second repo be renamed to the same display name, and the project stops
+resolving with the mark still standing (§5, §8) — rename either repo again and
+it comes back on with no gesture, on whichever repo now holds the name, which
+with two candidates was never determined to be the one the operator meant.
+This is the mechanism's boundary and not an oversight in it: closing the gap
+means the daemon reconciling resolution against the repo table as well as
+against the file, on repo events it does not watch today.
 
 **A no-op writes no line.** Turning on a project already on, turning off one
 already off, selecting the mode already selected, moving a repo to where it

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -1135,6 +1135,26 @@ leaves the operator's intent genuinely ambiguous, while an unregistered repo
 leaves it perfectly clear, so taking a project's supervision offline over a
 stale name would cost real coverage to fix nothing.
 
+**A project's name must be usable as a single path component**, because §6 puts
+that project's journal and proposals in a directory named by it. Where the
+requirement bites depends on where the name came from, and the asymmetry is
+deliberate:
+
+- **A declared name that fails is a loader rejection** (§8). That name came out
+  of the supervision file, so refusing the file refuses the operator's own
+  edit, and the fix is one line away in the document they were already editing.
+- **A singleton's name is its repo's display name**, which came from nowhere
+  near that file. Refusing there would take the whole fleet's coverage offline
+  over a repo renamed for unrelated reasons, with the remedy sitting in a file
+  the operator never touched. So resolution keeps the project — its mark, its
+  mode and its place in `status` intact — and reports the condition; what such
+  a project cannot have is a per-project directory until the repo is renamed.
+  The path helper itself refuses to compose a name it cannot safely use, so no
+  caller reopens the hole by building the path by hand.
+
+Coverage is not withheld over a naming problem — the same reasoning that
+resolves a phantom member rather than failing on it.
+
 **Each desk is addressed to its own project.** The daemon refuses a desk's send
 when the target lies outside that project — addressing correctness, not
 authority (§3). How the daemon knows the caller's project is deliberately
@@ -1823,7 +1843,9 @@ most one project; the loader rejects the file if one appears twice, because
 "exactly one" is the property the whole grouping rests on.
 
 `supervised` is the list of projects turned on — TBD's own attention covers
-exactly these, and an absent name is off (below). `modes` holds two things on the default-props chain: the **declared
+exactly these, and an absent name is off (below). A name here matching no
+current project is kept rather than pruned, because a project may be declared
+later; until one is, the name resolves to nothing. `modes` holds two things on the default-props chain: the **declared
 mode list** — the names a project's operator may select, defaulting to the
 built-in pair `attended`/`autonomous` when absent — and the operator's
 **selection** per project, defaulting to `attended` (§3). The map's value

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -684,10 +684,11 @@ carried for a hypothetical.
 
 ### The switch: supervision is on, or off (P0-2)
 
-One configuration column in the daemon, on or off — added by migration and
-**shipped off**, which is the house default-off-flag rule satisfied by the
-switch itself: no second flag hides behind it, and the soak is opt-in
-coverage. (Two §12 mechanisms carry default-off flags of their own beside
+One configuration column in the daemon, on or off — added by migration with no
+SQL default, so an install where nobody has chosen stays distinguishable from
+one that chose (§7) — and **shipped off**, which is the house
+default-off-flag rule satisfied by the switch itself: no second flag hides
+behind it, and the soak is opt-in coverage. (Two §12 mechanisms carry default-off flags of their own beside
 it: the delivery-verification re-check, which the public send offers every
 caller and supervision only shares, and the Channels delivery adapter.)
 Settable from the app and the
@@ -1108,6 +1109,32 @@ degenerate case is that arrangement exactly. Any behavior that differs
 between "no projects declared" and the plain per-repo arrangement is a bug, not
 a feature.
 
+**Every name resolves to exactly one project, and resolution refuses rather
+than repairs.** Because a repo declared nowhere is a project named by that
+repo, a name can be claimed twice, in two ways, and both are resolution
+errors that name the collision and serve no partial result:
+
+- **A declared project whose name is also a repo's display name**, where that
+  repo is not one of its members — that repo's own singleton would claim the
+  same name. The operator says which they meant: rename the project, or move
+  the repo into it.
+- **Two registered repos sharing a display name** — each would be its own
+  project under the one name. This constraint is supervision's own, worth
+  stating because nothing else in TBD requires repo display names to be
+  unique; grouping is the first thing that reads them as identity.
+
+Refusing whole is the posture the duplicate-membership rejection takes (§8),
+for the same reason. "Exactly one project" is what the grouping rests on, and
+a silent repair — picking a winner, suffixing a name — would hand an operator
+coverage on a policy they never declared.
+
+**A declared project naming a repo that is no longer registered keeps
+working**, the phantom member resolving into the project and contributing no
+sessions. The asymmetry with the two refusals is deliberate: a collision
+leaves the operator's intent genuinely ambiguous, while an unregistered repo
+leaves it perfectly clear, so taking a project's supervision offline over a
+stale name would cost real coverage to fix nothing.
+
 **Each desk is addressed to its own project.** The daemon refuses a desk's send
 when the target lies outside that project — addressing correctness, not
 authority (§3). How the daemon knows the caller's project is deliberately
@@ -1176,6 +1203,16 @@ offered: with "every repo belongs to exactly one project" as the invariant, a
 `remove` leaves a repo belonging to nothing and an `add` can put it in a second
 place, so the pair can express states the model forbids and every caller would
 have to sequence them correctly. `move` cannot express them at all.
+
+Two rules govern the edges of a move, and both follow from the same invariant.
+**`--to singleton` deletes a declaration the move empties, and deletes its
+mark, its mode entry and its supervisor binding with it.** A mark outliving its
+project would silently turn a later project of the same name on with no
+operator gesture — coverage nobody asked for, which is precisely what
+per-project marks exist to prevent (§8). And **a move is refused, naming the
+condition, when it would take a surviving project's designated policy source
+out from under it**: a project whose policy repo has left is a project with no
+resolvable playbook, so the operator designates another member's policy first.
 
 **Project mutations take effect on the next tick.** A definition edited
 while its desk is live is legal; it just does not retroactively change a desk that is already
@@ -1558,6 +1595,17 @@ account, not a wrong action. The third category is **human-authored process**.
   the purpose of the shared configuration object. Mode selections are *not*
   here; they are per-project operator choices in `supervision.json` (§8), which
   keeps this column a single fleet-wide gesture (P0-2).
+
+  **The column carries no SQL default, so it holds three states rather than
+  two**: NULL means nobody has chosen, `0` and `1` mean somebody did. The
+  shipped default — engaged — then lives in exactly one place, the fallback
+  applied when the column reads NULL, and graduating the brake to
+  shipped-released is a one-line change to that constant: it reaches every
+  install whose operator never touched the toggle and preserves every explicit
+  opt-out, with no forcing migration to overwrite either. Adding the column
+  with a SQL default would have destroyed that distinction on write, backfilling
+  every existing row and making the code-side default unreachable; root
+  `CLAUDE.md` carries the rule and the precedent that produced it.
 - **The actuation log** (`~/tbd/actuations.jsonl`): TBD's general
   append-only actuation record (§3, §6) — deliberately *not* supervision
   storage, because it exists for every caller; supervision's views read
@@ -1578,8 +1626,11 @@ account, not a wrong action. The third category is **human-authored process**.
     per-project sweep selections (§8). Atomically
     rewritten after each operator action; the daemon
     reloads it after a change and holds it in memory for lookups. Every change
-    appends a ledger line, so the current selections and the history of how they
-    came about live in the appropriate places.
+    appends a ledger line — a gesture that changes nothing is not a change and
+    writes none (§9) — so the current selections and the history of how they
+    came about live in the appropriate places. Selections are all it holds:
+    nothing derived lives here, and a coverage span's start is read back from
+    the ledger rather than stored beside the mark (§9).
   - `~/tbd/supervision/projects/<name>/sweep.py` — a project's customized
     sweep program, written exactly once by the "Customize sweep…" gesture and
     never touched by the tool after (sweep-program sub-document §7). Absent
@@ -1803,6 +1854,30 @@ no standing layer, no injected identity — so the daemon reports it as an
 anomaly rather than honoring it silently; the appoint gesture is the way to
 make a binding real.
 
+**What the loader rejects, and why it rejects whole.** The file is
+hand-editable and its project names become directories, so the loader refuses
+anything no consumer should act on, naming the offending repo, project, or
+condition on stderr. Nothing is repaired and nothing is partially loaded: a
+half-loaded topology would silently supervise a shape the operator did not
+declare, which is worse than an install that says plainly why it stopped.
+Beyond a version this build does not read, the refusals are:
+
+- **A repo in two projects, or listed twice in one** — "exactly one project" is
+  the property the whole grouping rests on (§5).
+- **A policy source that is not a member** of the project designating it —
+  a project has to be able to resolve its own playbook.
+- **A project declaring no repos** — an empty project names no work, resolves
+  to no sessions, and can only be an editing accident.
+- **A project name that cannot name a directory** under
+  `~/tbd/supervision/projects/` — the name is a path component holding that
+  project's playbook, journal, proposals and programs (§7), so slashes,
+  emptiness, `.` and `..`, and leading or trailing spaces are refused at the
+  door rather than discovered as a broken path later.
+- **An empty declared mode list** — no mode could be selected, so the project
+  could run no conduct at all.
+- **A selection outside the declared list** — the lookup this section already
+  requires, failing loudly instead of falling back to a mode nobody picked.
+
 **What this file never holds.** There is no `rules` array: no verbs, no scopes,
 no stances, no lifetimes, no origins. Nothing is gated (§3), so there is no
 vocabulary for a gate to consume. What the file does hold — topology and
@@ -1924,6 +1999,23 @@ do not survive a pause — anything still true reappears in a fresh briefing
 derived from current state — and a briefing left unanswered across a pause
 is the system's doing, not a dead desk, which any continuation policy sees
 plainly because the pause is on the record beside it (§6, below).
+
+**A span's start is recovered from the record, never stored as a field.** It is
+the most recent `projectOn` line for that project with no `projectOff` after
+it, so the closing line computes the span it summarizes by reading backward.
+That is what makes "a restart resumes coverage from two files" literally true:
+`supervision.json` and the config column say what is covered *now*, the ledger
+says *since when*, and `supervision.json` keeps holding selections only, with
+no derived "covered since" to drift out of step with the lines that record
+coverage. A span opened while nothing was recording has no `projectOn` to pair
+with, and its closing line reports the start as unknown rather than inventing
+one.
+
+**A no-op writes no line.** Turning on a project already on, turning off one
+already off, selecting the mode already selected, moving a repo to where it
+already is: none of these is a decision, so none reaches the record. A ledger
+padded with lines that changed nothing would make the one thing the record
+exists for — reading back what actually happened — harder for no gain.
 
 ### The transition ceremony: edges are compiled, ceremony is authored
 

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -698,8 +698,11 @@ substance: one gesture, one ledger, one account. The switch is
 the fleet **brake**, and only that: supervising anything also takes the
 per-project gesture (§8) — `tbd supervise on <project>` — because every
 project starts off and there is no default stance. A fleet switched on with
-no projects on supervises nothing, and `status` and the account must say so
-loudly rather than render it as a calm night. The bare bit is ANDed over the
+no projects on supervises nothing, and so does a fleet whose marks all stand
+under an engaged brake; `status`, the switching gestures themselves, and the
+account must say each of those loudly rather than render it as a calm night.
+The conditions are enumerated and distinguishable, never inferred from one
+boolean (§8). The bare bit is ANDed over the
 per-project marks and never writes them, so pulling the brake disturbs no
 configuration and releasing it restores exactly the coverage that stood.
 
@@ -1109,31 +1112,43 @@ degenerate case is that arrangement exactly. Any behavior that differs
 between "no projects declared" and the plain per-repo arrangement is a bug, not
 a feature.
 
-**Every name resolves to exactly one project, and resolution refuses rather
-than repairs.** Because a repo declared nowhere is a project named by that
-repo, a name can be claimed twice, in two ways, and both are resolution
-errors that name the collision and serve no partial result:
+**Every name identifies exactly one project, and a name that identifies none
+is reported rather than repaired.** Because a repo declared nowhere is a
+project named by that repo, a name can be claimed twice — and where the claim
+came from decides what happens:
 
 - **A declared project whose name is also a repo's display name**, where that
-  repo is not one of its members — that repo's own singleton would claim the
-  same name. The operator says which they meant: rename the project, or move
-  the repo into it.
-- **Two registered repos sharing a display name** — each would be its own
-  project under the one name. This constraint is supervision's own, worth
-  stating because nothing else in TBD requires repo display names to be
-  unique; grouping is the first thing that reads them as identity.
+  repo is not one of its members, is **refused whole**, no partial resolution
+  served. That repo's own singleton would claim the same name, and a silent
+  repair — picking a winner, suffixing a name — would hand an operator
+  coverage on a policy they never declared. The name came out of the
+  operator's own file, so the refusal points at a line they can fix: rename
+  the project, or move the repo into it.
+- **Two undeclared repos sharing a display name** resolve to **no project**
+  each, reported as a warning, while the rest of the fleet resolves normally.
+  A name with two candidates identifies nothing, so neither repo can be
+  addressed — but nothing about a coincidence between those two says anything
+  about the others.
 
-Refusing whole is the posture the duplicate-membership rejection takes (§8),
-for the same reason. "Exactly one project" is what the grouping rests on, and
-a silent repair — picking a winner, suffixing a name — would hand an operator
-coverage on a policy they never declared.
+The second is not leniency, and the asymmetry is the point: nothing in TBD
+constrains repo display names, so two clones of one upstream under different
+parents is an ordinary state an operator reaches without thinking about
+supervision at all. Refusing resolution there would take down `status`, the
+project list, every mark and mode gesture — and, decisively, the `status.json`
+heartbeat (§14), the one artifact that distinguishes a paused fleet from a
+dead daemon. A watchdog cannot tell a heartbeat stopped by a naming
+coincidence from a daemon that died, so failing whole in that direction
+silently disables the out-of-band safety net for a reason having nothing to do
+with supervision. Where this design does still refuse whole — a declared
+collision, the loader's rejections (§8) — the offending input came from the
+file the operator was editing.
 
 **A declared project naming a repo that is no longer registered keeps
 working**, the phantom member resolving into the project and contributing no
-sessions. The asymmetry with the two refusals is deliberate: a collision
-leaves the operator's intent genuinely ambiguous, while an unregistered repo
-leaves it perfectly clear, so taking a project's supervision offline over a
-stale name would cost real coverage to fix nothing.
+sessions. A declared collision leaves the operator's intent genuinely
+ambiguous, while an unregistered repo leaves it perfectly clear, so taking a
+project's supervision offline over a stale name would cost real coverage to
+fix nothing.
 
 **A project's name must be usable as a single path component**, because §6 puts
 that project's journal and proposals in a directory named by it. Where the
@@ -1152,8 +1167,10 @@ deliberate:
   The path helper itself refuses to compose a name it cannot safely use, so no
   caller reopens the hole by building the path by hand.
 
-Coverage is not withheld over a naming problem — the same reasoning that
-resolves a phantom member rather than failing on it.
+One principle runs through all of these: a naming problem costs the fleet
+nothing beyond the projects the name actually touches. It is why a phantom
+member resolves, why an ambiguous display name stops at the repos that share
+it, and why a project that cannot have a directory is still supervised.
 
 **Each desk is addressed to its own project.** The daemon refuses a desk's send
 when the target lies outside that project — addressing correctness, not
@@ -1224,15 +1241,14 @@ offered: with "every repo belongs to exactly one project" as the invariant, a
 place, so the pair can express states the model forbids and every caller would
 have to sequence them correctly. `move` cannot express them at all.
 
-Two rules govern the edges of a move, and both follow from the same invariant.
-**`--to singleton` deletes a declaration the move empties, and deletes its
-mark, its mode entry and its supervisor binding with it.** A mark outliving its
-project would silently turn a later project of the same name on with no
-operator gesture — coverage nobody asked for, which is precisely what
-per-project marks exist to prevent (§8). And **a move is refused, naming the
-condition, when it would take a surviving project's designated policy source
-out from under it**: a project whose policy repo has left is a project with no
-resolvable playbook, so the operator designates another member's policy first.
+Two rules govern the edges of a move. **`--to singleton` deletes a declaration
+the move empties**, and that project's mark, mode entry and supervisor binding
+go with it — one instance of the general rule that a project which stops
+resolving has its coverage closed, whatever made it stop (§9). And **a move is
+refused, naming the condition, when it would take a surviving project's
+designated policy source out from under it**: a project whose policy repo has
+left is a project with no resolvable playbook, so the operator designates
+another member's policy first.
 
 **Project mutations take effect on the next tick.** A definition edited
 while its desk is live is legal; it just does not retroactively change a desk that is already
@@ -1892,9 +1908,16 @@ Beyond a version this build does not read, the refusals are:
   to no sessions, and can only be an editing accident.
 - **A project name that cannot name a directory** under
   `~/tbd/supervision/projects/` — the name is a path component holding that
-  project's playbook, journal, proposals and programs (§7), so slashes,
-  emptiness, `.` and `..`, and leading or trailing spaces are refused at the
-  door rather than discovered as a broken path later.
+  project's playbook, journal, proposals and programs (§7), so emptiness, `.`
+  and `..`, and any name containing a slash are refused at the door rather
+  than discovered as a broken path later. The test is path safety and nothing
+  more: a singleton's name is a repo display name, so spaces, inner dots,
+  leading dots and non-ASCII all pass, and an over-tight rule would start
+  refusing ordinary repos for taste.
+- **A project named `singleton`** — that word is what `move --to` takes to
+  mean "back to being its own project", resolved before any project is looked
+  up, so a project holding the name could be created and then never be a move
+  destination. Reserving it is what keeps the sentinel unambiguous.
 - **An empty declared mode list** — no mode could be selected, so the project
   could run no conduct at all.
 - **A selection outside the declared list** — the lookup this section already
@@ -1958,6 +1981,31 @@ A project that is off gets none of TBD's own attention — no
 tick, no prompt cases, no desk. It still appears in the readout and the account —
 observability is never withheld, and "project X needed attention but is out of
 supervision" is the honest report.
+
+**The loud conditions are enumerated, not inferred.** A state that would
+otherwise render as a calm night carries a warning with a stable code beside
+the human sentence, so a program branches on the code and a person reads the
+words. Four exist:
+
+- **`noProjectsOn`** — the brake is released and not one project is marked.
+  Supervision is on and watching nothing.
+- **`brakeEngagedWithProjectsOn`** — the brake is engaged while at least one
+  mark stands, so nothing is watching projects the operator believes are
+  covered. It is emitted **only when a mark actually stands**: an engaged
+  brake over an unmarked fleet is a deliberately quiet system, and warning
+  there would train an operator to ignore the line, which costs more than it
+  buys.
+- **`ambiguousRepoName`** — two or more undeclared repos share a display name,
+  so none of them resolves to a project (§5). The message names them.
+- **`unusableProjectName`** — a project's name cannot be a directory name, so
+  nothing can be written beside it (§5). It is supervised regardless.
+
+The first two are why the loud case is a set of codes rather than a single
+"is anything covered" bit. A derived `effectivelySupervising` — the brake
+released *and* some mark standing — is false in both, and cannot tell them
+apart; yet they call for opposite gestures, releasing the brake in one case
+and marking a project in the other. A surface that reported only the bit would
+be telling an operator that something is wrong while withholding which thing.
 
 Coverage is also a recorded event, not only a resolved fact. Because
 membership derives — agent → repo → project → mark — a new agent spawned
@@ -2032,6 +2080,16 @@ no derived "covered since" to drift out of step with the lines that record
 coverage. A span opened while nothing was recording has no `projectOn` to pair
 with, and its closing line reports the start as unknown rather than inventing
 one.
+
+**A project that stops resolving has its coverage closed.** Whatever made it
+stop — a declared project deleted, one emptied by a `move`, a marked singleton
+absorbed into a declared project — the record sees one event: the span ends
+with that project's `projectOff` line, and its mark, mode selection and
+supervisor binding go with it. Stating it as an invariant rather than as a
+property of any one gesture is what keeps it true of gestures added later. A
+mark outliving its project would silently turn a later project of the same
+name on with no operator gesture — coverage nobody asked for, which is the
+failure per-project marks exist to prevent (§5, §8).
 
 **A no-op writes no line.** Turning on a project already on, turning off one
 already off, selecting the mode already selected, moving a repo to where it


### PR DESCRIPTION
## Summary

Fleet supervision watches a fleet of agent sessions and intervenes through a
supervisor — but before any of that can exist, it needs a skeleton: a way to
say *which* work is supervised, *whether* supervision may act at all, and a
record of both that survives a restart. This is that skeleton, and the first
slice of the new supervision path.

An operator can now group repos into **projects**, turn supervision on or off
**per project**, choose each project's **mode**, and pull one fleet-wide
**brake** that pauses TBD's authority to act everywhere without disturbing any
of those choices. Every one of those gestures lands in an append-only ledger,
and a heartbeat file publishes the current picture for a watchdog that outlives
the daemon.

At the end of this slice, `tbd supervise on <project>` **writes lines and does
nothing else**. That is the intended end state, not an unfinished one. Nothing
sweeps, no desk is spawned, no briefing is composed or delivered. What ships
here is the shape those later slices read — which is why the shapes got more
care than the behavior.

The whole subsystem is inert until the brake is released, and the brake ships
off.

## Why this shape

The design is [`docs/specs/2026-07-26-fleet-supervision-design.md`](docs/specs/2026-07-26-fleet-supervision-design.md)
(§3, §5, §6, §7, §8, §9, §14) with requirements in the
[companion doc](docs/specs/2026-07-26-fleet-supervision-requirements.md) (P3-1);
the CLI reference is [`docs/cli-supervise.md`](docs/cli-supervise.md). Decisions
this slice settled were written into those documents rather than left in this
description, so the next slice's reviewers can find them.

The load-bearing choices:

- **The singleton collapse is a property, not a branch.** A repo in no declared
  project *is* its own project, named by the repo. There is no `isSingleton`
  field for a consumer to branch on, and no code path distinguishes "nothing
  declared" from the plain per-repo arrangement — a property test drives it
  from generated repo sets rather than from examples. That is what lets an
  operator who never creates a project still get coherent supervision.

- **`move` only — deliberately no `add`/`remove` pair.** Every repo belongs to
  exactly one project. An `add`/`remove` pair can express states the model
  forbids (a repo in two projects, or in none mid-operation); `move` cannot
  express them at all. The restricted vocabulary *is* the invariant's
  enforcement.

- **Untouched and turned-off are the same state.** No third "never configured"
  tier. An absent `supervision.json` is a legitimate, load-bearing state that
  reads as the empty one.

- **Loud beats calm.** A fleet released with no project on, and a project marked
  on under an engaged brake, are both quiet failures — an account that looks
  peaceful because nothing was watched is worse than an obvious error. Both say
  so, in words, at the gesture as well as in `status`, with enumerated codes a
  program can branch on. `effectivelySupervising` alone cannot serve: it is
  false for two conditions that call for opposite operator actions.

- **A null project on the daemon's own ledger lines is the accurate answer.**
  The brake is fleet-wide; forcing a project onto its line would be a lie. The
  line factories take no project, so this holds by construction rather than by
  discipline.

- **Coverage is never withheld over a naming problem.** A project naming a repo
  that no longer exists still resolves; a project whose name cannot be a
  directory keeps its mark, mode and status row and loses only its directory;
  two undeclared repos sharing a display name resolve to no project each rather
  than taking the fleet down. The asymmetry is deliberate: a name that came from
  the operator's own file is refused loudly, because the fix is one line away in
  the document they were already editing.

- **Reading state is not re-deciding.** Startup recovers each open span from the
  ledger — the most recent `projectOn` with no later `projectOff` — and writes
  nothing, sends nothing, starts nothing.

## What this PR does

- **`Sources/TBDShared/Supervision/`** — the file model, its loader and atomic
  writer, topology resolution and the pure `move` transform, ledger line and
  status-file types. The loader refuses a file where a repo appears in two
  projects, naming the repo, and refuses whole rather than repairing.
- **`supervision_enabled`** — one `config` column (migration `v75`), the fleet
  brake, with the RPC setter, the change broadcast, and an app toggle.
- **`Sources/TBDCLI/Commands/Supervise*.swift`** — `on|off [<project>]`,
  `status [--json]`, `mode`, and `project list|create|delete|move`. Rendering is
  a pure function over the status DTO, so the loud case is asserted on composed
  output rather than on an internal flag.
- **`Sources/TBDDaemon/Supervision/`** — the store (single writer of
  `supervision.json`), the ledger writer (`O_APPEND`, `fsync` per row, inode
  identity checked), the `status.json` heartbeat on an injected clock, and a
  narrow read seam for the roster.
- **`RPCRouter+SupervisionHandlers.swift`** and dispatch for the `supervise.*`
  surface; brake engage/release lines in the config handler.
- Spec and CLI-reference updates.

## Flag & rollout

**Flag:** `supervision_enabled` on the `config` table — the fleet brake itself.
This is the house default-off requirement satisfied *by the switch*: there is no
second flag hiding behind it, and the whole subsystem is inert until it is
released.

That includes the `status.json` heartbeat, whose periodic timer runs **only
while the brake is released**. The file is published at boot and at every brake
edge, so it is always current at a transition, but nothing loops on a braked
daemon. This costs the watchdog nothing: its rule fires only when a project
claims to be *effectively on* — mark set and brake released — so a file saying
`engaged` claims nothing is running and no amount of staleness can trip it. The
boot publish is what makes that safe, since a file left by a previous run could
otherwise say "released, projects on" and go stale into a false alarm. One
consequence, documented on the type: while braked, marks and modes changed by an
operator do not reach `status.json` until the next edge — the file's consumer is
the watchdog, which is indifferent while braked, and `tbd supervise status` is
the live surface for a human.

**Default:** OFF. The column is added with **no SQL default**, so a
pre-migration row reads NULL — "nobody has chosen" stays distinguishable from
an explicit `0`/`1`. The shipped default lives in exactly one place,
`Config.supervisionEnabledDefault`, which makes graduation a one-line change
that reaches everyone who never touched the toggle while preserving every
explicit opt-out. (This departs from the generic migration guidance's
`.defaults(to:)` deliberately, following the flag-specific rule in `CLAUDE.md`
and the `queued_prompt_enabled` precedent; `auto_hibernate_enabled` is the
cautionary case.)

**Enabling it for the soak:** the Settings toggle, or the
`config.setSupervisionEnabled` RPC. Nothing acts on the column yet, so the soak
that matters begins with the slice that ships sweeps and delivery.

**Graduation:** flip `Config.supervisionEnabledDefault`, then eventually delete
the flag. Not before the acting half exists and has soaked.

## Assumptions

- **Repo display names are stable enough to name projects with.** A singleton
  project is named by its repo's display name, which nothing in TBD constrains
  to be unique or path-safe. Both failure modes are handled rather than
  prevented — ambiguous names resolve to no project and report; unsafe names
  keep coverage but lose their directory. If display names later gain a
  uniqueness constraint, the ambiguity path becomes dead code.
- **The daemon is the only writer of `supervision.json` and `ledger.jsonl`.**
  The file is hand-editable by design and edits are reconciled, but a second
  concurrent *program* writing either file would break the single-writer
  property.
- **`spawnSource` on a roster entry is the agent kind, not real provenance.**
  The database has no spawn-provenance concept today. A later slice wanting
  TBD-spawned vs adopted vs remote needs a new column, and should backfill the
  roster's meaning at the same time or the two line kinds will disagree.
- **The coverage summary's `sweepContacts` and `briefingsDelivered` are wired
  to counters nothing increments.** Zero is accurate now; the change that ships
  delivery must feed them, or every closing coverage line starts lying.

## Evidence & verification

Full suite green: **6222 tests in 647 suites**, zero failures.

Every guard was **mutation-checked** — broken, watched fail, restored — across
two passes, run against committed code so no mutation could survive into the
branch. The tri-state pair is the one worth naming: flipping
`Config.supervisionEnabledDefault` reddens the NULL-resolution test while
explicit values stay green, which is what proves the column discriminates
rather than merely defaulting. A second pass covered the guards the first
structurally could not reach, because a mutation applied alongside them made
their code unreachable.

**The exercise earned its keep: two tests passed against mutations of the very
guards they were written for.** One asserted that an unrecognized ledger line
neither opens nor closes a span, but its fixture never discriminated; the other
asserted a hand-cleared mark renders off, which was true whether or not startup
reconciled. Both now fail without their fix. A green test is evidence a guard
exists, not evidence it works.

Two review findings were raised and fixed here: the brake's ledger append could
record out of order under concurrent toggles (the commit and its line are now
decided in one serialized region — an actor alone was insufficient, since it
releases isolation across every `await`), and the heartbeat was an unflagged
background timer (now gated on the brake, above). Fixing the first surfaced the
same race one layer up, where two overlapping brake edges could leave the first
arming a timer the second had just disarmed; that is closed the same way.

A second review round asked for evidence behind two claims this section makes,
and both are now tested: the ledger writer's inode-identity guard (a file moved
or replaced under the daemon fails the append rather than writing into a file
nobody will read) and the heartbeat's overlapping-brake-edge guard. The ledger
pair is worth a note — removing the guard reddens both tests, but *weakening* it
to "does something exist at this path" still passes the removal case, because
`stat` fails on a deleted file either way. Only the replacement case catches
that, which is why both exist; the reasoning lives in the tests' own comments.

Two guards are stated as **not** mutation-proven rather than papered over: the
`fsync` (needs power loss or fault injection; stubbing the syscall would only
assert we called what we called), `ensureLoaded`'s post-await re-check (needs a
forced interleaving at a suspension with no injected dependency in front of it —
the one genuine gap), and the null-project-on-fleet-wide lines property — not a gap at all, but unmutable precisely *because* the line
factories take no project, so breaking it is a compile error at every call site
rather than a silent regression. (An earlier count of four shrank to these: two
guards first thought to need a new test seam turned out reachable by parking an
already-injected dependency. The ledger's fragment-flag-on-success is the
remaining follow-up, expected to be reachable the same way through the existing
`ActuationLogSyscalls` seam.)

A code-review pass over the branch found one High and two Medium defects, all
fixed here:

- A **marked singleton absorbed into a project lost its coverage silently** and
  could return on without a gesture — the vanished-project computation was
  phrased over declarations, which a singleton does not have. Fixed at the
  invariant (a topology gesture that ends a project closes its coverage,
  compared over *resolved* sets) rather than with a second special case.
- **Two repos sharing a display name took the whole surface offline**, and the
  heartbeat's `try?` then meant `status.json` was never written — leaving a
  healthy fleet indistinguishable from a dead daemon to the watchdog.
- The **Settings toggle inverted the brake**: switching on a control named
  "brake" granted authority rather than pausing it.

## Known gap

Coverage is **not** closed when a project stops resolving because the repo table
changed underneath it — a rename or unregistration is not a supervision gesture,
so nothing notices, and a mark can outlive the resolution it was set against.
Closing it means reconciling against repo events the daemon does not watch
today, which is a different mechanism from the file reconciliation built here.
Stated in §9 as current behavior so the next reader can pick it up.

[20260814-dusty-antlion](https://cheapsteak.github.io/tbd/open/?worktree=F3720009-32E2-4C28-B68D-CD60853BF9F3)


