### PR TITLE
Facts out: every session state carries its source and the moment it was observed

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -677,6 +677,12 @@ final class AppState: ObservableObject {
     @Published var editingWorktreeID: UUID? = nil
     @Published var isRenamingWorktree = false
     @Published var prStatuses: [UUID: PRStatus] = [:]
+    /// The outcome of the daemon's last attempt to learn each worktree's PR
+    /// state. Kept beside `prStatuses`, never merged into it: a worktree absent
+    /// from `prStatuses` has no PR only when this says `.none`, and a worktree
+    /// present in it may be showing a value the last attempt could not
+    /// reconfirm. A missing key means no attempt is on record.
+    @Published var prObservations: [UUID: PRObservation] = [:]
     /// Every live PR bound to each worktree, in bind order — the multi-PR
     /// surface behind the toolbar dropdown. `prStatuses` remains the single
     /// worst-of summary the daemon writes to `Worktree.prStatus`; this is the
@@ -706,6 +712,7 @@ final class AppState: ObservableObject {
             detachedCount: prDetachedCounts[worktreeID] ?? 0
         )
     }
+
     @Published var modelProfiles: [ModelProfileWithUsage] = []
     @Published var defaultProfileID: UUID? = nil
     /// Ephemeral one-shot Codex account/usage snapshot loaded when the
@@ -2575,6 +2582,15 @@ final class AppState: ObservableObject {
                     prStatuses[wt.id] = pr
                 }
             }
+            // Same rule for the attempt outcome: seed the persisted one on cold
+            // start so a row shows "not reconfirmed" from the first frame
+            // instead of looking freshly confirmed, and never overwrite a live
+            // entry.
+            for wt in fetched where prObservations[wt.id] == nil {
+                if let observation = wt.prObservation {
+                    prObservations[wt.id] = observation
+                }
+            }
 
             // A revive that was gated by a blocking preSession hook lingers
             // `.inFlight` until the daemon reports the row `.active` — this
@@ -2769,9 +2785,26 @@ final class AppState: ObservableObject {
     func refreshPRStatuses() async {
         do {
             let fetched = try await daemonClient.listPRStatuses()
-            // Only update if changed to avoid unnecessary SwiftUI redraws
-            if fetched != prStatuses {
-                prStatuses = fetched
+            // Only update if changed to avoid unnecessary SwiftUI redraws.
+            //
+            // These two comparisons deliberately DO include `observedAt`, which
+            // makes them true on every poll. That is the opposite of the rule
+            // `PRStatus.sameValue(as:)` states for the daemon's persistence
+            // decision, and the difference is the point: a write to SQLite is a
+            // cost with no reader, while a republication here is how the age
+            // these facts carry reaches the surfaces that render it. Both PR
+            // freshness surfaces (`WorktreeRowView.prUnknownTooltip` and the
+            // toolbar's `prFreshnessClauses`) read `now` in their view body, so
+            // this republication IS their ticker; suppressing it would freeze
+            // "checked 25m ago" at whatever it said when the pull request last
+            // actually changed. And it would save nothing either way — the
+            // observations below carry a stamp that advances every attempt, so
+            // the same rows are invalidated on the same cadence regardless.
+            if fetched.statuses != prStatuses {
+                prStatuses = fetched.statuses
+            }
+            if fetched.observations != prObservations {
+                prObservations = fetched.observations
             }
         } catch {
             logger.error("Failed to list PR statuses: \(error)")
@@ -2822,9 +2855,15 @@ final class AppState: ObservableObject {
     /// Trigger an immediate PR refresh for one worktree (on-select).
     func refreshPRStatus(worktreeID: UUID) async {
         do {
-            let status = try await daemonClient.refreshPRStatus(worktreeID: worktreeID)
-            if status != prStatuses[worktreeID] {
-                prStatuses[worktreeID] = status
+            let refreshed = try await daemonClient.refreshPRStatus(worktreeID: worktreeID)
+            if refreshed.status != prStatuses[worktreeID] {
+                prStatuses[worktreeID] = refreshed.status
+            }
+            // A nil observation means no attempt was made at all (the daemon
+            // no longer knows the worktree) — leave whatever is on record
+            // rather than erasing it into a third meaning.
+            if let observation = refreshed.observation, observation != prObservations[worktreeID] {
+                prObservations[worktreeID] = observation
             }
         } catch {
             logger.error("Failed to refresh PR status for \(worktreeID): \(error)")

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -147,6 +147,27 @@ struct ContentView: View {
                         // state, url, queue position, detached, and the reason
                         // + head branch every menu row's title carries), and
                         // colorScheme (baked icon colors).
+                        // Composed once and used in BOTH the help string and the
+                        // `.id` key: they must agree, or the item stops
+                        // rebuilding when the words it renders change. The
+                        // status it ages is the icon binding's — the same
+                        // selection rule the sidebar dot uses — so the two
+                        // surfaces never disagree about which PR they describe.
+                        //
+                        // `now: Date()` in the body is deliberate. Both facts it
+                        // ages come from `AppState`, and `prObservations` is
+                        // republished on every poll (its `observedAt` advances
+                        // each attempt), so this body re-evaluates on the same
+                        // ~30 s cadence as the facts — a coarse ticker driven by
+                        // the data instead of one running beside it, and much
+                        // finer than the five-minute buckets `checkedLabel`
+                        // renders. **If that republication is ever made
+                        // value-only, these clauses freeze and need a real
+                        // ticker.**
+                        let prFreshnessClauses = PRFreshness.clauses(
+                            status: PRBindingPresentation.iconBinding(bindings)?.status,
+                            observation: appState.prObservations[worktreeID],
+                            now: Date())
                         let splitButtonID = PRButtonLabel.prSplitButtonID(
                             worktreeID: worktreeID,
                             worktreeFound: worktree != nil,
@@ -154,11 +175,13 @@ struct ContentView: View {
                             hibernateArmed: hibernateArmed,
                             blocked: blocked,
                             bindings: bindings,
+                            freshnessClauses: prFreshnessClauses,
                             colorScheme: colorScheme
                         )
                         let helpText = Self.prSplitButtonHelp(
                             bindings: bindings, armed: armed,
-                            hibernateArmed: hibernateArmed, blocked: blocked)
+                            hibernateArmed: hibernateArmed, blocked: blocked,
+                            freshnessClauses: prFreshnessClauses)
 
                         // Exactly one PR whose URL parses keeps the split button
                         // it has always been: the label is the primary click
@@ -450,7 +473,8 @@ struct ContentView: View {
         bindings: [PRBinding],
         armed: Bool,
         hibernateArmed: Bool,
-        blocked: Bool
+        blocked: Bool,
+        freshnessClauses: [String] = []
     ) -> String {
         var clauses: [String] = []
         switch bindings.count {
@@ -470,6 +494,11 @@ struct ContentView: View {
             clauses.append("auto-archives on merge")
         }
         if hibernateArmed { clauses.append("auto-hibernates on merge") }
+        // The cache states its own age here, and says when its last re-read
+        // failed. This string is materialized once by AppKit, so the freshness
+        // clauses are also part of the `.id` key — otherwise the age would
+        // freeze at whatever it was when the item was first built.
+        clauses += freshnessClauses
         clauses.append("more options")
         return clauses.joined(separator: " · ")
     }
@@ -929,6 +958,13 @@ struct PRButtonLabel: View {
     /// failing" under an unchanged `.checksFailed`, or a re-pushed head branch,
     /// would otherwise leave the materialized menu showing the stale text.
     ///
+    /// `freshnessClauses` is in the key for the same reason: the help string
+    /// renders the cache's age and any unresolved last check, so an item built
+    /// before those words changed would keep promising a freshness it no longer
+    /// has. Note it is the *rendered clauses*, not the raw `observedAt` — the
+    /// clauses are bucketed (see `PRFreshness`), so a re-confirmation that does
+    /// not change the displayed words rebuilds nothing.
+    ///
     /// This key MUST stay a String. The macOS 26 toolbar bridge only honors
     /// `.id` identity changes for String values here — a custom Hashable
     /// struct key was observed NOT to trigger NSMenuToolbarItem recreation
@@ -941,6 +977,7 @@ struct PRButtonLabel: View {
         hibernateArmed: Bool,
         blocked: Bool,
         bindings: [PRBinding],
+        freshnessClauses: [String] = [],
         colorScheme: ColorScheme
     ) -> String {
         let rendered = bindings.map { binding in
@@ -953,6 +990,7 @@ struct PRButtonLabel: View {
         }.joined(separator: "|")
         return "pr-split-\(worktreeID)-\(worktreeFound)-\(armed)-\(hibernateArmed)-\(blocked)"
             + "-[\(rendered)]"
+            + "-[\(freshnessClauses.map(escapedIDField).joined(separator: "|"))]"
             + "-\(colorScheme)"
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -783,10 +783,14 @@ actor DaemonClient {
         )
     }
 
-    /// Fetch all cached PR statuses from the daemon.
-    func listPRStatuses() async throws -> [UUID: PRStatus] {
+    /// Fetch the daemon's PR snapshot: the cached values, and the outcome of
+    /// the last attempt to learn each. Both halves are returned because they
+    /// disagree — a value the last attempt failed to reconfirm is still the
+    /// newest anyone has, and a worktree with no value may have no PR or may be
+    /// one nobody could ask about.
+    func listPRStatuses() async throws -> (statuses: [UUID: PRStatus], observations: [UUID: PRObservation]) {
         let result = try await callNoParamsAsync(method: RPCMethod.prList, resultType: PRListResult.self)
-        return result.statuses
+        return (result.statuses, result.observations)
     }
 
     /// Fetch EVERY worktree's live PR bindings (tombstoned ones are excluded by
@@ -1328,14 +1332,17 @@ actor DaemonClient {
     }
 
     /// Trigger an immediate PR status refresh for one worktree.
-    /// Returns nil if no PR exists for the worktree's branch.
-    func refreshPRStatus(worktreeID: UUID) async throws -> PRStatus? {
+    ///
+    /// A nil `status` is not "no PR": it means nothing is cached, which the
+    /// accompanying `observation` disambiguates (the forge said there is none,
+    /// versus nobody could get an answer).
+    func refreshPRStatus(worktreeID: UUID) async throws -> (status: PRStatus?, observation: PRObservation?) {
         let result = try await callAsync(
             method: RPCMethod.prRefresh,
             params: PRRefreshParams(worktreeID: worktreeID),
             resultType: PRRefreshResult.self
         )
-        return result.status
+        return (result.status, result.observation)
     }
 
     // MARK: - State Subscription

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -2,6 +2,73 @@ import AppKit
 import SwiftUI
 import TBDShared
 
+/// How a display-tier PR fact describes its own age and its own uncertainty.
+///
+/// `PRStatus` is a cache, and it was measured lying — showing "Ready to merge"
+/// for pull requests merged days earlier. So no surface may render it as current
+/// truth: wherever it appears it carries when it was last read, and wherever the
+/// last attempt to read it failed, it says so. These are pure functions of
+/// (fact, now) precisely so both render sites compose the same words from the
+/// same inputs and cannot drift.
+enum PRFreshness {
+    /// Age buckets, coarsening as they grow.
+    ///
+    /// Deliberately not per-second or per-minute. The toolbar's split button is
+    /// materialized once by AppKit and only rebuilt when its `.id` changes, so
+    /// the id must include whatever the help string renders — and a label that
+    /// changed every minute would rebuild the item (and its NSMenu) every
+    /// minute. Five-minute resolution is far finer than the failure this stamp
+    /// exists to expose, which was measured in days.
+    static func checkedLabel(observedAt: Date?, now: Date) -> String {
+        guard let observedAt else { return "last checked at an unknown time" }
+        let seconds = Int(max(0, now.timeIntervalSince(observedAt)))
+        switch seconds {
+        case ..<300:
+            return "checked just now"
+        case ..<3600:
+            // Floored to a 5-minute step, so the string is stable between steps.
+            return "checked \((seconds / 60 / 5) * 5)m ago"
+        case ..<86_400:
+            return "checked \(seconds / 3600)h ago"
+        default:
+            return "checked \(seconds / 86_400)d ago"
+        }
+    }
+
+    /// The clause naming an unresolved last attempt, or nil when the last
+    /// attempt settled the question (either way) or when none is on record.
+    ///
+    /// `.none` deliberately produces nothing: "the forge answered, and this
+    /// branch has no PR" is settled knowledge, not a caveat.
+    static func undeterminedClause(_ observation: PRObservation?) -> String? {
+        guard case .undetermined(let cause) = observation?.outcome else { return nil }
+        return "last check did not resolve (\(cause))"
+    }
+
+    /// The trailing clauses every PR surface appends: how old the shown value
+    /// is, then whether the last attempt to reconfirm it failed. Both, in that
+    /// order, so a reader never sees a value without its age.
+    /// `status` is optional because the multi-PR surfaces choose the binding
+    /// they describe and a binding can carry no status yet; a missing status is
+    /// a missing stamp, which reads as an unknown check time rather than as
+    /// silence.
+    static func clauses(status: PRStatus?, observation: PRObservation?, now: Date) -> [String] {
+        var out = [checkedLabel(observedAt: status?.observedAt, now: now)]
+        if let clause = undeterminedClause(observation) { out.append(clause) }
+        return out
+    }
+
+    /// The tooltip for a worktree with **no** cached PR whose last attempt came
+    /// back `.undetermined` — the case that would otherwise be invisible and
+    /// therefore indistinguishable from having no pull request at all. nil for
+    /// every other observation, including `.none`.
+    static func unknownIndicatorTooltip(_ observation: PRObservation?, now: Date) -> String? {
+        guard case .undetermined(let cause) = observation?.outcome, let observation else { return nil }
+        return "PR status unknown — \(cause) · "
+            + checkedLabel(observedAt: observation.observedAt, now: now)
+    }
+}
+
 struct PRStatusPresentation: Equatable {
     enum ColorSemantic: Equatable {
         case pending

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -455,7 +455,9 @@ struct RemoteSessionRowView: View {
                 .foregroundStyle(Color.secondary.opacity(0.55))
                 .frame(width: 12, height: 12)
                 .help("Remote session")
-        case .prStatus, nil:
+        // Neither can occur here — a remote row passes `hasPRStatus: false` and
+        // never supplies a PR observation — but the switch must stay exhaustive.
+        case .prStatus, .prUnknown, nil:
             EmptyView()
         }
     }

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -7,6 +7,12 @@ import TBDShared
 enum LeadingRowIndicator: Equatable {
     case pending
     case prStatus
+    /// No cached PR, and the last attempt to learn whether there is one came
+    /// back `.undetermined`. Distinct from showing nothing, which is what a
+    /// worktree with a settled "no pull request" gets: a forge outage that
+    /// rendered identically to a quiet fleet is the exact failure
+    /// `PRObservation` exists to make visible.
+    case prUnknown
     /// Tucked-away marker that a row's session runs on a remote-agent
     /// backend rather than a local worktree. Deliberately the lowest
     /// priority in the slot — see `RowStatusIndicator.leading(isPending:hasPRStatus:isRemote:)`.
@@ -75,11 +81,23 @@ enum RowStatusIndicator {
     /// status and the starting spinner both take the slot first when
     /// present. Defaults to `false` so existing local-row callers are
     /// unaffected.
-    static func leading(isPending: Bool, hasPRStatus: Bool, isRemote: Bool = false) -> LeadingRowIndicator? {
+    /// `hasUndeterminedPR` sits below `.pending` — a row still being created
+    /// has nothing to have a pull request *for* yet, so its spinner is the more
+    /// informative glyph — and above `.remote`, because "we could not find out"
+    /// is an active-state signal while the remote marker is not. Defaults to
+    /// `false` so existing callers are unaffected.
+    static func leading(
+        isPending: Bool,
+        hasPRStatus: Bool,
+        isRemote: Bool = false,
+        hasUndeterminedPR: Bool = false
+    ) -> LeadingRowIndicator? {
         if hasPRStatus {
             return .prStatus
         } else if isPending {
             return .pending
+        } else if hasUndeterminedPR {
+            return .prUnknown
         } else if isRemote {
             return .remote
         }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -55,9 +55,32 @@ struct WorktreeRowView: View {
         RowStatusIndicator.shouldBoldName(notification)
     }
 
+    private var prObservation: PRObservation? {
+        appState.prObservations[worktree.id]
+    }
+
     private var prPresentation: PRStatusPresentation? {
         guard !isMain else { return nil }
         return PRStatusPresentation.make(for: prStatus)
+    }
+
+    /// Tooltip for the "nobody could find out" indicator: shown only when there
+    /// is no cached PR at all AND the last attempt came back `.undetermined`.
+    /// Without it that row renders exactly like a row with no pull request,
+    /// which is the collapse `PRObservation` exists to undo — a forge outage
+    /// would look like a fleet with nothing open.
+    ///
+    /// `Date()` inside the body is deliberate rather than overlooked. The age it
+    /// renders is the age of `prObservation`, and `AppState.prObservations` is
+    /// republished on every poll — the observation's own `observedAt` advances
+    /// each attempt, so the dictionary differs and this body re-evaluates on the
+    /// same ~30 s cadence as the fact it is describing. That is already a coarse
+    /// shared ticker, driven by the data rather than beside it, and it is far
+    /// finer than `checkedLabel`'s five-minute buckets. **If that republication
+    /// is ever made value-only, this string freezes and needs a real ticker.**
+    private var prUnknownTooltip: String? {
+        guard !isMain, prStatus == nil else { return nil }
+        return PRFreshness.unknownIndicatorTooltip(prObservation, now: Date())
     }
 
     /// Any PARKED terminal — hibernated (authoritative) or legacy-suspended.
@@ -158,12 +181,14 @@ struct WorktreeRowView: View {
     nonisolated static func leadingIndicator(
         worktree: Worktree,
         isPending: Bool,
-        hasPRStatus: Bool
+        hasPRStatus: Bool,
+        hasUndeterminedPR: Bool = false
     ) -> LeadingRowIndicator? {
         RowStatusIndicator.leading(
             isPending: isPending,
             hasPRStatus: hasPRStatus,
-            isRemote: !worktree.location.isLocal
+            isRemote: !worktree.location.isLocal,
+            hasUndeterminedPR: hasUndeterminedPR
         )
     }
 
@@ -172,7 +197,8 @@ struct WorktreeRowView: View {
         switch Self.leadingIndicator(
             worktree: worktree,
             isPending: isPending && !isEditing,
-            hasPRStatus: prPresentation != nil
+            hasPRStatus: prPresentation != nil,
+            hasUndeterminedPR: prUnknownTooltip != nil
         ) {
         case .prStatus:
             if let presentation = prPresentation, let status = prStatus {
@@ -180,6 +206,12 @@ struct WorktreeRowView: View {
                 // underlying (UNKNOWN→pending) check reason.
                 let detail = presentation.badge.map { "in merge queue, position \($0)" }
                     ?? (status.reason ?? status.state.displayReason)
+                // The cache never speaks without saying how old it is, and
+                // never hides that its last re-read failed.
+                let freshness = PRFreshness.clauses(
+                    status: status, observation: prObservation, now: Date())
+                let tooltip = (["PR #\(status.number)", detail] + freshness)
+                    .joined(separator: " · ")
                 Button(action: openPR) {
                     prGlyph(presentation)
                         .frame(width: 12, height: 12)
@@ -187,12 +219,23 @@ struct WorktreeRowView: View {
                 }
                 .buttonStyle(.plain)
                 .onHover { isPRIconHovered = $0 }
-                .accessibilityLabel("PR #\(status.number): \(detail)")
+                .accessibilityLabel(
+                    "PR #\(status.number): \(([detail] + freshness).joined(separator: ", "))")
                 .anchorPreference(key: RowTooltipPreferenceKey.self, value: .bounds) { anchor in
-                    isPRIconHovered
-                        ? RowTooltipPreference(text: "PR #\(status.number) · \(detail)", anchor: anchor)
-                        : nil
+                    isPRIconHovered ? RowTooltipPreference(text: tooltip, anchor: anchor) : nil
                 }
+            }
+        case .prUnknown:
+            if let tooltip = prUnknownTooltip {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 12, height: 12)
+                    .onHover { isPRIconHovered = $0 }
+                    .accessibilityLabel(tooltip)
+                    .anchorPreference(key: RowTooltipPreferenceKey.self, value: .bounds) { anchor in
+                        isPRIconHovered ? RowTooltipPreference(text: tooltip, anchor: anchor) : nil
+                    }
             }
         case .pending:
             Image(systemName: "circle.dotted")

--- a/Sources/TBDCLI/Commands/ConfigCommands.swift
+++ b/Sources/TBDCLI/Commands/ConfigCommands.swift
@@ -37,6 +37,19 @@ struct ConfigSet: AsyncParsableCommand {
     @Argument(help: "on or off")
     var value: OnOffArgument
 
+    /// What the command says it did.
+    ///
+    /// Pure, and separated from the call so it can be read — and tested —
+    /// against the branch actually taken. A key that explains what it changed
+    /// owes two sentences, one per state: a single sentence describing both is
+    /// false in one of them, and the user who just turned something off is the
+    /// one least able to catch it. Keys that only name the value they were
+    /// given fall through to the generic form, which satisfies that rule by
+    /// construction.
+    static func confirmation(key: String, value: OnOffArgument) -> String {
+        "Set \(key) default to \(value.rawValue)."
+    }
+
     mutating func run() async throws {
         let client = SocketClient()
         switch key {
@@ -44,12 +57,12 @@ struct ConfigSet: AsyncParsableCommand {
             try client.callVoid(
                 method: RPCMethod.configSetAutoArchiveOnMergeDefault,
                 params: ConfigSetAutoArchiveDefaultParams(enabled: value.boolValue))
-            print("Set auto-archive-on-merge default to \(value.rawValue).")
+            print(Self.confirmation(key: key, value: value))
         case "auto-hibernate-on-merge":
             try client.callVoid(
                 method: RPCMethod.configSetAutoHibernateOnMergeDefault,
                 params: ConfigSetAutoHibernateDefaultParams(enabled: value.boolValue))
-            print("Set auto-hibernate-on-merge default to \(value.rawValue).")
+            print(Self.confirmation(key: key, value: value))
         default:
             throw CLIError.invalidArgument("Unknown config key '\(key)'. Known keys: auto-archive-on-merge, auto-hibernate-on-merge")
         }

--- a/Sources/TBDCLI/Commands/HooksCommand.swift
+++ b/Sources/TBDCLI/Commands/HooksCommand.swift
@@ -8,7 +8,13 @@ struct HooksCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "hooks",
         abstract: "Inspect and manage TBD's Claude Code hook integration",
-        subcommands: [HooksStatusCommand.self, StopRenameCheckCommand.self, StopFailureCommand.self, FakeRateLimitCommand.self],
+        subcommands: [
+            HooksStatusCommand.self,
+            StopRenameCheckCommand.self,
+            StopFailureCommand.self,
+            NotificationHookCommand.self,
+            FakeRateLimitCommand.self
+        ],
         defaultSubcommand: HooksStatusCommand.self
     )
 }

--- a/Sources/TBDCLI/Commands/NotificationHookCommand.swift
+++ b/Sources/TBDCLI/Commands/NotificationHookCommand.swift
@@ -1,0 +1,115 @@
+import ArgumentParser
+import Foundation
+import os
+import TBDShared
+
+private let notificationLogger = Logger(subsystem: "com.tbd.cli", category: "hookNotification")
+
+/// `tbd hooks notification` — bridges Claude Code's `Notification` hook into
+/// TBD.
+///
+/// A dumb reporter, on purpose. It lifts the fields it can name, carries the
+/// whole payload verbatim, and forwards everything to the daemon: it matches
+/// nothing, classifies nothing, and drops nothing on the strength of a field's
+/// value. Every fork lives in the daemon's RPC handler, which is compiled and
+/// the same for every install — unlike this command's invocation, which sits in
+/// a settings file an operator can edit.
+///
+/// Every failure path is silent and exits 0. Claude Code surfaces a hook's
+/// stderr to the user, and a `Notification` hook cannot block or change
+/// anything anyway, so noise here would be pure cost.
+struct NotificationHookCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "notification",
+        abstract: "Internal: bridge Claude Code's Notification hook into TBD",
+        shouldDisplay: false
+    )
+
+    mutating func run() async throws {
+        let stdin = FileHandle.standardInput.readDataToEndOfFile()
+        switch NotificationHookPlan.make(
+            stdin: stdin,
+            environment: ProcessInfo.processInfo.environment
+        ) {
+        case .suppressed(let reason):
+            notificationLogger.debug("suppressed reason=\(reason.rawValue, privacy: .public)")
+        case .forward(let params):
+            let client = SocketClient()
+            guard client.isDaemonRunning else {
+                notificationLogger.debug("suppressed reason=daemonDown")
+                return
+            }
+            do {
+                try client.callVoid(method: RPCMethod.terminalNotificationEvent, params: params)
+            } catch {
+                notificationLogger.debug(
+                    "suppressed reason=rpcFailed err=\(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+}
+
+// MARK: - Pure core (testable)
+
+/// What the command will do with one hook invocation, decided without touching
+/// the socket — so every branch is a unit test rather than a live daemon.
+enum NotificationHookPlan {
+    case suppressed(Suppression)
+    case forward(TerminalNotificationEventParams)
+
+    /// Why nothing was sent. Named rather than boolean so the debug log says
+    /// which silence this was.
+    enum Suppression: String {
+        /// No `TBD_TERMINAL_ID` in the environment — the hook is firing for a
+        /// session TBD did not spawn, and there is nothing to route to.
+        case noTerminalID
+        /// Nothing on stdin, or more than the 1 MiB a hook payload can
+        /// plausibly be.
+        case unusablePayloadSize
+        /// stdin was not a JSON object.
+        case malformedPayload
+    }
+
+    /// Fields this build can name. Everything is optional and anything else is
+    /// ignored: Claude Code's payload extensions are additive, and an older
+    /// Claude Code sends neither `notification_type` nor `title`.
+    private struct HookPayload: Decodable {
+        let message: String?
+        let title: String?
+        let notification_type: String?
+        let cwd: String?
+    }
+
+    static func make(stdin: Data, environment: [String: String]) -> NotificationHookPlan {
+        guard let terminalIDString = environment["TBD_TERMINAL_ID"],
+              let terminalID = UUID(uuidString: terminalIDString) else {
+            return .suppressed(.noTerminalID)
+        }
+        // The 1 MiB cap limits *processing*, not the read — the caller has
+        // already allocated the buffer. It is a defensive guard against a
+        // runaway producer, not a protocol limit.
+        guard !stdin.isEmpty, stdin.count <= 1 << 20 else {
+            return .suppressed(.unusablePayloadSize)
+        }
+        // Not a JSON object → there is nothing to route and nothing to say.
+        // The command still interprets no *value*: it only refuses input it
+        // cannot read at all.
+        guard let payload = try? JSONDecoder().decode(HookPayload.self, from: stdin) else {
+            return .suppressed(.malformedPayload)
+        }
+        return .forward(TerminalNotificationEventParams(
+            terminalID: terminalID,
+            notificationType: payload.notification_type,
+            // A payload with no message is reported as an empty one rather
+            // than dropped: that a notification fired at all is the fact, and
+            // guessing text for it would be worse than carrying none.
+            message: payload.message ?? "",
+            title: payload.title,
+            // Verbatim, byte for byte as it arrived — this is what rides into a
+            // briefing, and what lets a later consumer read a field this build
+            // does not model.
+            rawPayload: String(data: stdin, encoding: .utf8),
+            cwd: payload.cwd
+        ))
+    }
+}

--- a/Sources/TBDDaemon/Claude/ContextLoadReader.swift
+++ b/Sources/TBDDaemon/Claude/ContextLoadReader.swift
@@ -1,0 +1,324 @@
+import Foundation
+import TBDShared
+
+/// Reads one session's `ContextLoad` — how full its context window is — from
+/// the two machine sources that can speak to it.
+///
+/// **There is no compiled model→window table here, and there must never be
+/// one.** The effective window is a session fact, not a model fact: Claude Code
+/// resolves it per session from the model id, a long-context suffix, a beta
+/// header, environment overrides and a remote feature flag, so the same model
+/// id can be a 200k session or a 1M session. A table — compiled, downloaded, or
+/// sniffed out of a model id or a `[1m]` suffix — reports *capability*, and
+/// capability errs in the dangerous direction: claiming 1M for a session
+/// actually running at 200k reads one-fifth full at the boundary, which is
+/// exactly where being wrong costs a session. Where nothing observed the
+/// window, this reader says `unknown` and says why.
+///
+/// Two paths, in preference order:
+///
+/// 1. **The statusline tee fired.** Prefer the captured JSON's own paired
+///    reading — Claude Code computed numerator, denominator and percentage at
+///    one instant from one source, and taking both halves from it is the only
+///    way to report a fraction that was ever simultaneously true.
+/// 2. **It did not** — every non-desk session, and a desk whose statusline has
+///    not run yet. The numerator comes from the transcript tail; the
+///    denominator is `unknown`, with a `why` naming which case it is.
+struct ContextLoadReader {
+    /// Whether this session has a statusline tee — and when it does not, why
+    /// not. Three shapes, because the `why` of an unknown window has to tell
+    /// them apart and two of them are easy to conflate.
+    enum TeeStatus: Sendable, Equatable {
+        /// A Claude desk session: the tee is installed and may simply not have
+        /// fired yet.
+        case installed
+        /// A desk session whose agent is not the one the tee installs on. The
+        /// tee lives in the Claude spawn path, so a desk created on a
+        /// Codex-preferring install is branded a desk and runs without one —
+        /// reporting "installed but has not fired yet" for it would be false.
+        case deskWithoutTee
+        /// An ordinary session. The tee installs on desk sessions only.
+        case notADesk
+    }
+
+    /// How much of the transcript's tail to read. The same 64 KiB window
+    /// `DeliveryVerifier` tails with: large enough to span several assistant
+    /// records, small enough that a multi-megabyte transcript costs one seek.
+    static let defaultTailWindowBytes = 64 * 1024
+
+    var tailWindowBytes: Int = ContextLoadReader.defaultTailWindowBytes
+    /// The date seam. Only reached when a transcript record carries no
+    /// parseable `timestamp` of its own — a persisted/compared timestamp, so
+    /// the date seam rather than a clock.
+    var now: @Sendable () -> Date = { Date() }
+
+    /// Read the load for a session.
+    ///
+    /// - Parameters:
+    ///   - capturePath: the statusline tee's capture file for this session.
+    ///     Passed explicitly rather than derived so the reader is hermetic.
+    ///   - transcriptPath: the session's transcript JSONL, when TBD knows one.
+    ///   - tee: whether the statusline tee was installed for this session, and
+    ///     if not, why not. Only used to word the `why` of an unknown window —
+    ///     a desk whose statusline has not run yet is a different situation
+    ///     from a desk that will never have one and from a fleet session that
+    ///     was never going to, and a reader deserves to be told which.
+    func read(
+        capturePath: String,
+        transcriptPath: String?,
+        tee: TeeStatus
+    ) -> ContextLoad {
+        guard let capture = readCapture(atPath: capturePath) else {
+            return ContextLoad(
+                used: transcriptUsed(transcriptPath: transcriptPath),
+                window: .unknown(why: unknownWindowReason(tee))
+            )
+        }
+        guard let size = capture.contextWindowSize else {
+            // The tee fired but this Claude Code build reported no
+            // `context_window_size`. Nothing observed the denominator, so it is
+            // unknown — the numerator the payload does carry is still better
+            // than nothing, and still labeled with where it came from.
+            return ContextLoad(
+                used: capture.usedTokens.map {
+                    ObservedFact(value: $0, source: .statuslineTee, observedAt: capture.observedAt)
+                } ?? transcriptUsed(transcriptPath: transcriptPath),
+                window: .unknown(
+                    why: "the statusline tee fired for this session but its payload carried no "
+                        + "context_window.context_window_size")
+            )
+        }
+        let window = ContextWindow.observed(
+            ObservedFact(value: size, source: .statuslineTee, observedAt: capture.observedAt))
+        if let used = capture.usedTokens {
+            return ContextLoad(
+                used: ObservedFact(value: used, source: .statuslineTee, observedAt: capture.observedAt),
+                window: window
+            )
+        }
+        // `current_usage` is null before the session's first API call and again
+        // after a `/compact` until the next one, and `used_percentage` can be
+        // null early for the same reason. The denominator is still good, so the
+        // numerator falls back to the transcript tail.
+        //
+        // A numerator and a denominator observed at different moments must not
+        // be silently presented as one coherent fraction. Nothing here hides
+        // that: the two halves carry their own sources and observed-ats, and
+        // `ContextLoad.isPairedReading` is false for exactly this result, so a
+        // consumer composing a percentage can say so.
+        return ContextLoad(used: transcriptUsed(transcriptPath: transcriptPath), window: window)
+    }
+
+    /// Why no denominator was observed, in the caller's own terms.
+    private func unknownWindowReason(_ tee: TeeStatus) -> String {
+        switch tee {
+        case .installed:
+            return "the statusline tee is installed for this desk session but has not fired yet"
+        case .deskWithoutTee:
+            return "this desk session does not run the agent the statusline tee installs on, so "
+                + "nothing will report its resolved context window"
+        case .notADesk:
+            return "the statusline tee installs on desk sessions only, so nothing has reported "
+                + "this session's resolved context window"
+        }
+    }
+
+    // MARK: - The transcript tail
+
+    /// Tokens in the window, from the last assistant record carrying a `usage`
+    /// block in the transcript's tail.
+    ///
+    /// **A known-fragile dependency, named rather than hidden.** Claude Code
+    /// documents the transcript JSONL as an internal, version-unstable format;
+    /// this read is coupled to its record shape and will break silently on a
+    /// change to it. It is accepted because no better machine source for the
+    /// numerator exists today, and it is written down here — and in the design
+    /// spec — so the coupling is a stated cost rather than a surprise.
+    private func transcriptUsed(transcriptPath: String?) -> ObservedFact<Int>? {
+        guard let transcriptPath, !transcriptPath.isEmpty,
+              let tail = readTail(atPath: transcriptPath) else {
+            return nil
+        }
+        guard let (tokens, observedAt) = Self.lastUsage(inTail: tail, fallbackDate: now()) else {
+            return nil
+        }
+        return ObservedFact(value: tokens, source: .transcriptTail, observedAt: observedAt)
+    }
+
+    /// Byte-bounded tail read, the shape `DeliveryVerifier.transcriptTail`
+    /// uses: seek to `size - window`, read to the end, and let an unreadable
+    /// file be nil rather than empty — "could not read" and "read nothing" are
+    /// different facts and collapsing them is how an absence becomes a zero.
+    private func readTail(atPath path: String) -> Data? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        guard let size = try? handle.seekToEnd() else { return nil }
+        let window = UInt64(max(tailWindowBytes, 0))
+        do {
+            try handle.seek(toOffset: size > window ? size - window : 0)
+            return try handle.readToEnd() ?? Data()
+        } catch {
+            return nil
+        }
+    }
+
+    /// The last assistant `usage` block in the tail, and the record's own
+    /// timestamp when it carried a parseable one.
+    ///
+    /// The token figure is **input + cache_creation + cache_read, excluding
+    /// output** — the same formula `TranscriptParser.extractUsage` feeds into
+    /// `TokenUsage.contextTotal` and the one `docs/transcript-context-usage.md`
+    /// documents. There is deliberately no second formula in this codebase.
+    ///
+    /// The first line of a tail read is usually a fragment of a record, so a
+    /// line that does not parse is skipped rather than treated as a failure.
+    static func lastUsage(inTail tail: Data, fallbackDate: Date) -> (tokens: Int, observedAt: Date)? {
+        guard let text = Self.decodeTail(tail) else { return nil }
+        var result: (tokens: Int, observedAt: Date)?
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data),
+                  let record = object as? [String: Any],
+                  let message = record["message"] as? [String: Any],
+                  let usage = message["usage"] as? [String: Any],
+                  let input = usage["input_tokens"] as? Int else {
+                continue
+            }
+            let tokens = input
+                + (usage["cache_creation_input_tokens"] as? Int ?? 0)
+                + (usage["cache_read_input_tokens"] as? Int ?? 0)
+            let observedAt = (record["timestamp"] as? String).flatMap(Self.parseTimestamp) ?? fallbackDate
+            result = (tokens, observedAt)
+        }
+        return result
+    }
+
+    /// Decode a byte-offset tail as text.
+    ///
+    /// A tail begins wherever `size - window` lands, so it routinely begins
+    /// **inside** a multi-byte sequence — agent output is full of emoji, box
+    /// drawing and curly quotes. Strict decoding answers nil for the *entire*
+    /// tail when it does, so a perfectly readable transcript reports
+    /// "numerator unreadable", indistinguishable from a missing one.
+    ///
+    /// The repair resumes at the first newline. That is the right boundary
+    /// rather than a convenient one: a record is a line, which is the single
+    /// property of this file format that holds across its revisions, and the
+    /// first line of a tail read is a fragment that the caller discards anyway.
+    /// So nothing whole is lost — only the partial record that was never going
+    /// to parse.
+    static func decodeTail(_ tail: Data) -> String? {
+        if let text = String(data: tail, encoding: .utf8) { return text }
+        guard let newline = tail.firstIndex(of: 0x0A) else { return nil }
+        return String(data: tail[tail.index(after: newline)...], encoding: .utf8)
+    }
+
+    private static func parseTimestamp(_ text: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: text) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: text)
+    }
+
+    // MARK: - The statusline capture
+
+    /// What one captured statusline payload says about context.
+    struct Capture: Equatable {
+        /// `context_window.context_window_size`, when present.
+        let contextWindowSize: Int?
+        /// Tokens in the window from `context_window.current_usage`, when that
+        /// object is present. Null before the first API call and again after a
+        /// `/compact`, which is why it is optional here.
+        let usedTokens: Int?
+        /// The capture file's modification time — when the tee published this
+        /// payload, which is when Claude Code observed it. Not the time TBD
+        /// read the file: aging a fact by the read would make a stale reading
+        /// look fresh on every poll.
+        let observedAt: Date
+    }
+
+    /// Read one capture, payload and stamp from the **same open file**.
+    ///
+    /// `contents(atPath:)` followed by `attributesOfItem(atPath:)` is two
+    /// lookups of the same name, and the tee publishes by `mv -f` — an atomic
+    /// rename that can land between them. The pair would then stamp one
+    /// payload with a different file's modification time, producing an
+    /// `ObservedFact` whose observed-at is newer than the value it labels,
+    /// which is the one thing this file's opening comment forbids. Opening once
+    /// and asking the descriptor pins both halves to one inode: a rename can
+    /// still swap the name, but never what this handle is holding.
+    func readCapture(atPath path: String) -> Capture? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        guard let data = try? handle.readToEnd() ?? Data(),
+              let modified = handle.modificationDate() else {
+            return nil
+        }
+        return Self.parseCapture(data: data, observedAt: modified)
+    }
+
+    /// Parse a captured payload. Every field is treated as absent-able —
+    /// `current_usage`, `used_percentage` and `remaining_percentage` are all
+    /// documented as nullable, and a payload TBD cannot read at all is nil
+    /// rather than a zero.
+    static func parseCapture(data: Data, observedAt: Date) -> Capture? {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              let root = object as? [String: Any],
+              let contextWindow = root["context_window"] as? [String: Any] else {
+            return nil
+        }
+        let size = positiveInt(contextWindow["context_window_size"])
+        var used: Int?
+        if let current = contextWindow["current_usage"] as? [String: Any],
+           let input = current["input_tokens"] as? Int {
+            // Same formula as the transcript tail, for the same reason: output
+            // tokens are not in the next request's window.
+            used = input
+                + (current["cache_creation_input_tokens"] as? Int ?? 0)
+                + (current["cache_read_input_tokens"] as? Int ?? 0)
+        }
+        return Capture(contextWindowSize: size, usedTokens: used, observedAt: observedAt)
+    }
+
+    /// A strictly-positive integer out of a JSON value, or nil.
+    ///
+    /// `as? Int` alone is not that test, and the gap is not theoretical: JSON
+    /// `true` arrives from `JSONSerialization` as an `NSNumber` that casts
+    /// cleanly to `1`, which would be reported as a one-token context window and
+    /// turn every percentage built on it into an absurdity. Zero and negatives
+    /// are refused for the same reason — a denominator that cannot divide is not
+    /// an observation, and `unknown` with a reason is the honest answer.
+    ///
+    /// This mirrors, field for field, the guard the Nightwatch reader applies to
+    /// the same payload (`isinstance(size, bool) or not isinstance(size, int) or
+    /// size <= 0`). The two read one file and must not disagree about whether it
+    /// carries a window.
+    private static func positiveInt(_ value: Any?) -> Int? {
+        guard let number = value as? NSNumber else { return nil }
+        guard CFGetTypeID(number as CFTypeRef) != CFBooleanGetTypeID() else { return nil }
+        // `NSNumber as? Int` is exact: a fractional or out-of-range value is nil
+        // rather than a truncation.
+        guard let intValue = number as? Int, intValue > 0 else { return nil }
+        return intValue
+    }
+}
+
+// MARK: - Stamping a payload with its own file's time
+
+extension FileHandle {
+    /// The modification time of the file this handle already has open.
+    ///
+    /// `fstat` on the descriptor, deliberately, rather than a second lookup by
+    /// path: a path can be re-pointed by a rename between two calls — which is
+    /// precisely how the statusline tee publishes — and a stamp taken from the
+    /// new file would label the old file's bytes. A descriptor names an inode,
+    /// so the answer belongs to the payload the caller is holding.
+    func modificationDate() -> Date? {
+        var info = stat()
+        guard fstat(fileDescriptor, &info) == 0 else { return nil }
+        let time = info.st_mtimespec
+        return Date(timeIntervalSince1970:
+            Double(time.tv_sec) + Double(time.tv_nsec) / 1_000_000_000)
+    }
+}

--- a/Sources/TBDDaemon/Claude/OperatorStatuslineResolver.swift
+++ b/Sources/TBDDaemon/Claude/OperatorStatuslineResolver.swift
@@ -1,0 +1,96 @@
+import Foundation
+import TBDShared
+
+/// Finds the statusline the operator would have seen had TBD not overridden it.
+///
+/// TBD installs its tee through the per-session `--settings` file, and
+/// `statusLine` is an object-valued key with no merge-across-scopes behavior:
+/// the highest scope wins outright. A `--settings` file outranks
+/// `.claude/settings.local.json`, `.claude/settings.json` and the user's global
+/// `~/.claude/settings.json`, so on a desk session TBD's entry displaces every
+/// statusline the operator can write. This resolver puts it back — whatever
+/// would have won becomes the tee's delegate, and the operator sees the status
+/// line they configured.
+///
+/// The scopes are checked in Claude Code's own descending precedence and the
+/// first hit wins. Managed/enterprise settings are deliberately **not**
+/// consulted: a managed `statusLine` outranks TBD's `--settings` file, so TBD's
+/// entry is simply ignored there, the tee never runs, and the denominator stays
+/// unknown. That is the correct outcome — the operator's organization owns the
+/// slot — and it needs no handling beyond not pretending otherwise.
+///
+/// Pure and total: a missing, unreadable or malformed file is skipped, never
+/// thrown from. A broken settings file must not change what a spawn does.
+enum OperatorStatuslineResolver {
+    /// - Parameters:
+    ///   - perSpawnSettingsJSON: the per-spawn `--settings` fragment, highest.
+    ///   - repoSettingsJSON: the per-repo `claude-settings.json` fragment.
+    ///   - worktreePath: the session's cwd, for the two project scopes. nil
+    ///     skips them.
+    ///   - profileConfigDir: the session's `CLAUDE_CONFIG_DIR`, when it runs
+    ///     under a model profile. **This is what the user scope means for that
+    ///     session** — Claude Code reads its user-scope `settings.json` out of
+    ///     `CLAUDE_CONFIG_DIR`, so a desk on a profile has its user scope in the
+    ///     profile directory and none at all in the host store. nil (no profile,
+    ///     the ambient install) falls back to `claudeHostHome`.
+    ///   - environment: resolves `TBD_CLAUDE_HOST_HOME` for the user scope.
+    ///   - readFile: injection seam so tests need no real home directory.
+    /// - Returns: the `statusLine.command` string of the highest scope that has
+    ///   one, or nil when no scope configures a statusline.
+    static func resolve(
+        perSpawnSettingsJSON: String? = nil,
+        repoSettingsJSON: String? = nil,
+        worktreePath: String? = nil,
+        profileConfigDir: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        readFile: (String) -> Data? = { FileManager.default.contents(atPath: $0) }
+    ) -> String? {
+        // Descending precedence. The fragments come in as strings because they
+        // are what the spawn path already holds; the file scopes are read here.
+        for json in [perSpawnSettingsJSON, repoSettingsJSON] {
+            if let command = command(inSettingsData: json.flatMap { Data($0.utf8) }) {
+                return command
+            }
+        }
+        var paths: [String] = []
+        if let worktreePath {
+            let claudeDir = URL(fileURLWithPath: worktreePath).appendingPathComponent(".claude")
+            paths.append(claudeDir.appendingPathComponent("settings.local.json").path)
+            paths.append(claudeDir.appendingPathComponent("settings.json").path)
+        }
+        // The user scope, resolved against the config dir this session will
+        // actually run with. Exactly one directory is the user scope for a given
+        // session — reading the host store for a profile-backed desk would
+        // delegate to a statusline that session never sees, or to none while one
+        // exists in the profile.
+        let userScopeDir = profileConfigDir.map { URL(fileURLWithPath: $0) }
+            ?? TBDConstants.claudeHostHome(environment: environment)
+        paths.append(userScopeDir.appendingPathComponent("settings.json").path)
+        for path in paths {
+            if let command = command(inSettingsData: readFile(path)) {
+                return command
+            }
+        }
+        return nil
+    }
+
+    /// `statusLine.command` out of one settings document, or nil.
+    ///
+    /// nil covers all of: no data, not JSON, not an object, no `statusLine`, a
+    /// `statusLine` that is not an object, no `command`, and an empty
+    /// `command`. Each of those means "this scope configures no statusline we
+    /// can delegate to", and the resolver moves on to the next.
+    private static func command(inSettingsData data: Data?) -> String? {
+        guard let data, !data.isEmpty else { return nil }
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any] else {
+            return nil
+        }
+        guard let statusLine = dict["statusLine"] as? [String: Any],
+              let command = statusLine["command"] as? String,
+              !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return command
+    }
+}

--- a/Sources/TBDDaemon/Claude/StatuslineTee.swift
+++ b/Sources/TBDDaemon/Claude/StatuslineTee.swift
@@ -1,0 +1,265 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "statusline-tee")
+
+/// The statusline tee: one shared shell script that publishes a session's
+/// statusline stdin JSON where the daemon can read it, then runs whatever
+/// statusline the operator configured.
+///
+/// **Why a tee at all.** A session's *effective* context window is a session
+/// fact, not a model fact — Claude Code resolves it per session from the model
+/// id, a long-context suffix, a beta header, environment overrides and a remote
+/// flag. The one surface on which Claude Code tells a third party the value it
+/// resolved is the statusline command's stdin JSON, whose `context_window`
+/// object carries `context_window_size` alongside the used/remaining figures.
+/// Reading it is the only honest way to get a denominator; every out-of-band
+/// source reports *capability* instead, and capability errs in the dangerous
+/// direction.
+///
+/// **Why desk sessions only.** The denominator exists to serve a desk's own
+/// context-recycling thresholds, which are fractions of the session's effective
+/// window. Fleet agents do not need it: auto-compaction bears their survival.
+/// And TBD's per-session `--settings` file outranks the operator's own
+/// `statusLine` in every file scope they can write — project-local, project,
+/// and user — so installing the tee fleet-wide would silently take over a
+/// display slot the operator owns in every session they open and type into. A
+/// desk is a session TBD configures end to end, so the same mechanism there
+/// costs nobody anything.
+///
+/// The consequence is carried honestly rather than papered over: for every
+/// non-desk session the context-window denominator is unknown and is reported
+/// as unknown — raw token counts with no percentage. See `ContextLoadReader`.
+///
+/// One script serves the whole fleet. It takes the capture path and the
+/// operator's statusline command as arguments, so nothing session-specific is
+/// baked into the file and there is no per-session script to prune.
+enum StatuslineTee {
+    /// Path of the shared script. Derived from `TBDConstants` so `TBD_HOME` is
+    /// honored — never hand-built from `$HOME`.
+    static var scriptPath: String { TBDConstants.statuslineTeeScriptPath }
+
+    /// Where one session's captured payload lands.
+    static func capturePath(sessionKey: String) -> String {
+        TBDConstants.statuslineCapturePath(sessionKey: sessionKey)
+    }
+
+    /// The `statusLine.command` string TBD installs in a desk session's
+    /// overlay: the tee script, its capture path, and the operator's own
+    /// statusline command (empty when they have none).
+    ///
+    /// All three are shell-escaped. The delegate arrives as a single argument
+    /// and is re-run by the script through `sh -c "$2"`, which is exactly how
+    /// Claude Code would have run it.
+    static func statusLineCommand(capturePath: String, delegateCommand: String?) -> String {
+        let script = SystemPromptBuilder.shellEscape(scriptPath)
+        let capture = SystemPromptBuilder.shellEscape(capturePath)
+        let delegate = SystemPromptBuilder.shellEscape(delegateCommand ?? "")
+        return "sh \(script) \(capture) \(delegate)"
+    }
+
+    /// Remove one session's capture file. Best-effort, like
+    /// `ClaudeHookOverlay.removePerSessionOverlay`, which calls this.
+    static func removeCapture(sessionKey: String) {
+        try? FileManager.default.removeItem(atPath: capturePath(sessionKey: sessionKey))
+    }
+
+    /// Startup sweep: delete every `statusline-capture-*.json` whose sanitized
+    /// session key is not in `liveSessionKeys`. Same reclaim contract as the
+    /// per-session overlay prune it runs beside — captures orphaned by a crash
+    /// or by a teardown path that never called `removeCapture` still go away,
+    /// so cleanup cannot drift as new teardown paths are added.
+    ///
+    /// This is also the only collector of the script's publish temp, which is
+    /// named `<capture>.<pid>.tmp.json` precisely so it matches the
+    /// prefix-and-suffix test here. A tee killed between its `cat` and its
+    /// `mv` — the session torn down, the machine asleep — leaves that file
+    /// behind, and `removeCapture` deletes only the exact capture path. Its
+    /// extracted "key" (`<key>.json.<pid>.tmp`) is never a live session key,
+    /// since `sanitizedSessionKey` maps `.` away, so a stray temp is always
+    /// collected and a live capture never is.
+    static func pruneOrphanedCaptures(liveSessionKeys: [String]) {
+        let fm = FileManager.default
+        let dir = TBDConstants.runtimeDir
+        guard let entries = try? fm.contentsOfDirectory(atPath: dir.path) else { return }
+        let live = Set(liveSessionKeys.map { TBDConstants.sanitizedSessionKey($0) })
+        let prefix = TBDConstants.statuslineCapturePrefix
+        let suffix = TBDConstants.statuslineCaptureSuffix
+        for entry in entries where entry.hasPrefix(prefix) && entry.hasSuffix(suffix) {
+            let key = String(entry.dropFirst(prefix.count).dropLast(suffix.count))
+            if live.contains(key) { continue }
+            try? fm.removeItem(atPath: dir.appendingPathComponent(entry).path)
+            logger.info("Pruned orphaned statusline capture \(entry, privacy: .public)")
+        }
+    }
+
+    /// Write the shared script to disk, executable (0o755), creating the
+    /// runtime directory if needed. Called at daemon startup beside the hook
+    /// overlay write; idempotent. Returns true on success.
+    @discardableResult
+    static func writeScript() -> Bool {
+        let path = scriptPath
+        do {
+            try FileManager.default.createDirectory(
+                at: TBDConstants.runtimeDir,
+                withIntermediateDirectories: true
+            )
+            try Data(scriptBody.utf8).write(to: URL(fileURLWithPath: path), options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+            logger.info("Wrote statusline tee at \(path, privacy: .private)")
+            return true
+        } catch {
+            // Both halves at the same privacy, deliberately: a Foundation file
+            // error routinely embeds the very filename and containing folder
+            // that `path` is marked `.private` for, so a `.public` error would
+            // print in the clear exactly what the interpolation beside it
+            // redacts.
+            logger.error(
+                "Failed to write statusline tee at \(path, privacy: .private): \(error.localizedDescription, privacy: .private)"
+            )
+            return false
+        }
+    }
+
+    /// The script. POSIX `sh`, no bashisms.
+    ///
+    /// Every branch is quiet and non-fatal, and that is load-bearing rather
+    /// than tidy: Claude Code blanks the status line when the command exits
+    /// non-zero or prints nothing, so a tee that failed loudly would take the
+    /// operator's status line down with it.
+    static let scriptBody: String = #"""
+    #!/bin/sh
+    # TBD statusline tee — generated by the daemon; edits are overwritten on restart.
+    #
+    # usage: statusline-tee.sh <capture-path> <delegate-command>
+    #
+    # Claude Code hands a statusline command the session's status JSON on stdin.
+    # That JSON is the one surface on which Claude Code reports the context
+    # window it RESOLVED for this session, so TBD publishes it verbatim and then
+    # gets out of the way: the statusline the operator configured runs next, on
+    # the same payload, with its stdout and its exit status passed through
+    # untouched.
+    #
+    # Quiet in every branch, deliberately. A non-zero exit or empty stdout
+    # blanks the status line, so:
+    #   - with no delegate we exit 0 having printed nothing (there was no status
+    #     line to blank, and inventing one would claim a slot we were not given);
+    #   - with a delegate we propagate ITS status instead of swallowing it, so a
+    #     broken operator statusline fails exactly the way it would have without
+    #     us in the path;
+    #   - a missing capture directory, an unwritable capture file, or no place
+    #     to buffer at all changes neither of those. The tee observes; it is
+    #     never a gate on the operator's statusline.
+    #
+    # The payload is data throughout. It moves only through file descriptors and
+    # files — never into a shell word or a here-document, where a `$`, a
+    # backtick or a quote in a repo path would be expanded.
+
+    umask 077
+
+    CAPTURE=$1
+    DELEGATE=$2
+
+    run_delegate() {
+        # stdin is whatever the caller redirected. exec, so the delegate's exit
+        # status is this script's with no extra shell left in the way.
+        if [ -n "$DELEGATE" ]; then
+            exec sh -c "$DELEGATE"
+        fi
+        exit 0
+    }
+
+    BUF=$(mktemp "${TMPDIR:-/tmp}/tbd-statusline-XXXXXX" 2>/dev/null) || BUF=
+    if [ -z "$BUF" ]; then
+        # Nowhere to buffer the payload. Capturing is the expendable half, so
+        # hand our own untouched stdin to the delegate and capture nothing.
+        run_delegate
+    fi
+
+    # Three descriptors on one inode: one to write the payload, two to read it
+    # back, because each open carries its own offset and POSIX sh cannot seek.
+    # Unlinking straight away means the buffer cannot outlive this process —
+    # not even across the final exec, which replaces the shell and would skip
+    # any EXIT trap. Reclaim is the unlink's job, never a trap's; the one trap
+    # below is armed across two lines and does something else entirely.
+    #
+    # mktemp just created the file, so these opens should not fail — but "should
+    # not" is not "cannot", and this is the one branch that could speak up. A
+    # failed redirection on `exec` is reported by the shell itself and ends the
+    # script, which blanks the operator's status line: exactly the outcome every
+    # other branch here is written to avoid.
+    #
+    # An `if !` around it is NOT enough to make that claim true. `exec` is a
+    # POSIX special built-in, and a redirection error on a special built-in is
+    # fatal to a non-interactive shell no matter what encloses it — dash exits 2
+    # on the spot, so neither the `if` nor the `2>/dev/null` ever runs. bash and
+    # zsh outside POSIX mode are laxer and report it instead, so a guard tested
+    # only under those two would read as handled while being nothing of the
+    # kind; the header above promises POSIX sh, so the guard has to hold under
+    # one.
+    #
+    # So the opens are PROBED first, in a subshell, where the same fatal error
+    # costs only the subshell and the enclosing group silences its message.
+    # Silenced and handled like the no-buffer case above, which it is — our own
+    # stdin is still the untouched payload, so the delegate loses nothing.
+    if ! ( exec 3>"$BUF" 4<"$BUF" 5<"$BUF" ) 2>/dev/null; then
+        rm -f "$BUF" 2>/dev/null
+        run_delegate
+    fi
+
+    # The probe NARROWS that window; it cannot close it. It proves the path was
+    # openable a moment ago, and the buffer lives in $TMPDIR — a per-user
+    # directory a cleaner or a sibling process can empty between the two opens.
+    # When the real open fails there, the shell is already dying and no `if`,
+    # `!` or `2>/dev/null` around it will ever run.
+    #
+    # An EXIT trap is the one handler that still gets control on that exit, so
+    # the fallback is armed here and disarmed the moment the opens land. It sits
+    # AFTER the probe rather than around it because the probe subshell exiting
+    # must not fire it — verified alongside the fatal-exit behavior itself in
+    # dash, macOS /bin/sh and zsh, all three of which run this trap on the
+    # failed open and none of which runs it for the subshell above.
+    trap 'rm -f "$BUF" 2>/dev/null; run_delegate' EXIT
+    # The real opens, on a path the probe just proved openable. The `if` is the
+    # arm for a lax shell (bash and zsh outside POSIX mode report the failure
+    # instead of dying on it); the trap is the arm for a strict one.
+    if ! { exec 3>"$BUF" 4<"$BUF" 5<"$BUF"; } 2>/dev/null; then
+        trap - EXIT
+        rm -f "$BUF" 2>/dev/null
+        run_delegate
+    fi
+    trap - EXIT
+    rm -f "$BUF" 2>/dev/null
+    cat >&3 2>/dev/null
+    exec 3>&-
+
+    # Publish atomically: a reader must never see a half-written payload, so
+    # write a sibling temp file and rename it over the capture path.
+    #
+    # The `.json` on the end is load-bearing, not decoration. This script can be
+    # killed between the `cat` and the `mv` — the session torn down, the machine
+    # asleep — and the temp then has no owner: nothing else knows its name, and
+    # the daemon's per-session cleanup deletes only the exact capture path. The
+    # daemon's startup sweep collects `statusline-capture-*.json`, so a temp
+    # named for both ends of that test is reclaimed, while a sibling in the same
+    # directory keeps the rename atomic. Widening the sweep instead would have
+    # worked equally well for reclaim and told a reader less about why the name
+    # has the shape it does.
+    TMP="$CAPTURE.$$.tmp.json"
+    mkdir -p "$(dirname "$CAPTURE")" 2>/dev/null
+    # The braces matter: a failing `>"$TMP"` redirection is reported by the
+    # shell itself, so the silencer has to wrap the whole compound command.
+    if { cat <&4 >"$TMP"; } 2>/dev/null; then
+        mv -f "$TMP" "$CAPTURE" 2>/dev/null || rm -f "$TMP" 2>/dev/null
+    else
+        rm -f "$TMP" 2>/dev/null
+    fi
+    exec 4<&-
+
+    # Replay the buffered payload on the delegate's own stdin.
+    exec 0<&5 5<&-
+    run_delegate
+
+    """#
+}

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -16,7 +16,14 @@ struct RuntimeIntegrationRefresher {
             writeFallbackSkill: { try SkillFileWriter().writeFallback() },
             writeClaudePlugin: { try PluginDirWriter().writePlugin() },
             ensureCodexProfilePlugin: { _ = try CodexHomeManager().ensureProfilePlugin() },
-            writeClaudeHookOverlay: { ClaudeHookOverlay.writeOverlay() }
+            writeClaudeHookOverlay: {
+                ClaudeHookOverlay.writeOverlay()
+                // The statusline tee ships beside the overlay and is rewritten
+                // on every startup for the same reason: a desk session's
+                // overlay points at it by path, so the file has to be current
+                // before the next spawn resolves that path.
+                StatuslineTee.writeScript()
+            }
         )
     }
 
@@ -496,6 +503,15 @@ public final class Daemon: Sendable {
         await prManager.setOnStatusPersist { worktreeID, status in
             try? await database.worktrees.setPRStatus(id: worktreeID, status: status)
         }
+        // The outcome of the last attempt rides alongside the value, and
+        // survives a restart for the same reason the value does: an
+        // `.undetermined` that reset to "no attempt on record" at every daemon
+        // start would quietly hide an outage that spans one.
+        let persistedPRObservations = (try? await database.worktrees.allPRObservations()) ?? [:]
+        await prManager.hydrateObservations(persistedPRObservations)
+        await prManager.setOnObservationPersist { worktreeID, observation in
+            try? await database.worktrees.setPRObservation(id: worktreeID, observation: observation)
+        }
 
         // 8. Initialize RPC router.
         //
@@ -544,9 +560,18 @@ public final class Daemon: Sendable {
         // coordinator needs `rpcRouter.hibernationCoordinator`, which only exists
         // after the RPCRouter is constructed above. It's safe here because the
         // only thing that fires a merged transition is `PRStatusManager.fetchAll`
-        // / `refresh`, both reachable ONLY via the `pr.list` / `pr.refresh` RPC
-        // handlers — and the socket server that serves those doesn't start until
-        // step 9 below. So no merge can be observed between construction and here.
+        // / `refresh`, and the three paths that reach them all start later: the
+        // `pr.list` / `pr.refresh` RPC handlers wait on the socket server (step
+        // 9), and `PRPoller`'s loop is not started until step 12f.
+        //
+        // ONE OWNER FOR THE EDGE. The merged transition is edge-triggered on a
+        // cache change, so whichever path updates the cache consumes it, and a
+        // second periodic driver would swallow edges this dispatcher's
+        // consumers are waiting for. The edge's owner is
+        // `PRStatusManager.apply` — the single funnel every cache write goes
+        // through, which fires this callback exactly once per non-merged →
+        // merged move. `PRPoller` is the only thing that calls into that funnel
+        // on a timer; `pr.list` serves the snapshot and never fetches.
         let autoArchiveCoordinator = AutoArchiveOnMergeCoordinator(
             db: database, lifecycle: lifecycle, subscriptions: subs, actuationLog: actuationLog)
         let autoHibernateCoordinator = AutoHibernateOnMergeCoordinator(
@@ -887,6 +912,14 @@ public final class Daemon: Sendable {
                 }
             }
 
+            // 12f. Pull-request poll on the daemon's own clock (30s foreground,
+            // 5min background — GitPollCadence.prInterval). This is the only
+            // periodic driver of the PR fetch, so PR facts keep arriving with
+            // no app running — and so exactly one path consumes the merged-PR
+            // transition edge (see the dispatcher wiring above).
+            await rpcRouter.prPoller.setForegroundGate(effectivelyForeground)
+            await rpcRouter.prPoller.start()
+
             // 14. Auto-hibernate idle sweep. Cheap poll every 30s; the actual
             // kill decision is made against the configured idle window (default
             // 30 min) with a debounce, inside the coordinator. The feature's
@@ -994,6 +1027,11 @@ public final class Daemon: Sendable {
         // Stop daywatch runner.
         if let runner = daywatchRunner {
             await runner.apply(mode: .off)
+        }
+
+        // Stop the daemon-clock PR poll (no-op when it was never started).
+        if let router = self.router {
+            await router.prPoller.stop()
         }
 
         // Stop any tmux control-mode connections (no-op when the gate is off).

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1351,6 +1351,48 @@ public final class TBDDatabase: Sendable {
                 type: .boolean, defaults: true)
         }
 
+        // Provenance for `terminal.activityState` (fleet-supervision design
+        // §2): a fact TBD reports about a session is the value, the source it
+        // came from, and when it was observed — never a bare enumeration.
+        //
+        // All four columns are deliberately nullable WITHOUT a default. There
+        // is no honest default for "where did this come from": a backfilled
+        // `derived` or `database` would attach manufactured provenance to
+        // rows nobody observed, which is precisely the laundering the state
+        // model exists to prevent. NULL means "not yet observed", and
+        // `Terminal.observedActivity` reads a half-stamped row as no fact at
+        // all rather than as a fact with a guessed source.
+        //
+        // Numbered v75/v76 because main took v70 through v74 while this branch
+        // was open. Renumbering is safe only because both bodies go through
+        // `addColumnIfMissing`: a machine that already applied them under the
+        // old ids re-runs the bodies, finds every column present, and logs a
+        // no-op instead of throwing.
+        migrator.registerMigration("v75_terminal_state_provenance") { db in
+            try db.addColumnIfMissing(
+                table: "terminal", column: "activityStateSource", type: .text)
+            try db.addColumnIfMissing(
+                table: "terminal", column: "activityStateObservedAt", type: .datetime)
+            try db.addColumnIfMissing(
+                table: "terminal", column: "awaitingInputReason", type: .text)
+            try db.addColumnIfMissing(
+                table: "terminal", column: "awaitingInputObservedAt", type: .datetime)
+        }
+
+        // The outcome of the last attempt to learn a worktree's PR state, as
+        // distinct from the value that attempt found (`worktree.prStatus`).
+        // A nil `prStatus` cannot tell "the forge answered; no PR" from "the
+        // query failed", and treating an outage as a fleet with no pull
+        // requests looks exactly like a calm night.
+        //
+        // Nullable without a default for the same reason as v75: NULL means no
+        // attempt is on record, which is a third thing again from a recorded
+        // `.none` or `.undetermined`.
+        migrator.registerMigration("v76_worktree_pr_observation") { db in
+            try db.addColumnIfMissing(
+                table: "worktree", column: "prObservation", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -28,6 +28,15 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var keepWarm: Bool?
     var pendingResumeAt: Date?
     var watch_desk_role: String?
+    /// JSON-encoded `FactSource` — where `activityState` came from. nil on rows
+    /// written before v70 and on any row stamped without provenance.
+    var activityStateSource: String?
+    var activityStateObservedAt: Date?
+    /// JSON-encoded `AwaitingInputReason`, carried verbatim from the
+    /// `Notification` hook. nil when the session is not waiting, or when the
+    /// wait carried no structured reason.
+    var awaitingInputReason: String?
+    var awaitingInputObservedAt: Date?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -49,6 +58,10 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.keepWarm = terminal.keepWarm
         self.pendingResumeAt = terminal.pendingResumeAt
         self.watch_desk_role = terminal.watchDeskRole?.rawValue
+        self.activityStateSource = FactColumnJSON.encode(terminal.activityStateSource)
+        self.activityStateObservedAt = terminal.activityStateObservedAt
+        self.awaitingInputReason = FactColumnJSON.encode(terminal.awaitingInputReason)
+        self.awaitingInputObservedAt = terminal.awaitingInputObservedAt
     }
 
     /// Failable decode: skips (returns nil after a logged warning) rather than
@@ -84,8 +97,31 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             pendingResumeAt: pendingResumeAt,
             watchDeskRole: watch_desk_role.map {
                 WatchDeskRole(rawValue: $0) ?? .readOnlyCoordinator
-            }
+            },
+            activityStateSource: FactColumnJSON.decode(FactSource.self, from: activityStateSource),
+            activityStateObservedAt: activityStateObservedAt,
+            awaitingInputReason: FactColumnJSON.decode(AwaitingInputReason.self, from: awaitingInputReason),
+            awaitingInputObservedAt: awaitingInputObservedAt
         )
+    }
+}
+
+/// JSON codec for the state-model blobs that ride in TEXT columns.
+///
+/// Failure is silent and produces nil on both sides, matching `prStatus`'s
+/// existing `try?` treatment: an unreadable provenance blob must degrade to
+/// "no provenance recorded" — which `Terminal.observedActivity` already reads
+/// as no fact — rather than take the whole row's decode with it.
+enum FactColumnJSON {
+    static func encode<T: Encodable>(_ value: T?) -> String? {
+        guard let value else { return nil }
+        guard let data = try? JSONEncoder().encode(value) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from json: String?) -> T? {
+        guard let json, let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
     }
 }
 
@@ -116,6 +152,14 @@ public struct TerminalStore: Sendable {
     /// only after the spawn succeeds, for crash consistency); the RPC
     /// handler rejects user-driven creates on archived rows before spawn.
     /// Promoted rows have no such flow — they are never revived.
+    ///
+    /// `watchDeskRole` is stamped here so that "this row was spawned as a Watch
+    /// Desk session" is durable from the row's first instant rather than only
+    /// from whenever a judge lease is first acquired. The wake path reads it to
+    /// decide whether to reinstall the statusline tee, and a desk that has
+    /// never held a lease is still a desk. The lease store keeps maintaining
+    /// the column afterwards — this is the same mechanism, given a starting
+    /// value, not a second one.
     public func create(
         id: UUID = UUID(),
         worktreeID: UUID,
@@ -124,7 +168,8 @@ public struct TerminalStore: Sendable {
         label: String? = nil,
         claudeSessionID: String? = nil,
         profileID: UUID? = nil,
-        kind: TerminalKind? = nil
+        kind: TerminalKind? = nil,
+        watchDeskRole: WatchDeskRole? = nil
     ) async throws -> Terminal {
         let terminal = Terminal(
             id: id,
@@ -134,7 +179,8 @@ public struct TerminalStore: Sendable {
             label: label,
             claudeSessionID: claudeSessionID,
             profileID: profileID,
-            kind: kind
+            kind: kind,
+            watchDeskRole: watchDeskRole
         )
         let record = TerminalRecord(from: terminal)
         try await writer.write { db in
@@ -256,7 +302,11 @@ public struct TerminalStore: Sendable {
 
     /// Clear Claude-specific metadata after window recreation.
     /// The recreated window runs a plain shell, not Claude.
-    public func clearRecreated(id: UUID) async throws {
+    ///
+    /// Takes `at` because it also writes an activity state, and every activity
+    /// state carries provenance: this one is `.derived`, composed from TBD's
+    /// own act of recreating the window, observed as that act completed.
+    public func clearRecreated(id: UUID, at date: Date = Date()) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
@@ -270,6 +320,10 @@ public struct TerminalStore: Sendable {
             record.label = TerminalLabel.shell
             record.kind = TerminalKind.shell.rawValue
             record.activityState = TerminalActivityState.unknown.rawValue
+            record.activityStateSource = FactColumnJSON.encode(FactSource.derived)
+            record.activityStateObservedAt = date
+            record.awaitingInputReason = nil
+            record.awaitingInputObservedAt = nil
             try record.update(db)
         }
     }
@@ -296,13 +350,137 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Update the current activity state for a terminal.
-    public func setActivityState(id: UUID, activityState: TerminalActivityState) async throws {
+    /// Record an observation of a terminal's activity state.
+    ///
+    /// `source` has no default, and that is the whole point of the signature:
+    /// there is no way to write an activity state without saying where it came
+    /// from, so a value with no provenance cannot enter the database at all.
+    /// `observedAt` follows the one-shot stamp seam (`at date: Date = Date()`
+    /// in CLAUDE.md's date-seam rule) — it is *data*, the moment the machine
+    /// fact was read, which callers that read earlier than they write must
+    /// pass explicitly.
+    ///
+    /// `awaitingInputReason` rides with the observation rather than in a writer
+    /// of its own, because a wait reason belongs to one state observation and
+    /// is superseded by the next: passing nil (the default) clears any previous
+    /// reason, so the stored reason always describes the state stored beside
+    /// it, never a wait that has since ended.
+    public func setActivityState(
+        id: UUID,
+        activityState: TerminalActivityState,
+        source: FactSource,
+        observedAt: Date = Date(),
+        awaitingInputReason: AwaitingInputReason? = nil
+    ) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.activityState = activityState.rawValue
+            record.activityStateSource = FactColumnJSON.encode(source)
+            record.activityStateObservedAt = observedAt
+            // Unconditional, including the nil case: this IS the superseding
+            // rail. A caller that observes a new activity state without naming
+            // a reason clears the old one, so a "needs your permission"
+            // recorded by a `Notification` hook cannot outlive the prompt it
+            // described. Making this write conditional on a non-nil reason
+            // would leave stale waits pinned to the row forever.
+            record.awaitingInputReason = FactColumnJSON.encode(awaitingInputReason)
+            record.awaitingInputObservedAt = awaitingInputReason == nil ? nil : observedAt
+            try record.update(db)
+        }
+    }
+
+    /// Record a wait reason observed by a hook, WITHOUT asserting an activity
+    /// state.
+    ///
+    /// `setActivityState` writes a reason alongside a state it is also
+    /// asserting; this writer exists for the one source that can report a
+    /// reason it is not entitled to turn into a state. Claude Code's
+    /// `Notification` hook says a prompt was raised — it does not say the
+    /// session is still sitting on it, and `activityState` is a *gating* field:
+    /// `HibernationGate.blockingRail` reads it, so writing `waiting_for_user`
+    /// here would change which sessions park, from a hook whose only job is to
+    /// report. So the two activity columns are left exactly as they were, and
+    /// the recorded reason is composed into a session state downstream instead.
+    ///
+    /// The superseding rail is unchanged and is what keeps this honest: the
+    /// next `setActivityState` observation clears both columns (its
+    /// `awaitingInputReason` defaults to nil), so a reason recorded here cannot
+    /// outlive the wait it described.
+    ///
+    /// `observedAt` is the moment the hook reported, following the one-shot
+    /// stamp seam — it is data, not behavior.
+    ///
+    /// **A write from a class that establishes no state cannot clear a standing
+    /// `promptOnScreen`.** The hook overlay registers `Notification` with no
+    /// matcher, so every type arrives here — including the ones that fire while
+    /// a permission prompt is up. A subagent finishing sends `agent_completed`
+    /// (`.informational`); an unconditional overwrite would replace the live
+    /// prompt with it, and the session would read as un-blocked while a human is
+    /// still being waited on. `.informational` and `.unrecognized` say nothing
+    /// about whether a prompt went away, so they are recorded only when no
+    /// `promptOnScreen` reason is standing. `.promptOnScreen` and `.doneWaiting`
+    /// write unconditionally: the first is a newer prompt, the second is the
+    /// agent reporting it is back at its own prompt.
+    ///
+    /// The *activity* rail is untouched by this and keeps superseding as it
+    /// always has: `setActivityState` clears both columns, so a genuine
+    /// observation of the session moving on still retracts the reason. This
+    /// guard only refuses to let a report that observed nothing do it.
+    public func recordAwaitingInputReason(
+        id: UUID,
+        reason: AwaitingInputReason,
+        observedAt: Date
+    ) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            let establishesNothing = reason.classification == .informational
+                || reason.classification == .unrecognized
+            if establishesNothing,
+               let standing = FactColumnJSON.decode(
+                    AwaitingInputReason.self, from: record.awaitingInputReason),
+               standing.classification == .promptOnScreen {
+                return
+            }
+            record.awaitingInputReason = FactColumnJSON.encode(reason)
+            record.awaitingInputObservedAt = observedAt
+            try record.update(db)
+        }
+    }
+
+    /// Retract a standing wait reason WITHOUT asserting an activity state.
+    ///
+    /// The mirror of `recordAwaitingInputReason`, and it exists for the same
+    /// reason: a caller can be entitled to say a recorded prompt is gone
+    /// without being entitled to say what the session is doing instead. The two
+    /// callers are both TBD's own knowledge that the process the prompt was
+    /// raised on has been replaced — the in-place profile swap, which kills the
+    /// pane's agent itself, and the SessionStart bridge, where Claude Code
+    /// reports a new session context (a `/clear`, a resume, a hand relaunch).
+    /// Neither knows what the new process is doing, so `activityState` and its
+    /// provenance are left exactly as they were; writing one here would move a
+    /// field `HibernationGate.blockingRail` gates on, from a step that observed
+    /// no turn boundary.
+    ///
+    /// The activity rail is **not** a sufficient retraction on its own here,
+    /// which is why this writer is not just a `setActivityState` call.
+    /// `handleTerminalActivityEvent` returns early when the state is unchanged,
+    /// so the SessionStart overlay's own `tbd terminal-activity idle` clears
+    /// nothing when the row already reads idle — and it is a second, separate,
+    /// best-effort CLI invocation that a stale `tbd` on `PATH` can lose while
+    /// the first one lands.
+    ///
+    /// Idempotent: clearing columns that are already nil is a no-op write.
+    public func clearAwaitingInputReason(id: UUID) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.awaitingInputReason = nil
+            record.awaitingInputObservedAt = nil
             try record.update(db)
         }
     }
@@ -343,6 +521,14 @@ public struct TerminalStore: Sendable {
                 record.suspendedSnapshot = snapshot
             }
             record.activityState = TerminalActivityState.idle.rawValue
+            // A parked session is idle because TBD's own record says it is
+            // parked — `.database`, observed at the moment of the park. A
+            // parked session is also waiting for nothing, so any carried
+            // awaiting-input reason is cleared with it.
+            record.activityStateSource = FactColumnJSON.encode(FactSource.database)
+            record.activityStateObservedAt = date
+            record.awaitingInputReason = nil
+            record.awaitingInputObservedAt = nil
             try record.update(db)
             // AFTER record.update: the routine nils pendingResumeAt via raw
             // SQL, and an update of the (stale-fetched) record afterward

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -47,6 +47,11 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     // `queued_prompt_enabled` flag) because it is data, not a gate; nil only on
     // rows the record type wrote explicitly, and resolves to true.
     var pending_prompt_submit: Bool?
+    // JSON-encoded PRObservation: the OUTCOME of the last attempt to learn this
+    // worktree's PR state, as opposed to `prStatus`, the value it found. nil =
+    // no attempt on record, which is a third thing again from a recorded
+    // `.none` ("the forge answered; no PR") or `.undetermined`.
+    var prObservation: String?
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -90,6 +95,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         }
         self.pending_prompt = wt.pendingPrompt
         self.pending_prompt_submit = wt.pendingPromptSubmit
+        self.prObservation = FactColumnJSON.encode(wt.prObservation)
     }
 
     /// Failable decode: skips (returns nil after a logged warning) only when the
@@ -162,8 +168,33 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             pinSortOrder: pinSortOrder,
             location: worktreeLocation,
             pendingPrompt: pending_prompt,
-            pendingPromptSubmit: pending_prompt_submit
+            pendingPromptSubmit: pending_prompt_submit,
+            prObservation: Self.decodePRObservation(prObservation)
         )
+    }
+
+    /// Decode the recorded PR-attempt outcome, keeping "no attempt was ever
+    /// made" apart from "an attempt was recorded and the record is unreadable".
+    ///
+    /// `FactColumnJSON.decode` collapses both into nil, which is right for the
+    /// provenance columns — there, nil means "no fact", and a fact that will not
+    /// decode is no fact. It is wrong here. nil on this column is a **third**
+    /// value, distinct from `.none` and `.undetermined`, and it asserts that the
+    /// forge was never asked about this worktree. A truncated blob asserts that
+    /// too, and it has no business doing so: bytes are on the row, so an attempt
+    /// happened, and the only thing lost is what it concluded — which is exactly
+    /// what `.undetermined` says.
+    ///
+    /// The stamp is `.distantPast` because nothing on hand says when the attempt
+    /// was, and that is the safe direction to be wrong in: it can only make the
+    /// record read as older than it is. A stamp of "now" would present a reading
+    /// nobody took as the freshest one anybody has.
+    private static func decodePRObservation(_ json: String?) -> PRObservation? {
+        guard let json, !json.isEmpty else { return nil }
+        if let decoded = FactColumnJSON.decode(PRObservation.self, from: json) { return decoded }
+        return PRObservation(
+            outcome: .undetermined(cause: PRUndeterminedCause.unreadableRecord),
+            observedAt: .distantPast)
     }
 }
 
@@ -1166,15 +1197,64 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Persist (or clear with nil) the outcome of the last attempt to learn
+    /// this worktree's PR state.
+    ///
+    /// Separate from `setPRStatus` because the two answer different questions
+    /// and can disagree: a failed query leaves the previous `prStatus` in place
+    /// (it is the newest value anyone has) while recording `.undetermined`
+    /// here, so a reader can see that the value it is holding is not confirmed.
+    public func setPRObservation(id: UUID, observation: PRObservation?) async throws {
+        let json = FactColumnJSON.encode(observation)
+        try await writer.write { db in
+            try db.execute(sql: "UPDATE worktree SET prObservation = ? WHERE id = ?",
+                           arguments: [json, id.uuidString])
+        }
+    }
 
-    /// All persisted PR statuses, keyed by worktree id. Used to hydrate the
-    /// in-memory PR cache at daemon startup so icons survive restart.
+    /// Persisted PR observations for every **unarchived** worktree, keyed by
+    /// worktree id. Used to hydrate the in-memory observation map at daemon
+    /// startup, so an `.undetermined` recorded before a restart is not
+    /// downgraded to "no attempt on record".
+    ///
+    /// Archived rows are excluded because the map is handed out whole in every
+    /// `pr.list` — a payload on a thirty-second cadence — and "every worktree
+    /// ever created" is not a set that stops growing. An archived worktree has
+    /// no pull request anyone is watching: the poller enumerates
+    /// `list(status: .active)` and would never refresh those entries anyway, so
+    /// carrying them is carrying a value nothing can correct. A revived
+    /// worktree starts from "no attempt on record", which is the truth about it.
+    ///
+    /// **Only archived rows, not "active rows only".** `.main`, `.creating` and
+    /// `.failed` are outside the poller's scope too, but they are bounded (one
+    /// main checkout per repo, the others transient) and `pr.refresh` accepts
+    /// any worktree id, so a status or outcome recorded directly on one of them
+    /// is a real value that must survive a restart. Narrowing to `.active`
+    /// silently dropped those at startup.
+    public func allPRObservations() async throws -> [UUID: PRObservation] {
+        try await unarchivedWorktreeRecords { $0.prObservation }
+    }
+
+    /// Persisted PR statuses for every **unarchived** worktree, keyed by
+    /// worktree id. Used to hydrate the in-memory PR cache at daemon startup so
+    /// icons survive restart. Scoped for the same reason `allPRObservations` is.
     public func allPRStatuses() async throws -> [UUID: PRStatus] {
+        try await unarchivedWorktreeRecords { $0.prStatus }
+    }
+
+    /// One field of every unarchived worktree, keyed by id, skipping the rows
+    /// where it is absent.
+    private func unarchivedWorktreeRecords<Value: Sendable>(
+        _ field: @Sendable @escaping (Worktree) -> Value?
+    ) async throws -> [UUID: Value] {
         try await writer.read { db in
-            var result: [UUID: PRStatus] = [:]
-            for record in try WorktreeRecord.fetchAll(db) {
+            var result: [UUID: Value] = [:]
+            let records = try WorktreeRecord
+                .filter(Column("status") != WorktreeStatus.archived.rawValue)
+                .fetchAll(db)
+            for record in records {
                 guard let wtID = UUID(uuidString: record.id),
-                      let model = record.toModel()?.prStatus else { continue }
+                      let model = record.toModel().flatMap(field) else { continue }
                 result[wtID] = model
             }
             return result

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -12,7 +12,7 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-overl
 /// its own overlay file pinned at spawn time without touching the user's
 /// settings.json at all.
 ///
-/// The overlay registers six event types:
+/// The overlay registers seven event types:
 /// - `SessionStart` (matcher `*`): calls `tbd session-event`, which
 ///   relays the new session ID + transcript path to the daemon. This is
 ///   what fixes the post-`/clear`/`/compact` transcript freeze. Also
@@ -39,6 +39,9 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-overl
 ///   (the overwhelming majority) from spawning a `tbd` process. It is a
 ///   cost optimization, not a gate — `PRBindingExtractor`'s tokenizer
 ///   decides what actually counts as a create.
+/// - `Notification` (no matcher): runs `tbd hooks notification`, which
+///   forwards the payload verbatim so the daemon can record a structured
+///   reason an agent is waiting.
 ///
 /// The overlay is regenerated on every daemon startup so changes to the
 /// shape (new hooks, new commands) take effect on the next worktree open.
@@ -96,6 +99,24 @@ public enum ClaudeHookOverlay {
     /// continues processing after the user answers.
     static let askUserQuestionPostCommand =
         #"tbd ask-user-question post 2>/dev/null || true; tbd terminal-activity working 2>/dev/null || true"#
+
+    /// Bridges Claude Code's `Notification` hook into TBD, so "waiting" can
+    /// carry a structured reason instead of being inferred.
+    ///
+    /// Why `Notification` and not `PreToolUse`: only `Notification` can say a
+    /// prompt is on screen *now*. `PreToolUse` fires before *every* tool call —
+    /// it is where an agent-native hook decides a permission for itself, which
+    /// is configuration at the source, and it can never report that a raised
+    /// prompt is currently waiting on a human.
+    ///
+    /// Why no matcher: a matcher here would decide, in a file the operator can
+    /// edit, which notification types TBD ever hears about. Any supervision
+    /// fork belongs in the daemon's RPC handler, where it is compiled, tested,
+    /// and the same for every install — so this entry reports every type and
+    /// decides nothing. Silent failure like every other entry: a hook must
+    /// never wedge the agent.
+    static let notificationCommand =
+        #"tbd hooks notification 2>/dev/null || true"#
 
     /// Sets the terminal activity state to working (shows the thinking
     /// indicator in the sidebar while Claude processes a prompt).
@@ -200,9 +221,18 @@ public enum ClaudeHookOverlay {
     /// `fallbackModel`: object-valued keys present in both recurse; any other
     /// clash lets the `extraSettings` value win. This preserves TBD's `hooks`
     /// when the fragment only adds top-level keys (e.g. `skillOverrides`).
+    ///
+    /// `statusLineCommand`, when present, installs the statusline tee — and is
+    /// applied AFTER the deep merge, so it wins over a `statusLine` a fragment
+    /// supplied. That is not a clobber: the caller resolved the operator's
+    /// statusline first (`OperatorStatuslineResolver`, which reads the same
+    /// fragment at the top of its precedence list) and the tee runs it as its
+    /// delegate. Nil — every non-desk spawn — leaves the key absent entirely,
+    /// so the body is byte-identical to one generated without this parameter.
     public static func generateBody(
         fallbackModels: [String]? = nil,
-        extraSettings: [String: Any]? = nil
+        extraSettings: [String: Any]? = nil,
+        statusLineCommand: String? = nil
     ) throws -> Data {
         var body: [String: Any] = [
             "hooks": [
@@ -262,6 +292,16 @@ public enum ClaudeHookOverlay {
                              "timeout": prBindTimeoutSeconds] as [String: Any]
                         ]
                     ]
+                ],
+                // No "matcher" key: omitting it runs the hook for every
+                // notification type. See `notificationCommand` for why the
+                // classification lives in the daemon instead.
+                "Notification": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": notificationCommand]
+                        ]
+                    ]
                 ]
             ]
         ]
@@ -270,6 +310,9 @@ public enum ClaudeHookOverlay {
         }
         if let extraSettings {
             deepMerge(&body, extraSettings)
+        }
+        if let statusLineCommand {
+            body["statusLine"] = ["type": "command", "command": statusLineCommand]
         }
         return try JSONSerialization.data(
             withJSONObject: body,
@@ -356,19 +399,60 @@ public enum ClaudeHookOverlay {
     /// spawn paths (fresh create, resume, wake, profile swap) and edits made
     /// during a preSession hook wait are picked up. The per-spawn fragment
     /// applies at FRESH spawn only — callers gate it.
+    ///
+    /// `watchDeskRole` is the **only** thing that installs the statusline tee,
+    /// and it is the existing desk-role concept rather than a parallel flag: a
+    /// non-nil role means this spawn is a Watch Desk session. The tee takes over
+    /// the `statusLine` slot, which TBD's `--settings` file outranks in every
+    /// scope an operator can write — acceptable on a desk TBD configures end to
+    /// end, never on a session someone opened to work in. Nil (every ordinary
+    /// spawn, and the default at every call site that does not opt in) produces
+    /// a byte-identical overlay to the one this function produced before the tee
+    /// existed. `worktreePath` is only read when a role is present, to find the
+    /// project-scope statusline the tee will delegate to, and `profileConfigDir`
+    /// — the `CLAUDE_CONFIG_DIR` this spawn will run with — for the same reason:
+    /// a desk on a model profile has its user-scope `settings.json` inside that
+    /// directory, not in the host Claude store. Pass the same value handed to
+    /// `ClaudeSpawnCommandBuilder.build`; nil means the ambient install.
     public static func resolveOverlayPath(
         fallbackModels: [String]?,
         sessionKey: String,
         repoSettingsJSON: String? = nil,
-        extraSettingsJSON: String? = nil
+        extraSettingsJSON: String? = nil,
+        watchDeskRole: WatchDeskRole? = nil,
+        worktreePath: String? = nil,
+        profileConfigDir: String? = nil
     ) -> String {
+        // A session that is not installing a tee must not be able to read one's
+        // leftovers. The capture path is keyed by the session, and several
+        // spawn paths reuse a session key across lives (a wake reuses the whole
+        // terminal row), so a capture published before this spawn would be read
+        // by `ContextLoadReader` and reported as an `.observed` window with
+        // `isPairedReading == true` — a stale denominator wearing a fresh
+        // session's clothes, which is the one failure the whole context-load
+        // path exists to avoid.
+        //
+        // Deleting it here rather than trusting the tee to be reinstalled is
+        // what makes that structural: every Claude spawn resolves an overlay,
+        // so every life of a session passes through this line, and the file
+        // simply is not there for a non-desk session to misread. It runs before
+        // the shared-overlay early return below, because a session with no
+        // fragments and no fallback models takes that return and still needs
+        // the capture gone.
+        if watchDeskRole == nil {
+            StatuslineTee.removeCapture(sessionKey: sessionKey)
+        }
         let hasFallback = !(fallbackModels?.isEmpty ?? true)
         // A non-empty fragment string forces a per-session overlay even if it
         // later fails to parse — a malformed fragment degrades to hooks-only,
         // it must not silently fall back to (and mutate) the shared global file.
         let hasExtra = !(extraSettingsJSON?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
             || !(repoSettingsJSON?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
-        guard hasFallback || hasExtra else {
+        // The tee is per-session (its capture path is keyed by session), so it
+        // forces a per-session overlay for the same reason the fragments do:
+        // the shared global file must never carry one session's statusline.
+        let isDesk = watchDeskRole != nil
+        guard hasFallback || hasExtra || isDesk else {
             return overlayPath
         }
         // Repo fragment first, per-spawn fragment deep-merged on top.
@@ -378,9 +462,27 @@ public enum ClaudeHookOverlay {
             deepMerge(&base, perSpawn)
             extraSettings = base
         }
+        // Resolve the operator's statusline BEFORE installing ours, so a
+        // statusline a fragment supplied becomes the tee's delegate instead of
+        // being clobbered by it.
+        let statusLineCommand: String? = isDesk
+            ? StatuslineTee.statusLineCommand(
+                capturePath: StatuslineTee.capturePath(sessionKey: sessionKey),
+                delegateCommand: OperatorStatuslineResolver.resolve(
+                    perSpawnSettingsJSON: extraSettingsJSON,
+                    repoSettingsJSON: repoSettingsJSON,
+                    worktreePath: worktreePath,
+                    profileConfigDir: profileConfigDir
+                )
+            )
+            : nil
         let path = perSessionOverlayPath(sessionKey: sessionKey)
         do {
-            let data = try generateBody(fallbackModels: fallbackModels, extraSettings: extraSettings)
+            let data = try generateBody(
+                fallbackModels: fallbackModels,
+                extraSettings: extraSettings,
+                statusLineCommand: statusLineCommand
+            )
             let parent = (path as NSString).deletingLastPathComponent
             try FileManager.default.createDirectory(
                 atPath: parent,
@@ -416,36 +518,39 @@ public enum ClaudeHookOverlay {
     static let perSessionPrefix = "claude-overlay-session-"
     static let perSessionSuffix = ".json"
 
-    private static var runtimeDir: URL {
-        TBDConstants.configDir.appendingPathComponent("runtime")
-    }
+    private static var runtimeDir: URL { TBDConstants.runtimeDir }
 
     /// Filesystem-safe rendering of `sessionKey` (non-`[A-Za-z0-9_-]` → `_`).
+    /// Delegates to `TBDConstants` so overlay files and statusline captures
+    /// sanitize identically — two implementations is how a path builder and a
+    /// prune sweep drift apart.
     static func sanitize(_ sessionKey: String) -> String {
-        String(sessionKey.unicodeScalars.map { scalar -> Character in
-            let isSafe = scalar == "-" || scalar == "_"
-                || (scalar >= "0" && scalar <= "9")
-                || (scalar >= "a" && scalar <= "z")
-                || (scalar >= "A" && scalar <= "Z")
-            return isSafe ? Character(scalar) : "_"
-        })
+        TBDConstants.sanitizedSessionKey(sessionKey)
     }
 
-    /// Delete the per-session overlay file for `sessionKey`, if present.
+    /// Delete the per-session overlay file for `sessionKey`, if present, and
+    /// the statusline capture that rode with it.
     /// Best-effort — a missing file or removal error is ignored. Called on
     /// terminal teardown so per-session overlays don't accumulate under
     /// `~/tbd/runtime/`.
+    ///
+    /// The capture goes here rather than at each teardown call site for the
+    /// same reason the orphan prune exists: one place to remove a session's
+    /// runtime files means a new teardown path cannot forget half of them.
     static func removePerSessionOverlay(sessionKey: String) {
         let path = perSessionOverlayPath(sessionKey: sessionKey)
         try? FileManager.default.removeItem(atPath: path)
+        StatuslineTee.removeCapture(sessionKey: sessionKey)
     }
 
     /// Startup sweep: delete every `claude-overlay-session-*.json` file whose
     /// (sanitized) session key is NOT in `liveSessionKeys`. This reclaims
     /// per-session overlays orphaned by crashes, worktree archive, or any
     /// teardown path that didn't call `removePerSessionOverlay` — so cleanup
-    /// can't drift as new teardown paths are added. Best-effort.
+    /// can't drift as new teardown paths are added. Best-effort. Sweeps the
+    /// statusline captures in the same pass, on the same liveness rule.
     static func pruneOrphanedSessionOverlays(liveSessionKeys: [String]) {
+        StatuslineTee.pruneOrphanedCaptures(liveSessionKeys: liveSessionKeys)
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(atPath: runtimeDir.path) else {
             return

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -277,21 +277,34 @@ public actor HibernationCoordinator {
     }
 
     /// Park a session because its worktree's PR merged. Honors every safety rail
-    /// (including keep-warm, unlike `manualHibernate`) but NOT the idle window or
-    /// the idle-sweep master switch — see `HibernationGate.decideForMerge`.
+    /// (including keep-warm, unlike `manualHibernate`, and the pending-input
+    /// veto, exactly as the sweep does) but NOT the idle window or the
+    /// idle-sweep master switch — see `HibernationGate.decideForMerge`.
+    ///
+    /// `inputVetoEnabled` is `config.hibernateInputVetoEnabled`, passed in by
+    /// the caller rather than re-read here: `AutoHibernateOnMergeCoordinator`
+    /// already loaded the config snapshot that armed the fan-out, and arming
+    /// the veto from that same snapshot keeps the two decisions consistent and
+    /// adds no config read that could fail open per terminal.
     ///
     /// A daemon-internal rail: no RPC carried this, so it writes its own row
     /// with no `method` and the rail-named actor. `AutoHibernateOnMergeCoordinator`
     /// fans out over every terminal in the worktree and most are refused by the
     /// rails above, so — like the idle sweep — the row goes after the gate, at
     /// the moment this rail is actually about to act on a session.
-    public func hibernateForMerge(terminalID: UUID) async -> HibernateResult {
+    public func hibernateForMerge(
+        terminalID: UUID, inputVetoEnabled: Bool
+    ) async -> HibernateResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
         }
         guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
-        if let blocked = HibernationGate.blockingRail(terminal: terminal) {
-            return .notEligible(reason: Self.mergeBlockReason(blocked))
+        let decision = HibernationGate.decideForMerge(
+            terminal: terminal,
+            inputVetoEnabled: inputVetoEnabled,
+            lastInputAt: inputActivity.lastInput(paneID: terminal.tmuxPaneID))
+        guard decision == .eligible else {
+            return .notEligible(reason: Self.mergeBlockReason(decision))
         }
 
         // Fail-closed, as everywhere else: an unrecordable park does not
@@ -318,7 +331,9 @@ public actor HibernationCoordinator {
 
     /// The reason a merge-park was refused, for logging/telemetry. Mirrors
     /// `manualBlockReason` but maps every `blockingRail` case — including
-    /// keep-warm, which merge-park honors but manual bypasses.
+    /// keep-warm, which merge-park honors but manual bypasses — plus the
+    /// pending-input veto, whose wording matches the backup TUI scrape's so a
+    /// reader cannot tell which of the two rails fired and does not need to.
     private static func mergeBlockReason(_ decision: HibernationGate.Decision) -> String {
         switch decision {
         case .notClaudeResumable: return "Not a resumable Claude session"
@@ -327,7 +342,8 @@ public actor HibernationCoordinator {
         case .keepWarm: return "Terminal is pinned keep-warm"
         case .running: return "Session is actively running"
         case .waitingForUser: return "Session is waiting on a permission prompt"
-        case .eligible, .featureDisabled, .notIdleLongEnough, .pendingTypedInput: return "Not hibernatable"
+        case .pendingTypedInput: return "Terminal has unsent typed input"
+        case .eligible, .featureDisabled, .notIdleLongEnough: return "Not hibernatable"
         }
     }
 
@@ -670,13 +686,44 @@ public actor HibernationCoordinator {
             repo: repo?.envOverrides,
             profile: resolvedProfile?.envOverrides
         )
+        let profileConfigDir = configDirManager.resolveConfigDir(for: resolvedProfile)
         let overlayPath = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: resolvedProfile?.fallbackModels,
             sessionKey: terminal.id.uuidString,
             // Repo fragment is file-backed config, read fresh — reapplied on wake.
-            repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
+            repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id),
+            // A wake reuses the SAME terminal row and therefore the same
+            // statusline capture path, so a desk woken without the tee would
+            // otherwise keep reading a capture whose mtime predates the resume.
+            //
+            // The row's own `watch_desk_role` is what this site reads, and it
+            // is durable in the direction that matters: the desk spawn path
+            // stamps it at create, so a desk is recognizable here from its first
+            // instant and without a lease ever having existed. It is **not**
+            // durable in every direction — `WatchDeskLeaseStore.release` and
+            // `.revoke` NULL the column for the whole worktree, and a
+            // hibernated desk is exactly the state that makes
+            // `DeskSessionManager` revoke (its pane no longer runs an agent, so
+            // the lease owner reads as gone). Such a desk wakes without a tee
+            // and reports its window as unknown until a lease is reacquired.
+            //
+            // Demoting instead of NULLing would not fix that: `setRoles` brands
+            // every terminal in the worktree, so a surviving role would install
+            // the tee — which outranks the operator's own statusline in every
+            // scope they can write — in ordinary sessions that merely happen to
+            // sit in a desk's worktree. Reporting no denominator is the right
+            // side to be wrong on, and it is only safe because the staleness is
+            // closed independently: `ClaudeHookOverlay.resolveOverlayPath`
+            // deletes the session's capture whenever it resolves an overlay
+            // WITHOUT a tee, so a session that is not (re)installing one cannot
+            // read a capture from a previous life. An ordinary terminal has nil
+            // here and gets a byte-identical overlay.
+            watchDeskRole: terminal.watchDeskRole,
+            worktreePath: worktree.path,
+            // The same config dir the resume below runs with, so the tee
+            // delegates to the user-scope statusline THIS session reads.
+            profileConfigDir: profileConfigDir
         )
-        let profileConfigDir = configDirManager.resolveConfigDir(for: resolvedProfile)
         // Pre-accept Claude's folder-trust dialog so a wake onto a fresh
         // isolated profile dir (never seeded before) doesn't re-prompt — the
         // dialog blocks before SessionStart, so the stalled wake would be

--- a/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
@@ -108,8 +108,47 @@ public enum HibernationGate {
     ///
     /// It still honors every hard safety rail via `blockingRail` — including
     /// keep-warm, unlike `manualHibernate` — because this is system-initiated,
-    /// not an explicit user request.
-    public static func decideForMerge(terminal: Terminal) -> Decision {
-        blockingRail(terminal: terminal) ?? .eligible
+    /// not an explicit user request. And it honors the pending-input veto on
+    /// the same terms the sweep does: a merge is not a reason to eat a
+    /// half-composed prompt, and merge-park now runs on the daemon's clock with
+    /// no app in front of it, so nobody is watching when it does.
+    ///
+    /// - Parameters:
+    ///   - terminal: the candidate.
+    ///   - inputVetoEnabled: soak flag for the input-pipeline pending-input
+    ///     veto (`config.hibernateInputVetoEnabled`). Not defaulted: a park
+    ///     path that silently forgets to arm this rail is the exact defect this
+    ///     parameter exists to prevent.
+    ///   - lastInputAt: the timestamp of the last keystroke/paste routed to
+    ///     this terminal's pane (from `InputActivityTracker`) — the same fact
+    ///     the sweep passes. `nil` means no input was recorded for the pane.
+    public static func decideForMerge(
+        terminal: Terminal,
+        inputVetoEnabled: Bool,
+        lastInputAt: Date?
+    ) -> Decision {
+        if let blocked = blockingRail(terminal: terminal) { return blocked }
+        guard inputVetoEnabled, let lastInputAt else { return .eligible }
+        // The sweep compares `lastInputAt` against its own `idleSince` marker.
+        // Merge-park has no such marker to compare against: it does not run the
+        // idle window at all, and the sweep's in-memory `idleSince` is cleared
+        // on every pass while the idle sweep's master switch is off (its
+        // default since v50), so it would read `nil` on most installs.
+        //
+        // The persisted equivalent is `activityStateObservedAt`: the moment
+        // this terminal was OBSERVED to enter the at-rest state it is in now.
+        // Input recorded at or after that moment has not been through a turn —
+        // sending it would have moved the session to `.working` and back, and
+        // the return to `.idle` would have re-stamped the observation later —
+        // so it is still sitting unsent in the composer.
+        guard let atRestSince = terminal.activityStateObservedAt else {
+            // No observation to prove the recorded input was ever consumed.
+            // Fail closed: a session that survives an armed merge-park is
+            // recoverable, typed-but-unsent input that got eaten is not.
+            return .pendingTypedInput
+        }
+        // `>=`, matching the sweep: input at exactly the at-rest instant counts
+        // as arriving after it.
+        return lastInputAt >= atRestSince ? .pendingTypedInput : .eligible
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1202,7 +1202,14 @@ extension WorktreeLifecycle {
         primaryAgentPreference: PrimaryAgentPreference? = nil,
         claudeSettingsOverlay: String? = nil,
         carryover: ConversationCarryover? = nil,
-        preparedCodexLaunch: CodexLaunchPreparation? = nil
+        preparedCodexLaunch: CodexLaunchPreparation? = nil,
+        /// Non-nil when this spawn is a Watch Desk session, and the only thing
+        /// that installs the statusline tee (`StatuslineTee`). The desk spawn
+        /// path passes `.readOnlyCoordinator` — the role a desk terminal holds
+        /// until the lease store promotes one of them to `.judge` — because at
+        /// spawn time no lease has been acquired yet. Every other caller leaves
+        /// it nil and gets exactly the overlay it got before the tee existed.
+        watchDeskRole: WatchDeskRole? = nil
     ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
@@ -1399,7 +1406,13 @@ extension WorktreeLifecycle {
                     // an archived-session resume must not reapply it. Hooks
                     // overlay still resolves for resumes — only
                     // extraSettingsJSON goes nil.
-                    extraSettingsJSON: isResume ? nil : claudeSettingsOverlay
+                    extraSettingsJSON: isResume ? nil : claudeSettingsOverlay,
+                    // Desk sessions only — see the parameter's doc comment.
+                    watchDeskRole: watchDeskRole,
+                    worktreePath: worktreePath,
+                    // The same config dir this spawn runs with, so the tee
+                    // delegates to the user-scope statusline THIS session reads.
+                    profileConfigDir: profileConfigDir
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides,
@@ -1434,7 +1447,11 @@ extension WorktreeLifecycle {
             label: primaryLabel,
             claudeSessionID: primarySessionID,
             profileID: primaryProfileID,
-            kind: primaryTerminalKind
+            kind: primaryTerminalKind,
+            // Same value the overlay above was built from, written to the row
+            // so the fact outlives this call. A desk woken from hibernation
+            // reuses this row, and the wake site has nothing else to read.
+            watchDeskRole: watchDeskRole
         )
         if carryover != nil {
             SessionRecaptureScheduler(db: db, tmux: tmux).schedule(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -42,6 +42,21 @@ extension WorktreeLifecycle {
         let baseTip = tips["origin/\(repo.defaultBranch)"]
         await conflictSweepCache.retain(repoID: repoID, worktreeIDs: Set(worktrees.map(\.id)))
 
+        // §13's "commits unchanged across cycles" rides along on the map that
+        // was just resolved: the sweep already knows every branch tip, so
+        // remembering when each one first arrived costs one actor hop and no
+        // subprocess. A tip that keeps arriving unchanged keeps its original
+        // stamp. Deliberately no working-tree diff fact — answering that half
+        // would mean a `git status` per worktree per sweep, and an
+        // unestablished fact is reported as nil rather than as "unchanged".
+        let observedAt = now()
+        await branchTipTracker.retain(repoID: repoID, worktreeIDs: Set(worktrees.map(\.id)))
+        for wt in worktrees {
+            guard let branchTip = tips[wt.branch] else { continue }
+            await branchTipTracker.record(
+                repoID: repoID, worktreeID: wt.id, branchTip: branchTip, at: observedAt)
+        }
+
         await withTaskGroup(of: Void.self) { group in
             for wt in worktrees {
                 group.addTask {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -80,6 +80,11 @@ public struct WorktreeLifecycle: Sendable {
     /// Dirty gate for the periodic conflict sweep (see `refreshGitStatuses`).
     /// An actor reference, so every copy of this struct shares one cache.
     public let conflictSweepCache = ConflictSweepCache()
+    /// Since when each worktree's commits have stood still — §13's third
+    /// runaway input, filled from the branch tips `refreshGitStatuses` already
+    /// resolves for the gate above, at no extra subprocess cost. An actor
+    /// reference for the same reason `conflictSweepCache` is one.
+    public let branchTipTracker = BranchTipTracker()
     /// In-flight `preSession` runs, keyed by worktree ID. An actor reference,
     /// so every copy of this struct shares one registry (same rationale as
     /// `conflictSweepCache`).
@@ -129,6 +134,15 @@ public struct WorktreeLifecycle: Sendable {
         ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
     }
 
+    /// Date seam for stamps this type produces that are **persisted or
+    /// compared** — today, the observation instant the git sweep hands
+    /// `BranchTipTracker`, which is reported as `commitsUnchangedSince` and
+    /// compared against by whatever reads it. `Duration` is behavior and takes
+    /// a clock; `Date` is data and takes this. A bare `Date()` at the call site
+    /// would defeat the tracker's own seam and leave no way to pin the fact
+    /// end to end.
+    let now: @Sendable () -> Date
+
     public init(
         db: TBDDatabase,
         git: GitManager,
@@ -144,8 +158,10 @@ public struct WorktreeLifecycle: Sendable {
         reaperGraceAttempts: Int = 30,
         reaperPollInterval: Duration = .milliseconds(100),
         codexExecutableResolver: (@Sendable () throws -> String)? = nil,
-        codexHomeEnsurer: (@Sendable () throws -> URL)? = nil
+        codexHomeEnsurer: (@Sendable () throws -> URL)? = nil,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
+        self.now = now
         self.db = db
         self.git = git
         self.tmux = tmux

--- a/Sources/TBDDaemon/Mock/MockSeeder.swift
+++ b/Sources/TBDDaemon/Mock/MockSeeder.swift
@@ -174,7 +174,11 @@ public struct MockSeeder: Sendable {
             )
 
             if let state = tSeed.activityState {
-                try await db.terminals.setActivityState(id: terminal.id, activityState: state)
+                // Mock fixtures are composed by TBD, not observed from any
+                // machine interface — `.derived` is the honest source, and the
+                // seeded row carries it like every other.
+                try await db.terminals.setActivityState(
+                    id: terminal.id, activityState: state, source: .derived)
             }
 
             if let fixture = tSeed.transcriptFixture {

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -933,7 +933,15 @@ public actor DeskSessionManager: DeskSessionManaging {
                 repo: nil,
                 skipClaude: false,
                 initialPrompt: initialPrompt,
-                preSessionTerminalID: nil
+                preSessionTerminalID: nil,
+                // Marks the spawn as a desk session, which is what installs the
+                // statusline tee — a desk's context-recycling thresholds are
+                // fractions of its effective window, and the tee is the only
+                // source that reports one. Fleet sessions never get it: TBD's
+                // per-session settings outrank the operator's own statusline in
+                // every scope they can write. `.readOnlyCoordinator` is the role
+                // a desk terminal holds before any judge lease exists.
+                watchDeskRole: .readOnlyCoordinator
             )
         } catch {
             await actuationLog.appendOutcome(

--- a/Sources/TBDDaemon/PR/AutoHibernateOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoHibernateOnMergeCoordinator.swift
@@ -42,7 +42,13 @@ public struct AutoHibernateOnMergeCoordinator: Sendable {
             let terminals = try await db.terminals.list(worktreeID: worktreeID)
             var parked = 0
             for terminal in terminals {
-                let result = await hibernation.hibernateForMerge(terminalID: terminal.id)
+                // The pending-input veto rides on the same config snapshot that
+                // armed this fan-out: merge-park kills a live session, and a
+                // merge is no more a reason to eat typed-but-unsent input than
+                // an idle timeout is.
+                let result = await hibernation.hibernateForMerge(
+                    terminalID: terminal.id,
+                    inputVetoEnabled: config.hibernateInputVetoEnabled)
                 switch result {
                 case .ok:
                     parked += 1

--- a/Sources/TBDDaemon/PR/PRPoller.swift
+++ b/Sources/TBDDaemon/PR/PRPoller.swift
@@ -1,0 +1,155 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "PRPoller")
+
+/// Owns the periodic pull-request fetch, on the daemon's own clock.
+///
+/// The problem it exists to solve: `PRStatusManager.fetchAll` used to run only
+/// inside the `pr.list` RPC handler, so PR facts were a side effect of an app
+/// being open and polling. They stopped overnight — which is when a fleet
+/// supervisor needs them most, and when the daemon is the only thing awake
+/// (fleet-supervision design §2, P1 gap 1).
+///
+/// It owns the timer and nothing else. The pass it drives is
+/// `RPCRouter.runPollPass`, which stays there because `pr.refresh` and the
+/// on-select path share its enumeration helpers (`pollWorkingDirectory`,
+/// `branchFacts`): an enumeration that drifted between the timer and a user
+/// gesture would let a worktree be polled under one candidate list and healed
+/// under another.
+///
+/// **This loop is the only periodic driver.** `pr.list` serves the snapshot
+/// this loop produced and never fetches. That matters beyond tidiness — the
+/// merged-PR transition is edge-triggered on a cache change, so whichever path
+/// updates the cache consumes the edge. A second periodic driver would race for
+/// it, and the loser's consumers (auto-archive, auto-hibernate-on-merge) would
+/// silently never fire.
+///
+/// The edge itself is not owned here. It has one owner and always did:
+/// `PRStatusManager.apply`, the single funnel every cache write goes through —
+/// including the user-gesture `pr.refresh` path, which is aperiodic and so
+/// races nothing. This type only owns the timer that calls into that funnel.
+public actor PRPoller {
+    /// One poll pass. Throws only on the DB enumeration failure `pr.list` used
+    /// to surface to the app; forge failures are recorded as `.undetermined`
+    /// observations inside the pass and never throw.
+    typealias Pass = @Sendable () async throws -> Void
+
+    /// The pass this timer drives — `RPCRouter.runPollPass`, installed at the
+    /// end of the router's `init` (see `installPass`). Defaults to a no-op so a
+    /// poller with nothing wired to it is inert rather than half-working.
+    ///
+    /// `nonisolated(unsafe)` for the same reason the router's own
+    /// post-construction wiring (`mergeTrigger`, `orphanGC`, …) is: it is
+    /// written exactly once, synchronously, inside the initializer of the object
+    /// that owns this poller — before `start()` exists to read it and before any
+    /// caller can hold a reference to tick it.
+    private nonisolated(unsafe) var pass: Pass = {}
+    /// Effective app-foreground gate, shared with the periodic git tasks.
+    /// Wired post-construction by `Daemon.start()` (the router is built before
+    /// the gate exists), defaulting to "no app" — a daemon nobody is watching
+    /// should idle at the background cadence, which is also the honest starting
+    /// assumption for a freshly-started daemon.
+    private var isForeground: @Sendable () async -> Bool
+    /// How long the gated sleep waits between re-evaluations of the interval.
+    /// Injectable so a test crosses a production-sized cadence in two or three
+    /// clock advances rather than thirty (`Tests/CLAUDE.md`, "keep advance
+    /// chains short"); production never passes it.
+    private let pollTick: Duration
+    /// Delay seam (`Tests/CLAUDE.md`, "Clock and date seams"). Existential, and
+    /// last, per the repo rule; the loop is pure `Duration` accumulation.
+    private let clock: any Clock<Duration>
+
+    private var loopTask: Task<Void, Never>?
+
+    init(
+        isForeground: @escaping @Sendable () async -> Bool = { false },
+        pollTick: Duration = GitPollCadence.pollTick,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.isForeground = isForeground
+        self.pollTick = pollTick
+        self.clock = clock
+    }
+
+    // MARK: - The loop
+
+    /// Install the pass this timer drives. Called once, from the end of
+    /// `RPCRouter.init` — the closure needs a fully formed router, which does
+    /// not exist while its own stored properties are still being assigned.
+    ///
+    /// `nonisolated` so that construction site can call it without an `await` it
+    /// has no way to perform. Synchronous on purpose: hopping through a `Task`
+    /// would let a caller that constructs a router and immediately ticks its
+    /// poller observe the no-op default.
+    nonisolated func installPass(_ pass: @escaping Pass) {
+        self.pass = pass
+    }
+
+    /// Install the effective-foreground gate. MUST be called before `start()`
+    /// so the first wait is already paced by a real answer.
+    func setForegroundGate(_ gate: @escaping @Sendable () async -> Bool) {
+        self.isForeground = gate
+    }
+
+    /// Start the periodic fetch. Idempotent — a second call is a no-op while a
+    /// loop is already running.
+    func start() {
+        guard loopTask == nil else { return }
+        let clock = self.clock
+        let waitStep = self.pollTick
+        // Captured strongly, not weakly: a `weak self` is an implicitly mutable
+        // binding, which the nested `@Sendable` interval closure cannot capture.
+        // The resulting retain cycle is broken by `stop()` (called from
+        // `Daemon.stop()`), and the poller is owned by the router for the whole
+        // process lifetime regardless.
+        loopTask = Task { [self] in
+            while !Task.isCancelled {
+                await Daemon.sleepThroughGatedInterval(
+                    { await currentInterval() }, tick: waitStep, clock: clock)
+                guard !Task.isCancelled else { break }
+                await tick()
+            }
+        }
+    }
+
+    func stop() {
+        loopTask?.cancel()
+        loopTask = nil
+    }
+
+    /// The interval to wait next, re-evaluated on every tick of the gated sleep
+    /// so a foreground transition (or the app disappearing) changes the cadence
+    /// within one tick.
+    private func currentInterval() async -> Duration {
+        GitPollCadence.prInterval(isForeground: await isForeground())
+    }
+
+    /// One pass of the loop.
+    ///
+    /// Swallows the enumeration failure `fetchOnce` throws: a tick is one of
+    /// many, and the next one is already scheduled, so a transient DB error
+    /// should cost a pass rather than tear down the loop.
+    func tick() async {
+        do {
+            try await fetchOnce()
+        } catch {
+            // `.private`: the only thing that throws here is the DB
+            // enumeration, and a GRDB error carries the failing SQL — which
+            // names columns, and can carry argument values with it.
+            logger.warning("PR poll skipped: \(error, privacy: .private)")
+        }
+    }
+
+    // MARK: - The shared pass
+
+    /// Drive one poll pass.
+    ///
+    /// Throws only on the DB enumeration failure inside the pass, which the
+    /// timer logs before waiting for the next tick. Forge failures never throw —
+    /// they are recorded as `.undetermined` observations inside `fetchAll`.
+    func fetchOnce() async throws {
+        try await pass()
+    }
+}

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -4,6 +4,35 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "PRStatusManager")
 
+/// Why an attempt to learn a worktree's PR state produced no answer.
+///
+/// Deliberately a small closed vocabulary of *failure classes*, never the
+/// underlying tool's message: these strings reach a tooltip, and a forge error
+/// routinely names a host, an organization, a repository, or an account. A
+/// class says what went wrong without carrying any of that.
+enum PRUndeterminedCause {
+    /// No forge CLI could be launched at all.
+    static let cliUnavailable = "the forge CLI was unavailable"
+    /// The CLI ran but the query did not produce an answer for this worktree.
+    static let queryFailed = "the forge query failed"
+    /// An answer came back in a shape this build could not read.
+    static let unparseableResponse = "the forge response did not parse"
+    /// Every branch this worktree is known by came back without a pull
+    /// request, yet a pull request is already cached for it — so the cached one
+    /// lives on a branch the query could not name (a fork head, a rename-push)
+    /// and this attempt settles nothing. Not `.none`: the branch list is a
+    /// guess at where to look, and its silence is not the forge saying "there
+    /// is no pull request here".
+    static let branchQueryFoundNothing = "no pull request was found on any branch this worktree is known by"
+    /// The pull request resolved, but its check state could not be read, so the
+    /// value on hand was kept rather than recomputed from partial data.
+    static let checkQueryFailed = "the forge check query failed"
+    /// A recorded outcome was on the row but could not be read back — a
+    /// truncated or malformed blob. Not the absence of a record: an attempt was
+    /// made, and only what it concluded is lost.
+    static let unreadableRecord = "the recorded outcome could not be read"
+}
+
 /// In-memory cache of GitHub PR status per worktree.
 ///
 /// `fetchAll` runs one batch GraphQL call for all viewer PRs, plus one combined per-PR
@@ -12,6 +41,14 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "PRStatusMana
 /// flag, and a pagination flag in a single round trip. `refresh` runs
 /// `gh pr view` plus the same combined call for OPEN PRs. On transient fetch failure,
 /// callers keep the previous cached status instead of guessing.
+///
+/// Two facts, not one. The cached `PRStatus` is the newest *value* anyone holds;
+/// the `PRObservation` beside it is the outcome of the last *attempt*. They
+/// disagree exactly when it matters: a failed fetch keeps the previous value
+/// (it remains the best anyone has) while recording `.undetermined`, so a reader
+/// gets a value from before, honestly labeled as not reconfirmed. And a worktree
+/// with no cached status is `.none` only when the forge actually answered —
+/// never because nobody could ask.
 public actor PRStatusManager {
 
     /// One worktree's poll inputs: its identity, the branch it owns, the branch
@@ -36,6 +73,12 @@ public actor PRStatusManager {
 
     private var cache: [UUID: PRStatus] = [:]
 
+    /// The outcome of the last attempt per worktree, kept beside `cache` rather
+    /// than inside it: an entry can exist here with no cache entry (the forge
+    /// answered "no PR"), and a cache entry can survive an attempt recorded
+    /// here as `.undetermined`.
+    private var observations: [UUID: PRObservation] = [:]
+
     /// TTL cache for `resolveNameWithOwner` so the periodic poll's by-number and
     /// open-PR queries don't spawn a `gh repo view` subprocess per call. Keyed by
     /// repoPath; ~15-min TTL (a checkout's owner/name effectively never changes).
@@ -58,6 +101,8 @@ public actor PRStatusManager {
     private var onMergedTransition: (@Sendable (UUID, Int) async -> Void)?
 
     private var onStatusPersist: (@Sendable (UUID, PRStatus?) async -> Void)?
+
+    private var onObservationPersist: (@Sendable (UUID, PRObservation?) async -> Void)?
 
     /// Worktrees whose cached PR head ref has been *attempted* in this daemon
     /// run (see the head-ref heal in `fetchAll`), whether or not the by-number
@@ -85,24 +130,84 @@ public actor PRStatusManager {
 
     private let ghRunner: GHRunner?
 
-    public init() {
+    /// Date seam for the observed-at this actor *stamps* on the facts it
+    /// records — `PRStatus.observedAt` and `PRObservation.observedAt`. Both are
+    /// persisted and later compared to age a cache, so they are data, and take
+    /// the `now:` seam rather than a `Clock` (`Duration` is behavior, `Date` is
+    /// data). This actor schedules nothing, so it has no clock at all.
+    private let now: @Sendable () -> Date
+
+    public init(now: @escaping @Sendable () -> Date = { Date() }) {
         self.ghRunner = nil
+        self.now = now
     }
 
-    init(ghRunner: @escaping GHRunner) {
+    init(ghRunner: @escaping GHRunner, now: @escaping @Sendable () -> Date = { Date() }) {
         self.ghRunner = ghRunner
+        self.now = now
     }
 
     // MARK: - Public interface
 
     public func allStatuses() -> [UUID: PRStatus] { cache }
 
-    public func invalidate(worktreeID: UUID) {
+    /// The outcome of the last attempt per worktree. A missing key means no
+    /// attempt is on record — a third thing again from `.none` or
+    /// `.undetermined`, and one no caller may fold into either.
+    public func allObservations() -> [UUID: PRObservation] { observations }
+
+    public func observation(for worktreeID: UUID) -> PRObservation? { observations[worktreeID] }
+
+    public func invalidate(worktreeID: UUID) async {
+        // FIRST, and above every `await` below. This actor's suspensions are
+        // reentrancy points: an in-flight `fetchAll` resumes inside one of the
+        // persist callbacks, reads `directRefreshLanded == false`, and rewrites
+        // both the cache entry and the row — resurrecting exactly what this call
+        // is removing. Stamping before anything suspends is what makes the
+        // invalidation hold.
+        lastDirectUpdate[worktreeID] = now()
         cache.removeValue(forKey: worktreeID)
-        lastDirectUpdate[worktreeID] = Date()   // an in-flight fetchAll must not resurrect the entry
+        await onStatusPersist?(worktreeID, nil)
+        // The value is gone, so any outcome recorded for it describes a value
+        // that no longer exists. Drop it — in memory **and** on disk, because
+        // `hydrateObservations` reads that row back at the next daemon start
+        // and an in-memory-only drop would resurrect the very `.observed`
+        // pointing at nothing this line exists to remove.
+        observations.removeValue(forKey: worktreeID)
+        await onObservationPersist?(worktreeID, nil)
         // Whatever PR attaches next is a different attachment and deserves its
         // own head-ref check.
         headRefVerifiedIDs.remove(worktreeID)
+    }
+
+    /// Drop the recorded outcome of every worktree not in `active`, bounding
+    /// this actor's memory to the fleet that still exists.
+    ///
+    /// The persisted side of this fact is already scoped that way:
+    /// `allPRObservations` reads **unarchived** rows only, so the map a fresh
+    /// daemon hydrates holds active worktrees and nothing else. Without this
+    /// call the running daemon drifts away from that shape — an entry recorded
+    /// while a worktree was active outlives its archival for the life of the
+    /// process and rides in every `pr.list` payload — and only `invalidate`,
+    /// which has no production caller, ever removed one.
+    ///
+    /// **The cached statuses are deliberately left alone.** They are the
+    /// baseline the merged-PR edge is computed against, and `.merged` is never
+    /// persisted (see `apply`), so an in-memory entry is the *only* record that
+    /// a worktree's pull request was already seen merged. Dropping it would rest
+    /// the whole no-double-fire guarantee on the per-worktree disarm that
+    /// archive/revive writes. The map is bounded in practice anyway: an entry
+    /// exists only for a worktree that had a pull request, it is persisted and
+    /// re-hydrated unarchived-only at every restart, and it is a small value
+    /// per worktree. The outcome map has none of those excuses — it grows an
+    /// entry per worktree *considered*, PR or no PR.
+    ///
+    /// Nothing is written through to the DB: the row belongs to a worktree that
+    /// may be revived, and clearing it would destroy a fact this call is only
+    /// declining to hold in memory. `invalidate` is the caller that means
+    /// "forget it everywhere".
+    public func retain(active: Set<UUID>) {
+        observations = observations.filter { active.contains($0.key) }
     }
 
     /// Register a callback fired when a worktree's cached PR state transitions
@@ -118,6 +223,62 @@ public actor PRStatusManager {
     /// next daemon start.
     public func setOnStatusPersist(_ cb: @escaping @Sendable (UUID, PRStatus?) async -> Void) {
         self.onStatusPersist = cb
+    }
+
+    /// Register a callback fired whenever an attempt's outcome is recorded, so
+    /// the daemon can persist it to `worktree.prObservation`.
+    ///
+    /// A nil observation means the entry was dropped and the DB row must be
+    /// cleared too — exactly as `onStatusPersist`'s nil does. `invalidate` is
+    /// the one caller: without the nil case `hydrateObservations` would
+    /// resurrect an outcome describing a value that no longer exists, which is
+    /// the `.observed`-pointing-at-nothing that invalidation exists to prevent.
+    /// "No attempt on record" is still expressed by never having fired.
+    public func setOnObservationPersist(_ cb: @escaping @Sendable (UUID, PRObservation?) async -> Void) {
+        self.onObservationPersist = cb
+    }
+
+    /// Seed the observation map from persisted DB state at startup, so an
+    /// `.undetermined` recorded before a restart is not silently downgraded to
+    /// "no attempt on record". Writes directly, firing no persist callback.
+    public func hydrateObservations(_ observed: [UUID: PRObservation]) {
+        for (id, observation) in observed { observations[id] = observation }
+    }
+
+    /// Whether a forge CLI could be launched at all — the difference between
+    /// "asked and got nothing back" and "there was nobody to ask". An injected
+    /// runner counts as available: it is what stands in for the binary.
+    private var forgeCLIAvailable: Bool {
+        ghRunner != nil || Self.resolvedGHPath != nil
+    }
+
+    /// Record one attempt's outcome and persist it — unless a newer attempt is
+    /// already on record.
+    ///
+    /// **An attempt is an attempt whether or not it resolved.** `fetchAll`
+    /// stamps its outcomes with `batchStartedAt` and skips any worktree a
+    /// *successful* direct refresh touched mid-batch (`directRefreshLanded`),
+    /// but only the success path writes `lastDirectUpdate`. Without this guard a
+    /// batch that started at T0 would land its `.none` over a `pr.refresh` that
+    /// failed at T1 > T0: `observedAt` would move backwards, the "the last check
+    /// did not resolve" clause would vanish from the tooltip, and the freshness
+    /// label would report an age older than the most recent attempt.
+    ///
+    /// The value is deliberately left to its own rules — a batch that resolved a
+    /// pull request still applies it, because it is the newest value anyone
+    /// holds. Only the *outcome* is monotonic, which is exactly the split this
+    /// type's two facts are for.
+    ///
+    /// Equal stamps still write: two attempts on one instant are ordered by
+    /// call, not by clock resolution.
+    private func record(_ outcome: PRObservation.Outcome, for worktreeID: UUID, at observedAt: Date) async {
+        if let existing = observations[worktreeID], existing.observedAt > observedAt {
+            logger.debug("skipping an outcome for worktree \(worktreeID, privacy: .public): a newer attempt is already on record")
+            return
+        }
+        let observation = PRObservation(outcome: outcome, observedAt: observedAt)
+        observations[worktreeID] = observation
+        await onObservationPersist?(worktreeID, observation)
     }
 
     /// Seed the cache from persisted DB state at startup. Writes directly (not via
@@ -150,6 +311,21 @@ public actor PRStatusManager {
     /// merge-while-daemon-down recovery guarantee. Re-archive loops are still
     /// prevented because archived worktrees leave the active poll set and revive
     /// disarms the override.
+    ///
+    /// **The change that triggers a write is a change of *value*, never of
+    /// stamp.** `PRStatus` is `Equatable` including `observedAt`, which advances
+    /// on every poll, so writing on `previous != status` would write one SQLite
+    /// transaction per worktree per cadence forever — on a forty-worktree fleet
+    /// whose steady state is zero. `sameValue(as:)` is the comparison for this
+    /// job and says why on the type itself.
+    ///
+    /// The cache still takes the fresh stamp either way, so the freshness a
+    /// surface ages by is current in the answer `pr.list` returns. What lags is
+    /// only the *persisted* stamp, between a value change and the next one —
+    /// and only until the first poll after a restart re-reads the pull request
+    /// and refreshes it. `PRObservation` covers that window directly: it is
+    /// written on every attempt, it is the fact that says when TBD last looked,
+    /// and it hydrates at startup beside this one.
     private func apply(_ status: PRStatus, for worktreeID: UUID) async {
         let previous = cache[worktreeID]
         let wasMerged = (previous?.state == .merged)
@@ -157,7 +333,7 @@ public actor PRStatusManager {
         // Persist every non-terminal change so the PR icon survives restart, but
         // deliberately skip `.merged` (the auto-archive trigger) — see the doc
         // comment above for why persisting it would break #295's recovery.
-        if previous != status && status.state != .merged {
+        if previous?.sameValue(as: status) != true && status.state != .merged {
             await onStatusPersist?(worktreeID, status)
         }
         if !wasMerged && status.state == .merged {
@@ -230,6 +406,19 @@ public actor PRStatusManager {
     /// — also emits the PR it cleared in `disproved`, because clearing the cache
     /// alone is not enough: a binding written by an earlier pass's branch match
     /// is re-queried by number and neither heal can see it.
+    ///
+    /// Every worktree this pass *considered* also leaves with a recorded
+    /// `PRObservation` — `.observed`, `.none`, or `.undetermined(cause:)` — and
+    /// the three are never interchanged. The exception is a worktree a
+    /// user-initiated refresh touched mid-batch, whose own attempt is newer than
+    /// this one:
+    ///
+    /// - a refresh that **landed a value** is skipped outright by
+    ///   `directRefreshLanded`, so this pass leaves both its value and its
+    ///   outcome alone;
+    /// - a refresh that **failed** wrote no value to protect, so this pass may
+    ///   still apply its own — but `record` is monotonic, so the newer failure's
+    ///   outcome and stamp stand.
     @discardableResult
     public func fetchAll(worktrees: [PollWorktree]) async -> PollOutcome {
         var outcome = PollOutcome()
@@ -237,7 +426,11 @@ public actor PRStatusManager {
         guard !fetchAllInProgress else { return outcome }   // a previous poll is still running; skip to avoid interleaved generations
         fetchAllInProgress = true
         defer { fetchAllInProgress = false }
-        let batchStartedAt = Date()
+        let batchStartedAt = now()
+        // Outcomes accrue here and are recorded in one pass at the end, so the
+        // "every considered worktree gets exactly one observation" rule is
+        // visible in one place instead of spread across six early exits.
+        var outcomes: [UUID: PRObservation.Outcome] = [:]
         // Worktrees may span multiple repos. repoPath is only gh's working
         // directory for the viewer batch (gh auth is host-scoped, so any
         // checkout works); by-number lookups resolve each worktree's own repo.
@@ -273,6 +466,10 @@ public actor PRStatusManager {
         // fetch or parse failure it contributes no matches, but the numbered
         // path above has already resolved independently.
         var batchSucceeded = false
+        /// Which failure class the viewer batch hit, when it hit one. Retained
+        /// rather than collapsed to a Bool so an unnumbered worktree's
+        /// `.undetermined` names what actually went wrong.
+        var batchFailureCause = PRUndeterminedCause.queryFailed
         if !unnumbered.isEmpty {
             // Resolve each unnumbered worktree's own repo once, mirroring the
             // numbered path's `resolved` dictionary. TTL-cached, so the poll
@@ -324,7 +521,12 @@ public actor PRStatusManager {
                     matches += branchMatches
                 } else {
                     logger.warning("Failed to parse GraphQL response")
+                    batchFailureCause = PRUndeterminedCause.unparseableResponse
                 }
+            } else {
+                batchFailureCause = forgeCLIAvailable
+                    ? PRUndeterminedCause.queryFailed
+                    : PRUndeterminedCause.cliUnavailable
             }
         }
 
@@ -418,12 +620,17 @@ public actor PRStatusManager {
         for match in matches {
             // A user-initiated refresh (or invalidate) landed after this batch's snapshot —
             // its data is fresher than ours; don't clobber it.
-            if let direct = lastDirectUpdate[match.worktreeID], direct > batchStartedAt { continue }
+            if directRefreshLanded(match.worktreeID, after: batchStartedAt) { continue }
             let signals: (failing: Bool, pending: Bool)
             if let fetched = signalsByID[match.worktreeID] ?? nil {
                 signals = fetched
             } else if cache[match.worktreeID] != nil {
-                continue   // transient failure: keep the previous status rather than guessing
+                // Transient failure: keep the previous status rather than
+                // guessing — and say so. The value stands because it is still
+                // the newest anyone has; the outcome records that this attempt
+                // did not reconfirm it. Both halves, together, are the point.
+                outcomes[match.worktreeID] = .undetermined(cause: PRUndeterminedCause.checkQueryFailed)
+                continue
             } else {
                 signals = Self.aggregateFallbackSignals(match.node.statusCheckRollupState)
             }
@@ -436,8 +643,36 @@ public actor PRStatusManager {
                 requiredChecksPending: signals.pending
             )
             let status = PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason,
-                                  mergeQueuePosition: match.node.mergeQueuePosition)
+                                  mergeQueuePosition: match.node.mergeQueuePosition,
+                                  observedAt: batchStartedAt)
             await apply(status, for: match.worktreeID)
+            outcomes[match.worktreeID] = .observed
+        }
+
+        // Everything this pass considered but did not resolve. The split is the
+        // whole point of `PRObservation`, so it is stated rather than implied:
+        //
+        // - A NUMBERED worktree that did not resolve is always `.undetermined`.
+        //   It carries a PR number, so "this branch has no PR" is a conclusion
+        //   the evidence cannot support — only the lookup failing can explain it.
+        // - An UNNUMBERED worktree is `.none` only when the viewer batch
+        //   actually parsed. `batchSucceeded` is exactly the "the forge
+        //   answered" predicate the fallback and the head-ref heals already
+        //   gate on: with a failed batch, "unmatched" means nothing at all.
+        //
+        // Worktrees cleared by a head-ref heal land here unmatched and, on a
+        // succeeded batch, correctly read `.none`: the heal's evidence is that
+        // the PR belonged to a branch this worktree merely tracks, so this
+        // worktree has none of its own.
+        for wt in numbered where outcomes[wt.id] == nil && !directRefreshLanded(wt.id, after: batchStartedAt) {
+            outcomes[wt.id] = .undetermined(cause: PRUndeterminedCause.queryFailed)
+        }
+        for wt in unnumbered where outcomes[wt.id] == nil && !directRefreshLanded(wt.id, after: batchStartedAt) {
+            outcomes[wt.id] = batchSucceeded ? PRObservation.Outcome.none
+                                             : .undetermined(cause: batchFailureCause)
+        }
+        for (id, observedOutcome) in outcomes {
+            await record(observedOutcome, for: id, at: batchStartedAt)
         }
 
         // The branch-match emitter. Derived from the post-heal `matches`, so a
@@ -448,6 +683,14 @@ public actor PRStatusManager {
         outcome.discovered = Self.branchMatchedPRURLs(
             matches.filter { branchMatchedIDs.contains($0.worktreeID) })
         return outcome
+    }
+
+    /// Whether a user-initiated refresh (or an invalidate) touched this
+    /// worktree after `batchStartedAt`. Such an entry has a newer attempt of its
+    /// own, so this pass overwrites neither its value nor its outcome.
+    private func directRefreshLanded(_ worktreeID: UUID, after batchStartedAt: Date) -> Bool {
+        guard let direct = lastDirectUpdate[worktreeID] else { return false }
+        return direct > batchStartedAt
     }
 
     /// Render matched PR nodes as `ParsedPRURL`s for `PRBindingCoordinator`.
@@ -655,8 +898,15 @@ public actor PRStatusManager {
                 requiredChecksPending: signals.pending
             )
             observations[binding.id] = PRBindingObservation(
+                // Stamped, like every other freshly observed status: a binding's
+                // status reaches the sidebar dot and the toolbar help through
+                // `worktree.prStatus`, and a value with no `observedAt` renders
+                // as "last checked at an unknown time" there. The failure paths
+                // above deliberately do NOT re-stamp — they carry a previous
+                // value forward, and its stamp says when it was actually read.
                 status: PRStatus(number: node.number, url: node.url, state: state,
-                                 reason: reason, mergeQueuePosition: node.mergeQueuePosition),
+                                 reason: reason, mergeQueuePosition: node.mergeQueuePosition,
+                                 observedAt: now()),
                 headBranch: Self.refOrNil(node.headRefName),
                 baseRef: Self.refOrNil(node.baseRefName))
         }
@@ -708,20 +958,47 @@ public actor PRStatusManager {
             return await refreshByNumber(worktreeID: worktreeID, number: prNumber, repoPath: repoPath)
         }
         guard let ownerRepo = await cachedNameWithOwner(repoPath: repoPath) else {
-            return cache[worktreeID]   // can't resolve owner/name → leave cache unchanged
+            // Can't resolve owner/name → leave cache unchanged, and say the
+            // attempt settled nothing rather than letting the unchanged value
+            // pass for a fresh one.
+            await record(.undetermined(cause: PRUndeterminedCause.queryFailed),
+                         for: worktreeID, at: now())
+            return cache[worktreeID]
         }
         let candidates = Self.branchCandidates(localBranch: branch, upstreamBranch: upstreamBranch,
                                                defaultBranch: defaultBranch, pushBranch: pushBranch)
+        // "The forge answered, and this branch has no PR" and "we could not ask"
+        // both used to fall out of the same `continue`. They are tracked apart
+        // here so the outcome recorded at the end can tell them apart.
+        var failureCause: String?
         for candidate in candidates {
             let args = Self.prByBranchArgs(owner: ownerRepo.owner, name: ownerRepo.name, branch: candidate)
             let result = await runGHResult(args: args, repoPath: repoPath)
             guard let result,
                   result.exitStatus == 0,
-                  let data = Self.graphQLOutputData(stdout: result.stdout),
-                  let obj = try? Self.parsePRByBranch(from: data) else {
+                  let data = Self.graphQLOutputData(stdout: result.stdout) else {
                 let exit = result?.exitStatus ?? -1
                 let errSuffix = result?.stderr.trimmingCharacters(in: .whitespacesAndNewlines) ?? "gh not launched"
-                logger.debug("refresh: gh graphql failed or unparseable for branch \(candidate, privacy: .public) (exit \(exit, privacy: .public)): \(errSuffix, privacy: .public); trying next candidate")
+                logger.debug("refresh: gh graphql failed for branch \(candidate, privacy: .private) (exit \(exit, privacy: .public)): \(errSuffix, privacy: .public); trying next candidate")
+                failureCause = (result == nil && !forgeCLIAvailable)
+                    ? PRUndeterminedCause.cliUnavailable
+                    : PRUndeterminedCause.queryFailed
+                continue
+            }
+            // `try?` would flatten the throw and the nil into one optional —
+            // exactly the collapse this whole path exists to undo. A malformed
+            // response is ignorance; an empty node list is an answer.
+            let parsed: GHPRViewResult?
+            do {
+                parsed = try Self.parsePRByBranch(from: data)
+            } catch {
+                logger.debug("refresh: gh graphql response was unparseable for branch \(candidate, privacy: .private); trying next candidate")
+                failureCause = PRUndeterminedCause.unparseableResponse
+                continue
+            }
+            guard let obj = parsed else {
+                // A parsed, empty node list: the forge answered, and this
+                // branch has no PR. Not a failure — try the next candidate.
                 continue
             }
 
@@ -731,9 +1008,21 @@ public actor PRStatusManager {
                 isDraft: obj.isDraft, mergeQueuePosition: obj.mergeQueuePosition, repoPath: repoPath)
         }
 
-        // gh exited non-zero or parse failed for every candidate — leave cache unchanged.
+        // No candidate yielded a PR — leave the cache unchanged either way, but
+        // record which kind of "no" this was.
         logger.debug("refresh: no candidate branch yielded a PR for worktree \(worktreeID, privacy: .public); keeping cached status")
-        return cache[worktreeID]
+        let cached = cache[worktreeID]
+        if let failureCause {
+            await record(.undetermined(cause: failureCause), for: worktreeID, at: now())
+        } else if cached != nil {
+            // Every candidate answered "no PR", yet one is cached — so it lives
+            // on a branch this query could not name. Nothing was settled.
+            await record(.undetermined(cause: PRUndeterminedCause.branchQueryFoundNothing),
+                         for: worktreeID, at: now())
+        } else {
+            await record(.none, for: worktreeID, at: now())
+        }
+        return cached
     }
 
     /// Refresh a single worktree by its stored PR number — one aliased
@@ -743,6 +1032,8 @@ public actor PRStatusManager {
     /// untouched on any failure to resolve the number.
     private func refreshByNumber(worktreeID: UUID, number: Int, repoPath: String) async -> PRStatus? {
         guard let ownerRepo = await cachedNameWithOwner(repoPath: repoPath) else {
+            await record(.undetermined(cause: PRUndeterminedCause.queryFailed),
+                         for: worktreeID, at: now())
             return cache[worktreeID]
         }
         let query = Self.numberedPRQuery(aliases: [(alias: "pr0", number: number)])
@@ -755,6 +1046,10 @@ public actor PRStatusManager {
         guard let result = await runGHResult(args: args, repoPath: repoPath),
               let data = Self.graphQLOutputData(stdout: result.stdout) else {
             logger.debug("refresh: by-number query produced no data for PR #\(number, privacy: .public); keeping cached status")
+            await record(.undetermined(cause: forgeCLIAvailable
+                                        ? PRUndeterminedCause.queryFailed
+                                        : PRUndeterminedCause.cliUnavailable),
+                         for: worktreeID, at: now())
             return cache[worktreeID]
         }
         if result.exitStatus != 0 {
@@ -764,6 +1059,11 @@ public actor PRStatusManager {
         let matches = Self.parseNumberedPRNodes(from: data, aliases: [(alias: "pr0", worktreeID: worktreeID)])
         guard let node = matches.first?.node else {
             logger.debug("refresh: PR #\(number, privacy: .public) did not resolve by number; keeping cached status")
+            // A stored number that will not resolve — deleted, inaccessible, or
+            // a partial batch error — is ignorance, never "this worktree has no
+            // pull request": it demonstrably had one, by number.
+            await record(.undetermined(cause: PRUndeterminedCause.queryFailed),
+                         for: worktreeID, at: now())
             return cache[worktreeID]
         }
         return await applyRefreshedNode(
@@ -783,13 +1083,18 @@ public actor PRStatusManager {
         mergeStateStatus: String, reviewDecision: String, isDraft: Bool,
         mergeQueuePosition: Int?, repoPath: String
     ) async -> PRStatus {
+        let observedAt = now()
         let signals: (failing: Bool, pending: Bool)
         if state != "OPEN" {
             signals = (false, false)   // mapState ignores signals for MERGED/CLOSED
         } else if let fetched = await fetchCheckSignals(url: url, number: number, repoPath: repoPath) {
             signals = fetched
         } else if let cached = cache[worktreeID] {
-            return cached   // transient failure: keep the previous status rather than guessing
+            // Transient failure: keep the previous status rather than guessing,
+            // and record that this attempt did not reconfirm it.
+            await record(.undetermined(cause: PRUndeterminedCause.checkQueryFailed),
+                         for: worktreeID, at: observedAt)
+            return cached
         } else {
             signals = (false, false)   // bootstrap with no data; the next poll corrects it
         }
@@ -802,9 +1107,10 @@ public actor PRStatusManager {
             requiredChecksPending: signals.pending
         )
         let status = PRStatus(number: number, url: url, state: mappedState, reason: reason,
-                              mergeQueuePosition: mergeQueuePosition)
+                              mergeQueuePosition: mergeQueuePosition, observedAt: observedAt)
         await apply(status, for: worktreeID)
-        lastDirectUpdate[worktreeID] = Date()
+        await record(.observed, for: worktreeID, at: observedAt)
+        lastDirectUpdate[worktreeID] = observedAt
         return status
     }
 
@@ -812,6 +1118,18 @@ public actor PRStatusManager {
     /// merge-transition logic is exercised exactly as in production.
     public func seedForTesting(worktreeID: UUID, status: PRStatus) async {
         await apply(status, for: worktreeID)
+    }
+
+    /// For tests only: the exact predicate an in-flight `fetchAll` consults
+    /// before it overwrites an entry.
+    ///
+    /// Exposed rather than re-derived in the test, because the property worth
+    /// pinning is that `invalidate`'s stamp is visible **to this question** by
+    /// the time the first persist callback suspends it — and a test that
+    /// reimplemented the comparison could agree with itself while disagreeing
+    /// with `fetchAll`.
+    func directRefreshLandedForTesting(_ worktreeID: UUID, after batchStartedAt: Date) -> Bool {
+        directRefreshLanded(worktreeID, after: batchStartedAt)
     }
 
     // MARK: - State mapping (internal but static for testability)

--- a/Sources/TBDDaemon/Server/GitPollingPolicy.swift
+++ b/Sources/TBDDaemon/Server/GitPollingPolicy.swift
@@ -27,6 +27,20 @@ public enum GitPollCadence {
         isForeground ? .seconds(60) : .seconds(300)
     }
 
+    /// Pull-request poll interval: 30s foregrounded, 5min backgrounded.
+    ///
+    /// The foreground value matches what the app's own `pr.list` cadence
+    /// produced before the fetch moved onto the daemon's clock (one poll per 15
+    /// two-second cycles), so a user watching the sidebar sees no change. The
+    /// background value is slower than the status sweep's because each pass is
+    /// a network round trip against a rate-limited forge rather than a local
+    /// subprocess — and because nothing overnight needs a PR state fresher than
+    /// five minutes. As with every loop here it never stops: supervision runs
+    /// with no app at all.
+    public static func prInterval(isForeground: Bool) -> Duration {
+        isForeground ? .seconds(30) : .seconds(300)
+    }
+
     /// How often the timer loops wake to re-evaluate the gated interval.
     /// Short enough that a foreground transition (or the app disappearing)
     /// changes the effective cadence within ~10s instead of one full

--- a/Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift
@@ -33,6 +33,11 @@ extension RPCRouter {
             timestamp: Date(timeIntervalSince1970: TimeInterval(p.timestampMillis) / 1000)
         )
         await pendingQuestions.set(terminalID: p.terminalID, pending)
+        // §13's hook-event rate. Keyed on the claimed terminal ID rather than a
+        // resolved row: this is a count of hook traffic, and traffic naming a
+        // terminal that has since been deleted still happened. `retain` drops
+        // the bookkeeping when the terminal leaves the fleet.
+        await sessionCounters.recordHookEvent(terminalID: p.terminalID, at: now())
         askUserQuestionLog.debug("pending stored terminalID=\(p.terminalID.uuidString, privacy: .public) toolUseID=\(p.toolUseID, privacy: .public)")
 
         // Resolve the worktree this terminal belongs to. If the terminal row
@@ -79,6 +84,7 @@ extension RPCRouter {
     /// returns).
     func handleTerminalAskUserQuestionCleared(_ paramsData: Data) async throws -> RPCResponse {
         let p = try decoder.decode(TerminalAskUserQuestionClearedParams.self, from: paramsData)
+        await sessionCounters.recordHookEvent(terminalID: p.terminalID, at: now())
         askUserQuestionLog.debug("cleared received terminalID=\(p.terminalID.uuidString, privacy: .public) toolUseID=\(p.toolUseID, privacy: .public)")
 
         if let terminal = try? await db.terminals.get(id: p.terminalID) {

--- a/Sources/TBDDaemon/Server/RPCRouter+SessionStateHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SessionStateHandlers.swift
@@ -1,0 +1,224 @@
+import Foundation
+import os
+import TBDShared
+
+private let sessionStateLog = Logger(subsystem: "com.tbd.daemon", category: "sessionState")
+
+// MARK: - Gathering the facts
+
+/// Reads the per-terminal machine facts `SessionStateResolver` composes, and
+/// the session's context load.
+///
+/// Separated from the handler so the whole fact-gathering pass is a value with
+/// injectable seams — and so the cost model is legible in one place. Per
+/// terminal it performs **at most two byte-bounded file reads** (the transcript
+/// tail, once for the rate-limit classification and once inside
+/// `ContextLoadReader`, plus the statusline capture when one exists) and
+/// **zero** subprocesses, tmux calls, pane reads and model calls. That is the
+/// property that lets the whole fleet be asked about every cycle.
+/// Not `Sendable`, and it does not need to be: one gatherer is built inside a
+/// single `session.states` pass and never crosses an isolation boundary.
+struct SessionStateFactGatherer {
+    /// The same 64 KiB window `DeliveryVerifier` and `ContextLoadReader` tail
+    /// with. A rate-limit record sits at the very end of a transcript when it
+    /// is the current state, so a tail is where it is or it is not current.
+    static let defaultTailWindowBytes = 64 * 1024
+
+    var tailWindowBytes: Int = SessionStateFactGatherer.defaultTailWindowBytes
+    var contextLoadReader = ContextLoadReader()
+    var now: @Sendable () -> Date = { Date() }
+    /// Resolves a session's statusline capture path. Injected so a test can
+    /// point it at a temp dir without reaching for `TBD_HOME`.
+    var capturePath: @Sendable (String) -> String = { StatuslineTee.capturePath(sessionKey: $0) }
+
+    /// Written out rather than left memberwise so the injected date seam
+    /// reaches the collaborator that has one of its own.
+    ///
+    /// `ContextLoadReader` carries a `now` because it needs a fallback stamp
+    /// for a transcript record that arrives with no parseable `timestamp`.
+    /// A memberwise `init(now:)` left that reader on its own default — wall
+    /// time — so a caller who pinned this type's clock still got `Date()` in
+    /// that one field. A reader passed in explicitly keeps whatever seam its
+    /// caller gave it; only the default one is threaded.
+    init(
+        tailWindowBytes: Int = SessionStateFactGatherer.defaultTailWindowBytes,
+        contextLoadReader: ContextLoadReader? = nil,
+        now: @escaping @Sendable () -> Date = { Date() },
+        capturePath: @escaping @Sendable (String) -> String = {
+            StatuslineTee.capturePath(sessionKey: $0)
+        }
+    ) {
+        self.tailWindowBytes = tailWindowBytes
+        self.contextLoadReader = contextLoadReader ?? ContextLoadReader(now: now)
+        self.now = now
+        self.capturePath = capturePath
+    }
+
+    func facts(for terminal: Terminal) -> SessionStateFacts {
+        // One tail read serves both transcript-derived facts: the rate-limit
+        // classification and the append stamp the resolver's staleness rule
+        // compares against. Reading twice would double the cost of the pass and
+        // let the two facts describe different moments of the same file.
+        let tail = transcriptTail(for: terminal)
+        return SessionStateFacts(
+            terminal: terminal,
+            transcriptRateLimit: transcriptRateLimit(tail),
+            transcriptLastAppendedAt: tail?.lastAppendedAt.map {
+                ObservedFact(value: $0, source: .transcriptTail, observedAt: tail?.readAt ?? now())
+            },
+            // Deliberately nil: nothing on this path establishes pane or
+            // process liveness, and this path does not go and find out. See
+            // `SessionStateResolver`'s note on `.gone`.
+            liveness: nil)
+    }
+
+    func contextLoad(for terminal: Terminal) -> ContextLoad {
+        contextLoadReader.read(
+            capturePath: capturePath(terminal.id.uuidString),
+            transcriptPath: terminal.transcriptPath,
+            tee: teeStatus(for: terminal))
+    }
+
+    /// The desk role brands the ROW; the tee installs on the Claude spawn path
+    /// only. `spawnPrimaryTerminals` resolves the primary agent from
+    /// `primaryAgentPreference`, so a desk created on a Codex-preferring install
+    /// gets a `.codex` row wearing a desk role and no tee — and reporting "the
+    /// tee is installed but has not fired yet" for it would be a false statement
+    /// about a session that will never produce a capture.
+    private func teeStatus(for terminal: Terminal) -> ContextLoadReader.TeeStatus {
+        guard terminal.watchDeskRole != nil else { return .notADesk }
+        return terminal.kind == .claude ? .installed : .deskWithoutTee
+    }
+
+    /// One bounded read of a session's transcript tail, and the two things the
+    /// pass learns from it.
+    private struct TranscriptTail {
+        let data: Data
+        /// The file's modification time — when it last grew — taken from the
+        /// same open descriptor as `data`, so the stamp and the bytes describe
+        /// one file rather than two. nil when `fstat` refused.
+        let lastAppendedAt: Date?
+        /// When TBD read it.
+        let readAt: Date
+    }
+
+    /// Classify the transcript tail with `RateLimitDetection` — the existing
+    /// classifier the CLI's StopFailure hook and `LimitResumeActuator` already
+    /// share. There is deliberately no second implementation of "is this a hard
+    /// limit": a supervision surface disagreeing with the actuator about
+    /// whether a session is rate-limited would be worse than not reporting it.
+    private func transcriptRateLimit(
+        _ tail: TranscriptTail?
+    ) -> SessionStateFacts.TranscriptRateLimit? {
+        guard let tail else { return nil }
+        guard let limit = RateLimitDetection.detect(transcriptData: tail.data, now: tail.readAt) else {
+            return nil
+        }
+        return SessionStateFacts.TranscriptRateLimit(limit: limit, observedAt: tail.readAt)
+    }
+
+    /// Byte-bounded tail read, the shape `DeliveryVerifier.transcriptTail` and
+    /// `ContextLoadReader.readTail` both use. Unreadable answers nil rather than
+    /// empty: "could not read" and "read nothing" are different facts.
+    private func transcriptTail(for terminal: Terminal) -> TranscriptTail? {
+        guard let path = terminal.transcriptPath, !path.isEmpty,
+              let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        guard let size = try? handle.seekToEnd() else { return nil }
+        let window = UInt64(max(tailWindowBytes, 0))
+        do {
+            try handle.seek(toOffset: size > window ? size - window : 0)
+            let data = try handle.readToEnd() ?? Data()
+            return TranscriptTail(
+                data: data, lastAppendedAt: handle.modificationDate(), readAt: now())
+        } catch {
+            return nil
+        }
+    }
+}
+
+// MARK: - The handler
+
+extension RPCRouter {
+    /// `session.states` — one `SessionStateReport` per terminal: the composed
+    /// state triple, the context load, and §13's counters.
+    ///
+    /// **There is deliberately no CLI twin for this method.** §10 of the
+    /// fleet-supervision design is normative for the `tbd supervise` namespace
+    /// and reserves `tbd supervise readout` for the sweep-program slice, which
+    /// owns what a readout contains and how it is shaped for a reader. Adding a
+    /// command here would either squat on that name or invent a second one for
+    /// the same job. The machine surface is this RPC; the human surface arrives
+    /// with the program that needs it.
+    ///
+    /// The pass is built to be called every cycle for the whole fleet: per
+    /// terminal it costs database reads plus bounded file tails, and no
+    /// subprocess, tmux call, pane read or model call. Keep it that way — the
+    /// moment anything here shells out, the method stops being askable at fleet
+    /// cadence and the supervision loop loses the facts it runs on.
+    func handleSessionStates(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SessionStatesParams.self, from: paramsData)
+        // Agent-bearing kinds only. A plain shell has no transcript, no context
+        // window and no hook rail, so a `SessionStateReport` about one would
+        // spend a stat and a transcript-tail attempt every cycle to explain why
+        // a session that never had a statusline tee has no denominator. A nil
+        // kind is a pre-`kind` row, which in practice is an agent terminal —
+        // included, because dropping a real agent from the fleet's readout is
+        // the worse error of the two.
+        let terminals = try await db.terminals.list(worktreeID: params.worktreeID)
+            .filter { $0.kind?.isAgentBearing ?? true }
+        let sampledAt = now()
+
+        let resolver = SessionStateResolver(now: now)
+        let gatherer = SessionStateFactGatherer(now: now)
+
+        // One worktree lookup per distinct worktree, not per terminal: several
+        // terminals commonly share one, and the only field needed is `repoID`.
+        var repoIDByWorktree: [UUID: UUID?] = [:]
+        var reports: [SessionStateReport] = []
+        reports.reserveCapacity(terminals.count)
+
+        for terminal in terminals {
+            let state = resolver.resolve(gatherer.facts(for: terminal))
+            let contextLoad = gatherer.contextLoad(for: terminal)
+
+            if !repoIDByWorktree.keys.contains(terminal.worktreeID) {
+                repoIDByWorktree[terminal.worktreeID] =
+                    (try? await db.worktrees.get(id: terminal.worktreeID))?.repoID
+            }
+            let commitsUnchangedSince: Date?
+            if let repoID = repoIDByWorktree[terminal.worktreeID] ?? nil {
+                commitsUnchangedSince = await lifecycle.branchTipTracker.unchangedSince(
+                    repoID: repoID, worktreeID: terminal.worktreeID)
+            } else {
+                // No repo (a scratch space), or the worktree row is gone. The
+                // sweep never resolved a tip for it, so the fact is not
+                // established — nil, never "unchanged".
+                commitsUnchangedSince = nil
+            }
+
+            let counters = await sessionCounters.sample(
+                terminalID: terminal.id,
+                worktreeID: terminal.worktreeID,
+                transcriptPath: terminal.transcriptPath,
+                commitsUnchangedSince: commitsUnchangedSince,
+                at: sampledAt)
+
+            reports.append(SessionStateReport(
+                terminalID: terminal.id,
+                worktreeID: terminal.worktreeID,
+                state: state,
+                contextLoad: contextLoad,
+                counters: counters))
+        }
+
+        // Scoped to whatever `terminals` was filtered by: a call about one
+        // worktree has not seen the rest of the fleet and may not prune it.
+        await sessionCounters.retain(
+            terminalIDs: Set(terminals.map(\.id)), inWorktree: params.worktreeID)
+
+        sessionStateLog.debug(
+            "session.states: reported \(reports.count, privacy: .public) terminal(s)")
+        return try RPCResponse(result: SessionStatesResult(reports: reports))
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1047,8 +1047,18 @@ extension RPCRouter {
                     windowID: window.windowID,
                     paneID: window.paneID
                 )
+                // TBD just recreated the window, so nothing has yet been
+                // observed about what runs in it: `.derived` from our own act.
+                //
+                // `observedAt` from the router's date seam, never the store's
+                // default `Date()`. This stamp is *compared*, not just stored:
+                // `SessionStateResolver`'s rung 4 orders it against the
+                // awaiting-input stamp to decide which observation is newer, so
+                // a stamp minted inside the store is one a test cannot pin and
+                // therefore a decision a test cannot pin either.
                 try await db.terminals.setActivityState(
-                    id: params.terminalID, activityState: .unknown)
+                    id: params.terminalID, activityState: .unknown, source: .derived,
+                    observedAt: now())
                 return try await db.terminals.get(id: params.terminalID)
             }
 
@@ -1464,6 +1474,15 @@ extension RPCRouter {
         // In-place respawn keeps the EXISTING terminal id so its `TBD_TERMINAL_ID`
         // (and thus SessionStart-hook routing) stays stable; fork uses a fresh id.
         let plannedTerminalID = mode == .inPlace ? oldTerminal.id : UUID()
+        // The desk role of the row this spawn will actually land on. An in-place
+        // swap keeps the row, and nothing in this handler touches
+        // `watch_desk_role`, so a resolve without the role would leave a row that
+        // still claims to be a desk running with no statusline tee — and, because
+        // a roleless resolve deletes the session's capture, with no denominator
+        // either. A fork creates a fresh row that is branded no desk (see
+        // `forkSwapNewTab`), so it must resolve without one or the overlay and
+        // the row would disagree in the other direction.
+        let swapDeskRole: WatchDeskRole? = mode == .inPlace ? oldTerminal.watchDeskRole : nil
         let swapConfig = try? await db.config.get()
         var env = SystemPromptBuilder.promptLayers(
             repo: repo, worktree: worktree.worktree, scratchInstructions: swapConfig?.scratchInstructions,
@@ -1586,7 +1605,10 @@ extension RPCRouter {
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolved?.fallbackModels,
                     sessionKey: plannedTerminalID.uuidString,
-                    repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
+                    repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id),
+                    watchDeskRole: swapDeskRole,
+                    worktreePath: worktree.path,
+                    profileConfigDir: configDirManager.resolveConfigDir(for: resolved)
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides,
@@ -1617,7 +1639,10 @@ extension RPCRouter {
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolved?.fallbackModels,
                     sessionKey: plannedTerminalID.uuidString,
-                    repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
+                    repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id),
+                    watchDeskRole: swapDeskRole,
+                    worktreePath: worktree.path,
+                    profileConfigDir: configDirManager.resolveConfigDir(for: resolved)
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides,
@@ -1781,6 +1806,16 @@ extension RPCRouter {
         //    later respawn failure still leaves the row on the new account.
         try await db.terminals.setProfileID(id: oldTerminal.id, profileID: newProfileID)
         try await db.terminals.updateSessionID(id: oldTerminal.id, sessionID: storedSessionID)
+        // Step 1 killed the process any recorded prompt was raised on, and this
+        // row survives the swap — so a `permission_prompt` standing here now
+        // describes a dead pane. `SessionStateResolver`'s rung 4 would keep
+        // reporting it as a live wait: `transcriptPath` is unchanged and its
+        // mtime still predates the reason, so the "prompt stands" branch holds
+        // until some later hook happens to write an activity state. Retract it
+        // from TBD's own act rather than waiting for the respawned session's
+        // hooks to arrive — they may be seconds away, or lost to a stale `tbd`
+        // on the pane's PATH.
+        try await db.terminals.clearAwaitingInputReason(id: oldTerminal.id)
 
         // 3. Respawn IN PLACE — same window id / pane id → the tab and terminal
         //    row survive.
@@ -2671,6 +2706,70 @@ extension RPCRouter {
             .appendingPathComponent("projects", isDirectory: true)
     }
 
+    /// Worktree-ownership guard shared by every hook bridge that routes on
+    /// `TBD_TERMINAL_ID`.
+    ///
+    /// That variable is injected at terminal creation and INHERITED by every
+    /// descendant process — including multi-agent teammates and subprocesses
+    /// that run their own Claude session and fire their own hooks. Routing
+    /// solely by it lets such a foreign session write to a terminal that is not
+    /// its own. Defend by requiring the hook's reported `cwd` to resolve to the
+    /// SAME worktree as the target terminal. A mismatch means the event came
+    /// from a foreign session living in a different worktree — the caller
+    /// rejects it (soft success; hooks are fire-and-forget).
+    ///
+    /// Self-heal: the guard ACCEPTS the legitimate session's events even when
+    /// the terminal's stored pointer is currently foreign, so a hijacked
+    /// terminal recovers on its next valid event (e.g. resume/clear).
+    ///
+    /// One guard, one behavior: every hook bridge gets the same answer,
+    /// including the promoted-scratch acceptance, rather than a per-handler
+    /// variant that drifts.
+    func hookCWDBelongsToTerminal(
+        _ cwd: String,
+        terminal: Terminal,
+        event: String
+    ) async throws -> Bool {
+        let resolved = try await resolvePathToRepoOrWorktree(cwd)
+        var accepted = resolved?.worktreeID == terminal.worktreeID
+        // Promotion follow-up: when the terminal's worktree is a promoted
+        // scratch row (promotedToRepoID set), its live session now runs in
+        // the moved folder — whose path resolves to the NEW repo's main
+        // worktree, not the scratch row. That's the same session, not a
+        // foreign one: accept when the cwd resolves to the main worktree
+        // of the promoted-to repo.
+        if !accepted,
+           let resolvedWorktreeID = resolved?.worktreeID,
+           let ownerWorktree = try await db.worktrees.getLocal(id: terminal.worktreeID),
+           let promotedRepoID = ownerWorktree.promotedToRepoID,
+           let resolvedWorktree = try await db.worktrees.getLocal(id: resolvedWorktreeID),
+           resolvedWorktree.repoID == promotedRepoID,
+           resolvedWorktree.status == .main {
+            accepted = true
+            logger.info("\(event, privacy: .public): accepted post-promote session for terminal \(terminal.id.uuidString, privacy: .public) — cwd resolves to main worktree of promoted repo \(promotedRepoID.uuidString, privacy: .public)")
+        }
+        if !accepted {
+            // The cwd is the one interpolation here that is not TBD's own
+            // vocabulary: it is a real checkout path, and in this product those
+            // routinely carry an employer, a client or a repository name. Every
+            // agent hook reaches this guard, so a `.public` cwd would write that
+            // into the system log on an ordinary cadence. The identifiers stay
+            // public — they are what the line is for.
+            logger.info(
+                """
+                \(event, privacy: .public): REJECTED foreign session for terminal \
+                \(terminal.id.uuidString, privacy: .public) — hook cwd \
+                \(cwd, privacy: .private) resolves to worktree \
+                \(resolved?.worktreeID?.uuidString ?? "none", privacy: .public) \
+                but terminal belongs to worktree \
+                \(terminal.worktreeID.uuidString, privacy: .public); \
+                event ignored
+                """
+            )
+        }
+        return accepted
+    }
+
     /// Bridge for the Claude SessionStart hook. The CLI relays the hook
     /// payload (session_id, transcript_path, source) plus the spawn-time
     /// `TBD_TERMINAL_ID` env to this method. We persist both fields and
@@ -2686,56 +2785,13 @@ extension RPCRouter {
             logger.debug("sessionEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
             return .ok()
         }
+        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
 
-        // Worktree-ownership guard: `TBD_TERMINAL_ID` is injected at terminal
-        // creation and INHERITED by every descendant process — including
-        // multi-agent teammates and subprocesses that run their own Claude
-        // session and fire their own SessionStart hook. Routing solely by
-        // `TBD_TERMINAL_ID` lets such a foreign session hijack the terminal's
-        // `claudeSessionID`, so the transcript pane shows the wrong
-        // conversation. Defend by requiring the hook's reported `cwd` to
-        // resolve to the SAME worktree as the target terminal. A mismatch
-        // means the event came from a foreign session living in a different
-        // worktree — reject it (soft success; the hook is fire-and-forget).
-        //
-        // Self-heal: the guard ACCEPTS the legitimate session's events even
-        // when the stored pointer is currently foreign, so a hijacked terminal
-        // recovers to its real session on the next valid SessionStart (e.g.
-        // resume/clear). `cwd` is optional for backward compatibility — when
-        // absent we cannot validate, so we fall back to the old behavior.
+        // `cwd` is optional for backward compatibility — when absent we cannot
+        // validate, so we fall back to the old behavior.
         if let cwd = params.cwd, !cwd.isEmpty {
-            let resolved = try await resolvePathToRepoOrWorktree(cwd)
-            var accepted = resolved?.worktreeID == terminal.worktreeID
-            // Promotion follow-up: when the terminal's worktree is a promoted
-            // scratch row (promotedToRepoID set), its live session now runs in
-            // the moved folder — whose path resolves to the NEW repo's main
-            // worktree, not the scratch row. That's the same session, not a
-            // foreign one: accept when the cwd resolves to the main worktree
-            // of the promoted-to repo.
-            if !accepted,
-               let resolvedWorktreeID = resolved?.worktreeID,
-               let ownerWorktree = try await db.worktrees.getLocal(id: terminal.worktreeID),
-               let promotedRepoID = ownerWorktree.promotedToRepoID,
-               let resolvedWorktree = try await db.worktrees.getLocal(id: resolvedWorktreeID),
-               resolvedWorktree.repoID == promotedRepoID,
-               resolvedWorktree.status == .main {
-                accepted = true
-                logger.info("sessionEvent: accepted post-promote session for terminal \(terminal.id.uuidString, privacy: .public) — cwd resolves to main worktree of promoted repo \(promotedRepoID.uuidString, privacy: .public)")
-            }
-            if !accepted {
-                logger.info(
-                    """
-                    sessionEvent: REJECTED foreign session for terminal \
-                    \(terminal.id.uuidString, privacy: .public) — hook cwd \
-                    \(cwd, privacy: .public) resolves to worktree \
-                    \(resolved?.worktreeID?.uuidString ?? "none", privacy: .public) \
-                    but terminal belongs to worktree \
-                    \(terminal.worktreeID.uuidString, privacy: .public); \
-                    not updating claudeSessionID
-                    """
-                )
-                return .ok()
-            }
+            guard try await hookCWDBelongsToTerminal(cwd, terminal: terminal, event: "sessionEvent")
+            else { return .ok() }
         }
 
         // Sanitize: an empty transcriptPath shouldn't overwrite an existing
@@ -2755,8 +2811,32 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )
+        // A new session context has started in this pane — a `/clear`, a
+        // resume after an in-place profile swap, or a hand relaunch — so a
+        // wait reason recorded against the PREVIOUS one is not on screen any
+        // more. It has to be retracted here, from the event that establishes
+        // it, for two reasons `SessionStateResolver`'s rung 4 makes concrete.
+        // A `/clear` points `transcriptPath` at a file Claude Code creates
+        // lazily, so the growth fact is nil and "we could not look is not
+        // evidence it went away" keeps the dead prompt standing; and the
+        // overlay's own `tbd terminal-activity idle` — the rail that would
+        // otherwise clear the columns — no-ops when the row already reads idle
+        // and can be lost on its own while this call lands.
+        //
+        // Deliberately NOT `setActivityState`: this event says a session
+        // exists, not what it is doing, and `activityState` gates hibernation.
+        try await db.terminals.clearAwaitingInputReason(id: terminal.id)
         if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
-            try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+            // This handler is driven by the session-start hook, which is what
+            // told us the session exists and is between turns.
+            //
+            // `observedAt` from the router's date seam, for the same reason as
+            // every other stamp this file writes: `SessionStateResolver`'s
+            // rung 4 *compares* it, and the store's default `Date()` is a
+            // timestamp nothing outside the store can name.
+            try await db.terminals.setActivityState(
+                id: terminal.id, activityState: .idle, source: .hookEvent("SessionStart"),
+                observedAt: now())
         }
 
         // Invalidate cached transcript parse for the OLD session file (if any)
@@ -2789,6 +2869,75 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Bridge for Claude Code's `Notification` hook — the one event that can
+    /// say a prompt is on screen *now*.
+    ///
+    /// The hook entry that feeds this handler carries no matcher, so every
+    /// notification type arrives here and every fork lives in this function.
+    /// That placement is the design, not an accident: the hook entry sits in a
+    /// settings file an operator can edit, so a matcher out there would be a
+    /// policy decision TBD could not depend on, while a fork here is compiled
+    /// and testable.
+    ///
+    /// The handler records a fact and changes nothing else. There is no
+    /// broadcast: no delta shape carries a wait reason, and inventing one to
+    /// carry a fact no surface renders yet would ship app behavior this slice
+    /// deliberately does not have.
+    func handleTerminalNotificationEvent(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalNotificationEventParams.self, from: paramsData)
+
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            // Soft success — the caller is a fire-and-forget hook, and the
+            // terminal may have been deleted between fire and arrival. An
+            // error response here would be noise nobody reads and a non-zero
+            // exit nobody wants in a hook.
+            logger.debug("notificationEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
+            return .ok()
+        }
+        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
+
+        if let cwd = params.cwd, !cwd.isEmpty {
+            guard try await hookCWDBelongsToTerminal(cwd, terminal: terminal, event: "notificationEvent")
+            else { return .ok() }
+        }
+
+        // The classification is a label on the record, computed once here from
+        // the verbatim type. An unrecognized or absent type stays unrecognized.
+        let reason = AwaitingInputReason(
+            message: params.message,
+            hookEventName: "Notification",
+            raw: params.rawPayload,
+            notificationType: params.notificationType)
+
+        // Deliberately NOT `setActivityState`: this hook reports that a prompt
+        // was raised, not that the session is still sitting on one, and
+        // `activityState` is a *gating* field — `HibernationGate.blockingRail`
+        // reads it, so writing `waiting_for_user` from here would silently
+        // change which sessions park, on the strength of a message TBD does
+        // not parse. `recordAwaitingInputReason` writes the reason columns and
+        // leaves the activity columns exactly as they were. The resolver
+        // composes `.awaitingInput(reason:)` from this record instead — so if
+        // you are here to "fix" a missing state transition, fix it there.
+        //
+        // `observedAt` comes from the router's date seam, never a bare `Date()`
+        // at the write site: a persisted observed-at is data, so it is the date
+        // seam rather than a `Clock`.
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id, reason: reason, observedAt: now())
+
+        // `message` may quote repo content, so it is `.private`; the type and
+        // the class are TBD's own closed vocabulary and stay public.
+        logger.debug(
+            """
+            notificationEvent: terminal=\(terminal.id.uuidString, privacy: .public) \
+            type=\(params.notificationType ?? "none", privacy: .public) \
+            class=\(reason.classification.rawValue, privacy: .public) \
+            message=\(params.message, privacy: .private)
+            """
+        )
+        return .ok()
+    }
+
     func handleTerminalActivityEvent(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalActivityEventParams.self, from: paramsData)
 
@@ -2796,6 +2945,13 @@ extension RPCRouter {
             logger.debug("activityEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
             return .ok()
         }
+
+        // §13's hook-event rate. Counted here — before the unchanged-state
+        // early return below — because a session emitting the same state over
+        // and over is exactly the shape the counter exists to make visible, and
+        // a count taken after that guard would report zero for it. One actor
+        // hop and an integer add, which is the whole per-event budget.
+        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
 
         // UserPromptSubmit reaches the daemon as activity=working. If a
         // session-limit auto-resume is pending, the user just continued
@@ -2841,7 +2997,22 @@ extension RPCRouter {
             return .ok()
         }
 
-        try await db.terminals.setActivityState(id: terminal.id, activityState: params.activityState)
+        // Every caller of this RPC is an agent hook bridged through
+        // `tbd terminal-activity`. The params do not yet carry WHICH hook event
+        // fired, so the RPC surface stands in as the source name until a later
+        // slice threads the event through — a coarser answer than we want, but
+        // a true one, and one no reader can mistake for an observation TBD made
+        // itself.
+        // `observedAt` from the router's date seam, never the store's default
+        // `Date()`. The resolver's rung-4 decision is an ordering comparison
+        // between exactly this stamp and the one `recordAwaitingInputReason`
+        // writes above, so a test that cannot pin both ends cannot pin the
+        // decision at all.
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: params.activityState,
+            source: .hookEvent(RPCMethod.terminalActivityEvent),
+            observedAt: now())
         subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -126,13 +126,26 @@ public final class RPCRouter: Sendable {
             title: title)
     }
 
+    /// Runaway-detection counters (design §13): turns appended per session and
+    /// hook events received per session, over one observation window. The
+    /// hook-driven handlers increment it; `session.states` samples it. An actor
+    /// reference held here so the whole daemon keeps one set of books.
+    ///
+    /// It reports numbers and nothing acts on them — see the actor's doc
+    /// comment for why no threshold lives in compiled TBD.
+    let sessionCounters = SessionCountersTracker()
     /// Single-flights concurrent `pr.list` RPCs so a poll storm collapses into
     /// one git enumeration + gh fetch instead of N overlapping ones.
     let prListCoordinator = PRListCoordinator()
     /// TTL cache for the per-worktree branch facts PR matching needs (upstream
     /// and `@{push}`), so `pr.list` stops spawning git subprocesses per worktree
     /// on every poll — and so the poll and an on-select refresh agree.
-    let branchTrackingCache = BranchTrackingCache()
+    let branchTrackingCache: BranchTrackingCache
+    /// The daemon-side timer that drives `runPollPass`, wired at the end of
+    /// `init`. The pass itself stays here because `pr.refresh` and the timer
+    /// must never enumerate differently, and the router keeps the timer because
+    /// `Daemon.start()` reaches it through the router to start the loop.
+    public let prPoller: PRPoller
     /// Coalesces fetch operations per repo using a TTL cache + singleflight.
     let fetchCache = FetchCache()
     /// Binding policy for the multi-PR-per-worktree bindings — repo validation,
@@ -159,6 +172,13 @@ public final class RPCRouter: Sendable {
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 
+    /// Date seam for facts the router *persists*. A stored observed-at is data,
+    /// not behavior, so this is the `now: @Sendable () -> Date` seam rather
+    /// than a `Clock` — tests pin it and assert the exact stamp instead of a
+    /// tolerance window. Only handlers that write an observation may read it;
+    /// it is not a general-purpose "what time is it".
+    let now: @Sendable () -> Date
+
     public init(
         db: TBDDatabase,
         lifecycle: WorktreeLifecycle,
@@ -178,8 +198,10 @@ public final class RPCRouter: Sendable {
         codexExecutableResolver: (@Sendable () throws -> String)? = nil,
         codexHomeEnsurer: (@Sendable () throws -> URL)? = nil,
         prBindingRepoResolver: (@Sendable (UUID) async -> (owner: String, name: String)?)? = nil,
+        now: @escaping @Sendable () -> Date = { Date() },
         actuationLog: ActuationLog
     ) {
+        self.now = now
         self.actuationLog = actuationLog
         self.db = db
         self.lifecycle = lifecycle
@@ -188,6 +210,12 @@ public final class RPCRouter: Sendable {
         self.startTime = startTime
         self.subscriptions = subscriptions
         self.prManager = prManager
+        // One cache instance, shared by the on-select refresh path and the
+        // poller's enumeration: a poll and a refresh judging the same worktree
+        // against different candidate lists is what the cache exists to stop.
+        let branchCache = BranchTrackingCache()
+        self.branchTrackingCache = branchCache
+        self.prPoller = PRPoller()
         let resolvedModelProfileResolver = modelProfileResolver ?? ModelProfileResolver(
             profiles: db.modelProfiles,
             repos: db.repos,
@@ -231,6 +259,14 @@ public final class RPCRouter: Sendable {
             }
             return try CodexHomeManager().ensureProfilePlugin()
         }
+        // The poller is a timer and nothing else; the pass it drives is
+        // `runPollPass`, which lives here because `pr.refresh` and the on-select
+        // path share its enumeration helpers. Wired at the end of `init` rather
+        // than handed to the initializer because the closure needs the fully
+        // formed router. `weak`, so a discarded router (every test that builds
+        // one) is not kept alive by its own poller; a pass on a deallocated
+        // router is a no-op, which is the honest answer.
+        prPoller.installPass { [weak self] in try await self?.runPollPass() }
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
@@ -318,6 +354,10 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalSessionEvent(request.paramsData)
             case RPCMethod.terminalActivityEvent:
                 return try await handleTerminalActivityEvent(request.paramsData)
+            case RPCMethod.terminalNotificationEvent:
+                return try await handleTerminalNotificationEvent(request.paramsData)
+            case RPCMethod.sessionStates:
+                return try await handleSessionStates(request.paramsData)
             case RPCMethod.notify:
                 return try await handleNotify(request.paramsData)
             case RPCMethod.terminalFocus:
@@ -606,16 +646,35 @@ public final class RPCRouter: Sendable {
         // await it and share the snapshot instead of each starting their own
         // git enumeration + gh fetch.
         let result = try await prListCoordinator.run { [self] in
-            try await computePRList()
+            await computePRList()
         }
         return try RPCResponse(result: result)
     }
 
-    /// Enumerate active worktrees, enrich each with its (cached) upstream branch,
-    /// refresh PR status, and return the snapshot. Throws on a DB enumeration
-    /// failure so the app sees an RPC error instead of a silently-stale snapshot;
-    /// `PRListCoordinator` propagates the error to every concurrent caller.
-    private func computePRList() async throws -> PRListResult {
+    /// Return the daemon's PR snapshot. Serving only — this handler never
+    /// drives a fetch.
+    ///
+    /// `PRPoller` owns the clock, and it owns it alone. That is not tidiness:
+    /// the merged-PR transition is edge-triggered on a cache change, so
+    /// whichever path updates the cache consumes the edge. A second periodic
+    /// driver here would swallow edges the first one's consumers (auto-archive,
+    /// auto-hibernate-on-merge) are waiting for, and they would silently never
+    /// fire.
+    private func computePRList() async -> PRListResult {
+        PRListResult(statuses: await prManager.allStatuses(),
+                     observations: await prManager.allObservations())
+    }
+
+    /// One poll pass: enumerate active worktrees, enrich each with its (cached)
+    /// branch facts, refresh PR status, and settle every binding that pass
+    /// implies. Throws on a DB enumeration failure — `PRPoller.tick` logs it and
+    /// waits for the next tick rather than tearing its loop down.
+    ///
+    /// Lives here rather than in `PRPoller` because `pr.refresh` and the
+    /// on-select path share `pollWorkingDirectory` and `branchFacts` with it: an
+    /// enumeration that drifted between the timer and a user gesture would let a
+    /// worktree be polled under one candidate list and healed under another.
+    func runPollPass() async throws {
         // Open the pass BEFORE anything can observe a merge. One pass raises
         // both merge edges for a worktree whose already-merged PR is discovered
         // with nothing bound yet — `fetchAll` fires the un-bound fallback, then
@@ -646,9 +705,14 @@ public final class RPCRouter: Sendable {
         }
         await seedProvenanceBindings(worktrees)
         await refreshBindingStatuses(polled: infos, repoPath: infos.first?.worktreePath)
-        // Prune at the END so we never drop an entry this pass just populated.
+        // Prune at the END so we never drop an entry this pass just populated,
+        // and **unconditionally** — including when the enumeration came back
+        // empty, which is the pass that has the most to prune.
         await branchTrackingCache.retain(active: infos.map { (worktreePath: $0.worktreePath, branch: $0.branch) })
-        return PRListResult(statuses: await prManager.allStatuses())
+        // Same contract, same reason, for the PR facts themselves: the outcome
+        // of an attempt on a worktree that has left the fleet is not a fact
+        // anyone can act on, and every `pr.list` payload would carry it.
+        await prManager.retain(active: Set(infos.map(\.id)))
     }
 
     /// Bind the PR a worktree was *created from* — `Worktree.prNumber` — so a
@@ -715,7 +779,11 @@ public final class RPCRouter: Sendable {
         refreshed.reserveCapacity(bindings.count)
         for binding in bindings {
             let updated = Self.folding(binding, onto: observations[binding.id])
-            if updated != binding {
+            // `sameValue`, never `!=`: a fresh reading of an unchanged PR
+            // differs only in its `observedAt`, and letting a freshness stamp
+            // decide "changed" would make an idle poll write every binding row
+            // every tick.
+            if !updated.sameValue(as: binding) {
                 try? await db.prBindings.updateObservation(
                     bindingID: binding.id, status: updated.status,
                     headBranch: updated.headBranch, baseRef: updated.baseRef)
@@ -731,7 +799,7 @@ public final class RPCRouter: Sendable {
         // SELECT per worktree that actually has bindings.
         for update in Self.worktreePRStatusUpdates(refreshed) {
             guard let current = try? await db.worktrees.get(id: update.worktreeID),
-                  current.prStatus != update.status else { continue }
+                  current.prStatus?.sameValue(as: update.status) != true else { continue }
             try? await db.worktrees.setPRStatus(id: update.worktreeID, status: update.status)
         }
 
@@ -942,7 +1010,9 @@ public final class RPCRouter: Sendable {
         // an unknown id, or a remote row whose repo is gone — gets "nothing to
         // report".
         guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
-            return try RPCResponse(result: PRRefreshResult(status: nil))
+            // No observation: no attempt was made, which is a third thing again
+            // from `.none` and `.undetermined` and must not be dressed as either.
+            return try RPCResponse(result: PRRefreshResult(status: nil, observation: nil))
         }
         var repo: Repo?
         if let repoID = wt.repoID {
@@ -968,7 +1038,8 @@ public final class RPCRouter: Sendable {
             repoPath: workingDirectory,
             prNumber: wt.prNumber
         )
-        return try RPCResponse(result: PRRefreshResult(status: status))
+        return try RPCResponse(result: PRRefreshResult(
+            status: status, observation: await prManager.observation(for: wt.id)))
     }
 
     // MARK: - PR bindings

--- a/Sources/TBDDaemon/Supervision/BranchTipTracker.swift
+++ b/Sources/TBDDaemon/Supervision/BranchTipTracker.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Since when each worktree's branch tip has stood still.
+///
+/// The third of §13's runaway inputs — "commits unchanged across cycles" — and
+/// it costs **no new subprocess**. `refreshGitStatuses` already resolves every
+/// branch tip in one `git for-each-ref` per repo to drive the conflict sweep's
+/// dirty gate; this actor is handed the same map on the way past and remembers
+/// when each tip was first found to have **stopped moving** — the second
+/// sighting of the same value, never the first. A tip that keeps arriving
+/// unchanged keeps that stamp, so "no commits since 09:14" falls out of
+/// comparisons the sweep was making anyway.
+///
+/// **A working-tree diff fact is deliberately absent.** §13 names "commits or
+/// the diff unchanged", but the sweep resolves refs, not worktree status —
+/// answering the diff half would mean a `git status` subprocess per worktree per
+/// sweep, which is the per-agent cost this slice exists to avoid. So only the
+/// commit half is reported, and an unestablished fact is reported as nil rather
+/// than as "unchanged": `SessionCounters.commitsUnchangedSince` is optional
+/// precisely so ignorance does not get to look like stillness.
+///
+/// Entries are scoped by repo for the same reason `ConflictSweepCache`'s are:
+/// the sweep runs per repo, so an unscoped `retain` during repo B's pass would
+/// evict repo A's entries and the stamps would restart on every sweep of a
+/// multi-repo install.
+public actor BranchTipTracker {
+    private struct Entry {
+        var tip: String
+        /// When this tip was observed to **stop** moving: the instant of the
+        /// first observation that found it unchanged since the one before.
+        ///
+        /// nil on a first sighting, and that is the whole point. A first
+        /// sighting establishes what the tip *is*, never how long it has been
+        /// that — the sweep has one sample and one sample cannot measure a
+        /// duration. Stamping it with the read would report a branch untouched
+        /// for three days as "unchanged since thirty seconds after the daemon
+        /// restarted", which disarms stall detection for hours after every
+        /// restart while looking like an answer.
+        var unchangedSince: Date?
+    }
+
+    /// repoID → (worktreeID → the tip last seen and when it arrived).
+    private var entries: [UUID: [UUID: Entry]] = [:]
+
+    public init() {}
+
+    /// Record a branch tip observed by the sweep.
+    ///
+    /// Three cases, and the first is the one worth stating: a **first** sighting
+    /// records the tip with no stillness stamp at all. It cannot have one —
+    /// nothing has yet been compared — and inventing one would make every
+    /// branch in the fleet look freshly still for the rest of the daemon's
+    /// life. The **second** sighting of the same tip is the first evidence of
+    /// stillness, and it stamps the moment that evidence arrived; further
+    /// unchanged sightings keep that stamp, because refreshing it would report
+    /// every still branch as having just moved. A **changed** tip starts over,
+    /// unstamped, exactly like a first sighting.
+    ///
+    /// The consequence is deliberate: "unchanged since" is always a duration
+    /// TBD actually watched elapse, and is understated by up to one sweep
+    /// interval rather than overstated by however long the branch had already
+    /// been quiet. Understating costs a late stall report; overstating disarms
+    /// the detector, which is the failure this exists to avoid.
+    ///
+    /// `date` is a one-shot stamp of an observation that gets persisted in a
+    /// reported fact — data, so the date seam rather than a clock.
+    public func record(repoID: UUID, worktreeID: UUID, branchTip: String, at date: Date = Date()) {
+        guard let existing = entries[repoID]?[worktreeID], existing.tip == branchTip else {
+            entries[repoID, default: [:]][worktreeID] = Entry(tip: branchTip, unchangedSince: nil)
+            return
+        }
+        guard existing.unchangedSince == nil else { return }
+        entries[repoID, default: [:]][worktreeID] = Entry(tip: branchTip, unchangedSince: date)
+    }
+
+    /// Since when this worktree's commits have not changed, or nil when the
+    /// sweep has not yet *established* that — either because it never resolved
+    /// the tip, or because it has resolved it exactly once and one sample
+    /// measures no duration. Both are "not established", which is what
+    /// `SessionCounters.commitsUnchangedSince`'s optionality is for.
+    public func unchangedSince(repoID: UUID, worktreeID: UUID) -> Date? {
+        entries[repoID]?[worktreeID]?.unchangedSince
+    }
+
+    /// Drop this repo's entries for worktrees no longer in its sweep. Other
+    /// repos' entries are untouched.
+    public func retain(repoID: UUID, worktreeIDs: Set<UUID>) {
+        entries[repoID] = entries[repoID]?.filter { worktreeIDs.contains($0.key) }
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SessionCountersTracker.swift
+++ b/Sources/TBDDaemon/Supervision/SessionCountersTracker.swift
@@ -1,0 +1,389 @@
+import Foundation
+import TBDShared
+
+// MARK: - Reading appended records
+
+/// How many JSONL records were appended past a byte offset, and where the file
+/// now ends.
+struct AppendedRecords: Sendable, Equatable {
+    /// Newline-terminated records seen in the appended span. **Nothing is
+    /// parsed** — a record is a `\n`, which is the one property of this file
+    /// that survives every change to its internal format.
+    let records: Int
+    /// The file's end offset at the moment of the read, which becomes the next
+    /// baseline.
+    let endOffset: UInt64
+}
+
+/// The seam `SessionCountersTracker` reads transcripts through.
+///
+/// A protocol rather than a direct `FileHandle` call so the counter arithmetic
+/// — window rolls, rollover resets, truncation — is a tier-1 test with no
+/// filesystem, and so a fake can *count reads* and prove the tracker never
+/// re-reads a file it has already advanced past.
+protocol TranscriptAppendReading: Sendable {
+    /// The file's current end offset, or nil when it cannot be read at all.
+    ///
+    /// nil and 0 are different answers and must stay different: 0 is an empty
+    /// file, nil is no observation, and collapsing them turns a missing
+    /// transcript into a claim of inactivity.
+    func endOffset(atPath path: String) -> UInt64?
+
+    /// Records appended between `offset` and the file's end.
+    func appendedRecords(atPath path: String, from offset: UInt64) -> AppendedRecords?
+}
+
+/// The production reader: seek to the baseline, stream to the end in bounded
+/// chunks, count newlines.
+///
+/// Streaming rather than `readToEnd` is not premature caution. The span is
+/// normally one cycle's worth of appends — kilobytes — but the baseline is set
+/// to the file's *end* on first sighting, so a multi-megabyte transcript is
+/// never read wholesale on any path; bounding the buffer keeps that true even
+/// if a cycle is missed for an hour.
+struct FileTranscriptAppendReader: TranscriptAppendReading {
+    /// Read buffer. Not a limit on how much may be counted — the loop runs to
+    /// the end — only on how much is resident at once.
+    static let chunkBytes = 64 * 1024
+
+    func endOffset(atPath path: String) -> UInt64? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        return try? handle.seekToEnd()
+    }
+
+    func appendedRecords(atPath path: String, from offset: UInt64) -> AppendedRecords? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        guard let end = try? handle.seekToEnd() else { return nil }
+        guard end > offset else { return AppendedRecords(records: 0, endOffset: end) }
+        do {
+            try handle.seek(toOffset: offset)
+        } catch {
+            return nil
+        }
+        var records = 0
+        while true {
+            guard let chunk = try? handle.read(upToCount: Self.chunkBytes), !chunk.isEmpty else {
+                break
+            }
+            records += chunk.reduce(into: 0) { count, byte in
+                if byte == 0x0A { count += 1 }
+            }
+        }
+        return AppendedRecords(records: records, endOffset: end)
+    }
+}
+
+// MARK: - The tracker
+
+/// Runaway-detection counters for the fleet (design §13): how much has happened
+/// on each session lately.
+///
+/// **These numbers are reported and never acted on.** There is no threshold in
+/// this file and there will not be one. §13 rejects automatic pauses at a
+/// threshold outright, and the reason is worth keeping next to the arithmetic:
+/// a counter cannot tell "burning quota without progress" from "thinking hard",
+/// and pausing a working agent by mistake destroys trust in overnight
+/// supervision faster than any missed runaway. What counts as too many turns is
+/// a project's convention and lives in its shipped sweep program; this actor
+/// hands over the numbers and the sweep program decides whether they mean
+/// anything.
+///
+/// Three inputs, all from interfaces the daemon already reads:
+///
+/// - **Turns** — records appended to the session's transcript JSONL, counted by
+///   newline **without parsing content**. The format is documented as internal
+///   and version-unstable; "a record is a line" is the one thing about it that
+///   holds across its revisions.
+/// - **Hook events** — the hook-driven RPCs (activity, session, notification,
+///   ask-user-question) increment a counter as they arrive. One actor hop per
+///   event and nothing else.
+/// - **Commits unchanged** — supplied by the caller from `BranchTipTracker`,
+///   which the git sweep fills from the `for-each-ref` it already runs. No new
+///   subprocess.
+///
+/// ## The window is an observation window, not a threshold
+///
+/// `observationWindow` bounds *how far back the numbers look*. Crossing it
+/// causes nothing: the counts reset and a new window begins. It is compiled
+/// because it describes how this actor keeps its books, not what any number
+/// means — the thresholds those numbers are compared against ship in the sweep
+/// program, where a project can edit them in a file it owns.
+///
+/// ## Baselines, and the rollover that would otherwise lie
+///
+/// A session's transcript path moves under it: `/clear` and `/compact` roll the
+/// session onto a different file. Comparing the new file's size against the old
+/// file's offset would report a wildly wrong delta — a negative one, or a
+/// several-thousand-record "burst" that never happened. So a path change (and a
+/// file that shrank below its own baseline) **resets the baseline** instead:
+/// the offset moves to the new file's end and the turn count restarts at zero
+/// within the same window. Zero-since-the-rollover is a true statement about
+/// what TBD observed; a bogus delta is not.
+actor SessionCountersTracker {
+    /// How far back the counts look. See the type's note — an observation
+    /// window, never a threshold.
+    static let observationWindow: TimeInterval = 30 * 60
+
+    private struct Baseline {
+        /// The worktree this terminal belonged to when it was last sampled.
+        /// Carried so a worktree-scoped `retain` can tell "this terminal is
+        /// gone" from "this terminal was never in the caller's scope" — see
+        /// `retain(terminalIDs:inWorktree:)`.
+        var worktreeID: UUID
+        var transcriptPath: String
+        var byteOffset: UInt64
+        var turns: Int
+        var hookEvents: Int
+        var windowStart: Date
+    }
+
+    /// terminalID → its baseline. Flat, and deliberately not nested by worktree
+    /// the way `ConflictSweepCache` and `BranchTipTracker` are: `recordHookEvent`
+    /// runs on every hook RPC the fleet produces and is handed a terminal ID
+    /// alone, so a nested map would make the hot path scan every worktree.
+    /// The scoping rule those two keep is honoured by the `worktreeID` each
+    /// entry carries instead.
+    private var baselines: [UUID: Baseline] = [:]
+    /// Hook events for terminals with no transcript baseline yet. Kept so an
+    /// event that arrives before the first sample is not lost; folded into the
+    /// baseline when one is established.
+    ///
+    /// **Self-bounded, because nothing else bounds it.** Its only pruner is the
+    /// fleet-wide `retain`, and every terminal the fleet has ever produced a
+    /// hook for lands here on its first event — a session that is never sampled
+    /// (no transcript path, a `session.states` call that is always
+    /// worktree-scoped, or no caller at all) leaves an entry behind forever, on
+    /// a daemon that runs for weeks. So an entry whose window has expired is
+    /// dropped rather than restarted at the next write: the count it carries
+    /// describes a window that is over, and holding it is holding nothing.
+    /// Same defect as the one `b38a899d` fixed on `baselines`, one map over.
+    private var pendingHookEvents: [UUID: (count: Int, windowStart: Date)] = [:]
+    /// Size at which `recordHookEvent` starts sweeping expired pending entries.
+    /// Above the largest fleet anyone runs, so the sweep costs the hot path
+    /// nothing in the ordinary case.
+    static let pendingHookEventSweepThreshold = 256
+    /// Hard ceiling on `pendingHookEvents`. Reached only pathologically — every
+    /// entry is normally either folded into a baseline on the terminal's first
+    /// sample or expired by its own window — so the eviction below is a
+    /// backstop against unbounded growth, not a working cache policy.
+    static let maxPendingHookEventTerminals = 4096
+    private let windowLength: TimeInterval
+    private let reader: any TranscriptAppendReading
+    private let pendingSweepThreshold: Int
+    private let pendingLimit: Int
+    /// The size `pendingHookEvents` must **exceed** before the next sweep, never
+    /// below `pendingSweepThreshold` and ratcheted to the post-sweep size after
+    /// each one.
+    ///
+    /// Without it the threshold alone does not amortize anything: a fleet
+    /// holding more than `pendingSweepThreshold` *fresh* entries drops nothing
+    /// on a sweep, stays over the threshold, and pays a whole-map rebuild on
+    /// every hook event thereafter — on the path whose entire budget is "one
+    /// actor hop and an integer add". The map only grows when a terminal TBD has
+    /// never seen produces its first event, so gating on growth makes the sweep
+    /// cost proportional to new terminals rather than to traffic.
+    private var pendingSweepWatermark: Int
+    /// How many sweeps `expirePendingHookEvents` has actually run.
+    ///
+    /// The amortization above is invisible in the map's contents — a gated sweep
+    /// and an ungated one that drops nothing leave the same state — so it is
+    /// counted, and the counter is what a test asserts against.
+    private(set) var pendingSweepsPerformed = 0
+
+    /// - Parameters:
+    ///   - pendingSweepThreshold: size at which `recordHookEvent` starts
+    ///     sweeping; injectable so a test crosses it in a handful of events
+    ///     rather than 257 of them.
+    ///   - pendingLimit: the hard ceiling, injectable for the same reason.
+    init(
+        windowLength: TimeInterval = SessionCountersTracker.observationWindow,
+        reader: any TranscriptAppendReading = FileTranscriptAppendReader(),
+        pendingSweepThreshold: Int = SessionCountersTracker.pendingHookEventSweepThreshold,
+        pendingLimit: Int = SessionCountersTracker.maxPendingHookEventTerminals
+    ) {
+        self.windowLength = windowLength
+        self.reader = reader
+        self.pendingSweepThreshold = max(0, pendingSweepThreshold)
+        self.pendingLimit = max(1, pendingLimit)
+        self.pendingSweepWatermark = max(0, pendingSweepThreshold)
+    }
+
+    /// Count one hook-driven RPC for a terminal.
+    ///
+    /// Deliberately trivial: this runs on every activity, session, notification
+    /// and ask-user-question event the fleet produces, so it must cost one
+    /// actor hop and an integer add. `date` is a one-shot stamp — persisted and
+    /// compared, so the date seam, not a clock.
+    func recordHookEvent(terminalID: UUID, at date: Date = Date()) {
+        if baselines[terminalID] != nil {
+            rollWindowIfNeeded(terminalID: terminalID, at: date)
+            baselines[terminalID]?.hookEvents += 1
+            return
+        }
+        var pending = pendingHookEvents[terminalID] ?? (count: 0, windowStart: date)
+        if date.timeIntervalSince(pending.windowStart) >= windowLength {
+            pending = (count: 0, windowStart: date)
+        }
+        pending.count += 1
+        pendingHookEvents[terminalID] = pending
+        expirePendingHookEvents(at: date)
+    }
+
+    /// Drop pending entries whose observation window has closed, and — if the
+    /// map is somehow still over its ceiling — the oldest ones past it.
+    ///
+    /// Expiry is not an approximation of `retain`: an entry older than one
+    /// window would have been reset to zero by the next event anyway, so
+    /// dropping it loses no count that would ever have been reported. It is
+    /// what makes the map's size a function of recent fleet activity instead of
+    /// of how long the daemon has been up.
+    ///
+    /// Gated on a size **watermark** rather than run on every event, because the
+    /// caller is the hot path and owes it one actor hop and an integer add. In
+    /// the ordinary steady state the map holds a handful of entries — each one
+    /// is folded into a baseline on its terminal's first sample — so the sweep
+    /// does not run at all. Past the threshold it runs only when the map has
+    /// grown since the last sweep, which happens once per newly-seen terminal
+    /// and never on repeat traffic from terminals already in the map. See
+    /// `pendingSweepWatermark`.
+    private func expirePendingHookEvents(at date: Date) {
+        guard pendingHookEvents.count > pendingSweepWatermark else { return }
+        pendingSweepsPerformed += 1
+        pendingHookEvents = pendingHookEvents.filter {
+            date.timeIntervalSince($0.value.windowStart) < windowLength
+        }
+        if pendingHookEvents.count > pendingLimit {
+            let survivors = pendingHookEvents
+                .sorted { $0.value.windowStart > $1.value.windowStart }
+                .prefix(pendingLimit)
+            pendingHookEvents = Dictionary(uniqueKeysWithValues: survivors.map { ($0.key, $0.value) })
+        }
+        // Ratchet to what survived, never below the threshold: the next sweep
+        // waits for the map to grow past this size again.
+        pendingSweepWatermark = max(pendingSweepThreshold, pendingHookEvents.count)
+    }
+
+    /// Sample one terminal's counters.
+    ///
+    /// Returns nil when the transcript could not be read — a session with no
+    /// readable transcript has no honest `turnsInWindow`, and `SessionCounters`
+    /// has nowhere to say "unknown". `SessionStateReport.counters` is optional
+    /// for exactly this: reporting the state without the counters is the honest
+    /// shape, and reporting a zero would be a claim of inactivity TBD never
+    /// observed.
+    ///
+    /// - Parameters:
+    ///   - worktreeID: the terminal's worktree, remembered so a scoped
+    ///     `retain` knows which entries are inside its scope. A terminal that
+    ///     moves re-homes on its next sample.
+    ///   - transcriptPath: the session's transcript JSONL, when TBD knows one.
+    ///   - commitsUnchangedSince: from `BranchTipTracker`. Passed through
+    ///     verbatim, nil included — nil means "not established", which is a
+    ///     different fact from "changed just now".
+    ///   - date: the sample instant.
+    func sample(
+        terminalID: UUID,
+        worktreeID: UUID,
+        transcriptPath: String?,
+        commitsUnchangedSince: Date?,
+        at date: Date = Date()
+    ) -> SessionCounters? {
+        guard let transcriptPath, !transcriptPath.isEmpty else { return nil }
+
+        rollWindowIfNeeded(terminalID: terminalID, at: date)
+
+        guard var baseline = baselines[terminalID],
+              baseline.transcriptPath == transcriptPath else {
+            // First sighting, or the session rolled onto a different file. The
+            // baseline starts at the file's END: nothing before this instant is
+            // "in the window", and scanning a multi-megabyte history to find
+            // out otherwise is exactly the cost this design refuses.
+            guard let end = reader.endOffset(atPath: transcriptPath) else { return nil }
+            let pending = pendingHookEvents.removeValue(forKey: terminalID)
+            let existing = baselines[terminalID]
+            baselines[terminalID] = Baseline(
+                worktreeID: worktreeID,
+                transcriptPath: transcriptPath,
+                byteOffset: end,
+                turns: 0,
+                hookEvents: existing?.hookEvents ?? pending?.count ?? 0,
+                windowStart: existing?.windowStart ?? pending?.windowStart ?? date)
+            return counters(baselines[terminalID], commitsUnchangedSince: commitsUnchangedSince, at: date)
+        }
+
+        guard let appended = reader.appendedRecords(
+            atPath: transcriptPath, from: baseline.byteOffset) else { return nil }
+        if appended.endOffset < baseline.byteOffset {
+            // The file shrank below its own baseline — replaced, truncated, or
+            // rotated in place. Same treatment as a path change: re-baseline
+            // rather than report a delta computed against bytes that are gone.
+            baseline.byteOffset = appended.endOffset
+            baseline.turns = 0
+        } else {
+            baseline.byteOffset = appended.endOffset
+            baseline.turns += appended.records
+        }
+        // Re-home a terminal that changed worktree, so the next scoped retain
+        // reasons about where it lives now rather than where it used to.
+        baseline.worktreeID = worktreeID
+        baselines[terminalID] = baseline
+        return counters(baseline, commitsUnchangedSince: commitsUnchangedSince, at: date)
+    }
+
+    /// Drop bookkeeping for terminals that no longer exist, so a long-lived
+    /// daemon does not accumulate an entry per terminal ever created.
+    ///
+    /// **`worktreeID` is the scope the caller's terminal list was filtered by,
+    /// and pruning never reaches outside it.** Same rule as `ConflictSweepCache`
+    /// and `BranchTipTracker`, for the same reason: `session.states` may be
+    /// asked about one worktree, and that call enumerates only that worktree's
+    /// terminals. Pruning fleet-wide against such a list would evict every
+    /// *other* worktree's baselines — terminals that are alive and busy — so
+    /// the next fleet-wide call would re-baseline them as first sightings, with
+    /// turns and hook events back at zero and the observation window thrown
+    /// away. Silently, on every scoped call, for every session outside the
+    /// scope. nil means the caller enumerated the whole fleet, and only that
+    /// caller may prune it.
+    ///
+    /// Hook events counted before a terminal's first sample carry no worktree —
+    /// nothing has yet told this actor where that terminal lives — so a scoped
+    /// call leaves them alone and the fleet-wide call collects them.
+    func retain(terminalIDs: Set<UUID>, inWorktree worktreeID: UUID?) {
+        guard let worktreeID else {
+            baselines = baselines.filter { terminalIDs.contains($0.key) }
+            pendingHookEvents = pendingHookEvents.filter { terminalIDs.contains($0.key) }
+            return
+        }
+        baselines = baselines.filter {
+            $0.value.worktreeID != worktreeID || terminalIDs.contains($0.key)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func rollWindowIfNeeded(terminalID: UUID, at date: Date) {
+        guard var baseline = baselines[terminalID] else { return }
+        guard date.timeIntervalSince(baseline.windowStart) >= windowLength else { return }
+        baseline.windowStart = date
+        baseline.turns = 0
+        baseline.hookEvents = 0
+        // The byte offset deliberately survives the roll: it marks where the
+        // file was last read, not where the window began. Resetting it would
+        // re-count everything appended since the previous read.
+        baselines[terminalID] = baseline
+    }
+
+    private func counters(
+        _ baseline: Baseline?, commitsUnchangedSince: Date?, at date: Date
+    ) -> SessionCounters? {
+        guard let baseline else { return nil }
+        return SessionCounters(
+            turnsInWindow: baseline.turns,
+            hookEventsInWindow: baseline.hookEvents,
+            windowStart: baseline.windowStart,
+            observedAt: date,
+            commitsUnchangedSince: commitsUnchangedSince)
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SessionStateResolver.swift
+++ b/Sources/TBDDaemon/Supervision/SessionStateResolver.swift
@@ -1,0 +1,460 @@
+import Foundation
+import TBDShared
+
+// MARK: - The facts one resolve pass composes
+
+/// Everything `SessionStateResolver` is allowed to look at for one terminal.
+///
+/// A value type rather than "the router plus the world", for the same reason
+/// `TerminalDeliveryFacts` is one: with the inputs enumerated, the resolver
+/// cannot quietly start consulting a source this design did not license — a
+/// rendered pane, a model, a subprocess. Everything here is either a column the
+/// daemon already holds or a bounded read something else already paid for.
+struct SessionStateFacts: Sendable, Equatable {
+    /// A hard usage limit classified off the session's transcript tail, and the
+    /// moment that tail was read.
+    ///
+    /// `DetectedRateLimit` is not `Codable`, so it cannot ride in an
+    /// `ObservedFact`; the pair carries the same triple by hand and the
+    /// resolver stamps `.transcriptTail` when it uses it.
+    struct TranscriptRateLimit: Sendable, Equatable {
+        let limit: DetectedRateLimit
+        let observedAt: Date
+
+        init(limit: DetectedRateLimit, observedAt: Date) {
+            self.limit = limit
+            self.observedAt = observedAt
+        }
+    }
+
+    /// The terminal row: `hibernatedAt`/`hibernateReason`, `pendingResumeAt`,
+    /// and the two provenance-bearing facts `observedActivity` and
+    /// `observedAwaitingInput`.
+    let terminal: Terminal
+    /// The transcript tail's rate-limit classification, when it found one.
+    let transcriptRateLimit: TranscriptRateLimit?
+    /// When the session's transcript last grew, or nil when TBD could not read
+    /// the file at all.
+    ///
+    /// **Byte-level evidence, not content.** The value is the transcript file's
+    /// own append stamp, taken from the same descriptor the tail was read
+    /// through; nothing anywhere on this path parses, matches or interprets a
+    /// record. It exists for one comparison — see the resolver's staleness rule
+    /// — and nil is "no observation", never "it did not grow".
+    let transcriptLastAppendedAt: ObservedFact<Date>?
+    /// Pane/process liveness — **supplied only by a caller that already
+    /// established it for another reason**, never probed by this path. See the
+    /// resolver's note on `.gone`.
+    let liveness: ObservedFact<Bool>?
+
+    init(
+        terminal: Terminal,
+        transcriptRateLimit: TranscriptRateLimit? = nil,
+        transcriptLastAppendedAt: ObservedFact<Date>? = nil,
+        liveness: ObservedFact<Bool>? = nil
+    ) {
+        self.terminal = terminal
+        self.transcriptRateLimit = transcriptRateLimit
+        self.transcriptLastAppendedAt = transcriptLastAppendedAt
+        self.liveness = liveness
+    }
+}
+
+// MARK: - The resolver
+
+/// Composes one terminal's `SessionState` — the phase-1 triple — out of the
+/// machine facts the daemon already holds.
+///
+/// Cheap enough to ask about every agent every cycle, and that bound is a
+/// design constraint rather than an aspiration: **no model call, no rendered
+/// screen, no subprocess.** Every input is a database column or a byte-bounded
+/// file read a caller already made.
+///
+/// ## Precedence, and why it is this order
+///
+/// The facts are not ranked by how much anyone likes them. Each rung outranks
+/// the ones below it because a fact on the lower rung would be a statement
+/// about a session that the higher rung has already shown is not the session
+/// in front of us.
+///
+/// 1. **`.gone`** — the pane or process is not there. Every other value asserts
+///    something about a live session, so reporting one about a torn-down pane
+///    would be a claim about nothing. It goes first for that reason alone.
+/// 2. **`.parked`** — `hibernatedAt` says TBD tore the agent process down
+///    itself. Above the activity facts because those describe the *previous*
+///    process: an `idle` recorded before a park is true about a process that no
+///    longer runs, and repeating it would present a parked session as one
+///    sitting quietly at a prompt. Below `.gone` because parking deliberately
+///    keeps the window alive, so a park is only meaningful while the pane is.
+/// 3. **`.rateLimited`** — a scheduled resume TBD recorded (`pendingResumeAt`,
+///    source `.database`), else the transcript tail's own classification
+///    (source `.transcriptTail`). Above the activity facts because a
+///    rate-limited session reads as `idle` on the hook rail — its turn *did*
+///    end — and reporting `idle` invites a supervisor to send work the session
+///    cannot do until the limit resets.
+/// 4. **`.awaitingInput` vs `.working`/`.idle`** — decided by **observed-at**,
+///    not by a fixed rank, and a recorded prompt the transcript has grown past
+///    resolves `.unknown(why:)` rather than either — unless a second rail
+///    corroborates it. See the staleness rule below.
+/// 5. **`.unknown(why:)`** — nothing could speak. A real answer, not an error,
+///    and its `why` names the fact that was missing.
+///
+/// ## The staleness rule between the wait reason and the activity state
+///
+/// `Terminal.observedAwaitingInput` and `Terminal.observedActivity` are
+/// **independent** facts written by different handlers.
+/// `handleTerminalNotificationEvent` records a reason without touching
+/// `activityState` (deliberately — `activityState` gates hibernation), and
+/// `handleTerminalActivityEvent` returns early when the state is unchanged, so
+/// a repeated same-state event does **not** rewrite the activity stamp and does
+/// **not** supersede a recorded reason.
+///
+/// So neither fact may be given a standing rank, and observed-at decides
+/// between them. A reason older than the newest activity observation is a
+/// prompt the session has already moved past, and it must never be reported as
+/// a live one. Symmetrically, when the activity fact wins and its value is
+/// `waiting_for_user`, the state is `.awaitingInput(reason: nil)` — the older
+/// recorded message is not attached, because presenting stale prompt text
+/// beside a fresh observation is the same lie in a smaller font.
+///
+/// **The two mechanisms do not compose safely on their own, and this is the
+/// direction they fail in.** The activity stamp does not advance during a turn:
+/// the overlay emits `tbd terminal-activity` only at turn boundaries
+/// (`UserPromptSubmit`, `Stop`/`StopFailure`, and the `AskUserQuestion` pair),
+/// and the handler returns early on an unchanged value without rewriting
+/// provenance. So a `permission_prompt` recorded a second *after* the turn's
+/// `working` stamp keeps outranking it for the rest of the turn — ten minutes
+/// of reporting `.awaitingInput` for a prompt answered seconds after it
+/// appeared. Nothing on the hook rail ever retracts the reason.
+///
+/// The transcript is the only other interface that speaks during a turn, and it
+/// **cannot settle this either — so growth is evidence of ambiguity, not of an
+/// answer.** Answering a prompt does append (the tool runs and its result is
+/// written), but so do several things that happen while the prompt is still on
+/// screen: a parallel `Task` subagent appends sidechain records to the same
+/// JSONL, a backgrounded task's completion record lands, a queued user message
+/// is written. Reading growth as proof of an answer therefore fails in the one
+/// direction that costs a night — Claude issues a `Task` and a `Bash` in one
+/// turn, the `Bash` raises a permission prompt, the subagent appends two seconds
+/// later, and a resolver that discarded the reason would fall through to an
+/// `activityState` still reading `working` from `UserPromptSubmit` and report
+/// `.working` for a session blocked on a human, indefinitely.
+///
+/// **The resolver must never report `.working` for a session that may be
+/// blocked on a human.** So the three cases are:
+///
+/// - A recorded `promptOnScreen` reason with **no** growth since its
+///   observed-at → `.awaitingInput(reason:)`.
+/// - A recorded `promptOnScreen` reason **with** growth since → `.unknown(why:)`,
+///   whose `why` names both possibilities: a prompt was reported at that moment,
+///   the transcript has grown since, and whether it was answered cannot be told
+///   from machine facts.
+/// - The same growth, but with an activity fact whose value is
+///   `waiting_for_user` → `.awaitingInput(reason: nil)`, on the activity fact's
+///   provenance. The `AskUserQuestion` pre-hook writes that value, so this is
+///   the shape where a second, independent rail is already saying the session
+///   is blocked on a human. Growth casts doubt on *which* prompt is up, not on
+///   whether one is — so no reason is attached, and the answer stays the
+///   confident one. `unknown` is for genuine ambiguity, never for discarding
+///   corroboration: consumers gate on `isConfident`, so reporting `unknown`
+///   here would downgrade a correct actionable answer to a non-answer.
+/// - No recorded prompt → the activity rail.
+///
+/// This is the same doctrine the delegation trap below already follows: when
+/// compiled facts cannot separate two situations, do not guess — report
+/// `unknown` and let the tier that may read text decide. Its converse is the
+/// case above: when a fact *can* separate them, spending `unknown` anyway is
+/// not caution, it is throwing away an observation TBD already paid for.
+///
+/// The evidence is **byte-level only**: the fact consulted is
+/// `SessionStateFacts.transcriptLastAppendedAt`, the transcript file's own
+/// append stamp, read from the same descriptor the tail was read through. No
+/// record is parsed, matched or interpreted anywhere on this path — a rule this
+/// file shares with `SessionCountersTracker`, whose turn count is likewise a
+/// count of appends and never a reading of them. And an *absent* growth fact (no
+/// transcript path, or a file TBD could not read) establishes nothing: the
+/// prompt stands, because "we could not look" is not evidence that it went away.
+///
+/// **One assumption rides on the comparison, and it is unmeasured.** It holds
+/// that Claude Code flushes the assistant record carrying the `tool_use` to the
+/// JSONL *before* it fires the `Notification` hook, so an unanswered prompt's
+/// newest append predates the reason's observed-at. If the flush happens after
+/// the hook instead, every prompt shows growth immediately and **every prompt
+/// resolves `unknown`** — that is the symptom to look for, and it is visible in
+/// the composed output rather than hidden. The fix that would then apply is a
+/// small tolerance on this comparison, sized to a measured flush lag. It is
+/// deliberately not written yet: an unmeasured tolerance constant would paper
+/// over the assumption instead of exposing it, and honest-and-detectable beats a
+/// magic number.
+///
+/// Only the `.promptOnScreen` class produces `.awaitingInput`.
+/// `.informational` and `.unrecognized` say nothing about whether a human is
+/// being waited on, so they establish no state and the resolver falls through
+/// to the activity fact. `.unrecognized` in particular is **never** guessed
+/// into `.awaitingInput` — that is phase 2's refusal to file an unknown type by
+/// the sound of its spelling, kept intact one layer up. The branch is on
+/// `classification`, which is TBD's own closed vocabulary derived mechanically
+/// from a machine field; nothing here branches on `message`.
+///
+/// `.doneWaiting` is the one other class that decides something, and it
+/// resolves `.idle`. Its only member is `idle_prompt` — Claude Code reporting
+/// that it has finished and is sitting at its own prompt, which is precisely
+/// what `.idle` denotes here ("the rail last told us a turn ended, at this
+/// time"). It is deliberately not `.awaitingInput`: nothing is on screen for a
+/// human to answer, and reporting a prompt that does not exist would send a
+/// supervisor looking for one. **What it must never resolve to is `.working`**,
+/// and that is why it is decided here rather than left to fall through. When
+/// `Stop`/`StopFailure` never reaches the daemon — a hook failure, or a stale
+/// `tbd` on the pane's `PATH` — `activityState` is stuck at `working` from
+/// `UserPromptSubmit`, and falling through would discard a newer, more specific
+/// observation in favour of a stale one, reporting `.working` for a session
+/// whose turn demonstrably ended. That is the same rule the growth branch above
+/// serves: never `.working` for a session that may be blocked on a human, least
+/// of all in the case where the activity rail has failed.
+///
+/// ## `.gone`, and the probe this resolver refuses to add
+///
+/// There is **no cheap per-terminal liveness fact in the daemon today.** Pane
+/// and window liveness live in the tmux server, and every way to ask costs a
+/// subprocess; nothing durable records it (a terminal whose window dies is
+/// *parked* by the reconcile sweep with `.recovery`, and a deleted terminal has
+/// no row left to report on). Adding a probe here would put one subprocess per
+/// agent on a path built to run every cycle for the whole fleet, which is the
+/// cost this whole slice exists to avoid.
+///
+/// So `liveness` is an input, not something this type goes and gets. A caller
+/// that already established it — the send path consults the pane
+/// synchronously at act time, which is where staleness actually bites — may
+/// pass it in. When nobody did, the resolver does not guess: it falls through,
+/// and if nothing else can speak the answer is `.unknown(why:)` naming the
+/// missing liveness fact.
+///
+/// ## The ambiguity this resolver carries rather than resolves
+///
+/// **A session waiting on a background subagent reads as `idle`, and no machine
+/// signal fixes that.** Measured on a live session: a worktree that delegated to
+/// a background agent showed idle for twenty minutes while its subagent
+/// churned, because `Stop` fires when the *parent's* turn ends and the parent's
+/// turn genuinely does end at delegation.
+///
+/// The obvious detector does not work. "An `Agent` tool-use with no matching
+/// `tool_result` means a delegation is outstanding" fails on exactly this case:
+/// a backgrounded agent's `tool_result` lands immediately, so the transcript
+/// shows a completed tool call while the work runs out of band — measured at 27
+/// tool-uses, 27 results, zero pending, subagent running throughout.
+///
+/// **Do not build a delegation detector here.** Telling the two shapes apart
+/// would mean matching launches against later completion notices by reading
+/// result prose: content interpretation at a layer that is not allowed to
+/// interpret content, and brittle against a wording change nobody would think
+/// to look for. The design already answers this — when compiled facts cannot
+/// separate two situations, the case goes to a desk, and the desk reads the
+/// transcript, which is the tier licensed to interpret text.
+///
+/// What this type owes instead is **carrying the ambiguity honestly**. `idle`
+/// with a source and an observed-at is a fine answer; `idle` presented as "not
+/// working" is not, and nothing here presents it that way — the triple is all a
+/// consumer ever receives, so it can always see that `idle` means "the hook
+/// rail last told us a turn ended, at this time", which is exactly what it
+/// means.
+struct SessionStateResolver: Sendable {
+    /// Date seam. Read for the two stamps that are genuinely "when TBD looked":
+    /// the database read behind `.rateLimited(from pendingResumeAt)` and the
+    /// `.unavailable` stamp on an `.unknown` nobody could speak to.
+    var now: @Sendable () -> Date = { Date() }
+
+    init(now: @escaping @Sendable () -> Date = { Date() }) {
+        self.now = now
+    }
+
+    func resolve(_ facts: SessionStateFacts) -> SessionState {
+        let terminal = facts.terminal
+
+        // 1. Gone.
+        if let liveness = facts.liveness, liveness.value == false {
+            return SessionState(
+                value: .gone, source: liveness.source, observedAt: liveness.observedAt)
+        }
+
+        // 2. Parked. Observed-at is the park instant, not the read: the fact
+        //    became true then, and aging it by the read would make a
+        //    three-day-old park look like it happened on this cycle.
+        if let hibernatedAt = terminal.hibernatedAt {
+            return SessionState(
+                value: .parked(reason: terminal.hibernateReason?.rawValue ?? "unspecified"),
+                source: .database,
+                observedAt: hibernatedAt)
+        }
+
+        // 3. Rate-limited. TBD's own scheduled-resume mirror first: it is the
+        //    record of a limit TBD already classified AND scheduled, and the
+        //    activity rail cancels it the moment the user continues manually,
+        //    so it cannot outlive the wait it describes.
+        if let pendingResumeAt = terminal.pendingResumeAt {
+            return SessionState(
+                value: .rateLimited(until: pendingResumeAt),
+                source: .database,
+                observedAt: now())
+        }
+        // Else the transcript tail's classification — the same
+        // `RateLimitDetection` the CLI and the actuator use, never a second
+        // classifier. Reported only while the announced reset is still ahead:
+        // the detector classifies a *record*, not whether the limit still
+        // holds, and a reset that has passed is stopping nothing.
+        if let transcriptRateLimit = facts.transcriptRateLimit,
+           transcriptRateLimit.limit.resetsAt > transcriptRateLimit.observedAt {
+            return SessionState(
+                value: .rateLimited(until: transcriptRateLimit.limit.resetsAt),
+                source: .transcriptTail,
+                observedAt: transcriptRateLimit.observedAt)
+        }
+
+        // 4. The wait reason and the activity state, newest first.
+        let reasonFact = terminal.observedAwaitingInput
+        let activityFact = terminal.observedActivity
+
+        if let reasonFact, reasonIsNewer(reasonFact, than: activityFact) {
+            switch reasonFact.value.classification {
+            case .promptOnScreen:
+                // Growth since the prompt does not retract it — it makes the two
+                // situations indistinguishable from machine facts. Say so, rather
+                // than falling through to an activity rail that would report
+                // `.working` for a session possibly blocked on a human.
+                if let growth = facts.transcriptLastAppendedAt,
+                   growth.value > reasonFact.observedAt {
+                    // Unless the activity rail is independently saying the
+                    // session is blocked on a human. Then the two facts do not
+                    // conflict — only the prompt's identity is in doubt — and
+                    // an `unknown` here would discard a confident observation
+                    // rather than report an ambiguity. No reason is attached:
+                    // which prompt is up is exactly what growth put in doubt.
+                    if let activityFact, activityFact.value == .waitingForUser {
+                        return SessionState(
+                            value: .awaitingInput(reason: nil), source: activityFact.source,
+                            observedAt: activityFact.observedAt)
+                    }
+                    return SessionState(
+                        value: .unknown(why: ambiguousPromptWhy(reason: reasonFact, growth: growth)),
+                        source: growth.source,
+                        observedAt: growth.observedAt)
+                }
+                return SessionState(
+                    value: .awaitingInput(reason: reasonFact.value),
+                    source: reasonFact.source,
+                    observedAt: reasonFact.observedAt)
+            case .doneWaiting:
+                // The agent's own report that its turn is over, newer than
+                // anything the activity rail managed to record. `.idle` is what
+                // that means here — see the doc comment's rule; the one answer
+                // it must never become is `.working`.
+                return SessionState(
+                    value: .idle, source: reasonFact.source,
+                    observedAt: reasonFact.observedAt)
+            case .informational, .unrecognized:
+                // Establishes no state. Fall through to the activity rail.
+                break
+            }
+        }
+
+        if let activityFact {
+            switch activityFact.value {
+            case .working:
+                return SessionState(
+                    value: .working, source: activityFact.source,
+                    observedAt: activityFact.observedAt)
+            case .idle:
+                return SessionState(
+                    value: .idle, source: activityFact.source,
+                    observedAt: activityFact.observedAt)
+            case .waitingForUser:
+                // No reason is attached even when one is on record: this branch
+                // is reached only when the activity observation is the newer of
+                // the two, so any stored message describes an earlier prompt.
+                return SessionState(
+                    value: .awaitingInput(reason: nil), source: activityFact.source,
+                    observedAt: activityFact.observedAt)
+            case .unknown:
+                // A recorded fact whose value is "we do not know" — an
+                // observation, so it keeps the hook's source and stamp.
+                return SessionState(
+                    value: .unknown(why: "the activity rail recorded state 'unknown' for this session"),
+                    source: activityFact.source,
+                    observedAt: activityFact.observedAt)
+            }
+        }
+
+        // 5. Nothing could speak. Say which fact was missing.
+        return SessionState(
+            value: .unknown(why: unknownWhy(facts: facts, reasonFact: reasonFact)),
+            source: .unavailable,
+            observedAt: now())
+    }
+
+    /// True when the recorded wait reason is at least as new as the newest
+    /// activity observation.
+    ///
+    /// Ties go to the reason. Two facts stamped at the same instant cannot be
+    /// ordered, and the reason is the more specific of the two — it names what
+    /// is being waited on, where the activity value only says a turn boundary
+    /// was crossed.
+    private func reasonIsNewer(
+        _ reason: ObservedFact<AwaitingInputReason>,
+        than activity: ObservedFact<TerminalActivityState>?
+    ) -> Bool {
+        guard let activity else { return true }
+        return reason.observedAt >= activity.observedAt
+    }
+
+    /// The `why` for a prompt the transcript has grown past: both possibilities,
+    /// named, with the two stamps that put them in tension.
+    ///
+    /// **Never the prompt's `message`.** That text may quote repo content, and
+    /// it is carried on the `.awaitingInput` value for readers entitled to it;
+    /// a `why` string is composed into briefings and logs. The classification
+    /// and the verbatim `notification_type` are TBD's own closed vocabulary and
+    /// Claude Code's, so both are safe to name.
+    private func ambiguousPromptWhy(
+        reason: ObservedFact<AwaitingInputReason>, growth: ObservedFact<Date>
+    ) -> String {
+        let type = reason.value.notificationType ?? "none"
+        return "a prompt was reported for this session at \(Self.stamp(reason.observedAt)) "
+            + "(notification_type '\(type)', classified "
+            + "'\(reason.value.classification.rawValue)') and the transcript has grown since "
+            + "(last append \(Self.stamp(growth.value))); whether it was answered cannot be told "
+            + "from machine facts — answering a prompt appends, and so do a parallel subagent's "
+            + "records, a backgrounded task's completion record and a queued user message"
+    }
+
+    /// One stable textual form for the stamps a `why` names, so two readers of
+    /// the same string never disagree about which instant it means.
+    private static func stamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
+    }
+
+    /// Which fact was missing, in the reader's own terms. Never a generic
+    /// "could not determine": a `why` that does not name the gap is a shrug
+    /// with provenance attached.
+    private func unknownWhy(
+        facts: SessionStateFacts, reasonFact: ObservedFact<AwaitingInputReason>?
+    ) -> String {
+        var missing: [String] = [
+            "no activity observation is recorded (activityStateSource / "
+                + "activityStateObservedAt are absent)"
+        ]
+        if let reasonFact {
+            missing.append(
+                "the newest recorded Notification is classified "
+                    + "'\(reasonFact.value.classification.rawValue)', which establishes no session state")
+        } else {
+            missing.append("no Notification wait reason is on record")
+        }
+        if facts.liveness == nil {
+            missing.append(
+                "and no pane/process liveness fact was supplied — this path never probes for one")
+        }
+        return missing.joined(separator: "; ")
+    }
+}

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -251,4 +251,68 @@ public enum TBDConstants {
     public static var actuationLogPath: String {
         actuationLogPath(environment: ProcessInfo.processInfo.environment)
     }
+
+    /// Directory holding daemon-managed runtime files — the Claude settings
+    /// overlays, the statusline tee and its captures: `~/tbd/runtime`.
+    public static func runtimeDir(environment: [String: String]) -> URL {
+        configDir(environment: environment).appendingPathComponent("runtime")
+    }
+    public static var runtimeDir: URL { runtimeDir(environment: ProcessInfo.processInfo.environment) }
+
+    /// The one shared statusline tee script: `~/tbd/runtime/statusline-tee.sh`.
+    ///
+    /// One file for the whole fleet rather than one per session — the script
+    /// takes its capture path and its delegate command as arguments, so nothing
+    /// session-specific is baked into it.
+    public static func statuslineTeeScriptPath(environment: [String: String]) -> String {
+        runtimeDir(environment: environment)
+            .appendingPathComponent("statusline-tee.sh")
+            .path
+    }
+    public static var statuslineTeeScriptPath: String {
+        statuslineTeeScriptPath(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// Filename prefix/suffix for a session's statusline capture file. Shared
+    /// between the path builder and the orphan-prune sweep so the two can't
+    /// drift, exactly as the per-session overlay's pair is.
+    public static let statuslineCapturePrefix = "statusline-capture-"
+    public static let statuslineCaptureSuffix = ".json"
+
+    /// Where the tee publishes one session's statusline stdin JSON:
+    /// `~/tbd/runtime/statusline-capture-<sessionKey>.json`.
+    ///
+    /// The payload carries the session's cwd and repo paths, so the tee writes
+    /// it under a restrictive umask; the path itself is only an opaque terminal
+    /// id.
+    public static func statuslineCapturePath(
+        sessionKey: String,
+        environment: [String: String]
+    ) -> String {
+        runtimeDir(environment: environment)
+            .appendingPathComponent(
+                "\(statuslineCapturePrefix)\(sanitizedSessionKey(sessionKey))\(statuslineCaptureSuffix)")
+            .path
+    }
+    public static func statuslineCapturePath(sessionKey: String) -> String {
+        statuslineCapturePath(sessionKey: sessionKey, environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// Filesystem-safe rendering of a session key (non-`[A-Za-z0-9_-]` → `_`).
+    ///
+    /// Callers MUST pass a unique opaque id (the terminal UUID): the mapping is
+    /// only collision-safe for such inputs, since two distinct human-readable
+    /// strings could sanitize to the same filename while distinct UUIDs never
+    /// do. Lives here so the overlay files and the capture files sanitize
+    /// identically — a second implementation is how the prune sweep and the
+    /// path builder drift apart.
+    public static func sanitizedSessionKey(_ sessionKey: String) -> String {
+        String(sessionKey.unicodeScalars.map { scalar -> Character in
+            let isSafe = scalar == "-" || scalar == "_"
+                || (scalar >= "0" && scalar <= "9")
+                || (scalar >= "a" && scalar <= "z")
+                || (scalar >= "A" && scalar <= "Z")
+            return isSafe ? Character(scalar) : "_"
+        })
+    }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -87,6 +87,16 @@ public enum TerminalKind: String, Codable, Sendable {
     case shell
     case claude
     case codex
+
+    /// Whether a terminal of this kind hosts an agent session — one with a
+    /// transcript, a context window, and hooks that report state.
+    ///
+    /// A plain shell has none of those, so a surface that describes agent
+    /// sessions must not describe it: a report explaining that a shell's
+    /// context window is unknown because no statusline tee fired is a true
+    /// sentence about a session that was never going to have one, and the stat
+    /// and transcript-tail attempt behind it are paid every cycle for nothing.
+    public var isAgentBearing: Bool { self != .shell }
 }
 
 public enum PrimaryAgentPreference: String, Codable, Sendable, Equatable, CaseIterable {
@@ -205,6 +215,14 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// PR poll; the app seeds from this only when it has no fresher live value.
     public var prStatus: PRStatus?
 
+    /// The outcome of the last attempt to learn this worktree's PR state,
+    /// separate from `prStatus` (the value that attempt found, if any).
+    ///
+    /// `prStatus == nil` cannot distinguish "the forge answered; no PR on this
+    /// branch" from "the query failed"; this can. `nil` here means no attempt
+    /// has been recorded since the column existed.
+    public var prObservation: PRObservation?
+
     /// Set only on promoted scratch rows: the repo created by `tbd scratch promote`.
     public var promotedToRepoID: UUID?
 
@@ -300,7 +318,8 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 pinSortOrder: Int? = nil,
                 location: WorktreeLocation = .local,
                 pendingPrompt: String? = nil,
-                pendingPromptSubmit: Bool? = nil) {
+                pendingPromptSubmit: Bool? = nil,
+                prObservation: PRObservation? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -328,6 +347,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.location = location
         self.pendingPrompt = pendingPrompt
         self.pendingPromptSubmit = pendingPromptSubmit
+        self.prObservation = prObservation
     }
 
     enum CodingKeys: String, CodingKey {
@@ -338,6 +358,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         case autoHibernateOnMerge
         case promotedToRepoID, prStatus, prNumber, foreignHead, pinnedAt, pinSortOrder
         case locationKind, providerName, providerSessionID, pendingPrompt, pendingPromptSubmit
+        case prObservation
     }
 
     public init(from decoder: Decoder) throws {
@@ -384,6 +405,9 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         // `nil` submit resolves to the shipped `true`.
         pendingPrompt = try c.decodeIfPresent(String.self, forKey: .pendingPrompt)
         pendingPromptSubmit = try c.decodeIfPresent(Bool.self, forKey: .pendingPromptSubmit)
+        // Absent in JSON written before the PR-observation column: no attempt
+        // is on record, which is itself distinct from a recorded `.none`.
+        prObservation = try c.decodeIfPresent(PRObservation.self, forKey: .prObservation)
     }
 
     /// Hand-written because `location` is an enum with an associated value that
@@ -427,6 +451,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         }
         try c.encodeIfPresent(pendingPrompt, forKey: .pendingPrompt)
         try c.encodeIfPresent(pendingPromptSubmit, forKey: .pendingPromptSubmit)
+        try c.encodeIfPresent(prObservation, forKey: .prObservation)
     }
 }
 
@@ -527,6 +552,56 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// Explicit Watch Desk authority. Nil means an ordinary terminal.
     /// The lease row, not this display marker, is authoritative for mutation.
     public var watchDeskRole: WatchDeskRole?
+    /// Where `activityState` came from. `nil` on rows written before the
+    /// provenance columns existed, and on rows a future writer forgets to
+    /// stamp — which is why `observedActivity` refuses to build a fact out of
+    /// half a triple.
+    public var activityStateSource: FactSource?
+    /// When `activityState` was observed — the moment the machine fact was
+    /// read, not the moment the row was written.
+    public var activityStateObservedAt: Date?
+    /// The structured reason this session is waiting, carried verbatim from
+    /// Claude Code's `Notification` hook. Superseded by the next activity
+    /// observation, so it describes the *current* wait or nothing at all.
+    public var awaitingInputReason: AwaitingInputReason?
+    /// When `awaitingInputReason` was observed.
+    public var awaitingInputObservedAt: Date?
+
+    /// `activityState` as a fact — value, source, observed-at — or nil.
+    ///
+    /// Nil whenever either provenance column is missing, deliberately: a bare
+    /// value with no source and no age must not be able to masquerade as an
+    /// observation. Callers that want the raw enumeration can still read
+    /// `activityState`; callers that want to *reason* about it get the triple
+    /// or nothing.
+    public var observedActivity: ObservedFact<TerminalActivityState>? {
+        guard let activityStateSource, let activityStateObservedAt else { return nil }
+        return ObservedFact(
+            value: activityState, source: activityStateSource, observedAt: activityStateObservedAt)
+    }
+
+    /// The recorded wait reason as a fact — value, source, observed-at — or nil.
+    ///
+    /// The source is not a column of its own: a wait reason is only ever
+    /// recorded from a hook event, and the event's name is already carried on
+    /// the reason, so `.hookEvent(name)` IS the provenance rather than a second
+    /// copy of it. A reason with no event name — or with an empty one, which
+    /// names a source just as poorly — is therefore half a triple and reports
+    /// no fact, on the same rule `observedActivity` follows.
+    ///
+    /// This is a *recorded reason*, not a claim about what the session is doing
+    /// now — nothing here asserts `activityState`. Composing the two into a
+    /// session state is the resolver's job.
+    public var observedAwaitingInput: ObservedFact<AwaitingInputReason>? {
+        guard let awaitingInputReason,
+              let awaitingInputObservedAt,
+              let hookEventName = awaitingInputReason.hookEventName,
+              !hookEventName.isEmpty else { return nil }
+        return ObservedFact(
+            value: awaitingInputReason,
+            source: .hookEvent(hookEventName),
+            observedAt: awaitingInputObservedAt)
+    }
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
@@ -540,7 +615,11 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 hibernateReason: HibernateReason? = nil,
                 keepWarm: Bool = false,
                 pendingResumeAt: Date? = nil,
-                watchDeskRole: WatchDeskRole? = nil) {
+                watchDeskRole: WatchDeskRole? = nil,
+                activityStateSource: FactSource? = nil,
+                activityStateObservedAt: Date? = nil,
+                awaitingInputReason: AwaitingInputReason? = nil,
+                awaitingInputObservedAt: Date? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -560,6 +639,10 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.keepWarm = keepWarm
         self.pendingResumeAt = pendingResumeAt
         self.watchDeskRole = watchDeskRole
+        self.activityStateSource = activityStateSource
+        self.activityStateObservedAt = activityStateObservedAt
+        self.awaitingInputReason = awaitingInputReason
+        self.awaitingInputObservedAt = awaitingInputObservedAt
     }
 
     enum CodingKeys: String, CodingKey {
@@ -567,6 +650,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
         case activityState
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
+        case activityStateSource, activityStateObservedAt
+        case awaitingInputReason, awaitingInputObservedAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -590,6 +675,13 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         keepWarm = try c.decodeIfPresent(Bool.self, forKey: .keepWarm) ?? false
         pendingResumeAt = try c.decodeIfPresent(Date.self, forKey: .pendingResumeAt)
         watchDeskRole = try c.decodeIfPresent(WatchDeskRole.self, forKey: .watchDeskRole)
+        // Absent in JSON written before the state model's provenance columns.
+        // Such a row carries a value with no source and no age, and
+        // `observedActivity` reports exactly that by returning nil.
+        activityStateSource = try c.decodeIfPresent(FactSource.self, forKey: .activityStateSource)
+        activityStateObservedAt = try c.decodeIfPresent(Date.self, forKey: .activityStateObservedAt)
+        awaitingInputReason = try c.decodeIfPresent(AwaitingInputReason.self, forKey: .awaitingInputReason)
+        awaitingInputObservedAt = try c.decodeIfPresent(Date.self, forKey: .awaitingInputObservedAt)
     }
 }
 
@@ -1486,9 +1578,23 @@ public struct PRStatus: Codable, Sendable, Equatable {
     /// so no new migration is required.
     public let mergeQueuePosition: Int?
 
+    /// When this status was read from the forge.
+    ///
+    /// The persisted `PRStatus` is display-tier and must be labeled as such:
+    /// this cache was measured showing "Ready to merge" for pull requests
+    /// merged days earlier, so no surface may render it as current truth
+    /// without its age. Optional with a nil default so JSON persisted before
+    /// this field existed still decodes — it rides in the existing
+    /// `worktree.prStatus` TEXT column (migration v34), exactly as
+    /// `mergeQueuePosition` does, so **no migration is required**.
+    ///
+    /// `var`, unlike every field beside it, so `withObservedAt(_:)` can restamp
+    /// a whole value without re-listing the others — see `sameValue(as:)`.
+    public var observedAt: Date?
+
     public init(number: Int, url: String, state: PRMergeableState, reason: String? = nil,
                 files: [String]? = nil, commits: Int? = nil, authorWorktreeID: UUID? = nil,
-                mergeQueuePosition: Int? = nil) {
+                mergeQueuePosition: Int? = nil, observedAt: Date? = nil) {
         self.number = number
         self.url = url
         self.state = state
@@ -1497,6 +1603,46 @@ public struct PRStatus: Codable, Sendable, Equatable {
         self.commits = commits
         self.authorWorktreeID = authorWorktreeID
         self.mergeQueuePosition = mergeQueuePosition
+        self.observedAt = observedAt
+    }
+
+    /// Whether two readings describe the **same pull request state**, ignoring
+    /// when each was read.
+    ///
+    /// **Change detection uses this; `==` does not.** `observedAt` advances on
+    /// every poll, so an equality that includes it answers "different" every
+    /// cadence — which turns any "on change" rule built on it into "every
+    /// time". That is not hypothetical: including the stamp in `Equatable` once
+    /// turned `PRStatusManager.apply`'s persist-on-change into one SQLite write
+    /// transaction per worktree per poll, forever, on a fleet whose steady
+    /// state had been zero. A freshness stamp is a fact *about* a reading, and
+    /// a fact about a reading may never decide whether the reading changed.
+    ///
+    /// `Equatable` itself deliberately keeps the stamp: two `PRStatus` values
+    /// read at different moments really are different values, and a persisted
+    /// round trip has to be able to prove the stamp survived.
+    ///
+    /// **Structural, not a hand-written field list**, and that is the whole
+    /// point of the shape. A list has to be remembered: a ninth property added
+    /// to this type and forgotten here would silently stop persisting on change,
+    /// with nothing red to say so. Stamping both sides to the same `observedAt`
+    /// and deferring to synthesized `Equatable` covers every field this type
+    /// will ever have, because the compiler writes that comparison.
+    public func sameValue(as other: PRStatus) -> Bool {
+        withObservedAt(nil) == other.withObservedAt(nil)
+    }
+
+    /// This reading with its freshness stamp replaced.
+    ///
+    /// A whole-value copy (`var copy = self`), deliberately, rather than a call
+    /// to the memberwise initializer: every parameter there past `reason` has a
+    /// default, so a field added to the struct and omitted from such a call
+    /// would compile and be silently dropped. Copying carries fields this code
+    /// has never heard of.
+    public func withObservedAt(_ date: Date?) -> PRStatus {
+        var copy = self
+        copy.observedAt = date
+        return copy
     }
 }
 

--- a/Sources/TBDShared/NightwatchDeskPrompts.swift
+++ b/Sources/TBDShared/NightwatchDeskPrompts.swift
@@ -51,7 +51,7 @@ public enum NightwatchDeskPrompts {
         • Single-driver rule: Before actioning any atlantis apply/merge, claim the item in queue/claims
         • Escalations in batches ≤4: Each question with exact PR#/command/recommendation
         • Capacity check: Before nudging others, verify profile usage <80% weekly cap
-        • Context ceiling: At ~600k tokens, run the handoff relay (below) — do NOT defer it and keep working
+        • Context ceiling: When `handoff.py --check` reports OVER, run the handoff relay (below) — do NOT defer it and keep working
         • Merging: only loop-perfect PRs authored by `zionts` qualify, and only nightwatch acts (see below)
         • NEVER trigger `/closeout` — a finished-looking worktree is an archive question for the human
 
@@ -67,11 +67,15 @@ public enum NightwatchDeskPrompts {
         **Hand off at the context ceiling — never push through it.** Nothing respawns this desk
         by itself: a machine-local babysitter daemon may be watching worker panes, but it does
         not restart the judge, and the only thing that spawns your successor is you running
-        `handoff.py --act`. It does work — run it, don't "flag for respawn". When this session
-        passes ~600k tokens it starts truncating its own shift, so use the relay:
+        `handoff.py --act`. It does work — run it, don't "flag for respawn". Past its context
+        ceiling this session starts truncating its own shift, and the ceiling is a fraction of
+        the context window THIS session reported — a different number on a different desk, so
+        there is nothing to watch for by eye. Ask the script, and use the relay:
 
             python3 \(skillDir)/scripts/handoff.py --check
                 # exit 0 = under the ceiling · exit 10 = OVER
+                # prints the ceiling and whether it came from this session's
+                # reported window or from the fallback guess
 
             python3 \(skillDir)/scripts/handoff.py --act --notes-file <your-notes.md>
                 # writes the handoff doc and spawns a fresh successor in this worktree
@@ -230,7 +234,8 @@ public enum NightwatchDeskPrompts {
           panes, but it does not restart the judge. The relay below is what continues the
           shift, and it does work: run it rather than deferring to something that won't.
         - Check: `python3 \(skillDir)/scripts/handoff.py --check` (exit 0 = under, 10 = OVER;
-          the ceiling is 600k tokens — the script is the authority, don't eyeball it)
+          the ceiling is a fraction of the context window this session reported, so it
+          differs desk to desk — the script is the authority, don't eyeball it)
         - When OVER: write your handoff notes to a file, then
           `python3 \(skillDir)/scripts/handoff.py --act --notes-file <your-notes.md>`
           which writes the handoff doc and spawns a fresh successor in this worktree

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -138,9 +138,12 @@ is an *archive question for the human*, not a harvest to fire. Report it and mov
 they are wrong; this rule wins.)
 
 **Hand off at the context ceiling — never push through it.** A judge session that runs past
-~600k tokens starts truncating its own shift. (The ceiling was 200k until 2026-07-29; on a
-1000k Opus window that forced a relay roughly every two hours, so the desk spent its shift
-handing off instead of judging. `handoff.py --check` is the authority — don't eyeball it.)
+its context ceiling starts truncating its own shift. That ceiling is three quarters of the
+context window *this* session reported — TBD installs a statusline tee on desk sessions so
+the window Claude Code resolved is knowable — and falls back to a fixed guess when there is
+no capture to read. It is therefore a different number on a different desk, and there is no
+figure to memorise: `handoff.py --check` computes it and says which of the two it used.
+That script is the authority — don't eyeball it.
 Do not "flag for respawn" and keep working, and
 do NOT use `tbd terminal close --all` — **that command does not exist**. The relay uses
 the supported single-terminal `tbd terminal close --terminal <id>`, which preserves
@@ -744,22 +747,114 @@ def _lastmeaning(lines):
         return s[:90]
     return ""
 
-CTX_PAT = re.compile(r"(\d+)%\s*context used")
-COMPACT_PAT = re.compile(r"(\d+)%\s*until auto-compact")
-def burn_risk(cap):
+# The window a percentage is computed against when nothing has reported the
+# session's real one. It is an ASSUMPTION, and every line that prints a
+# percentage derived from it says so. 200k errs early: if the real window is
+# larger the flag fires sooner than it needed to, which costs attention, while
+# the opposite error costs a session.
+#
+# The same number is spelled in Swift as `ContextWindow.assumedTokens`
+# (Sources/TBDShared/SessionStateModel.swift). Two languages, one assumption and
+# no way to share it, so it is stated twice on purpose — change one, change the
+# other, and keep the word ASSUMED next to it in whatever a human reads.
+ASSUMED_WINDOW = 200_000
+BURN_PCT = 85
+
+# How much of a transcript's tail to read for the numerator. The same 64 KiB
+# window `ContextLoadReader.defaultTailWindowBytes` uses, for the same reasons:
+# it spans several assistant records, and a supervision tick reads one
+# transcript per agent, where these files run to many megabytes.
+TAIL_WINDOW_BYTES = 64 * 1024
+
+def _usage_int(usage, key):
+    """One usage bucket as an int — 0 when it is absent, null, or not a number.
+
+    A `null` bucket is a shape that really appears in these files, and adding
+    one to an int raises. The raise would not stay local: burn_risk() is called
+    inline in the fleet loop with no `try` around it, so ONE such record ends
+    the whole tick — classification table, decision queue, everything — not just
+    that agent's numerator.
+
+    Coercing to 0 is also what keeps the two implementations in step:
+    ContextLoadReader.lastUsage sums the same buckets with `as? Int ?? 0`, so a
+    bucket Swift counts as nothing has to count as nothing here too.
+    """
+    value = usage.get(key)
+    return value if isinstance(value, int) else 0
+
+def context_tokens(transcript_path):
+    """Current context size, read off the transcript's own usage records.
+
+    Claude Code stamps every assistant message with the usage that produced it;
+    input + both cache buckets is the prompt weight the next request carries.
+    Returns None when the transcript can't be read rather than guessing zero —
+    a bogus low reading would silently un-flag a session that is actually full.
+
+    THIS MUST AGREE WITH `ContextLoadReader.lastUsage`
+    (Sources/TBDDaemon/Claude/ContextLoadReader.swift), record for record. The
+    same session is reported by two surfaces — TBD's `session.states` and this
+    desk's burn-risk list — and two selection rules over one file give a reader
+    two numbers with nothing to say which is right. So the rule is the Swift
+    one: the LAST record carrying a usage block wins, never the largest. A
+    parent session's subagents append into the same JSONL, so "largest" reports
+    whichever turn was heaviest anywhere in the tail rather than what this
+    session is carrying now.
+
+    The read is bounded to the tail for the same reason the Swift side bounds
+    it — one seek per agent per tick instead of a whole file. The accepted cost
+    is that a session whose last TAIL_WINDOW_BYTES hold no usage record reads as
+    unknown rather than as a figure from further back, which is the same answer
+    the Swift reader gives and the same direction it errs in.
+    """
+    if not transcript_path: return None
+    try:
+        with open(transcript_path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - TAIL_WINDOW_BYTES))
+            tail = fh.read()
+    except OSError:
+        return None
+    best = None
+    # A tail begins wherever the seek landed, so its first line is usually a
+    # fragment of a record. It fails to parse and is skipped, which is what the
+    # Swift reader does with it too.
+    for raw in tail.split(b"\n"):
+        try:
+            rec = json.loads(raw)
+        except ValueError:
+            continue
+        if not isinstance(rec, dict): continue
+        msg = rec.get("message")
+        if not isinstance(msg, dict): continue
+        u = msg.get("usage")
+        if not isinstance(u, dict): continue
+        inp = u.get("input_tokens")
+        if not isinstance(inp, int): continue
+        best = (inp
+                + _usage_int(u, "cache_creation_input_tokens")
+                + _usage_int(u, "cache_read_input_tokens"))
+    return best
+
+def burn_risk(transcript_path):
     """The dominant quota driver is token WEIGHT per request: a session dragging a
-    near-full context window (esp. 1M Opus) sends up to ~1M input tokens EVERY request.
-    Flag agents at high context — they incinerate the weekly cap fastest. Returns
-    (pct:int|None, is_1m:bool, risk:bool)."""
-    pct = None
-    m = CTX_PAT.search(cap)
-    if m: pct = int(m.group(1))
-    else:
-        c = COMPACT_PAT.search(cap)
-        if c: pct = 100 - int(c.group(1))
-    is_1m = "opus[1m]" in cap or "[1m]" in cap
-    risk = pct is not None and pct >= 85
-    return pct, is_1m, risk
+    near-full context window sends its whole prompt on EVERY request. Flag agents
+    at high context — they incinerate the weekly cap fastest.
+
+    The numerator is the transcript's own usage record. The denominator is NOT
+    known: only Claude Code resolves a session's effective window, and it reports
+    it on exactly one surface (the statusline), which TBD tees on desk sessions
+    only. So the percentage here is against ASSUMED_WINDOW and is labelled as an
+    assumption wherever it is printed. Reading the rendered pane for it — which
+    this used to do — was screen-scraping: it broke silently whenever Claude Code
+    reworded its status line, and a `[1m]` suffix sniffed off the screen reports
+    capability rather than the window actually in force.
+
+    Returns (tokens:int|None, pct:int|None, risk:bool)."""
+    used = context_tokens(transcript_path)
+    if used is None: return None, None, False
+    pct = int(round(100.0 * used / ASSUMED_WINDOW))
+    return used, pct, pct >= BURN_PCT
 
 def _composer(lines, raw_lines=None):
     """Text a HUMAN actually left in the composer, or "" if there's nothing real there.
@@ -815,31 +910,50 @@ def codex_state(activity):
         "unknown": ("IDLE", "Codex activity is not known yet"),
     }.get(activity or "unknown", ("IDLE", f"Codex hook state: {activity}"))
 
+FLEET_COLUMNS = 8
+
+def _fleet_row(line, ncols=FLEET_COLUMNS):
+    """One tab-separated fleet row as a tuple, or None when it isn't one.
+
+    A worktree display name is free text a human typed, and a transcript path
+    can hold anything a filesystem accepts — either may contain a tab, which
+    widens the row and makes every field after it ambiguous. Unpacking such a
+    row raises, and a raise here ends the tick for the WHOLE fleet: one odd
+    display name and nothing gets supervised tonight.
+
+    There is no honest way to put a widened row back together — the separator
+    is the only thing that said where the name ended — so the row is dropped.
+    Losing one agent from a tick is a cost; losing every agent is an outage.
+    """
+    parts = line.split("\t")
+    return tuple(parts) if len(parts) == ncols else None
+
 def fleet():
     rows = sh(["sqlite3","-separator","\t",DB,
       "SELECT t.tmuxPaneID, w.displayName, w.tmuxServer, t.id, w.repoID, t.kind, "
-      "COALESCE(t.activityState,'unknown') "
+      "COALESCE(t.activityState,'unknown'), COALESCE(t.transcriptPath,'') "
       "FROM worktree w JOIN terminal t ON t.worktreeID=w.id "
       "AND t.kind IN ('claude','codex') AND t.suspendedAt IS NULL AND t.hibernatedAt IS NULL "
       "WHERE w.status='active' ORDER BY w.tmuxServer, w.displayName;"])
     out = []
     for l in rows.splitlines():
-        p = l.split("\t")
-        if len(p) < 7: continue
-        pane, name, srv, tid, rid, kind, activity = p
+        row = _fleet_row(l)
+        if row is None: continue
+        pane, name, srv, tid, rid, kind, activity, transcript = row
+        # Context load comes off the transcript for every agent kind — it is a
+        # file the agent writes, not a picture of its screen.
+        ctx_tokens, ctx_pct, burn = burn_risk(transcript)
         if kind == "codex":
             # Codex installs TBD hooks that publish activityState. Its rendered
             # terminal is not Claude's UI and must not be interpreted with the
             # grandfathered Claude-only screen classifier.
             state, note = codex_state(activity)
-            ctx_pct, is_1m, burn = None, False, False
         else:
             # -e keeps the escapes: dimness is the only thing distinguishing a ghost
             # suggestion from typed input, and it's gone by the time tmux strips ANSI.
             cap_raw = sh(["tmux","-L",srv,"capture-pane","-p","-e","-t",pane])
             cap = ANSI_RE.sub("", cap_raw)
             state, note = classify(cap, cap_raw)
-            ctx_pct, is_1m, burn = burn_risk(cap)
         hook = POLICIES.get(rid, {})
         pol = hook.get("policy", {})
         # priorities/dont-touch are the UNION of global config + the repo's own hook
@@ -852,7 +966,8 @@ def fleet():
                     "priority": prio, "protected": protect,
                     "repo": hook.get("name"), "gate": pol.get("gate", {}).get("ready_when"),
                     "advance_skill": pol.get("advance_skill"), "deploy_skill": pol.get("deploy_skill"),
-                    "ctx_pct": ctx_pct, "is_1m": is_1m, "burn_risk": burn})
+                    "ctx_tokens": ctx_tokens, "ctx_pct": ctx_pct,
+                    "ctx_window_assumed": ASSUMED_WINDOW, "burn_risk": burn})
     return out
 
 def _pane(*lines):
@@ -938,6 +1053,79 @@ def selftest():
           codex_state("waiting_for_user"), ("DECISION", "Codex is waiting for user input"))
     check("codex unknown fails quiet",
           codex_state("unknown"), ("IDLE", "Codex activity is not known yet"))
+
+    # A row is dropped, never fatal. Unpacking a widened row raises, and the
+    # raise takes the whole tick down — so a single display name with a tab in
+    # it would leave the entire fleet unsupervised for the night.
+    check("a well-formed fleet row parses",
+          _fleet_row("%1\tworktree\tsrv\tT1\tR1\tclaude\tworking\t/t.jsonl"),
+          ("%1", "worktree", "srv", "T1", "R1", "claude", "working", "/t.jsonl"))
+    check("a display name containing a tab drops its row instead of raising",
+          _fleet_row("%1\twork\ttree\tsrv\tT1\tR1\tclaude\tworking\t/t.jsonl"), None)
+    check("a truncated row drops too", _fleet_row("%1\tworktree"), None)
+
+    # context_tokens must answer exactly what ContextLoadReader.lastUsage
+    # answers for the same file: TBD's session.states and this desk's burn-risk
+    # list describe the same sessions, and two selection rules over one
+    # transcript put two numbers in front of a reader with no way to tell which
+    # is right.
+    import tempfile
+
+    def transcript(*records):
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
+            for rec in records:
+                fh.write(rec + "\n")
+            return fh.name
+
+    def usage(total):
+        return json.dumps({"message": {"usage": {
+            "input_tokens": total - 30, "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 10}}})
+
+    # LAST wins, not largest: a parent session's subagents append into the same
+    # file, so the heaviest record in the tail can belong to something that has
+    # already finished while the session itself is nearly empty.
+    ordered = transcript(usage(180_000), usage(12_345),
+                         "not json at all", json.dumps({"message": {}}))
+    check("the last usage record wins, not the largest",
+          context_tokens(ordered), 12_345)
+    check("an unreadable transcript is unknown, never zero",
+          context_tokens("/nonexistent/transcript.jsonl"), None)
+    check("no transcript path is unknown", context_tokens(""), None)
+
+    # The read is bounded to the tail. A usage record pushed past the window by
+    # a large intervening record is not seen — which is what makes this a seek
+    # rather than a whole-file read on multi-megabyte transcripts.
+    beyond = transcript(usage(999_999),
+                        json.dumps({"filler": "x" * (TAIL_WINDOW_BYTES + 4096)}))
+    check("a usage record beyond the tail window is not read",
+          context_tokens(beyond), None)
+
+    # A usage bucket the record spells as null contributes nothing rather than
+    # raising. This is the whole-tick failure mode: burn_risk() runs inline in
+    # the fleet loop with no `try`, so one such record used to end the tick for
+    # EVERY agent — no classification table, no decision queue. Swift's
+    # ContextLoadReader coerces the same buckets the same way, so tolerating it
+    # is also what keeps the two numerators agreeing.
+    nulls = transcript(json.dumps({"message": {"usage": {
+        "input_tokens": 100, "cache_creation_input_tokens": None,
+        "cache_read_input_tokens": None}}}))
+    check("a null cache bucket counts as nothing instead of ending the tick",
+          context_tokens(nulls), 100)
+    check("and burn_risk survives it too", burn_risk(nulls), (100, 0, False))
+    strings = transcript(json.dumps({"message": {"usage": {
+        "input_tokens": 100, "cache_read_input_tokens": "12"}}}))
+    check("a non-numeric cache bucket counts as nothing too",
+          context_tokens(strings), 100)
+
+    # The percentage is against an ASSUMPTION, and burn_risk's caller prints it
+    # as one. Pinned so the denominator cannot quietly become a model figure.
+    full = transcript(usage(ASSUMED_WINDOW))
+    check("burn risk is a fraction of the assumed window",
+          burn_risk(full), (ASSUMED_WINDOW, 100, True))
+
+    for path in (ordered, beyond, nulls, strings, full):
+        os.unlink(path)
 
     print(f"selftest: {n}/{n} agent-state scenarios passed")
 
@@ -1054,10 +1242,14 @@ def main():
     burners = sorted([a for a in rep["agents"] if a.get("burn_risk")],
                      key=lambda a: -(a.get("ctx_pct") or 0))
     if burners:
-        print(f"🔥 BURN-RISK ({len(burners)} at ctx≥85% — top quota drivers, weight not count):")
+        print(f"🔥 BURN-RISK ({len(burners)} at ctx≥{BURN_PCT}% of an ASSUMED {ASSUMED_WINDOW:,}-token "
+              f"window — top quota drivers, weight not count):")
         for a in burners[:8]:
-            print(f"  · {a['name']} ({a['pane']}): {a['ctx_pct']}% ctx{' [1M]' if a['is_1m'] else ''}"
+            print(f"  · {a['name']} ({a['pane']}): {a['ctx_tokens']:,} tokens "
+                  f"= {a['ctx_pct']}% of assumed {ASSUMED_WINDOW:,}"
                   f" — {'compact/clear' if a['ctx_pct']>=95 else 'watch'}")
+        print("    (percentages assume a 200k window: only Claude Code knows the window it "
+              "resolved, and it reports it on the statusline, which TBD tees on desks only.)")
     if auto:
         print(f"AUTO (Tier-0 safe, {len(auto)}):")
         for x in auto: print(f"  · {x['kind']}: {x['name']} ({x['pane']})")
@@ -1107,11 +1299,23 @@ import time
 
 QUEUE = pathlib.Path(__file__).resolve().parent.parent / "queue"
 LATEST = QUEUE / "HANDOFF-LATEST.md"
-# 600k of a 1000k Opus window. Raised from 200k on 2026-07-29: at 200k a desk
-# session hit the ceiling roughly every two hours and spent the shift relaying
-# instead of judging, while the model it runs on had 800k of headroom left.
-# 600k still leaves ~400k of slack for the handoff write + the successor's boot.
-DEFAULT_THRESHOLD = 600_000
+# The ceiling is a fraction of THIS session's context window. The remaining
+# quarter is what the handoff write and the successor's boot run in.
+CEILING_FRACTION = 0.75
+# The ceiling when this session's window could not be read.
+#
+# It is a capability guess, not a fraction of anything — there is no window here
+# to take a fraction of — and every line that prints it says so.
+#
+# The figure is the one the desk has been running. A 200k ceiling was measured
+# as too aggressive: on a large window it forced a relay roughly every two
+# hours, so the desk spent its shift relaying instead of working. Guessing below
+# a value already measured as too small would reintroduce exactly that. The
+# tradeoff is accepted deliberately: on a genuinely small window this fallback
+# sits above the real ceiling and the desk can truncate — but that is the case
+# `observed_window` below covers, and regressing a measured behaviour for every
+# desk in order to guess at a case that has a real answer is the worse trade.
+FALLBACK_THRESHOLD = 600_000
 SUCCESSOR_MODEL = "opus"
 
 
@@ -1144,29 +1348,162 @@ def tmux_server():
     return pathlib.PurePath(tmux.split(",")[0]).name if tmux else ""
 
 
+def _sanitized_session_key(key):
+    """Filesystem-safe session key — the same mapping Swift applies.
+
+    `TBDConstants.sanitizedSessionKey` (Sources/TBDShared/Constants.swift) maps
+    every character outside `[A-Za-z0-9_-]` to `_`, and names the capture file
+    with the result. One rule spelled in two languages with nothing connecting
+    them, so each site names the other: change one, change this.
+    """
+    return "".join(
+        c if (c.isascii() and (c.isalnum() or c in "-_")) else "_" for c in key
+    )
+
+
+def statusline_capture_path(terminal_id):
+    """Where the tee publishes this session's statusline payload.
+
+    Derived exactly as `TBDConstants.statuslineCapturePath(sessionKey:)` does —
+    `TBD_HOME` first, never hand-built from `$HOME`, which is how a path
+    silently stops following the rest of TBD. The session key is the terminal
+    id, the same one `resolve_self` reads out of the environment.
+    """
+    root = os.environ.get("TBD_HOME") or os.path.expanduser("~/tbd")
+    name = "statusline-capture-" + _sanitized_session_key(terminal_id) + ".json"
+    return os.path.join(root, "runtime", name)
+
+
+def observed_window(terminal_id):
+    """The context window Claude Code actually resolved for this session.
+
+    A session's effective window is a session fact, not a model fact: Claude
+    Code resolves it from the model id, a long-context suffix, a beta header,
+    environment overrides and a remote flag, and reports the result on exactly
+    one surface — the statusline command's stdin JSON. The desk is the session
+    that HAS a statusline tee: TBD installs one on desk sessions precisely so
+    this value is knowable, and it publishes the payload verbatim.
+
+    Returns None when nothing reported it. Every field is treated as
+    absent-able — a missing file, an unreadable one, malformed JSON, a missing
+    key or a non-positive number are all "not observed" — and nothing here
+    raises: this runs on the path that keeps a shift alive, so an odd capture
+    file must cost a ceiling's precision, never the ceiling itself.
+    """
+    if not terminal_id:
+        return None
+    try:
+        with open(statusline_capture_path(terminal_id), "rb") as fh:
+            payload = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    window = payload.get("context_window")
+    if not isinstance(window, dict):
+        return None
+    size = window.get("context_window_size")
+    if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
+        return None
+    return size
+
+
+def resolve_ceiling(terminal_id, override=None):
+    """The ceiling for this session, and where the number came from.
+
+    The provenance is returned rather than left implicit because the two cases
+    are not equally trustworthy and a bare number reads as though something had
+    measured it. An observed window gives a ceiling that is genuinely three
+    quarters of what this session has; the fallback is a guess (see
+    FALLBACK_THRESHOLD) and says so wherever it is printed.
+    """
+    if override is not None:
+        return override, "set explicitly with --threshold"
+    window = observed_window(terminal_id)
+    if window is None:
+        return FALLBACK_THRESHOLD, (
+            "this session's window was NOT observed — no statusline capture to read, "
+            "so this ceiling is a fallback guess rather than a fraction of a known window"
+        )
+    return int(window * CEILING_FRACTION), (
+        f"{int(CEILING_FRACTION * 100)}% of this session's OBSERVED "
+        f"{window:,}-token window"
+    )
+
+
+# How much of a transcript's tail to read. The same 64 KiB window tick.py and
+# ContextLoadReader seek to, for the same reason: it spans several assistant
+# records, and these files run to many megabytes. `--check` runs on the hot path
+# of a shift that is already near its ceiling, so reading the whole file into
+# memory to keep its last few hundred lines is the one thing this must not do.
+TAIL_WINDOW_BYTES = 64 * 1024
+
+
+def _usage_int(usage, key):
+    """One usage bucket as an int — 0 when it is absent, null, or not a number.
+
+    A `null` bucket is a shape that really appears in these files, and adding
+    one to an int raises. cmd_check documents exactly two outcomes, 0 and 10;
+    a traceback is neither, and it exits 1 — which no caller reads as OVER. So
+    every bucket is coerced and the fail-closed contract stays true for a
+    malformed record as much as for an unreadable file.
+    """
+    value = usage.get(key)
+    return value if isinstance(value, int) else 0
+
+
 def context_tokens(transcript_path):
     """Current context size, read off the transcript's own usage records.
 
     Claude Code stamps every assistant message with the usage that produced it;
-    input + both cache buckets is what the statusline renders as `NNNk/1000k`.
+    input + both cache buckets is the numerator the statusline renders.
     Returns None when the transcript can't be read rather than guessing zero —
     a bogus low reading would silently disable the ceiling.
+
+    The LARGEST record in the tail wins here, where tick.py's same-named
+    function takes the last one. The two are answering different questions and
+    the difference is deliberate: tick.py reports what a session is carrying
+    right now, and must agree with what TBD reports for the same session, while
+    this is a one-way ceiling on a shift that has already been running. Reading
+    high is the safe direction for a ceiling — it relays early — and it survives
+    a tail whose last record belongs to a subagent that finished small.
+
+    Nothing in here may raise on a malformed record. A record whose usage block
+    holds a null, a line that is not valid UTF-8, a line that is not JSON, a
+    record that is not an object — each is skipped. This function is the whole
+    input to cmd_check's fail-closed decision, and an exception escaping it is
+    not "OVER", it is a traceback and exit 1.
     """
     try:
         with open(transcript_path, "rb") as fh:
-            tail = fh.readlines()[-400:]
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - TAIL_WINDOW_BYTES))
+            tail = fh.read()
     except OSError:
         return None
     best = None
-    for raw in tail:
+    # A tail begins wherever the seek landed, so its first line is usually a
+    # fragment of a record. It fails to parse and is skipped. `ValueError`
+    # covers both ways that happens: json.JSONDecodeError for a broken record,
+    # and UnicodeDecodeError — also a ValueError — for bytes that are not UTF-8.
+    for raw in tail.split(b"\n"):
         try:
-            u = json.loads(raw).get("message", {}).get("usage") or {}
-        except (json.JSONDecodeError, AttributeError):
+            rec = json.loads(raw)
+        except ValueError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        msg = rec.get("message")
+        if not isinstance(msg, dict):
+            continue
+        u = msg.get("usage")
+        if not isinstance(u, dict):
             continue
         total = (
-            u.get("input_tokens", 0)
-            + u.get("cache_creation_input_tokens", 0)
-            + u.get("cache_read_input_tokens", 0)
+            _usage_int(u, "input_tokens")
+            + _usage_int(u, "cache_creation_input_tokens")
+            + _usage_int(u, "cache_read_input_tokens")
         )
         if total and (best is None or total > best):
             best = total
@@ -1193,22 +1530,27 @@ def cmd_check(args):
     one costs the shift to truncation, which is the failure this script exists
     to prevent.
     """
-    *_, row = resolve_self()
+    tid, _, row = resolve_self()
     transcript = row.get("transcriptPath") or ""
     used = context_tokens(transcript) if transcript else None
+    threshold, provenance = resolve_ceiling(tid, args.threshold)
     if used is None:
         why = "no transcriptPath on the terminal row" if not transcript else "transcript unreadable"
         print(f"context: UNKNOWN ({why}) — failing closed, treat as OVER")
         return 10
-    over = used >= args.threshold
-    print(f"context: {used:,} / ceiling {args.threshold:,} — {'OVER' if over else 'ok'}")
+    over = used >= threshold
+    # The ceiling is quoted with its provenance, in both cases. A reader has to
+    # be able to tell a fraction of this session's real window from a fallback
+    # guess, and a number printed bare reads as though something had measured it.
+    print(f"context: {used:,} / ceiling {threshold:,} ({provenance}) — "
+          f"{'OVER' if over else 'ok'}")
     return 10 if over else 0
 
 
-def successor_prompt(doc_path, pred_tid, pred_window, server, threshold):
+def successor_prompt(doc_path, pred_tid, pred_window, server, threshold, provenance):
     return f"""You are the successor Nightwatch/Daywatch judge session for this desk.
-The previous session hit its context ceiling ({threshold:,} tokens) and handed off
-to you rather than getting truncated mid-shift.
+The previous session hit its context ceiling ({threshold:,} tokens — {provenance})
+and handed off to you rather than getting truncated mid-shift.
 
 FIRST, before anything else:
 1. Read the handoff document: {doc_path}
@@ -1236,7 +1578,9 @@ FIRST, before anything else:
 4. Confirm in your first message what you picked up and what you closed.
 
 STANDING INSTRUCTION — this applies to YOU now, and to every session you spawn:
-When your own context passes {threshold:,} tokens, do not push through it. Run
+Do not push through your own context ceiling. Your ceiling is yours, not this one:
+--check resolves it against the window YOUR session reports, so run it rather than
+watching for a number.
   python3 "{pathlib.Path(__file__).resolve()}" --check
 and when it reports OVER, write your own handoff notes to a file and run
   python3 "{pathlib.Path(__file__).resolve()}" --act --notes-file <your-notes.md>
@@ -1294,7 +1638,8 @@ Transcript: {row.get('transcriptPath')}
         LATEST.unlink()
     LATEST.symlink_to(doc.name)
 
-    prompt = successor_prompt(doc, tid, row.get("tmuxWindowID"), server, args.threshold)
+    threshold, provenance = resolve_ceiling(tid, args.threshold)
+    prompt = successor_prompt(doc, tid, row.get("tmuxWindowID"), server, threshold, provenance)
     spawn = _run(
         [
             "tbd", "terminal", "create", wid,
@@ -1384,11 +1729,15 @@ def cmd_close(args):
 def selftest():
     """Offline test of the ceiling arithmetic and the fail-closed paths.
 
-    No subprocesses, no tbd, no tmux, no transcript on disk. Covers the two
-    behaviours that decide whether a shift survives: context_tokens() picking
+    No subprocesses, no tbd, no tmux, no transcript on disk. Covers the three
+    behaviours that decide whether a shift survives: the ceiling resolving
+    against the window this session actually reported, context_tokens() picking
     the largest usage record, and cmd_check refusing to report "under" when it
     cannot actually tell.
     """
+    import contextlib
+    import io
+    import shutil
     import tempfile
     n = 0
 
@@ -1398,7 +1747,9 @@ def selftest():
         n += 1
 
     class Args:
-        threshold = DEFAULT_THRESHOLD
+        # None, not a number: the ceiling is resolved per session, and pinning
+        # one here would test arithmetic no caller performs.
+        threshold = None
 
     def with_row(row):
         """Run cmd_check against a fixed terminal row, no tbd/env involved."""
@@ -1410,13 +1761,77 @@ def selftest():
         finally:
             g["resolve_self"] = real
 
+    # A scratch TBD_HOME for the whole selftest, so the capture cases below read
+    # files this function wrote and never the running desk's own.
+    home = tempfile.mkdtemp(prefix="handoff-selftest-")
+    prior_home = os.environ.get("TBD_HOME")
+    os.environ["TBD_HOME"] = home
+
+    def publish_capture(payload, terminal_id="T"):
+        """Put a statusline payload where the tee would have put it."""
+        path = statusline_capture_path(terminal_id)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as fh:
+            fh.write(payload)
+        return path
+
+    def window_payload(size):
+        return json.dumps({"context_window": {"context_window_size": size}})
+
+    # The capture path is the one Swift builds. Nothing mechanical ties the two
+    # spellings together, so a drift here reads as "no capture" — the ceiling
+    # would fall back on every desk forever, silently.
+    check("the capture path is TBD_HOME/runtime/statusline-capture-<key>.json",
+          statusline_capture_path("T-1_2"),
+          os.path.join(home, "runtime", "statusline-capture-T-1_2.json"))
+    check("a key with unsafe characters sanitizes the way Swift sanitizes",
+          os.path.basename(statusline_capture_path("a/b .c")),
+          "statusline-capture-a_b__c.json")
+
+    # THE CEILING IS THREE QUARTERS OF THE WINDOW THIS SESSION REPORTED. A desk
+    # on a large window that was held to a small ceiling spends its shift
+    # relaying instead of working; one on a small window held to a large ceiling
+    # truncates. Only the capture can tell them apart.
+    publish_capture(window_payload(1_000_000))
+    check("a 1M-window desk gets a 750k ceiling", resolve_ceiling("T")[0], 750_000)
+    check("and is told the window was observed",
+          "OBSERVED" in resolve_ceiling("T")[1], True)
+    publish_capture(window_payload(200_000))
+    check("a 200k-window desk gets a 150k ceiling", resolve_ceiling("T")[0], 150_000)
+
+    # Every unreadable shape is "not observed", never an exception: this runs on
+    # the path that keeps a shift alive.
+    for label, payload in (
+        ("malformed JSON", "{not json"),
+        ("no context_window object", json.dumps({"model": {"id": "x"}})),
+        ("no context_window_size key", json.dumps({"context_window": {}})),
+        ("a zero window", window_payload(0)),
+        ("a negative window", window_payload(-1)),
+        ("a non-numeric window", json.dumps({"context_window": {"context_window_size": "1m"}})),
+        ("a payload that is not an object", json.dumps([1, 2, 3])),
+    ):
+        publish_capture(payload)
+        check(f"{label} reads as no capture", observed_window("T"), None)
+        check(f"{label} falls back rather than raising",
+              resolve_ceiling("T")[0], FALLBACK_THRESHOLD)
+
+    os.unlink(statusline_capture_path("T"))
+    check("no capture at all falls back", resolve_ceiling("T")[0], FALLBACK_THRESHOLD)
+    check("and the fallback says it is a guess, not a measurement",
+          ("NOT observed" in resolve_ceiling("T")[1]
+           and "fallback" in resolve_ceiling("T")[1]), True)
+    check("an explicit --threshold wins over both",
+          resolve_ceiling("T", 42), (42, "set explicitly with --threshold"))
+
+    # Everything below runs in the fallback regime — there is no capture left on
+    # disk — so the ceiling in effect is FALLBACK_THRESHOLD.
+    #
     # context_tokens: the reported figure is input + BOTH cache buckets, and the
     # largest record in the tail wins (the tail holds smaller earlier turns).
-    # Derived from DEFAULT_THRESHOLD, never a literal: the 2026-07-29 raise to
-    # 600k silently turned a hardcoded 250_000 "over" fixture into an "under"
-    # one, so the selftest would have kept passing while asserting the opposite
-    # of its own label.
-    over_total = DEFAULT_THRESHOLD + 50_000
+    # Derived from the ceiling in effect, never a literal: a hardcoded "over"
+    # fixture becomes an "under" one the moment the ceiling moves past it, and
+    # the selftest keeps passing while asserting the opposite of its own label.
+    over_total = FALLBACK_THRESHOLD + 50_000
     with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
         for total in (10_000, over_total, 40_000):
             fh.write(json.dumps({"message": {"usage": {
@@ -1433,6 +1848,26 @@ def selftest():
         small = fh.name
     check("under ceiling exits 0", with_row({"transcriptPath": small}), 0)
 
+    # --check prints the ceiling WITH its provenance, in both regimes. A reader
+    # who cannot tell a fraction of a real window from a fallback guess has been
+    # handed a number that looks measured and is not.
+    said = io.StringIO()
+    with contextlib.redirect_stdout(said):
+        with_row({"transcriptPath": small})
+    reported = said.getvalue()
+    check("a fallback ceiling is reported as not observed",
+          (f"{FALLBACK_THRESHOLD:,}" in reported and "NOT observed" in reported), True)
+
+    publish_capture(window_payload(1_000_000))
+    said = io.StringIO()
+    with contextlib.redirect_stdout(said):
+        with_row({"transcriptPath": small})
+    observed_report = said.getvalue()
+    check("an observed ceiling is reported as observed, with the window it came from",
+          ("750,000" in observed_report and "OBSERVED" in observed_report
+           and "1,000,000-token window" in observed_report), True)
+    os.unlink(statusline_capture_path("T"))
+
     # FAIL CLOSED. Each of these once returned 0 ("under ceiling"), which is how
     # a session runs past its ceiling with nobody ever telling it to hand off.
     check("unreadable transcript fails closed",
@@ -1441,8 +1876,48 @@ def selftest():
     check("empty transcriptPath fails closed", with_row({"transcriptPath": ""}), 10)
     check("no usage records fails closed", context_tokens(os.devnull), None)
 
+    # A MALFORMED record must fail closed too, and that is a different claim
+    # from an unreadable file: each of these once raised out of context_tokens,
+    # past cmd_check, and out of the process as a traceback with status 1 —
+    # neither documented outcome, so no caller reads it as OVER and the shift
+    # runs on to truncation. Every shape is asserted through cmd_check, since
+    # the exit status is the contract.
+    with tempfile.NamedTemporaryFile("wb", suffix=".jsonl", delete=False) as fh:
+        fh.write(json.dumps({"message": {"usage": {
+            "input_tokens": None, "cache_creation_input_tokens": None,
+            "cache_read_input_tokens": None}}}).encode() + b"\n")
+        fh.write(b"\xff\xfe not utf-8 at all\n")
+        fh.write(json.dumps({"message": {"usage": {
+            "input_tokens": over_total - 30, "cache_creation_input_tokens": None,
+            "cache_read_input_tokens": 30}}}).encode() + b"\n")
+        fh.write(json.dumps([1, 2, 3]).encode() + b"\n")
+        malformed = fh.name
+    check("null buckets and invalid UTF-8 are skipped, not raised",
+          context_tokens(malformed), over_total)
+    check("and the surviving record still drives the exit status",
+          with_row({"transcriptPath": malformed}), 10)
+
+    # The read is bounded to the tail, so `--check` costs one seek rather than a
+    # multi-megabyte file read on the hot path of a shift that is already tiring.
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
+        fh.write(json.dumps({"message": {"usage": {
+            "input_tokens": over_total}}}) + "\n")
+        fh.write(json.dumps({"filler": "x" * (TAIL_WINDOW_BYTES + 4096)}) + "\n")
+        beyond = fh.name
+    check("a usage record beyond the tail window is not read",
+          context_tokens(beyond), None)
+    check("and an unreadable tail still fails closed",
+          with_row({"transcriptPath": beyond}), 10)
+
+    os.unlink(malformed)
+    os.unlink(beyond)
     os.unlink(path)
     os.unlink(small)
+    shutil.rmtree(home, ignore_errors=True)
+    if prior_home is None:
+        os.environ.pop("TBD_HOME", None)
+    else:
+        os.environ["TBD_HOME"] = prior_home
     print(f"selftest: {n}/{n} handoff ceiling scenarios passed")
 
 
@@ -1457,7 +1932,12 @@ def main():
     g.add_argument("--close-predecessor", metavar="TID", help="successor closes the old session")
     g.add_argument("--selftest", action="store_true", help="offline ceiling/fail-closed test")
     p.add_argument("--notes-file", help="markdown file holding the handoff body (required with --act)")
-    p.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
+    # No default: the ceiling is resolved per session (resolve_ceiling), and a
+    # default here would be a third number competing with the two that mean
+    # something. Passing --threshold is an explicit override and says so.
+    p.add_argument("--threshold", type=int, default=None,
+                   help="override the resolved ceiling (default: ¾ of this session's "
+                        "reported window, else the fallback)")
     args = p.parse_args()
 
     if args.check:

--- a/Sources/TBDShared/PRBinding.swift
+++ b/Sources/TBDShared/PRBinding.swift
@@ -70,6 +70,28 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
                   status: status, source: source, detached: detached, boundAt: boundAt)
     }
 
+    /// Whether two bindings describe the **same observation**, ignoring when
+    /// the status inside them was read.
+    ///
+    /// **Change detection uses this; `==` does not**, for exactly the reason
+    /// `PRStatus.sameValue(as:)` states: `observedAt` advances on every poll, so
+    /// an equality that includes it answers "different" every cadence and turns
+    /// the poll's persist-on-change into one row UPDATE per binding per tick,
+    /// forever, on a fleet whose steady state is zero writes.
+    ///
+    /// `Equatable` itself keeps the stamp, so a persisted round trip can still
+    /// prove the stamp survived.
+    public func sameValue(as other: PRBinding) -> Bool {
+        unstamped == other.unstamped
+    }
+
+    /// This binding with its status's freshness stamp cleared, so the compiler
+    /// writes the field-by-field comparison `sameValue(as:)` needs.
+    private var unstamped: PRBinding {
+        withObservation(status: status?.withObservedAt(nil),
+                        headBranch: headBranch, baseRef: baseRef)
+    }
+
     /// Identity for deduplication — matches the table's UNIQUE constraint.
     /// Owner and repo compare case-insensitively because GitHub treats them so.
     public var identityKey: String {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -203,6 +203,7 @@ public enum RPCMethod {
     public static let terminalSwapProfile = "terminal.swapProfile"
     public static let terminalSessionEvent = "terminal.sessionEvent"
     public static let terminalActivityEvent = "terminal.activityEvent"
+    public static let terminalNotificationEvent = "terminal.notificationEvent"
     public static let terminalAskUserQuestionPending = "terminal.askUserQuestionPending"
     public static let terminalAskUserQuestionCleared = "terminal.askUserQuestionCleared"
     public static let appSetForegroundState = "app.setForegroundState"
@@ -212,6 +213,7 @@ public enum RPCMethod {
     public static let repoSetExpanded = "repo.setExpanded"
     public static let sessionList = "session.list"
     public static let sessionMessages = "session.messages"
+    public static let sessionStates = "session.states"
     public static let setMainAreaSize = "app.setMainAreaSize"
     public static let daemonLegacyHooksStatus = "daemon.legacyHooksStatus"
     public static let daemonRemoveLegacyGlobalHooks = "daemon.removeLegacyGlobalHooks"
@@ -849,7 +851,36 @@ public struct NotificationsMarkReadParams: Codable, Sendable {
 
 public struct PRListResult: Codable, Sendable {
     public let statuses: [UUID: PRStatus]
-    public init(statuses: [UUID: PRStatus]) { self.statuses = statuses }
+
+    /// The outcome of the last attempt to learn each worktree's PR state.
+    ///
+    /// Carried beside `statuses` rather than folded into it, because the two
+    /// answer different questions and routinely disagree: a worktree absent
+    /// from `statuses` may have no PR (`.none`) or may be one nobody could ask
+    /// about (`.undetermined`), and a worktree *present* in `statuses` may be
+    /// holding a value the last attempt failed to reconfirm. Collapsing them
+    /// is the bug this field exists to prevent — an outage that reads as a
+    /// fleet with no pull requests looks exactly like a calm night.
+    ///
+    /// Empty when the daemon predates the field; a missing entry means no
+    /// attempt is on record, which is a third thing again from either outcome.
+    public let observations: [UUID: PRObservation]
+
+    public init(statuses: [UUID: PRStatus], observations: [UUID: PRObservation] = [:]) {
+        self.statuses = statuses
+        self.observations = observations
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case statuses
+        case observations
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        statuses = try c.decode([UUID: PRStatus].self, forKey: .statuses)
+        observations = try c.decodeIfPresent([UUID: PRObservation].self, forKey: .observations) ?? [:]
+    }
 }
 
 public struct PRRefreshParams: Codable, Sendable {
@@ -857,11 +888,39 @@ public struct PRRefreshParams: Codable, Sendable {
     public init(worktreeID: UUID) { self.worktreeID = worktreeID }
 }
 
-// PRRefreshResult wraps an optional PRStatus.
-// nil means no PR found for this worktree's branch.
+/// The result of an on-demand `pr.refresh`.
+///
+/// `status` is the newest value anyone holds for the worktree — which is not
+/// the same as the value this refresh found. A refresh that could not reach the
+/// forge deliberately returns the *previous cached* status rather than guessing,
+/// so a non-nil `status` does not mean "confirmed just now", and a nil `status`
+/// does not mean "no PR": it means nothing is cached, whether because the forge
+/// said there is no PR or because nobody ever got an answer.
+///
+/// `observation` is what disambiguates. It reports the outcome of *this*
+/// attempt — `.observed`, `.none`, or `.undetermined(cause:)` — with the moment
+/// it was made. nil only when the attempt could not be made at all (the
+/// worktree is no longer known), or when talking to a daemon that predates the
+/// field.
 public struct PRRefreshResult: Codable, Sendable {
     public let status: PRStatus?
-    public init(status: PRStatus?) { self.status = status }
+    public let observation: PRObservation?
+
+    public init(status: PRStatus?, observation: PRObservation? = nil) {
+        self.status = status
+        self.observation = observation
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case observation
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        status = try c.decodeIfPresent(PRStatus.self, forKey: .status)
+        observation = try c.decodeIfPresent(PRObservation.self, forKey: .observation)
+    }
 }
 
 // MARK: - PR bindings (multi-PR per worktree)
@@ -1622,6 +1681,24 @@ public struct TerminalContinueInCodexResult: Codable, Sendable, Equatable {
 public struct TerminalListParams: Codable, Sendable {
     public let worktreeID: UUID?
     public init(worktreeID: UUID? = nil) { self.worktreeID = worktreeID }
+}
+
+/// Which terminals `session.states` should report on. Absent `worktreeID` means
+/// the whole fleet — the ordinary call, since the point of the method is asking
+/// about every agent every cycle.
+public struct SessionStatesParams: Codable, Sendable {
+    public let worktreeID: UUID?
+    public init(worktreeID: UUID? = nil) { self.worktreeID = worktreeID }
+}
+
+/// One `session.states` answer: a `SessionStateReport` per terminal.
+///
+/// A wrapper rather than a bare array so a later slice can add a fleet-level
+/// field (a pass timestamp, a count of terminals skipped) without changing the
+/// shape every existing reader decodes.
+public struct SessionStatesResult: Codable, Sendable {
+    public let reports: [SessionStateReport]
+    public init(reports: [SessionStateReport]) { self.reports = reports }
 }
 
 /// One `terminal.send` request. Exactly one payload kind per call — `text` or
@@ -2629,6 +2706,54 @@ public struct TerminalActivityEventParams: Codable, Sendable {
     public init(terminalID: UUID, activityState: TerminalActivityState) {
         self.terminalID = terminalID
         self.activityState = activityState
+    }
+}
+
+/// Params for `terminal.notificationEvent` — sent by `tbd hooks notification`
+/// for EVERY Claude Code `Notification` event, whatever its type.
+///
+/// The CLI interprets nothing: it lifts the fields it can name, carries the
+/// whole payload in `rawPayload`, and lets the daemon do the only classifying
+/// there is. Keeping the fork daemon-side is deliberate — the hook entry lives
+/// in a file an operator can edit, so a matcher or a branch out there would be
+/// a policy decision TBD could not rely on.
+public struct TerminalNotificationEventParams: Codable, Sendable, Equatable {
+    public let terminalID: UUID
+    /// `notification_type` verbatim, or nil when the payload carried none.
+    /// Never normalized, never defaulted to a known type.
+    public let notificationType: String?
+    /// The notification text, verbatim.
+    public let message: String
+    /// The notification title, when the payload carried one. Reported rather
+    /// than persisted in a column of its own: `AwaitingInputReason` models the
+    /// message and the type, and the title survives inside `rawPayload` for a
+    /// consumer that wants it. Carried on the wire anyway so the daemon can
+    /// start using it without a CLI release — an older CLI is the thing that
+    /// cannot be fixed retroactively.
+    public let title: String?
+    /// The entire stdin payload as it arrived, so a later consumer can read a
+    /// field this build does not model.
+    public let rawPayload: String?
+    /// Claude's reported working directory, used only for the same
+    /// foreign-session guard `terminal.sessionEvent` applies: a hook fired by a
+    /// session living in another worktree must not write to this terminal.
+    /// Optional for backward compatibility with older CLIs.
+    public let cwd: String?
+
+    public init(
+        terminalID: UUID,
+        notificationType: String?,
+        message: String,
+        title: String? = nil,
+        rawPayload: String? = nil,
+        cwd: String? = nil
+    ) {
+        self.terminalID = terminalID
+        self.notificationType = notificationType
+        self.message = message
+        self.title = title
+        self.rawPayload = rawPayload
+        self.cwd = cwd
     }
 }
 

--- a/Sources/TBDShared/SessionStateModel.swift
+++ b/Sources/TBDShared/SessionStateModel.swift
@@ -1,0 +1,772 @@
+import Foundation
+
+// MARK: - The governing idea
+//
+// A fact TBD reports about a session is never a bare enumeration. It is a
+// triple — the value, the source it came from, and the moment it was observed —
+// so that a consumer can always ask two questions of anything it is told: *how
+// do you know*, and *when did you learn it*. `ObservedFact` is that triple, and
+// every state-shaped thing in this file either is one or is built out of them.
+//
+// The consequence that matters is what becomes unspellable. A value with no
+// provenance cannot be constructed, so it cannot drift into a briefing, a
+// threshold comparison, or a rendered surface pretending to be current. And
+// because provenance is structural rather than conventional, `unknown` gets to
+// be a first-class answer — "nothing could speak to this" is a fact with a
+// source (`.unavailable`) and an observed-at like any other, not an error and
+// not an excuse to substitute a confident value that happens to be at hand.
+//
+// This is the state-model half of the fleet-supervision design
+// (`docs/specs/2026-07-26-fleet-supervision-design.md` §2). It defines shapes
+// and says nothing about policy: no thresholds, no verdicts, no actions. What
+// counts as too long, too many, or too full is a project's convention and lives
+// in its sweep program.
+
+// MARK: - FactSource
+
+/// Where a fact came from.
+///
+/// Every case names a machine interface TBD already talks to, or the honest
+/// absence of one. That is deliberate: a source vocabulary that could name a
+/// *guess* would let a guess be recorded as an observation. `.derived` is the
+/// closest thing to an exception and is fenced by its own doc comment.
+///
+/// The wire form is a tagged object — `{"kind": "hook", "detail":
+/// "Notification"}` — rather than a bare string, so a source that carries a
+/// qualifier (which hook event, specifically) does not have to smuggle it
+/// through string concatenation.
+///
+/// New kinds are additive. A reader meeting a `kind` it does not know decodes
+/// `.unrecognized(raw)` and carries the name through verbatim rather than
+/// failing the whole record — the same forward-compatibility promise
+/// `RecordedResult.unrecognized` makes for the actuation ledger. The one
+/// bounded loss: an unrecognized kind's `detail` is not retained, because the
+/// case has nowhere to put it. Nothing re-writes a stored fact in place — the
+/// daemon replaces facts with fresh observations — so the loss cannot compound.
+public enum FactSource: Sendable, Equatable, Hashable, Codable {
+    /// A Claude Code hook event reported it; the associated value is the event
+    /// name (`SessionStart`, `Stop`, `Notification`, …). The name is carried,
+    /// never matched against a rendered screen.
+    case hookEvent(String)
+    /// The session's transcript JSONL, read from the tail.
+    case transcriptTail
+    /// The statusline wrapper's captured stdin JSON — the one surface on which
+    /// Claude Code tells a third party its *resolved* context window.
+    case statuslineTee
+    /// TBD's own persisted record: the hibernation columns, the scheduled-resume
+    /// rows, anything the daemon wrote down earlier and is now reading back.
+    case database
+    /// tmux pane and process liveness.
+    case processLiveness
+    /// The git forge — a pull-request query.
+    case forge
+    /// The daemon's git sweep.
+    case gitSweep
+    /// Composed by TBD from other facts.
+    ///
+    /// Not a laundering channel: a `.derived` fact must be a function of facts
+    /// that were themselves observed, and its `observedAt` must be no later
+    /// than the oldest input it was composed from. Deriving a value nobody
+    /// observed and stamping it `.derived` is the one way to defeat everything
+    /// this file exists to guarantee.
+    case derived
+    /// Nothing could speak to it. Pairs with an `unknown` value: this is what
+    /// the source field says when the honest answer is "we do not know".
+    case unavailable
+    /// A `kind` this build does not know — written by a newer daemon, or by
+    /// hand. Carried through verbatim so it can be reported rather than lost.
+    case unrecognized(String)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case detail
+    }
+
+    /// The wire tag. `.unrecognized` reports the raw kind it was given, so a
+    /// name a newer daemon wrote survives a decode/encode round trip.
+    public var kind: String {
+        switch self {
+        case .hookEvent: return "hook"
+        case .transcriptTail: return "transcript-tail"
+        case .statuslineTee: return "statusline-tee"
+        case .database: return "database"
+        case .processLiveness: return "process-liveness"
+        case .forge: return "forge"
+        case .gitSweep: return "git-sweep"
+        case .derived: return "derived"
+        case .unavailable: return "unavailable"
+        case .unrecognized(let raw): return raw
+        }
+    }
+
+    /// The kind's qualifier, when it has one.
+    public var detail: String? {
+        if case .hookEvent(let event) = self { return event }
+        return nil
+    }
+
+    /// One line, for composition into `ObservedFact.summary`.
+    public var summary: String {
+        guard let detail else { return kind }
+        return "\(kind):\(detail)"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try c.decode(String.self, forKey: .kind)
+        let detail = try c.decodeIfPresent(String.self, forKey: .detail)
+        switch kind {
+        case "hook":
+            // `hook` without a `detail` is not a source: the qualifier IS the
+            // provenance — which hook fired — and an empty one renders as the
+            // bare `hook:` and satisfies every "does this fact name its source"
+            // check while naming nothing. It is filed as unrecognized, which is
+            // what this decoder already does with a kind it cannot make sense
+            // of, and which round-trips back to the same bytes.
+            if let detail, !detail.isEmpty { self = .hookEvent(detail) } else { self = .unrecognized(kind) }
+        case "transcript-tail": self = .transcriptTail
+        case "statusline-tee": self = .statuslineTee
+        case "database": self = .database
+        case "process-liveness": self = .processLiveness
+        case "forge": self = .forge
+        case "git-sweep": self = .gitSweep
+        case "derived": self = .derived
+        case "unavailable": self = .unavailable
+        default: self = .unrecognized(kind)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(kind, forKey: .kind)
+        try c.encodeIfPresent(detail, forKey: .detail)
+    }
+}
+
+// MARK: - ObservedFact
+
+/// A value that renders its own provenance.
+///
+/// Types conform so that `ObservedFact.summary` can print something better than
+/// `String(describing:)` for values that have a human reading. Conformance is
+/// optional — the default is the describing form — because the point of the
+/// protocol is presentation, not correctness.
+public protocol FactValueSummarizable {
+    var factSummary: String { get }
+}
+
+/// The triple: a value, the source it came from, and when it was observed.
+///
+/// `observedAt` is the moment the machine facts were *read*, which is not the
+/// moment anything was written down — the same distinction `ActuationRow` draws
+/// between `observedAt` and `ts`. Downstream code that ages a fact must age it
+/// by this field; a write timestamp would make a stale fact look fresh every
+/// time the row was rewritten.
+public struct ObservedFact<Value: Codable & Sendable & Equatable>: Codable, Sendable, Equatable {
+    public let value: Value
+    public let source: FactSource
+    public let observedAt: Date
+
+    public init(value: Value, source: FactSource, observedAt: Date) {
+        self.value = value
+        self.source = source
+        self.observedAt = observedAt
+    }
+
+    /// The whole triple on one line.
+    ///
+    /// There is deliberately no "just the value" rendering on this type. A
+    /// surface that wants to print a fact gets its provenance whether it asked
+    /// for it or not, which is what stops a bare value from reaching a reader
+    /// who would then have no way to ask how old it is.
+    public var summary: String {
+        let rendered = (value as? FactValueSummarizable)?.factSummary ?? String(describing: value)
+        return "\(rendered) (source: \(source.summary), observed \(FactTimestamp.string(from: observedAt)))"
+    }
+}
+
+/// The one timestamp rendering used by every `summary` in this file: ISO 8601
+/// in UTC, so a composed line is stable across machines and test runs.
+public enum FactTimestamp {
+    /// Built per call rather than cached in a `static let`:
+    /// `ISO8601DateFormatter` is a mutable class and not `Sendable`, and these
+    /// strings are composed for display and diagnostics, never in a hot loop.
+    public static func string(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Awaiting-input reason
+
+/// The closed vocabulary a `Notification` payload's `notification_type` is
+/// filed under.
+///
+/// Four classes, and the fourth is the important one. `notification_type` is
+/// Claude Code's vocabulary, not TBD's: it gains values on their release
+/// schedule, and a value this build has never heard of is filed as
+/// `.unrecognized` and left there. It is **never** guessed into a neighbouring
+/// class on the strength of its spelling — a "sounds like a prompt" heuristic
+/// would be screen-scraping moved one layer inward, and would make TBD's
+/// reading of a session change silently when a type is renamed.
+///
+/// The class is a *label on a recorded fact*, not a branch in a decision. What
+/// a class means — whether `promptOnScreen` warrants waking someone, whether
+/// `informational` is worth a line in a briefing — is a project's convention
+/// and lives in its sweep program, exactly as the thresholds in this file's
+/// other types do.
+public enum AwaitingInputClass: String, Sendable, Equatable, Codable {
+    /// A prompt is on screen now and a human has to answer it.
+    case promptOnScreen = "prompt_on_screen"
+    /// The agent finished its turn and is waiting for a next instruction.
+    case doneWaiting = "done_waiting"
+    /// Something happened worth reporting; nobody is being waited on.
+    case informational = "informational"
+    /// A type this build does not know, or no type at all. Recorded verbatim
+    /// beside this label so a reader — human or program — can still see what
+    /// arrived.
+    case unrecognized
+
+    /// File a `notification_type` under its class. Absent or unknown →
+    /// `.unrecognized`.
+    ///
+    /// The three groups are Claude Code's documented types, listed exhaustively
+    /// so that adding one is a visible edit rather than a silent reclassification.
+    public init(notificationType: String?) {
+        switch notificationType {
+        case "permission_prompt", "elicitation_dialog", "agent_needs_input":
+            self = .promptOnScreen
+        case "idle_prompt":
+            self = .doneWaiting
+        case "auth_success", "elicitation_complete", "elicitation_response", "agent_completed":
+            self = .informational
+        default:
+            // Absent, or a type this build has never heard of. It stops here:
+            // no prefix match, no case folding, no "sounds like a prompt".
+            self = .unrecognized
+        }
+    }
+
+    /// A tag this build does not know decodes to `.unrecognized` rather than
+    /// throwing.
+    ///
+    /// **This is not what makes an `AwaitingInputReason` forward-compatible,
+    /// and it is worth being exact about which mechanism is load-bearing.**
+    /// That type's decoder routes through its memberwise init and re-derives
+    /// `classification` from the decoded `notificationType`, so the encoded
+    /// class is never read and this initializer is never reached from there —
+    /// a record written by a newer build survives because *this build's*
+    /// vocabulary re-files it, not because the tag decoded leniently. This
+    /// initializer covers the remaining case: someone decoding an
+    /// `AwaitingInputClass` on its own, where a `rawValue` from a newer build
+    /// must be an admission of ignorance rather than a thrown error that takes
+    /// the enclosing record with it.
+    public init(from decoder: any Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = AwaitingInputClass(rawValue: raw) ?? .unrecognized
+    }
+}
+
+/// The structured reason an agent is waiting, carried verbatim from Claude
+/// Code's `Notification` hook.
+///
+/// **TBD never branches on `message`.** It is carried into a briefing, into a
+/// question raised on a project's question route, and into the one-minute
+/// re-check — and read by a human or by a project's own program, both of which
+/// may interpret it however they like. Compiled TBD may not, because matching
+/// on that text would be screen-scraping with an extra hop: the string is a
+/// display artifact of one Claude Code version, and a reworded prompt would
+/// silently change TBD's behavior.
+///
+/// `raw` keeps the payload JSON as it arrived, so a later consumer can read a
+/// field this build does not model without waiting for a TBD release.
+public struct AwaitingInputReason: Codable, Sendable, Equatable {
+    /// The prompt text, verbatim. Carried, never parsed.
+    public let message: String
+    /// The hook event that delivered it, when known — `Notification` today.
+    public let hookEventName: String?
+    /// The verbatim payload JSON, when it was captured.
+    public let raw: String?
+    /// `notification_type` exactly as it arrived, or nil when the payload
+    /// carried none (an older Claude Code). Stored unmodified even when this
+    /// build does not recognize it.
+    public let notificationType: String?
+    /// Which class `notificationType` falls under.
+    ///
+    /// Derived from `notificationType` at construction and **re-derived on
+    /// decode** rather than trusted from the wire, so the pair can never
+    /// disagree: a stored row cannot claim a class its own type does not
+    /// support, and this build's vocabulary is always the one that decides.
+    /// It is encoded anyway, because a reader outside TBD — a briefing, a
+    /// project's own program — should not have to reimplement the grouping to
+    /// read the record.
+    public let classification: AwaitingInputClass
+
+    public init(
+        message: String,
+        hookEventName: String? = nil,
+        raw: String? = nil,
+        notificationType: String? = nil
+    ) {
+        self.message = message
+        self.hookEventName = hookEventName
+        self.raw = raw
+        self.notificationType = notificationType
+        self.classification = AwaitingInputClass(notificationType: notificationType)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case message
+        case hookEventName
+        case raw
+        case notificationType
+        case classification
+    }
+
+    /// Decodes through the memberwise init so `classification` is recomputed
+    /// from the decoded `notificationType`. The encoded `classification` is
+    /// deliberately ignored — see the property's doc comment.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            message: try c.decode(String.self, forKey: .message),
+            hookEventName: try c.decodeIfPresent(String.self, forKey: .hookEventName),
+            raw: try c.decodeIfPresent(String.self, forKey: .raw),
+            notificationType: try c.decodeIfPresent(String.self, forKey: .notificationType)
+        )
+    }
+}
+
+extension AwaitingInputReason: FactValueSummarizable {
+    /// Class and verbatim type first, then the message — so a composed
+    /// `ObservedFact.summary` line carries what was asked, how TBD filed it,
+    /// where it came from, and when, and a reader can never see the message
+    /// without the label TBD put on it.
+    public var factSummary: String {
+        "awaiting input [\(classification.rawValue)] type=\(notificationType ?? "none"): \(message)"
+    }
+}
+
+// MARK: - Session state
+
+/// The P0 session-state vocabulary: what an agent is doing now.
+///
+/// `.unknown` is a real answer, not an error path. Every other case asserts
+/// something about the session, and asserting one of them wrongly is worse than
+/// admitting ignorance — a supervisor that is told `idle` about a session
+/// nobody could read will act on a session it cannot see. So `unknown` carries
+/// `why`, rides the same triple as every other value, and is what a decoder
+/// produces when it meets a tag it does not recognize. It is never repaired
+/// into a confident value on the way through.
+///
+/// The wire form is a tagged object keyed on `state`. New tags are additive:
+/// a reader meeting one it does not know decodes `.unknown(why:)` naming the
+/// raw tag, rather than throwing and taking the whole record with it.
+public enum SessionStateValue: Sendable, Equatable, Codable {
+    /// Mid-turn.
+    case working
+    /// Finished a turn and waiting for nothing in particular.
+    case idle
+    /// Blocked on a human — a permission prompt or a question. The reason is
+    /// present when the `Notification` hook supplied one.
+    case awaitingInput(reason: AwaitingInputReason?)
+    /// Stopped by a usage limit. `until` is absolute when the limit announced
+    /// one, nil when it did not.
+    case rateLimited(until: Date?)
+    /// Parked by TBD — the agent's process was torn down deliberately. The
+    /// reason is free text because who-parked-and-why is TBD's own vocabulary
+    /// (`HibernateReason`) plus whatever a wake program adds.
+    case parked(reason: String)
+    /// The session no longer exists: the pane, the window, or the process is
+    /// gone.
+    case gone
+    /// Nothing could establish the state. `why` says what was tried or what was
+    /// missing.
+    case unknown(why: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case reason
+        case until
+        case why
+    }
+
+    private enum Tag {
+        static let working = "working"
+        static let idle = "idle"
+        static let awaitingInput = "awaiting_input"
+        static let rateLimited = "rate_limited"
+        static let parked = "parked"
+        static let gone = "gone"
+        static let unknown = "unknown"
+    }
+
+    /// Short human reading. Stable enough to compose into a line; never parsed
+    /// back.
+    public var label: String {
+        switch self {
+        case .working: return "working"
+        case .idle: return "idle"
+        case .awaitingInput: return "awaiting input"
+        case .rateLimited(let until):
+            guard let until else { return "rate-limited" }
+            return "rate-limited until \(FactTimestamp.string(from: until))"
+        case .parked(let reason): return "parked (\(reason))"
+        case .gone: return "gone"
+        case .unknown(let why): return "unknown (\(why))"
+        }
+    }
+
+    /// False for `.unknown` and true for everything else. The question a
+    /// consumer asks before treating a state as something to act on.
+    public var isConfident: Bool {
+        if case .unknown = self { return false }
+        return true
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let tag = try c.decode(String.self, forKey: .state)
+        switch tag {
+        case Tag.working: self = .working
+        case Tag.idle: self = .idle
+        case Tag.awaitingInput:
+            self = .awaitingInput(reason: try c.decodeIfPresent(AwaitingInputReason.self, forKey: .reason))
+        case Tag.rateLimited:
+            self = .rateLimited(until: try c.decodeIfPresent(Date.self, forKey: .until))
+        case Tag.parked:
+            self = .parked(reason: try c.decodeIfPresent(String.self, forKey: .reason) ?? "")
+        case Tag.gone: self = .gone
+        case Tag.unknown:
+            self = .unknown(why: try c.decodeIfPresent(String.self, forKey: .why) ?? "")
+        default:
+            // Never a confident value, never a throw: an older build meeting a
+            // newer daemon's tag learns that it does not know, and says so.
+            self = .unknown(why: "unrecognized state tag '\(tag)'")
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .working:
+            try c.encode(Tag.working, forKey: .state)
+        case .idle:
+            try c.encode(Tag.idle, forKey: .state)
+        case .awaitingInput(let reason):
+            try c.encode(Tag.awaitingInput, forKey: .state)
+            try c.encodeIfPresent(reason, forKey: .reason)
+        case .rateLimited(let until):
+            try c.encode(Tag.rateLimited, forKey: .state)
+            try c.encodeIfPresent(until, forKey: .until)
+        case .parked(let reason):
+            try c.encode(Tag.parked, forKey: .state)
+            try c.encode(reason, forKey: .reason)
+        case .gone:
+            try c.encode(Tag.gone, forKey: .state)
+        case .unknown(let why):
+            try c.encode(Tag.unknown, forKey: .state)
+            try c.encode(why, forKey: .why)
+        }
+    }
+}
+
+extension SessionStateValue: FactValueSummarizable {
+    public var factSummary: String { label }
+}
+
+/// A session state as it is always stored and reported: value, source, and the
+/// moment it was observed.
+///
+/// The alias is the point. There is no other `SessionState` type, so there is
+/// no way to hold a session state without its provenance — the triple is
+/// structural, not a convention that a later call site can quietly drop.
+public typealias SessionState = ObservedFact<SessionStateValue>
+
+// MARK: - Context load
+
+/// The size of a session's context window, as an observed fact or an honest
+/// absence.
+///
+/// **There is no compiled model→window table, and there must never be one.**
+/// The effective window is a session fact, not a model fact: Claude Code
+/// resolves it per session from the model id, a `[1m]` suffix, a long-context
+/// beta header, environment overrides, and a remote feature flag, so the same
+/// model id can be a 200k session or a 1M session. Any out-of-band table
+/// reports *capability*, and capability errs in the dangerous direction — a
+/// table claiming 1M for a session actually running at 200k reads one-fifth
+/// full at the boundary, which is exactly where being wrong costs the most.
+///
+/// The only party that knows the resolved window is Claude Code, and the one
+/// surface where it tells a third party is the statusline's stdin JSON. Where
+/// that tee has not fired, the answer is `.unknown` and the report carries raw
+/// token counts with no percentage.
+public enum ContextWindow: Codable, Sendable, Equatable {
+    case observed(ObservedFact<Int>)
+    case unknown(why: String)
+
+    /// The window assumed when something needs a denominator anyway.
+    ///
+    /// It is a **labeled** assumption — every computation that uses it hands
+    /// back `assumed: true` alongside the number, and no caller may drop that
+    /// flag on the way to a surface. 200k is chosen because it errs early: if
+    /// the real window is larger, a threshold fires sooner than it needed to,
+    /// which costs attention. The opposite error costs a session.
+    ///
+    /// The same number is spelled again in Python as `ASSUMED_WINDOW`, in the
+    /// `tick.py` body inside `NightwatchSkillContent.swift`. Two languages, one
+    /// assumption and no way to share it, so it is stated twice on purpose —
+    /// change one, change the other, and keep it labeled as an assumption in
+    /// whatever a human reads.
+    public static let assumedTokens = 200_000
+
+    /// The denominator to use, and whether it was assumed.
+    public func effectiveTokens() -> (tokens: Int, assumed: Bool) {
+        switch self {
+        case .observed(let fact): return (fact.value, false)
+        case .unknown: return (Self.assumedTokens, true)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case window
+        case fact
+        case why
+    }
+
+    private enum Tag {
+        static let observed = "observed"
+        static let unknown = "unknown"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let tag = try c.decode(String.self, forKey: .window)
+        switch tag {
+        case Tag.observed:
+            self = .observed(try c.decode(ObservedFact<Int>.self, forKey: .fact))
+        case Tag.unknown:
+            self = .unknown(why: try c.decodeIfPresent(String.self, forKey: .why) ?? "")
+        default:
+            // Same rule as `SessionStateValue`: an unfamiliar tag becomes an
+            // admission of ignorance, never a number.
+            self = .unknown(why: "unrecognized window tag '\(tag)'")
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .observed(let fact):
+            try c.encode(Tag.observed, forKey: .window)
+            try c.encode(fact, forKey: .fact)
+        case .unknown(let why):
+            try c.encode(Tag.unknown, forKey: .window)
+            try c.encode(why, forKey: .why)
+        }
+    }
+}
+
+/// How full a session's context is: a numerator that may be unknown over a
+/// denominator that may be assumed.
+///
+/// The two halves are separately fallible and are modeled separately for that
+/// reason. `used` comes from the last assistant record's `usage` block at the
+/// transcript tail; the window comes from the statusline tee. Either can be
+/// missing without the other, and collapsing them into one optional percentage
+/// would lose which one was missing.
+public struct ContextLoad: Codable, Sendable, Equatable {
+    /// Tokens currently in the window. nil when the transcript tail could not
+    /// be read or carried no usage block.
+    public let used: ObservedFact<Int>?
+    public let window: ContextWindow
+
+    public init(used: ObservedFact<Int>?, window: ContextWindow) {
+        self.used = used
+        self.window = window
+    }
+
+    /// Whether numerator and denominator are one reading rather than two.
+    ///
+    /// True only when both halves came from the same source at the same
+    /// instant — in practice, when the statusline tee's captured payload
+    /// carried a `current_usage` and a `context_window_size` together, which is
+    /// Claude Code computing both at once from its own state. False whenever
+    /// the numerator was read from the transcript tail while the denominator
+    /// came from an earlier capture, and false when the window is unknown.
+    ///
+    /// The distinction is not pedantry: a numerator and a denominator observed
+    /// at different moments were never simultaneously true, so a percentage
+    /// composed from them is an estimate and has to be shown as one. This is
+    /// what lets a consumer say so instead of silently presenting the pair as
+    /// one coherent fraction.
+    public var isPairedReading: Bool {
+        guard let used, case .observed(let windowFact) = window else { return false }
+        return used.source == windowFact.source && used.observedAt == windowFact.observedAt
+    }
+
+    /// Fraction of the window in use, and whether the 200k assumption was used
+    /// to get it.
+    ///
+    /// nil when the numerator is unknown — there is no percentage to report and
+    /// none may be invented — or when the denominator is non-positive, which
+    /// only a malformed observation can produce. `assumedWindow` is true
+    /// exactly when the window was unknown, and callers must carry it onto
+    /// whatever surface shows the number.
+    public func percentUsed() -> (percent: Double, assumedWindow: Bool)? {
+        guard let used else { return nil }
+        let (tokens, assumed) = window.effectiveTokens()
+        guard tokens > 0 else { return nil }
+        return (Double(used.value) / Double(tokens) * 100, assumed)
+    }
+}
+
+// MARK: - PR observation
+
+/// The outcome of one attempt to learn a worktree's pull-request state — a
+/// different fact from the PR value itself.
+///
+/// This type exists to prevent one specific bug: collapsing "the forge answered
+/// and this branch has no PR" into "we could not find out". They are opposite
+/// facts. The first is settled knowledge a program can act on; the second is
+/// ignorance that must be retried or reported. A single nil `PRStatus` says
+/// both, and a night spent treating an outage as "no PR anywhere" looks exactly
+/// like a calm night.
+public struct PRObservation: Codable, Sendable, Equatable {
+    public enum Outcome: Sendable, Equatable, Codable {
+        /// The forge answered and there is a PR; its value rides in `PRStatus`.
+        case observed
+        /// The forge answered; this branch has no PR.
+        case none
+        /// The attempt did not produce an answer. `cause` says why — a network
+        /// failure, a missing credential, a query error.
+        case undetermined(cause: String)
+
+        private enum CodingKeys: String, CodingKey {
+            case outcome
+            case cause
+        }
+
+        private enum Tag {
+            static let observed = "observed"
+            static let none = "none"
+            static let undetermined = "undetermined"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            let tag = try c.decode(String.self, forKey: .outcome)
+            switch tag {
+            case Tag.observed: self = .observed
+            case Tag.none: self = .none
+            case Tag.undetermined:
+                self = .undetermined(cause: try c.decodeIfPresent(String.self, forKey: .cause) ?? "")
+            default:
+                // An unfamiliar tag is ignorance, and ignorance is
+                // `.undetermined`. Decoding it as `.none` would assert the
+                // forge answered — the exact collapse this type prevents.
+                self = .undetermined(cause: "unrecognized outcome tag '\(tag)'")
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .observed:
+                try c.encode(Tag.observed, forKey: .outcome)
+            case .none:
+                try c.encode(Tag.none, forKey: .outcome)
+            case .undetermined(let cause):
+                try c.encode(Tag.undetermined, forKey: .outcome)
+                try c.encode(cause, forKey: .cause)
+            }
+        }
+    }
+
+    public let outcome: Outcome
+    /// When the attempt was made. Carried so a persisted `PRStatus` can be
+    /// labeled display-tier wherever it appears rather than rendered as current
+    /// truth — that cache was measured showing "Ready to merge" for pull
+    /// requests merged days earlier.
+    public let observedAt: Date
+
+    public init(outcome: Outcome, observedAt: Date) {
+        self.outcome = outcome
+        self.observedAt = observedAt
+    }
+}
+
+// MARK: - Counters
+
+/// Runaway-input counters for one session: how much has happened lately, and
+/// how long the working tree has stood still.
+///
+/// Every number here is a count of *events*, never of content. `turnsInWindow`
+/// counts records appended to the session's transcript JSONL without parsing a
+/// single one of them — the file is a version-unstable internal format, and
+/// counting appended lines is the one thing that stays true across its changes.
+///
+/// **Crossing any of these numbers causes nothing to happen here.** There are
+/// no thresholds in this type and there will not be any: what counts as a
+/// runaway is a project's convention and lives in its shipped sweep program.
+/// This type reports numbers; something else decides what they mean.
+public struct SessionCounters: Codable, Sendable, Equatable {
+    /// Transcript JSONL records appended since `windowStart`.
+    public let turnsInWindow: Int
+    /// Hook events received since `windowStart`.
+    public let hookEventsInWindow: Int
+    /// Start of the window both counts are taken over.
+    public let windowStart: Date
+    /// When the counts were read.
+    public let observedAt: Date
+    /// Since when the worktree's commits have not changed. nil when that was
+    /// not established — distinct from "changed just now".
+    public let commitsUnchangedSince: Date?
+
+    public init(
+        turnsInWindow: Int,
+        hookEventsInWindow: Int,
+        windowStart: Date,
+        observedAt: Date,
+        commitsUnchangedSince: Date? = nil
+    ) {
+        self.turnsInWindow = turnsInWindow
+        self.hookEventsInWindow = hookEventsInWindow
+        self.windowStart = windowStart
+        self.observedAt = observedAt
+        self.commitsUnchangedSince = commitsUnchangedSince
+    }
+}
+
+// MARK: - Report
+
+/// Everything the state model knows about one terminal, at one moment.
+///
+/// The optionals are optional because their sources are separately fallible,
+/// not because they are unimportant: a session whose transcript could not be
+/// read still has a state, and reporting the state without the context load is
+/// the honest shape. A caller that needs one of them must handle its absence
+/// rather than receiving a filled-in default.
+public struct SessionStateReport: Codable, Sendable, Equatable {
+    public let terminalID: UUID
+    public let worktreeID: UUID
+    public let state: SessionState
+    public let contextLoad: ContextLoad?
+    public let counters: SessionCounters?
+
+    public init(
+        terminalID: UUID,
+        worktreeID: UUID,
+        state: SessionState,
+        contextLoad: ContextLoad? = nil,
+        counters: SessionCounters? = nil
+    ) {
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.state = state
+        self.contextLoad = contextLoad
+        self.counters = counters
+    }
+}

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -221,7 +221,7 @@ rate on `main` with **zero** logic assertions failing.
 `.timeLimit(.minutes(4))` = 240 s. The suite limit and the two wait deadlines
 race each other for real: `AttachRPCOrchestrationTests` and
 `PaneRepairCoordinatorTests` are both `.clockDriven` **and** consume
-`ciSafeDeadline`, across 48 `waitFor` call sites. Every one of those sites is
+`ciSafeDeadline`, across 44 `waitFor` call sites. Every one of those sites is
 unguarded — `waitFor` is `@discardableResult` and non-throwing on timeout, so
 the test continues and chained waits are real (the `try` covers only the inner
 `Task.sleep`).
@@ -247,7 +247,24 @@ are worth knowing before someone reaches for a raise.**
 **Count `advanceWhenSuspended` as a `waitForSuspension`** — it opens with one
 (`await waitForSuspension(...)`, then `advance`), so it pays the full 45 s
 guard. Grepping only for the literal `waitForSuspension(` undercounts every
-chain below, which is exactly the miscount a PR #547 reviewer made.
+chain below, which is exactly the miscount a PR #547 reviewer made. Count
+`advanceUntil` as **one** guard (45 s) too — it replaces an
+`advanceWhenSuspended` plus the `waitFor` that used to follow it, so converting
+a site takes 135 s off that test's paper worst case.
+
+**A single advance is the wrong instrument for a poll-and-re-arm loop, and the
+failure it produces is a hang, not a red.** `advanceWhenSuspended` proves a
+sleeper was armed when it advanced; it cannot prove the loop *observes* the
+state the test just created on the probe that follows. Where the code under test
+probes external state and re-arms if it is not there yet, one advance stakes the
+run on one probe, and a probe that reads "keep waiting" re-arms a sleep nothing
+will ever advance again. `PaneRepairCoordinatorTests`' broken-pipe test wedged
+in CI that way for its full 240 s limit — one write, `repairing` still set —
+and had already done so once before, on a diff that touched only
+`Sources/TBDCLI`. Drive those with `advanceUntil` (`Tests/TestSupport/ClockTestSupport.swift`),
+which advances for as long as the code keeps re-arming and fails with a named
+diagnostic carrying the advance count. Keep explicit single advances where the
+*number* of advances is the property under test.
 
 On that basis, the deepest chains in the tree are the poller tests, and their
 paper tallies do not all fit under the ceiling:
@@ -270,7 +287,7 @@ cannot happen. That is a property of these chains' *shape*, not of strictness
 alone: put a `next()` mid-chain and its 45 s becomes payable on top of whatever
 follows. Suites on the predecessor helpers have no such property at all and pay
 the full tally. And counting `waitFor` at 90 s plus
-each clock wait at 45 s, **9 of the 13** `PaneRepairCoordinatorTests` have a
+each clock wait at 45 s, **6 of the 13** `PaneRepairCoordinatorTests` have a
 worst case above 240 s — not just the 6-deep chain (540 s) usually cited. Every one of those is still consistent with
 the invariant, because only an already-failing test walks a full chain of
 timeouts and the first diagnostic is already recorded by then.

--- a/Tests/TBDAppTests/PRButtonLabelTests.swift
+++ b/Tests/TBDAppTests/PRButtonLabelTests.swift
@@ -37,6 +37,7 @@ struct PRButtonLabelTests {
         hibernateArmed: Bool = false,
         blocked: Bool = false,
         prStatus: PRStatus,
+        freshnessClauses: [String] = ["checked just now"],
         colorScheme: ColorScheme = .light
     ) -> String {
         PRButtonLabel.prSplitButtonID(
@@ -46,6 +47,7 @@ struct PRButtonLabelTests {
             hibernateArmed: hibernateArmed,
             blocked: blocked,
             bindings: [makeBinding(prStatus)],
+            freshnessClauses: freshnessClauses,
             colorScheme: colorScheme
         )
     }
@@ -277,8 +279,12 @@ struct PRButtonLabelTests {
         // position badge), plus the nightwatch gate metadata (files, commits,
         // authorWorktreeID), which it does NOT render — deliberately excluded,
         // else every metadata fetch would force a spurious item rebuild.
+        // 9 adds observedAt — when the forge was last asked. The RAW stamp is
+        // deliberately not keyed; the bucketed words it produces are, as
+        // `freshnessClauses`, so a re-confirmation that changes no displayed
+        // text rebuilds nothing while an age that visibly moved does.
         let status = Self.makeStatus()
-        #expect(Mirror(reflecting: status).children.count == 8)
+        #expect(Mirror(reflecting: status).children.count == 9)
     }
 
     @Test("id key differs by merge-queue position so a queue move rebuilds the item")

--- a/Tests/TBDAppTests/PRFreshnessTests.swift
+++ b/Tests/TBDAppTests/PRFreshnessTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import TBDApp
+@testable import TBDShared
+
+// DEFECT UNDER TEST: a view renders the persisted `PRStatus` as current truth.
+// That cache was measured lying — "Ready to merge" for pull requests merged days
+// earlier — so every surface that shows it must show how old it is, and must
+// distinguish "nobody could find out" from "there is no pull request". These are
+// assertions on the COMPOSED strings the row and the toolbar actually render,
+// not on the inputs, because a helper that computed the right words and a view
+// that dropped them would be the same bug.
+
+@Suite("PR freshness presentation")
+struct PRFreshnessTests {
+
+    private static let now = Date(timeIntervalSince1970: 1_760_000_000)
+
+    private static func status(observedAt: Date?) -> PRStatus {
+        PRStatus(number: 42, url: "https://example.com/42", state: .mergeable,
+                 reason: "Ready to merge", observedAt: observedAt)
+    }
+
+    private static func ago(_ seconds: TimeInterval) -> Date {
+        now.addingTimeInterval(-seconds)
+    }
+
+    // MARK: - Age
+
+    @Test("a fresh reading reads as just now")
+    func freshReadingReadsAsJustNow() {
+        #expect(PRFreshness.checkedLabel(observedAt: Self.ago(30), now: Self.now) == "checked just now")
+    }
+
+    @Test("a days-old reading says so — the measured lie, now labeled")
+    func daysOldReadingSaysSo() {
+        // The exact failure the stamp exists for: three days after the last
+        // read, a "Ready to merge" icon must carry its age.
+        let rendered = PRFreshness.checkedLabel(observedAt: Self.ago(3 * 86_400), now: Self.now)
+        #expect(rendered == "checked 3d ago")
+    }
+
+    @Test("age buckets coarsen: minutes, hours, days")
+    func ageBucketsCoarsen() {
+        #expect(PRFreshness.checkedLabel(observedAt: Self.ago(12 * 60), now: Self.now) == "checked 10m ago")
+        #expect(PRFreshness.checkedLabel(observedAt: Self.ago(3 * 3600), now: Self.now) == "checked 3h ago")
+    }
+
+    @Test("a five-minute bucket is stable between steps, so the toolbar item is not rebuilt per minute")
+    func minuteBucketsAreStable() {
+        // AppKit materializes the split button once and only rebuilds it when
+        // its `.id` changes — and the id includes these words. A per-minute
+        // label would rebuild the item (and its NSMenu) every minute.
+        let early = PRFreshness.checkedLabel(observedAt: Self.ago(21 * 60), now: Self.now)
+        let later = PRFreshness.checkedLabel(observedAt: Self.ago(24 * 60), now: Self.now)
+        #expect(early == later)
+        #expect(early == "checked 20m ago")
+        #expect(PRFreshness.checkedLabel(observedAt: Self.ago(26 * 60), now: Self.now) == "checked 25m ago")
+    }
+
+    @Test("a status with no stamp says its age is unknown rather than implying freshness")
+    func missingStampIsNotSilence() {
+        // A row persisted before the stamp existed must not read as current.
+        #expect(PRFreshness.checkedLabel(observedAt: nil, now: Self.now) == "last checked at an unknown time")
+    }
+
+    // MARK: - Undetermined vs settled
+
+    @Test("an undetermined last check is surfaced with its cause")
+    func undeterminedIsSurfaced() {
+        let clause = PRFreshness.undeterminedClause(
+            PRObservation(outcome: .undetermined(cause: "the forge query failed"), observedAt: Self.now))
+        #expect(clause == "last check did not resolve (the forge query failed)")
+    }
+
+    @Test("a settled .none adds no caveat — and is therefore not the same as .undetermined")
+    func settledNoneAddsNoCaveat() {
+        let none = PRFreshness.undeterminedClause(
+            PRObservation(outcome: .none, observedAt: Self.now))
+        let observed = PRFreshness.undeterminedClause(
+            PRObservation(outcome: .observed, observedAt: Self.now))
+        let undetermined = PRFreshness.undeterminedClause(
+            PRObservation(outcome: .undetermined(cause: "the forge query failed"), observedAt: Self.now))
+        #expect(none == nil)
+        #expect(observed == nil)
+        #expect(undetermined != nil)
+        #expect(none != undetermined)
+    }
+
+    @Test("a stale value whose last check failed renders BOTH its age and the failure")
+    func staleUnconfirmedRendersBothClauses() {
+        // The pair that is the whole point: a value from before, honestly
+        // labeled as not reconfirmed.
+        let clauses = PRFreshness.clauses(
+            status: Self.status(observedAt: Self.ago(2 * 86_400)),
+            observation: PRObservation(
+                outcome: .undetermined(cause: "the forge CLI was unavailable"), observedAt: Self.now),
+            now: Self.now)
+        #expect(clauses == ["checked 2d ago", "last check did not resolve (the forge CLI was unavailable)"])
+    }
+
+    @Test("a confirmed value renders its age and nothing else")
+    func confirmedRendersAgeOnly() {
+        let clauses = PRFreshness.clauses(
+            status: Self.status(observedAt: Self.ago(60)),
+            observation: PRObservation(outcome: .observed, observedAt: Self.now),
+            now: Self.now)
+        #expect(clauses == ["checked just now"])
+    }
+
+    // MARK: - Invisible is not acceptable
+
+    @Test("no cached PR plus an undetermined check produces a visible indicator")
+    func undeterminedWithNoStatusIsVisible() {
+        // Without this the row renders exactly like a worktree with no pull
+        // request, and a forge outage looks like a quiet fleet.
+        let tooltip = PRFreshness.unknownIndicatorTooltip(
+            PRObservation(outcome: .undetermined(cause: "the forge query failed"),
+                          observedAt: Self.ago(600)),
+            now: Self.now)
+        let rendered = try? #require(tooltip)
+        #expect(rendered == "PR status unknown — the forge query failed · checked 10m ago")
+        #expect(RowStatusIndicator.leading(
+            isPending: false, hasPRStatus: false, hasUndeterminedPR: true) == .prUnknown)
+    }
+
+    @Test("no cached PR plus a settled .none produces no indicator at all")
+    func settledNoneWithNoStatusIsSilent() {
+        // The complement, and the reason the case above is not just noise: a
+        // worktree the forge answered about shows nothing.
+        #expect(PRFreshness.unknownIndicatorTooltip(
+            PRObservation(outcome: .none, observedAt: Self.now), now: Self.now) == nil)
+        #expect(PRFreshness.unknownIndicatorTooltip(nil, now: Self.now) == nil)
+        #expect(RowStatusIndicator.leading(
+            isPending: false, hasPRStatus: false, hasUndeterminedPR: false) == nil)
+    }
+
+    @Test("a real PR status still wins the leading slot over an undetermined marker")
+    func cachedStatusOutranksTheUnknownMarker() {
+        #expect(RowStatusIndicator.leading(
+            isPending: false, hasPRStatus: true, hasUndeterminedPR: true) == .prStatus)
+        #expect(RowStatusIndicator.leading(
+            isPending: true, hasPRStatus: false, hasUndeterminedPR: true) == .pending)
+    }
+
+    // MARK: - App state keeps the two facts apart
+
+    @Test("app state carries the outcome beside the value, never merged into it")
+    @MainActor
+    func appStateKeepsBothFacts() {
+        // The layer between the RPC and the views. Merging them — dropping an
+        // observation because there is no status, or vice versa — is the same
+        // collapse one layer further out.
+        let suiteName = "TBDAppTests.PRFreshness.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+        let withValue = UUID()
+        let noValue = UUID()
+
+        state.prStatuses[withValue] = Self.status(observedAt: Self.ago(86_400))
+        state.prObservations[withValue] = PRObservation(
+            outcome: .undetermined(cause: "the forge query failed"), observedAt: Self.now)
+        state.prObservations[noValue] = PRObservation(outcome: .none, observedAt: Self.now)
+
+        // A retained value whose last check failed keeps both halves.
+        #expect(state.prStatuses[withValue]?.number == 42)
+        #expect(state.prObservations[withValue]?.outcome
+                == .undetermined(cause: "the forge query failed"))
+        // And a worktree with no value still reports which kind of "no" it is.
+        #expect(state.prStatuses[noValue] == nil)
+        #expect(state.prObservations[noValue]?.outcome == PRObservation.Outcome.none)
+        #expect(state.prObservations[noValue]?.outcome != state.prObservations[withValue]?.outcome)
+    }
+
+    // MARK: - The toolbar carries it too
+
+    @Test("the toolbar split button rebuilds when the rendered age changes")
+    @MainActor
+    func toolbarIDTracksTheRenderedAge() {
+        // AppKit materializes the label once, so an id that ignored these words
+        // would freeze the help string at whatever age it was first built with.
+        let pr = Self.status(observedAt: Self.ago(3 * 86_400))
+        let worktreeID = UUID()
+        func key(_ clauses: [String]) -> String {
+            PRButtonLabel.prSplitButtonID(
+                worktreeID: worktreeID, worktreeFound: true, armed: false, hibernateArmed: false,
+                blocked: false,
+                bindings: [PRBinding(
+                    worktreeID: worktreeID, owner: "acme", repo: "acme-prod",
+                    number: pr.number, url: pr.url, status: pr, source: .hook)],
+                freshnessClauses: clauses, colorScheme: .light)
+        }
+        #expect(key(["checked 3d ago"]) != key(["checked 4d ago"]))
+        #expect(key(["checked 3d ago"]) != key(["checked 3d ago", "last check did not resolve (x)"]))
+        #expect(key(["checked 3d ago"]) == key(["checked 3d ago"]))
+    }
+}

--- a/Tests/TBDCLITests/ConfigCommandsTests.swift
+++ b/Tests/TBDCLITests/ConfigCommandsTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import TBDCLI
+
+/// Tier 1. `config set` reports what it did, and a report is only worth
+/// printing if it is different when the thing done is different.
+@Suite("ConfigSet confirmations")
+struct ConfigCommandsTests {
+
+    /// The whole message, for every key and both values.
+    ///
+    /// Asserted as composed output rather than by hunting for a forbidden
+    /// phrase: the failure this guards against is a key printing one state's
+    /// explanation for both, and any blacklist narrow enough to catch that
+    /// would be one more thing to keep in step with the wording.
+    @Test func everyKeyAndValueDescribesTheBranchItTook() {
+        #expect(ConfigSet.confirmation(key: "auto-archive-on-merge", value: .on)
+            == "Set auto-archive-on-merge default to on.")
+        #expect(ConfigSet.confirmation(key: "auto-archive-on-merge", value: .off)
+            == "Set auto-archive-on-merge default to off.")
+        #expect(ConfigSet.confirmation(key: "auto-hibernate-on-merge", value: .on)
+            == "Set auto-hibernate-on-merge default to on.")
+        #expect(ConfigSet.confirmation(key: "auto-hibernate-on-merge", value: .off)
+            == "Set auto-hibernate-on-merge default to off.")
+    }
+
+    /// The property behind the pinned strings, stated once so a future key
+    /// cannot quietly inherit one state's explanation for both: no key may
+    /// produce the same sentence for `on` and for `off`, and each sentence has
+    /// to open by naming the value it was actually given.
+    @Test func noKeySaysTheSameThingForBothStates() {
+        for key in ["auto-archive-on-merge", "auto-hibernate-on-merge"] {
+            let on = ConfigSet.confirmation(key: key, value: .on)
+            let off = ConfigSet.confirmation(key: key, value: .off)
+            #expect(on != off, "\(key) reports the same thing whichever state it was set to")
+            #expect(on.hasSuffix(" on.") || on.contains(" to on. "),
+                    "\(key) on: \(on)")
+            #expect(off.hasSuffix(" off.") || off.contains(" to off. "),
+                    "\(key) off: \(off)")
+        }
+    }
+}

--- a/Tests/TBDCLITests/NotificationHookCommandTests.swift
+++ b/Tests/TBDCLITests/NotificationHookCommandTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import TBDCLI
+import TBDShared
+
+/// Tier 1. `tbd hooks notification` is a dumb reporter, and these tests pin
+/// exactly that: what it forwards, what it stays silent about, and that it
+/// never interprets a field on the way through.
+///
+/// The decision is tested through `NotificationHookPlan.make` rather than
+/// `run()`, because every path in `run()` is "make a plan, then either log or
+/// speak to a socket" — the plan IS the behavior, and it is pure.
+@Suite struct NotificationHookCommandTests {
+
+    private let terminalID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+    private var env: [String: String] { ["TBD_TERMINAL_ID": terminalID.uuidString] }
+
+    private func plan(_ json: String, environment: [String: String]? = nil) -> NotificationHookPlan {
+        NotificationHookPlan.make(stdin: Data(json.utf8), environment: environment ?? env)
+    }
+
+    /// Thrown rather than `Issue.record`ed so the observed plan lands on the
+    /// PRIMARY failure line — a trailing `↳` message is dropped by CI
+    /// summaries (Tests/CLAUDE.md, assertion hygiene rule 4).
+    private struct WrongPlan: Error, CustomStringConvertible {
+        let expected: String
+        let observed: NotificationHookPlan
+        var description: String { "expected a \(expected) plan — observed \(observed)" }
+    }
+
+    private func forwarded(_ plan: NotificationHookPlan) throws -> TerminalNotificationEventParams {
+        guard case .forward(let params) = plan else {
+            throw WrongPlan(expected: "forwarded", observed: plan)
+        }
+        return params
+    }
+
+    private func suppression(_ plan: NotificationHookPlan) throws -> NotificationHookPlan.Suppression {
+        guard case .suppressed(let reason) = plan else {
+            throw WrongPlan(expected: "suppressed", observed: plan)
+        }
+        return reason
+    }
+
+    // MARK: - Forwarding
+
+    @Test func fullPayloadForwardsEveryFieldAndTheVerbatimBody() throws {
+        let json = #"""
+        {"session_id":"abc123","transcript_path":"/x/00893aaf.jsonl","cwd":"/x/wt",\#
+        "hook_event_name":"Notification","message":"Claude needs your permission to use Bash",\#
+        "title":"Permission needed","notification_type":"permission_prompt"}
+        """#
+        let params = try forwarded(plan(json))
+        #expect(params.terminalID == terminalID)
+        #expect(params.notificationType == "permission_prompt")
+        #expect(params.message == "Claude needs your permission to use Bash")
+        #expect(params.title == "Permission needed")
+        #expect(params.cwd == "/x/wt")
+        // Verbatim: byte-for-byte what arrived, so a field this build does not
+        // model still reaches whoever reads the record later.
+        #expect(params.rawPayload == json)
+    }
+
+    @Test func payloadWithoutNotificationTypeForwardsWithNilType() throws {
+        // An older Claude Code sends no `notification_type`. The absence is
+        // carried as an absence — never filled in with a plausible type.
+        let json = #"{"hook_event_name":"Notification","message":"Something happened"}"#
+        let params = try forwarded(plan(json))
+        #expect(params.notificationType == nil)
+        #expect(params.message == "Something happened")
+        #expect(params.title == nil)
+    }
+
+    @Test func payloadWithoutTitleForwardsWithNilTitle() throws {
+        let json = #"{"message":"Waiting for your input","notification_type":"idle_prompt"}"#
+        let params = try forwarded(plan(json))
+        #expect(params.title == nil)
+        #expect(params.notificationType == "idle_prompt")
+        #expect(params.message == "Waiting for your input")
+    }
+
+    @Test func unknownNotificationTypeIsForwardedUntouched() throws {
+        // The CLI matches nothing: a type this build never heard of goes to the
+        // daemon spelled exactly as it arrived.
+        let json = #"{"message":"?","notification_type":"some_future_type"}"#
+        #expect(try forwarded(plan(json)).notificationType == "some_future_type")
+    }
+
+    @Test func payloadWithoutMessageForwardsAnEmptyOne() throws {
+        // That a notification fired is itself the fact; text is never invented.
+        let json = #"{"notification_type":"auth_success"}"#
+        let params = try forwarded(plan(json))
+        #expect(params.message == "")
+        #expect(params.notificationType == "auth_success")
+    }
+
+    // MARK: - Silence
+
+    @Test func absentTerminalIDIsSilent() throws {
+        let json = #"{"message":"m","notification_type":"permission_prompt"}"#
+        #expect(try suppression(plan(json, environment: [:])) == .noTerminalID)
+    }
+
+    @Test func unparseableTerminalIDIsSilent() throws {
+        let json = #"{"message":"m"}"#
+        let reason = try suppression(plan(json, environment: ["TBD_TERMINAL_ID": "not-a-uuid"]))
+        #expect(reason == .noTerminalID)
+    }
+
+    @Test func malformedJSONIsSilent() throws {
+        #expect(try suppression(plan("{not json")) == .malformedPayload)
+    }
+
+    @Test func nonObjectJSONIsSilent() throws {
+        #expect(try suppression(plan("[1,2,3]")) == .malformedPayload)
+    }
+
+    @Test func emptyStdinIsSilent() throws {
+        #expect(try suppression(plan("")) == .unusablePayloadSize)
+    }
+
+    @Test func oversizePayloadIsSilent() throws {
+        let huge = Data(repeating: UInt8(ascii: "x"), count: (1 << 20) + 1)
+        let reason = try suppression(NotificationHookPlan.make(stdin: huge, environment: env))
+        #expect(reason == .unusablePayloadSize)
+    }
+
+    /// The terminal-ID check runs first: with no route for the event, the
+    /// payload is never even parsed, so a malformed one is still just silence.
+    @Test func absentTerminalIDWinsOverMalformedPayload() throws {
+        #expect(try suppression(plan("{not json", environment: [:])) == .noTerminalID)
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
@@ -230,7 +230,7 @@ struct ActuationLogSpawnWiringTests {
         let terminal = try await db.terminals.create(
             worktreeID: worktree.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
             label: TerminalLabel.claudeCode, claudeSessionID: "sess-1", kind: .claude)
-        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle, source: .derived)
         if keepWarm {
             try await db.terminals.setKeepWarm(id: terminal.id, keepWarm: true)
         }
@@ -257,7 +257,8 @@ struct ActuationLogSpawnWiringTests {
         let logPath = try makeLogPath()
         let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
 
-        let result = await coordinator.hibernateForMerge(terminalID: fixture.terminalID)
+        let result = await coordinator.hibernateForMerge(
+            terminalID: fixture.terminalID, inputVetoEnabled: false)
         #expect(result == .ok)
 
         let written = try rows(at: logPath)
@@ -281,9 +282,57 @@ struct ActuationLogSpawnWiringTests {
         let logPath = try makeLogPath()
         let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
 
-        let result = await coordinator.hibernateForMerge(terminalID: fixture.terminalID)
+        let result = await coordinator.hibernateForMerge(
+            terminalID: fixture.terminalID, inputVetoEnabled: false)
         #expect(result == .notEligible(reason: "Terminal is pinned keep-warm"))
         #expect(try rows(at: logPath).isEmpty)
+    }
+
+    /// The pending-input veto is a rail like any other on this path: it refuses
+    /// BEFORE the request row is written, so a session the rail saved leaves no
+    /// trace of an act that never happened.
+    @Test("the pending-input veto refuses the merge park, and writes no row")
+    func mergeParkRefusedByPendingInputWritesNothing() async throws {
+        let fixture = try await makeParkable()
+        let logPath = try makeLogPath()
+        let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
+
+        // The session came to rest, then was typed into a minute later — the
+        // keystrokes are still sitting unsent in its composer.
+        let atRest = Date(timeIntervalSince1970: 1_700_000_000)
+        try await fixture.db.terminals.setActivityState(
+            id: fixture.terminalID, activityState: .idle, source: .derived, observedAt: atRest)
+        let tracker = InputActivityTracker(now: { atRest.addingTimeInterval(60) })
+        tracker.recordInput(paneID: "%0")
+        await coordinator.setInputActivity(tracker)
+
+        let result = await coordinator.hibernateForMerge(
+            terminalID: fixture.terminalID, inputVetoEnabled: true)
+        #expect(result == .notEligible(reason: "Terminal has unsent typed input"))
+        #expect(try rows(at: logPath).isEmpty)
+        #expect(try await fixture.db.terminals.get(id: fixture.terminalID)?.hibernatedAt == nil)
+    }
+
+    /// The same fixture with the flag OFF parks and records the act — today's
+    /// behavior, unchanged for every install that has not opted into the soak.
+    @Test("with the veto off the same pending input still parks")
+    func mergeParkWithVetoOffParksDespitePendingInput() async throws {
+        let fixture = try await makeParkable()
+        let logPath = try makeLogPath()
+        let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
+
+        let atRest = Date(timeIntervalSince1970: 1_700_000_000)
+        try await fixture.db.terminals.setActivityState(
+            id: fixture.terminalID, activityState: .idle, source: .derived, observedAt: atRest)
+        let tracker = InputActivityTracker(now: { atRest.addingTimeInterval(60) })
+        tracker.recordInput(paneID: "%0")
+        await coordinator.setInputActivity(tracker)
+
+        let result = await coordinator.hibernateForMerge(
+            terminalID: fixture.terminalID, inputVetoEnabled: false)
+        #expect(result == .ok)
+        #expect(try rows(at: logPath).count == 2)
+        #expect(try await fixture.db.terminals.get(id: fixture.terminalID)?.hibernatedAt != nil)
     }
 
     @Test("an unwritable record skips the merge park — the session stays live")
@@ -291,7 +340,8 @@ struct ActuationLogSpawnWiringTests {
         let fixture = try await makeParkable()
         let coordinator = makeCoordinator(db: fixture.db, logPath: try makeUnwritablePath())
 
-        let result = await coordinator.hibernateForMerge(terminalID: fixture.terminalID)
+        let result = await coordinator.hibernateForMerge(
+            terminalID: fixture.terminalID, inputVetoEnabled: false)
         guard case .notEligible(let reason) = result else {
             Issue.record("expected the park to be skipped, got \(result)")
             return

--- a/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
@@ -26,7 +26,9 @@ struct AutoHibernateOnMergeCoordinatorTests {
         sessionID: String? = "sess-1",
         kind: TerminalKind? = .claude,
         status: WorktreeStatus = .active,
-        logPath: String? = nil
+        logPath: String? = nil,
+        activityObservedAt: Date? = nil,
+        inputTracker: InputActivityTracker? = nil
     ) async throws -> (AutoHibernateOnMergeCoordinator, TBDDatabase, wtID: UUID, terminalID: UUID) {
         let db = try TBDDatabase(inMemory: true)
         let subs = StateSubscriptionManager()
@@ -45,7 +47,15 @@ struct AutoHibernateOnMergeCoordinatorTests {
             worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
             label: "claude", claudeSessionID: sessionID, kind: kind)
         if activityState != .unknown {
-            try await db.terminals.setActivityState(id: terminal.id, activityState: activityState)
+            try await db.terminals.setActivityState(
+                id: terminal.id, activityState: activityState, source: .derived,
+                observedAt: activityObservedAt ?? Date())
+        }
+        if let inputTracker {
+            // The daemon wires the input router's shared tracker into the
+            // coordinator post-construction; tests do the same so keystrokes
+            // can be driven through the merge path.
+            await hibernation.setInputActivity(inputTracker)
         }
         if keepWarm {
             try await db.terminals.setKeepWarm(id: terminal.id, keepWarm: true)
@@ -187,7 +197,7 @@ struct AutoHibernateOnMergeCoordinatorTests {
         let terminal2 = try await db.terminals.create(
             worktreeID: wtID, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "claude2", claudeSessionID: "sess-2", kind: .claude)
-        try await db.terminals.setActivityState(id: terminal2.id, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminal2.id, activityState: .idle, source: .derived)
 
         await coord.handleMergedTransition(worktreeID: wtID, prNumber: 11)
 
@@ -205,6 +215,119 @@ struct AutoHibernateOnMergeCoordinatorTests {
         #expect(notifications.first?.type == .taskComplete)
         #expect(notifications.first?.message?.contains("2 sessions") == true)
         #expect(notifications.first?.message?.contains("#11") == true)
+    }
+
+    // MARK: - Pending typed input (the input veto) on the MERGE path
+    //
+    // `TmuxManager(dryRun: true)` has no `dryRunCapturePane`, so the backup TUI
+    // scrape in `performHibernate` reads an empty pane and never fires: what
+    // these four tests exercise is the gate rail alone. Merge-park runs on the
+    // daemon's clock now, so this fires unattended — and a park that eats a
+    // half-composed prompt is not undone by reverting a commit.
+
+    /// The at-rest instant these tests pin the terminal's observation to.
+    private static let atRest = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// A tracker whose recorded input lands `after` seconds from `atRest`.
+    private func tracker(secondsAfterAtRest after: TimeInterval) -> InputActivityTracker {
+        InputActivityTracker(now: { Self.atRest.addingTimeInterval(after) })
+    }
+
+    @Test func vetoEnabledDoesNotParkSessionWithTypedInput() async throws {
+        // Typed into a minute AFTER it came to rest: the keystrokes never went
+        // through a turn, so they are still unsent. Armed merge → no park.
+        let input = tracker(secondsAfterAtRest: 60)
+        let (coord, db, wtID, terminalID) = try await makeDeps(
+            activityObservedAt: Self.atRest, inputTracker: input)
+        input.recordInput(paneID: "%0")
+        try await db.config.setHibernateInputVeto(enabled: true)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 20)
+
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+        // Nothing parked → no summary notification either.
+        #expect(try await db.notifications.unread(worktreeID: wtID).isEmpty)
+    }
+
+    @Test func vetoEnabledStillParksSessionWithNoPendingInput() async throws {
+        // Same flag, input recorded BEFORE the at-rest observation — i.e. it
+        // was submitted and the turn that consumed it is what returned the
+        // session to rest. Parks exactly as it does today.
+        let input = tracker(secondsAfterAtRest: -600)
+        let (coord, db, wtID, terminalID) = try await makeDeps(
+            activityObservedAt: Self.atRest, inputTracker: input)
+        input.recordInput(paneID: "%0")
+        try await db.config.setHibernateInputVeto(enabled: true)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 21)
+
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.hibernateReason == .merged)
+    }
+
+    @Test func vetoDisabledParksDespiteTypedInput() async throws {
+        // The flag's OFF branch, with the exact inputs that block above. This
+        // is today's behavior, and — since the column defaults to false — what
+        // every install that has not opted into the soak still gets.
+        let input = tracker(secondsAfterAtRest: 60)
+        let (coord, db, wtID, terminalID) = try await makeDeps(
+            activityObservedAt: Self.atRest, inputTracker: input)
+        input.recordInput(paneID: "%0")
+        try await db.config.setHibernateInputVeto(enabled: false)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 22)
+
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.hibernateReason == .merged)
+    }
+
+    @Test func vetoDisabledParksSessionWithNoPendingInput() async throws {
+        // The other half of the OFF branch: no recorded input, flag off. The
+        // wiring must not have changed the ordinary merge-park at all.
+        let (coord, db, wtID, terminalID) = try await makeDeps(activityObservedAt: Self.atRest)
+        try await db.config.setHibernateInputVeto(enabled: false)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 23)
+
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.hibernateReason == .merged)
+    }
+
+    @Test func vetoEnabledFailsClosedWhenNoActivityObservationExists() async throws {
+        // `.unknown` with no observation stamp (a row written before the
+        // provenance columns) plus recorded input: nothing proves the input was
+        // ever consumed, so the park is refused rather than guessed.
+        let input = tracker(secondsAfterAtRest: 0)
+        let (coord, db, wtID, terminalID) = try await makeDeps(
+            activityState: .unknown, inputTracker: input)
+        input.recordInput(paneID: "%0")
+        try await db.config.setHibernateInputVeto(enabled: true)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+        #expect(try await db.terminals.get(id: terminalID)?.activityStateObservedAt == nil)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 24)
+
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func hardRailStillBlocksWithVetoEnabledAndNoPendingInput() async throws {
+        // The rails the merge path already had are untouched by the new arm:
+        // keep-warm refuses even with the veto on and nothing typed.
+        let (coord, db, wtID, terminalID) = try await makeDeps(
+            keepWarm: true, activityObservedAt: Self.atRest)
+        try await db.config.setHibernateInputVeto(enabled: true)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 25)
+
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
     }
 
     // MARK: - The rail's own actuation record
@@ -228,7 +351,7 @@ struct AutoHibernateOnMergeCoordinatorTests {
         let keptWarm = try await db.terminals.create(
             worktreeID: wtID, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "claude2", claudeSessionID: "sess-2", kind: .claude)
-        try await db.terminals.setActivityState(id: keptWarm.id, activityState: .idle)
+        try await db.terminals.setActivityState(id: keptWarm.id, activityState: .idle, source: .derived)
         try await db.terminals.setKeepWarm(id: keptWarm.id, keepWarm: true)
 
         await coord.handleMergedTransition(worktreeID: wtID, prNumber: 12)

--- a/Tests/TBDDaemonTests/BranchTipTrackerTests.swift
+++ b/Tests/TBDDaemonTests/BranchTipTrackerTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Tier 1. The tracker is fed by the sweep's existing `for-each-ref` map, so
+/// its whole job is remembering when a tip first arrived — no git, no
+/// subprocess, and none of these tests spawns one.
+@Suite("BranchTipTracker")
+struct BranchTipTrackerTests {
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test func anUnchangedTipKeepsItsOriginalStamp() async {
+        let tracker = BranchTipTracker()
+        let repo = UUID()
+        let wt = UUID()
+        let firstStill = t0.addingTimeInterval(600)
+
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "abc123", at: t0)
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "abc123", at: firstStill)
+        await tracker.record(
+            repoID: repo, worktreeID: wt, branchTip: "abc123", at: t0.addingTimeInterval(5_400))
+
+        // Refreshing the stamp on every sweep would report every still branch
+        // as having just moved — the one bug this type exists to avoid.
+        #expect(await tracker.unchangedSince(repoID: repo, worktreeID: wt) == firstStill)
+    }
+
+    /// The **first** sighting establishes what the tip is, not how long it has
+    /// been that. Stamping it with the read would tell a supervisor that a
+    /// branch untouched for three days has been unchanged only since thirty
+    /// seconds after the daemon restarted — which disarms every stall threshold
+    /// in the fleet for hours after every restart, while looking like an answer.
+    @Test func aFirstSightingEstablishesNoStillnessAtAll() async {
+        let tracker = BranchTipTracker()
+        let repo = UUID()
+        let wt = UUID()
+
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "abc123", at: t0)
+
+        #expect(await tracker.unchangedSince(repoID: repo, worktreeID: wt) == nil,
+                "one sample cannot measure a duration, and must not pretend to")
+    }
+
+    @Test func stillnessIsStampedAtTheSecondSighting() async {
+        let tracker = BranchTipTracker()
+        let repo = UUID()
+        let wt = UUID()
+        let secondSweep = t0.addingTimeInterval(30)
+
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "abc123", at: t0)
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "abc123", at: secondSweep)
+
+        // Understated by one sweep interval, deliberately: understating costs a
+        // late stall report, overstating disarms the detector.
+        #expect(await tracker.unchangedSince(repoID: repo, worktreeID: wt) == secondSweep)
+    }
+
+    @Test func aNewTipRestartsUnestablished() async {
+        let tracker = BranchTipTracker()
+        let repo = UUID()
+        let wt = UUID()
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "abc123", at: t0)
+        await tracker.record(
+            repoID: repo, worktreeID: wt, branchTip: "abc123", at: t0.addingTimeInterval(30))
+        let committedAt = t0.addingTimeInterval(900)
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "def456", at: committedAt)
+
+        // A tip that just moved is not still; it is a first sighting again.
+        #expect(await tracker.unchangedSince(repoID: repo, worktreeID: wt) == nil)
+
+        let nextSweep = committedAt.addingTimeInterval(30)
+        await tracker.record(repoID: repo, worktreeID: wt, branchTip: "def456", at: nextSweep)
+        #expect(await tracker.unchangedSince(repoID: repo, worktreeID: wt) == nextSweep)
+    }
+
+    @Test func anUnobservedWorktreeIsNilNotUnchanged() async {
+        let tracker = BranchTipTracker()
+        // Ignorance must not be able to look like stillness.
+        #expect(await tracker.unchangedSince(repoID: UUID(), worktreeID: UUID()) == nil)
+    }
+
+    @Test func retainIsScopedToOneRepo() async {
+        let tracker = BranchTipTracker()
+        let repoA = UUID()
+        let repoB = UUID()
+        let wtA = UUID()
+        let wtB = UUID()
+        for at in [t0, t0.addingTimeInterval(30)] {
+            await tracker.record(repoID: repoA, worktreeID: wtA, branchTip: "a", at: at)
+            await tracker.record(repoID: repoB, worktreeID: wtB, branchTip: "b", at: at)
+        }
+
+        // Repo B's sweep must not evict repo A's entries — otherwise the stamps
+        // would restart on every sweep of a multi-repo install.
+        await tracker.retain(repoID: repoB, worktreeIDs: [])
+        #expect(await tracker.unchangedSince(repoID: repoA, worktreeID: wtA)
+                == t0.addingTimeInterval(30))
+        #expect(await tracker.unchangedSince(repoID: repoB, worktreeID: wtB) == nil)
+    }
+
+    @Test func retainDropsWorktreesNoLongerInTheSweep() async {
+        let tracker = BranchTipTracker()
+        let repo = UUID()
+        let kept = UUID()
+        let dropped = UUID()
+        for at in [t0, t0.addingTimeInterval(30)] {
+            await tracker.record(repoID: repo, worktreeID: kept, branchTip: "a", at: at)
+            await tracker.record(repoID: repo, worktreeID: dropped, branchTip: "b", at: at)
+        }
+        await tracker.retain(repoID: repo, worktreeIDs: [kept])
+        #expect(await tracker.unchangedSince(repoID: repo, worktreeID: kept)
+                == t0.addingTimeInterval(30))
+        #expect(await tracker.unchangedSince(repoID: repo, worktreeID: dropped) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -676,6 +676,71 @@ extension TBDHomeSerialized {
         #expect(parsed?.keys.sorted() == ["hooks"])
     }
 
+    // MARK: - Notification hook
+
+    /// Renders the composed overlay body's `hooks` dict as one sorted line per
+    /// registered command: `event|matcher|command`, with `matcher` rendered as
+    /// `<none>` when the entry omits the key entirely. Comparing the whole
+    /// rendering — rather than probing one field — is what makes a test that
+    /// adds an event also prove the others are untouched.
+    private func renderHookEntries(_ data: Data) throws -> [String] {
+        let parsed = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try #require(parsed["hooks"] as? [String: Any])
+        var lines: [String] = []
+        for (event, value) in hooks {
+            let entries = try #require(value as? [[String: Any]])
+            for entry in entries {
+                let matcher = entry["matcher"] as? String ?? "<none>"
+                let inner = try #require(entry["hooks"] as? [[String: Any]])
+                for hook in inner {
+                    let command = try #require(hook["command"] as? String)
+                    lines.append("\(event)|\(matcher)|\(command)")
+                }
+            }
+        }
+        return lines.sorted()
+    }
+
+    @Test func registersNotificationHookWithoutAMatcherAndLeavesTheOthersUntouched() throws {
+        let rendered = try renderHookEntries(try ClaudeHookOverlay.generateBody())
+        let expected = [
+            // The new entry: no matcher key at all, so Claude Code runs it for
+            // EVERY notification type and the hook decides nothing.
+            "Notification|<none>|\(ClaudeHookOverlay.notificationCommand)",
+            "PostToolUse|AskUserQuestion|\(ClaudeHookOverlay.askUserQuestionPostCommand)",
+            "PostToolUse|Bash|\(ClaudeHookOverlay.prBindCommand)",
+            "PreToolUse|AskUserQuestion|\(ClaudeHookOverlay.askUserQuestionPreCommand)",
+            "SessionStart|*|\(ClaudeHookOverlay.sessionStartCommand)",
+            "Stop|<none>|\(ClaudeHookOverlay.stopCommand)",
+            "Stop|<none>|\(ClaudeHookOverlay.stopRenameCheckCommand)",
+            "StopFailure|<none>|\(ClaudeHookOverlay.stopFailureCommand)",
+            "UserPromptSubmit|<none>|\(ClaudeHookOverlay.workingCommand)"
+        ].sorted()
+        #expect(rendered == expected)
+    }
+
+    @Test func notificationCommandInvokesTheHookBridgeAndNeverFails() throws {
+        let rendered = try renderHookEntries(try ClaudeHookOverlay.generateBody())
+        let notification = try #require(rendered.first { $0.hasPrefix("Notification|") })
+        #expect(notification.contains("tbd hooks notification"))
+        // Silent + never-fail, like every other entry: a hook must not wedge
+        // the agent when `tbd` is missing or the daemon is down.
+        #expect(notification.hasSuffix("2>/dev/null || true"))
+    }
+
+    @Test func notificationHookSurvivesFragmentMergeAndFallbackModels() throws {
+        // The new event must ride the same merge paths as the rest, not just
+        // the default body.
+        let data = try ClaudeHookOverlay.generateBody(
+            fallbackModels: ["claude-haiku-4-5-20251001"],
+            extraSettings: ["skillOverrides": ["x": "off"]])
+        let rendered = try renderHookEntries(data)
+        #expect(rendered.contains("Notification|<none>|\(ClaudeHookOverlay.notificationCommand)"))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect((parsed?["fallbackModel"] as? [String]) == ["claude-haiku-4-5-20251001"])
+    }
+
     @Test func roundtripsAsValidJSON() throws {
         let data = try ClaudeHookOverlay.generateBody()
         // Must round-trip — a malformed overlay file would crash Claude

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -118,7 +118,7 @@ struct CodexActivityReconciliationTests {
             sessionID: "codex-session",
             transcriptPath: transcriptPath.path
         )
-        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle, source: .derived)
 
         let request = try RPCRequest(
             method: RPCMethod.terminalList,
@@ -133,5 +133,94 @@ struct CodexActivityReconciliationTests {
 
         let persisted = try await db.terminals.get(id: terminal.id)
         #expect(persisted?.activityState == .idle)
+    }
+
+    // MARK: - The date seam on the two handlers that WRITE codex activity
+
+    /// Pinned through the router's date seam, so each stored stamp is an exact
+    /// assertion rather than a freshness window.
+    static let observedAt = Date(timeIntervalSince1970: 1_781_234_567)
+
+    /// A second router over the same database, with its `now` pinned.
+    ///
+    /// `setActivityState` defaults `observedAt` to a bare `Date()` **at the
+    /// store**, so a handler that omits the argument mints a timestamp nothing
+    /// outside the store can name. That is not a cosmetic difference: the stamp
+    /// is *compared* — `SessionStateResolver` orders it against the
+    /// awaiting-input stamp at rung 4 to decide which observation is newer — so
+    /// per the root `CLAUDE.md` date-seam rule it is data, and it belongs on the
+    /// router's seam like every sibling call site in this file.
+    private func pinnedRouter() -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            now: { Self.observedAt },
+            actuationLog: makeTestActuationLog())
+    }
+
+    @Test("terminal.sessionEvent stamps the codex idle observation from the router's date seam")
+    func sessionEventStampsFromTheDateSeam() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-seam-repo-\(UUID().uuidString)",
+            displayName: "car-seam-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-seam-wt-\(UUID().uuidString)", tmuxServer: "tbd-car-seam")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "codex-session",
+                transcriptPath: nil, source: "SessionStart"))
+        #expect(await pinnedRouter().handle(request).success)
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.activityState == .idle)
+        #expect(after.activityStateObservedAt == Self.observedAt)
+        #expect(after.observedActivity?.observedAt == Self.observedAt)
+    }
+
+    @Test("terminal.recreateWindow stamps the derived codex unknown from the router's date seam")
+    func recreateWindowStampsFromTheDateSeam() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-car-recreate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let repo = try await db.repos.create(
+            path: root.path, displayName: "car-recreate-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: root.path, tmuxServer: "tbd-car-recreate")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@old", tmuxPaneID: "%old",
+            label: TerminalLabel.codex, kind: .codex)
+        // A prior observation, so "the stamp moved" is a real claim rather than
+        // a column that happened to be nil before and non-nil after.
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working, source: .hookEvent("TurnStart"),
+            observedAt: Date(timeIntervalSince1970: 1_770_000_000))
+
+        let router = pinnedRouter()
+        router.codexExecutableResolver = { "/opt/test/bin/codex" }
+        router.codexHomeEnsurer = { root.appendingPathComponent("codex-home", isDirectory: true) }
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalRecreateWindow,
+            params: TerminalRecreateWindowParams(terminalID: terminal.id))
+        let response = await router.handle(request)
+        #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.activityState == .unknown)
+        #expect(after.activityStateObservedAt == Self.observedAt)
+        #expect(after.observedActivity?.observedAt == Self.observedAt)
     }
 }

--- a/Tests/TBDDaemonTests/ContextLoadReaderTests.swift
+++ b/Tests/TBDDaemonTests/ContextLoadReaderTests.swift
@@ -1,0 +1,412 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Tier 2 — real files in a temp directory, because the reader's contract
+/// includes the capture file's modification time and a byte-bounded tail read,
+/// neither of which survives being mocked away. No `TBD_HOME` involved: every
+/// path is passed in.
+@Suite struct ContextLoadReaderTests {
+
+    private struct Scratch {
+        let root: URL
+        let capturePath: String
+        let transcriptPath: String
+
+        init() throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tbd-ctx-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            capturePath = root.appendingPathComponent("capture.json").path
+            transcriptPath = root.appendingPathComponent("transcript.jsonl").path
+        }
+
+        func writeCapture(_ json: String, modified: Date) throws {
+            try Data(json.utf8).write(to: URL(fileURLWithPath: capturePath))
+            try FileManager.default.setAttributes(
+                [.modificationDate: modified], ofItemAtPath: capturePath)
+        }
+
+        /// Two assistant records; the later one is what the reader must use.
+        func writeTranscript(tokens: Int, timestamp: String) throws {
+            let earlier = #"{"type":"assistant","timestamp":"2026-08-10T00:00:00Z","message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#
+            let latest = """
+            {"type":"assistant","timestamp":"\(timestamp)","message":{"usage":\
+            {"input_tokens":\(tokens - 30),"output_tokens":9999,\
+            "cache_creation_input_tokens":20,"cache_read_input_tokens":10}}}
+            """
+            try Data(([earlier, latest].joined(separator: "\n") + "\n").utf8)
+                .write(to: URL(fileURLWithPath: transcriptPath))
+        }
+
+        func cleanUp() { try? FileManager.default.removeItem(at: root) }
+    }
+
+    private static let captureModified = Date(timeIntervalSince1970: 1_770_000_000)
+    private static let transcriptStamp = "2026-08-10T12:00:00Z"
+    private static var transcriptDate: Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: transcriptStamp)!
+    }
+
+    private static func fullCapture(size: Int = 1_000_000, used: Int = 250_000) -> String {
+        """
+        {"session_id":"s","context_window":{"total_input_tokens":1,"total_output_tokens":2,
+        "context_window_size":\(size),"used_percentage":25.0,"remaining_percentage":75.0,
+        "current_usage":{"input_tokens":\(used - 30),"output_tokens":5000,
+        "cache_creation_input_tokens":20,"cache_read_input_tokens":10}}}
+        """
+    }
+
+    // MARK: - Tee absent
+
+    @Test func nonDeskSessionReportsAnUnknownWindowNamingTheCase() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeTranscript(tokens: 120_000, timestamp: Self.transcriptStamp)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: scratch.transcriptPath,
+            tee: .notADesk)
+
+        // Never a guess. The numerator is real and labeled with where it came
+        // from; the denominator says it does not know, and why.
+        let used = try #require(load.used)
+        #expect(used.value == 120_000)
+        #expect(used.source == .transcriptTail)
+        #expect(used.observedAt == Self.transcriptDate)
+        guard case .unknown(let why) = load.window else {
+            Issue.record("expected an unknown window, got \(load.window)")
+            return
+        }
+        #expect(why.contains("desk sessions only"))
+        #expect(!load.isPairedReading)
+    }
+
+    @Test func deskWhoseTeeHasNotFiredSaysSoRatherThanBlamingTheFleetRule() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeTranscript(tokens: 50_000, timestamp: Self.transcriptStamp)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: scratch.transcriptPath,
+            tee: .installed)
+
+        guard case .unknown(let why) = load.window else {
+            Issue.record("expected an unknown window, got \(load.window)")
+            return
+        }
+        #expect(why.contains("has not fired yet"))
+    }
+
+    @Test func noTranscriptAndNoCaptureLeavesBothHalvesHonestlyEmpty() {
+        let load = ContextLoadReader().read(
+            capturePath: "/nonexistent/capture.json", transcriptPath: nil, tee: .notADesk)
+        #expect(load.used == nil)
+        #expect(load.percentUsed() == nil)
+    }
+
+    @Test func theTwoHundredKFallbackIsLabelledEverywhereItIsUsed() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeTranscript(tokens: 100_000, timestamp: Self.transcriptStamp)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: scratch.transcriptPath,
+            tee: .notADesk)
+
+        let percent = try #require(load.percentUsed())
+        #expect(percent.percent == 50.0)
+        // The flag rides with the number: a caller cannot receive the
+        // percentage without also receiving "this denominator was assumed".
+        #expect(percent.assumedWindow)
+        #expect(load.window.effectiveTokens() == (ContextWindow.assumedTokens, true))
+    }
+
+    // MARK: - Tee present
+
+    @Test func fullCaptureGivesThePairedReadingWithTheCapturesMtime() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        // A transcript exists and disagrees — the paired reading must win.
+        try scratch.writeTranscript(tokens: 999_999, timestamp: Self.transcriptStamp)
+        try scratch.writeCapture(Self.fullCapture(), modified: Self.captureModified)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: scratch.transcriptPath,
+            tee: .installed)
+
+        guard case .observed(let window) = load.window else {
+            Issue.record("expected an observed window, got \(load.window)")
+            return
+        }
+        #expect(window.value == 1_000_000)
+        #expect(window.source == .statuslineTee)
+        // The capture's mtime is when Claude Code observed it, not when TBD
+        // read the file — aging by the read makes a stale fact look fresh.
+        #expect(window.observedAt == Self.captureModified)
+        let used = try #require(load.used)
+        // input + both cache buckets, output excluded — one formula, the same
+        // one the transcript path uses.
+        #expect(used.value == 250_000)
+        #expect(used.source == .statuslineTee)
+        #expect(used.observedAt == Self.captureModified)
+        #expect(load.isPairedReading)
+        let percent = try #require(load.percentUsed())
+        #expect(percent.percent == 25.0)
+        #expect(!percent.assumedWindow)
+    }
+
+    @Test func nullCurrentUsageFallsBackToTheTranscriptAndSaysItIsNotPaired() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeTranscript(tokens: 77_000, timestamp: Self.transcriptStamp)
+        // The documented shape right after a `/compact`, before the next call.
+        try scratch.writeCapture(
+            #"{"context_window":{"context_window_size":200000,"used_percentage":null,"current_usage":null}}"#,
+            modified: Self.captureModified)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: scratch.transcriptPath,
+            tee: .installed)
+
+        guard case .observed(let window) = load.window else {
+            Issue.record("expected an observed window, got \(load.window)")
+            return
+        }
+        #expect(window.value == 200_000)
+        let used = try #require(load.used)
+        #expect(used.value == 77_000)
+        #expect(used.source == .transcriptTail)
+        // Two moments, two sources — so the pair is NOT presented as one
+        // coherent reading, and a consumer composing a percentage can say so.
+        #expect(used.observedAt != window.observedAt)
+        #expect(!load.isPairedReading)
+    }
+
+    @Test func captureWithoutAWindowSizeStillRefusesToGuessOne() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeCapture(
+            #"{"model":{"id":"claude-opus-4-1[1m]"},"context_window":{"current_usage":{"input_tokens":5}}}"#,
+            modified: Self.captureModified)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: nil, tee: .installed)
+
+        // A `[1m]` in the model id is exactly the sniff this design refuses:
+        // it reports capability, not the window in force.
+        guard case .unknown(let why) = load.window else {
+            Issue.record("expected an unknown window, got \(load.window)")
+            return
+        }
+        #expect(why.contains("context_window_size"))
+        #expect(load.used?.value == 5)
+    }
+
+    /// A malformed `context_window_size` is "no denominator", not a denominator.
+    ///
+    /// `as? Int` alone is not that test, and the boolean case is the one that
+    /// bites: JSON `true` arrives from `JSONSerialization` as an `NSNumber` that
+    /// casts cleanly to `1`, so the session would be reported as running in a
+    /// one-token window with every percentage built on it absurd. The Nightwatch
+    /// reader rejects the same set (`isinstance(size, bool) or not
+    /// isinstance(size, int) or size <= 0`); the two read one file and must not
+    /// disagree about whether it carries a window.
+    @Test(arguments: ["true", "false", "0", "-1", "1.5", #""200000""#, "null", "[]", "{}"])
+    func aMalformedWindowSizeIsNoWindowRatherThanAWrongOne(literal: String) throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeCapture(
+            """
+            {"context_window":{"context_window_size":\(literal),
+            "current_usage":{"input_tokens":5}}}
+            """,
+            modified: Self.captureModified)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: nil, tee: .installed)
+
+        guard case .unknown(let why) = load.window else {
+            Issue.record("a \(literal) context_window_size was reported as a window: \(load.window)")
+            return
+        }
+        #expect(why.contains("context_window_size"))
+        // The numerator the payload does carry is still better than nothing.
+        #expect(load.used?.value == 5)
+        #expect(!load.isPairedReading)
+    }
+
+    /// The guard's own OFF branch: an ordinary positive integer still reads.
+    @Test func anOrdinaryWindowSizeStillReads() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeCapture(
+            #"{"context_window":{"context_window_size":1,"current_usage":{"input_tokens":5}}}"#,
+            modified: Self.captureModified)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: nil, tee: .installed)
+
+        guard case .observed(let window) = load.window else {
+            Issue.record("expected an observed window, got \(load.window)")
+            return
+        }
+        #expect(window.value == 1)
+    }
+
+    /// A desk on an agent the tee does not install on is neither "installed but
+    /// not fired" nor "not a desk", and saying either would be false.
+    /// `spawnPrimaryTerminals` resolves the primary agent from
+    /// `primaryAgentPreference`, so a desk on a Codex-preferring install is
+    /// branded a desk and runs with no tee at all.
+    @Test func aDeskWithoutATeeIsNotDescribedAsOneWaitingToFire() {
+        let load = ContextLoadReader().read(
+            capturePath: "/nonexistent/capture.json", transcriptPath: nil,
+            tee: .deskWithoutTee)
+
+        guard case .unknown(let why) = load.window else {
+            Issue.record("expected an unknown window, got \(load.window)")
+            return
+        }
+        #expect(!why.contains("has not fired yet"))
+        #expect(why.contains("does not run the agent the statusline tee installs on"))
+    }
+
+    @Test func malformedCaptureFallsBackToTheTranscriptRatherThanFailing() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        try scratch.writeTranscript(tokens: 33_000, timestamp: Self.transcriptStamp)
+        try scratch.writeCapture("{ half a payl", modified: Self.captureModified)
+
+        let load = ContextLoadReader().read(
+            capturePath: scratch.capturePath, transcriptPath: scratch.transcriptPath,
+            tee: .installed)
+
+        #expect(load.used?.value == 33_000)
+        #expect(load.used?.source == .transcriptTail)
+    }
+
+    // MARK: - The tail read
+
+    @Test func tailReadIsByteBoundedAndTolerantOfATruncatedFirstLine() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        var lines: [String] = []
+        for index in 1...500 {
+            lines.append(
+                #"{"type":"assistant","message":{"usage":{"input_tokens":\#(index),"#
+                + #""cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#)
+        }
+        try Data((lines.joined(separator: "\n") + "\n").utf8)
+            .write(to: URL(fileURLWithPath: scratch.transcriptPath))
+
+        var reader = ContextLoadReader()
+        reader.tailWindowBytes = 512
+
+        let load = reader.read(
+            capturePath: "/nonexistent", transcriptPath: scratch.transcriptPath, tee: .notADesk)
+
+        // The window lands mid-record, so the first line in it is a fragment.
+        // It is skipped, and the last complete record still wins.
+        #expect(load.used?.value == 500)
+    }
+
+    @Test func recordWithoutATimestampFallsBackToTheInjectedDate() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        let line = #"{"message":{"usage":{"input_tokens":42}}}"# + "\n"
+        try Data(line.utf8).write(to: URL(fileURLWithPath: scratch.transcriptPath))
+        let fixed = Date(timeIntervalSince1970: 1_234_567)
+
+        var reader = ContextLoadReader()
+        reader.now = { fixed }
+
+        let load = reader.read(
+            capturePath: "/nonexistent", transcriptPath: scratch.transcriptPath, tee: .notADesk)
+
+        #expect(load.used?.observedAt == fixed)
+        // Cache buckets absent entirely — defaulted to zero, not treated as a
+        // parse failure, since sessions without prompt caching omit them.
+        #expect(load.used?.value == 42)
+    }
+
+    /// The ASCII cut above is the easy case. A real transcript is full of
+    /// emoji, box drawing and curly quotes, so a byte-offset tail routinely
+    /// starts **inside** a multi-byte sequence — and strict UTF-8 decoding
+    /// answers nil for the whole tail when it does, erasing a numerator that
+    /// was sitting there in plain ASCII a few hundred bytes later. The failure
+    /// is indistinguishable from a missing transcript, which is what makes it
+    /// worth a test of its own.
+    @Test func aTailCutInsideAMultiByteSequenceStillReportsTheNumerator() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        // 4-byte emoji as the padding — ordinary agent output.
+        let padding = String(repeating: "🙂", count: 200)
+        let filler = #"{"type":"user","message":{"content":"\#(padding)"}}"#
+        let record = #"{"type":"assistant","message":{"usage":{"input_tokens":777,"#
+            + #""cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#
+        let bytes = Data((filler + "\n" + record + "\n").utf8)
+        try bytes.write(to: URL(fileURLWithPath: scratch.transcriptPath))
+
+        // Pin the cut **inside** the filler's last emoji rather than hoping for
+        // it: the tail then opens on a UTF-8 continuation byte, which is the
+        // exact shape that used to erase the whole read.
+        let lastEmojiStart = try #require(
+            bytes.range(of: Data("🙂".utf8), options: .backwards)?.lowerBound)
+        let cut = lastEmojiStart + 1
+        #expect(bytes[cut] & 0xC0 == 0x80, "the cut must land on a continuation byte")
+        #expect(String(data: bytes[cut...], encoding: .utf8) == nil,
+                "if this tail decodes strictly, the test is not exercising the defect")
+
+        var reader = ContextLoadReader()
+        reader.tailWindowBytes = bytes.count - cut
+
+        let load = reader.read(
+            capturePath: "/nonexistent", transcriptPath: scratch.transcriptPath,
+            tee: .notADesk)
+
+        #expect(load.used?.value == 777,
+                "a tail cut mid-codepoint erased a numerator that was plainly there")
+    }
+
+    // MARK: - The stamp belongs to the payload
+
+    /// `contents(atPath:)` then `attributesOfItem(atPath:)` are two lookups of
+    /// the same *name*, and the two can answer about different files — the tee
+    /// publishes by `mv -f`, and `attributesOfItem` does not even follow a
+    /// symlink, so the pair can hand back one file's bytes with another's
+    /// modification time. That produces an `ObservedFact` whose observed-at is
+    /// newer than the value it labels, which is the one thing this file's
+    /// opening comment forbids. One open, one inode, both halves.
+    @Test func theCaptureStampComesFromTheFileTheBytesCameFrom() throws {
+        let scratch = try Scratch()
+        defer { scratch.cleanUp() }
+        let target = scratch.root.appendingPathComponent("real-capture.json").path
+        let published = Date(timeIntervalSince1970: 1_700_000_000)
+        try Data(#"{"context_window":{"context_window_size":123456}}"#.utf8)
+            .write(to: URL(fileURLWithPath: target))
+        try FileManager.default.setAttributes(
+            [.modificationDate: published], ofItemAtPath: target)
+
+        // The name the reader is given resolves to that file, but is itself a
+        // different filesystem object with its own, much newer stamp.
+        let link = scratch.root.appendingPathComponent("capture-link.json").path
+        try FileManager.default.createSymbolicLink(
+            atPath: link, withDestinationPath: target)
+
+        let capture = try #require(ContextLoadReader().readCapture(atPath: link))
+        #expect(capture.contextWindowSize == 123456)
+        #expect(capture.observedAt == published,
+                "the payload was stamped with a different file's modification time")
+    }
+
+    @Test func unreadableTranscriptIsAbsenceNotZero() {
+        let load = ContextLoadReader().read(
+            capturePath: "/nonexistent", transcriptPath: "/nonexistent/transcript.jsonl",
+            tee: .notADesk)
+        #expect(load.used == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -54,9 +54,9 @@ import Testing
 /// Two suites that consume this value ARE `.clockDriven`, so its time limit and
 /// this deadline race each other: `AttachRPCOrchestrationTests`
 /// (`Tests/TBDDaemonTests/AttachRPCTests.swift`, 13 `waitFor` call sites) and
-/// `PaneRepairCoordinatorTests` (35 call sites).
+/// `PaneRepairCoordinatorTests` (31 call sites).
 ///
-/// All 48 of those call sites are **unguarded**. They read
+/// All 44 of those call sites are **unguarded**. They read
 /// `try await waitFor(…)`, but `waitFor` is `@discardableResult` and does not
 /// throw on timeout — it records an `Issue` and returns `false`, and the `try`
 /// covers only the inner `Task.sleep`. Execution therefore continues past a
@@ -84,7 +84,7 @@ import Testing
 ///   must afford both waits" property the old pairing reasoned about)
 ///
 /// The margin past that is thin, and the 6-deep chain is not the only case that
-/// overruns: counting `waitFor` at 90 s and each clock wait at 45 s, **9 of the
+/// overruns: counting `waitFor` at 90 s and each clock wait at 45 s, **6 of the
 /// 13** `PaneRepairCoordinatorTests` have a worst case above 240 s (the 6-deep
 /// one needs 540 s). All of them are consistent with the invariant above — only
 /// an already-failing test walks a full chain of timeouts, and the first

--- a/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
@@ -230,7 +230,7 @@ struct DeliveryVerificationWiringTests {
             id: fixture.terminal.id, sessionID: UUID().uuidString,
             transcriptPath: transcriptPath)
         try await fixture.db.terminals.setActivityState(
-            id: fixture.terminal.id, activityState: .working)
+            id: fixture.terminal.id, activityState: .working, source: .derived)
         let clock = TestClock()
         let verifier = DeliveryVerifier(
             log: fixture.log,

--- a/Tests/TBDDaemonTests/DeskResumeStatuslineTeeTests.swift
+++ b/Tests/TBDDaemonTests/DeskResumeStatuslineTeeTests.swift
@@ -1,0 +1,319 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The statusline tee across a **wake from hibernation** — the gap phase 3 left
+/// open, and the two resume paths where it stays open.
+///
+/// A wake reuses the same terminal row, so it reuses the same statusline
+/// capture path. A desk woken without the tee would therefore keep reading a
+/// capture whose mtime predates the resume: a stale denominator wearing a fresh
+/// session's clothes.
+///
+/// Two independent things close that, and they are tested separately because
+/// only one of them always holds. The wake site reads the row's own
+/// `watch_desk_role`, which the desk spawn path stamps at create and the lease
+/// store maintains — so a desk is recognizable from its first instant, lease or
+/// no lease. But `release`/`revoke` NULL that column for the whole worktree, and
+/// a hibernated desk is exactly what makes `DeskSessionManager` revoke, so the
+/// role is not durable in every direction. The staleness is closed regardless:
+/// resolving an overlay **without** a tee deletes the session's capture, so a
+/// session that is not (re)installing one has nothing left to misread.
+///
+/// Nested under `TBDHomeSerialized`: the per-session overlay and the capture
+/// path resolve through the process-global `TBD_HOME`.
+extension TBDHomeSerialized {
+@Suite struct DeskResumeStatuslineTeeTests {
+
+    private struct Scratch {
+        let home: URL
+        let prior: String?
+        init() {
+            home = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tbd-desk-resume-\(UUID().uuidString)", isDirectory: true)
+            prior = setTBDHome(home.path)
+        }
+        func cleanUp() {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: home)
+        }
+    }
+
+    private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-desk-resume-claude-\(UUID().uuidString)", isDirectory: true)
+        return ClaudeProfileConfigDirManager(
+            baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+            hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true))
+    }
+
+    /// How a desk terminal came to be marked as one.
+    private enum DeskMarking {
+        /// Not a desk at all.
+        case none
+        /// Stamped by the spawn path at row creation, with no lease ever taken.
+        /// This is the state a freshly-spawned desk is in for its whole life
+        /// until `DeskSessionManager` first resolves a judge.
+        case stampedAtCreate
+        /// Written by the lease store, the way an acquired judge lease writes it.
+        case byLease
+    }
+
+    /// A parked Claude terminal in a worktree whose path exists on disk (wake
+    /// refuses to respawn into a missing directory).
+    private func parkedTerminal(
+        db: TBDDatabase, repoPath: String, desk: DeskMarking
+    ) async throws -> Terminal {
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "repo", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main", path: repoPath,
+            tmuxServer: "tbd-desk-resume")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-desk", kind: .claude,
+            watchDeskRole: desk == .stampedAtCreate ? .readOnlyCoordinator : nil)
+        if desk == .byLease {
+            _ = try await db.watchDeskLeases.acquire(
+                worktreeID: worktree.id, terminalID: terminal.id)
+        }
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-desk", reason: .auto)
+        return try #require(try await db.terminals.get(id: terminal.id))
+    }
+
+    private func statusLine(inOverlayFor sessionKey: String) -> [String: Any]? {
+        let path = ClaudeHookOverlay.perSessionOverlayPath(sessionKey: sessionKey)
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return parsed["statusLine"] as? [String: Any]
+    }
+
+    private func makeRepoDir(_ scratch: Scratch) throws -> String {
+        let path = scratch.home.appendingPathComponent("repo", isDirectory: true).path
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return path
+    }
+
+    // MARK: - Closed: hibernation wake
+
+    @Test func wakingADeskReinstallsTheStatuslineTee() async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await parkedTerminal(
+            db: db, repoPath: try makeRepoDir(scratch), desk: .byLease)
+
+        let coordinator = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
+        _ = await coordinator.wake(terminalID: terminal.id)
+
+        let entry = try #require(statusLine(inOverlayFor: terminal.id.uuidString),
+                                 "a woken desk got no statusLine in its overlay")
+        let command = try #require(entry["command"] as? String)
+        #expect(command.contains(StatuslineTee.scriptPath))
+        // The capture path is keyed by the terminal, which is exactly why the
+        // stale-mtime problem existed: the woken desk reads the same file.
+        #expect(command.contains(StatuslineTee.capturePath(sessionKey: terminal.id.uuidString)))
+    }
+
+    /// The role a desk actually has for most of its life.
+    ///
+    /// `DeskSessionManager` spawns a desk and only later resolves a judge, so a
+    /// desk that has never held a lease is the ordinary case, not an edge one —
+    /// and before the spawn path stamped the row, `watch_desk_role` was written
+    /// by nothing but the lease store, so such a desk woke with no tee at all.
+    @Test func wakingADeskThatNeverHeldALeaseReinstallsTheStatuslineTee() async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await parkedTerminal(
+            db: db, repoPath: try makeRepoDir(scratch), desk: .stampedAtCreate)
+        #expect(try await db.watchDeskLeases.status(worktreeID: terminal.worktreeID) == nil,
+                "the point of this test is a desk with no lease on record")
+
+        let coordinator = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
+        _ = await coordinator.wake(terminalID: terminal.id)
+
+        let entry = try #require(statusLine(inOverlayFor: terminal.id.uuidString),
+                                 "a woken desk got no statusLine in its overlay")
+        #expect(try #require(entry["command"] as? String).contains(StatuslineTee.scriptPath))
+    }
+
+    @Test func wakingAnOrdinaryTerminalInstallsNoStatusline() async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await parkedTerminal(
+            db: db, repoPath: try makeRepoDir(scratch), desk: .none)
+
+        let coordinator = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
+        _ = await coordinator.wake(terminalID: terminal.id)
+
+        // TBD's per-session `--settings` outranks the operator's `statusLine`
+        // in every scope they can write, so a leak here would take over a slot
+        // they own in every session they wake.
+        #expect(statusLine(inOverlayFor: terminal.id.uuidString) == nil)
+    }
+
+    /// The row is where the desk fact has to land, because the wake path has
+    /// nothing else to read. `WatchDeskLeaseStore.setRoles` is the only thing
+    /// that used to write `watch_desk_role`, so a desk lived its whole
+    /// pre-lease life — which is every desk, until `DeskSessionManager` first
+    /// resolves a judge — with a nil role on its row.
+    @Test func theDeskSpawnPathStampsTheRoleOnTheRowItCreates() async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        let repoPath = try makeRepoDir(scratch)
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "repo", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main", path: repoPath,
+            tmuxServer: "tbd-desk-spawn")
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(), configDirManager: isolatedConfigDirManager())
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: worktree, repo: repo, skipClaude: false,
+            preSessionTerminalID: nil, watchDeskRole: .readOnlyCoordinator)
+
+        let terminals = try await db.terminals.list(worktreeID: worktree.id)
+        let primary = try #require(terminals.first { $0.kind == .claude })
+        #expect(primary.watchDeskRole == .readOnlyCoordinator,
+                "the desk spawn path did not write its role to the row it created")
+
+        // And an ordinary spawn in the same shape leaves the column alone —
+        // otherwise every session in the fleet would install the tee.
+        let plainPath = scratch.home.appendingPathComponent("plain", isDirectory: true).path
+        try FileManager.default.createDirectory(
+            atPath: plainPath, withIntermediateDirectories: true)
+        let plainWorktree = try await db.worktrees.create(
+            repoID: repo.id, name: "plain", branch: "plain", path: plainPath,
+            tmuxServer: "tbd-desk-spawn")
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: plainWorktree, repo: repo, skipClaude: false, preSessionTerminalID: nil)
+        let plain = try await db.terminals.list(worktreeID: plainWorktree.id)
+        #expect(plain.allSatisfy { $0.watchDeskRole == nil })
+    }
+
+    // MARK: - The invariant that does not depend on the tee coming back
+
+    /// The more important half of the fix, and the one that holds even when the
+    /// role does not survive: a session resolving an overlay **without** a tee
+    /// cannot read a capture published in a previous life.
+    ///
+    /// A wake reuses the terminal row and therefore the capture path, so
+    /// without this the reader would find a months-old payload, take its
+    /// `context_window_size`, and report the window as `.observed` with
+    /// `isPairedReading == true` — a stale denominator wearing a fresh
+    /// session's clothes.
+    @Test func aSpawnWithNoTeeDeletesTheCaptureFromThePreviousLife() throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let sessionKey = UUID().uuidString
+        let capturePath = StatuslineTee.capturePath(sessionKey: sessionKey)
+        try FileManager.default.createDirectory(
+            at: URL(fileURLWithPath: capturePath).deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let payload = #"{"context_window":{"context_window_size":200000,"current_usage":{"input_tokens":150000}}}"#
+        try Data(payload.utf8).write(to: URL(fileURLWithPath: capturePath))
+
+        // A reader would happily believe it, which is why it must not be there.
+        let stale = ContextLoadReader().read(
+            capturePath: capturePath, transcriptPath: nil, tee: .notADesk)
+        #expect(stale.isPairedReading)
+
+        _ = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil, sessionKey: sessionKey, watchDeskRole: nil, worktreePath: nil)
+
+        #expect(!FileManager.default.fileExists(atPath: capturePath))
+        let load = ContextLoadReader().read(
+            capturePath: capturePath, transcriptPath: nil, tee: .notADesk)
+        guard case .unknown = load.window else {
+            Issue.record("a session with no tee read a capture from a previous life: \(load.window)")
+            return
+        }
+        #expect(!load.isPairedReading)
+    }
+
+    @Test func aSpawnThatInstallsTheTeeKeepsTheSessionsCapture() throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let sessionKey = UUID().uuidString
+        let capturePath = StatuslineTee.capturePath(sessionKey: sessionKey)
+        try FileManager.default.createDirectory(
+            at: URL(fileURLWithPath: capturePath).deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data(#"{"context_window":{"context_window_size":200000}}"#.utf8)
+            .write(to: URL(fileURLWithPath: capturePath))
+
+        _ = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil, sessionKey: sessionKey,
+            watchDeskRole: .readOnlyCoordinator, worktreePath: nil)
+
+        // The tee is about to republish over it, and until it does the desk's
+        // own previous reading is the best anyone has.
+        #expect(FileManager.default.fileExists(atPath: capturePath))
+    }
+
+    // MARK: - Known limitation, pinned rather than papered over
+
+    /// `terminal.swapProfile` in `.fork` mode and `terminalHistory.revive` mint
+    /// a **new** terminal ID, so a desk cannot be identified at those sites from
+    /// a durable fact: `watch_desk_role` belongs to the row the lease store
+    /// wrote, and the new row has none until a lease is acquired against it.
+    /// (An `.inPlace` swap is the other case entirely — it keeps the row, so the
+    /// role is right there to read; see
+    /// `SwapProfileStatuslineTeeTests`.)
+    ///
+    /// This is left as it is deliberately. Carrying the old row's role onto a
+    /// new one would be inventing a desk-marking mechanism parallel to the
+    /// lease — the one thing this slice was told not to do — and it would
+    /// change what "this terminal is the desk" means without the lease store
+    /// agreeing. The consequence is bounded and is the opposite of the
+    /// hibernation bug: a new terminal ID means a new capture path, so the
+    /// session reads **no** capture rather than a stale one, and the
+    /// denominator is honestly unknown until a lease is acquired and the
+    /// session respawns.
+    ///
+    /// The test pins that current behavior so a future change to it is a
+    /// deliberate edit rather than a silent drift.
+    @Test func aFreshTerminalIDHasNoDeskRoleAndSoReadsNoStaleCapture() async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        let desk = try await parkedTerminal(
+            db: db, repoPath: try makeRepoDir(scratch), desk: .byLease)
+        #expect(desk.watchDeskRole != nil)
+
+        // The role lives on the row, not on the worktree: a second terminal in
+        // the same worktree is not a desk.
+        let successor = try await db.terminals.create(
+            worktreeID: desk.worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-desk", kind: .claude)
+        #expect(successor.watchDeskRole == nil)
+
+        // So a resume keyed on the successor writes no tee and, having a
+        // different capture path, cannot read the desk's stale capture.
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: successor.id.uuidString,
+            watchDeskRole: successor.watchDeskRole,
+            worktreePath: nil)
+        #expect(path == ClaudeHookOverlay.overlayPath)
+        #expect(StatuslineTee.capturePath(sessionKey: successor.id.uuidString)
+                != StatuslineTee.capturePath(sessionKey: desk.id.uuidString))
+    }
+}
+}

--- a/Tests/TBDDaemonTests/GitStatusTests.swift
+++ b/Tests/TBDDaemonTests/GitStatusTests.swift
@@ -356,4 +356,48 @@ struct GitStatusTests {
         await lifecycle.refreshGitStatuses(repoID: repo.id)
         #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == true)
     }
+
+    /// The sweep's branch-tip observation instant is **persisted and compared**
+    /// — it is reported as `SessionCounters.commitsUnchangedSince` — so it is
+    /// data and goes through the date seam. Built from a bare `Date()` it
+    /// defeated `BranchTipTracker`'s own seam, and no test could pin the fact
+    /// end to end. This one does exactly that.
+    @Test func theSweepStampsBranchTipsThroughTheInjectedDateSeam() async throws {
+        let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+        let repoDir = tempBase.appendingPathComponent("tbd-test-tipstamp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repoDir) }
+
+        try await runShell("git init -b main", at: repoDir)
+        try await runShell("git config commit.gpgSign false", at: repoDir)
+        try await runShell("git config user.email 'test@test.com'", at: repoDir)
+        try await runShell("git config user.name 'Test'", at: repoDir)
+        try await runShell("echo 'line1' > f.txt && git add . && git commit -m 'initial'", at: repoDir)
+        try await runShell("git checkout -b tbd/stamped", at: repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "stamped", branch: "tbd/stamped",
+            path: repoDir.path + "/.tbd/worktrees/stamped", tmuxServer: "tbd-test")
+
+        let pinned = Date(timeIntervalSince1970: 1_700_000_000)
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(), subscriptions: StateSubscriptionManager(),
+            now: { pinned }
+        )
+
+        // Two sweeps: the first sighting establishes the tip, the second is the
+        // first evidence that it stopped moving and is what carries the stamp.
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+        #expect(await lifecycle.branchTipTracker.unchangedSince(
+            repoID: repo.id, worktreeID: wt.id) == nil)
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+
+        #expect(await lifecycle.branchTipTracker.unchangedSince(
+            repoID: repo.id, worktreeID: wt.id) == pinned,
+                "the sweep stamped a tip with something other than its injected clock")
+    }
 }

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -52,7 +52,7 @@ struct HibernationCoordinatorTests {
             label: "claude", claudeSessionID: sessionID, kind: kind
         )
         if activityState != .unknown {
-            try await db.terminals.setActivityState(id: terminal.id, activityState: activityState)
+            try await db.terminals.setActivityState(id: terminal.id, activityState: activityState, source: .derived)
         }
         if keepWarm {
             try await db.terminals.setKeepWarm(id: terminal.id, keepWarm: true)

--- a/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
@@ -9,20 +9,36 @@ import Foundation
 /// CLAUDE.md's "test every gated branch" rule.
 @Suite("HibernationGateMerge")
 struct HibernationGateMergeTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
     private func claudeTerminal(
         activityState: TerminalActivityState = .idle,
         keepWarm: Bool = false,
         hibernatedAt: Date? = nil,
         suspendedAt: Date? = nil,
         sessionID: String? = "sess-1",
-        kind: TerminalKind? = .claude
+        kind: TerminalKind? = .claude,
+        activityStateObservedAt: Date? = nil
     ) -> Terminal {
         Terminal(
             worktreeID: UUID(), tmuxWindowID: "@0", tmuxPaneID: "%0",
             label: "claude", claudeSessionID: sessionID,
             suspendedAt: suspendedAt, kind: kind,
-            activityState: activityState, hibernatedAt: hibernatedAt, keepWarm: keepWarm
+            activityState: activityState, hibernatedAt: hibernatedAt, keepWarm: keepWarm,
+            activityStateObservedAt: activityStateObservedAt
         )
+    }
+
+    /// Default-carrying wrapper so the rail tests read as they did before the
+    /// veto arguments existed: veto OFF, no recorded input — i.e. exactly
+    /// today's merge-park behavior.
+    private func decideForMerge(
+        _ terminal: Terminal,
+        inputVetoEnabled: Bool = false,
+        lastInputAt: Date? = nil
+    ) -> HibernationGate.Decision {
+        HibernationGate.decideForMerge(
+            terminal: terminal, inputVetoEnabled: inputVetoEnabled, lastInputAt: lastInputAt)
     }
 
     // MARK: - The go path: no idle window at all
@@ -32,13 +48,13 @@ struct HibernationGateMergeTests {
         // merge-park. An idle resumable Claude terminal is a valid park target
         // the instant its PR merges.
         let t = claudeTerminal(activityState: .idle)
-        #expect(HibernationGate.decideForMerge(terminal: t) == .eligible)
+        #expect(decideForMerge(t) == .eligible)
     }
 
     @Test func eligibleForUnknownActivity() {
         // `.unknown` (hook hasn't fired) is treated as at-rest, same as the sweep.
         let t = claudeTerminal(activityState: .unknown)
-        #expect(HibernationGate.decideForMerge(terminal: t) == .eligible)
+        #expect(decideForMerge(t) == .eligible)
     }
 
     // MARK: - Independence from the idle-sweep master switch
@@ -55,7 +71,7 @@ struct HibernationGateMergeTests {
             idleSince: Date(timeIntervalSince1970: 0), now: Date()
         )
         #expect(sweepWithSwitchOff == .featureDisabled)
-        #expect(HibernationGate.decideForMerge(terminal: t) == .eligible)
+        #expect(decideForMerge(t) == .eligible)
     }
 
     // MARK: - Hard safety rails (each blocks)
@@ -63,31 +79,125 @@ struct HibernationGateMergeTests {
     @Test func keepWarmBlocks() {
         // Merge-park HONORS keep-warm (unlike manualHibernate).
         let t = claudeTerminal(keepWarm: true)
-        #expect(HibernationGate.decideForMerge(terminal: t) == .keepWarm)
+        #expect(decideForMerge(t) == .keepWarm)
     }
 
     @Test func runningTurnBlocks() {
         let t = claudeTerminal(activityState: .working)
-        #expect(HibernationGate.decideForMerge(terminal: t) == .running)
+        #expect(decideForMerge(t) == .running)
     }
 
     @Test func waitingForUserBlocks() {
         let t = claudeTerminal(activityState: .waitingForUser)
-        #expect(HibernationGate.decideForMerge(terminal: t) == .waitingForUser)
+        #expect(decideForMerge(t) == .waitingForUser)
     }
 
     @Test func alreadyHibernatedBlocks() {
         let t = claudeTerminal(hibernatedAt: Date(timeIntervalSince1970: 1))
-        #expect(HibernationGate.decideForMerge(terminal: t) == .alreadyHibernated)
+        #expect(decideForMerge(t) == .alreadyHibernated)
     }
 
     @Test func suspendedBlocks() {
         let t = claudeTerminal(suspendedAt: Date(timeIntervalSince1970: 1))
-        #expect(HibernationGate.decideForMerge(terminal: t) == .suspended)
+        #expect(decideForMerge(t) == .suspended)
     }
 
     @Test func nonClaudeBlocks() {
         let t = claudeTerminal(sessionID: nil, kind: .shell)
-        #expect(HibernationGate.decideForMerge(terminal: t) == .notClaudeResumable)
+        #expect(decideForMerge(t) == .notClaudeResumable)
+    }
+
+    // MARK: - Rail: pending typed input (input veto)
+    //
+    // Merge-park has no idle marker, so it compares `lastInputAt` against
+    // `activityStateObservedAt` — the moment the session was observed to enter
+    // the at-rest state it is in now.
+
+    @Test func typedInputAfterGoingIdleBlocksWhenVetoEnabled() {
+        // The headline guarantee, on the MERGE path: a session that was typed
+        // into after it came to rest is not parked when its PR merges. Nobody
+        // is watching — merge-park now runs on the daemon's clock.
+        let atRest = now.addingTimeInterval(-10 * 60)
+        let t = claudeTerminal(activityStateObservedAt: atRest)
+        #expect(decideForMerge(
+            t, inputVetoEnabled: true,
+            lastInputAt: now.addingTimeInterval(-30)) == .pendingTypedInput)
+    }
+
+    @Test func typedInputAfterGoingIdleIsEligibleWhenVetoDisabled() {
+        // Flag OFF + identical inputs → `.eligible`. Proves the rail is truly
+        // gated and pins today's behavior for installs that have not opted in.
+        let atRest = now.addingTimeInterval(-10 * 60)
+        let t = claudeTerminal(activityStateObservedAt: atRest)
+        #expect(decideForMerge(
+            t, inputVetoEnabled: false,
+            lastInputAt: now.addingTimeInterval(-30)) == .eligible)
+    }
+
+    @Test func inputConsumedBeforeGoingIdleIsEligible() {
+        // Input recorded BEFORE the at-rest observation was submitted: the turn
+        // it started is what put the session back at rest. Nothing pending, so
+        // merge-park proceeds exactly as it does today.
+        let atRest = now.addingTimeInterval(-60)
+        let t = claudeTerminal(activityStateObservedAt: atRest)
+        #expect(decideForMerge(
+            t, inputVetoEnabled: true,
+            lastInputAt: now.addingTimeInterval(-10 * 60)) == .eligible)
+    }
+
+    @Test func noRecordedInputIsEligibleWithVetoOn() {
+        // Veto ON but nothing was ever typed into this pane (post-restart, or a
+        // pane only ever driven by TBD). The gate has no reason to refuse.
+        let t = claudeTerminal(activityStateObservedAt: now.addingTimeInterval(-60))
+        #expect(decideForMerge(t, inputVetoEnabled: true, lastInputAt: nil) == .eligible)
+    }
+
+    @Test func inputAtExactlyTheAtRestInstantBlocks() {
+        // `>=`, matching the sweep: input at the same instant as the at-rest
+        // observation counts as arriving after it.
+        let atRest = now.addingTimeInterval(-5 * 60)
+        let t = claudeTerminal(activityStateObservedAt: atRest)
+        #expect(decideForMerge(
+            t, inputVetoEnabled: true, lastInputAt: atRest) == .pendingTypedInput)
+    }
+
+    @Test func recordedInputWithNoObservationFailsClosed() {
+        // A row with no `activityStateObservedAt` (written before the
+        // provenance columns, or by a writer that never stamped one) offers no
+        // evidence the recorded input was ever consumed. Refuse: a session that
+        // survives a merge-park is recoverable, eaten input is not.
+        let t = claudeTerminal(activityStateObservedAt: nil)
+        #expect(decideForMerge(
+            t, inputVetoEnabled: true,
+            lastInputAt: now.addingTimeInterval(-60)) == .pendingTypedInput)
+    }
+
+    @Test func noObservationAndNoInputIsStillEligible() {
+        // The fail-closed arm above is scoped to rows that HAVE recorded input.
+        // A row with neither is the ordinary pre-provenance case and still parks.
+        let t = claudeTerminal(activityStateObservedAt: nil)
+        #expect(decideForMerge(t, inputVetoEnabled: true, lastInputAt: nil) == .eligible)
+    }
+
+    // MARK: - Precedence: hard rails still win
+
+    @Test func inputVetoLosesToRunning() {
+        let t = claudeTerminal(
+            activityState: .working, activityStateObservedAt: now.addingTimeInterval(-10 * 60))
+        #expect(decideForMerge(
+            t, inputVetoEnabled: true, lastInputAt: now) == .running)
+    }
+
+    @Test func inputVetoLosesToKeepWarm() {
+        let t = claudeTerminal(
+            keepWarm: true, activityStateObservedAt: now.addingTimeInterval(-10 * 60))
+        #expect(decideForMerge(t, inputVetoEnabled: true, lastInputAt: now) == .keepWarm)
+    }
+
+    @Test func inputVetoLosesToAlreadyHibernated() {
+        let t = claudeTerminal(
+            hibernatedAt: now.addingTimeInterval(-60),
+            activityStateObservedAt: now.addingTimeInterval(-10 * 60))
+        #expect(decideForMerge(t, inputVetoEnabled: true, lastInputAt: now) == .alreadyHibernated)
     }
 }

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -169,7 +169,7 @@ struct FakeInspector: PaneProcessInspecting {
     @Test func paneWithNoIdentityStillGetsTheResume() async throws {
         // The no-regression branch: absence is not disagreement.
         tmux.paneTarget = .live(terminalID: nil)
-        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working, source: .derived)
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .sent)
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
@@ -177,7 +177,7 @@ struct FakeInspector: PaneProcessInspecting {
 
     @Test func paneIdentityMatchIsCaseInsensitiveAndSends() async throws {
         tmux.paneTarget = .live(terminalID: terminalID.uuidString.lowercased())
-        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working, source: .derived)
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .sent)
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
@@ -233,7 +233,7 @@ struct FakeInspector: PaneProcessInspecting {
 
     @Test func happyPathSendsEscapeContinueEnterAndVerifiesViaActivity() async throws {
         // Activity hook already reports working → first verify poll succeeds.
-        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working, source: .derived)
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .sent)
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
@@ -241,7 +241,7 @@ struct FakeInspector: PaneProcessInspecting {
 
     @Test func verifyTimeoutRetriesOnceThenFails() async throws {
         // Activity never becomes working and transcript never grows.
-        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle, source: .derived)
         let outcome = await makeActuator().actuate(row)
         if case .failed = outcome {} else { Issue.record("expected .failed, got \(outcome)") }
         // Sequence sent twice: initial + one retry (spec §Actuation 6).
@@ -250,7 +250,7 @@ struct FakeInspector: PaneProcessInspecting {
     }
 
     @Test func transcriptGrowthCountsAsVerification() async throws {
-        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle, source: .derived)
         // Transcript grows between pre-send snapshot and verify polls.
         let counter = OSAllocatedUnfairLock(initialState: 0)
         let growing: @Sendable (String) -> Data? = { _ in
@@ -272,7 +272,7 @@ struct FakeInspector: PaneProcessInspecting {
         // 1's verify window times out (idle, flat transcript); attempt 2's
         // eligibility RE-CHECK sees copy-mode now set and reschedules
         // instead of blind-Escaping the user's scrollback.
-        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle, source: .derived)
         tmux.inModeSequence = [false, true]
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .paneInCopyMode)
@@ -285,7 +285,7 @@ struct FakeInspector: PaneProcessInspecting {
         // 2's eligibility RE-CHECK reads a transcript that now has a record
         // newer than the limit (user typed manually in the window) and
         // cancels instead of sending again.
-        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle, source: .derived)
         let counter = OSAllocatedUnfairLock(initialState: 0)
         // Padding is deliberately LARGER than the newer-record line so the
         // growth check during attempt 1's verify polls (which only compares
@@ -316,7 +316,7 @@ struct FakeInspector: PaneProcessInspecting {
         // interKeyPause after attempt 1's Escape), so by the time attempt
         // 2's eligibility RE-CHECK (step 0a) runs, the gate is off and it
         // cancels instead of sending again.
-        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle, source: .derived)
         let counter = OSAllocatedUnfairLock(initialState: 0)
         let flippingWaiter: @Sendable (Duration) async -> Void = { _ in
             let n = counter.withLock { $0 += 1; return $0 }
@@ -366,7 +366,7 @@ struct FakeInspector: PaneProcessInspecting {
     @Test func apiErrorRowProceedsPastEligibility0aWhenApiErrorToggleOnEvenIfLimitResetOff() async throws {
         try await db.config.setAutoResumeOnLimitReset(false)
         try await db.config.setAutoResumeOnApiError(true)
-        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working, source: .derived)
         let apiErrorRow = try await insertApiErrorRow()
         let outcome = await makeActuator().actuate(apiErrorRow)
         // Falls through past 0a and runs the full send sequence (happy path).
@@ -377,7 +377,7 @@ struct FakeInspector: PaneProcessInspecting {
     @Test func sessionRowUnaffectedByApiErrorToggle() async throws {
         try await db.config.setAutoResumeOnLimitReset(true)
         try await db.config.setAutoResumeOnApiError(false)
-        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working, source: .derived)
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .sent)
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
@@ -400,7 +400,7 @@ struct FakeInspector: PaneProcessInspecting {
         // seam as the toggle test above). Attempt 2's eligibility RE-CHECK
         // (step 1b) sees the row is no longer `.pending` and cancels
         // instead of sending again.
-        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle, source: .derived)
         let counter = OSAllocatedUnfairLock(initialState: 0)
         let cancellingWaiter: @Sendable (Duration) async -> Void = { _ in
             let n = counter.withLock { $0 += 1; return $0 }
@@ -519,7 +519,7 @@ struct FakeInspector: PaneProcessInspecting {
     // MARK: - Thrown send retries instead of instant .failed
 
     @Test func throwingSendOnFirstAttemptRetriesAndSucceeds() async throws {
-        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working, source: .derived)
         tmux.throwOnEscapeAttempts = [1]
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .sent)
@@ -528,7 +528,7 @@ struct FakeInspector: PaneProcessInspecting {
     }
 
     @Test func throwingSendOnBothAttemptsFails() async throws {
-        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle, source: .derived)
         tmux.throwOnEscapeAttempts = [1, 2]
         let outcome = await makeActuator().actuate(row)
         if case .failed = outcome {} else { Issue.record("expected .failed, got \(outcome)") }

--- a/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
+++ b/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
@@ -71,7 +71,7 @@ struct MergedTransitionPrecedenceTests {
         let terminal = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
             label: "claude", claudeSessionID: "sess-1", kind: .claude)
-        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle, source: .derived)
         return (wt.id, terminal.id)
     }
 

--- a/Tests/TBDDaemonTests/MigrationV75StateProvenanceTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV75StateProvenanceTests.swift
@@ -1,0 +1,379 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 1. v75 gives `terminal.activityState` its provenance columns and v76
+/// gives `worktree` the outcome of its last PR lookup. Both migrations are
+/// nullable-without-default on purpose, so the tests below assert two things
+/// that are easy to lose: a pre-existing row survives with NULL provenance, and
+/// a row with only *half* a triple reports no fact at all.
+@Suite struct MigrationV75StateProvenanceTests {
+
+    private let epoch = Date(timeIntervalSince1970: 1_770_000_000)
+
+    /// Which half of the triple a row carries. Neither combination is a fact.
+    enum HalfTriple: Sendable {
+        case sourceOnly
+        case observedAtOnly
+        case neither
+    }
+
+    private func makeTerminal(_ db: TBDDatabase) async throws -> Terminal {
+        let repo = try await db.repos.create(
+            path: "/tmp/v75-repo-\(UUID().uuidString)", displayName: "V75", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v75-wt-\(UUID().uuidString)", tmuxServer: "tbd-v75")
+        return try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "s-1", kind: .claude)
+    }
+
+    // MARK: - Schema
+
+    @Test func provenanceColumnsExist() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let terminalCols = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+            #expect(terminalCols.contains("activityStateSource"))
+            #expect(terminalCols.contains("activityStateObservedAt"))
+            #expect(terminalCols.contains("awaitingInputReason"))
+            #expect(terminalCols.contains("awaitingInputObservedAt"))
+
+            let worktreeCols = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(worktree)")
+                .compactMap { $0["name"] as String? }
+            #expect(worktreeCols.contains("prObservation"))
+        }
+    }
+
+    /// Seeds a DB migrated only through v74, inserts real repo/worktree/terminal
+    /// rows, then applies v75 and v76: the rows survive, and their new columns
+    /// read NULL rather than a manufactured default.
+    @Test func forwardMigrationPreservesExistingRows() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v74_worktree_pending_prompt")
+
+        let repoID = "55555555-5555-5555-5555-555555555555"
+        let wtID = "66666666-6666-6666-6666-666666666666"
+        let terminalID = "77777777-7777-7777-7777-777777777777"
+        try queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                VALUES (?, '/tmp/v75-pre-repo', 'V75', 'main', ?)
+                """, arguments: [repoID, epoch])
+            try db.execute(sql: """
+                INSERT INTO worktree (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                VALUES (?, ?, 'w', 'w', 'main', '/tmp/v75-pre-wt', 'active', ?, 'tbd-v75')
+                """, arguments: [wtID, repoID, epoch])
+            try db.execute(sql: """
+                INSERT INTO terminal (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt, activityState)
+                VALUES (?, ?, '@9', '%9', ?, 'working')
+                """, arguments: [terminalID, wtID, epoch])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let terminals = try Int.fetchOne(
+                db, sql: "SELECT COUNT(*) FROM terminal WHERE id = ?", arguments: [terminalID]) ?? -1
+            #expect(terminals == 1, "pre-existing terminal row must survive v75")
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM terminal WHERE id = ?",
+                                       arguments: [terminalID])
+            #expect(row?["activityState"] == "working")
+            #expect(row?["activityStateSource"] == nil)
+            #expect(row?["activityStateObservedAt"] == nil)
+            #expect(row?["awaitingInputReason"] == nil)
+            #expect(row?["awaitingInputObservedAt"] == nil)
+
+            let worktrees = try Int.fetchOne(
+                db, sql: "SELECT COUNT(*) FROM worktree WHERE id = ?", arguments: [wtID]) ?? -1
+            #expect(worktrees == 1, "pre-existing worktree row must survive v76")
+            let wtRow = try Row.fetchOne(db, sql: "SELECT * FROM worktree WHERE id = ?",
+                                         arguments: [wtID])
+            #expect(wtRow?["prObservation"] == nil)
+        }
+    }
+
+    // MARK: - The triple, through the store
+
+    @Test func setActivityStateStoresTheWholeTriple() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working,
+            source: .hookEvent("UserPromptSubmit"), observedAt: epoch)
+
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.activityState == .working)
+        #expect(stored.activityStateSource == .hookEvent("UserPromptSubmit"))
+        #expect(stored.activityStateObservedAt == epoch)
+
+        let fact = try #require(stored.observedActivity)
+        #expect(fact.value == .working)
+        #expect(fact.source == .hookEvent("UserPromptSubmit"))
+        #expect(fact.observedAt == epoch)
+    }
+
+    /// The reason rides with the observation it belongs to, and the next
+    /// observation supersedes it — a stale "needs your permission" must not
+    /// outlive the wait it described.
+    @Test func awaitingInputReasonRidesAndIsSuperseded() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        let reason = AwaitingInputReason(
+            message: "Claude needs your permission to use Bash",
+            hookEventName: "Notification",
+            raw: #"{"hook_event_name":"Notification"}"#)
+
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .waitingForUser,
+            source: .hookEvent("Notification"), observedAt: epoch,
+            awaitingInputReason: reason)
+
+        let waiting = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(waiting.awaitingInputReason == reason)
+        #expect(waiting.awaitingInputObservedAt == epoch)
+
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working,
+            source: .hookEvent("UserPromptSubmit"), observedAt: epoch.addingTimeInterval(60))
+
+        let working = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(working.awaitingInputReason == nil)
+        #expect(working.awaitingInputObservedAt == nil)
+    }
+
+    /// Half a triple is not a fact. A row carrying a value but no source (or no
+    /// observed-at) must report nil rather than let a bare enumeration
+    /// masquerade as an observation.
+    @Test(arguments: [HalfTriple.sourceOnly, .observedAtOnly, .neither])
+    func observedActivityIsNilWhenEitherHalfIsMissing(half: HalfTriple) async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+
+        let sourceJSON = half == .sourceOnly
+            ? String(data: try JSONEncoder().encode(FactSource.derived), encoding: .utf8)
+            : nil
+        let observedAt: Date? = half == .observedAtOnly ? epoch : nil
+        try await db.writerForTests.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    UPDATE terminal
+                    SET activityState = 'working',
+                        activityStateSource = ?,
+                        activityStateObservedAt = ?
+                    WHERE id = ?
+                    """,
+                arguments: [sourceJSON, observedAt, terminal.id.uuidString])
+        }
+
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.activityState == .working)
+        #expect(stored.observedActivity == nil)
+    }
+
+    /// A row written by a daemon that predates the columns loads fine and
+    /// carries no fact.
+    @Test func legacyRowLoadsWithNoProvenance() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v75-legacy-repo-\(UUID().uuidString)", displayName: "V75",
+            defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v75-legacy-wt-\(UUID().uuidString)", tmuxServer: "tbd-v75")
+
+        let id = UUID()
+        try await db.writerForTests.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO terminal (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt, activityState)
+                    VALUES (?, ?, '@9', '%9', ?, 'idle')
+                    """,
+                arguments: [id.uuidString, wt.id.uuidString, epoch])
+        }
+
+        let legacy = try #require(try await db.terminals.get(id: id))
+        #expect(legacy.activityState == .idle)
+        #expect(legacy.activityStateSource == nil)
+        #expect(legacy.observedActivity == nil)
+    }
+
+    /// Parking writes an activity state, so it must stamp provenance like every
+    /// other writer — and it clears any carried wait reason with it.
+    @Test func parkingStampsProvenance() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .waitingForUser,
+            source: .hookEvent("Notification"), observedAt: epoch,
+            awaitingInputReason: AwaitingInputReason(message: "permission?"))
+
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "s-1", reason: .manual, at: epoch.addingTimeInterval(120))
+
+        let parked = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(parked.activityState == .idle)
+        #expect(parked.activityStateSource == .database)
+        #expect(parked.activityStateObservedAt == epoch.addingTimeInterval(120))
+        #expect(parked.awaitingInputReason == nil)
+        let fact = try #require(parked.observedActivity)
+        #expect(fact.value == .idle)
+    }
+
+    @Test func recreatingAWindowStampsDerivedProvenance() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working,
+            source: .hookEvent("UserPromptSubmit"), observedAt: epoch)
+
+        try await db.terminals.clearRecreated(id: terminal.id, at: epoch.addingTimeInterval(30))
+
+        let recreated = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(recreated.activityState == .unknown)
+        #expect(recreated.activityStateSource == .derived)
+        #expect(recreated.activityStateObservedAt == epoch.addingTimeInterval(30))
+    }
+
+    /// Legacy `Terminal` JSON (an older app or daemon over RPC) still decodes,
+    /// with no provenance and therefore no fact.
+    @Test func legacyTerminalJSONDecodes() throws {
+        let json = """
+            {
+                "id": "\(UUID().uuidString)",
+                "worktreeID": "\(UUID().uuidString)",
+                "tmuxWindowID": "@1",
+                "tmuxPaneID": "%1",
+                "createdAt": 0,
+                "activityState": "working"
+            }
+            """
+        let terminal = try JSONDecoder().decode(Terminal.self, from: Data(json.utf8))
+        #expect(terminal.activityState == .working)
+        #expect(terminal.activityStateSource == nil)
+        #expect(terminal.activityStateObservedAt == nil)
+        #expect(terminal.awaitingInputReason == nil)
+        #expect(terminal.observedActivity == nil)
+    }
+
+    @Test func terminalProvenanceSurvivesJSONRoundTrip() throws {
+        let original = Terminal(
+            id: UUID(), worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            activityState: .waitingForUser,
+            activityStateSource: .hookEvent("Notification"),
+            activityStateObservedAt: epoch,
+            awaitingInputReason: AwaitingInputReason(
+                message: "permission?", hookEventName: "Notification"),
+            awaitingInputObservedAt: epoch)
+        let decoded = try JSONDecoder().decode(
+            Terminal.self, from: JSONEncoder().encode(original))
+
+        #expect(decoded.activityStateSource == .hookEvent("Notification"))
+        #expect(decoded.awaitingInputReason?.message == "permission?")
+        let fact = try #require(decoded.observedActivity)
+        #expect(fact.summary.contains("hook:Notification"))
+    }
+
+    // MARK: - PR observation
+
+    @Test(arguments: [
+        PRObservation.Outcome.observed,
+        .none,
+        .undetermined(cause: "network unreachable")
+    ])
+    func prObservationRoundTripsThroughTheDB(outcome: PRObservation.Outcome) async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v76-repo-\(UUID().uuidString)", displayName: "V76", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v76-wt-\(UUID().uuidString)", tmuxServer: "tbd-v76")
+
+        let observation = PRObservation(outcome: outcome, observedAt: epoch)
+        try await db.worktrees.setPRObservation(id: wt.id, observation: observation)
+
+        let stored = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(stored.prObservation == observation)
+    }
+
+    /// "The forge answered; no PR" and "we could not find out" must stay
+    /// different facts after a trip through the database — the whole reason the
+    /// column exists beside `prStatus`.
+    @Test func noneAndUndeterminedStayDistinctInTheDB() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v76-distinct-repo-\(UUID().uuidString)", displayName: "V76",
+            defaultBranch: "main")
+        let answeredWT = try await db.worktrees.create(
+            repoID: repo.id, name: "a", branch: "a",
+            path: "/tmp/v76-a-\(UUID().uuidString)", tmuxServer: "tbd-v76")
+        let failedWT = try await db.worktrees.create(
+            repoID: repo.id, name: "b", branch: "b",
+            path: "/tmp/v76-b-\(UUID().uuidString)", tmuxServer: "tbd-v76")
+
+        try await db.worktrees.setPRObservation(
+            id: answeredWT.id, observation: PRObservation(outcome: .none, observedAt: epoch))
+        try await db.worktrees.setPRObservation(
+            id: failedWT.id,
+            observation: PRObservation(
+                outcome: .undetermined(cause: "network unreachable"), observedAt: epoch))
+
+        let answered = try #require(try await db.worktrees.get(id: answeredWT.id))
+        let failed = try #require(try await db.worktrees.get(id: failedWT.id))
+        #expect(answered.prObservation?.outcome == PRObservation.Outcome.none)
+        #expect(failed.prObservation?.outcome == .undetermined(cause: "network unreachable"))
+        #expect(answered.prObservation != failed.prObservation)
+    }
+
+    /// A worktree with no recorded attempt is a third state again: not `.none`,
+    /// not `.undetermined`, but nothing on record.
+    @Test func noRecordedAttemptReadsAsNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v76-none-repo-\(UUID().uuidString)", displayName: "V76",
+            defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v76-none-wt-\(UUID().uuidString)", tmuxServer: "tbd-v76")
+
+        let stored = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(stored.prObservation == nil)
+    }
+
+    /// Legacy `Worktree` JSON still decodes, and `PRStatus` gains its
+    /// `observedAt` inside the existing blob — no migration involved.
+    @Test func legacyWorktreeJSONDecodesAndPRStatusCarriesObservedAt() throws {
+        let json = """
+            {
+                "id": "\(UUID().uuidString)",
+                "name": "w",
+                "displayName": "w",
+                "branch": "b",
+                "path": "/tmp/w",
+                "status": "active",
+                "createdAt": 0,
+                "tmuxServer": "tbd-x",
+                "prStatus": {
+                    "number": 7,
+                    "url": "https://example.test/pr/7",
+                    "state": "mergeable"
+                }
+            }
+            """
+        let worktree = try JSONDecoder().decode(Worktree.self, from: Data(json.utf8))
+        #expect(worktree.prObservation == nil)
+        #expect(worktree.prStatus?.number == 7)
+        #expect(worktree.prStatus?.observedAt == nil)
+
+        let stamped = PRStatus(
+            number: 7, url: "https://example.test/pr/7", state: .mergeable, observedAt: epoch)
+        let decoded = try JSONDecoder().decode(PRStatus.self, from: JSONEncoder().encode(stamped))
+        #expect(decoded.observedAt == epoch)
+    }
+}

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -741,6 +741,66 @@ struct ModelProfileSpawnTests {
         #expect(joined.contains("CLAUDE_CONFIG_DIR="))
     }
 
+    /// An in-place swap kills the pane's Claude and respawns it, keeping the
+    /// SAME terminal row — so a permission prompt that was on screen when the
+    /// user switched account died with the old process while its recorded
+    /// reason stayed on the row.
+    ///
+    /// Nothing on the row's own rails retracts it: the swap writes only
+    /// `profile_id` and the session id, `transcriptPath` is unchanged so the
+    /// resolver's growth comparison still says "no growth since the prompt",
+    /// and the respawned session's `tbd terminal-activity idle` is a separate
+    /// best-effort CLI invocation seconds away at best. So the swap retracts it
+    /// itself, from its own act.
+    @Test("in-place swap: retracts a prompt recorded against the process it killed")
+    func inPlaceSwapRetractsAStandingWaitReason() async throws {
+        let (router, db, _) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let a = try await seedOAuthProfile(db, name: "A")
+        let b = try await seedOAuthProfile(db, name: "B")
+        try await db.config.setDefaultProfileID(a.id)
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        let oldTerm = try createResp.decodeResult(Terminal.self)
+
+        let workingAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let promptAt = workingAt.addingTimeInterval(30)
+        try await db.terminals.setActivityState(
+            id: oldTerm.id, activityState: .working,
+            source: .hookEvent(RPCMethod.terminalActivityEvent), observedAt: workingAt)
+        try await db.terminals.recordAwaitingInputReason(
+            id: oldTerm.id,
+            reason: AwaitingInputReason(
+                message: "Claude needs your permission to use Bash",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: promptAt)
+
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: oldTerm.id, newProfileID: b.id, mode: .inPlace)
+        ))
+        #expect(swapResp.success)
+
+        let after = try #require(try await db.terminals.get(id: oldTerm.id))
+        #expect(after.profileID == b.id)
+        #expect(after.awaitingInputReason == nil)
+        #expect(after.awaitingInputObservedAt == nil)
+        // The dead prompt is gone from the composed answer — and with no
+        // growth fact at all, which is the shape that used to pin it.
+        let state = SessionStateResolver().resolve(SessionStateFacts(terminal: after))
+        #expect(state.value == .working)
+        // The activity columns are untouched: the swap knows the old prompt is
+        // gone, not what the respawned session is doing.
+        #expect(after.activityState == .working)
+        #expect(after.activityStateObservedAt == workingAt)
+    }
+
     // MARK: - Swap over a NON-BLANK session: resume + --fork-session flag
 
     /// Seed a real claude terminal, then give its session a NON-blank transcript

--- a/Tests/TBDDaemonTests/NightwatchContextNumeratorAgreementTests.swift
+++ b/Tests/TBDDaemonTests/NightwatchContextNumeratorAgreementTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2. One session's context numerator is computed twice in this product —
+/// once in Swift, for `session.states`, and once in the Python that the
+/// nightwatch desk runs — and both numbers are put in front of the same
+/// operator. Two selection rules over one transcript is not a rounding
+/// difference: it is two answers with nothing to say which is right.
+///
+/// So the agreement is asserted by running both implementations over the same
+/// bytes, rather than by reading the two sources and believing they match. The
+/// duplication of the rule is unavoidable across languages; the duplication
+/// going *unnoticed* is what this suite is for.
+@Suite("Nightwatch context numerator agrees with ContextLoadReader")
+struct NightwatchContextNumeratorAgreementTests {
+
+    // MARK: - Harness
+
+    /// What the shipped `tick.py` answers for one transcript, plus the two
+    /// constants it must share with the Swift side.
+    private struct PythonAnswer {
+        let tokens: Int?
+        let assumedWindow: Int
+        let tailWindowBytes: Int
+    }
+
+    /// Loads the installed `tick.py` as a module and calls into it directly.
+    /// `--selftest` proves the script agrees with itself; only this proves it
+    /// agrees with `ContextLoadReader`.
+    private static let driver = """
+    import importlib.util, json, sys
+    spec = importlib.util.spec_from_file_location("nightwatch_tick", sys.argv[1])
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    print(json.dumps({"tokens": mod.context_tokens(sys.argv[2]),
+                      "assumed_window": mod.ASSUMED_WINDOW,
+                      "tail_window": mod.TAIL_WINDOW_BYTES}))
+    """
+
+    /// The driver exited non-zero — almost always because `context_tokens`
+    /// raised. Carries the traceback so the failure names the defect.
+    private struct DriverFailure: Error, CustomStringConvertible {
+        let status: Int32
+        let stderr: String
+        var description: String {
+            "tick.py driver exited \(status) instead of answering — "
+                + "context_tokens raised on a shape it must tolerate:\n\(stderr)"
+        }
+    }
+
+    private func askPython(tickPath: String, transcriptPath: String) throws -> PythonAnswer {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["python3", "-c", Self.driver, tickPath, transcriptPath]
+        let out = Pipe(), err = Pipe()
+        proc.standardOutput = out
+        proc.standardError = err
+        try proc.run()
+        let stdout = out.fileHandleForReading.readDataToEndOfFile()
+        let stderr = String(decoding: err.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        proc.waitUntilExit()
+        // Thrown, not `#expect`ed: a raise inside `context_tokens` prints
+        // nothing on stdout, so an expectation here would be followed by an
+        // opaque JSON-parse error and the traceback — the finding — would never
+        // reach the failure line. `Issue.record(_: some Error)` is the only
+        // shape that carries it there.
+        guard proc.terminationStatus == 0 else {
+            throw DriverFailure(status: proc.terminationStatus, stderr: stderr)
+        }
+        let object = try JSONSerialization.jsonObject(with: stdout) as? [String: Any]
+        let root = try #require(object, "tick.py driver printed no JSON. stderr:\n\(stderr)")
+        return PythonAnswer(
+            tokens: root["tokens"] as? Int,
+            assumedWindow: try #require(root["assumed_window"] as? Int),
+            tailWindowBytes: try #require(root["tail_window"] as? Int)
+        )
+    }
+
+    /// One assistant record whose three window-relevant buckets sum to `total`.
+    private func usageRecord(_ total: Int) throws -> String {
+        let usage = ["input_tokens": total - 30,
+                     "cache_creation_input_tokens": 20,
+                     "cache_read_input_tokens": 10]
+        let data = try JSONSerialization.data(withJSONObject: ["message": ["usage": usage]])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func writeTranscript(_ lines: [String], in dir: URL) throws -> String {
+        let path = dir.appendingPathComponent("transcript-\(UUID().uuidString).jsonl")
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: path)
+        return path.path
+    }
+
+    // MARK: - The agreement
+
+    @Test("Both implementations read the same numerator out of the same transcript")
+    func numeratorsAgree() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-ctx-agree-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try PluginDirWriter(applicationSupportRoot: root.path).writePlugin()
+        let tick = root.appendingPathComponent("TBD/plugin/skills/nightwatch/scripts/tick.py").path
+
+        // Each case is one where a plausible *other* rule gives a different
+        // answer, so agreement here is evidence rather than coincidence.
+        let cases: [(name: String, lines: [String])] = try [
+            // Largest ≠ last. A parent session's subagents append into the same
+            // file, so "largest in the tail" and "what this session carries"
+            // diverge by an order of magnitude on an ordinary desk transcript.
+            ("largest is not last", [usageRecord(180_000), usageRecord(12_345)]),
+            // Unparseable lines and records without a usage block are skipped
+            // by both, rather than ending the read.
+            ("noise after the last usage record",
+             [usageRecord(41_000), "not json at all", #"{"message":{}}"#]),
+            // Beyond the tail window: both bound the read, so both answer
+            // "unknown" rather than reporting a figure from further back.
+            ("usage record beyond the tail window",
+             [usageRecord(999_999),
+              #"{"filler":"\#(String(repeating: "x", count: ContextLoadReader.defaultTailWindowBytes + 4096))"}"#]),
+            // Nothing to read at all.
+            ("no usage records anywhere", [#"{"message":{}}"#]),
+            // A bucket the record spells as `null`, and one spelled as a
+            // string. Swift counts each as nothing (`as? Int ?? 0`), so Python
+            // has to as well — and the cost of getting this one wrong is not a
+            // disagreeing number, it is a `TypeError` out of `burn_risk`, which
+            // `tick.py` calls inline in its fleet loop with no `try`. One such
+            // record in one agent's transcript would end the tick for the whole
+            // fleet: no classification table, no decision queue, nothing
+            // supervised that night.
+            ("a null cache bucket",
+             [#"{"message":{"usage":{"input_tokens":100,"cache_read_input_tokens":null}}}"#]),
+            ("a non-numeric cache bucket",
+             [#"{"message":{"usage":{"input_tokens":100,"cache_creation_input_tokens":"12"}}}"#])
+        ]
+
+        let reader = ContextLoadReader()
+        for testCase in cases {
+            let path = try writeTranscript(testCase.lines, in: root)
+            let swift = reader.read(
+                capturePath: root.appendingPathComponent("absent.json").path,
+                transcriptPath: path,
+                tee: .notADesk
+            ).used?.value
+            let python = try askPython(tickPath: tick, transcriptPath: path).tokens
+            let detail = "\(testCase.name): Swift read \(String(describing: swift)), "
+                + "tick.py read \(String(describing: python))"
+            #expect(swift == python, "\(detail)")
+        }
+    }
+
+    /// The two constants the rule is expressed in terms of. They cannot be
+    /// shared across the language boundary, so the only thing standing between
+    /// them and silent divergence is this assertion.
+    @Test("The assumed window and the tail window are the same number on both sides")
+    func constantsAgree() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-ctx-const-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try PluginDirWriter(applicationSupportRoot: root.path).writePlugin()
+        let tick = root.appendingPathComponent("TBD/plugin/skills/nightwatch/scripts/tick.py").path
+        let empty = try writeTranscript([#"{"message":{}}"#], in: root)
+
+        let python = try askPython(tickPath: tick, transcriptPath: empty)
+
+        #expect(python.assumedWindow == ContextWindow.assumedTokens)
+        #expect(python.tailWindowBytes == ContextLoadReader.defaultTailWindowBytes)
+    }
+
+    /// Each spelling of the assumption has to name the other, since nothing
+    /// mechanical connects them: an editor who arrives at one site is otherwise
+    /// given no reason to believe there is a second.
+    ///
+    /// `handoff.py` is deliberately not in this list. It resolves its ceiling
+    /// against the window its own session reported, so it holds no copy of the
+    /// assumption to keep in step — the only two spellings are tick.py's and
+    /// Swift's.
+    @Test("Each spelling of the assumed window points at the other")
+    func eachSpellingNamesTheOther() {
+        #expect(NightwatchSkillContent.tickPy.contains("ContextWindow.assumedTokens"),
+                "tick.py's ASSUMED_WINDOW no longer names its Swift twin")
+        #expect(!NightwatchSkillContent.handoffPy.contains("ASSUMED_WINDOW"),
+                "handoff.py assumes a window again instead of reading the one its session reported")
+        #expect(NightwatchSkillContent.tickPy.contains("ContextLoadReader.lastUsage"),
+                "tick.py's numerator no longer names the rule it has to agree with")
+    }
+
+    /// The assumption also has to be labeled where a **human** reads it, not
+    /// only where an editor does. A percentage printed bare is indistinguishable
+    /// from one taken against a window something actually measured, and the
+    /// desk acts on these lines.
+    @Test("Every reported percentage says its denominator was assumed")
+    func theReportSaysTheWindowWasAssumed() {
+        let tick = NightwatchSkillContent.tickPy
+        #expect(tick.contains("of an ASSUMED {ASSUMED_WINDOW:,}-token "),
+                "tick.py's burn-risk header prints a percentage without calling the window assumed")
+        #expect(tick.contains("% of assumed {ASSUMED_WINDOW:,}"),
+                "tick.py's per-agent burn line prints a percentage without calling the window assumed")
+    }
+}

--- a/Tests/TBDDaemonTests/NightwatchHandoffCeilingTests.swift
+++ b/Tests/TBDDaemonTests/NightwatchHandoffCeilingTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2. The desk's handoff ceiling is three quarters of the context window
+/// **its own session** resolved, and the only report of that window is the
+/// statusline capture TBD's tee publishes for desk sessions.
+///
+/// Two halves have to line up across a language boundary for that to work: the
+/// Python has to look where the Swift writes, and it has to take the same field
+/// out of the payload. Neither is checked by anything else — a capture the
+/// script cannot find is indistinguishable, from inside the script, from a
+/// session that never reported a window, so a drift would silently put every
+/// desk on the fallback forever. So the agreement is asserted by pointing the
+/// script at a capture written through `TBDConstants` and asking what ceiling
+/// it resolved.
+@Suite("Nightwatch handoff ceiling reads the session's own window")
+struct NightwatchHandoffCeilingTests {
+
+    /// What the shipped `handoff.py` resolves for one session key.
+    private struct Answer {
+        let capturePath: String
+        let window: Int?
+        let ceiling: Int
+        let provenance: String
+        let fallback: Int
+    }
+
+    /// Loads the installed `handoff.py` as a module and calls into it. Its
+    /// `--selftest` proves the arithmetic against captures it wrote itself;
+    /// only this proves it against a capture path TBD built.
+    private static let driver = """
+    import importlib.util, json, sys
+    spec = importlib.util.spec_from_file_location("nightwatch_handoff", sys.argv[1])
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    ceiling, provenance = mod.resolve_ceiling(sys.argv[2])
+    print(json.dumps({"path": mod.statusline_capture_path(sys.argv[2]),
+                      "window": mod.observed_window(sys.argv[2]),
+                      "ceiling": ceiling,
+                      "provenance": provenance,
+                      "fallback": mod.FALLBACK_THRESHOLD}))
+    """
+
+    /// Runs the driver with `TBD_HOME` in the child's environment — the
+    /// injection seam, so no test in this process mutates its own environment.
+    private func ask(handoffPath: String, sessionKey: String, tbdHome: String) throws -> Answer {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["python3", "-c", Self.driver, handoffPath, sessionKey]
+        var env = ProcessInfo.processInfo.environment
+        env["TBD_HOME"] = tbdHome
+        proc.environment = env
+        let out = Pipe(), err = Pipe()
+        proc.standardOutput = out
+        proc.standardError = err
+        try proc.run()
+        let stdout = out.fileHandleForReading.readDataToEndOfFile()
+        let stderr = String(decoding: err.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        proc.waitUntilExit()
+        #expect(proc.terminationStatus == 0, "handoff.py driver failed:\n\(stderr)")
+        let object = try JSONSerialization.jsonObject(with: stdout) as? [String: Any]
+        let root = try #require(object, "handoff.py driver printed no JSON. stderr:\n\(stderr)")
+        return Answer(
+            capturePath: try #require(root["path"] as? String),
+            window: root["window"] as? Int,
+            ceiling: try #require(root["ceiling"] as? Int),
+            provenance: try #require(root["provenance"] as? String),
+            fallback: try #require(root["fallback"] as? Int)
+        )
+    }
+
+    /// A scratch `TBD_HOME` with the plugin written into it, plus the path of
+    /// the installed `handoff.py`.
+    private func fixture() throws -> (home: URL, handoff: String) {
+        let home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-handoff-ceiling-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try PluginDirWriter(applicationSupportRoot: home.path).writePlugin()
+        return (home, home.appendingPathComponent(
+            "TBD/plugin/skills/nightwatch/scripts/handoff.py").path)
+    }
+
+    private func publish(window: Int, forKey key: String, home: URL) throws {
+        let path = TBDConstants.statuslineCapturePath(
+            sessionKey: key, environment: ["TBD_HOME": home.path])
+        try FileManager.default.createDirectory(
+            at: URL(fileURLWithPath: path).deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let payload = try JSONSerialization.data(
+            withJSONObject: ["context_window": ["context_window_size": window]])
+        try payload.write(to: URL(fileURLWithPath: path))
+    }
+
+    @Test("The script looks exactly where TBDConstants publishes, sanitizing identically")
+    func capturePathAgrees() throws {
+        let (home, handoff) = try fixture()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        // A terminal id is a UUID, but the sanitizer is what makes that safe, so
+        // the agreement is asserted on a key that actually exercises it.
+        for key in [UUID().uuidString, "a/b .c", "T-1_2"] {
+            let answer = try ask(handoffPath: handoff, sessionKey: key, tbdHome: home.path)
+            #expect(answer.capturePath == TBDConstants.statuslineCapturePath(
+                sessionKey: key, environment: ["TBD_HOME": home.path]),
+                    "handoff.py builds a different capture path than TBDConstants for \(key)")
+        }
+    }
+
+    @Test("A desk on a real window gets three quarters of THAT window, and is told so")
+    func ceilingFollowsTheObservedWindow() throws {
+        let (home, handoff) = try fixture()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let key = UUID().uuidString
+
+        for (window, expected) in [(1_000_000, 750_000), (200_000, 150_000)] {
+            try publish(window: window, forKey: key, home: home)
+            let answer = try ask(handoffPath: handoff, sessionKey: key, tbdHome: home.path)
+            #expect(answer.window == window)
+            #expect(answer.ceiling == expected,
+                    "a \(window)-token desk got a ceiling of \(answer.ceiling)")
+            #expect(answer.provenance.contains("OBSERVED"),
+                    "the ceiling does not say the window was observed: \(answer.provenance)")
+        }
+    }
+
+    /// With no capture the ceiling stays where the desk has been running it. A
+    /// smaller guess is the measured failure — a 200k-derived ceiling forced a
+    /// relay roughly every two hours on a large window — and the output has to
+    /// admit the number is a guess, since nothing here measured anything.
+    @Test("No capture keeps the fallback ceiling, labeled as a guess")
+    func noCaptureFallsBackAndSaysSo() throws {
+        let (home, handoff) = try fixture()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let answer = try ask(handoffPath: handoff, sessionKey: UUID().uuidString, tbdHome: home.path)
+
+        #expect(answer.window == nil)
+        #expect(answer.fallback == 600_000)
+        #expect(answer.ceiling == 600_000, "the no-capture ceiling moved off 600k")
+        #expect(answer.provenance.contains("NOT observed"),
+                "a fallback ceiling reads as though something measured it: \(answer.provenance)")
+    }
+
+    /// Every unreadable shape is "no capture", and none of them raises: this
+    /// code runs on the path that keeps a shift alive, so a malformed payload
+    /// may cost the ceiling its precision but never the ceiling itself.
+    @Test("An unreadable capture falls back rather than raising", arguments: [
+        "{not json",
+        #"{"context_window":{}}"#,
+        #"{"context_window":{"context_window_size":0}}"#,
+        #"{"context_window":{"context_window_size":-5}}"#,
+        #"{"context_window":{"context_window_size":"1m"}}"#,
+        "[]"
+    ])
+    func malformedCaptureFallsBack(payload: String) throws {
+        let (home, handoff) = try fixture()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let key = UUID().uuidString
+        let path = TBDConstants.statuslineCapturePath(
+            sessionKey: key, environment: ["TBD_HOME": home.path])
+        try FileManager.default.createDirectory(
+            at: URL(fileURLWithPath: path).deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data(payload.utf8).write(to: URL(fileURLWithPath: path))
+
+        let answer = try ask(handoffPath: handoff, sessionKey: key, tbdHome: home.path)
+
+        #expect(answer.window == nil, "\(payload) was read as a window")
+        #expect(answer.ceiling == answer.fallback)
+    }
+}

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -1,0 +1,338 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// Tier 1. `terminal.notificationEvent` records one fact and changes nothing
+/// else. Two properties carry most of the weight here:
+///
+/// 1. Every classification branch records the message verbatim beside the label
+///    TBD put on it, and an unrecognized type stays unrecognized.
+/// 2. **`activityState` is untouched by all of them.** It gates parking, so a
+///    hook that could move it would silently change which sessions hibernate.
+///    Every branch test asserts the activity triple is byte-identical
+///    afterward, and the hibernation gate's own decision is asserted alongside
+///    it rather than inferred from that.
+@Suite struct NotificationHookRPCTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+    let terminalID: UUID
+    let worktreeID: UUID
+    let worktreePath: String
+
+    /// Pinned through the router's date seam, so the stored observed-at is an
+    /// exact assertion rather than a freshness window.
+    static let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+
+    init() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            now: { Self.observedAt },
+            actuationLog: makeTestActuationLog())
+        let repo = try await db.repos.create(
+            path: "/tmp/notif-repo-\(UUID().uuidString)", displayName: "N", defaultBranch: "main")
+        worktreePath = "/tmp/notif-wt-\(UUID().uuidString)"
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: worktreePath, tmuxServer: "tbd-notif")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "s-1", kind: .claude)
+        terminalID = terminal.id
+        // A resting, park-eligible session with a full activity triple, so the
+        // "unchanged" assertions have something specific to be unchanged.
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .idle,
+            source: .hookEvent("Stop"), observedAt: Self.baselineActivityAt)
+    }
+
+    static let baselineActivityAt = Date(timeIntervalSince1970: 1_779_000_000)
+
+    private func notify(
+        type: String?,
+        message: String = "Claude needs your permission to use Bash",
+        title: String? = nil,
+        rawPayload: String? = nil,
+        cwd: String? = nil,
+        terminalID: UUID? = nil
+    ) async -> RPCResponse {
+        let request = try! RPCRequest(
+            method: RPCMethod.terminalNotificationEvent,
+            params: TerminalNotificationEventParams(
+                terminalID: terminalID ?? self.terminalID,
+                notificationType: type,
+                message: message,
+                title: title,
+                rawPayload: rawPayload,
+                cwd: cwd))
+        return await router.handle(request)
+    }
+
+    private func terminal() async throws -> Terminal {
+        try #require(try await db.terminals.get(id: terminalID))
+    }
+
+    /// The park decision for the current row, plus the raw activity triple —
+    /// the two things this slice must leave alone.
+    private func parkDecision(_ terminal: Terminal) -> HibernationGate.Decision {
+        HibernationGate.decide(
+            terminal: terminal,
+            autoHibernateEnabled: true,
+            idleTimeout: 60,
+            idleSince: Self.baselineActivityAt,
+            now: Self.baselineActivityAt.addingTimeInterval(3600))
+    }
+
+    // MARK: - Classification branches
+
+    struct Branch: Sendable, CustomStringConvertible {
+        let type: String?
+        let expected: AwaitingInputClass
+        var description: String { "\(type ?? "<absent>") → \(expected.rawValue)" }
+    }
+
+    /// Every documented `notification_type`, plus an absent one and one this
+    /// build has never seen. One case per branch of the classifier.
+    static let classifications: [Branch] = [
+        Branch(type: "permission_prompt", expected: .promptOnScreen),
+        Branch(type: "elicitation_dialog", expected: .promptOnScreen),
+        Branch(type: "agent_needs_input", expected: .promptOnScreen),
+        Branch(type: "idle_prompt", expected: .doneWaiting),
+        Branch(type: "auth_success", expected: .informational),
+        Branch(type: "elicitation_complete", expected: .informational),
+        Branch(type: "elicitation_response", expected: .informational),
+        Branch(type: "agent_completed", expected: .informational),
+        Branch(type: "some_future_type", expected: .unrecognized),
+        Branch(type: nil, expected: .unrecognized)
+    ]
+
+    @Test(arguments: classifications)
+    func recordsTheReasonWithItsClassAndLeavesActivityAlone(branch: Branch) async throws {
+        let before = try await terminal()
+        let message = "Claude needs your permission to use Bash"
+
+        let response = await notify(type: branch.type, message: message, title: "Permission needed")
+        #expect(response.success)
+
+        let after = try await terminal()
+        let reason = try #require(after.awaitingInputReason)
+        #expect(reason.message == message)
+        #expect(reason.notificationType == branch.type)
+        #expect(reason.classification == branch.expected)
+        #expect(reason.hookEventName == "Notification")
+        #expect(after.awaitingInputObservedAt == Self.observedAt)
+
+        // The composed output — what any surface that reports this fact must
+        // print — carries the message, the class, the source and the age.
+        let fact = try #require(after.observedAwaitingInput)
+        #expect(fact.source == .hookEvent("Notification"))
+        #expect(fact.observedAt == Self.observedAt)
+        let summary = fact.summary
+        #expect(summary.contains(message))
+        #expect(summary.contains(branch.expected.rawValue))
+        #expect(summary.contains("source: hook:Notification"))
+        #expect(summary.contains(FactTimestamp.string(from: Self.observedAt)))
+
+        // …and the activity fact is byte-identical: same value, same source,
+        // same observed-at. Nothing here may move a gating field.
+        #expect(after.activityState == before.activityState)
+        #expect(after.activityStateSource == before.activityStateSource)
+        #expect(after.activityStateObservedAt == before.activityStateObservedAt)
+        #expect(after.observedActivity == before.observedActivity)
+
+        // Hibernation eligibility follows from that, but is asserted directly
+        // rather than assumed.
+        #expect(parkDecision(after) == parkDecision(before))
+        #expect(parkDecision(after) == .eligible)
+        #expect(HibernationGate.blockingRail(terminal: after) == nil)
+    }
+
+    /// A near-miss spelling of a known type is the case a "helpful" matcher
+    /// would fold into `promptOnScreen`. It must not be.
+    @Test(arguments: ["permission_prompt_v2", "PERMISSION_PROMPT", " permission_prompt", "prompt", ""])
+    func lookalikeTypesAreNeverFoldedIntoAKnownClass(type: String) async throws {
+        #expect(await notify(type: type).success)
+        let reason = try #require(try await terminal().awaitingInputReason)
+        #expect(reason.notificationType == type, "the type is recorded verbatim")
+        #expect(reason.classification == .unrecognized)
+    }
+
+    // MARK: - The verbatim payload
+
+    @Test func rawPayloadSurvivesTheRoundTripUnmodified() async throws {
+        // Includes a field this build does not model (`permission_mode`) and
+        // unicode, because the point of carrying it verbatim is that a later
+        // consumer can read what TBD never parsed.
+        let raw = #"""
+        {"session_id":"abc123","cwd":"/x","hook_event_name":"Notification",\#
+        "message":"Claude needs your permission — “Bash”","title":"Permission needed",\#
+        "notification_type":"permission_prompt","permission_mode":"default","prompt_id":"p-1"}
+        """#
+        #expect(await notify(type: "permission_prompt", rawPayload: raw).success)
+
+        let reason = try #require(try await terminal().awaitingInputReason)
+        #expect(reason.raw == raw)
+        // Still parseable as the JSON it was — nothing re-encoded it.
+        let storedRaw = try #require(reason.raw)
+        let object = try JSONSerialization.jsonObject(with: Data(storedRaw.utf8))
+        #expect((object as? [String: Any])?["permission_mode"] as? String == "default")
+    }
+
+    @Test func absentRawPayloadIsCarriedAsAnAbsence() async throws {
+        #expect(await notify(type: "idle_prompt", rawPayload: nil).success)
+        let reason = try #require(try await terminal().awaitingInputReason)
+        #expect(reason.raw == nil)
+        #expect(reason.classification == .doneWaiting)
+    }
+
+    // MARK: - Guards
+
+    @Test func unknownTerminalIsASoftNoOp() async throws {
+        let response = await notify(type: "permission_prompt", terminalID: UUID())
+        #expect(response.success, "an unknown terminal must not throw at a fire-and-forget hook")
+        // …and nothing was written to the real terminal.
+        #expect(try await terminal().awaitingInputReason == nil)
+    }
+
+    @Test func aForeignSessionsCWDIsRejected() async throws {
+        // A hook fired by a session living in another worktree — the shape
+        // `TBD_TERMINAL_ID` inheritance makes possible — must not write here.
+        let otherRepo = try await db.repos.create(
+            path: "/tmp/notif-other-repo-\(UUID().uuidString)", displayName: "O",
+            defaultBranch: "main")
+        let otherPath = "/tmp/notif-other-wt-\(UUID().uuidString)"
+        _ = try await db.worktrees.create(
+            repoID: otherRepo.id, name: "o", branch: "ob",
+            path: otherPath, tmuxServer: "tbd-notif")
+
+        let response = await notify(type: "permission_prompt", cwd: otherPath)
+        #expect(response.success)
+        #expect(try await terminal().awaitingInputReason == nil)
+    }
+
+    @Test func theOwningWorktreesCWDIsAccepted() async throws {
+        #expect(await notify(type: "permission_prompt", cwd: worktreePath).success)
+        #expect(try await terminal().awaitingInputReason != nil)
+    }
+
+    @Test func anAbsentCWDCannotBeValidatedSoTheEventIsAccepted() async throws {
+        // Backward compatibility with a CLI that doesn't send it — the same
+        // fallback `terminal.sessionEvent` makes.
+        #expect(await notify(type: "permission_prompt", cwd: nil).success)
+        #expect(try await terminal().awaitingInputReason != nil)
+    }
+
+    // MARK: - Superseding
+
+    /// The rail that keeps a recorded reason honest: the next activity
+    /// observation clears it, so a "needs your permission" cannot outlive the
+    /// prompt it described.
+    @Test func theNextActivityObservationSupersedesTheRecordedReason() async throws {
+        #expect(await notify(type: "permission_prompt").success)
+        #expect(try await terminal().awaitingInputReason != nil)
+
+        // The user answered and the turn resumed — UserPromptSubmit arrives as
+        // activity=working through the ordinary bridge.
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminalID, activityState: .working))
+        #expect(await router.handle(request).success)
+
+        let after = try await terminal()
+        #expect(after.awaitingInputReason == nil)
+        #expect(after.awaitingInputObservedAt == nil)
+        #expect(after.observedAwaitingInput == nil)
+        #expect(after.activityState == .working)
+    }
+
+    /// A second notification replaces the first rather than accumulating —
+    /// the stored reason always describes the most recent one.
+    @Test func aLaterNotificationReplacesTheRecordedReason() async throws {
+        #expect(await notify(type: "permission_prompt", message: "first").success)
+        #expect(await notify(type: "idle_prompt", message: "second").success)
+        let reason = try #require(try await terminal().awaitingInputReason)
+        #expect(reason.message == "second")
+        #expect(reason.classification == .doneWaiting)
+    }
+
+    // MARK: - What may and may not clear a standing prompt
+
+    /// The overlay registers `Notification` with **no matcher**, so every type
+    /// arrives here — including the ones that fire while a permission prompt is
+    /// still on screen. A subagent finishing sends `agent_completed`, which is
+    /// `informational`: it observed nothing about the prompt, and letting it
+    /// overwrite the reason columns would erase a live prompt and leave the
+    /// session reading as un-blocked.
+    @Test(arguments: ["agent_completed", "auth_success", "elicitation_complete",
+                      "elicitation_response", "some_future_type", nil])
+    func aClassThatEstablishesNothingCannotClearAStandingPrompt(type: String?) async throws {
+        #expect(await notify(type: "permission_prompt", message: "needs your permission").success)
+
+        #expect(await notify(type: type, message: "a subagent finished").success)
+
+        let after = try await terminal()
+        let reason = try #require(after.awaitingInputReason)
+        #expect(reason.message == "needs your permission")
+        #expect(reason.classification == .promptOnScreen)
+        #expect(reason.notificationType == "permission_prompt")
+        // The stamp stays the prompt's own, so the resolver's ordering
+        // comparison still describes the moment the prompt was reported.
+        #expect(after.awaitingInputObservedAt == Self.observedAt)
+    }
+
+    /// The other half of the same rule, so the guard is a refusal and not a
+    /// freeze: a newer prompt, and the agent reporting it is back at its own
+    /// prompt, both write.
+    @Test(arguments: [("permission_prompt", AwaitingInputClass.promptOnScreen),
+                      ("idle_prompt", AwaitingInputClass.doneWaiting)])
+    func aClassThatDoesSpeakStillSupersedesAStandingPrompt(
+        type: String, expected: AwaitingInputClass
+    ) async throws {
+        #expect(await notify(type: "permission_prompt", message: "first prompt").success)
+
+        #expect(await notify(type: type, message: "the newer report").success)
+
+        let reason = try #require(try await terminal().awaitingInputReason)
+        #expect(reason.message == "the newer report")
+        #expect(reason.classification == expected)
+    }
+
+    /// And the activity rail is untouched by the guard: a genuine observation
+    /// that the session moved on still retracts the prompt, exactly as before.
+    @Test func theActivityRailStillClearsAStandingPrompt() async throws {
+        #expect(await notify(type: "permission_prompt").success)
+        #expect(await notify(type: "agent_completed", message: "subagent done").success)
+        #expect(try await terminal().awaitingInputReason?.classification == .promptOnScreen)
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminalID, activityState: .working))
+        #expect(await router.handle(request).success)
+
+        #expect(try await terminal().awaitingInputReason == nil)
+    }
+
+    /// The router's date seam reaches BOTH stamps the resolver's rung-4 decision
+    /// compares. `setActivityState` defaults `observedAt` to a bare `Date()` at
+    /// the store, so a handler that omitted it would leave one end of that
+    /// ordering un-pinnable by any test.
+    @Test func theActivityObservationIsStampedFromTheRoutersDateSeam() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminalID, activityState: .working))
+        #expect(await router.handle(request).success)
+
+        let after = try await terminal()
+        #expect(after.activityStateObservedAt == Self.observedAt)
+        #expect(after.observedActivity?.observedAt == Self.observedAt)
+    }
+}

--- a/Tests/TBDDaemonTests/OperatorStatuslineResolverTests.swift
+++ b/Tests/TBDDaemonTests/OperatorStatuslineResolverTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Tier 1. Every file the resolver would read is supplied through its injected
+/// reader, so no real home directory — the developer's or a scratch one — is
+/// involved and the suite needs no `TBD_HOME` serialization.
+@Suite struct OperatorStatuslineResolverTests {
+
+    private static func settings(_ command: String) -> String {
+        #"{"statusLine":{"type":"command","command":"\#(command)"}}"#
+    }
+
+    /// A reader over an in-memory filesystem.
+    private static func reader(_ files: [String: String]) -> (String) -> Data? {
+        { path in files[path].map { Data($0.utf8) } }
+    }
+
+    private static let worktree = "/w"
+    private static let hostHome = "/host/.claude"
+    private static let environment = ["TBD_CLAUDE_HOST_HOME": hostHome]
+    private static let localPath = "/w/.claude/settings.local.json"
+    private static let projectPath = "/w/.claude/settings.json"
+    private static let userPath = "/host/.claude/settings.json"
+
+    /// Every scope populated. Removing scopes one at a time from the top walks
+    /// the precedence order, so each case asserts the *whole* ladder rather
+    /// than one rung.
+    private static let allScopes: [String: String] = [
+        localPath: settings("local"),
+        projectPath: settings("project"),
+        userPath: settings("user"),
+    ]
+
+    private static func resolve(
+        perSpawn: String? = nil,
+        repo: String? = nil,
+        files: [String: String] = allScopes,
+        worktreePath: String? = worktree
+    ) -> String? {
+        OperatorStatuslineResolver.resolve(
+            perSpawnSettingsJSON: perSpawn,
+            repoSettingsJSON: repo,
+            worktreePath: worktreePath,
+            environment: environment,
+            readFile: reader(files)
+        )
+    }
+
+    @Test func perSpawnFragmentWinsOverEveryOtherScope() {
+        #expect(Self.resolve(perSpawn: Self.settings("spawn"), repo: Self.settings("repo")) == "spawn")
+    }
+
+    @Test func repoFragmentWinsOverTheFileScopes() {
+        #expect(Self.resolve(repo: Self.settings("repo")) == "repo")
+    }
+
+    @Test func projectLocalWinsOverProjectAndUser() {
+        #expect(Self.resolve() == "local")
+    }
+
+    @Test func projectWinsOverUser() {
+        var files = Self.allScopes
+        files[Self.localPath] = nil
+        #expect(Self.resolve(files: files) == "project")
+    }
+
+    @Test func userScopeIsTheLastResort() {
+        #expect(Self.resolve(files: [Self.userPath: Self.settings("user")]) == "user")
+    }
+
+    @Test func consultsExactlyTheDocumentedScopesInOrder() {
+        // Whitelist, not blacklist: assert the composed list of paths the
+        // resolver actually asked for. A managed/enterprise settings path must
+        // not appear — a managed statusline outranks TBD's overlay, so the tee
+        // never runs there and reading it would only invite acting on it.
+        var asked: [String] = []
+        _ = OperatorStatuslineResolver.resolve(
+            worktreePath: Self.worktree,
+            environment: Self.environment,
+            readFile: { path in asked.append(path); return nil }
+        )
+        #expect(asked == [Self.localPath, Self.projectPath, Self.userPath])
+    }
+
+    @Test func userScopeHonorsTheClaudeHostHomeOverride() {
+        // The path is derived through `TBDConstants.claudeHostHome`, so the
+        // test fence redirects it exactly as it redirects `~/tbd`. A
+        // hand-built `$HOME/.claude` here would read the developer's real one.
+        var asked: [String] = []
+        _ = OperatorStatuslineResolver.resolve(
+            environment: ["TBD_CLAUDE_HOST_HOME": "/elsewhere/store"],
+            readFile: { path in asked.append(path); return nil }
+        )
+        #expect(asked == ["/elsewhere/store/settings.json"])
+    }
+
+    @Test func noStatuslineAnywhereResolvesToNil() {
+        #expect(Self.resolve(files: [:]) == nil)
+    }
+
+    @Test func missingUnreadableAndMalformedFilesAreSkipped() {
+        let files = [
+            Self.localPath: "{ not json at all",
+            Self.projectPath: #"{"statusLine":"a bare string, not an object"}"#,
+            Self.userPath: Self.settings("user"),
+        ]
+        // Each broken scope is stepped over rather than throwing or resolving
+        // to a wrong value; the first well-formed one wins.
+        #expect(Self.resolve(files: files) == "user")
+    }
+
+    @Test func statuslineWithoutACommandIsNotAScopeHit() {
+        let files = [
+            Self.localPath: #"{"statusLine":{"type":"command","padding":0}}"#,
+            Self.projectPath: #"{"statusLine":{"type":"command","command":"   "}}"#,
+            Self.userPath: Self.settings("user"),
+        ]
+        #expect(Self.resolve(files: files) == "user")
+    }
+
+    @Test func malformedFragmentDoesNotShadowALaterScope() {
+        #expect(Self.resolve(perSpawn: "{oops", files: [Self.userPath: Self.settings("user")]) == "user")
+    }
+
+    @Test func withoutAWorktreePathOnlyTheUserScopeIsConsulted() {
+        // A scratch space has no project scope to read; the project files must
+        // not be consulted from some other session's cwd.
+        #expect(Self.resolve(worktreePath: nil) == "user")
+    }
+
+    // MARK: - The user scope belongs to the session's own config dir
+
+    private static let profileDir = "/profiles/p1"
+    private static let profileUserPath = "/profiles/p1/settings.json"
+
+    /// A desk spawned under a model profile runs with `CLAUDE_CONFIG_DIR`
+    /// pointed at the profile directory, so Claude Code's user-scope
+    /// `settings.json` for that session lives there — not in the host store.
+    /// Reading the host store would hand the tee a statusline the session never
+    /// sees.
+    @Test func aProfileBackedSessionsUserScopeIsInsideItsConfigDir() {
+        var asked: [String] = []
+        _ = OperatorStatuslineResolver.resolve(
+            worktreePath: Self.worktree,
+            profileConfigDir: Self.profileDir,
+            environment: Self.environment,
+            readFile: { path in asked.append(path); return nil }
+        )
+        // Whitelist: exactly the three scopes, with the profile's own
+        // `settings.json` standing in for the user one. The host store must not
+        // appear at all — for this session it is not a scope.
+        #expect(asked == [Self.localPath, Self.projectPath, Self.profileUserPath])
+    }
+
+    @Test func theProfilesUserScopeSuppliesTheDelegateCommand() {
+        let command = OperatorStatuslineResolver.resolve(
+            worktreePath: Self.worktree,
+            profileConfigDir: Self.profileDir,
+            environment: Self.environment,
+            readFile: Self.reader([
+                Self.userPath: Self.settings("host store"),
+                Self.profileUserPath: Self.settings("profile store"),
+            ])
+        )
+        #expect(command == "profile store")
+    }
+
+    /// And with no profile the host store is still the user scope — the fix
+    /// adds a case, it does not move the ambient one.
+    @Test func withoutAProfileTheHostStoreIsStillTheUserScope() {
+        #expect(Self.resolve(files: [Self.userPath: Self.settings("user")]) == "user")
+    }
+}

--- a/Tests/TBDDaemonTests/PRObservationRecordingTests.swift
+++ b/Tests/TBDDaemonTests/PRObservationRecordingTests.swift
@@ -1,0 +1,431 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// DEFECT UNDER TEST: "the forge answered, and this branch has no pull request"
+// and "nobody could get an answer" used to be the same absence — a worktree
+// missing from the fetch results, indistinguishable either way. A night spent
+// treating an outage as a fleet with nothing open looks exactly like a calm
+// night, and the old `PRRefreshResult` doc comment ("nil means no PR found")
+// asserted the collapsed reading outright.
+//
+// Every test here therefore asserts the two are DIFFERENT, not merely that each
+// is producible: an implementation that recorded `.none` for both would satisfy
+// "records an observation" and still be the bug.
+
+/// A `gh` stand-in whose viewer batch and by-number lookups can each be told to
+/// succeed with given nodes, return no output at all, or return garbage.
+/// `acme/acme-prod` is a placeholder, as everywhere in this suite.
+private actor ScriptedGH {
+    enum Answer: Sendable {
+        /// Parsed successfully, with these PR nodes (possibly none).
+        case nodes([String])
+        /// gh produced nothing usable — the "could not ask" shape.
+        case noOutput
+        /// gh answered with something unparseable.
+        case garbage
+    }
+
+    private var viewer: Answer
+    private let byNumber: [Int: String]
+    private let byNumberAnswer: Answer
+    private let checkSignals: Answer
+
+    init(viewer: Answer = .nodes([]),
+         byNumber: [Int: String] = [:],
+         byNumberAnswer: Answer = .nodes([]),
+         checkSignals: Answer = .nodes([])) {
+        self.viewer = viewer
+        self.byNumber = byNumber
+        self.byNumberAnswer = byNumberAnswer
+        self.checkSignals = checkSignals
+    }
+
+    /// Change what the viewer batch answers, so one manager can see a pull
+    /// request change between two polls.
+    func replaceViewer(_ answer: Answer) { viewer = answer }
+
+    func run(args: [String], repoPath: String) -> GHCommandResult? {
+        if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+        guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
+        if query.contains("viewer {") {
+            switch viewer {
+            case .nodes(let nodes):
+                return GHCommandResult(
+                    stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[\#(nodes.joined(separator: ","))]}}}}"#)
+            case .noOutput: return nil
+            case .garbage: return GHCommandResult(stdout: "{\"nope\":true}")
+            }
+        }
+        if query.contains("statusCheckRollup { state contexts") {
+            switch checkSignals {
+            case .nodes:
+                return GHCommandResult(stdout: #"{"data":{"repository":{"pullRequest":{"commits":{"nodes":[]}}}}}"#)
+            case .noOutput: return nil
+            case .garbage: return GHCommandResult(stdout: "{\"nope\":true}")
+            }
+        }
+        if query.contains("pullRequest(number:") {
+            switch byNumberAnswer {
+            case .nodes:
+                let fields = Self.aliasedNumbers(inQuery: query).map { alias, number in
+                    "\"\(alias)\": \(byNumber[number] ?? "null")"
+                }
+                return GHCommandResult(stdout: #"{"data":{"repository":{\#(fields.joined(separator: ","))}}}"#)
+            case .noOutput: return nil
+            case .garbage: return GHCommandResult(stdout: "{\"nope\":true}")
+            }
+        }
+        return nil
+    }
+
+    private static func aliasedNumbers(inQuery query: String) -> [(alias: String, number: Int)] {
+        query.split(separator: "\n").compactMap { line in
+            guard let colon = line.firstIndex(of: ":"),
+                  let open = line.range(of: "pullRequest(number: "),
+                  let close = line[open.upperBound...].firstIndex(of: ")"),
+                  let number = Int(line[open.upperBound..<close]) else { return nil }
+            return (String(line[line.startIndex..<colon]).trimmingCharacters(in: .whitespaces), number)
+        }
+    }
+}
+
+@Suite("PR observation recording")
+struct PRObservationRecordingTests {
+
+    private static let stamp = Date(timeIntervalSince1970: 1_760_000_000)
+
+    private static func nodeJSON(
+        number: Int, head: String, state: String = "OPEN", rollup: String = "SUCCESS"
+    ) -> String {
+        """
+        {"number": \(number), "url": "https://github.com/acme/acme-prod/pull/\(number)",
+         "state": "\(state)", "mergeStateStatus": "CLEAN", "reviewDecision": "APPROVED",
+         "headRefName": "\(head)", "createdAt": "2026-07-01T00:00:00Z", "isDraft": false,
+         "statusCheckRollup": {"state": "\(rollup)"}}
+        """
+    }
+
+    private static func worktree(
+        _ id: UUID, branch: String = "tbd/w", prNumber: Int? = nil
+    ) -> PRStatusManager.PollWorktree {
+        (id: id, branch: branch, upstreamBranch: "main", defaultBranch: "main",
+         pushBranch: .noPushDestination, worktreePath: "/wt/acme-prod", prNumber: prNumber)
+    }
+
+    private static func makeManager(_ gh: ScriptedGH) -> PRStatusManager {
+        PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) },
+                        now: { Self.stamp })
+    }
+
+    // MARK: - `.none` and `.undetermined` are different answers
+
+    @Test("a branch the forge answered about with no PR records .none, not .undetermined")
+    func answeredWithNoPRRecordsNone() async {
+        // An empty node list from a query that PARSED is the forge saying "no
+        // pull request here" — settled knowledge a program can act on.
+        let wt = UUID()
+        let manager = Self.makeManager(ScriptedGH(viewer: .nodes([])))
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        let observation = await manager.observation(for: wt)
+        #expect(observation?.outcome == PRObservation.Outcome.none)
+        #expect(observation?.observedAt == Self.stamp)
+        #expect(await manager.allStatuses()[wt] == nil)
+    }
+
+    @Test("a failed batch records .undetermined with a cause, never .none")
+    func failedBatchRecordsUndetermined() async {
+        let wt = UUID()
+        let manager = Self.makeManager(ScriptedGH(viewer: .noOutput))
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        let outcome = await manager.observation(for: wt)?.outcome
+        guard case .undetermined(let cause) = outcome else {
+            Issue.record("expected .undetermined, observed \(String(describing: outcome))")
+            return
+        }
+        #expect(!cause.isEmpty)
+        #expect(outcome != PRObservation.Outcome.none, "an outage must never read as 'no pull request'")
+    }
+
+    @Test("an unparseable response is undetermined and names the parse failure")
+    func unparseableResponseNamesItsCause() async {
+        let wt = UUID()
+        let manager = Self.makeManager(ScriptedGH(viewer: .garbage))
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        #expect(await manager.observation(for: wt)?.outcome
+                == .undetermined(cause: PRUndeterminedCause.unparseableResponse))
+    }
+
+    @Test(".none and .undetermined are not equal and neither folds into the other")
+    func noneAndUndeterminedAreDistinct() async {
+        // Two worktrees, one poll each, same manager shape — composed side by
+        // side so the assertion is about the pair, not about either alone.
+        let answered = UUID()
+        let unreachable = UUID()
+        let answeredManager = Self.makeManager(ScriptedGH(viewer: .nodes([])))
+        let unreachableManager = Self.makeManager(ScriptedGH(viewer: .noOutput))
+
+        await answeredManager.fetchAll(worktrees: [Self.worktree(answered)])
+        await unreachableManager.fetchAll(worktrees: [Self.worktree(unreachable)])
+
+        let noneOutcome = await answeredManager.observation(for: answered)?.outcome
+        let undetermined = await unreachableManager.observation(for: unreachable)?.outcome
+        #expect(noneOutcome == PRObservation.Outcome.none)
+        #expect(noneOutcome != undetermined)
+        if case .undetermined = noneOutcome {
+            Issue.record("the settled 'no pull request' answer was folded into .undetermined")
+        }
+        if case PRObservation.Outcome.none = undetermined ?? .observed {
+            Issue.record("an unreachable forge was folded into 'no pull request'")
+        }
+    }
+
+    // MARK: - A failed fetch keeps the value AND admits it is unconfirmed
+
+    @Test("a failed check query keeps the prior status and records .undetermined — both")
+    func failedCheckQueryKeepsValueAndRecordsUndetermined() async {
+        // The combination is the point: a value from before, honestly labeled
+        // as not reconfirmed. Asserting either half alone would pass an
+        // implementation that dropped the other.
+        let wt = UUID()
+        let gh = ScriptedGH(
+            viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w", rollup: "FAILURE")]),
+            checkSignals: .noOutput)
+        let manager = Self.makeManager(gh)
+        let cached = PRStatus(number: 12, url: "https://github.com/acme/acme-prod/pull/12",
+                              state: .mergeable, reason: "Ready to merge")
+        await manager.seedForTesting(worktreeID: wt, status: cached)
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        #expect(await manager.allStatuses()[wt] == cached, "the previous value must survive a transient failure")
+        #expect(await manager.observation(for: wt)?.outcome
+                == .undetermined(cause: PRUndeterminedCause.checkQueryFailed))
+    }
+
+    @Test("a failed fetch with no prior status does not invent .none")
+    func failedFetchWithNoCacheDoesNotInventNone() async {
+        let wt = UUID()
+        let manager = Self.makeManager(ScriptedGH(viewer: .noOutput))
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        #expect(await manager.allStatuses()[wt] == nil)
+        let outcome = await manager.observation(for: wt)?.outcome
+        #expect(outcome != PRObservation.Outcome.none,
+                "with nothing cached and nothing learned, the honest answer is ignorance")
+        if case .undetermined = outcome {} else {
+            Issue.record("expected .undetermined, observed \(String(describing: outcome))")
+        }
+    }
+
+    @Test("a numbered worktree that will not resolve is undetermined, never .none")
+    func unresolvableNumberIsUndetermined() async {
+        // It demonstrably HAS a pull request — it carries the number — so "no
+        // pull request" is a conclusion the evidence cannot support.
+        let wt = UUID()
+        let manager = Self.makeManager(ScriptedGH(byNumberAnswer: .noOutput))
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt, prNumber: 404)])
+
+        let outcome = await manager.observation(for: wt)?.outcome
+        #expect(outcome != PRObservation.Outcome.none)
+        #expect(outcome == .undetermined(cause: PRUndeterminedCause.queryFailed))
+    }
+
+    // MARK: - observedAt is stamped on every write
+
+    @Test("a resolved PR is .observed and its status carries the observed-at stamp")
+    func resolvedPRStampsObservedAt() async {
+        let wt = UUID()
+        let manager = Self.makeManager(
+            ScriptedGH(viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")])))
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        #expect(await manager.observation(for: wt)?.outcome == .observed)
+        #expect(await manager.allStatuses()[wt]?.observedAt == Self.stamp,
+                "a cache that cannot say when it was read is the cache that was measured lying")
+    }
+
+    @Test("a re-read of an unchanged PR keeps the stamp current without rewriting the row")
+    func reReadAdvancesTheStampWithoutRePersisting() async {
+        // Two rules meet here, and both are load-bearing.
+        //
+        // The cache's stamp MUST advance: it is what `pr.list` hands a surface,
+        // and a stamp that only moved when the pull request itself changed
+        // would make a value confirmed a minute ago read as days old.
+        //
+        // The DB write MUST NOT happen: `observedAt` advances every poll, so
+        // deciding "has it changed" on an equality that includes it writes one
+        // SQLite transaction per worktree per cadence, forever, on a fleet
+        // whose steady state was zero. Change detection is `sameValue(as:)`.
+        let wt = UUID()
+        let gh = ScriptedGH(viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")]))
+        let later = Self.stamp.addingTimeInterval(600)
+        let clock = MutableStamp(Self.stamp)
+        let manager = PRStatusManager(
+            ghRunner: { args, path in await gh.run(args: args, repoPath: path) },
+            now: { clock.value })
+        let persisted = StatusPersistRecorder()
+        await manager.setOnStatusPersist { id, status in await persisted.record(id, status) }
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+        clock.value = later
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        #expect(await manager.allStatuses()[wt]?.observedAt == later,
+                "the in-memory stamp must follow the newest read")
+        let stamps = await persisted.observedAts
+        #expect(stamps == [Self.stamp],
+                "an unchanged pull request must not rewrite its row, observed \(stamps)")
+    }
+
+    // MARK: - An attempt is an attempt whether or not it resolved
+
+    @Test("a batch cannot stamp its older outcome over a refresh that failed mid-batch")
+    func aFailedRefreshMidBatchKeepsItsNewerOutcome() async {
+        // The scenario, in one call: a batch starts at T0; the user hits refresh
+        // at T1 while it is parked in `gh`; the forge is not answering, so the
+        // refresh records `.undetermined @ T1` and — having landed no value —
+        // writes no `lastDirectUpdate`. The batch then finishes and records its
+        // own `.none @ T0` for the same worktree.
+        //
+        // Only the SUCCESS path stamps `lastDirectUpdate`, so `directRefreshLanded`
+        // does not cover this: `observedAt` moved backwards, the "the last check
+        // did not resolve" clause vanished from the tooltip, and the freshness
+        // label reported an age older than the most recent attempt.
+        let wt = UUID()
+        let batchStartedAt = Self.stamp
+        let refreshedAt = Self.stamp.addingTimeInterval(30)
+        let clock = MutableStamp(batchStartedAt)
+        let box = ManagerBox()
+        let interrupt = OneShot()
+        let manager = PRStatusManager(
+            ghRunner: { args, _ in
+                if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+                guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
+                // Everything except the viewer batch fails: that outage is what
+                // the user's refresh runs into.
+                guard query.contains("viewer {") else { return nil }
+                if interrupt.claim() {
+                    clock.value = refreshedAt
+                    _ = await box.value?.refresh(
+                        worktreeID: wt, branch: "tbd/w", upstreamBranch: "main",
+                        defaultBranch: "main", pushBranch: .noPushDestination,
+                        repoPath: "/wt/acme-prod")
+                }
+                return GHCommandResult(
+                    stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[]}}}}"#)
+            },
+            now: { clock.value })
+        box.set(manager)
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        let observation = await manager.observation(for: wt)
+        #expect(observation?.observedAt == refreshedAt,
+                "the recorded attempt moved backwards in time, to \(String(describing: observation?.observedAt))")
+        guard case .undetermined = observation?.outcome else {
+            Issue.record("the failed refresh's outcome was overwritten by the batch: \(String(describing: observation?.outcome))")
+            return
+        }
+    }
+
+    // MARK: - The in-memory facts are bounded to the fleet that exists
+
+    @Test("retain drops the outcomes of worktrees that left the fleet, and keeps the values")
+    func retainBoundsTheOutcomeMapToTheActiveFleet() async {
+        let alive = UUID(), archived = UUID()
+        let manager = Self.makeManager(ScriptedGH(viewer: .nodes([])))
+        await manager.seedForTesting(
+            worktreeID: archived,
+            status: PRStatus(number: 5, url: "https://github.com/acme/acme-prod/pull/5",
+                             state: .merged, reason: "Merged"))
+
+        await manager.fetchAll(worktrees: [Self.worktree(alive), Self.worktree(archived)])
+        #expect(await manager.allObservations().count == 2,
+                "both worktrees must be on record first, or the prune below proves nothing")
+
+        await manager.retain(active: [alive])
+
+        #expect(Set(await manager.allObservations().keys) == [alive],
+                "an outcome recorded for a worktree that has left the fleet outlived it")
+        // The cached VALUE is deliberately kept: `.merged` is never persisted,
+        // so this in-memory entry is the only record that the merged edge has
+        // already been consumed for this worktree.
+        #expect(await manager.allStatuses()[archived]?.state == .merged)
+    }
+
+    @Test("a pull request whose value changed is persisted")
+    func aChangedValueStillPersists() async {
+        let wt = UUID()
+        let gh = ScriptedGH(viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")]))
+        let clock = MutableStamp(Self.stamp)
+        let manager = PRStatusManager(
+            ghRunner: { args, path in await gh.run(args: args, repoPath: path) },
+            now: { clock.value })
+        let persisted = StatusPersistRecorder()
+        await manager.setOnStatusPersist { id, status in await persisted.record(id, status) }
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+        await gh.replaceViewer(.nodes([Self.nodeJSON(number: 12, head: "tbd/w", state: "CLOSED")]))
+        clock.value = Self.stamp.addingTimeInterval(600)
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        let states = await persisted.states
+        #expect(states == [.mergeable, .closed],
+                "a real state change must still reach the DB, observed \(states)")
+    }
+}
+
+/// A mutable stamp for the date seam. A class rather than an actor so the
+/// `@Sendable () -> Date` closure can read it synchronously; the tests that use
+/// it drive it from one task.
+private final class MutableStamp: @unchecked Sendable {
+    var value: Date
+    init(_ value: Date) { self.value = value }
+}
+
+/// Holds the manager under test so a scripted `gh` call can reach back into it,
+/// which is how a user gesture is interleaved with a batch: the runner is
+/// invoked from inside the actor's own `await`, so the reentrant call lands
+/// exactly where a real mid-batch `pr.refresh` would.
+private final class ManagerBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var manager: PRStatusManager?
+    func set(_ manager: PRStatusManager) {
+        lock.lock(); self.manager = manager; lock.unlock()
+    }
+    var value: PRStatusManager? {
+        lock.lock(); defer { lock.unlock() }; return manager
+    }
+}
+
+/// One-shot latch, so an interruption injected into a query cannot re-enter
+/// through the queries it makes itself.
+private final class OneShot: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    func claim() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if fired { return false }
+        fired = true
+        return true
+    }
+}
+
+private actor StatusPersistRecorder {
+    private(set) var persisted: [(id: UUID, status: PRStatus?)] = []
+    func record(_ id: UUID, _ status: PRStatus?) { persisted.append((id, status)) }
+    var observedAts: [Date?] { persisted.map { $0.status?.observedAt } }
+    var states: [PRMergeableState?] { persisted.map { $0.status?.state } }
+}

--- a/Tests/TBDDaemonTests/PRObservationRoundTripTests.swift
+++ b/Tests/TBDDaemonTests/PRObservationRoundTripTests.swift
@@ -1,0 +1,302 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// DEFECT UNDER TEST: `.none` and `.undetermined` survive at the manager and
+// then quietly collapse somewhere on the way out — a JSON column that drops the
+// cause, an RPC result that only carries statuses, a hydrate that turns a
+// recorded outage back into "no attempt on record". Each layer is asserted
+// separately here, on composed output, because a collapse at any ONE of them
+// restores the original bug in full while every other layer's test still passes.
+//
+// Layers traced: manager → persist callback → `worktree.prObservation` column →
+// `worktree.list` model → `hydrateObservations` after a restart → `pr.list`
+// RPC → `pr.refresh` RPC.
+
+@Suite("PR observation round trip")
+struct PRObservationRoundTripTests {
+
+    private static let stamp = Date(timeIntervalSince1970: 1_760_000_000)
+
+    private static func makeDB() async throws -> (db: TBDDatabase, worktreeID: UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/repoPRO-\(UUID().uuidString)", displayName: "repoPRO", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "tbd/w",
+            path: "/tmp/repoPRO/w-\(UUID().uuidString)", tmuxServer: "s")
+        return (db, wt.id)
+    }
+
+    private static func wire(_ manager: PRStatusManager, to db: TBDDatabase) async {
+        await manager.setOnObservationPersist { id, observation in
+            try? await db.worktrees.setPRObservation(id: id, observation: observation)
+        }
+    }
+
+    // MARK: - Persistence
+
+    @Test("a .none and an .undetermined persist and reload as different outcomes")
+    func persistedOutcomesStayDistinct() async throws {
+        let (db, wtID) = try await Self.makeDB()
+        let repo2 = try await db.repos.create(
+            path: "/tmp/repoPRO2-\(UUID().uuidString)", displayName: "repoPRO2", defaultBranch: "main")
+        let other = try await db.worktrees.create(
+            repoID: repo2.id, name: "o", branch: "tbd/o",
+            path: "/tmp/repoPRO/o-\(UUID().uuidString)", tmuxServer: "s")
+
+        try await db.worktrees.setPRObservation(
+            id: wtID, observation: PRObservation(outcome: .none, observedAt: Self.stamp))
+        try await db.worktrees.setPRObservation(
+            id: other.id,
+            observation: PRObservation(outcome: .undetermined(cause: PRUndeterminedCause.queryFailed),
+                                       observedAt: Self.stamp))
+
+        let reloaded = try await db.worktrees.allPRObservations()
+        #expect(reloaded[wtID]?.outcome == PRObservation.Outcome.none)
+        #expect(reloaded[other.id]?.outcome
+                == .undetermined(cause: PRUndeterminedCause.queryFailed))
+        #expect(reloaded[wtID]?.outcome != reloaded[other.id]?.outcome)
+        #expect(reloaded[wtID]?.observedAt == Self.stamp)
+    }
+
+    @Test("a worktree with no attempt on record reads as neither outcome")
+    func noAttemptIsNeitherOutcome() async throws {
+        // The third state. A row that has never been polled must not decode as
+        // `.none` (which would claim the forge answered) nor as `.undetermined`
+        // (which would claim an attempt failed).
+        let (db, wtID) = try await Self.makeDB()
+
+        let observations = try await db.worktrees.allPRObservations()
+        #expect(observations[wtID] == nil)
+        let model = try #require(try await db.worktrees.get(id: wtID))
+        #expect(model.prObservation == nil)
+    }
+
+    @Test("the manager's recorded outcome reaches the worktree row verbatim")
+    func recordedOutcomeReachesTheRow() async throws {
+        let (db, wtID) = try await Self.makeDB()
+        let manager = PRStatusManager(now: { Self.stamp })
+        await Self.wire(manager, to: db)
+
+        // No gh at all: the poll cannot ask, and must say so rather than
+        // reporting an empty fleet.
+        await manager.fetchAll(worktrees: [(
+            id: wtID, branch: "tbd/w", upstreamBranch: "main", defaultBranch: "main",
+            pushBranch: .noPushDestination, worktreePath: "/wt/acme-prod", prNumber: 7)])
+
+        let row = try #require(try await db.worktrees.get(id: wtID))
+        let outcome = try #require(row.prObservation?.outcome)
+        guard case .undetermined(let cause) = outcome else {
+            Issue.record("expected .undetermined on the row, observed \(outcome)")
+            return
+        }
+        #expect(!cause.isEmpty)
+        #expect(row.prObservation?.observedAt == Self.stamp)
+    }
+
+    /// nil on this column is the third value — "the forge was never asked" —
+    /// and a blob that will not decode has no business asserting it. Bytes are
+    /// on the row, so an attempt happened; what it concluded is all that was
+    /// lost, and that is precisely `.undetermined`.
+    @Test("an unreadable recorded outcome is ignorance, not 'never attempted'")
+    func anUnreadableObservationBlobIsUndeterminedNotAbsent() async throws {
+        let (db, wtID) = try await Self.makeDB()
+        // A truncated blob — the shape a partial write or a schema change
+        // leaves behind.
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "UPDATE worktree SET prObservation = ? WHERE id = ?",
+                arguments: [#"{"outcome":"und"#, wtID.uuidString])
+        }
+
+        let model = try #require(try await db.worktrees.get(id: wtID))
+        let observation = try #require(
+            model.prObservation,
+            "an unreadable record decoded as 'no attempt has ever been made'")
+        guard case .undetermined(let cause) = observation.outcome else {
+            Issue.record("expected .undetermined, observed \(observation.outcome)")
+            return
+        }
+        #expect(cause == PRUndeterminedCause.unreadableRecord)
+        // Nothing on hand says when the attempt was, and the safe direction to
+        // be wrong in is "older than it is" — never presenting a reading nobody
+        // took as the freshest anyone has.
+        #expect(observation.observedAt == .distantPast)
+    }
+
+    /// The map hydrated from these rows is handed out whole in every `pr.list`,
+    /// on a thirty-second cadence. "Every worktree ever created" is not a set
+    /// that stops growing, and an archived worktree's pull request is one
+    /// nothing will ever refresh — the poller enumerates active worktrees only.
+    @Test("archived worktrees are not hydrated into the PR maps")
+    func hydrationIsScopedToActiveWorktrees() async throws {
+        let (db, activeID) = try await Self.makeDB()
+        let repo = try #require(try await db.repos.list().first)
+        let archived = try await db.worktrees.create(
+            repoID: repo.id, name: "old", branch: "tbd/old",
+            path: "/tmp/repoPRO/old-\(UUID().uuidString)", tmuxServer: "s")
+        for id in [activeID, archived.id] {
+            try await db.worktrees.setPRObservation(
+                id: id, observation: PRObservation(outcome: .observed, observedAt: Self.stamp))
+            try await db.worktrees.setPRStatus(
+                id: id,
+                status: PRStatus(number: 5, url: "https://github.com/acme/acme-prod/pull/5",
+                                 state: .mergeable, observedAt: Self.stamp))
+        }
+        try await db.worktrees.updateStatus(id: archived.id, status: .archived)
+
+        let observations = try await db.worktrees.allPRObservations()
+        let statuses = try await db.worktrees.allPRStatuses()
+        #expect(observations.keys.sorted() == [activeID].sorted())
+        #expect(statuses.keys.sorted() == [activeID].sorted())
+    }
+
+    @Test("hydrate restores a recorded .undetermined across a daemon restart")
+    func hydrateRestoresUndetermined() async throws {
+        // Without this, every daemon start would downgrade a recorded outage to
+        // "no attempt on record" — losing exactly the fact that spans a restart.
+        let (db, wtID) = try await Self.makeDB()
+        try await db.worktrees.setPRObservation(
+            id: wtID,
+            observation: PRObservation(outcome: .undetermined(cause: PRUndeterminedCause.cliUnavailable),
+                                       observedAt: Self.stamp))
+
+        let restarted = PRStatusManager(now: { Self.stamp })
+        await restarted.hydrateObservations(try await db.worktrees.allPRObservations())
+
+        #expect(await restarted.observation(for: wtID)?.outcome
+                == .undetermined(cause: PRUndeterminedCause.cliUnavailable))
+    }
+
+    // MARK: - RPC
+
+    @Test("pr.list carries both outcomes, distinctly, alongside the statuses")
+    func prListCarriesBothOutcomes() async throws {
+        let (db, answeredID) = try await Self.makeDB()
+        let repo2 = try await db.repos.create(
+            path: "/tmp/repoPRO2-\(UUID().uuidString)", displayName: "repoPRO2", defaultBranch: "main")
+        let unreachable = try await db.worktrees.create(
+            repoID: repo2.id, name: "u", branch: "tbd/u",
+            path: "/tmp/repoPRO/u-\(UUID().uuidString)", tmuxServer: "s")
+        let manager = PRStatusManager(now: { Self.stamp })
+        await manager.hydrateObservations([
+            answeredID: PRObservation(outcome: .none, observedAt: Self.stamp),
+            unreachable.id: PRObservation(
+                outcome: .undetermined(cause: PRUndeterminedCause.queryFailed), observedAt: Self.stamp)
+        ])
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            prManager: manager,
+            actuationLog: makeTestActuationLog())
+
+        let response = await router.handle(RPCRequest(method: RPCMethod.prList))
+        #expect(response.success)
+        let result = try response.decodeResult(PRListResult.self)
+
+        #expect(result.observations[answeredID]?.outcome == PRObservation.Outcome.none)
+        #expect(result.observations[unreachable.id]?.outcome
+                == .undetermined(cause: PRUndeterminedCause.queryFailed))
+        #expect(result.observations[answeredID]?.outcome != result.observations[unreachable.id]?.outcome)
+        // Both are absent from `statuses`. That absence is exactly what used to
+        // be the only signal, and it says nothing on its own.
+        #expect(result.statuses[answeredID] == nil)
+        #expect(result.statuses[unreachable.id] == nil)
+    }
+
+    @Test("the pr.list wire form survives a JSON round trip")
+    func prListWireFormSurvivesEncoding() throws {
+        // The RPC crosses a socket as JSON, so the tagged-object encoding has to
+        // preserve the cause text — a wire form that dropped it would leave
+        // `.undetermined` decoding as a bare, cause-less "something went wrong".
+        let id = UUID()
+        let original = PRListResult(
+            statuses: [:],
+            observations: [id: PRObservation(
+                outcome: .undetermined(cause: PRUndeterminedCause.unparseableResponse),
+                observedAt: Self.stamp)])
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PRListResult.self, from: data)
+
+        #expect(decoded.observations[id]?.outcome
+                == .undetermined(cause: PRUndeterminedCause.unparseableResponse))
+        #expect(decoded.observations[id]?.observedAt == Self.stamp)
+    }
+
+    @Test("a pr.list result from an older daemon decodes with no observations, not empty outcomes")
+    func olderDaemonDecodesWithoutObservations() throws {
+        let id = UUID()
+        // Encoded through a shape with NO `observations` key, which is exactly
+        // what an older daemon puts on the wire. (Hand-writing the JSON would
+        // get the `[UUID: PRStatus]` encoding wrong — Foundation emits a
+        // non-String-keyed dictionary as a flat array.)
+        let legacy = try JSONEncoder().encode(LegacyPRListResult(
+            statuses: [id: PRStatus(number: 3, url: "u", state: .mergeable)]))
+
+        let decoded = try JSONDecoder().decode(PRListResult.self, from: legacy)
+
+        #expect(decoded.statuses[id]?.number == 3)
+        #expect(decoded.observations.isEmpty, "an absent field means no attempt is on record — not `.none`")
+    }
+
+    @Test("pr.refresh reports the attempt's own outcome beside the retained value")
+    func prRefreshCarriesItsObservation() async throws {
+        // The doc comment this fixes claimed a nil status meant "no PR found".
+        // Here the status is non-nil (a value was retained) while the attempt
+        // itself did not resolve — the pair the old shape could not express.
+        let (db, wtID) = try await Self.makeDB()
+        let manager = PRStatusManager(now: { Self.stamp })
+        await manager.seedForTesting(
+            worktreeID: wtID,
+            status: PRStatus(number: 5, url: "https://github.com/acme/acme-prod/pull/5", state: .mergeable))
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            prManager: manager,
+            actuationLog: makeTestActuationLog())
+
+        // No gh available in the test environment's sandbox → the refresh
+        // cannot resolve, keeps the cached value, and says the attempt failed.
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.prRefresh, params: PRRefreshParams(worktreeID: wtID)))
+        let result = try response.decodeResult(PRRefreshResult.self)
+
+        #expect(result.status?.number == 5, "the retained value is still the newest anyone has")
+        let outcome = try #require(result.observation?.outcome)
+        if case .undetermined = outcome {} else {
+            Issue.record("expected the unresolved attempt to be .undetermined, observed \(outcome)")
+        }
+        #expect(outcome != PRObservation.Outcome.none)
+    }
+
+    @Test("pr.refresh for an unknown worktree reports no observation at all")
+    func prRefreshOnUnknownWorktreeReportsNoAttempt() async throws {
+        let (db, _) = try await Self.makeDB()
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            actuationLog: makeTestActuationLog())
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.prRefresh, params: PRRefreshParams(worktreeID: UUID())))
+        let result = try response.decodeResult(PRRefreshResult.self)
+
+        #expect(result.status == nil)
+        #expect(result.observation == nil, "no attempt was made — which is neither outcome")
+    }
+}
+
+/// The `pr.list` result as a daemon that predates `observations` encodes it.
+private struct LegacyPRListResult: Encodable {
+    let statuses: [UUID: PRStatus]
+}

--- a/Tests/TBDDaemonTests/PRPollReconcileTests.swift
+++ b/Tests/TBDDaemonTests/PRPollReconcileTests.swift
@@ -203,9 +203,18 @@ struct PRPollReconcileTests {
             return worktree.id
         }
 
+        /// One poll pass, driven the way the daemon drives it. `pr.list` is
+        /// serve-only — `PRPoller` owns the clock and the pass — so a test that
+        /// polled through the RPC would assert against a snapshot nothing
+        /// refreshed.
         @discardableResult
         func poll() async -> Bool {
-            await router.handle(RPCRequest(method: RPCMethod.prList)).success
+            do {
+                try await router.runPollPass()
+                return true
+            } catch {
+                return false
+            }
         }
 
         func seedBinding(_ number: Int, worktreeID: UUID, source: PRBindingSource,

--- a/Tests/TBDDaemonTests/PRPollRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/PRPollRemoteLaneTests.swift
@@ -189,7 +189,7 @@ struct PRPollRemoteLaneTests {
     /// three rows of one repo, three open PRs on three branches, one `gh` stub.
     /// Each row must end up with ITS OWN PR number, and no `gh` invocation may
     /// ever have run in a `remote://` directory.
-    @Test("pr.list gives each of three rows its own PR and never runs gh in a remote:// path")
+    @Test("the poll gives each of three rows its own PR and never runs gh in a remote:// path")
     func prListDistinguishesThreeRowsOfOneRepo() async throws {
         let (tempDir, repoDir) = try await createTestRepo()
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -215,6 +215,9 @@ struct PRPollRemoteLaneTests {
         ])
         let router = Self.makeRouter(db: db, gh: gh)
 
+        // The poll pass, not `pr.list`: the RPC serves the snapshot the
+        // daemon's own clock produced and never fetches.
+        try await router.runPollPass()
         let response = await router.handle(RPCRequest(method: RPCMethod.prList))
         #expect(response.success)
         let result = try response.decodeResult(PRListResult.self)

--- a/Tests/TBDDaemonTests/PRPollerTests.swift
+++ b/Tests/TBDDaemonTests/PRPollerTests.swift
@@ -1,0 +1,357 @@
+import Clocks
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Tier 1 (docs/specs/2026-07-24-test-hardening-design.md §3): in-process,
+// deterministic, driven entirely by virtual time. The only real sleeping is the
+// scheduling handshake inside `advanceWhenSuspended`.
+//
+// DEFECT UNDER TEST: PR facts are a side effect of an app being open. Before
+// `PRPoller`, `PRStatusManager.fetchAll` ran only inside the `pr.list` RPC
+// handler, so the moment the app stopped polling — overnight, which is exactly
+// when a fleet supervisor needs them — nothing learned anything about any pull
+// request. A regression here is silent: every existing test drives `fetchAll`
+// directly or through the RPC, so a poller that never fires would keep them all
+// green.
+//
+// The second thing these tests defend is that exactly ONE driver runs the
+// periodic fetch. The merged-PR transition is edge-triggered on a cache change,
+// so a second driver would race for the edge and the loser's consumers
+// (auto-archive, auto-hibernate-on-merge) would silently stop firing. `pr.list`
+// is that second driver's obvious hiding place, so it gets its own test.
+
+/// A `gh` stand-in that counts viewer-batch queries and answers with a fixed
+/// node list. `acme/acme-prod` is a placeholder, as everywhere in this suite.
+private actor CountingGH {
+    private let nodes: [String]
+    private(set) var viewerQueries = 0
+
+    init(nodes: [String] = []) {
+        self.nodes = nodes
+    }
+
+    func run(args: [String], repoPath: String) -> GHCommandResult? {
+        if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+        guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
+        guard query.contains("viewer {") else { return nil }
+        viewerQueries += 1
+        return GHCommandResult(
+            stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[\#(nodes.joined(separator: ","))]}}}}"#)
+    }
+}
+
+/// Records every merged transition the manager fired.
+private actor MergedRecorder {
+    private(set) var transitions: [(id: UUID, number: Int)] = []
+    func record(_ id: UUID, _ number: Int) { transitions.append((id, number)) }
+    var count: Int { transitions.count }
+}
+
+@Suite(.clockDriven, .serialized)
+struct PRPollerTests {
+
+    /// Injected pacing, not production values: with a 150s tick the foreground
+    /// cadence (30s) is due after one advance and the background cadence (300s)
+    /// after two, so both thresholds are crossed inside a single-digit chain
+    /// while still being the real `GitPollCadence` numbers.
+    private static let tick: Duration = .seconds(150)
+
+    private static func nodeJSON(number: Int, head: String, state: String = "OPEN") -> String {
+        """
+        {"number": \(number), "url": "https://github.com/acme/acme-prod/pull/\(number)",
+         "state": "\(state)", "mergeStateStatus": "CLEAN", "reviewDecision": "APPROVED",
+         "headRefName": "\(head)", "createdAt": "2026-07-01T00:00:00Z", "isDraft": false,
+         "statusCheckRollup": {"state": "SUCCESS"}}
+        """
+    }
+
+    /// A DB holding one active worktree on branch `tbd/w`, plus its repo.
+    private static func makeDB() async throws -> (db: TBDDatabase, worktreeID: UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/repoPRP-\(UUID().uuidString)", displayName: "repoPRP", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "tbd/w",
+            path: "/tmp/repoPRP/w-\(UUID().uuidString)", tmuxServer: "s")
+        return (db, wt.id)
+    }
+
+    /// A router carrying the manager under test. It owns the poll pass — the
+    /// enumeration helpers are shared with `pr.refresh`, so they cannot move
+    /// into the poller — and its own `prPoller` is never started, so nothing but
+    /// the poller built below drives anything.
+    private static func makeRouter(db: TBDDatabase, manager: PRStatusManager) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            prManager: manager,
+            actuationLog: makeTestActuationLog())
+    }
+
+    /// A poller on injected pacing, driving `router`'s real pass. Everything
+    /// these tests assert — cadence, one driver, the prune — is a property of
+    /// the timer around that pass, so the pass itself stays the production one.
+    private static func makePoller(
+        router: RPCRouter,
+        isForeground: @escaping @Sendable () async -> Bool,
+        clock: any Clock<Duration>
+    ) -> PRPoller {
+        let poller = PRPoller(
+            isForeground: isForeground,
+            pollTick: Self.tick,
+            clock: clock)
+        poller.installPass { try await router.runPollPass() }
+        return poller
+    }
+
+    // MARK: - The loop runs on the daemon's clock, with no app
+
+    @Test("the poller fetches on its own clock with no app connected")
+    func fetchesWithNoAppConnected() async throws {
+        // `isForeground` returns false exactly as it does when no client is
+        // connected (GitPollCadence.isEffectivelyForeground), so this is the
+        // overnight case: nothing is polling `pr.list`, and the facts must
+        // still arrive.
+        let (db, wtID) = try await Self.makeDB()
+        let gh = CountingGH(nodes: [Self.nodeJSON(number: 41, head: "tbd/w")])
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+        let clock = TestClock<Duration>()
+        let poller = Self.makePoller(
+            router: Self.makeRouter(db: db, manager: manager),
+            isForeground: { false }, clock: clock)
+
+        await poller.start()
+        // 300s background cadence, 150s tick: due on the second advance.
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.waitForSuspension()
+
+        let queries = await gh.viewerQueries
+        #expect(queries == 1, "expected 1 daemon-driven fetch with no app connected, observed \(queries)")
+        #expect(await manager.allStatuses()[wtID]?.number == 41)
+        await poller.stop()
+    }
+
+    @Test("the poller honors the foreground cadence")
+    func honorsForegroundCadence() async throws {
+        // Same clock, same tick, opposite gate: 30s foreground is due after the
+        // FIRST advance, where 300s background was not.
+        let (db, _) = try await Self.makeDB()
+        let gh = CountingGH()
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+        let clock = TestClock<Duration>()
+        let poller = Self.makePoller(
+            router: Self.makeRouter(db: db, manager: manager),
+            isForeground: { true }, clock: clock)
+
+        await poller.start()
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.waitForSuspension()
+
+        let queries = await gh.viewerQueries
+        #expect(queries == 1, "expected the 30s foreground cadence to be due after one 150s tick, observed \(queries) fetches")
+        await poller.stop()
+    }
+
+    @Test("the background cadence is not due after one tick")
+    func backgroundCadenceIsNotDueEarly() async throws {
+        // The falsifying half of the cadence pair: without it, a poller that
+        // ignored the gate entirely and fired every tick would pass the two
+        // tests above.
+        let (db, _) = try await Self.makeDB()
+        let gh = CountingGH()
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+        let clock = TestClock<Duration>()
+        let poller = Self.makePoller(
+            router: Self.makeRouter(db: db, manager: manager),
+            isForeground: { false }, clock: clock)
+
+        await poller.start()
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.waitForSuspension()
+
+        let early = await gh.viewerQueries
+        #expect(early == 0, "150s waited against the 300s background cadence should not have fetched; observed \(early)")
+
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.waitForSuspension()
+        let after = await gh.viewerQueries
+        #expect(after == 1, "the 300s background cadence should be due after two 150s ticks, observed \(after)")
+        await poller.stop()
+    }
+
+    // MARK: - One owner for the merged-transition edge
+
+    @Test("the merged transition fires exactly once across repeated polls")
+    func mergedTransitionFiresOnce() async throws {
+        // The edge is owned by `PRStatusManager.apply`, and moving the clock
+        // must not change that: a second poll of the same merged PR observes no
+        // new edge.
+        let (db, wtID) = try await Self.makeDB()
+        let gh = CountingGH(nodes: [Self.nodeJSON(number: 77, head: "tbd/w", state: "MERGED")])
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+        let recorder = MergedRecorder()
+        await manager.setOnMergedTransition { id, number in await recorder.record(id, number) }
+        let poller = Self.makePoller(
+            router: Self.makeRouter(db: db, manager: manager),
+            isForeground: { true }, clock: TestClock<Duration>())
+
+        await poller.tick()
+        await poller.tick()
+
+        let transitions = await recorder.transitions
+        #expect(transitions.count == 1, "expected exactly 1 merged transition, observed \(transitions.count)")
+        #expect(transitions.first?.id == wtID)
+        #expect(transitions.first?.number == 77)
+    }
+
+    @Test("pr.list serves the snapshot and cannot swallow the edge")
+    func prListDoesNotFetchWhilePollDrives() async throws {
+        // The split that would silently break auto-archive: if `pr.list` also
+        // fetched, whichever driver landed first would consume the edge and the
+        // other's consumers would never fire. `pr.list` performs no fetch at all
+        // — so the transition is the poller's, exactly once, and the RPC still
+        // reports it.
+        let (db, wtID) = try await Self.makeDB()
+        let gh = CountingGH(nodes: [Self.nodeJSON(number: 77, head: "tbd/w", state: "MERGED")])
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+        let recorder = MergedRecorder()
+        await manager.setOnMergedTransition { id, number in await recorder.record(id, number) }
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            prManager: manager,
+            actuationLog: makeTestActuationLog())
+
+        // `pr.list` first: it must not fetch, so nothing is learned yet.
+        let beforeResponse = await router.handle(RPCRequest(method: RPCMethod.prList))
+        #expect(beforeResponse.success)
+        let before = try beforeResponse.decodeResult(PRListResult.self)
+        #expect(before.statuses.isEmpty)
+        #expect(await gh.viewerQueries == 0, "pr.list must not fetch while the daemon clock owns the poll")
+
+        // Now the poller's tick supplies the fact — and the edge.
+        await router.prPoller.tick()
+        let afterResponse = await router.handle(RPCRequest(method: RPCMethod.prList))
+        let after = try afterResponse.decodeResult(PRListResult.self)
+
+        #expect(after.statuses[wtID]?.state == .merged)
+        #expect(await recorder.count == 1)
+        #expect(await gh.viewerQueries == 1, "exactly one driver should have fetched")
+    }
+
+    @Test("repeated pr.list calls neither fetch nor re-fire the edge")
+    func repeatedPRListNeitherFetchesNorRefires() async throws {
+        // The falsifying half of the pair above. `prListDoesNotFetchWhilePollDrives`
+        // would still pass if `pr.list` fetched only on calls after the first;
+        // this drives it repeatedly, before and after the one tick that supplies
+        // the fact, and pins the fetch count and the edge count to exactly one.
+        let (db, wtID) = try await Self.makeDB()
+        let gh = CountingGH(nodes: [Self.nodeJSON(number: 77, head: "tbd/w", state: "MERGED")])
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+        let recorder = MergedRecorder()
+        await manager.setOnMergedTransition { id, number in await recorder.record(id, number) }
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            prManager: manager,
+            actuationLog: makeTestActuationLog())
+
+        for _ in 0..<3 {
+            _ = await router.handle(RPCRequest(method: RPCMethod.prList))
+        }
+        let beforeFetches = await gh.viewerQueries
+        #expect(beforeFetches == 0, "pr.list must never fetch; observed \(beforeFetches) fetches over 3 calls")
+        #expect(await recorder.count == 0)
+
+        await router.prPoller.tick()
+
+        for _ in 0..<3 {
+            _ = await router.handle(RPCRequest(method: RPCMethod.prList))
+        }
+        let response = await router.handle(RPCRequest(method: RPCMethod.prList))
+        let result = try response.decodeResult(PRListResult.self)
+
+        #expect(result.statuses[wtID]?.state == .merged)
+        let fetches = await gh.viewerQueries
+        #expect(fetches == 1, "only the poller's single tick should have fetched, observed \(fetches)")
+        let count = await recorder.count
+        #expect(count == 1, "expected exactly 1 merged transition, observed \(count)")
+    }
+
+    // MARK: - The prune happens on every pass, including the empty one
+
+    /// `fetchOnce` used to return early when the enumeration came back empty,
+    /// taking the branch-cache prune with it — a silent behavior change from
+    /// the extraction, since the `computePRList` it replaced pruned
+    /// unconditionally. The empty pass is the one with the most to drop: it is
+    /// what a fleet that has just been archived wholesale looks like.
+    @Test("a pass with nothing to poll still prunes the branch cache")
+    func anEmptyPassStillPrunesTheBranchCache() async throws {
+        let (db, wtID) = try await Self.makeDB()
+        try await db.worktrees.updateStatus(id: wtID, status: .archived)
+        let fetches = CallCounter()
+        let router = Self.makeRouter(db: db, manager: PRStatusManager(ghRunner: { _, _ in nil }))
+        let cache = router.branchTrackingCache
+        let poller = Self.makePoller(
+            router: router, isForeground: { false }, clock: TestClock<Duration>())
+
+        // Prime an entry for a worktree that is about to leave the poll set.
+        _ = await cache.upstreamBranchName(worktreePath: "/gone", branch: "tbd/w") {
+            await fetches.bump(); return "main"
+        }
+        #expect(await fetches.count == 1)
+
+        try await poller.fetchOnce()
+
+        // A cache miss — i.e. the entry was pruned — makes the fetch run again.
+        _ = await cache.upstreamBranchName(worktreePath: "/gone", branch: "tbd/w") {
+            await fetches.bump(); return "main"
+        }
+        #expect(await fetches.count == 2,
+                "the pass kept the branch cache of a fleet that no longer exists")
+    }
+
+    /// The same contract for the PR facts themselves, and the wiring that makes
+    /// `PRStatusManager.retain` more than a method nobody calls.
+    ///
+    /// The persisted side is already bounded — `allPRObservations` reads
+    /// unarchived rows only, so a restarted daemon hydrates active worktrees and
+    /// nothing else. A running daemon has to hold the same shape, or an outcome
+    /// recorded while a worktree was active outlives its archival for the life
+    /// of the process and rides in every 30-second `pr.list` payload.
+    @Test("a worktree that left the fleet does not keep its recorded outcome")
+    func anArchivedWorktreesRecordedOutcomeIsDroppedByThePass() async throws {
+        let (db, wtID) = try await Self.makeDB()
+        let gh = CountingGH()   // the forge answers, with no pull requests
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+        let poller = Self.makePoller(
+            router: Self.makeRouter(db: db, manager: manager),
+            isForeground: { false }, clock: TestClock<Duration>())
+
+        try await poller.fetchOnce()
+        #expect(await manager.observation(for: wtID) != nil,
+                "the pass recorded no outcome for an active worktree, so this case proves nothing")
+
+        try await db.worktrees.updateStatus(id: wtID, status: .archived)
+        try await poller.fetchOnce()
+
+        #expect(await manager.observation(for: wtID) == nil,
+                "the outcome of an attempt on an archived worktree outlived it")
+    }
+}
+
+/// Counts how many times a cache miss reached the underlying fetch.
+private actor CallCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
+}

--- a/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
+++ b/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
@@ -170,13 +170,21 @@ struct PRProvenanceSeedingTests {
                 prNumber: prNumber).id
         }
 
+        /// One poll pass, driven the way the daemon drives it. `pr.list` is
+        /// serve-only — `PRPoller` owns the clock and the pass — so a test that
+        /// polled through the RPC would seed nothing.
         @discardableResult
         func poll() async -> Bool {
-            await router.handle(RPCRequest(method: RPCMethod.prList)).success
+            do {
+                try await router.runPollPass()
+                return true
+            } catch {
+                return false
+            }
         }
     }
 
-    @Test("the pr.list poll seeds a binding from Worktree.prNumber")
+    @Test("the poll pass seeds a binding from Worktree.prNumber")
     func pollSeedsFromStoredNumber() async throws {
         let harness = try await PollHarness()
         let wt = try await harness.newWorktree(prNumber: 412)

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -942,6 +942,39 @@ struct PRStatusManagerTests {
         #expect(all[id] == nil)
     }
 
+    /// Invalidation has to reach the row, not just the map.
+    ///
+    /// `hydrate`/`hydrateObservations` read those rows back at the next daemon
+    /// start, so an in-memory-only drop resurrects exactly what invalidation
+    /// removed — an `.observed` outcome describing a value that no longer
+    /// exists, which is the thing the code's own comment promises not to leave
+    /// behind. The nil is the clear, in both persisters.
+    @Test("invalidate clears the persisted row too, not only the in-memory maps")
+    func invalidatePersistsTheClear() async {
+        let manager = PRStatusManager()
+        let id = UUID()
+        let persistedStatuses = PersistedClearRecorder()
+        let persistedObservations = PersistedClearRecorder()
+        await manager.setOnStatusPersist { worktreeID, status in
+            await persistedStatuses.record(worktreeID, isClear: status == nil)
+        }
+        await manager.setOnObservationPersist { worktreeID, observation in
+            await persistedObservations.record(worktreeID, isClear: observation == nil)
+        }
+        await manager.seedForTesting(
+            worktreeID: id,
+            status: PRStatus(number: 3, url: "https://github.com/o/r/pull/3", state: .mergeable))
+        await manager.hydrateObservations([id: PRObservation(outcome: .observed, observedAt: Date())])
+
+        await manager.invalidate(worktreeID: id)
+
+        #expect(await manager.observation(for: id) == nil)
+        #expect(await persistedObservations.clears == [id],
+                "the dropped observation was never written through to the row")
+        #expect(await persistedStatuses.clears.contains(id),
+                "the dropped status was never written through to the row")
+    }
+
     // MARK: - Reason computation
 
     @Test("computeReason returns 'Merged' for merged state")
@@ -2425,5 +2458,106 @@ struct PRStatusManagerFetchAllTests {
 
         #expect(await manager.allStatuses()[wt]?.number == 88)
         #expect(await recorder.clearedIDs.isEmpty)
+    }
+}
+
+/// Records which worktrees a persist callback was asked to CLEAR (nil value),
+/// so a test can prove an in-memory drop was written through.
+private actor PersistedClearRecorder {
+    private(set) var clears: [UUID] = []
+    func record(_ id: UUID, isClear: Bool) { if isClear { clears.append(id) } }
+}
+
+// MARK: - Actor reentrancy around `invalidate`
+
+/// A `now` seam that never returns the same instant twice, so "later than the
+/// batch started" is a fact about ordering rather than about clock resolution.
+private final class MonotonicNow: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tick = 0
+    private let base = Date(timeIntervalSince1970: 1_780_000_000)
+    func next() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        tick += 1
+        return base.addingTimeInterval(Double(tick))
+    }
+}
+
+/// What each persist callback saw when it ran. Lock-guarded rather than an
+/// actor: it is written from inside a callback that is already suspending the
+/// actor under test, and an extra hop there buys nothing.
+private final class StampProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seen: [String: Bool] = [:]
+    func record(_ label: String, _ landed: Bool) {
+        lock.lock(); seen[label] = landed; lock.unlock()
+    }
+    subscript(label: String) -> Bool? {
+        lock.lock(); defer { lock.unlock() }; return seen[label]
+    }
+}
+
+@Suite("PRStatusManager invalidate reentrancy")
+struct PRStatusManagerInvalidateReentrancyTests {
+
+    /// `invalidate` stamps `lastDirectUpdate` **before** it suspends, and that
+    /// ordering is the whole invalidation.
+    ///
+    /// On an actor every `await` is a reentrancy point. `invalidate`'s two
+    /// persist callbacks are awaits, so a `fetchAll` parked in its `gh` call
+    /// resumes *inside* them, asks `directRefreshLanded`, and — if the answer is
+    /// still no — applies its match and puts back the very entry this call had
+    /// just removed. That is the thing the line's own comment says it prevents.
+    ///
+    /// So the invariant is exactly: **by the time the first persist callback
+    /// runs, the stamp is already in place.** This asserts it from inside the
+    /// callbacks themselves, which *are* the suspension points, and through the
+    /// same predicate `fetchAll` consults.
+    ///
+    /// Tier 1, and deliberately single-task. An earlier cut staged a real
+    /// two-task interleaving with latches; it proved the same property far less
+    /// reliably (it stalled in the parallel pass, reporting a latch state its
+    /// own choreography said was impossible) and a test whose result "says
+    /// nothing" is worse than no test. The reentrancy is real; the *guarantee*
+    /// is an ordering within one call, and that is directly observable.
+    @Test func theStampLandsBeforeTheFirstSuspensionSoAnInFlightBatchCannotResurrectTheEntry() async {
+        let wt = UUID()
+        let clock = MonotonicNow()
+        // Stands in for an in-flight batch's `batchStartedAt`, taken before
+        // `invalidate` runs so any stamp it writes is strictly newer.
+        let batchStartedAt = clock.next()
+        let manager = PRStatusManager(ghRunner: { _, _ in nil }, now: { clock.next() })
+        let probe = StampProbe()
+
+        // Seed BEFORE registering the callbacks: `seedForTesting` routes through
+        // `apply`, which persists, and that call is not the one under test.
+        await manager.seedForTesting(
+            worktreeID: wt,
+            status: PRStatus(number: 77, url: "https://github.com/acme/acme-prod/pull/77",
+                             state: .pending))
+        await manager.hydrateObservations(
+            [wt: PRObservation(outcome: .observed, observedAt: Date())])
+
+        await manager.setOnStatusPersist { [weak manager] _, _ in
+            guard let manager else { return }
+            probe.record("status", await manager.directRefreshLandedForTesting(
+                wt, after: batchStartedAt))
+        }
+        await manager.setOnObservationPersist { [weak manager] _, _ in
+            guard let manager else { return }
+            probe.record("observation", await manager.directRefreshLandedForTesting(
+                wt, after: batchStartedAt))
+        }
+
+        await manager.invalidate(worktreeID: wt)
+
+        #expect(probe["status"] == true,
+                "the status persist callback is invalidate's FIRST suspension point; it ran before the stamp, so an in-flight fetchAll resuming there would resurrect the entry")
+        #expect(probe["observation"] == true,
+                "the observation persist callback ran before the stamp")
+        // …and the invalidation itself still does what it always did.
+        #expect(await manager.allStatuses()[wt] == nil)
+        #expect(await manager.observation(for: wt) == nil)
     }
 }

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -158,10 +158,15 @@ struct PaneRepairCoordinatorTests {
         #expect(recorder.writes.count == 1,
                 "captures+continue must not be sent while the reader is behind")
 
-        // The app catches up — the pipe becomes writable.
+        // The app catches up — the pipe becomes writable. Virtual time is
+        // driven for as long as the reader-wait keeps re-arming (see
+        // `advanceUntil`): one advance would stake the test on a single
+        // writability probe, and a probe that reads "keep waiting" re-arms a
+        // sleep nothing would ever advance again.
         drainPipe(readFD)
-        await clock.advanceWhenSuspended(by: checkInterval)
-        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        await clock.advanceUntil("captures+continue write", by: checkInterval) {
+            recorder.writes.count >= 2
+        }
         try #require(recorder.writes.count >= 2, "the captures+continue batch was never sent")
         #expect(recorder.writes[1] == """
             capture-pane -peqJN -S -50000 -E -1 -q -t %1
@@ -380,8 +385,9 @@ struct PaneRepairCoordinatorTests {
         // proceeds — batch 2 (captures + continue), replay behind the fence,
         // endRepair, streaming resumed. No new attach needed.
         drainPipe(readFD)
-        await clock.advanceWhenSuspended(by: slow)
-        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        await clock.advanceUntil("captures+continue write", by: slow) {
+            recorder.writes.count >= 2
+        }
         try #require(recorder.writes.count >= 2, "the captures+continue batch was never sent")
         #expect(recorder.writes[1].hasSuffix("refresh-client -A '%4:continue'"),
                 "the same repair must send batch 2 once the reader drains")
@@ -498,8 +504,15 @@ struct PaneRepairCoordinatorTests {
         Darwin.close(readFD)
         readClosed = true
 
-        await clock.advanceWhenSuspended(by: checkInterval)
-        try await waitFor("trailing continue write") { recorder.writes.count >= 2 }
+        // The reader-wait is a poll-and-re-arm loop, so virtual time is driven
+        // for as long as it keeps re-arming rather than exactly once: a single
+        // advance stakes the test on one `poll(2)` reading the closed read end,
+        // and a probe that reads "keep waiting" re-arms a sleep nothing would
+        // ever advance again — a 240 s hang instead of a failure. See
+        // `advanceUntil`. The contract asserted below is unchanged.
+        await clock.advanceUntil("trailing continue write", by: checkInterval) {
+            recorder.writes.count >= 2
+        }
         #expect(recorder.writes.last == "refresh-client -A '%5:continue'",
                 "a broken pipe must unpause the pane")
         #expect(!recorder.writes.contains { $0.contains("capture-pane") },
@@ -718,8 +731,9 @@ struct PaneRepairCoordinatorTests {
         // bridge threaded its clock into the coordinator it constructed.
         await clock.waitForSuspension()
         drainPipe(readFD)
-        await clock.advanceWhenSuspended(by: checkInterval)
-        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        await clock.advanceUntil("captures+continue write", by: checkInterval) {
+            recorder.writes.count >= 2
+        }
         await succeed(client, captureAndContinueReplies(paneID: paneID))
         try await waitFor("repair completion") {
             let stats = bridge.supervisor.fanout.flowStats(key: key)

--- a/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
@@ -651,7 +651,8 @@ struct QueuedPromptDeliveryTests {
         let terminal = try await fixture.db.terminals.create(
             worktreeID: fixture.worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             kind: .codex)
-        try await fixture.db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+        try await fixture.db.terminals.setActivityState(
+            id: terminal.id, activityState: .idle, source: .hookEvent("Stop"))
         let announced = try #require(try await fixture.db.terminals.get(id: terminal.id))
         #expect(announced.transcriptPath == nil)
         #expect(PendingPromptCoordinator.hasAnnouncedItself(announced))

--- a/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
@@ -102,7 +102,7 @@ import TestSupport
         let hibTerminal = try await db.terminals.create(
             worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2",
             claudeSessionID: "sess-hib", kind: .claude)
-        try await db.terminals.setActivityState(id: hibTerminal.id, activityState: .idle)
+        try await db.terminals.setActivityState(id: hibTerminal.id, activityState: .idle, source: .derived)
         _ = try await db.scheduledResumes.insertPending(ScheduledResume(
             terminalID: hibTerminal.id, worktreeID: worktreeID,
             resetsAt: Date().addingTimeInterval(3600),

--- a/Tests/TBDDaemonTests/SessionCountersTrackerTests.swift
+++ b/Tests/TBDDaemonTests/SessionCountersTrackerTests.swift
@@ -1,0 +1,538 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// A transcript reader backed by an in-memory map, so the counter arithmetic is
+/// tier 1 — no filesystem, no real appends, and every read is countable.
+private final class FakeAppendReader: TranscriptAppendReading, @unchecked Sendable {
+    /// path → the file's bytes.
+    var files: [String: Data] = [:]
+
+    func endOffset(atPath path: String) -> UInt64? {
+        guard let data = files[path] else { return nil }
+        return UInt64(data.count)
+    }
+
+    func appendedRecords(atPath path: String, from offset: UInt64) -> AppendedRecords? {
+        guard let data = files[path] else { return nil }
+        let end = UInt64(data.count)
+        guard end > offset else { return AppendedRecords(records: 0, endOffset: end) }
+        let span = data.suffix(from: Int(offset))
+        let records = span.reduce(into: 0) { count, byte in if byte == 0x0A { count += 1 } }
+        return AppendedRecords(records: records, endOffset: end)
+    }
+
+    func append(_ recordCount: Int, to path: String) {
+        var data = files[path] ?? Data()
+        for _ in 0..<recordCount {
+            data.append(contentsOf: Array(#"{"type":"assistant"}"#.utf8))
+            data.append(0x0A)
+        }
+        files[path] = data
+    }
+}
+
+/// Tier 1.
+@Suite("SessionCountersTracker")
+struct SessionCountersTrackerTests {
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+    /// The worktree the tests that don't care about scoping sample into.
+    private let wt = UUID()
+
+    // MARK: - Turns
+
+    @Test func turnsCountOnlyRecordsAppendedAfterTheFirstSample() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-a.jsonl"
+        reader.append(4_000, to: path)  // pre-existing history
+        let tracker = SessionCountersTracker(reader: reader)
+        let id = UUID()
+
+        // First sighting baselines at the file's end: history is not a burst.
+        let first = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil, at: t0)
+        #expect(first?.turnsInWindow == 0)
+
+        reader.append(7, to: path)
+        let second = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(60))
+        #expect(second?.turnsInWindow == 7)
+
+        // And the count accumulates across samples within one window.
+        reader.append(3, to: path)
+        let third = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(120))
+        #expect(third?.turnsInWindow == 10)
+    }
+
+    @Test func nothingIsParsed_onlyNewlinesAreCounted() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-b.jsonl"
+        reader.files[path] = Data()
+        let tracker = SessionCountersTracker(reader: reader)
+        let id = UUID()
+        _ = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil, at: t0)
+
+        // Bytes that are not JSON at all still count as records: the format is
+        // internal and version-unstable, and "a record is a line" is the one
+        // property that survives its changes.
+        reader.files[path] = Data("not json\nnot json either\n".utf8)
+        let counters = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(30))
+        #expect(counters?.turnsInWindow == 2)
+    }
+
+    @Test func aTranscriptPathChangeResetsTheBaselineInsteadOfReportingABogusDelta() async {
+        let reader = FakeAppendReader()
+        let old = "/fake/before-clear.jsonl"
+        let new = "/fake/after-clear.jsonl"
+        reader.append(3, to: old)
+        let tracker = SessionCountersTracker(reader: reader)
+        let id = UUID()
+
+        _ = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: old, commitsUnchangedSince: nil, at: t0)
+        reader.append(6, to: old)
+        let onOld = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: old, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(60))
+        #expect(onOld?.turnsInWindow == 6)
+
+        // `/compact` rolls the session onto a different file that is LONGER
+        // than the old baseline offset — the case that produces a plausible
+        // and completely fictitious burst if the path is not compared, because
+        // the bytes past the old offset in the *new* file were never appends.
+        reader.append(100, to: new)
+        let rolled = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: new, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(120))
+        #expect(rolled?.turnsInWindow == 0)
+
+        reader.append(5, to: new)
+        let after = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: new, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(180))
+        #expect(after?.turnsInWindow == 5)
+    }
+
+    @Test func aTranscriptTruncatedBelowItsBaselineAlsoReBaselines() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-c.jsonl"
+        reader.append(10, to: path)
+        let tracker = SessionCountersTracker(reader: reader)
+        let id = UUID()
+        _ = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil, at: t0)
+
+        // A real count accumulates first, so the reset below is observable.
+        reader.append(6, to: path)
+        let before = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(30))
+        #expect(before?.turnsInWindow == 6)
+
+        reader.files[path] = Data("one\n".utf8)  // rotated in place
+        let counters = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(60))
+        // The bytes those 6 records were counted from are gone; carrying the
+        // count forward would report a window that no longer has evidence.
+        #expect(counters?.turnsInWindow == 0)
+    }
+
+    @Test func anUnreadableTranscriptReportsNoCountersRatherThanZero() async {
+        let tracker = SessionCountersTracker(reader: FakeAppendReader())
+        #expect(await tracker.sample(
+            terminalID: UUID(), worktreeID: wt, transcriptPath: "/fake/missing.jsonl",
+            commitsUnchangedSince: nil, at: t0) == nil)
+        #expect(await tracker.sample(
+            terminalID: UUID(), worktreeID: wt, transcriptPath: nil,
+            commitsUnchangedSince: nil, at: t0) == nil)
+    }
+
+    // MARK: - Hook events
+
+    @Test func hookEventsAreCountedPerTerminalPerWindow() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-d.jsonl"
+        reader.files[path] = Data()
+        let tracker = SessionCountersTracker(reader: reader)
+        let a = UUID()
+        let b = UUID()
+
+        _ = await tracker.sample(
+            terminalID: a, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil, at: t0)
+        for _ in 0..<5 { await tracker.recordHookEvent(terminalID: a, at: t0.addingTimeInterval(10)) }
+        await tracker.recordHookEvent(terminalID: b, at: t0.addingTimeInterval(10))
+
+        let counters = await tracker.sample(
+            terminalID: a, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(20))
+        #expect(counters?.hookEventsInWindow == 5)
+    }
+
+    @Test func hookEventsArrivingBeforeTheFirstSampleAreNotLost() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-e.jsonl"
+        reader.files[path] = Data()
+        let tracker = SessionCountersTracker(reader: reader)
+        let id = UUID()
+
+        for _ in 0..<3 { await tracker.recordHookEvent(terminalID: id, at: t0) }
+        let counters = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(5))
+        #expect(counters?.hookEventsInWindow == 3)
+    }
+
+    // MARK: - The pending map is bounded
+
+    /// `pendingHookEvents` gets an entry for every terminal the fleet produces a
+    /// hook for, and its only pruner is the fleet-wide `retain` — which nothing
+    /// in `Sources/` calls today. On a daemon that runs for weeks that is an
+    /// unbounded map, so it expires its own entries.
+    ///
+    /// Asserted through what a sample reports, not through the map's size: an
+    /// expired pending entry contributes nothing to the terminal's first
+    /// counters, and a live one contributes its count.
+    @Test func pendingHookEventsOlderThanTheWindowAreDropped() async {
+        let reader = FakeAppendReader()
+        let stale = "/fake/pending-stale.jsonl"
+        let live = "/fake/pending-live.jsonl"
+        reader.files[stale] = Data()
+        reader.files[live] = Data()
+        let tracker = SessionCountersTracker(
+            windowLength: 100, reader: reader, pendingSweepThreshold: 1)
+        let old = UUID()
+        let recent = UUID()
+
+        await tracker.recordHookEvent(terminalID: old, at: t0)
+        // Two windows later. This event's own write is what makes the map
+        // exceed the sweep threshold, so the sweep runs and finds `old` expired.
+        await tracker.recordHookEvent(terminalID: recent, at: t0.addingTimeInterval(200))
+
+        let expired = await tracker.sample(
+            terminalID: old, worktreeID: wt, transcriptPath: stale,
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(200))
+        #expect(expired?.hookEventsInWindow == 0,
+                "a pending count from a window that closed two windows ago was folded in anyway")
+
+        let kept = await tracker.sample(
+            terminalID: recent, worktreeID: wt, transcriptPath: live,
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(200))
+        #expect(kept?.hookEventsInWindow == 1, "a pending count inside its own window was lost")
+    }
+
+    @Test func pendingHookEventsAreCappedEvenWhenEveryWindowIsStillOpen() async {
+        let reader = FakeAppendReader()
+        let tracker = SessionCountersTracker(
+            windowLength: 10_000, reader: reader, pendingSweepThreshold: 1, pendingLimit: 2)
+        let oldest = UUID()
+        let newest = UUID()
+
+        await tracker.recordHookEvent(terminalID: oldest, at: t0)
+        await tracker.recordHookEvent(terminalID: UUID(), at: t0.addingTimeInterval(1))
+        await tracker.recordHookEvent(terminalID: newest, at: t0.addingTimeInterval(2))
+
+        for path in ["/fake/cap-oldest.jsonl", "/fake/cap-newest.jsonl"] { reader.files[path] = Data() }
+        let evicted = await tracker.sample(
+            terminalID: oldest, worktreeID: wt, transcriptPath: "/fake/cap-oldest.jsonl",
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(2))
+        #expect(evicted?.hookEventsInWindow == 0)
+        let survivor = await tracker.sample(
+            terminalID: newest, worktreeID: wt, transcriptPath: "/fake/cap-newest.jsonl",
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(2))
+        #expect(survivor?.hookEventsInWindow == 1)
+    }
+
+    /// The sweep is amortized against **growth**, not against traffic.
+    ///
+    /// A bare size threshold amortizes nothing once the map sits above it with
+    /// every entry fresh: the filter drops nothing, the count stays over the
+    /// line, and every subsequent hook event pays a whole-map rebuild — on the
+    /// path whose documented budget is one actor hop and an integer add. The map
+    /// only grows when a terminal TBD has never seen produces its first event,
+    /// so gating on growth makes the sweep cost proportional to new terminals.
+    @Test func theSweepRunsOnGrowthNotOnEveryEventPastTheThreshold() async {
+        let reader = FakeAppendReader()
+        let tracker = SessionCountersTracker(
+            windowLength: 10_000, reader: reader, pendingSweepThreshold: 2)
+        let known = [UUID(), UUID(), UUID()]
+
+        // Three never-seen terminals; the third takes the map past the
+        // threshold and sweeps.
+        for (i, id) in known.enumerated() {
+            await tracker.recordHookEvent(terminalID: id, at: t0.addingTimeInterval(Double(i)))
+        }
+        let afterGrowth = await tracker.pendingSweepsPerformed
+        #expect(afterGrowth == 1, "the sweep did not run when the map first grew past its threshold")
+
+        // Fifty more events, all from terminals already in the map. Nothing can
+        // have expired (the window is 10_000s) and the map cannot grow.
+        for i in 0..<50 {
+            await tracker.recordHookEvent(
+                terminalID: known[i % known.count], at: t0.addingTimeInterval(Double(10 + i)))
+        }
+        #expect(await tracker.pendingSweepsPerformed == afterGrowth,
+                "an event from a terminal already in the map paid a whole-map rebuild")
+
+        // …and the gate is not a disarm: a new terminal grows the map past the
+        // watermark and sweeps again.
+        await tracker.recordHookEvent(terminalID: UUID(), at: t0.addingTimeInterval(100))
+        #expect(await tracker.pendingSweepsPerformed == afterGrowth + 1,
+                "growth past the watermark no longer sweeps at all")
+    }
+
+    // MARK: - The window
+
+    @Test func theWindowRollsAndBothCountsRestartWithoutRereadingTheTranscript() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-f.jsonl"
+        reader.files[path] = Data()
+        let tracker = SessionCountersTracker(windowLength: 100, reader: reader)
+        let id = UUID()
+
+        _ = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil, at: t0)
+        reader.append(4, to: path)
+        await tracker.recordHookEvent(terminalID: id, at: t0.addingTimeInterval(10))
+        let inWindow = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(20))
+        #expect(inWindow?.turnsInWindow == 4)
+        #expect(inWindow?.hookEventsInWindow == 1)
+        #expect(inWindow?.windowStart == t0)
+
+        // Past the window: counts restart, and the byte offset survives so the
+        // records already counted are not counted a second time.
+        let rolled = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(200))
+        #expect(rolled?.turnsInWindow == 0)
+        #expect(rolled?.hookEventsInWindow == 0)
+        #expect(rolled?.windowStart == t0.addingTimeInterval(200))
+    }
+
+    @Test func theObservationWindowIsAWindowNotAThreshold() async throws {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-g.jsonl"
+        reader.files[path] = Data()
+        let tracker = SessionCountersTracker(windowLength: 10_000, reader: reader)
+        let id = UUID()
+        _ = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil, at: t0)
+
+        // Far past §13's shipped-program figures (30 turns, and then some).
+        reader.append(500, to: path)
+        for _ in 0..<400 { await tracker.recordHookEvent(terminalID: id, at: t0.addingTimeInterval(1)) }
+
+        let counters = try #require(await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(2)))
+        // The only effect of a huge count is a huge number. Nothing is paused,
+        // nothing is sent, no state is mutated — the tracker has no actuation
+        // surface at all, which is what "reported, never acted on" means.
+        #expect(counters.turnsInWindow == 500)
+        #expect(counters.hookEventsInWindow == 400)
+        #expect(counters.observedAt == t0.addingTimeInterval(2))
+    }
+
+    // MARK: - Commits
+
+    @Test func commitsUnchangedSinceIsCarriedThroughVerbatimIncludingNil() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-h.jsonl"
+        reader.files[path] = Data()
+        let tracker = SessionCountersTracker(reader: reader)
+        let id = UUID()
+        let since = t0.addingTimeInterval(-3_600)
+
+        let withFact = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: since, at: t0)
+        #expect(withFact?.commitsUnchangedSince == since)
+
+        let withoutFact = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(60))
+        #expect(withoutFact?.commitsUnchangedSince == nil)
+    }
+
+    // MARK: - Housekeeping
+
+    @Test func retainDropsBookkeepingForTerminalsThatNoLongerExist() async {
+        let reader = FakeAppendReader()
+        let path = "/fake/session-i.jsonl"
+        reader.files[path] = Data()
+        let tracker = SessionCountersTracker(reader: reader)
+        let id = UUID()
+
+        _ = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil, at: t0)
+        await tracker.recordHookEvent(terminalID: id, at: t0)
+        await tracker.retain(terminalIDs: [], inWorktree: nil)
+
+        // Re-sampling starts a fresh window with a fresh baseline.
+        let counters = await tracker.sample(
+            terminalID: id, worktreeID: wt, transcriptPath: path, commitsUnchangedSince: nil,
+            at: t0.addingTimeInterval(60))
+        #expect(counters?.hookEventsInWindow == 0)
+        #expect(counters?.windowStart == t0.addingTimeInterval(60))
+    }
+
+    /// Counters established for one terminal per worktree, so scoped and
+    /// unscoped pruning can be told apart by what survives.
+    private func trackerWithTwoWorktrees() async -> (
+        tracker: SessionCountersTracker, reader: FakeAppendReader,
+        here: UUID, there: UUID, hereWorktree: UUID, thereWorktree: UUID,
+        herePath: String, therePath: String
+    ) {
+        let reader = FakeAppendReader()
+        let herePath = "/fake/session-here.jsonl"
+        let therePath = "/fake/session-there.jsonl"
+        reader.files[herePath] = Data()
+        reader.files[therePath] = Data()
+        let tracker = SessionCountersTracker(reader: reader)
+        let here = UUID(), there = UUID()
+        let hereWorktree = UUID(), thereWorktree = UUID()
+
+        for (id, worktree, path) in [(here, hereWorktree, herePath), (there, thereWorktree, therePath)] {
+            _ = await tracker.sample(
+                terminalID: id, worktreeID: worktree, transcriptPath: path,
+                commitsUnchangedSince: nil, at: t0)
+            reader.append(2, to: path)
+            await tracker.recordHookEvent(terminalID: id, at: t0.addingTimeInterval(10))
+            let established = await tracker.sample(
+                terminalID: id, worktreeID: worktree, transcriptPath: path,
+                commitsUnchangedSince: nil, at: t0.addingTimeInterval(20))
+            #expect(established?.turnsInWindow == 2)
+            #expect(established?.hookEventsInWindow == 1)
+        }
+        return (tracker, reader, here, there, hereWorktree, thereWorktree, herePath, therePath)
+    }
+
+    @Test func aWorktreeScopedRetainLeavesOtherWorktreesCountersIntact() async throws {
+        let f = await trackerWithTwoWorktrees()
+
+        // The shape `session.states` takes when it is asked about one worktree:
+        // the terminal list it enumerated names only that worktree's terminals.
+        // Pruning against it fleet-wide would evict the other worktree's live
+        // baseline, and the next fleet-wide call would re-baseline it as a
+        // first sighting with both counts back at zero.
+        await f.tracker.retain(terminalIDs: [f.here], inWorktree: f.hereWorktree)
+
+        let survivor = try #require(await f.tracker.sample(
+            terminalID: f.there, worktreeID: f.thereWorktree, transcriptPath: f.therePath,
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(30)))
+        #expect(survivor.turnsInWindow == 2)
+        #expect(survivor.hookEventsInWindow == 1)
+        #expect(survivor.windowStart == t0)
+    }
+
+    @Test func aWorktreeScopedRetainStillPrunesTerminalsGoneFromThatWorktree() async throws {
+        let f = await trackerWithTwoWorktrees()
+        let departed = UUID()
+        _ = await f.tracker.sample(
+            terminalID: departed, worktreeID: f.hereWorktree, transcriptPath: f.herePath,
+            commitsUnchangedSince: nil, at: t0)
+        await f.tracker.recordHookEvent(terminalID: departed, at: t0.addingTimeInterval(10))
+
+        // Scoping is not an excuse to stop pruning: a terminal that is gone
+        // from the very worktree being enumerated still goes.
+        await f.tracker.retain(terminalIDs: [f.here], inWorktree: f.hereWorktree)
+
+        let reBaselined = try #require(await f.tracker.sample(
+            terminalID: departed, worktreeID: f.hereWorktree, transcriptPath: f.herePath,
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(30)))
+        #expect(reBaselined.hookEventsInWindow == 0)
+        #expect(reBaselined.windowStart == t0.addingTimeInterval(30))
+
+        // And the terminal that is still there kept its window.
+        let kept = try #require(await f.tracker.sample(
+            terminalID: f.here, worktreeID: f.hereWorktree, transcriptPath: f.herePath,
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(30)))
+        #expect(kept.hookEventsInWindow == 1)
+        #expect(kept.windowStart == t0)
+    }
+
+    @Test func anUnscopedRetainPrunesFleetWide() async throws {
+        let f = await trackerWithTwoWorktrees()
+
+        // nil scope means the caller enumerated the whole fleet, so it is the
+        // one call that may evict a terminal in any worktree.
+        await f.tracker.retain(terminalIDs: [f.here], inWorktree: nil)
+
+        let evicted = try #require(await f.tracker.sample(
+            terminalID: f.there, worktreeID: f.thereWorktree, transcriptPath: f.therePath,
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(30)))
+        #expect(evicted.turnsInWindow == 0)
+        #expect(evicted.hookEventsInWindow == 0)
+        #expect(evicted.windowStart == t0.addingTimeInterval(30))
+
+        let kept = try #require(await f.tracker.sample(
+            terminalID: f.here, worktreeID: f.hereWorktree, transcriptPath: f.herePath,
+            commitsUnchangedSince: nil, at: t0.addingTimeInterval(30)))
+        #expect(kept.hookEventsInWindow == 1)
+        #expect(kept.windowStart == t0)
+    }
+}
+
+/// Tier 2 — the production reader against real files in a temp dir. The
+/// arithmetic above is proven on the fake; this proves the seam's own
+/// implementation agrees with it.
+@Suite("FileTranscriptAppendReader")
+struct FileTranscriptAppendReaderTests {
+
+    private func scratchFile(_ contents: String) throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-append-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("session.jsonl").path
+        try Data(contents.utf8).write(to: URL(fileURLWithPath: path))
+        return path
+    }
+
+    @Test func countsNewlinesPastTheOffsetAndReportsTheNewEnd() throws {
+        let path = try scratchFile("a\nb\nc\n")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let reader = FileTranscriptAppendReader()
+
+        let end = try #require(reader.endOffset(atPath: path))
+        #expect(end == 6)
+
+        let handle = try #require(FileHandle(forWritingAtPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("d\ne\n".utf8))
+        try handle.close()
+
+        // Two records appended past the old end, and nothing before it counted.
+        let appended = try #require(reader.appendedRecords(atPath: path, from: end))
+        #expect(appended.records == 2)
+        #expect(appended.endOffset == 10)
+
+        // Asking again from the new end sees nothing, and says so with zero
+        // rather than nil — readable-and-empty is evidence.
+        let again = try #require(reader.appendedRecords(atPath: path, from: appended.endOffset))
+        #expect(again.records == 0)
+    }
+
+    @Test func spansMoreThanOneChunk() throws {
+        let lineCount = FileTranscriptAppendReader.chunkBytes / 2 + 100
+        let path = try scratchFile(String(repeating: "x\n", count: lineCount))
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let appended = try #require(
+            FileTranscriptAppendReader().appendedRecords(atPath: path, from: 0))
+        #expect(appended.records == lineCount)
+    }
+
+    @Test func anUnreadableFileAnswersNilNeverZero() {
+        let reader = FileTranscriptAppendReader()
+        #expect(reader.endOffset(atPath: "/nonexistent/tbd/session.jsonl") == nil)
+        #expect(reader.appendedRecords(atPath: "/nonexistent/tbd/session.jsonl", from: 0) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/SessionStateResolverTests.swift
+++ b/Tests/TBDDaemonTests/SessionStateResolverTests.swift
@@ -1,0 +1,661 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 1. `SessionStateResolver` is a pure function of an enumerated fact
+/// bundle — no database, no filesystem, no daemon — so every branch and the
+/// ordering between branches is a plain value assertion.
+///
+/// Every test asserts on the **composed output** (value, source, observed-at),
+/// not on the presence of fields. A state whose provenance is right by accident
+/// and wrong by construction would pass a field-presence check.
+@Suite("SessionStateResolver")
+struct SessionStateResolverTests {
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+    private let resolveNow = Date(timeIntervalSince1970: 1_700_010_000)
+
+    private func resolver() -> SessionStateResolver {
+        let pinned = resolveNow
+        return SessionStateResolver(now: { pinned })
+    }
+
+    private func terminal(
+        activityState: TerminalActivityState = .unknown,
+        activityStateSource: FactSource? = nil,
+        activityStateObservedAt: Date? = nil,
+        awaitingInputReason: AwaitingInputReason? = nil,
+        awaitingInputObservedAt: Date? = nil,
+        hibernatedAt: Date? = nil,
+        hibernateReason: HibernateReason? = nil,
+        pendingResumeAt: Date? = nil
+    ) -> Terminal {
+        Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@0",
+            tmuxPaneID: "%0",
+            activityState: activityState,
+            hibernatedAt: hibernatedAt,
+            hibernateReason: hibernateReason,
+            pendingResumeAt: pendingResumeAt,
+            activityStateSource: activityStateSource,
+            activityStateObservedAt: activityStateObservedAt,
+            awaitingInputReason: awaitingInputReason,
+            awaitingInputObservedAt: awaitingInputObservedAt)
+    }
+
+    private func promptReason(_ message: String = "Claude needs your permission") -> AwaitingInputReason {
+        AwaitingInputReason(
+            message: message,
+            hookEventName: "Notification",
+            notificationType: "permission_prompt")
+    }
+
+    // MARK: - One test per precedence branch
+
+    @Test func parkedCarriesTheParkInstantAndTheDatabaseSource() {
+        let parkedAt = t0.addingTimeInterval(500)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(hibernatedAt: parkedAt, hibernateReason: .manual)))
+
+        #expect(state.value == .parked(reason: "manual"))
+        #expect(state.source == .database)
+        #expect(state.observedAt == parkedAt)
+        #expect(state.value.isConfident)
+    }
+
+    @Test func scheduledResumeMirrorReportsRateLimitedFromTheDatabase() {
+        let until = t0.addingTimeInterval(3_600)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(pendingResumeAt: until)))
+
+        #expect(state.value == .rateLimited(until: until))
+        #expect(state.source == .database)
+        // The database read IS the observation, so it is stamped at resolve
+        // time rather than at whenever the row was written.
+        #expect(state.observedAt == resolveNow)
+    }
+
+    @Test func transcriptClassificationReportsRateLimitedFromTheTail() {
+        let readAt = t0.addingTimeInterval(100)
+        let resetsAt = readAt.addingTimeInterval(1_800)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(),
+            transcriptRateLimit: .init(
+                limit: DetectedRateLimit(
+                    resetsAt: resetsAt, limitType: "session", rawMessage: "hit your session limit"),
+                observedAt: readAt)))
+
+        #expect(state.value == .rateLimited(until: resetsAt))
+        #expect(state.source == .transcriptTail)
+        #expect(state.observedAt == readAt)
+    }
+
+    @Test func aTranscriptLimitWhoseResetHasPassedIsNotReported() {
+        let readAt = t0.addingTimeInterval(100)
+        let hookAt = t0.addingTimeInterval(50)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: hookAt),
+            transcriptRateLimit: .init(
+                limit: DetectedRateLimit(
+                    resetsAt: readAt.addingTimeInterval(-60),
+                    limitType: "session",
+                    rawMessage: "hit your session limit"),
+                observedAt: readAt)))
+
+        // The detector classifies a record, not whether the limit still holds.
+        #expect(state.value == .idle)
+        #expect(state.source == .hookEvent("Stop"))
+    }
+
+    @Test func goneComesOnlyFromASuppliedLivenessFact() {
+        let observedAt = t0.addingTimeInterval(42)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent("UserPromptSubmit"),
+                activityStateObservedAt: t0),
+            liveness: ObservedFact(value: false, source: .processLiveness, observedAt: observedAt)))
+
+        #expect(state.value == .gone)
+        #expect(state.source == .processLiveness)
+        #expect(state.observedAt == observedAt)
+    }
+
+    @Test func aLivenessFactSayingAliveDoesNotItselfDecideTheState() {
+        let hookAt = t0.addingTimeInterval(7)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent("UserPromptSubmit"),
+                activityStateObservedAt: hookAt),
+            liveness: ObservedFact(value: true, source: .processLiveness, observedAt: t0)))
+
+        #expect(state.value == .working)
+        #expect(state.source == .hookEvent("UserPromptSubmit"))
+        #expect(state.observedAt == hookAt)
+    }
+
+    @Test func awaitingInputCarriesTheHookSourceAndTheReasonVerbatim() {
+        let reasonAt = t0.addingTimeInterval(300)
+        let reason = promptReason("Claude needs your permission to use Bash")
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: reason,
+                awaitingInputObservedAt: reasonAt)))
+
+        #expect(state.value == .awaitingInput(reason: reason))
+        #expect(state.source == .hookEvent("Notification"))
+        #expect(state.observedAt == reasonAt)
+    }
+
+    @Test func workingAndIdleCarryTheActivityRailsProvenance() {
+        let at = t0.addingTimeInterval(11)
+        let working = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: at)))
+        #expect(working.value == .working)
+        #expect(working.source == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(working.observedAt == at)
+
+        let idle = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: at)))
+        #expect(idle.value == .idle)
+        #expect(idle.source == .hookEvent("Stop"))
+        #expect(idle.observedAt == at)
+    }
+
+    @Test func aFreshWaitingForUserActivityStateDoesNotBorrowAnOlderPromptsText() {
+        let reasonAt = t0.addingTimeInterval(100)
+        let activityAt = t0.addingTimeInterval(400)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .waitingForUser,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: activityAt,
+                awaitingInputReason: promptReason("an older prompt"),
+                awaitingInputObservedAt: reasonAt)))
+
+        #expect(state.value == .awaitingInput(reason: nil))
+        #expect(state.source == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(state.observedAt == activityAt)
+    }
+
+    // MARK: - The ordering itself
+
+    @Test func aParkedTerminalWithAStaleAwaitingInputReasonResolvesAsParked() {
+        let parkedAt = t0.addingTimeInterval(900)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: t0.addingTimeInterval(200),
+                awaitingInputReason: promptReason(),
+                // Newer than the activity fact, and still outranked: the park
+                // tore down the process the prompt was on.
+                awaitingInputObservedAt: t0.addingTimeInterval(800),
+                hibernatedAt: parkedAt,
+                hibernateReason: .auto)))
+
+        #expect(state.value == .parked(reason: "auto"))
+        #expect(state.source == .database)
+        #expect(state.observedAt == parkedAt)
+    }
+
+    @Test func goneOutranksParked() {
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(hibernatedAt: t0, hibernateReason: .auto),
+            liveness: ObservedFact(value: false, source: .processLiveness, observedAt: t0)))
+        #expect(state.value == .gone)
+    }
+
+    @Test func rateLimitedOutranksAnIdleHookObservation() {
+        let until = t0.addingTimeInterval(2_400)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: t0.addingTimeInterval(1_000),
+                pendingResumeAt: until)))
+
+        // A rate-limited session's turn genuinely did end, so the hook rail
+        // says idle. Reporting idle would invite a send it cannot act on.
+        #expect(state.value == .rateLimited(until: until))
+        #expect(state.source == .database)
+    }
+
+    @Test func parkedOutranksRateLimited() {
+        let parkedAt = t0.addingTimeInterval(1_500)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                hibernatedAt: parkedAt,
+                hibernateReason: .merged,
+                pendingResumeAt: t0.addingTimeInterval(9_000))))
+        #expect(state.value == .parked(reason: "merged"))
+        #expect(state.observedAt == parkedAt)
+    }
+
+    // MARK: - The staleness rule, both directions
+
+    @Test func aReasonNewerThanTheLastActivityObservationWins() {
+        let activityAt = t0.addingTimeInterval(100)
+        let reasonAt = t0.addingTimeInterval(200)
+        let reason = promptReason()
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: activityAt,
+                awaitingInputReason: reason,
+                awaitingInputObservedAt: reasonAt)))
+
+        #expect(state.value == .awaitingInput(reason: reason))
+        #expect(state.observedAt == reasonAt)
+    }
+
+    @Test func aReasonOlderThanTheLastActivityObservationIsNotReportedAsALivePrompt() {
+        let reasonAt = t0.addingTimeInterval(100)
+        let activityAt = t0.addingTimeInterval(200)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: activityAt,
+                awaitingInputReason: promptReason("stale permission request"),
+                awaitingInputObservedAt: reasonAt)))
+
+        #expect(state.value == .working)
+        #expect(state.source == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(state.observedAt == activityAt)
+        // Nothing anywhere in the composed answer repeats the stale prompt.
+        #expect(!state.summary.contains("stale permission request"))
+    }
+
+    // MARK: - The staleness rule the observed-at comparison cannot express
+
+    /// The mirror of `aReasonOlderThanTheLastActivityObservationIsNotReportedAsALivePrompt`,
+    /// and the case that one cannot catch.
+    ///
+    /// A prompt recorded a second AFTER the turn's `working` stamp wins on
+    /// observed-at forever: the activity rail only stamps at turn boundaries and
+    /// its handler returns early on an unchanged value, so nothing on that rail
+    /// ever retracts the reason. The transcript is the only other interface that
+    /// speaks mid-turn — and it cannot settle it either, because a parallel
+    /// subagent, a backgrounded task's completion record and a queued user
+    /// message all append while the prompt is still up. So growth makes the two
+    /// situations indistinguishable, and the answer is `unknown`.
+    ///
+    /// **The direction this test pins is the dangerous one.** Falling through to
+    /// the activity rail here would report `.working` — from a `working` stamp
+    /// left by `UserPromptSubmit` at the top of the turn — for a session blocked
+    /// on a human, indefinitely.
+    @Test func aPromptTheTranscriptHasGrownPastResolvesUnknownRatherThanWorking() {
+        let activityAt = t0.addingTimeInterval(100)
+        let reasonAt = t0.addingTimeInterval(200)
+        let appendedAt = t0.addingTimeInterval(260)
+        let readAt = t0.addingTimeInterval(300)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: activityAt,
+                awaitingInputReason: promptReason("possibly answered permission request"),
+                awaitingInputObservedAt: reasonAt),
+            transcriptLastAppendedAt: ObservedFact(
+                value: appendedAt, source: .transcriptTail, observedAt: readAt)))
+
+        guard case .unknown(let why) = state.value else {
+            Issue.record("expected .unknown, got \(state.value)")
+            return
+        }
+        // Both possibilities named, and the two stamps that put them in tension.
+        #expect(why.contains("a prompt was reported"))
+        #expect(why.contains("the transcript has grown since"))
+        #expect(why.contains("cannot be told from machine facts"))
+        #expect(why.contains("permission_prompt"))
+        #expect(why.contains("prompt_on_screen"))
+        // The evidence that made it unknown is the transcript read, so that is
+        // the provenance the answer carries.
+        #expect(state.source == .transcriptTail)
+        #expect(state.observedAt == readAt)
+        // The prompt's own text is never composed into a `why` — it may quote
+        // repo content, and it rides on `.awaitingInput` for readers entitled
+        // to it.
+        #expect(!state.summary.contains("possibly answered permission request"))
+    }
+
+    /// The symptom that would reveal the unmeasured assumption under the
+    /// comparison, made visible on purpose.
+    ///
+    /// The rule assumes Claude Code flushes the assistant record carrying the
+    /// `tool_use` BEFORE it fires the `Notification` hook. If it flushes after,
+    /// an unanswered prompt's newest append lands a hair past the reason's
+    /// observed-at and **every** prompt resolves unknown — which is what this
+    /// asserts, so the day that assumption breaks the failure is a fleet of
+    /// unknowns rather than a silent wrong answer. The fix that would then apply
+    /// is a tolerance sized to a measured flush lag, deliberately not written
+    /// yet.
+    @Test func aFlushLandingAfterTheHookWouldMakeEveryPromptResolveUnknown() {
+        let reasonAt = t0.addingTimeInterval(200)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: promptReason(),
+                awaitingInputObservedAt: reasonAt),
+            transcriptLastAppendedAt: ObservedFact(
+                value: reasonAt.addingTimeInterval(0.001), source: .transcriptTail,
+                observedAt: reasonAt.addingTimeInterval(0.001))))
+
+        guard case .unknown = state.value else {
+            Issue.record("expected .unknown, got \(state.value)")
+            return
+        }
+    }
+
+    @Test func aPromptStandsWhileTheTranscriptHasNotGrownPastIt() {
+        let reasonAt = t0.addingTimeInterval(200)
+        // The last append predates the prompt: the assistant's tool-use record
+        // was written, then the prompt appeared, and nothing has been appended
+        // since — which is what an unanswered prompt looks like in bytes.
+        let appendedAt = t0.addingTimeInterval(199)
+        let reason = promptReason()
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: reason,
+                awaitingInputObservedAt: reasonAt),
+            transcriptLastAppendedAt: ObservedFact(
+                value: appendedAt, source: .transcriptTail, observedAt: appendedAt)))
+
+        #expect(state.value == .awaitingInput(reason: reason))
+        #expect(state.observedAt == reasonAt)
+    }
+
+    @Test func withNoGrowthFactAtAllTheRecordedPromptStillStands() {
+        // "We could not read the transcript" is not evidence that the prompt
+        // went away, and must never be spent as though it were.
+        let reasonAt = t0.addingTimeInterval(200)
+        let reason = promptReason()
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: reason,
+                awaitingInputObservedAt: reasonAt),
+            transcriptLastAppendedAt: nil))
+
+        #expect(state.value == .awaitingInput(reason: reason))
+        #expect(state.observedAt == reasonAt)
+    }
+
+    @Test func aTranscriptThatGrewBeforeThePromptDecidesNothing() {
+        // Ordering, not presence: an append stamp that predates the reason is
+        // the ordinary case (the tool-use record itself) and must not read as
+        // evidence of an answer.
+        let reasonAt = t0.addingTimeInterval(200)
+        let reason = promptReason()
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: reason,
+                awaitingInputObservedAt: reasonAt),
+            transcriptLastAppendedAt: ObservedFact(
+                value: reasonAt, source: .transcriptTail, observedAt: reasonAt)))
+
+        #expect(state.value == .awaitingInput(reason: reason))
+    }
+
+    /// Growth puts the *identity* of the live prompt in doubt, not whether one
+    /// is live — so when a second rail already says the session is blocked on a
+    /// human, the answer stays the confident one.
+    ///
+    /// Reachable exactly as written: `PreToolUse:AskUserQuestion` sets
+    /// `waiting_for_user` on the activity rail (and clears any carried reason),
+    /// a `Notification` records a `permission_prompt` after it, and the
+    /// transcript then grows. Spending `.unknown` here would discard an
+    /// independent, confident observation and — because consumers gate on
+    /// `isConfident` — turn a correct actionable answer into a non-answer.
+    @Test func aPromptTheTranscriptGrewPastStaysAwaitingInputWhenTheActivityRailCorroboratesIt() {
+        let activityAt = t0.addingTimeInterval(100)
+        let reasonAt = t0.addingTimeInterval(200)
+        let appendedAt = t0.addingTimeInterval(260)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .waitingForUser,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: activityAt,
+                awaitingInputReason: promptReason("possibly answered permission request"),
+                awaitingInputObservedAt: reasonAt),
+            transcriptLastAppendedAt: ObservedFact(
+                value: appendedAt, source: .transcriptTail,
+                observedAt: t0.addingTimeInterval(300))))
+
+        // The corroborating fact is the activity observation, so it is that
+        // fact's provenance the answer carries — not the transcript read's.
+        #expect(state.value == .awaitingInput(reason: nil))
+        #expect(state.source == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(state.observedAt == activityAt)
+        #expect(state.value.isConfident)
+        // No reason is attached: which prompt is on screen is exactly what the
+        // growth put in doubt, and the text may quote repo content besides.
+        #expect(!state.summary.contains("possibly answered permission request"))
+    }
+
+    /// The same growth with the activity rail saying anything else is still
+    /// ambiguous — the corroboration branch must not swallow the `unknown` case
+    /// it sits in front of.
+    @Test func growthPastAPromptIsStillUnknownWhenTheActivityRailSaysWorking() {
+        let reasonAt = t0.addingTimeInterval(200)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: promptReason(),
+                awaitingInputObservedAt: reasonAt),
+            transcriptLastAppendedAt: ObservedFact(
+                value: t0.addingTimeInterval(260), source: .transcriptTail,
+                observedAt: t0.addingTimeInterval(300))))
+
+        #expect(state.value.isConfident == false)
+        #expect(state.source == .transcriptTail)
+    }
+
+    // MARK: - `doneWaiting` outranks a stale activity stamp
+
+    /// `idle_prompt` is Claude Code saying its turn is over and it is sitting at
+    /// its own prompt. When `Stop`/`StopFailure` never reached the daemon — a
+    /// hook failure, or a stale `tbd` on the pane's PATH, a known failure class
+    /// here — `activityState` is stuck at `working` from `UserPromptSubmit`, and
+    /// falling through to it would report `.working` for a session whose turn
+    /// demonstrably ended: the one answer this resolver may never give for a
+    /// session that may be blocked on a human.
+    ///
+    /// It resolves `.idle`, not `.awaitingInput`: nothing is on screen to
+    /// answer, and reporting a prompt that does not exist would send a
+    /// supervisor looking for one.
+    @Test func aDoneWaitingReasonNewerThanAStaleWorkingStampResolvesIdleNotWorking() {
+        let reasonAt = t0.addingTimeInterval(400)
+        let idlePrompt = AwaitingInputReason(
+            message: "Claude is waiting for your input",
+            hookEventName: "Notification",
+            notificationType: "idle_prompt")
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: idlePrompt,
+                awaitingInputObservedAt: reasonAt)))
+
+        #expect(state.value == .idle)
+        #expect(state.source == .hookEvent("Notification"))
+        #expect(state.observedAt == reasonAt)
+        #expect(state.value.isConfident)
+    }
+
+    /// The ordering still decides: a `doneWaiting` reason OLDER than the newest
+    /// activity observation is a turn that has since restarted, and the rail
+    /// wins. Without this the fix above would be a standing rank rather than an
+    /// observed-at comparison.
+    @Test func aDoneWaitingReasonOlderThanTheActivityStampDoesNotOutrankIt() {
+        let activityAt = t0.addingTimeInterval(500)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: activityAt,
+                awaitingInputReason: AwaitingInputReason(
+                    message: "Claude is waiting for your input",
+                    hookEventName: "Notification",
+                    notificationType: "idle_prompt"),
+                awaitingInputObservedAt: t0.addingTimeInterval(400))))
+
+        #expect(state.value == .working)
+        #expect(state.observedAt == activityAt)
+    }
+
+    @Test func onlyThePromptOnScreenClassProducesAwaitingInput() {
+        // `agent_completed` is `informational`: something happened, nobody is
+        // being waited on. It is newer than the activity fact and still does
+        // not become `awaitingInput`.
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: AwaitingInputReason(
+                    message: "Agent finished",
+                    hookEventName: "Notification",
+                    notificationType: "agent_completed"),
+                awaitingInputObservedAt: t0.addingTimeInterval(500))))
+
+        #expect(state.value == .idle)
+        #expect(state.source == .hookEvent("Stop"))
+    }
+
+    @Test func anUnrecognizedNotificationTypeIsNeverGuessedIntoAwaitingInput() {
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: t0.addingTimeInterval(100),
+                awaitingInputReason: AwaitingInputReason(
+                    message: "Claude needs your permission to do a new thing",
+                    hookEventName: "Notification",
+                    // Spelled exactly like a prompt; this build has never heard
+                    // of it, so it stays unrecognized and establishes nothing.
+                    notificationType: "permission_prompt_v2"),
+                awaitingInputObservedAt: t0.addingTimeInterval(900))))
+
+        #expect(state.value == .working)
+    }
+
+    // MARK: - `.unknown` is a distinct outcome
+
+    @Test func nothingToSayResolvesToAnUnknownThatNamesTheMissingFacts() {
+        let state = resolver().resolve(SessionStateFacts(terminal: terminal()))
+
+        #expect(state.value.isConfident == false)
+        guard case .unknown(let why) = state.value else {
+            Issue.record("expected .unknown, got \(state.value)")
+            return
+        }
+        #expect(why.contains("activityStateSource"))
+        #expect(why.contains("Notification"))
+        #expect(why.contains("liveness"))
+        #expect(state.source == .unavailable)
+        #expect(state.observedAt == resolveNow)
+    }
+
+    @Test func aHalfTripleActivityRowCannotMasqueradeAsAnObservation() {
+        // A value with a source but no observed-at: `Terminal.observedActivity`
+        // refuses to build a fact out of it, so the resolver must not report
+        // `working`.
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .working,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: nil)))
+
+        #expect(state.value.isConfident == false)
+        #expect(state.source == .unavailable)
+    }
+
+    @Test func aRecordedUnknownActivityStateKeepsItsHookProvenance() {
+        let at = t0.addingTimeInterval(60)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .unknown,
+                activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+                activityStateObservedAt: at)))
+
+        #expect(state.value.isConfident == false)
+        guard case .unknown(let why) = state.value else {
+            Issue.record("expected .unknown, got \(state.value)")
+            return
+        }
+        #expect(why.contains("activity rail recorded state 'unknown'"))
+        // An unknown that *was* observed keeps the observation's provenance —
+        // it is not folded into the `.unavailable` shrug.
+        #expect(state.source == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(state.observedAt == at)
+    }
+
+    // MARK: - The delegation trap, pinned
+
+    /// A session waiting on a **background subagent** resolves as `idle`, with
+    /// its source and observed-at, and the resolver claims nothing more.
+    ///
+    /// This shape is deliberate, not an oversight, and the test is named so
+    /// that survives. Measured on a live session: a worktree that delegated to
+    /// a background agent read idle for twenty minutes while its subagent
+    /// churned, because `Stop` fires when the parent's turn ends and the
+    /// parent's turn really does end at delegation. The plausible detector —
+    /// "an `Agent` tool-use with no matching `tool_result` means a delegation is
+    /// outstanding" — fails on exactly this case: a backgrounded agent's
+    /// `tool_result` lands immediately (measured: 27 tool-uses, 27 results,
+    /// zero pending, subagent running throughout), so the transcript shows a
+    /// completed tool call while the work runs out of band.
+    ///
+    /// Separating the two shapes would mean reading result prose — content
+    /// interpretation at a layer that may not interpret content. The design
+    /// sends the case to a desk instead, which is the tier allowed to read the
+    /// transcript. What compiled TBD owes is carrying the ambiguity honestly:
+    /// `idle` **with provenance**, never `idle` presented as "not working".
+    @Test func aSessionWaitingOnABackgroundSubagentResolvesAsIdleWithProvenanceNotAsNotWorking() {
+        let stopAt = t0.addingTimeInterval(60)
+        let state = resolver().resolve(SessionStateFacts(
+            terminal: terminal(
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: stopAt)))
+
+        #expect(state.value == .idle)
+        #expect(state.source == .hookEvent("Stop"))
+        #expect(state.observedAt == stopAt)
+        // The composed answer always carries how and when, so a consumer can
+        // never receive a bare "idle" it might read as "not working".
+        #expect(state.summary.contains("hook:Stop"))
+        #expect(state.summary.contains(FactTimestamp.string(from: stopAt)))
+    }
+}

--- a/Tests/TBDDaemonTests/SessionStatesRPCTests.swift
+++ b/Tests/TBDDaemonTests/SessionStatesRPCTests.swift
@@ -1,0 +1,517 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Records every tmux interaction the router would have had. `session.states`
+/// must leave it empty — that is the cheap-path property, asserted rather than
+/// assumed.
+///
+/// `dryRunRecorder` alone is **not** enough, and the gap matters here more than
+/// anywhere: it fires on the mutating commands, while `capturePaneOutput`,
+/// `capturePaneWithAnsi`, `capturePaneScrollback`, `paneCurrentCommand`,
+/// `paneSendTarget`, `listWindows` and `windowExists` short-circuit on their own
+/// dryRun hooks and never reach it. A pane *read* is exactly what this method
+/// must never do, so the fixture wires every one of those hooks into the same
+/// recorder and the assertion covers the composed set rather than one arm of it.
+private final class TmuxCommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+
+    func record(_ args: [String]) {
+        lock.lock()
+        defer { lock.unlock() }
+        commands.append(args)
+    }
+
+    var recorded: [[String]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return commands
+    }
+}
+
+/// Tier 2 — in-memory database plus real (temp-dir) transcript files, no tmux
+/// server and no subprocess.
+@Suite("session.states RPC")
+struct SessionStatesRPCTests {
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let recorder: TmuxCommandRecorder
+        let scratch: URL
+        let worktreeID: UUID
+
+        func cleanUp() { try? FileManager.default.removeItem(at: scratch) }
+    }
+
+    /// - Parameter now: the router's date seam. Defaulted so every existing
+    ///   case is unchanged; the fallback-stamp case below pins it, which is the
+    ///   only way to tell an injected clock from wall time.
+    private func makeFixture(
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) async throws -> Fixture {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-session-states-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = TmuxCommandRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunWindowIsDead: { window in
+                recorder.record(["window-exists", window])
+                return false
+            },
+            dryRunListWindows: { server, session in
+                recorder.record(["list-windows", server, session])
+                return []
+            },
+            dryRunCapturePane: { server, pane in
+                recorder.record(["capture-pane", server, pane])
+                return ""
+            },
+            dryRunPaneCurrentCommand: { server, pane in
+                recorder.record(["pane-current-command", server, pane])
+                return "zsh"
+            },
+            dryRunPaneSendTarget: { server, pane in
+                recorder.record(["pane-send-target", server, pane])
+                return .live(terminalID: nil)
+            })
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            now: now,
+            actuationLog: makeTestActuationLog())
+
+        let repo = try await db.repos.create(
+            path: scratch.appendingPathComponent("repo").path,
+            displayName: "repo", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "feature",
+            path: scratch.appendingPathComponent("repo").path, tmuxServer: "tbd-states-test")
+        return Fixture(
+            db: db, router: router, recorder: recorder, scratch: scratch,
+            worktreeID: worktree.id)
+    }
+
+    private func writeTranscript(_ fixture: Fixture, name: String, lines: [String]) throws -> String {
+        let path = fixture.scratch.appendingPathComponent(name).path
+        try Data((lines.joined(separator: "\n") + "\n").utf8)
+            .write(to: URL(fileURLWithPath: path))
+        return path
+    }
+
+    private func states(_ fixture: Fixture, worktreeID: UUID? = nil) async throws -> [SessionStateReport] {
+        let request = try RPCRequest(
+            method: RPCMethod.sessionStates, params: SessionStatesParams(worktreeID: worktreeID))
+        let response = await fixture.router.handle(request)
+        #expect(response.error == nil, "session.states errored: \(response.error ?? "")")
+        return try response.decodeResult(SessionStatesResult.self).reports
+    }
+
+    // MARK: -
+
+    @Test func reportsOnePerTerminalWithProvenanceOnEveryState() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+
+        let a = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        let c = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "codex", kind: .codex)
+        try await fixture.db.terminals.setActivityState(
+            id: a.id, activityState: .working, source: .hookEvent(RPCMethod.terminalActivityEvent))
+
+        let reports = try await states(fixture)
+        #expect(reports.count == 2)
+        #expect(Set(reports.map(\.terminalID)) == [a.id, c.id])
+        for report in reports {
+            #expect(report.worktreeID == fixture.worktreeID)
+            // Composed output, not field presence: the summary is only
+            // constructible from all three parts of the triple.
+            #expect(report.state.summary.contains("source:"))
+            #expect(report.state.summary.contains("observed "))
+        }
+
+        let reportA = try #require(reports.first { $0.terminalID == a.id })
+        #expect(reportA.state.value == .working)
+        #expect(reportA.state.source == .hookEvent(RPCMethod.terminalActivityEvent))
+
+        // The terminal nothing ever spoke about is `unknown`, not `idle`.
+        let reportC = try #require(reports.first { $0.terminalID == c.id })
+        #expect(reportC.state.value.isConfident == false)
+    }
+
+    /// A plain shell is not a session this model has anything to say about: no
+    /// transcript, no context window, no hook rail. Reporting one spends a stat
+    /// and a transcript-tail attempt every cycle to produce a paragraph
+    /// explaining why a session that was never going to have a statusline tee
+    /// has no denominator.
+    @Test func aPlainShellIsNotReportedOnAtAll() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+
+        let agent = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        let shell = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "shell", kind: .shell)
+        // A pre-`kind` row carries nil and is treated as an agent: dropping a
+        // real agent from the fleet's readout is the worse of the two errors.
+        let legacy = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2", label: "legacy")
+
+        let reported = Set(try await states(fixture).map(\.terminalID))
+        #expect(reported == [agent.id, legacy.id])
+        #expect(!reported.contains(shell.id))
+    }
+
+    /// End to end for the resolver's staleness rule: the append stamp has to be
+    /// a real file's, or the rule is a well-tested decoration.
+    ///
+    /// The prompt is recorded AFTER the turn's `working` stamp, so it wins on
+    /// observed-at and nothing on the hook rail will ever retract it — the
+    /// activity handler returns early on an unchanged value. Then the transcript
+    /// grows, which could be the answered tool's result or a parallel subagent's
+    /// records with the prompt still up. Machine facts cannot separate the two,
+    /// so the answer becomes `unknown` — never `.working`, which is what the
+    /// stale hook stamp on the row would otherwise say.
+    @Test func aPromptTheTranscriptHasGrownPastIsReportedAsUnknownByTheRPC() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        let path = try writeTranscript(
+            fixture, name: "prompt.jsonl",
+            lines: [#"{"type":"assistant","message":{"usage":{"input_tokens":10}}}"#])
+        try await fixture.db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-prompt", transcriptPath: path)
+
+        let turnStartedAt = Date().addingTimeInterval(-120)
+        try await fixture.db.terminals.setActivityState(
+            id: terminal.id, activityState: .working,
+            source: .hookEvent(RPCMethod.terminalActivityEvent), observedAt: turnStartedAt)
+        // Recorded a minute into the turn, and never superseded.
+        let promptAt = turnStartedAt.addingTimeInterval(60)
+        // The transcript's last append is the assistant record that RAISED the
+        // prompt, so it predates it — which is what an unanswered prompt looks
+        // like in bytes.
+        try FileManager.default.setAttributes(
+            [.modificationDate: turnStartedAt.addingTimeInterval(59)], ofItemAtPath: path)
+        try await fixture.db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: AwaitingInputReason(
+                message: "Claude needs your permission to run rm",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: promptAt)
+
+        let beforeAnswer = try #require(try await states(fixture).first)
+        #expect(beforeAnswer.state.value.label == "awaiting input")
+
+        // Something appended. It could be the answered tool's result — or a
+        // parallel subagent's sidechain record with the prompt still on screen.
+        // Nothing reads what was appended, so nothing can tell those apart.
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(#"{"type":"user","message":{"role":"user"}}"#.utf8))
+        try handle.write(contentsOf: Data("\n".utf8))
+        try handle.close()
+
+        let afterGrowth = try #require(try await states(fixture).first)
+        // NOT `.working`: the stale `working` stamp from `UserPromptSubmit` is
+        // still on the row, and reporting it would present a session possibly
+        // blocked on a human as one making progress.
+        #expect(afterGrowth.state.value != .working)
+        guard case .unknown(let why) = afterGrowth.state.value else {
+            Issue.record("expected .unknown, got \(afterGrowth.state.value)")
+            return
+        }
+        #expect(why.contains("a prompt was reported"))
+        #expect(why.contains("the transcript has grown since"))
+        #expect(afterGrowth.state.source == .transcriptTail)
+        #expect(!afterGrowth.state.summary.contains("permission to run rm"))
+    }
+
+    @Test func performsNoSubprocessOrPaneRead() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        let path = try writeTranscript(
+            fixture, name: "session.jsonl",
+            lines: [#"{"type":"assistant","message":{"usage":{"input_tokens":1000}}}"#])
+        try await fixture.db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-1", transcriptPath: path)
+
+        _ = try await states(fixture)
+
+        // Every tmux interaction the router could have in dryRun lands in the
+        // recorder — the mutating commands and, separately wired, every
+        // read-only query and pane capture. An empty recorder is the proof
+        // that the pass costs no subprocess and reads no pane, which is what
+        // lets this method be called every cycle for the whole fleet.
+        #expect(fixture.recorder.recorded.isEmpty,
+                "session.states touched tmux: \(fixture.recorder.recorded)")
+    }
+
+    @Test func theWorktreeFilterNarrowsTheReport() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+        let repo = try #require(try await fixture.db.repos.list().first)
+        let other = try await fixture.db.worktrees.create(
+            repoID: repo.id, name: "other", branch: "other",
+            path: fixture.scratch.appendingPathComponent("other").path,
+            tmuxServer: "tbd-states-test")
+
+        _ = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0", label: "a")
+        let elsewhere = try await fixture.db.terminals.create(
+            worktreeID: other.id, tmuxWindowID: "@1", tmuxPaneID: "%1", label: "b")
+
+        let filtered = try await states(fixture, worktreeID: other.id)
+        #expect(filtered.map(\.terminalID) == [elsewhere.id])
+        #expect(try await states(fixture).count == 2)
+    }
+
+    @Test func aWorktreeScopedCallLeavesCountersOutsideTheScopeIntact() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+        let repo = try #require(try await fixture.db.repos.list().first)
+        let other = try await fixture.db.worktrees.create(
+            repoID: repo.id, name: "other", branch: "other",
+            path: fixture.scratch.appendingPathComponent("other").path,
+            tmuxServer: "tbd-states-test")
+
+        let here = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "here", kind: .claude)
+        let elsewhere = try await fixture.db.terminals.create(
+            worktreeID: other.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "elsewhere", kind: .claude)
+        let herePath = try writeTranscript(fixture, name: "here.jsonl", lines: ["{}"])
+        let elsewherePath = try writeTranscript(fixture, name: "elsewhere.jsonl", lines: ["{}"])
+        try await fixture.db.terminals.updateSession(
+            id: here.id, sessionID: "sess-here", transcriptPath: herePath)
+        try await fixture.db.terminals.updateSession(
+            id: elsewhere.id, sessionID: "sess-elsewhere", transcriptPath: elsewherePath)
+
+        _ = try await states(fixture)  // fleet-wide: both baselines established
+
+        // Give the out-of-scope session something to lose: one hook event and
+        // three appended records inside its observation window.
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: elsewhere.id, activityState: .working))
+        _ = await fixture.router.handle(request)
+        let handle = try #require(FileHandle(forWritingAtPath: elsewherePath))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("{}\n{}\n{}\n".utf8))
+        try handle.close()
+
+        // A call about the *other* worktree enumerates only its terminals, and
+        // must not treat that narrowed list as the whole fleet.
+        _ = try await states(fixture, worktreeID: fixture.worktreeID)
+
+        let report = try #require(try await states(fixture).first { $0.terminalID == elsewhere.id })
+        let counters = try #require(report.counters)
+        #expect(counters.turnsInWindow == 3)
+        #expect(counters.hookEventsInWindow == 1)
+    }
+
+    @Test func contextLoadReportsAnUnknownWindowForAFleetSession() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        let path = try writeTranscript(
+            fixture, name: "session.jsonl",
+            lines: [
+                #"{"type":"assistant","message":{"usage":{"input_tokens":900,"cache_read_input_tokens":100}}}"#
+            ])
+        try await fixture.db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-1", transcriptPath: path)
+
+        let report = try #require(try await states(fixture).first)
+        let load = try #require(report.contextLoad)
+        #expect(load.used?.value == 1_000)
+        #expect(load.used?.source == .transcriptTail)
+        // The statusline tee installs on desk sessions only, so the
+        // denominator is unknown and reported as unknown.
+        guard case .unknown = load.window else {
+            Issue.record("expected an unknown window for a fleet session, got \(load.window)")
+            return
+        }
+        #expect(load.isPairedReading == false)
+    }
+
+    /// The router's date seam has to reach every fact this pass stamps,
+    /// including the ones a collaborator stamps on its behalf.
+    ///
+    /// A transcript record that carries no parseable `timestamp` of its own
+    /// gets the reader's fallback date. That reader is `ContextLoadReader`,
+    /// which the gatherer owns — so if the gatherer keeps its injected `now` to
+    /// itself, this one field comes back as wall time while every other stamp
+    /// in the same report is pinned. The two are only distinguishable by a
+    /// pinned clock, which is exactly what makes this worth asserting.
+    @Test func aTranscriptRecordWithNoTimestampIsStampedWithTheRoutersClock() async throws {
+        let pinned = Date(timeIntervalSince1970: 1_700_000_000)
+        let fixture = try await makeFixture(now: { pinned })
+        defer { fixture.cleanUp() }
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        // No `timestamp` key: the record cannot say when it was written, so the
+        // fallback date is the only stamp the fact can carry.
+        let path = try writeTranscript(
+            fixture, name: "no-timestamp.jsonl",
+            lines: [
+                #"{"type":"assistant","message":{"usage":{"input_tokens":900,"cache_read_input_tokens":100}}}"#
+            ])
+        try await fixture.db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-1", transcriptPath: path)
+
+        let report = try #require(try await states(fixture).first)
+        let load = try #require(report.contextLoad)
+        let used = try #require(load.used)
+
+        #expect(used.value == 1_000)
+        #expect(used.observedAt == pinned,
+                "the numerator's fallback stamp came from wall time, not the injected seam: \(used.observedAt)")
+    }
+
+    /// The desk role brands the ROW; the tee installs on the Claude spawn path
+    /// only. `spawnPrimaryTerminals` resolves the primary agent from
+    /// `primaryAgentPreference`, so a desk created on a Codex-preferring install
+    /// is a `.codex` row wearing `.readOnlyCoordinator` — and telling its reader
+    /// "the tee is installed but has not fired yet" would be a claim about a
+    /// capture that will never appear.
+    @Test func aCodexDeskIsNotDescribedAsWaitingForATeeItDoesNotHave() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+        let codexDesk = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "codex", kind: .codex, watchDeskRole: .readOnlyCoordinator)
+        let claudeDesk = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", kind: .claude, watchDeskRole: .readOnlyCoordinator)
+
+        let reports = try await states(fixture)
+
+        let codexReport = try #require(reports.first { $0.terminalID == codexDesk.id })
+        guard case .unknown(let codexWhy) = try #require(codexReport.contextLoad).window else {
+            Issue.record("expected an unknown window for a Codex desk")
+            return
+        }
+        #expect(!codexWhy.contains("has not fired yet"))
+        #expect(codexWhy.contains("does not run the agent the statusline tee installs on"))
+
+        // The Claude desk keeps the wording it had — the fix adds a case rather
+        // than moving the existing one.
+        let claudeReport = try #require(reports.first { $0.terminalID == claudeDesk.id })
+        guard case .unknown(let claudeWhy) = try #require(claudeReport.contextLoad).window else {
+            Issue.record("expected an unknown window for a desk whose tee has not fired")
+            return
+        }
+        #expect(claudeWhy.contains("has not fired yet"))
+    }
+
+    @Test func countersAppearForASessionWithAReadableTranscriptAndNotForOneWithout() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+
+        let withTranscript = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        // An agent whose session has not started yet: it is reported on, and
+        // its counters are absent rather than zero. (A plain shell would not be
+        // reported at all — see `aPlainShellIsNotReportedOnAtAll`.)
+        let withoutTranscript = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", kind: .claude)
+        let path = try writeTranscript(fixture, name: "session.jsonl", lines: ["{}"])
+        try await fixture.db.terminals.updateSession(
+            id: withTranscript.id, sessionID: "sess-1", transcriptPath: path)
+
+        let reports = try await states(fixture)
+        let counted = try #require(reports.first { $0.terminalID == withTranscript.id })
+        let counters = try #require(counted.counters)
+        // First sighting baselines at the file's end — history is never a burst.
+        #expect(counters.turnsInWindow == 0)
+        // No sweep has run in this fixture, so the commits fact is not
+        // established. nil, never "unchanged".
+        #expect(counters.commitsUnchangedSince == nil)
+
+        let uncounted = try #require(reports.first { $0.terminalID == withoutTranscript.id })
+        #expect(uncounted.counters == nil)
+    }
+
+    @Test func hookEventsRaiseTheCountAndAppendedRecordsRaiseTheTurns() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        let path = try writeTranscript(fixture, name: "session.jsonl", lines: ["{}"])
+        try await fixture.db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-1", transcriptPath: path)
+        _ = try await states(fixture)  // establish the baseline
+
+        // Two hook-driven RPCs, one of which repeats a state the row already
+        // holds — the shape the activity handler's unchanged-state early
+        // return skips. The counter must still see it.
+        for state in [TerminalActivityState.working, .working] {
+            let request = try RPCRequest(
+                method: RPCMethod.terminalActivityEvent,
+                params: TerminalActivityEventParams(terminalID: terminal.id, activityState: state))
+            _ = await fixture.router.handle(request)
+        }
+
+        let handle = try #require(FileHandle(forWritingAtPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("{}\n{}\n{}\n".utf8))
+        try handle.close()
+
+        let counters = try #require(try await states(fixture).first?.counters)
+        #expect(counters.hookEventsInWindow == 2)
+        #expect(counters.turnsInWindow == 3)
+    }
+
+    @Test func aScheduledResumeMirrorSurfacesAsRateLimited() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanUp() }
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktreeID, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", kind: .claude)
+        let until = Date().addingTimeInterval(3_600)
+        _ = try await fixture.db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal.id, worktreeID: fixture.worktreeID,
+            resetsAt: until, fireAt: until,
+            limitType: "session", rawMessage: "hit your session limit"))
+
+        let report = try #require(try await states(fixture).first)
+        guard case .rateLimited(let reported) = report.state.value else {
+            Issue.record("expected .rateLimited, got \(report.state.value)")
+            return
+        }
+        #expect(reported != nil)
+        #expect(report.state.source == .database)
+    }
+}

--- a/Tests/TBDDaemonTests/StatuslineTeeOverlayGateTests.swift
+++ b/Tests/TBDDaemonTests/StatuslineTeeOverlayGateTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+import TBDShared
+
+/// The guard the whole design decision rests on: the statusline tee is
+/// installed on desk sessions and on nothing else.
+///
+/// TBD's per-session `--settings` file outranks the operator's `statusLine` in
+/// every scope they can write, so a leak here would silently take over a
+/// display slot the operator owns in every session they open. The non-desk case
+/// is therefore asserted as **byte-identical** to the overlay produced without
+/// the parameter at all, not merely as "no statusLine key" — a weaker assertion
+/// would let some other difference ride along unnoticed.
+///
+/// Nested under `TBDHomeSerialized`: the per-session overlay writes go through
+/// the process-global `TBD_HOME`.
+extension TBDHomeSerialized {
+@Suite struct StatuslineTeeOverlayGateTests {
+
+    private struct Scratch {
+        let home: URL
+        let prior: String?
+        init() {
+            home = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tbd-tee-gate-\(UUID().uuidString)")
+            prior = setTBDHome(home.path)
+        }
+        func cleanUp() {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: home)
+        }
+    }
+
+    private func statusLine(inOverlayAt path: String) throws -> [String: Any]? {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return parsed?["statusLine"] as? [String: Any]
+    }
+
+    @Test func deskSpawnGetsTheTeeStatusLine() throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let key = UUID().uuidString
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: key,
+            watchDeskRole: .readOnlyCoordinator,
+            worktreePath: nil
+        )
+
+        // A desk with no fallback models and no fragments still gets a
+        // per-session overlay, because the tee's capture path is per session.
+        #expect(path != ClaudeHookOverlay.overlayPath)
+        let entry = try #require(try statusLine(inOverlayAt: path))
+        #expect(entry["type"] as? String == "command")
+        let command = try #require(entry["command"] as? String)
+        #expect(command.contains(StatuslineTee.scriptPath))
+        #expect(command.contains(StatuslineTee.capturePath(sessionKey: key)))
+    }
+
+    @Test func judgeRoleAlsoCountsAsADesk() throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil, sessionKey: UUID().uuidString, watchDeskRole: .judge)
+        #expect(try statusLine(inOverlayAt: path) != nil)
+    }
+
+    @Test func nonDeskSpawnOverlayIsByteIdenticalToTodays() throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let models = ["claude-haiku-4-5-20251001"]
+        let fragment = #"{"skillOverrides":{"x":"off"}}"#
+
+        // Explicit nil role, and the parameter omitted entirely: both must
+        // produce exactly the bytes the overlay had before the tee existed.
+        let withNilRole = try ClaudeHookOverlay.generateBody(
+            fallbackModels: models,
+            extraSettings: ["skillOverrides": ["x": "off"]],
+            statusLineCommand: nil
+        )
+        let withoutParameter = try ClaudeHookOverlay.generateBody(
+            fallbackModels: models,
+            extraSettings: ["skillOverrides": ["x": "off"]]
+        )
+        #expect(withNilRole == withoutParameter)
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: models,
+            sessionKey: UUID().uuidString,
+            extraSettingsJSON: fragment
+        )
+        let written = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(written == withoutParameter)
+        #expect(try statusLine(inOverlayAt: path) == nil)
+    }
+
+    @Test func nonDeskSpawnWithNothingElseStillUsesTheSharedGlobalOverlay() {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        // The tee is the only reason a bare spawn would need a per-session
+        // file, so a non-desk bare spawn must still take the shared path.
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil, sessionKey: UUID().uuidString)
+        #expect(path == ClaudeHookOverlay.overlayPath)
+    }
+
+    @Test func fragmentSuppliedStatusLineBecomesTheDelegateRatherThanBeingClobbered() throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let key = UUID().uuidString
+        let operatorCommand = "~/bin/my-statusline.sh --fancy"
+        let fragment = #"{"statusLine":{"type":"command","command":"\#(operatorCommand)"}}"#
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: key,
+            extraSettingsJSON: fragment,
+            watchDeskRole: .readOnlyCoordinator
+        )
+
+        let entry = try #require(try statusLine(inOverlayAt: path))
+        let command = try #require(entry["command"] as? String)
+        // The tee wins the slot — and carries the operator's command as its
+        // delegate, so nothing they configured stops being displayed.
+        #expect(command.contains(StatuslineTee.scriptPath))
+        #expect(command.contains(operatorCommand))
+    }
+
+    @Test func aFragmentStatusLineOnANonDeskSpawnIsLeftExactlyAsGiven() throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let operatorCommand = "~/bin/my-statusline.sh"
+        let fragment = #"{"statusLine":{"type":"command","command":"\#(operatorCommand)"}}"#
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil, sessionKey: UUID().uuidString, extraSettingsJSON: fragment)
+
+        let entry = try #require(try statusLine(inOverlayAt: path))
+        #expect(entry["command"] as? String == operatorCommand)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/StatuslineTeeTests.swift
+++ b/Tests/TBDDaemonTests/StatuslineTeeTests.swift
@@ -1,0 +1,489 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Tier 2. The tee is a shell script whose whole contract is behavioral — what
+/// it prints, what status it exits with, what lands on disk — so it is executed
+/// for real against a temp directory rather than string-matched. Asserting on
+/// the source text would prove only that the source text is what it is.
+///
+/// Nested under `TBDHomeSerialized`: the path-derivation and cleanup cases
+/// mutate the process-global `TBD_HOME`.
+extension TBDHomeSerialized {
+@Suite struct StatuslineTeeTests {
+
+    // MARK: - Harness
+
+    /// One scratch directory with the tee script written into it, and a runner.
+    private struct Fixture {
+        let root: URL
+        let scriptPath: String
+        let capturePath: String
+
+        /// - Parameters:
+        ///   - body: the script to install. Defaults to the shipped one; the
+        ///     fault-injection cases below pass a copy of it with exactly one
+        ///     line replaced, so the code under test stays the real script.
+        ///   - capture: where the tee should publish. Defaults to a file in
+        ///     this fixture's own scratch directory.
+        init(body: String = StatuslineTee.scriptBody, capture: String? = nil) throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tbd-tee-test-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            scriptPath = root.appendingPathComponent("statusline-tee.sh").path
+            capturePath = capture ?? root.appendingPathComponent("capture.json").path
+            try Data(body.utf8).write(to: URL(fileURLWithPath: scriptPath))
+        }
+
+        func cleanUp() {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        struct Run {
+            let stdout: String
+            let stderr: String
+            let status: Int32
+        }
+
+        /// Run the tee with `payload` on stdin and `delegate` as its second
+        /// argument, exactly as Claude Code would run the installed command.
+        ///
+        /// - Parameter shell: the interpreter. Defaults to `/bin/sh`, which is
+        ///   what Claude Code invokes. The strict-POSIX case below passes
+        ///   `/bin/dash` instead, because macOS `/bin/sh` is bash and bash is
+        ///   lax about exactly the thing that branch is written to survive.
+        ///   The `environment` overlay is merged over the inherited one; the
+        ///   between-the-opens case below uses it to give the script a `TMPDIR`
+        ///   it owns, so the buffer's directory can be taken away underneath it.
+        func run(
+            payload: String, delegate: String, capture: String? = nil,
+            shell: String = "/bin/sh", environment: [String: String] = [:]
+        ) throws -> Run {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: shell)
+            process.arguments = [scriptPath, capture ?? capturePath, delegate]
+            if !environment.isEmpty {
+                process.environment = ProcessInfo.processInfo.environment
+                    .merging(environment) { _, new in new }
+            }
+            let stdin = Pipe(), stdout = Pipe(), stderr = Pipe()
+            process.standardInput = stdin
+            process.standardOutput = stdout
+            process.standardError = stderr
+            try process.run()
+            stdin.fileHandleForWriting.write(Data(payload.utf8))
+            try stdin.fileHandleForWriting.close()
+            let out = stdout.fileHandleForReading.readDataToEndOfFile()
+            let err = stderr.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return Run(
+                stdout: String(decoding: out, as: UTF8.self),
+                stderr: String(decoding: err, as: UTF8.self),
+                status: process.terminationStatus
+            )
+        }
+
+        func captureBytes(_ path: String? = nil) -> Data? {
+            FileManager.default.contents(atPath: path ?? capturePath)
+        }
+    }
+
+    // MARK: - The script's real behavior
+
+    @Test func delegateStdoutPassesThroughAndCaptureHoldsExactStdin() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let payload = #"{"session_id":"abc","context_window":{"context_window_size":200000}}"#
+
+        let run = try fixture.run(payload: payload, delegate: "echo STATUS-FROM-OPERATOR")
+
+        #expect(run.stdout == "STATUS-FROM-OPERATOR\n")
+        #expect(run.status == 0)
+        #expect(fixture.captureBytes() == Data(payload.utf8))
+    }
+
+    @Test func delegateReceivesThePayloadOnItsOwnStdin() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let payload = #"{"model":{"display_name":"Opus"}}"#
+
+        // `cat` proves the delegate got the bytes, not just that it ran.
+        let run = try fixture.run(payload: payload, delegate: "cat")
+
+        #expect(run.stdout == payload)
+        #expect(run.status == 0)
+    }
+
+    @Test func noDelegateExitsZeroAndPrintsNothingButStillCaptures() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let payload = #"{"cwd":"/tmp/x"}"#
+
+        let run = try fixture.run(payload: payload, delegate: "")
+
+        // Printing anything here would claim a status-line slot nobody gave
+        // TBD; exiting non-zero would blank one the operator may still own.
+        #expect(run.stdout.isEmpty)
+        #expect(run.status == 0)
+        #expect(fixture.captureBytes() == Data(payload.utf8))
+    }
+
+    @Test func failingDelegatePropagatesItsStatusAndCaptureStillLands() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let payload = #"{"v":1}"#
+
+        let run = try fixture.run(payload: payload, delegate: "exit 7")
+
+        // Propagated, not swallowed: a broken operator statusline must fail
+        // exactly as it would have without the tee in the path.
+        #expect(run.status == 7)
+        #expect(fixture.captureBytes() == Data(payload.utf8))
+    }
+
+    @Test func unwritableCapturePathStillRunsTheDelegateAndSaysNothing() throws {
+        let fixture = try Fixture()
+        defer {
+            // Restore write permission first or the tree cannot be removed.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: fixture.root.appendingPathComponent("sealed").path)
+            fixture.cleanUp()
+        }
+        let sealed = fixture.root.appendingPathComponent("sealed")
+        try FileManager.default.createDirectory(at: sealed, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: sealed.path)
+        let unwritable = sealed.appendingPathComponent("nested").appendingPathComponent("cap.json").path
+
+        let run = try fixture.run(payload: #"{"v":2}"#, delegate: "echo STILL-RAN", capture: unwritable)
+
+        #expect(run.stdout == "STILL-RAN\n")
+        #expect(run.status == 0)
+        // Quiet in this branch too: nothing on stderr either, and no temp file
+        // left behind next to the path it could not write.
+        #expect(run.stderr.isEmpty)
+        #expect(fixture.captureBytes(unwritable) == nil)
+    }
+
+    @Test func payloadWithShellMetacharactersRoundTripsByteIdentical() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        // Every expansion trigger a repo path can carry: command substitution
+        // in both spellings, a bare variable, quotes, a backslash, a newline.
+        let payload = """
+        {"cwd":"/Users/x/$(touch \(fixture.root.path)/PWNED)/`touch \
+        \(fixture.root.path)/PWNED2`/${HOME}/it's \\"quoted\\"\\\\odd",
+        "extra":"line two"}
+        """
+
+        let run = try fixture.run(payload: payload, delegate: "cat")
+
+        #expect(fixture.captureBytes() == Data(payload.utf8))
+        #expect(run.stdout == payload)
+        // Nothing was expanded on the way through — the payload is data, and
+        // the two witnesses a substitution would have created do not exist.
+        #expect(!FileManager.default.fileExists(atPath: fixture.root.appendingPathComponent("PWNED").path))
+        #expect(!FileManager.default.fileExists(atPath: fixture.root.appendingPathComponent("PWNED2").path))
+    }
+
+    @Test func capturePublishesAtomicallyRatherThanInPlace() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        // A pre-existing capture is replaced wholesale, and no `.tmp` sibling
+        // survives — the rename either happened or was cleaned up.
+        try Data("STALE-AND-MUCH-LONGER-THAN-THE-NEW-ONE".utf8)
+            .write(to: URL(fileURLWithPath: fixture.capturePath))
+
+        _ = try fixture.run(payload: "{}", delegate: "")
+
+        #expect(fixture.captureBytes() == Data("{}".utf8))
+        let siblings = try FileManager.default.contentsOfDirectory(atPath: fixture.root.path)
+        #expect(!siblings.contains { $0.hasSuffix(".tmp") })
+    }
+
+    // MARK: - Fault injection: the two branches a live run cannot be made to take
+
+    /// A tee killed between writing its temp and renaming it must leave a file
+    /// the startup sweep can collect, or `~/tbd/runtime` accumulates one orphan
+    /// per interrupted statusline render, forever.
+    ///
+    /// The kill is injected by replacing exactly the publish line with `exit 0`
+    /// — everything up to it, the temp's name included, is the shipped script.
+    /// A real signal cannot be timed into that window deterministically.
+    @Test func aTeeKilledBeforeThePublishLeavesOnlyASweepableTemp() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tee-orphan-\(UUID().uuidString)")
+        let prior = setTBDHome(tmp.path)
+        defer {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        let publish = #"mv -f "$TMP" "$CAPTURE" 2>/dev/null || rm -f "$TMP" 2>/dev/null"#
+        #expect(StatuslineTee.scriptBody.contains(publish), "the publish line moved; re-derive this injection")
+        let killed = StatuslineTee.scriptBody.replacingOccurrences(of: publish, with: "exit 0")
+        let key = UUID().uuidString
+        let fixture = try Fixture(body: killed, capture: StatuslineTee.capturePath(sessionKey: key))
+        defer { fixture.cleanUp() }
+
+        let run = try fixture.run(payload: #"{"context_window":{"context_window_size":200000}}"#, delegate: "")
+
+        #expect(run.stderr.isEmpty)
+        // Died before the rename, so nothing was published and the temp is the
+        // only thing on disk — the state the sweep has to be able to reason about.
+        #expect(fixture.captureBytes() == nil)
+        let stranded = try FileManager.default.contentsOfDirectory(atPath: TBDConstants.runtimeDir.path)
+        #expect(stranded.count == 1, "expected exactly the stranded temp, saw \(stranded)")
+
+        StatuslineTee.pruneOrphanedCaptures(liveSessionKeys: [key])
+
+        // The session is LIVE, so its capture would have survived; the temp is
+        // collected anyway, which is the whole point of the name it carries.
+        let remaining = try FileManager.default.contentsOfDirectory(atPath: TBDConstants.runtimeDir.path)
+        #expect(remaining.isEmpty, "the startup sweep cannot collect the tee's temp: \(remaining)")
+    }
+
+    /// The buffer opens are the one redirection the script does not silence,
+    /// and an `exec` whose redirection fails is reported by the shell and ends
+    /// the script — which blanks the status line the whole file exists to
+    /// protect. Injected by pointing the buffer at a directory that is not
+    /// there, since a buffer `mktemp` just created cannot be made to fail.
+    @Test func anUnopenableBufferStaysQuietAndStillRunsTheDelegate() throws {
+        let mktemp = #"BUF=$(mktemp "${TMPDIR:-/tmp}/tbd-statusline-XXXXXX" 2>/dev/null) || BUF="#
+        #expect(StatuslineTee.scriptBody.contains(mktemp), "the buffer line moved; re-derive this injection")
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tee-nobuf-\(UUID().uuidString)")
+        let unopenable = StatuslineTee.scriptBody.replacingOccurrences(
+            of: mktemp, with: "BUF=\(root.path)/absent/buffer")
+        let fixture = try Fixture(body: unopenable)
+        defer { fixture.cleanUp() }
+
+        let run = try fixture.run(payload: #"{"v":9}"#, delegate: "echo STILL-RAN")
+
+        // Same contract as every other failure branch: nothing said, nothing
+        // blanked, and the operator's own statusline still runs on the payload.
+        #expect(run.stderr.isEmpty)
+        #expect(run.stdout == "STILL-RAN\n")
+        #expect(run.status == 0)
+        #expect(fixture.captureBytes() == nil)
+    }
+
+    /// The same branch again, under a **strict POSIX shell**, because that is
+    /// the only place the guard is load-bearing and the only place it was false.
+    ///
+    /// `exec` is a POSIX special built-in, and a redirection error on a special
+    /// built-in is fatal to a non-interactive shell regardless of what encloses
+    /// it. `dash` therefore exits 2 the instant the buffer open fails: the
+    /// `if !` never evaluates, the `2>/dev/null` never applies, the delegate
+    /// never runs, and the operator's status line goes blank — the one outcome
+    /// this whole file is written to prevent. bash and zsh are laxer, so the
+    /// case above passes under macOS `/bin/sh` whether or not the script is
+    /// correct, which is exactly why it could not catch this.
+    ///
+    /// The script's own header promises POSIX `sh` with no bashisms, so the
+    /// claim is tested against one. `/bin/dash` is an Apple system binary
+    /// (`com.apple.dash`); its absence is asserted rather than skipped, because
+    /// a skip here would silently retire the only arm that proves the claim.
+    @Test func everyBranchStaysQuietAndNonFatalUnderAStrictPOSIXShell() throws {
+        let dash = "/bin/dash"
+        #expect(FileManager.default.isExecutableFile(atPath: dash),
+                "/bin/dash is gone; it is the only strict POSIX shell this suite runs the tee under — find another rather than dropping the case")
+
+        // 1. The ordinary path still works there: three descriptors on one
+        //    inode, an atomic publish, and the payload replayed to the delegate.
+        let healthy = try Fixture()
+        defer { healthy.cleanUp() }
+        let payload = #"{"context_window":{"context_window_size":200000}}"#
+
+        let good = try healthy.run(payload: payload, delegate: "cat", shell: dash)
+
+        #expect(good.stdout == payload)
+        #expect(good.stderr.isEmpty)
+        #expect(good.status == 0)
+        #expect(healthy.captureBytes() == Data(payload.utf8))
+
+        // 2. And the unopenable-buffer branch is handled rather than fatal.
+        //    Same injection as the case above — the buffer points somewhere
+        //    that is not there — so the code under test is the shipped script.
+        let mktemp = #"BUF=$(mktemp "${TMPDIR:-/tmp}/tbd-statusline-XXXXXX" 2>/dev/null) || BUF="#
+        #expect(StatuslineTee.scriptBody.contains(mktemp), "the buffer line moved; re-derive this injection")
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tee-dash-\(UUID().uuidString)")
+        let unopenable = StatuslineTee.scriptBody.replacingOccurrences(
+            of: mktemp, with: "BUF=\(root.path)/absent/buffer")
+        let broken = try Fixture(body: unopenable)
+        defer { broken.cleanUp() }
+
+        let run = try broken.run(payload: #"{"v":9}"#, delegate: "echo STILL-RAN", shell: dash)
+
+        // Before the fix this arm reported status 2, empty stdout and an empty
+        // capture: the shell died on the redirection and took the operator's
+        // status line with it.
+        #expect(run.stdout == "STILL-RAN\n", "the delegate never ran under \(dash)")
+        #expect(run.status == 0, "the tee exited \(run.status) under \(dash) instead of deferring to the delegate")
+        #expect(run.stderr.isEmpty, "the tee spoke up under \(dash): \(run.stderr)")
+        #expect(broken.captureBytes() == nil)
+    }
+
+    /// The residual the probe cannot cover: the buffer's directory goes away
+    /// **between** the probe and the real opens.
+    ///
+    /// The probe proves the path was openable a moment ago and nothing more.
+    /// The buffer lives in `$TMPDIR`, a per-user directory a cleaner or a
+    /// sibling process can empty at any moment, so the second open can still
+    /// fail — and there the shell is already dying: `!`, `||` and `2>/dev/null`
+    /// are all inert against a redirection error on a POSIX special built-in.
+    /// Before the EXIT-trap fallback, `dash` exited 2 here having printed
+    /// nothing, the delegate never ran, and the operator's status line blanked.
+    ///
+    /// Injected by inserting one `rm -rf "$TMPDIR"` immediately before the real
+    /// opens, with `TMPDIR` pointed at a directory this fixture owns — so the
+    /// script under test is the shipped one and the window is the real one.
+    /// Run under both shells: `dash` is where the branch is load-bearing, and
+    /// macOS `/bin/sh` is what Claude Code actually invokes.
+    @Test(arguments: ["/bin/dash", "/bin/sh"])
+    func aBufferThatVanishesBetweenTheProbeAndTheOpensStillRunsTheDelegate(shell: String) throws {
+        #expect(FileManager.default.isExecutableFile(atPath: shell),
+                "\(shell) is gone; it is one of the two shells this branch is proven under — find another rather than dropping the case")
+        let realOpens = #"if ! { exec 3>"$BUF" 4<"$BUF" 5<"$BUF"; } 2>/dev/null; then"#
+        #expect(StatuslineTee.scriptBody.contains(realOpens),
+                "the buffer opens moved; re-derive this injection")
+        let vanishing = StatuslineTee.scriptBody.replacingOccurrences(
+            of: realOpens, with: "rm -rf \"$TMPDIR\"\n" + realOpens)
+        let fixture = try Fixture(body: vanishing)
+        defer { fixture.cleanUp() }
+        let tmpdir = fixture.root.appendingPathComponent("buffers")
+        try FileManager.default.createDirectory(at: tmpdir, withIntermediateDirectories: true)
+
+        let run = try fixture.run(
+            payload: #"{"v":11}"#, delegate: "echo STILL-RAN",
+            shell: shell, environment: ["TMPDIR": tmpdir.path])
+
+        // Same contract as every other failure branch: nothing said, nothing
+        // blanked, and the operator's own statusline still runs on the payload.
+        #expect(run.stdout == "STILL-RAN\n", "the delegate never ran under \(shell)")
+        #expect(run.status == 0,
+                "the tee exited \(run.status) under \(shell) instead of deferring to the delegate")
+        #expect(run.stderr.isEmpty, "the tee spoke up under \(shell): \(run.stderr)")
+        #expect(fixture.captureBytes() == nil)
+        // The buffer's directory is gone, so nothing can have leaked into it,
+        // and nothing leaked beside the capture either.
+        let siblings = try FileManager.default.contentsOfDirectory(atPath: fixture.root.path)
+        #expect(!siblings.contains { $0.hasSuffix(".tmp.json") }, "left a temp behind: \(siblings)")
+    }
+
+    // MARK: - The daemon-side write
+
+    /// One log line, one privacy decision. `path` is `.private`, and a
+    /// Foundation file error routinely embeds that same filename and its
+    /// containing folder — so a `.public` error beside it prints in the clear
+    /// exactly what the interpolation next to it redacts.
+    ///
+    /// Asserted against the source text because a privacy annotation has no
+    /// runtime surface a test can read back: `os.Logger` resolves it inside the
+    /// logging system, and `OSLogMessage` exposes nothing about it. A source
+    /// pin is a weak instrument in general; here it is the only one, and the
+    /// property it pins is exact.
+    @Test func theWriteFailureLogsThePathAndTheErrorAtTheSamePrivacy() throws {
+        let source = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // Tests/TBDDaemonTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repo root
+            .appendingPathComponent("Sources/TBDDaemon/Claude/StatuslineTee.swift")
+        let text = try String(contentsOf: source, encoding: .utf8)
+        let line = try #require(
+            text.split(separator: "\n").first { $0.contains("Failed to write statusline tee at") },
+            "the write-failure log line moved; re-derive this check")
+
+        #expect(line.contains("\\(path, privacy: .private)"))
+        #expect(line.contains("\\(error.localizedDescription, privacy: .private)"),
+                "the error is logged at a different privacy than the path it names: \(line)")
+    }
+
+    // MARK: - Installed command and on-disk paths
+
+    @Test func writeScriptLandsExecutableUnderTBDHome() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tee-write-\(UUID().uuidString)")
+        let prior = setTBDHome(tmp.path)
+        defer {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        #expect(StatuslineTee.writeScript())
+
+        let path = StatuslineTee.scriptPath
+        #expect(path == tmp.appendingPathComponent("runtime/statusline-tee.sh").path)
+        let mode = try #require(
+            try FileManager.default.attributesOfItem(atPath: path)[.posixPermissions] as? NSNumber)
+        #expect(mode.int16Value == 0o755)
+    }
+
+    @Test func statusLineCommandEscapesAllThreeArguments() {
+        let command = StatuslineTee.statusLineCommand(
+            capturePath: "/tmp/it's odd/cap.json",
+            delegateCommand: "printf '%s' \"$(date)\""
+        )
+        // Single-quoted with the `'\''` escape, so a quote in a path or in the
+        // operator's own command cannot break out into a new shell word.
+        #expect(command.hasPrefix("sh '"))
+        #expect(command.contains("/tmp/it'\\''s odd/cap.json'"))
+        #expect(command.contains("'printf '\\''%s'\\'' \"$(date)\"'"))
+    }
+
+    @Test func statusLineCommandWithNoDelegatePassesAnEmptyArgument() {
+        let command = StatuslineTee.statusLineCommand(capturePath: "/tmp/c.json", delegateCommand: nil)
+        // The empty third argument is what the script's no-delegate branch
+        // tests for — dropping it would shift argv and silently break both.
+        #expect(command.hasSuffix(" ''"))
+    }
+
+    // MARK: - Cleanup
+
+    @Test func captureIsRemovedWithThePerSessionOverlay() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tee-clean-\(UUID().uuidString)")
+        let prior = setTBDHome(tmp.path)
+        defer {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        let key = UUID().uuidString
+        let overlay = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil, sessionKey: key,
+            watchDeskRole: .readOnlyCoordinator, worktreePath: nil)
+        let capture = StatuslineTee.capturePath(sessionKey: key)
+        try Data("{}".utf8).write(to: URL(fileURLWithPath: capture))
+        #expect(FileManager.default.fileExists(atPath: capture))
+
+        ClaudeHookOverlay.removePerSessionOverlay(sessionKey: key)
+
+        #expect(!FileManager.default.fileExists(atPath: overlay))
+        #expect(!FileManager.default.fileExists(atPath: capture))
+    }
+
+    @Test func orphanedCapturesArePrunedAndLiveOnesSurvive() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tee-prune-\(UUID().uuidString)")
+        let prior = setTBDHome(tmp.path)
+        defer {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        try FileManager.default.createDirectory(
+            at: TBDConstants.runtimeDir, withIntermediateDirectories: true)
+        let live = UUID().uuidString, orphan = UUID().uuidString
+        for key in [live, orphan] {
+            try Data("{}".utf8).write(
+                to: URL(fileURLWithPath: StatuslineTee.capturePath(sessionKey: key)))
+        }
+
+        ClaudeHookOverlay.pruneOrphanedSessionOverlays(liveSessionKeys: [live])
+
+        #expect(FileManager.default.fileExists(atPath: StatuslineTee.capturePath(sessionKey: live)))
+        #expect(!FileManager.default.fileExists(atPath: StatuslineTee.capturePath(sessionKey: orphan)))
+    }
+}
+}

--- a/Tests/TBDDaemonTests/SwapProfileStatuslineTeeTests.swift
+++ b/Tests/TBDDaemonTests/SwapProfileStatuslineTeeTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The statusline tee across `terminal.swapProfile` — "Switch account" on a
+/// Watch Desk.
+///
+/// An `.inPlace` swap keeps the terminal row (`plannedTerminalID ==
+/// oldTerminal.id`) and never touches `watch_desk_role`, so the row goes on
+/// claiming to be a desk across the respawn. Resolving the overlay without that
+/// role would leave it running with no tee — and, because a roleless resolve
+/// deletes the session's capture, with no denominator either — while
+/// `session.states` keeps reporting "the tee is installed but has not fired
+/// yet" forever.
+///
+/// A `.fork` swap is the opposite case: it mints a fresh row branded no desk, so
+/// its overlay must carry no tee or the two would disagree the other way.
+///
+/// Nested under `TBDHomeSerialized`: the per-session overlay and the capture
+/// path resolve through the process-global `TBD_HOME`.
+extension TBDHomeSerialized {
+@Suite struct SwapProfileStatuslineTeeTests {
+
+    private struct Scratch {
+        let home: URL
+        let prior: String?
+        init() {
+            home = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tbd-swap-tee-\(UUID().uuidString)", isDirectory: true)
+            prior = setTBDHome(home.path)
+        }
+        func cleanUp() {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: home)
+        }
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let terminal: Terminal
+    }
+
+    private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-swap-tee-claude-\(UUID().uuidString)", isDirectory: true)
+        return ClaudeProfileConfigDirManager(
+            baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+            hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true))
+    }
+
+    /// A live (unparked) Claude terminal, optionally branded a desk, in a
+    /// worktree whose path exists on disk.
+    ///
+    /// - Parameter withConversation: when true the session's transcript carries
+    ///   a user message, so `isSessionBlank` is false and the swap takes the
+    ///   **resume** branch; when false it takes the **fresh** branch. Both
+    ///   branches resolve their own overlay, so both are covered.
+    private func makeFixture(
+        _ scratch: Scratch, desk: Bool, withConversation: Bool
+    ) async throws -> Fixture {
+        let repoPath = scratch.home.appendingPathComponent("repo", isDirectory: true).path
+        try FileManager.default.createDirectory(atPath: repoPath, withIntermediateDirectories: true)
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "repo", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main", path: repoPath,
+            tmuxServer: "tbd-swap-tee")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-swap", kind: .claude,
+            watchDeskRole: desk ? .readOnlyCoordinator : nil)
+        if withConversation {
+            let transcript = scratch.home.appendingPathComponent("sess-swap.jsonl").path
+            let record = #"{"type":"user","message":{"content":"hello"}}"# + "\n"
+            try Data(record.utf8).write(to: URL(fileURLWithPath: transcript))
+            try await db.terminals.updateSession(
+                id: terminal.id, sessionID: "sess-swap", transcriptPath: transcript)
+        }
+        let tmux = TmuxManager(dryRun: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let reloaded = try #require(try await db.terminals.get(id: terminal.id))
+        return Fixture(db: db, router: router, terminal: reloaded)
+    }
+
+    private func swap(
+        _ fixture: Fixture, mode: TerminalSwapMode
+    ) async throws -> RPCResponse {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: fixture.terminal.id, newProfileID: nil, mode: mode))
+        return await fixture.router.handle(request)
+    }
+
+    private func statusLineCommand(forSessionKey key: String) -> String? {
+        let path = ClaudeHookOverlay.perSessionOverlayPath(sessionKey: key)
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entry = parsed["statusLine"] as? [String: Any] else {
+            return nil
+        }
+        return entry["command"] as? String
+    }
+
+    // MARK: -
+
+    @Test(arguments: [true, false])
+    func anInPlaceSwapOnADeskKeepsTheStatuslineTee(withConversation: Bool) async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let fixture = try await makeFixture(
+            scratch, desk: true, withConversation: withConversation)
+
+        let response = try await swap(fixture, mode: .inPlace)
+        #expect(response.error == nil, "swap errored: \(response.error ?? "")")
+
+        // The row still claims to be a desk…
+        let after = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
+        #expect(after.watchDeskRole != nil)
+        // …so the overlay it just respawned with had better install the tee.
+        let command = try #require(
+            statusLineCommand(forSessionKey: fixture.terminal.id.uuidString),
+            "an in-place swap on a desk produced an overlay with no statusLine")
+        #expect(command.contains(StatuslineTee.scriptPath))
+        // The row is reused, so the capture path is too — and it must still be
+        // the one the tee publishes to.
+        #expect(command.contains(
+            StatuslineTee.capturePath(sessionKey: fixture.terminal.id.uuidString)))
+    }
+
+    @Test func anInPlaceSwapOnAnOrdinaryTerminalInstallsNoStatusline() async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let fixture = try await makeFixture(scratch, desk: false, withConversation: true)
+
+        let response = try await swap(fixture, mode: .inPlace)
+        #expect(response.error == nil, "swap errored: \(response.error ?? "")")
+
+        // TBD's per-session `--settings` outranks the operator's `statusLine` in
+        // every scope they can write, so a leak here takes over a slot they own.
+        #expect(statusLineCommand(forSessionKey: fixture.terminal.id.uuidString) == nil)
+    }
+
+    /// The other direction of the same rule. A fork mints a fresh row branded
+    /// no desk (`forkSwapNewTab` passes no role), so carrying the source row's
+    /// role onto its overlay would install a tee on a session the desk
+    /// machinery does not consider a desk.
+    @Test func aForkSwapDoesNotCarryTheSourceRowsDeskRole() async throws {
+        let scratch = Scratch()
+        defer { scratch.cleanUp() }
+        let fixture = try await makeFixture(scratch, desk: true, withConversation: true)
+
+        let response = try await swap(fixture, mode: .fork)
+        #expect(response.error == nil, "swap errored: \(response.error ?? "")")
+
+        let terminals = try await fixture.db.terminals.list(worktreeID: fixture.terminal.worktreeID)
+        let forked = try #require(terminals.first { $0.id != fixture.terminal.id },
+                                  "a fork swap created no new terminal")
+        #expect(forked.watchDeskRole == nil)
+        #expect(statusLineCommand(forSessionKey: forked.id.uuidString) == nil)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
+++ b/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
@@ -31,7 +31,7 @@ struct TerminalCloseRailsTests {
         var terminal = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "Build", claudeSessionID: claudeSessionID, kind: .claude)
-        try await db.terminals.setActivityState(id: terminal.id, activityState: activityState)
+        try await db.terminals.setActivityState(id: terminal.id, activityState: activityState, source: .derived)
         terminal = try #require(try await db.terminals.get(id: terminal.id))
         return Fixture(db: db, worktree: wt, terminal: terminal)
     }

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -152,6 +152,68 @@ struct TerminalSessionEventHandlerTests {
         #expect(updated?.transcriptPath == "/abs/s1.jsonl")
     }
 
+    /// A `/clear`, a resume after an in-place profile swap, and a hand relaunch
+    /// all arrive here as one event: a NEW session context in this pane. A
+    /// prompt recorded against the previous one died with it.
+    ///
+    /// Nothing else retracts it. `SessionStateResolver`'s rung 4 keeps a
+    /// standing `promptOnScreen` live while the transcript has not grown past
+    /// it, and after a `/clear` the new `transcriptPath` points at a file Claude
+    /// Code creates lazily — so the growth fact is absent and "we could not look
+    /// is not evidence it went away" pins the dead prompt in place. The
+    /// overlay's own `tbd terminal-activity idle` does not save it either: this
+    /// row already reads idle, and `handleTerminalActivityEvent` returns early
+    /// on an unchanged state without rewriting provenance.
+    @Test("SessionStart retracts a wait reason recorded against the previous session")
+    func sessionStartRetractsAStandingWaitReason() async throws {
+        let (terminal, _) = try await makeTerminal(initialSession: "old-id")
+        let idleAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let promptAt = idleAt.addingTimeInterval(60)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .idle, source: .hookEvent("Stop"),
+            observedAt: idleAt)
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: AwaitingInputReason(
+                message: "Claude needs your permission to use Bash",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: promptAt)
+
+        let before = try #require(try await db.terminals.get(id: terminal.id))
+        guard case .awaitingInput = SessionStateResolver()
+            .resolve(SessionStateFacts(terminal: before)).value else {
+            Issue.record("precondition: the prompt should read as live before the SessionStart")
+            return
+        }
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "cleared-id",
+                transcriptPath: "/Users/me/.claude/projects/-x/cleared-id.jsonl",
+                source: "clear"
+            )
+        ))
+        #expect(response.success)
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.awaitingInputReason == nil)
+        #expect(after.awaitingInputObservedAt == nil)
+        // The composed answer no longer reports a wait that ended.
+        let state = SessionStateResolver().resolve(SessionStateFacts(terminal: after))
+        #expect(state.value == .idle)
+
+        // And the retraction did NOT reach for `setActivityState`: this event
+        // says a session exists, not what it is doing, and `activityState` is
+        // what `HibernationGate.blockingRail` gates on. All three activity
+        // columns survive unchanged, provenance included.
+        #expect(after.activityState == .idle)
+        #expect(after.activityStateSource == .hookEvent("Stop"))
+        #expect(after.activityStateObservedAt == idleAt)
+    }
+
     @Test("unknown terminalID is a soft no-op (success, no error)")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -416,6 +416,45 @@ import TBDShared
         #expect(try await db.worktrees.allPRStatuses()[wt.id] == nil)
     }
 
+    /// The hydration scope, asserted per status rather than as "active only".
+    ///
+    /// The maps these two feed are handed out whole in every `pr.list`, so
+    /// archived rows — the set that never stops growing, and that the poller
+    /// (`list(status: .active)`) would never refresh — must stay out. `.main`,
+    /// `.creating` and `.failed` are outside the poller's scope too, but they
+    /// are bounded and `pr.refresh` accepts any worktree id, so a value recorded
+    /// on one of them is real and must survive a restart. Narrowing to `.active`
+    /// dropped their icons at startup.
+    @Test func prHydrationCoversEveryUnarchivedStatusAndNoArchivedOne() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let status = PRStatus(number: 7, url: "https://example.com/pr/7", state: .mergeable)
+        let observation = PRObservation(outcome: .observed, observedAt: Date())
+
+        var ids: [WorktreeStatus: UUID] = [:]
+        for wtStatus in [WorktreeStatus.active, .main, .creating, .failed, .archived] {
+            let wt = try await db.worktrees.create(
+                repoID: repo.id, name: "wt-\(wtStatus.rawValue)", branch: "b-\(wtStatus.rawValue)",
+                path: "/tmp/pr-scope-\(UUID())", tmuxServer: "srv", status: wtStatus)
+            try await db.worktrees.setPRStatus(id: wt.id, status: status)
+            try await db.worktrees.setPRObservation(id: wt.id, observation: observation)
+            ids[wtStatus] = wt.id
+        }
+
+        let statuses = try await db.worktrees.allPRStatuses()
+        let observations = try await db.worktrees.allPRObservations()
+
+        for wtStatus in [WorktreeStatus.active, .main, .creating, .failed] {
+            let id = try #require(ids[wtStatus])
+            #expect(statuses[id] == status, "\(wtStatus.rawValue) lost its PR status at hydration")
+            #expect(observations[id] != nil,
+                    "\(wtStatus.rawValue) lost its PR observation at hydration")
+        }
+        let archived = try #require(ids[.archived])
+        #expect(statuses[archived] == nil)
+        #expect(observations[archived] == nil)
+    }
+
     // MARK: - scratchOnly filter
 
     /// `scratchOnly: true` + `status: .archived` must return exactly the

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -571,3 +571,142 @@ import Testing
     let decoded = try JSONDecoder().decode(PRStatus.self, from: data)
     #expect(decoded.mergeQueuePosition == 2)
 }
+
+// MARK: - `sameValue(as:)` — change detection without the freshness stamp
+
+/// The rule this method exists to enforce: a fact *about* a reading may never
+/// decide whether the reading changed. `observedAt` advances every poll, so an
+/// "on change" test built on `==` fires every poll — which is exactly how
+/// persist-on-change became persist-every-poll on a forty-worktree fleet.
+@Test func prStatusSameValueIgnoresOnlyTheObservedAtStamp() {
+    let base = PRStatus(number: 7, url: "https://github.com/acme/acme-prod/pull/7",
+                        state: .mergeable, reason: "Ready to merge",
+                        mergeQueuePosition: nil,
+                        observedAt: Date(timeIntervalSince1970: 1_700_000_000))
+    let reRead = PRStatus(number: 7, url: "https://github.com/acme/acme-prod/pull/7",
+                          state: .mergeable, reason: "Ready to merge",
+                          mergeQueuePosition: nil,
+                          observedAt: Date(timeIntervalSince1970: 1_700_000_600))
+
+    #expect(base != reRead, "Equatable deliberately keeps the stamp")
+    #expect(base.sameValue(as: reRead))
+}
+
+@Test func prStatusSameValueSeesEveryValueField() {
+    let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+    let base = PRStatus(number: 7, url: "https://github.com/acme/acme-prod/pull/7",
+                        state: .mergeable, reason: "Ready to merge",
+                        files: ["a.swift"], commits: 3,
+                        authorWorktreeID: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA"),
+                        mergeQueuePosition: 1, observedAt: stamp)
+    // Each field, one at a time — a `sameValue` that forgot one would let a
+    // real change go unpersisted, which is the opposite and worse failure.
+    let variants: [PRStatus] = [
+        PRStatus(number: 8, url: base.url, state: base.state, reason: base.reason,
+                 files: base.files, commits: base.commits,
+                 authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: stamp),
+        PRStatus(number: base.number, url: "https://github.com/acme/acme-prod/pull/8",
+                 state: base.state, reason: base.reason, files: base.files,
+                 commits: base.commits, authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: stamp),
+        PRStatus(number: base.number, url: base.url, state: .closed, reason: base.reason,
+                 files: base.files, commits: base.commits,
+                 authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: stamp),
+        PRStatus(number: base.number, url: base.url, state: base.state, reason: "Blocked",
+                 files: base.files, commits: base.commits,
+                 authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: stamp),
+        PRStatus(number: base.number, url: base.url, state: base.state, reason: base.reason,
+                 files: ["b.swift"], commits: base.commits,
+                 authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: stamp),
+        PRStatus(number: base.number, url: base.url, state: base.state, reason: base.reason,
+                 files: base.files, commits: 4, authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: stamp),
+        PRStatus(number: base.number, url: base.url, state: base.state, reason: base.reason,
+                 files: base.files, commits: base.commits, authorWorktreeID: UUID(),
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: stamp),
+        PRStatus(number: base.number, url: base.url, state: base.state, reason: base.reason,
+                 files: base.files, commits: base.commits,
+                 authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: 2, observedAt: stamp)
+    ]
+    for variant in variants {
+        #expect(!base.sameValue(as: variant), "sameValue missed a changed field: \(variant)")
+    }
+}
+
+// MARK: - The structural half: a ninth field cannot be forgotten
+
+/// `sameValue` must not be a hand-written field list, because a list has to be
+/// remembered. This pins the two halves that together make it structural.
+///
+/// **Half one — `sameValue` is exactly `==` modulo the stamp.** Asserted as an
+/// equivalence over a matrix, so a `sameValue` rewritten as a hand list that
+/// omits any field disagrees with `==` on the pair that differs in it, and this
+/// reds naming the pair.
+@Test func prStatusSameValueAgreesWithEqualityOnStampStrippedValues() {
+    let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+    let later = Date(timeIntervalSince1970: 1_700_000_600)
+    let base = PRStatus(number: 7, url: "https://github.com/acme/acme-prod/pull/7",
+                        state: .mergeable, reason: "Ready to merge",
+                        files: ["a.swift"], commits: 3,
+                        authorWorktreeID: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA"),
+                        mergeQueuePosition: 1, observedAt: stamp)
+    let matrix: [PRStatus] = [
+        base,
+        base.withObservedAt(later),
+        base.withObservedAt(nil),
+        PRStatus(number: 8, url: base.url, state: base.state, reason: base.reason,
+                 files: base.files, commits: base.commits,
+                 authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: base.mergeQueuePosition, observedAt: later),
+        PRStatus(number: base.number, url: base.url, state: .closed, reason: nil,
+                 files: nil, commits: nil, authorWorktreeID: nil,
+                 mergeQueuePosition: nil, observedAt: stamp),
+        PRStatus(number: base.number, url: base.url, state: base.state, reason: base.reason,
+                 files: base.files, commits: base.commits,
+                 authorWorktreeID: base.authorWorktreeID,
+                 mergeQueuePosition: 2, observedAt: stamp)
+    ]
+    for a in matrix {
+        for b in matrix {
+            #expect(a.sameValue(as: b) == (a.withObservedAt(nil) == b.withObservedAt(nil)),
+                    "sameValue disagreed with stamp-stripped equality for \(a) vs \(b)")
+        }
+    }
+}
+
+/// **Half two — `withObservedAt` carries every field.** A copy written with the
+/// memberwise initializer would compile with a new field omitted (every
+/// parameter past `reason` has a default) and silently drop it, which would put
+/// the hole straight back. Asserted against the type's own encoding, so the
+/// field roster comes from `PRStatus` rather than from this test.
+@Test func prStatusWithObservedAtChangesTheStampAndNothingElse() throws {
+    let base = PRStatus(number: 7, url: "https://github.com/acme/acme-prod/pull/7",
+                        state: .mergeable, reason: "Ready to merge",
+                        files: ["a.swift"], commits: 3,
+                        authorWorktreeID: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA"),
+                        mergeQueuePosition: 1,
+                        observedAt: Date(timeIntervalSince1970: 1_700_000_000))
+    let restamped = base.withObservedAt(Date(timeIntervalSince1970: 1_700_000_600))
+
+    func fields(_ status: PRStatus) throws -> [String: String] {
+        let data = try JSONEncoder().encode(status)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return object
+            .filter { $0.key != "observedAt" }
+            .mapValues { String(describing: $0) }
+    }
+
+    let before = try fields(base)
+    #expect(!before.isEmpty)
+    #expect(before == (try fields(restamped)),
+            "withObservedAt dropped or altered a field other than the stamp")
+    #expect(restamped.observedAt == Date(timeIntervalSince1970: 1_700_000_600))
+    // …and putting the original stamp back yields the original value, whole.
+    #expect(restamped.withObservedAt(base.observedAt) == base)
+}

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -52,7 +52,7 @@ struct NightwatchDeskPromptsTests {
     @Test("The only context-ceiling remedy offered is the handoff relay", arguments: liveModes)
     func ceilingRemedyIsTheRelay(mode: NightwatchMode) {
         for (label, text) in prompts(mode: mode, skillDir: "/skill") {
-            let mentionsCeiling = text.contains("600k") || text.lowercased().contains("context ceiling")
+            let mentionsCeiling = text.lowercased().contains("context ceiling")
             #expect(mentionsCeiling, "\(mode) \(label) never states the context ceiling")
 
             #expect(
@@ -316,33 +316,54 @@ struct NightwatchDeskPromptsTests {
             }
         }
 
-        /// The ceiling is the one number in this skill that both prompts quote in
-        /// prose, so a change to `DEFAULT_THRESHOLD` that misses the prose leaves
-        /// the judge acting on a figure the script disagrees with.
+        /// The ceiling is a per-session figure, and the prose must not pretend
+        /// otherwise.
         ///
-        /// The literal fixture is also pinned. `handoff.py --selftest` asserted
-        /// "over ceiling exits 10" against a hardcoded 250_000, which the raise to
-        /// 600k turned into an *under*-ceiling case — the selftest would have kept
-        /// passing while testing the opposite of its label, so the fixture is now
-        /// derived from `DEFAULT_THRESHOLD` and that derivation is what's checked.
-        @Test("The context ceiling is 600k in the script and in every prompt")
+        /// Two properties. The script resolves the ceiling from the window this
+        /// session actually reported through its statusline capture, falling
+        /// back to a fixed guess only when there is nothing to read — so a
+        /// prompt that names a token count is naming a number it cannot know,
+        /// and a desk on a different window is then told to act on someone
+        /// else's ceiling. The prompts therefore point at the script instead.
+        ///
+        /// The fallback is pinned as a literal on purpose: it is the value the
+        /// desk has been running, and a 200k-derived guess below it was measured
+        /// to force a relay roughly every two hours.
+        ///
+        /// The selftest's own fixture is pinned as a derivation for the same
+        /// reason: "over ceiling exits 10" was once written against a hardcoded
+        /// 250_000, and a ceiling that moved past it turned the case into an
+        /// *under*-ceiling one that kept passing while asserting the opposite of
+        /// its label.
+        @Test("The context ceiling is resolved per session, and no prose quotes a fixed one")
         func ceilingIsConsistent() {
-            #expect(NightwatchSkillContent.handoffPy.contains("DEFAULT_THRESHOLD = 600_000"),
-                    "handoff.py's ceiling moved off 600k")
-            #expect(NightwatchSkillContent.handoffPy.contains("over_total = DEFAULT_THRESHOLD + 50_000"),
+            let handoff = NightwatchSkillContent.handoffPy
+            #expect(handoff.contains("CEILING_FRACTION = 0.75"),
+                    "handoff.py's ceiling is no longer three quarters of the window")
+            #expect(handoff.contains("FALLBACK_THRESHOLD = 600_000"),
+                    "handoff.py's no-capture fallback moved off the value the desk has been running")
+            #expect(handoff.contains("window = observed_window(terminal_id)"),
+                    "handoff.py's ceiling stopped reading this session's own reported window")
+            #expect(handoff.contains("over_total = FALLBACK_THRESHOLD + 50_000"),
                     "the selftest's over-ceiling fixture is a literal again; it will rot on the next raise")
-            #expect(NightwatchSkillContent.skillMd.contains("~600k tokens"),
-                    "SKILL.md quotes a ceiling other than the script's")
+            #expect(NightwatchSkillContent.skillMd.contains("handoff.py --check"),
+                    "SKILL.md no longer points at the script as the ceiling's authority")
 
             for mode in NightwatchDeskPromptsTests.liveModes {
                 for (label, text) in [
                     ("initialPrompt", NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: "/skill")),
                     ("judgePrompt", NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: "/skill"))
                 ] {
-                    #expect(!text.contains("200k"),
-                            "\(mode) \(label) still quotes the retired 200k ceiling as current")
-                    #expect(text.contains("600k"),
-                            "\(mode) \(label) does not state the 600k ceiling")
+                    // Any k-suffixed token count in the ceiling prose is a number
+                    // the prompt cannot know. Asserted against every plausible
+                    // spelling rather than the one that was there, since the
+                    // failure is "a figure got written down", not "600k did".
+                    for figure in ["150k", "200k", "600k", "750k", "1000k"] {
+                        #expect(!text.contains(figure),
+                                "\(mode) \(label) quotes a fixed ceiling (\(figure)) the script resolves per session")
+                    }
+                    #expect(text.contains("handoff.py --check"),
+                            "\(mode) \(label) does not point at the script for the ceiling")
                 }
             }
         }

--- a/Tests/TBDSharedTests/SessionStateModelTests.swift
+++ b/Tests/TBDSharedTests/SessionStateModelTests.swift
@@ -1,0 +1,416 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Tier 1. The state model's promise is that a fact never loses its
+/// provenance and never repairs ignorance into confidence. These tests assert
+/// exactly those two things, on the wire and on the composed output a reader
+/// actually sees.
+@Suite struct SessionStateModelTests {
+
+    private let epoch = Date(timeIntervalSince1970: 1_770_000_000)
+
+    private func roundTrip<T: Codable>(_ value: T) throws -> T {
+        try JSONDecoder().decode(T.self, from: JSONEncoder().encode(value))
+    }
+
+    // MARK: - SessionStateValue
+
+    @Test(arguments: [
+        SessionStateValue.working,
+        .idle,
+        .awaitingInput(reason: nil),
+        .awaitingInput(reason: AwaitingInputReason(
+            message: "Claude needs your permission to use Bash",
+            hookEventName: "Notification",
+            raw: #"{"hook_event_name":"Notification"}"#)),
+        .rateLimited(until: nil),
+        .rateLimited(until: Date(timeIntervalSince1970: 1_770_003_600)),
+        .parked(reason: "manual"),
+        .gone,
+        .unknown(why: "transcript unreadable")
+    ])
+    func everyStateRoundTrips(state: SessionStateValue) throws {
+        #expect(try roundTrip(state) == state)
+    }
+
+    /// An unrecognized tag is ignorance, and stays ignorance: it must not throw
+    /// (which would take the whole record with it) and must not become a
+    /// confident value (which would have a supervisor act on a session nobody
+    /// could read).
+    @Test func unrecognizedStateTagDecodesToUnknown() throws {
+        let json = #"{"state":"compacting","detail":"whatever"}"#
+        let decoded = try JSONDecoder().decode(SessionStateValue.self, from: Data(json.utf8))
+
+        #expect(decoded.isConfident == false)
+        guard case .unknown(let why) = decoded else {
+            Issue.record("expected .unknown, got \(decoded)")
+            return
+        }
+        #expect(why == "unrecognized state tag 'compacting'")
+        // And the raw tag survives into anything rendered from it.
+        #expect(decoded.label.contains("compacting"))
+    }
+
+    @Test func onlyUnknownIsUnconfident() {
+        #expect(SessionStateValue.working.isConfident)
+        #expect(SessionStateValue.idle.isConfident)
+        #expect(SessionStateValue.awaitingInput(reason: nil).isConfident)
+        #expect(SessionStateValue.rateLimited(until: nil).isConfident)
+        #expect(SessionStateValue.parked(reason: "manual").isConfident)
+        #expect(SessionStateValue.gone.isConfident)
+        #expect(SessionStateValue.unknown(why: "no source").isConfident == false)
+    }
+
+    /// The reason is carried, never interpreted — so it survives a round trip
+    /// byte for byte, including the raw payload.
+    @Test func awaitingInputReasonIsCarriedVerbatim() throws {
+        let reason = AwaitingInputReason(
+            message: "Claude needs your permission to use Bash",
+            hookEventName: "Notification",
+            raw: #"{"message":"Claude needs your permission to use Bash"}"#)
+        let decoded = try roundTrip(reason)
+        #expect(decoded == reason)
+        #expect(decoded.message == "Claude needs your permission to use Bash")
+        #expect(decoded.raw == #"{"message":"Claude needs your permission to use Bash"}"#)
+    }
+
+    // MARK: - Awaiting-input classification
+
+    struct ClassCase: Sendable, CustomStringConvertible {
+        let type: String?
+        let expected: AwaitingInputClass
+        var description: String { "\(type ?? "<absent>") → \(expected.rawValue)" }
+    }
+
+    /// One case per branch of the classifier, including the two that must
+    /// land in `unrecognized`.
+    @Test(arguments: [
+        ClassCase(type: "permission_prompt", expected: .promptOnScreen),
+        ClassCase(type: "elicitation_dialog", expected: .promptOnScreen),
+        ClassCase(type: "agent_needs_input", expected: .promptOnScreen),
+        ClassCase(type: "idle_prompt", expected: .doneWaiting),
+        ClassCase(type: "auth_success", expected: .informational),
+        ClassCase(type: "elicitation_complete", expected: .informational),
+        ClassCase(type: "elicitation_response", expected: .informational),
+        ClassCase(type: "agent_completed", expected: .informational),
+        ClassCase(type: "a_type_from_a_later_release", expected: .unrecognized),
+        ClassCase(type: nil, expected: .unrecognized)
+    ])
+    func notificationTypeIsFiledUnderItsClass(branch: ClassCase) throws {
+        let reason = AwaitingInputReason(
+            message: "m", hookEventName: "Notification", notificationType: branch.type)
+        #expect(reason.classification == branch.expected)
+        // Verbatim through a round trip, class and all.
+        let decoded = try roundTrip(reason)
+        #expect(decoded.notificationType == branch.type)
+        #expect(decoded.classification == branch.expected)
+    }
+
+    /// The stored class is a convenience for outside readers, never an input:
+    /// a record claiming `prompt_on_screen` for a type this build does not
+    /// know is re-derived to `unrecognized` on the way in. Without that, a
+    /// hand-edited row (or a newer daemon's vocabulary) could put a type in a
+    /// class this build's own classifier would refuse it.
+    @Test func decodingRederivesTheClassRatherThanTrustingIt() throws {
+        let json = #"""
+        {"message":"m","hookEventName":"Notification",\#
+        "notificationType":"a_type_from_a_later_release","classification":"prompt_on_screen"}
+        """#
+        let decoded = try JSONDecoder().decode(AwaitingInputReason.self, from: Data(json.utf8))
+        #expect(decoded.notificationType == "a_type_from_a_later_release")
+        #expect(decoded.classification == .unrecognized)
+    }
+
+    /// An unrecognized class *tag* is also ignorance rather than a throw — the
+    /// same promise `FactSource` and `SessionStateValue` make.
+    @Test func unrecognizedClassTagDecodesToUnrecognized() throws {
+        let decoded = try JSONDecoder().decode(
+            AwaitingInputClass.self, from: Data(#""some_future_class""#.utf8))
+        #expect(decoded == .unrecognized)
+    }
+
+    /// A row written before the type was modelled still decodes, with no type
+    /// and no invented class.
+    @Test func legacyReasonJSONDecodesAsUnrecognized() throws {
+        let json = #"{"message":"Claude needs your permission","hookEventName":"Notification"}"#
+        let decoded = try JSONDecoder().decode(AwaitingInputReason.self, from: Data(json.utf8))
+        #expect(decoded.message == "Claude needs your permission")
+        #expect(decoded.notificationType == nil)
+        #expect(decoded.classification == .unrecognized)
+    }
+
+    /// The composed line a reader sees carries the message, the class, the
+    /// verbatim type, the source and the age — none of them droppable.
+    @Test func reasonFactSummaryComposesEverything() {
+        let reason = AwaitingInputReason(
+            message: "Claude needs your permission to use Bash",
+            hookEventName: "Notification",
+            notificationType: "permission_prompt")
+        let fact = ObservedFact(
+            value: reason, source: .hookEvent("Notification"), observedAt: epoch)
+        let summary = fact.summary
+        #expect(summary.contains("Claude needs your permission to use Bash"))
+        #expect(summary.contains("prompt_on_screen"))
+        #expect(summary.contains("type=permission_prompt"))
+        #expect(summary.contains("source: hook:Notification"))
+        #expect(summary.contains(FactTimestamp.string(from: epoch)))
+    }
+
+    /// Half a triple is not a fact here either. The wait reason's source is the
+    /// hook event that delivered it, so a reason with no event name — like a
+    /// reason with no observed-at — reports nothing rather than letting a bare
+    /// message masquerade as an observation.
+    @Test func awaitingInputFactNeedsBothItsHalves() {
+        let reason = AwaitingInputReason(
+            message: "Claude needs your permission",
+            hookEventName: "Notification",
+            notificationType: "permission_prompt")
+        func terminal(
+            reason: AwaitingInputReason?, observedAt: Date?
+        ) -> Terminal {
+            Terminal(
+                worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+                awaitingInputReason: reason, awaitingInputObservedAt: observedAt)
+        }
+
+        let whole = terminal(reason: reason, observedAt: epoch).observedAwaitingInput
+        #expect(whole?.value == reason)
+        #expect(whole?.source == .hookEvent("Notification"))
+        #expect(whole?.observedAt == epoch)
+
+        #expect(terminal(reason: reason, observedAt: nil).observedAwaitingInput == nil)
+        #expect(terminal(reason: nil, observedAt: epoch).observedAwaitingInput == nil)
+        let nameless = AwaitingInputReason(message: "m", hookEventName: nil)
+        #expect(terminal(reason: nameless, observedAt: epoch).observedAwaitingInput == nil)
+        // An EMPTY name names a source exactly as poorly as no name at all: it
+        // would render as the bare `hook:` and pass every "does this fact say
+        // where it came from" check while saying nothing.
+        let blank = AwaitingInputReason(message: "m", hookEventName: "")
+        #expect(terminal(reason: blank, observedAt: epoch).observedAwaitingInput == nil)
+    }
+
+    // MARK: - FactSource
+
+    @Test(arguments: [
+        FactSource.hookEvent("Notification"),
+        .transcriptTail,
+        .statuslineTee,
+        .database,
+        .processLiveness,
+        .forge,
+        .gitSweep,
+        .derived,
+        .unavailable,
+        .unrecognized("screen-scrape")
+    ])
+    func everySourceRoundTrips(source: FactSource) throws {
+        #expect(try roundTrip(source) == source)
+    }
+
+    @Test func unrecognizedSourceKindDecodesWithoutThrowing() throws {
+        let json = #"{"kind":"telepathy","detail":"ignored"}"#
+        let decoded = try JSONDecoder().decode(FactSource.self, from: Data(json.utf8))
+        #expect(decoded == .unrecognized("telepathy"))
+        // The unknown name is reportable, not swallowed.
+        #expect(decoded.summary == "telepathy")
+    }
+
+    /// `hook` with no `detail` is not a source. The qualifier IS the
+    /// provenance — which hook fired — so an empty one produces a fact that
+    /// renders as the bare `hook:` and satisfies every check for "does this
+    /// name its source" while naming nothing.
+    @Test func aHookSourceWithNoEventNameIsNotAHookSource() throws {
+        for json in [#"{"kind":"hook"}"#, #"{"kind":"hook","detail":""}"#] {
+            let decoded = try JSONDecoder().decode(FactSource.self, from: Data(json.utf8))
+            #expect(decoded == .unrecognized("hook"), "decoded \(json) as \(decoded)")
+            #expect(decoded.summary == "hook")
+            // And it round-trips back to the same bytes rather than inventing
+            // an empty detail on the way out.
+            #expect(try roundTrip(decoded) == decoded)
+        }
+    }
+
+    @Test func hookEventSourceCarriesItsEventName() throws {
+        let decoded = try roundTrip(FactSource.hookEvent("Notification"))
+        #expect(decoded == .hookEvent("Notification"))
+        #expect(decoded.summary == "hook:Notification")
+    }
+
+    // MARK: - ObservedFact.summary
+
+    /// Assert on the COMPOSED line, not on the presence of the three fields:
+    /// the guarantee is that no rendering of a fact can omit where it came from
+    /// or when it was seen, and only the composed output can show that.
+    @Test func summaryComposesValueSourceAndObservedAt() {
+        let fact = SessionState(
+            value: .awaitingInput(reason: nil),
+            source: .hookEvent("Notification"),
+            observedAt: epoch)
+
+        #expect(fact.summary ==
+            "awaiting input (source: hook:Notification, observed 2026-02-02T02:40:00Z)")
+    }
+
+    @Test func summaryOfAnUnknownStateNamesWhyAndItsSource() {
+        let fact = SessionState(
+            value: .unknown(why: "no transcript"), source: .unavailable, observedAt: epoch)
+        #expect(fact.summary ==
+            "unknown (no transcript) (source: unavailable, observed 2026-02-02T02:40:00Z)")
+    }
+
+    @Test func summaryOfAPlainValueStillCarriesProvenance() {
+        let fact = ObservedFact(value: 42, source: .transcriptTail, observedAt: epoch)
+        #expect(fact.summary == "42 (source: transcript-tail, observed 2026-02-02T02:40:00Z)")
+    }
+
+    @Test func observedFactRoundTrips() throws {
+        let fact = SessionState(
+            value: .rateLimited(until: epoch), source: .transcriptTail, observedAt: epoch)
+        #expect(try roundTrip(fact) == fact)
+    }
+
+    // MARK: - Context load
+
+    @Test func unknownWindowFallsBackToTheLabeledAssumption() {
+        let (tokens, assumed) = ContextWindow.unknown(why: "no statusline tee").effectiveTokens()
+        #expect(tokens == 200_000)
+        #expect(assumed)
+        #expect(ContextWindow.assumedTokens == 200_000)
+    }
+
+    @Test func observedWindowIsNotAssumed() {
+        let window = ContextWindow.observed(
+            ObservedFact(value: 1_000_000, source: .statuslineTee, observedAt: epoch))
+        let (tokens, assumed) = window.effectiveTokens()
+        #expect(tokens == 1_000_000)
+        #expect(assumed == false)
+    }
+
+    @Test func percentUsedIsNilWhenTheNumeratorIsUnknown() {
+        let load = ContextLoad(used: nil, window: .observed(
+            ObservedFact(value: 200_000, source: .statuslineTee, observedAt: epoch)))
+        #expect(load.percentUsed() == nil)
+    }
+
+    @Test func percentUsedFlagsTheAssumedWindow() throws {
+        let load = ContextLoad(
+            used: ObservedFact(value: 50_000, source: .transcriptTail, observedAt: epoch),
+            window: .unknown(why: "no statusline tee"))
+        let result = try #require(load.percentUsed())
+        #expect(result.percent == 25.0)
+        #expect(result.assumedWindow)
+    }
+
+    @Test func percentUsedDoesNotFlagAnObservedWindow() throws {
+        let load = ContextLoad(
+            used: ObservedFact(value: 50_000, source: .transcriptTail, observedAt: epoch),
+            window: .observed(
+                ObservedFact(value: 1_000_000, source: .statuslineTee, observedAt: epoch)))
+        let result = try #require(load.percentUsed())
+        #expect(result.percent == 5.0)
+        #expect(result.assumedWindow == false)
+    }
+
+    @Test func contextLoadRoundTrips() throws {
+        let load = ContextLoad(
+            used: ObservedFact(value: 50_000, source: .transcriptTail, observedAt: epoch),
+            window: .unknown(why: "no statusline tee"))
+        #expect(try roundTrip(load) == load)
+    }
+
+    /// An unfamiliar window tag becomes `unknown`, so the denominator falls back
+    /// to the LABELED assumption rather than to a number nobody observed.
+    @Test func unrecognizedWindowTagDecodesToUnknown() throws {
+        let json = #"{"window":"estimated","fact":{}}"#
+        let decoded = try JSONDecoder().decode(ContextWindow.self, from: Data(json.utf8))
+        let (tokens, assumed) = decoded.effectiveTokens()
+        #expect(tokens == 200_000)
+        #expect(assumed)
+        guard case .unknown(let why) = decoded else {
+            Issue.record("expected .unknown, got \(decoded)")
+            return
+        }
+        #expect(why == "unrecognized window tag 'estimated'")
+    }
+
+    // MARK: - PRObservation
+
+    @Test(arguments: [
+        PRObservation.Outcome.observed,
+        .none,
+        .undetermined(cause: "network unreachable")
+    ])
+    func everyPROutcomeRoundTrips(outcome: PRObservation.Outcome) throws {
+        let observation = PRObservation(outcome: outcome, observedAt: epoch)
+        #expect(try roundTrip(observation) == observation)
+    }
+
+    /// The bug this type exists to prevent: "the forge answered; no PR" and
+    /// "we could not find out" are different facts, before AND after the wire.
+    @Test func noneAndUndeterminedStayDistinguishable() throws {
+        let answered = PRObservation(outcome: .none, observedAt: epoch)
+        let failed = PRObservation(
+            outcome: .undetermined(cause: "network unreachable"), observedAt: epoch)
+
+        #expect(answered != failed)
+        #expect(answered.outcome != failed.outcome)
+
+        let answeredBack = try roundTrip(answered)
+        let failedBack = try roundTrip(failed)
+        #expect(answeredBack != failedBack)
+        #expect(answeredBack.outcome == .none)
+        #expect(failedBack.outcome == .undetermined(cause: "network unreachable"))
+    }
+
+    @Test func unrecognizedOutcomeTagDecodesToUndetermined() throws {
+        let json = #"{"outcome":"rate_limited"}"#
+        let decoded = try JSONDecoder().decode(PRObservation.Outcome.self, from: Data(json.utf8))
+        guard case .undetermined(let cause) = decoded else {
+            Issue.record("expected .undetermined, got \(decoded)")
+            return
+        }
+        #expect(cause == "unrecognized outcome tag 'rate_limited'")
+        // Emphatically NOT `.none`: that would assert the forge answered.
+        #expect(decoded != PRObservation.Outcome.none)
+    }
+
+    // MARK: - Counters and report
+
+    @Test func sessionCountersRoundTrip() throws {
+        let counters = SessionCounters(
+            turnsInWindow: 12,
+            hookEventsInWindow: 40,
+            windowStart: epoch,
+            observedAt: epoch.addingTimeInterval(600),
+            commitsUnchangedSince: epoch.addingTimeInterval(-3600))
+        #expect(try roundTrip(counters) == counters)
+    }
+
+    @Test func reportRoundTripsWithItsOptionalsEmpty() throws {
+        let report = SessionStateReport(
+            terminalID: UUID(),
+            worktreeID: UUID(),
+            state: SessionState(value: .working, source: .hookEvent("UserPromptSubmit"),
+                                observedAt: epoch))
+        let decoded = try roundTrip(report)
+        #expect(decoded == report)
+        #expect(decoded.contextLoad == nil)
+        #expect(decoded.counters == nil)
+    }
+
+    @Test func reportRoundTripsWithItsOptionalsFilled() throws {
+        let report = SessionStateReport(
+            terminalID: UUID(),
+            worktreeID: UUID(),
+            state: SessionState(value: .idle, source: .hookEvent("Stop"), observedAt: epoch),
+            contextLoad: ContextLoad(
+                used: ObservedFact(value: 90_000, source: .transcriptTail, observedAt: epoch),
+                window: .observed(
+                    ObservedFact(value: 200_000, source: .statuslineTee, observedAt: epoch))),
+            counters: SessionCounters(
+                turnsInWindow: 3, hookEventsInWindow: 9,
+                windowStart: epoch, observedAt: epoch))
+        #expect(try roundTrip(report) == report)
+    }
+}

--- a/Tests/TBDSharedTests/WorktreeLocationTests.swift
+++ b/Tests/TBDSharedTests/WorktreeLocationTests.swift
@@ -78,7 +78,12 @@ import Foundation
             foreignHead: true,
             pinnedAt: Date(timeIntervalSince1970: 1_700_000_200),
             pinSortOrder: 2,
-            location: .remote(provider: "agentbox", sessionID: "s-1")
+            location: .remote(provider: "agentbox", sessionID: "s-1"),
+            pendingPrompt: "look at the failing check",
+            pendingPromptSubmit: true,
+            prObservation: PRObservation(
+                outcome: .undetermined(cause: "network unreachable"),
+                observedAt: Date(timeIntervalSince1970: 1_700_000_400))
         )
         let decoded = try JSONDecoder().decode(Worktree.self, from: JSONEncoder().encode(wt))
         #expect(decoded == wt)

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -40,7 +40,7 @@ public extension Trait where Self == TimeLimitTrait {
     /// `Tests/TBDDaemonTests/ControlModeTestSupport.swift`). Clock-driven
     /// suites really do consume the latter — `AttachRPCOrchestrationTests` and
     /// `PaneRepairCoordinatorTests` are both `.clockDriven, .serialized` and
-    /// between them hold 48 `waitFor` call sites — so the two values race and
+    /// between them hold 44 `waitFor` call sites — so the two values race and
     /// must be derived together.
     ///
     /// The invariant is **not** "every chained wait in a test fits inside this
@@ -91,9 +91,11 @@ public extension Trait where Self == TimeLimitTrait {
     ///   with nothing behind it to inherit the run, so at most one 45 s guard
     ///   elapses in any single run and 270 s describes a run that cannot
     ///   happen (see "The event-driven alternative" below).
-    /// - In `PaneRepairCoordinatorTests`, **9 of 13** tests have a worst case
+    /// - In `PaneRepairCoordinatorTests`, **6 of 13** tests have a worst case
     ///   above 240 s (counting `waitFor` at 90 s and each clock wait at 45 s),
-    ///   not just the one 6-deep chain (540 s) usually cited.
+    ///   not just the one 6-deep chain (540 s) usually cited. Four of the sites
+    ///   that used to push that count to 9 of 13 are now single `advanceUntil`
+    ///   guards instead of an advance plus a 90 s `waitFor`.
     ///
     /// **If these start tripping, shorten the chain — do not raise this limit
     /// again.** `Tests/CLAUDE.md` already requires advance chains to stay in
@@ -123,6 +125,28 @@ public extension Trait where Self == TimeLimitTrait {
 
 // MARK: - TestClock
 
+/// A clock-driven wait that never saw its effect, rendered onto the **primary**
+/// failure line.
+///
+/// Thrown-`Error` shape on purpose (`Tests/CLAUDE.md` assertion-hygiene rule 4):
+/// only `Issue.record(_: some Error)` survives into a CI summary — both
+/// `#expect(cond, "message")` and `Issue.record(String)` demote the text to a
+/// trailing `↳` line the summary drops. `advances` is the observed half: zero
+/// says the code under test never armed a sleep at all, while a large count says
+/// it kept re-arming and never produced the effect. Those are different bugs.
+public struct ClockAdvanceTimeout: Error, CustomStringConvertible {
+    public let what: String
+    public let advances: Int
+    public let timeout: Swift.Duration
+
+    public var description: String {
+        """
+        timed out waiting for \(what) — observed \(advances) clock advance(s) \
+        over up to \(timeout) of real time
+        """
+    }
+}
+
 public extension TestClock {
     /// Waits until the code under test has actually registered a sleep on this
     /// clock, then advances virtual time by `duration`.
@@ -147,6 +171,105 @@ public extension TestClock {
                               sourceLocation: SourceLocation = #_sourceLocation) async {
         await waitForSuspension(sourceLocation: sourceLocation)
         await advance(by: duration)
+    }
+
+    /// Advances virtual time in `interval` steps for as long as the code under
+    /// test keeps **re-arming** a sleep, until `condition` holds. Returns
+    /// whether it held.
+    ///
+    /// ## Why one advance is not enough for a poll-and-re-arm loop
+    ///
+    /// `advanceWhenSuspended` proves exactly one thing: a sleeper was armed at
+    /// the instant it advanced. It cannot prove that the loop under test
+    /// *observes* the state the test just created on the probe that follows
+    /// that advance. Where the code under test is a **poll-and-re-arm loop** —
+    /// probe some external state, and if it is not yet the state we are waiting
+    /// for, arm another sleep — a test that grants exactly one advance stakes
+    /// the whole run on a single probe. Any transient that makes that one probe
+    /// read "keep waiting" re-arms a sleep that nothing will ever advance
+    /// again, and the test does not fail: it **hangs** until its `.timeLimit`,
+    /// with no assertion fired, a diagnostic that names the symptom rather than
+    /// the cause, and minutes of CI burned.
+    ///
+    /// That failure is field-observed, not hypothetical.
+    /// `PaneRepairCoordinatorTests`' broken-pipe test drove the repair's
+    /// reader-wait — a `poll(2)`-and-re-arm loop — with a single advance after
+    /// closing the pipe's read end, and wedged in CI for the full 240 s limit
+    /// with only the pause written, the sink still `repairing` and the repair
+    /// still in flight: the exact fingerprint of a probe that read "keep
+    /// waiting" once and then never got another advance. It survived a
+    /// `.timeLimit` raise from 60 s to 240 s, because the wait was not slow —
+    /// it was over.
+    ///
+    /// ## What this does instead
+    ///
+    /// Each step is gated on the code under test actually being armed, so no
+    /// advance is spent on an empty clock and virtual time never runs ahead of
+    /// a sleeper that has not arrived yet: an armed clock is advanced, an
+    /// unarmed one is stepped aside for. The loop ends the moment `condition`
+    /// holds. **The assertion is not weakened** — code that never produces the
+    /// effect still fails, and now inside this helper's own deadline with a
+    /// named diagnostic on the primary failure line, rather than as an
+    /// unattributed suite timeout.
+    ///
+    /// ## When NOT to use it
+    ///
+    /// Where the **number** of advances is itself the property under test.
+    /// `PaneRepairCoordinatorTests.readerWaitEscalatesToTheSlowInterval` pins
+    /// the pacing-escalation boundary by advancing an exact number of times and
+    /// asserting nothing happened; this helper deliberately advances as often
+    /// as the code re-arms, which would dissolve that proof. Use the explicit
+    /// `advanceWhenSuspended` pair there.
+    ///
+    /// - Parameters:
+    ///   - what: names the effect being waited for, for the timeout diagnostic.
+    ///   - interval: virtual time per step — normally the pacing the code under
+    ///     test sleeps on, so one step wakes it once.
+    ///   - timeout: real-time hang guard, same family and same 45 s value as
+    ///     `waitForSuspension` (see its note for the derivation). Count one call
+    ///     to this helper as one guard when tallying a test's worst case; it
+    ///     *replaces* an `advanceWhenSuspended` (45 s) plus the `waitFor` (90 s)
+    ///     that used to follow it, so converting a site shortens the chain.
+    ///   - pollInterval: how long to step aside when nothing is armed yet. Each
+    ///     probe costs a `megaYield`, so lazier is better — same reasoning as
+    ///     `waitForSuspension`.
+    @discardableResult
+    func advanceUntil(
+        _ what: String,
+        by interval: Duration,
+        timeout: Swift.Duration = .seconds(45),
+        pollInterval: Swift.Duration = .milliseconds(25),
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ condition: @Sendable () async -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        var advances = 0
+        repeat {
+            if await condition() { return true }
+            if await isArmed() {
+                await advance(by: interval)
+                advances += 1
+            } else {
+                try? await Task.sleep(for: pollInterval)
+            }
+        } while ContinuousClock.now < deadline
+        if await condition() { return true }
+        Issue.record(
+            ClockAdvanceTimeout(what: what, advances: advances, timeout: timeout),
+            sourceLocation: sourceLocation)
+        return false
+    }
+
+    /// Whether a task is suspended on this clock right now — the quiet form of
+    /// `waitForSuspension`'s probe, for callers that loop on it. Same inverted
+    /// detection: `checkSuspension()` throws when a sleeper *is* registered.
+    private func isArmed() async -> Bool {
+        do {
+            try await checkSuspension()
+            return false
+        } catch {
+            return true
+        }
     }
 
     /// Waits until at least one task is suspended on this clock.

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -184,18 +184,42 @@ knows the resolved window is Claude Code itself, and the one surface where it
 tells a third party is the statusline: its stdin JSON carries
 `context_window.context_window_size` alongside used/remaining percentages.
 
-So the denominator's source is a **statusline tee**. For every session TBD
-spawns, the per-session settings overlay installs a statusline wrapper that
-writes the stdin JSON where the daemon can read it, then execs the statusline
-the operator configured — or exits quietly when there is none. Presence is by
-construction for TBD-spawned sessions, and nothing clobbers a display slot the
-user owns, which is what makes the statusline usable as a source at all.
-Where the tee is absent or has not yet fired — an older Claude Code, a session
-TBD did not spawn — the denominator is **unknown and reported as unknown**:
-raw token counts with no percentage, never a guessed one. Anything that needs
-a number anyway assumes 200k as a labeled assumption, because 200k errs safe —
-thresholds fire early, never late. The current pane-read for context goes
-away.
+So the denominator's source is a **statusline tee**, and it is installed on
+**desk sessions only**. A desk's per-session settings overlay carries a
+statusline wrapper that writes the stdin JSON where the daemon can read it,
+then execs the statusline the operator configured — or exits quietly when
+there is none, since a wrapper that printed something of its own would be
+claiming a slot nobody gave it.
+
+The narrow scope follows from what the denominator is for and from what
+installing it costs. It exists to serve a desk's own context-recycling
+thresholds (§9), which are fractions of the session's effective window. Fleet
+agents need no such number: auto-compaction bears their survival, exactly as
+§9 says it bears a desk's. And the cost is not hypothetical — `statusLine` is
+an object-valued setting with no merge across scopes, so the highest scope
+wins outright, and TBD's per-session settings file outranks every scope an
+operator can write: the project-local file, the project file, and their user
+settings. A fleet-wide tee would therefore take over a display slot the
+operator owns in every session they open and type into. A desk is a session
+TBD configures end to end, so the same mechanism there costs nobody anything.
+Above TBD sits managed/enterprise settings, which outrank the overlay: where
+an organization sets a statusline, TBD's entry is ignored, the tee never runs,
+and the denominator stays unknown — the correct outcome, and one that needs no
+handling beyond not pretending otherwise.
+
+The ordinary case is therefore that there is no tee reading, and the design
+says so plainly: for every fleet session, and for a desk whose statusline has
+not run yet, the denominator is **unknown and reported as unknown** — raw
+token counts with no percentage, never a guessed one. Anything that needs a
+number anyway assumes 200k as a labeled assumption, because 200k errs safe —
+thresholds fire early, never late. Where the tee has fired, its captured
+payload supplies numerator and denominator together, computed by Claude Code
+at one instant from one source; a numerator taken from the transcript against a
+denominator captured earlier is an estimate and is labeled as one rather than
+presented as a single coherent fraction. The pane-read for context goes away:
+inferring context from a rendered status line is screen-scraping, it breaks
+silently whenever Claude Code rewords its display, and a `[1m]` suffix read off
+the screen reports capability rather than the window in force.
 
 **P1 — make existing work facts available overnight.** The daemon already
 calculates almost all work state. It gets pull request (PR) status for each
@@ -3102,7 +3126,9 @@ to inaction at the largest scale.
   author the account.
 - **Fleet-agent context management** — auto-compaction is fine for fleet
   sessions. No handoff templates, recycle flags, or compaction counters for
-  agents; the context fact is informational only (§2, §9). Deliberate
+  agents; the context fact is informational only (§2, §9), and for a fleet
+  session it is raw token counts with no denominator, because the statusline
+  tee that would supply one is installed on desks alone (§2). Deliberate
   recycling exists solely for the supervisor's own session (§9).
 - **A compiled model → window-size table** — refused, because the effective
   window is a session fact, not a model fact:
@@ -3114,7 +3140,8 @@ to inaction at the largest scale.
   session hides the boundary). The Models API would be authoritative but
   subscription OAuth tokens are contractually and technically scoped to
   Claude Code itself. The statusline tee (§2) is the one source that reports
-  the resolved value; wherever it is absent the design says unknown rather
+  the resolved value, and it runs on desk sessions only; everywhere else — and
+  on a desk before its first statusline fires — the design says unknown rather
   than consulting a table.
 - **Pinning the compaction window at spawn** — rejected. Claude Code clamps
   `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to the model's real window silently, so a


### PR DESCRIPTION
## Summary

When something asks TBD what an agent is doing right now, it gets back a bare word — `working`, `idle` — with no way to ask how TBD knows or when it last checked. That is fine for a sidebar dot a human is looking at. It is not fine for anything acting on the answer unattended, because a stale word and a fresh word are indistinguishable, and a word TBD had to guess at looks exactly like one it observed.

This makes every session fact a triple: the value, the source it came from, and the moment it was observed. `unknown` becomes a real answer rather than a confident value standing in for a missing one — so "the agent is idle" and "nothing has told us anything for twenty minutes" stop being the same sentence.

Concretely, an operator or a supervision program can now ask what a session is doing and get back where that came from; can see how full an agent's context is with an honest denominator or an explicit "we don't know"; can tell a pull request that genuinely doesn't exist from one we simply failed to look up; and gets PR facts that keep arriving overnight instead of stopping when the app does.

## Why this shape

Spec: [`docs/specs/2026-07-26-fleet-supervision-design.md`](docs/specs/2026-07-26-fleet-supervision-design.md) §2 (P0-5), with §9 and §13; requirements P0-5 and P0-8. This is slice 2 of that migration — slice 1 made the actuation record honest about what TBD *did* (#593, #595, #597, #602); this makes reported state honest about where it came from.

**Awaiting-input uses the `Notification` hook, not `PreToolUse`.** Only `Notification` can say a prompt is on screen *now*; `PreToolUse` fires before every tool call and cannot report a live prompt. The hook is installed with no matcher and does nothing but forward its payload — every classification decision lives in the daemon's handler, because a matcher in user-land is a policy decision baked into a file the operator can edit out.

**The context-window denominator comes from a statusline tee, on desk sessions only.** The effective window is a session fact, not a model fact — the same model id can be a 200k session or a 1M one, and the only party that knows which is Claude Code itself. The one surface where it tells a third party is the statusline. Scoping the tee to desks is not incidental: `statusLine` is an object-valued setting with no cross-scope merge, so TBD's per-session settings file outranks *every* scope an operator can write. A fleet-wide tee would silently take over a display slot they own in every session they open and type into. Desks are sessions TBD configures end to end, so there the cost disappears.

**Rejected: a compiled model→window table.** A table reports what a model is *capable* of, not what a session resolved to, and it errs in the dangerous direction — a table saying 1M for a session running at 200k reads one-fifth full at the boundary. Where the tee has not fired the denominator is unknown and reported as unknown, and anything that needs a number anyway uses 200k as a *labeled* assumption, because 200k errs early.

**Rejected: a delegation detector.** A session waiting on a background subagent reads as `idle`, and no machine signal fixes it — `Stop` fires when the parent's turn ends, and it does end at delegation. The obvious detector ("an `Agent` tool-use with no matching result means work is outstanding") fails on exactly this case: a backgrounded agent's result lands immediately. Measured on a live session — 27 tool-uses, 27 results, zero pending, subagent running throughout. Telling the two shapes apart would mean interpreting result prose, which is content interpretation at the wrong layer. So the model carries the ambiguity instead, and the case goes to a tier that is allowed to read text.

## What this PR does

- Adds the fact triple and its vocabulary in `SessionStateModel.swift`: `rate-limited(until?)`, `parked(reason)`, `gone`, `unknown(why)`. No decode path anywhere can turn an unrecognized tag into a confident value.
- Installs the `Notification` hook, a CLI bridge, and a daemon handler that records a structured reason verbatim and classifies it without branching on its text.
- Adds the statusline tee: a POSIX `sh` wrapper that captures the stdin JSON, then re-execs whatever statusline the operator configured (resolved across all four scopes TBD can see), or exits quietly when there is none. Every failure branch is silent and non-fatal.
- **Removes** the pane-read for context from the embedded Nightwatch tick — it regex-matched `NN% context used` off a rendered pane. It now reads the transcript. One scraper deleted, no SwiftLint exclusion added.
- Moves PR fetching onto the daemon's clock and records `undetermined(cause)` distinctly from "no PR" at every layer that carries it. The persisted status is display-tier and carries its observed-at wherever it surfaces, including the sidebar and the toolbar.
- Adds runaway counters — turns in the window from appended transcript records without parsing their content, hook-event rate, commits-unchanged-since — reported and never acted on. No threshold is compiled; thresholds live in the shipped sweep program.
- Adds `session.states`, one cheap answer per agent per cycle: no model call, no subprocess, no pane read. No CLI verb — §10 reserves that namespace.
- Routes the merge-driven hibernate through `HibernationGate.decideForMerge`, because PR facts on the daemon's clock let the merged transition fire unattended.
- Migrations `v75_terminal_state_provenance` and `v76_worktree_pr_observation`, both nullable with no SQL default so "not yet observed" stays a third state, with records and Codable models updated alongside.

## Assumptions

- **Claude Code writes the assistant record carrying the `tool_use` before it fires the `Notification` hook.** The awaiting-input rung compares the reason's timestamp against the transcript's newest append to decide whether a prompt is still live. If the flush actually happens *after* the hook, every prompt will resolve `unknown` — that flood is the designed symptom, visible in the composed output rather than hidden. The tolerance that would fix it is deliberately unwritten until someone measures the real lag.
- **`hibernate_input_veto_enabled` is off by default, so merge-park is unprotected on a default install.** Wiring the merge path through the veto makes the rail *reachable*; it does not engage unless the operator has opted in. Until then, merge-park's only pending-input protection is a TUI scrape that fails open. If that default flips, this path gets the protection for free.
- **The transcript's `usage` block keeps its current shape.** The context numerator reads the last assistant record's usage at the transcript tail. Claude Code's docs mark that format internal and version-unstable; there is no better machine source for the numerator today, so the dependency is named in the code rather than hidden.
- **Observations are recorded per worktree while PR values are now per binding.** Coherent today, since a poll records one outcome per worktree — but if per-binding observations ever land, the freshness clause and the "PR status unknown" sidebar indicator both need re-pointing.

## Evidence & verification

6361 tests, `swiftlint --strict` clean. Every guard added was mutation-checked — broken, watched red, restored; two that leaked on a first pass were rewritten until they discriminated. Highlights of the discriminating tests rather than the count:

- The statusline tee is executed for real, under `/bin/dash` as well as `/bin/sh`, including a failure injected *between* the probe and the real opens. The `dash` arm is load-bearing: the old form passed under `/bin/sh` and exited 2 under `dash`, blanking the operator's status line, which is why the bug survived the `/bin/sh`-only test.
- `.none` and `.undetermined` are asserted unequal and mutually non-folding after a full round trip through persistence, the RPC and app state.
- The delegation trap is pinned by a named test: a transcript whose tool-uses all have matching results while work continues out of band resolves `idle` *with its source and observed-at*, and never claims "not working".
- Tee absent → the denominator reports unknown and names which case; tee present → the real number with its capture's mtime as observed-at; the 200k fallback is labeled wherever it is used.
- The Swift and Python context numerators are run over the same bytes and asserted to agree, so a future divergence is caught by execution rather than by reading.

Four review rounds ran locally before this opened, finding and fixing two High-severity defects and roughly thirty smaller ones. Worth flagging for whoever reviews: **both Highs were introduced by a repair, not by the original code**, and both were in the awaiting-input rung — the one place this branch has to say something definite about something it can only observe indirectly. The shape it landed on is the humble one: confident when the facts agree, `unknown` when they genuinely conflict, and never `working` for a session that may be blocked on a human.
