### PR TITLE
Feat: Reclaim the model-profile config dirs that a failed delete strands forever

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ All `ChannelHandlerContext` property access (`context.channel`, `context.pipelin
 ### Every durable external resource needs a named reconciler
 Creation against git, tmux, the process table, or the filesystem cannot be transactional — the external system commits before TBD records the intent, and a crash, a cancellation, or a partial failure in between leaves a resource nobody owns. Creation-time rollback is therefore best-effort everywhere; the standing guarantee is a background sweep that compares ground truth against intent and reclaims the difference. Three reconcilers carry that load:
 
-- **`OrphanGC`** (`Sources/TBDDaemon/GC/OrphanGC.swift`) – hourly when `gcEnabled` (the default), over agent worktrees, scratchpads, the deletion queue, and stale git registrations.
+- **`OrphanGC`** (`Sources/TBDDaemon/GC/OrphanGC.swift`) – hourly when `gcEnabled` (the default), over agent worktrees, scratchpads, the deletion queue, and stale git registrations. Also over per-profile config directories under `~/tbd/profiles/`, gated additionally by `gcProfileDirsEnabled` (default off during soak) and reclaiming by quarantine rather than deletion — see [`docs/specs/2026-08-15-profile-dir-gc-design.md`](docs/specs/2026-08-15-profile-dir-gc-design.md).
 - **`AgentReaper`** (`Sources/TBDDaemon/Process/AgentReaper.swift`) – every 60 seconds, over orphaned agent processes.
 - **`WorktreeLifecycle+Reconcile`** (`Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift`) – at startup and on demand, reconciling DB rows against git worktrees and tmux windows and servers.
 

--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -6,8 +6,29 @@ struct GCCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "gc",
         abstract: "Orphan GC: list reaps, restore a reaped agent worktree, trigger a sweep",
-        subcommands: [GCList.self, GCRestore.self, GCSweep.self]
+        subcommands: [GCList.self, GCRestore.self, GCSweep.self, GCProfileDirs.self]
     )
+}
+
+/// The soak switch for the profile-dir collector. It quarantines orphaned
+/// `~/tbd/profiles/<uuid>/` directories, which hold per-profile credentials and
+/// user content, so it ships off and is opted into by hand.
+struct GCProfileDirs: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "profile-dirs",
+        abstract: "Enable or disable reclaiming orphaned model-profile config dirs (default off)")
+    @Argument(help: "on | off") var state: String
+    mutating func run() async throws {
+        let enabled: Bool
+        switch state.lowercased() {
+        case "on", "true", "enable": enabled = true
+        case "off", "false", "disable": enabled = false
+        default: throw ValidationError("Expected 'on' or 'off', got: \(state)")
+        }
+        try SocketClient().callVoid(method: RPCMethod.configSetGCProfileDirsEnabled,
+                                    params: ConfigSetGCProfileDirsEnabledParams(enabled: enabled))
+        print("Profile-dir GC \(enabled ? "enabled" : "disabled").")
+    }
 }
 
 struct GCList: AsyncParsableCommand {

--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -46,7 +46,10 @@ struct GCList: AsyncParsableCommand {
             let size = r.apparentBytes.map { ByteCountFormatter.string(fromByteCount: $0, countStyle: .file) } ?? "?"
             let snap = r.snapshotRef != nil ? "snapshot ✓" : "clean"
             let restored = r.restoredAt != nil ? " (restored)" : ""
-            print("\(r.id)  \(r.kind.rawValue)  \(r.worktreePath)  \(size)  \(snap)\(restored)")
+            // A quarantined reap has no restore path, so this is the only
+            // handle a user has on the data before retention expires — print it.
+            let quarantine = r.quarantinePath.map { "  quarantined→ \($0)" } ?? ""
+            print("\(r.id)  \(r.kind.rawValue)  \(r.worktreePath)  \(size)  \(snap)\(restored)\(quarantine)")
         }
     }
 }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -55,6 +55,13 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// `nil` here means "never chose" rather than "off". Resolve it through
     /// `Config.supervisionEnabledDefault`, never through `?? false`.
     var supervision_enabled: Bool?
+    /// Gate for the profile-dir collector
+    /// (design 2026-08-15). **Genuinely tri-state**, same shape as
+    /// `supervision_enabled`: the `v78_config_gc_profile_dirs` column carries
+    /// no SQL default, so `nil` here means "never chose" rather than "off".
+    /// Resolve it through `Config.gcProfileDirsEnabledDefault`, never through
+    /// `?? false`.
+    var gc_profile_dirs_enabled: Bool?
 
     /// - Parameter queuedPromptDefault: the shipped default a NULL
     ///   `queued_prompt_enabled` resolves to. Defaulted to the real constant;
@@ -65,9 +72,12 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   same NULL-follows/explicit-sticks property for the fleet brake
     ///   without waiting for the real `Config.supervisionEnabledDefault`
     ///   constant to change.
+    /// - Parameter gcProfileDirsDefault: same shape again, for
+    ///   `gc_profile_dirs_enabled` — the profile-dir collector's own soak gate.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
-        supervisionEnabledDefault: Bool = Config.supervisionEnabledDefault
+        supervisionEnabledDefault: Bool = Config.supervisionEnabledDefault,
+        gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -112,7 +122,10 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // that is the whole point of v70_config_queued_prompt.
             queuedPromptEnabled: queued_prompt_enabled ?? queuedPromptDefault,
             // Same reasoning, for the fleet supervision brake — NOT `?? false`.
-            supervisionEnabled: supervision_enabled ?? supervisionEnabledDefault
+            supervisionEnabled: supervision_enabled ?? supervisionEnabledDefault,
+            // Same reasoning again, for the profile-dir collector's gate —
+            // NOT `?? false`.
+            gcProfileDirsEnabled: gc_profile_dirs_enabled ?? gcProfileDirsDefault
         )
     }
 }
@@ -426,6 +439,19 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET gc_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the profile-dir collector gate (default OFF, soaking) — read on
+    /// top of the GC master switch, so both must be on for the phase to run.
+    /// The column is written on every call, because writing either value is
+    /// the explicit gesture that lifts it out of NULL forever after.
+    public func setGCProfileDirsEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_profile_dirs_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1422,6 +1422,15 @@ public final class TBDDatabase: Sendable {
                 table: "config", column: "gc_profile_dirs_enabled", type: .boolean)
         }
 
+        // Where a quarantined `.profileDir` reap parked the directory. Nullable
+        // and left NULL by every other kind, which deletes outright. camelCase
+        // to match the columns this table already has (`repoPath`,
+        // `worktreePath`, `snapshotRef`).
+        migrator.registerMigration("v79_reap_records_quarantine_path") { db in
+            try db.addColumnIfMissing(
+                table: "reap_records", column: "quarantinePath", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1408,6 +1408,20 @@ public final class TBDDatabase: Sendable {
                 table: "config", column: "supervision_enabled", type: .boolean)
         }
 
+        // Gate for `ProfileDirCollector` — the reconciler for
+        // `~/tbd/profiles/<uuid>/` (docs/specs/2026-08-15-profile-dir-gc-design.md).
+        // Ships OFF: unlike the other collectors' targets, those directories
+        // hold per-profile credentials and user content, so the classifier
+        // soaks behind its own switch before graduating. Tri-state like
+        // v73/v77 — no SQL default, so a pre-migration row reads NULL ("never
+        // chose") rather than 0, and NULL resolves through
+        // `Config.gcProfileDirsEnabledDefault` in `ConfigRecord.toModel()`,
+        // the single place graduation changes.
+        migrator.registerMigration("v78_config_gc_profile_dirs") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "gc_profile_dirs_enabled", type: .boolean)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/ReapRecordStore.swift
+++ b/Sources/TBDDaemon/Database/ReapRecordStore.swift
@@ -17,6 +17,9 @@ struct ReapRecordRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var headSHA: String?
     var snapshotRef: String?
     var apparentBytes: Int64?
+    /// Set by quarantining reaps (`profileDir`) only; NULL for kinds that
+    /// delete outright.
+    var quarantinePath: String?
     var reapedAt: Date
     var restoredAt: Date?
 
@@ -29,6 +32,7 @@ struct ReapRecordRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.headSHA = record.headSHA
         self.snapshotRef = record.snapshotRef
         self.apparentBytes = record.apparentBytes
+        self.quarantinePath = record.quarantinePath
         self.reapedAt = record.reapedAt
         self.restoredAt = record.restoredAt
     }
@@ -55,6 +59,7 @@ struct ReapRecordRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             headSHA: headSHA,
             snapshotRef: snapshotRef,
             apparentBytes: apparentBytes,
+            quarantinePath: quarantinePath,
             reapedAt: reapedAt,
             restoredAt: restoredAt
         )

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -505,6 +505,11 @@ public actor OrphanGC {
     /// rather than deletes and the classifier soaks behind its own switch
     /// before graduating.
     ///
+    /// `dryRun` bypasses the flag exactly as `sweep` lets it bypass
+    /// `gcEnabled`: planning is read-only, and someone deciding whether to
+    /// enable a default-off flag needs to see what enabling it would reclaim
+    /// before flipping it. A NON-dry run still requires the flag.
+    ///
     /// Every DB read lives here rather than in the collector (the same division
     /// as `DeletionQueueCollector`), and a failed read skips the whole phase —
     /// the keep-favoring direction every other gate in this sweep takes.
@@ -514,7 +519,7 @@ public actor OrphanGC {
     private func reclaimProfileDirs(
         config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
     ) async {
-        guard config.gcProfileDirsEnabled else { return }
+        guard config.gcProfileDirsEnabled || dryRun else { return }
 
         let candidates = profileDirCollector.candidates()
         guard let profiles = try? await db.modelProfiles.list(),
@@ -542,6 +547,8 @@ public actor OrphanGC {
                 """)
             case .reap:
                 planned.append("REAP profile-dir \(candidate.path)")
+                // The phase guard is `gcProfileDirsEnabled || dryRun`, so every
+                // line below this point runs only with the flag actually on.
                 guard !dryRun else { continue }
                 await beforeProfileDirReap?()
                 // Re-read immediately before acting: the candidate list and the

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -75,7 +75,7 @@ public actor OrphanGC {
     private let beforeInterruptedArchiveReap: (@Sendable () async -> Void)?
     /// Test-only injection seam, the profile-dir twin of
     /// `beforeInterruptedArchiveReap`: awaited once inside
-    /// `reclaimProfileDirs`, after the candidate list and the row snapshot have
+    /// `reapOrphanProfileDirs`, after the candidate list and the row snapshot have
     /// been taken and before any candidate is reaped. That is the exact window
     /// the pre-reap row re-read closes, and nothing else in that phase is slow
     /// or interruptible enough to land a concurrent profile creation in it
@@ -499,28 +499,57 @@ public actor OrphanGC {
     /// `model_profiles` row is gone, and purges quarantine entries past the
     /// retention window.
     ///
-    /// Gated by its own default-off flag on top of `gcEnabled`: unlike the
-    /// other collectors' targets, these directories hold per-profile
-    /// credentials and user content with no other copy, so reaping quarantines
-    /// rather than deletes and the classifier soaks behind its own switch
-    /// before graduating.
+    /// The two halves answer to different switches, and that split is
+    /// deliberate. **Classifying** an orphan is gated by
+    /// `gcProfileDirsEnabled` on top of `gcEnabled`: unlike the other
+    /// collectors' targets, these directories hold per-profile credentials and
+    /// user content with no other copy, so reaping quarantines rather than
+    /// deletes and the classifier soaks behind its own switch before
+    /// graduating. **Purging** the quarantine is not classification of a user
+    /// resource at all — it is cleanup of GC's own artifacts, of data this
+    /// sweep already moved aside — so it runs whenever the sweep runs, i.e.
+    /// under `gcEnabled` alone. Turning the classifier off ends a soak; it must
+    /// never strand credentials in `.reaped/` indefinitely, since "the same
+    /// sweep expires the quarantine" is the whole basis on which quarantining
+    /// was preferred to deleting outright.
     ///
     /// `dryRun` bypasses the flag exactly as `sweep` lets it bypass
     /// `gcEnabled`: planning is read-only, and someone deciding whether to
     /// enable a default-off flag needs to see what enabling it would reclaim
     /// before flipping it. A NON-dry run still requires the flag.
+    private func reclaimProfileDirs(
+        config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
+    ) async {
+        if config.gcProfileDirsEnabled || dryRun {
+            await reapOrphanProfileDirs(
+                config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
+            )
+        }
+
+        // Quarantine expiry — the second half of the bargain. Without it the
+        // quarantine grows unboundedly, which is the disease this phase treats.
+        for path in profileDirCollector.expiredQuarantineEntries(
+            retentionDays: config.gcSnapshotRetentionDays
+        ) {
+            planned.append("PURGE quarantine \(path)")
+            guard !dryRun else { continue }
+            _ = profileDirCollector.purge(quarantinePath: path)
+        }
+    }
+
+    /// The classifier arm of the profile-dir phase: enumerate candidates, gate
+    /// them, and quarantine what is eligible. Runs only with
+    /// `gcProfileDirsEnabled` on (or in a dry run, which plans without acting).
     ///
     /// Every DB read lives here rather than in the collector (the same division
-    /// as `DeletionQueueCollector`), and a failed read skips the whole phase —
+    /// as `DeletionQueueCollector`), and a failed read skips the whole arm —
     /// the keep-favoring direction every other gate in this sweep takes.
     /// Directories are enumerated BEFORE the rows are read, so a profile
     /// created mid-sweep is always in the row set and can never be classified
     /// as an orphan.
-    private func reclaimProfileDirs(
+    private func reapOrphanProfileDirs(
         config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
     ) async {
-        guard config.gcProfileDirsEnabled || dryRun else { return }
-
         let candidates = profileDirCollector.candidates()
         guard let profiles = try? await db.modelProfiles.list(),
               let terminals = try? await db.terminals.list() else {
@@ -547,20 +576,34 @@ public actor OrphanGC {
                 """)
             case .reap:
                 planned.append("REAP profile-dir \(candidate.path)")
-                // The phase guard is `gcProfileDirsEnabled || dryRun`, so every
+                // This arm's guard is `gcProfileDirsEnabled || dryRun`, so every
                 // line below this point runs only with the flag actually on.
                 guard !dryRun else { continue }
                 await beforeProfileDirReap?()
                 // Re-read immediately before acting: the candidate list and the
                 // row snapshot above are exactly that, and a profile recreated
                 // with this UUID in between must not have its directory pulled
-                // out from under it. A read failure reads as "keep".
-                let refreshed = (try? await db.modelProfiles.get(id: candidate.profileID)) ?? nil
-                guard refreshed == nil else {
-                    planned.append("KEEP row-appeared \(candidate.path)")
-                    logger.info("""
-                    gc: keep row-appeared \(candidate.path, privacy: .public) — \
-                    a profile row with this id exists again since this sweep listed it
+                // out from under it. Both non-reap outcomes keep the directory,
+                // and they are kept distinct on purpose — a row that exists
+                // again, and a read that never answered. Collapsing a thrown
+                // read into "no row" would reap on exactly the evidence that
+                // says nothing, inverting this sweep's fail-toward-keeping
+                // direction.
+                do {
+                    if try await db.modelProfiles.get(id: candidate.profileID) != nil {
+                        planned.append("KEEP row-appeared \(candidate.path)")
+                        logger.info("""
+                        gc: keep row-appeared \(candidate.path, privacy: .public) — \
+                        a profile row with this id exists again since this sweep listed it
+                        """)
+                        continue
+                    }
+                } catch {
+                    planned.append("KEEP row-read-failed \(candidate.path)")
+                    logger.warning("""
+                    gc: keep row-read-failed \(candidate.path, privacy: .public) — \
+                    the pre-reap profile-row re-read failed: \
+                    \(String(describing: error), privacy: .public)
                     """)
                     continue
                 }
@@ -583,16 +626,6 @@ public actor OrphanGC {
                 await insertReapRecord(record)
                 reaped += 1
             }
-        }
-
-        // Quarantine expiry — the second half of the bargain. Without it the
-        // quarantine grows unboundedly, which is the disease this phase treats.
-        for path in profileDirCollector.expiredQuarantineEntries(
-            retentionDays: config.gcSnapshotRetentionDays
-        ) {
-            planned.append("PURGE quarantine \(path)")
-            guard !dryRun else { continue }
-            _ = profileDirCollector.purge(quarantinePath: path)
         }
     }
 

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import Security
 import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
@@ -59,6 +60,11 @@ public actor OrphanGC {
     private let agentCollector: AgentWorktreeCollector
     private let scratchpadCollector: ScratchpadCollector
     private let deletionQueueCollector: DeletionQueueCollector
+    private let profileDirCollector: ProfileDirCollector
+    /// Deletes the path-keyed Claude Code credentials item belonging to a
+    /// quarantined profile dir. Injected so tests never reach the real login
+    /// keychain, which `scripts/test.sh` cannot fence.
+    private let credentialsKeychain: any ClaudeCredentialsKeychainDeleting
     /// Test-only injection seam: awaited once inside `reclaimDeletionQueue`,
     /// after the interrupted-archive candidate list has been computed and
     /// before any candidate is reaped. That is the exact window the pre-reap
@@ -67,6 +73,15 @@ public actor OrphanGC {
     /// deterministically. `nil` in production (both public inits omit it), so
     /// the sweep is unchanged there.
     private let beforeInterruptedArchiveReap: (@Sendable () async -> Void)?
+    /// Test-only injection seam, the profile-dir twin of
+    /// `beforeInterruptedArchiveReap`: awaited once inside
+    /// `reclaimProfileDirs`, after the candidate list and the row snapshot have
+    /// been taken and before any candidate is reaped. That is the exact window
+    /// the pre-reap row re-read closes, and nothing else in that phase is slow
+    /// or interruptible enough to land a concurrent profile creation in it
+    /// deterministically. `nil` in production (both public inits omit it), so
+    /// the sweep is unchanged there.
+    private let beforeProfileDirReap: (@Sendable () async -> Void)?
 
     /// Production seam: an injected `lsofProvider` returns a non-optional
     /// `[String]` — by definition authoritative, it can't signal
@@ -77,7 +92,9 @@ public actor OrphanGC {
         broadcast: @escaping @Sendable (StateDelta) -> Void,
         lsofProvider: (@Sendable () async -> [String])? = nil,
         scratchpadBase: URL? = nil,
-        now: (@Sendable () -> Date)? = nil
+        now: (@Sendable () -> Date)? = nil,
+        profileDirBase: URL? = nil,
+        credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain()
     ) {
         var wrapped: (@Sendable () async -> [String]?)?
         if let lsofProvider {
@@ -85,7 +102,8 @@ public actor OrphanGC {
         }
         self.init(
             db: db, git: git, broadcast: broadcast, liveCWDsProvider: wrapped,
-            scratchpadBase: scratchpadBase, now: now
+            scratchpadBase: scratchpadBase, now: now,
+            profileDirBase: profileDirBase, credentialsKeychain: credentialsKeychain
         )
     }
 
@@ -101,10 +119,18 @@ public actor OrphanGC {
         liveCWDsProvider: (@Sendable () async -> [String]?)?,
         scratchpadBase: URL? = nil,
         now: (@Sendable () -> Date)? = nil,
-        beforeInterruptedArchiveReap: (@Sendable () async -> Void)? = nil
+        beforeInterruptedArchiveReap: (@Sendable () async -> Void)? = nil,
+        profileDirBase: URL? = nil,
+        credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
+        beforeProfileDirReap: (@Sendable () async -> Void)? = nil
     ) {
         let resolvedNow = now ?? Date.init
         let resolvedScratchpadBase = scratchpadBase ?? TBDConstants.claudeScratchpadBase
+        // `ClaudeProfileConfigDirManager` owns where profile dirs live (and
+        // honors `TBD_HOME` through `TBDConstants`), so the collector's base is
+        // read from it rather than rebuilt here.
+        let resolvedProfileDirBase = profileDirBase
+            ?? ClaudeProfileConfigDirManager().baseDirectory
         let snap = ReapSnapshot(git: git)
 
         self.db = db
@@ -115,9 +141,13 @@ public actor OrphanGC {
         self.now = resolvedNow
         self.snapshot = snap
         self.beforeInterruptedArchiveReap = beforeInterruptedArchiveReap
+        self.beforeProfileDirReap = beforeProfileDirReap
+        self.credentialsKeychain = credentialsKeychain
         self.agentCollector = AgentWorktreeCollector(git: git, snapshot: snap, now: resolvedNow)
         self.scratchpadCollector = ScratchpadCollector(base: resolvedScratchpadBase)
         self.deletionQueueCollector = DeletionQueueCollector(git: git, now: resolvedNow)
+        self.profileDirCollector = ProfileDirCollector(
+            base: resolvedProfileDirBase, now: resolvedNow)
     }
 
     // MARK: - Sweep
@@ -189,6 +219,10 @@ public actor OrphanGC {
         await reconcileScratchpads(
             repos: repos, archived: archived, dryRun: dryRun,
             planned: &planned, reaped: &reaped
+        )
+
+        await reclaimProfileDirs(
+            config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
         )
 
         // Snapshot retention never runs in dryRun; the outer guard already
@@ -458,6 +492,100 @@ public actor OrphanGC {
             reaped += 1
             planned.append("REAP scratchpad \(record.worktreePath)")
             logger.info("gc: reaped scratchpad \(record.worktreePath, privacy: .public)")
+        }
+    }
+
+    /// Reclaims per-profile config directories under `~/tbd/profiles/` whose
+    /// `model_profiles` row is gone, and purges quarantine entries past the
+    /// retention window.
+    ///
+    /// Gated by its own default-off flag on top of `gcEnabled`: unlike the
+    /// other collectors' targets, these directories hold per-profile
+    /// credentials and user content with no other copy, so reaping quarantines
+    /// rather than deletes and the classifier soaks behind its own switch
+    /// before graduating.
+    ///
+    /// Every DB read lives here rather than in the collector (the same division
+    /// as `DeletionQueueCollector`), and a failed read skips the whole phase —
+    /// the keep-favoring direction every other gate in this sweep takes.
+    /// Directories are enumerated BEFORE the rows are read, so a profile
+    /// created mid-sweep is always in the row set and can never be classified
+    /// as an orphan.
+    private func reclaimProfileDirs(
+        config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
+    ) async {
+        guard config.gcProfileDirsEnabled else { return }
+
+        let candidates = profileDirCollector.candidates()
+        guard let profiles = try? await db.modelProfiles.list(),
+              let terminals = try? await db.terminals.list() else {
+            logger.warning("gc: profile-dir phase skipped — DB read failed")
+            return
+        }
+        let known = Set(profiles.map(\.id))
+        // A terminal row keeps its `profile_id` after the profile is deleted,
+        // so a live (or hibernated, resumable) session can still be pointing
+        // `CLAUDE_CONFIG_DIR` at this directory. Deliberately stricter than the
+        // interactive delete path: a background sweep yanking credentials out
+        // from under a running session is worse than a user doing it knowingly.
+        let referenced = Set(terminals.compactMap(\.profileID))
+
+        for candidate in candidates {
+            switch profileDirCollector.decide(
+                candidate, knownProfileIDs: known, referencedProfileIDs: referenced,
+                graceSeconds: config.gcGraceSeconds
+            ) {
+            case .keep(let reason):
+                planned.append("KEEP \(reason) \(candidate.path)")
+                logger.debug("""
+                gc: keep \(reason, privacy: .public) \(candidate.path, privacy: .public)
+                """)
+            case .reap:
+                planned.append("REAP profile-dir \(candidate.path)")
+                guard !dryRun else { continue }
+                await beforeProfileDirReap?()
+                // Re-read immediately before acting: the candidate list and the
+                // row snapshot above are exactly that, and a profile recreated
+                // with this UUID in between must not have its directory pulled
+                // out from under it. A read failure reads as "keep".
+                let refreshed = (try? await db.modelProfiles.get(id: candidate.profileID)) ?? nil
+                guard refreshed == nil else {
+                    planned.append("KEEP row-appeared \(candidate.path)")
+                    logger.info("""
+                    gc: keep row-appeared \(candidate.path, privacy: .public) — \
+                    a profile row with this id exists again since this sweep listed it
+                    """)
+                    continue
+                }
+                guard let record = await profileDirCollector.reap(candidate) else {
+                    planned.append("KEEP quarantine-failed \(candidate.path)")
+                    continue
+                }
+                // The Claude Code credentials item is keyed on the ORIGINAL
+                // config dir path, which the rename just invalidated — delete it
+                // now or it is unreachable garbage forever. `errSecItemNotFound`
+                // is success: there was nothing to clean.
+                let configDirPath = candidate.path + "/claude"
+                let status = credentialsKeychain.deleteCredentials(forConfigDirPath: configDirPath)
+                if status != errSecSuccess && status != errSecItemNotFound {
+                    logger.warning("""
+                    gc: failed to delete Claude credentials for \
+                    \(configDirPath, privacy: .public): OSStatus \(status, privacy: .public)
+                    """)
+                }
+                await insertReapRecord(record)
+                reaped += 1
+            }
+        }
+
+        // Quarantine expiry — the second half of the bargain. Without it the
+        // quarantine grows unboundedly, which is the disease this phase treats.
+        for path in profileDirCollector.expiredQuarantineEntries(
+            retentionDays: config.gcSnapshotRetentionDays
+        ) {
+            planned.append("PURGE quarantine \(path)")
+            guard !dryRun else { continue }
+            _ = profileDirCollector.purge(quarantinePath: path)
         }
     }
 

--- a/Sources/TBDDaemon/GC/ProfileDirCollector.swift
+++ b/Sources/TBDDaemon/GC/ProfileDirCollector.swift
@@ -1,0 +1,228 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// A directory under the profiles base whose name parses as a profile UUID.
+public struct ProfileDirCandidate: Sendable, Equatable {
+    public var profileID: UUID
+    public var path: String
+    /// Directory creation date, or `nil` when it could not be read — which the
+    /// grace gate treats as "too young to touch".
+    public var createdAt: Date?
+
+    public init(profileID: UUID, path: String, createdAt: Date?) {
+        self.profileID = profileID
+        self.path = path
+        self.createdAt = createdAt
+    }
+}
+
+/// Outcome of gating one candidate. `reason` is one of `"row-exists"`,
+/// `"terminal-reference"`, `"grace"`, `"unknown-age"`.
+public enum ProfileDirDecision: Sendable, Equatable {
+    case keep(reason: String)
+    case reap
+}
+
+/// Enumerates, gates, quarantines and expires per-profile config directories
+/// under `~/tbd/profiles/` — the named reconciler for that resource class
+/// (`docs/specs/2026-08-15-profile-dir-gc-design.md`).
+///
+/// Reaping does NOT delete: the directory is renamed into `.reaped/` and only
+/// purged after the retention window, because unlike agent worktrees
+/// (restorable from a snapshot ref) and scratchpads (disposable tmp) these
+/// directories hold per-profile credentials and user content with no other
+/// copy. Every failure path fails toward KEEPING — an unreadable creation
+/// date, an unreadable listing, a failed rename and an undatable quarantine
+/// entry all leave the directory where it is for the next sweep to reconsider.
+///
+/// This type never reads the database: the caller supplies `knownProfileIDs`
+/// and `referencedProfileIDs`, the same division of labor `DeletionQueueCollector`
+/// keeps with `OrphanGC`.
+public struct ProfileDirCollector: Sendable {
+    /// Quarantine directory name, an immediate child of the profiles base.
+    /// Not a UUID, so it is never itself a candidate.
+    public static let quarantineDirName = ".reaped"
+
+    let base: URL
+    let now: @Sendable () -> Date
+
+    public init(base: URL, now: @escaping @Sendable () -> Date = Date.init) {
+        self.base = base
+        self.now = now
+    }
+
+    var quarantineBase: URL {
+        base.appendingPathComponent(Self.quarantineDirName, isDirectory: true)
+    }
+
+    /// Immediate children whose name parses as a UUID and which are directories.
+    /// Non-UUID entries, files, and the quarantine directory are never
+    /// candidates; an unreadable or missing base yields none.
+    public func candidates() -> [ProfileDirCandidate] {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: base.path) else {
+            return []
+        }
+        return names.compactMap { name -> ProfileDirCandidate? in
+            guard let id = UUID(uuidString: name) else { return nil }
+            let url = base.appendingPathComponent(name, isDirectory: true)
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir),
+                  isDir.boolValue else { return nil }
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            return ProfileDirCandidate(
+                profileID: id, path: url.path,
+                createdAt: attributes?[.creationDate] as? Date)
+        }.sorted { $0.path < $1.path }
+    }
+
+    /// Gate order: live row → terminal reference → grace. Every gate fails
+    /// toward keeping, and an unreadable creation date keeps too.
+    public func decide(
+        _ candidate: ProfileDirCandidate,
+        knownProfileIDs: Set<UUID>,
+        referencedProfileIDs: Set<UUID>,
+        graceSeconds: Int
+    ) -> ProfileDirDecision {
+        if knownProfileIDs.contains(candidate.profileID) {
+            return .keep(reason: "row-exists")
+        }
+        if referencedProfileIDs.contains(candidate.profileID) {
+            return .keep(reason: "terminal-reference")
+        }
+        guard let created = candidate.createdAt else {
+            return .keep(reason: "unknown-age")
+        }
+        if now().timeIntervalSince(created) < Double(graceSeconds) {
+            return .keep(reason: "grace")
+        }
+        return .reap
+    }
+
+    /// Renames the candidate into `.reaped/<uuid>-<timestamp>/`. The rename is
+    /// the commit point; a failure leaves the candidate untouched for the next
+    /// sweep and returns `nil`.
+    public func reap(_ candidate: ProfileDirCandidate) async -> ReapRecord? {
+        let reapedAt = now()
+        // Measure before the rename — the last moment the size is readable at
+        // the original path, which is the path the record names.
+        let bytes = await GCDiskUsage.apparentBytes(path: candidate.path)
+        let destination = quarantineBase.appendingPathComponent(
+            "\(candidate.profileID.uuidString.lowercased())-\(Self.stamp(reapedAt))",
+            isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(
+                at: quarantineBase, withIntermediateDirectories: true)
+            try FileManager.default.moveItem(
+                at: URL(fileURLWithPath: candidate.path), to: destination)
+        } catch {
+            logger.warning("""
+            gc: quarantine failed for \(candidate.path, privacy: .public): \
+            \(String(describing: error), privacy: .public)
+            """)
+            return nil
+        }
+        logger.info("""
+        gc: quarantined profile dir \(candidate.path, privacy: .public) -> \
+        \(destination.path, privacy: .public)
+        """)
+        return ReapRecord(
+            kind: .profileDir,
+            repoPath: "",
+            worktreePath: candidate.path,
+            apparentBytes: bytes,
+            quarantinePath: destination.path,
+            reapedAt: reapedAt
+        )
+    }
+
+    /// Quarantine entries older than the retention window. Age comes from the
+    /// timestamp this collector stamped into the entry's own name; a name that
+    /// does not carry one falls back to the entry's own filesystem dates, and
+    /// an entry with no readable date at all is kept — visible in
+    /// `tbd gc list`, never silently destroyed.
+    public func expiredQuarantineEntries(retentionDays: Int) -> [String] {
+        guard let names = try? FileManager.default.contentsOfDirectory(
+            atPath: quarantineBase.path) else {
+            return []
+        }
+        let formatter = Self.makeStampFormatter()
+        let cutoff = now().addingTimeInterval(-Double(retentionDays) * 86_400)
+        return names.compactMap { name -> String? in
+            let url = quarantineBase.appendingPathComponent(name, isDirectory: true)
+            guard let stamped = Self.timestamp(fromEntryName: name, formatter: formatter)
+                ?? Self.filesystemDate(ofItemAtPath: url.path),
+                stamped < cutoff
+            else { return nil }
+            return url.path
+        }.sorted()
+    }
+
+    /// Deletes one quarantine entry. Refuses any path not strictly under the
+    /// quarantine directory — the same anchor guard `ScratchpadCollector` keeps
+    /// in front of its recursive delete, and for the same reason: never trust
+    /// the caller's path blindly this close to `removeItem`.
+    public func purge(quarantinePath: String) -> Bool {
+        guard quarantinePath.hasPrefix(self.quarantineBase.path + "/") else {
+            logger.warning("""
+            gc: refusing to purge \(quarantinePath, privacy: .public) — not strictly under \
+            \(self.quarantineBase.path, privacy: .public)
+            """)
+            return false
+        }
+        do {
+            try FileManager.default.removeItem(atPath: quarantinePath)
+        } catch {
+            logger.warning("""
+            gc: purge failed for \(quarantinePath, privacy: .public): \
+            \(String(describing: error), privacy: .public)
+            """)
+            return false
+        }
+        logger.info("gc: purged expired quarantine \(quarantinePath, privacy: .public)")
+        return true
+    }
+
+    // MARK: - Quarantine naming
+
+    /// `yyyyMMdd'T'HHmmss'Z'` in UTC — sortable, filesystem-safe, and
+    /// round-trippable by `timestamp(fromEntryName:)`.
+    static func stamp(_ date: Date) -> String {
+        makeStampFormatter().string(from: date)
+    }
+
+    static func timestamp(fromEntryName name: String) -> Date? {
+        timestamp(fromEntryName: name, formatter: makeStampFormatter())
+    }
+
+    /// The stamp is everything after the final `-`: the UUID prefix contains
+    /// dashes, the stamp itself contains none.
+    private static func timestamp(fromEntryName name: String, formatter: DateFormatter) -> Date? {
+        guard let dash = name.lastIndex(of: "-") else { return nil }
+        return formatter.date(from: String(name[name.index(after: dash)...]))
+    }
+
+    /// Newest of the entry's own creation and modification dates — the
+    /// keep-favoring reading, used only when the name carries no stamp.
+    /// `nil` when neither is readable, which keeps the entry.
+    private static func filesystemDate(ofItemAtPath path: String) -> Date? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path) else {
+            return nil
+        }
+        let dates = [attributes[.creationDate], attributes[.modificationDate]]
+            .compactMap { $0 as? Date }
+        return dates.max()
+    }
+
+    /// Built per use rather than shared: `DateFormatter` is not `Sendable`, and
+    /// this type is. The cost is once per reap and once per expiry pass.
+    private static func makeStampFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        return formatter
+    }
+}

--- a/Sources/TBDDaemon/GC/ProfileDirCollector.swift
+++ b/Sources/TBDDaemon/GC/ProfileDirCollector.swift
@@ -104,7 +104,21 @@ public struct ProfileDirCollector: Sendable {
     /// Renames the candidate into `.reaped/<uuid>-<timestamp>/`. The rename is
     /// the commit point; a failure leaves the candidate untouched for the next
     /// sweep and returns `nil`.
+    ///
+    /// Anchored first, the twin of `purge`'s guard and for the same reason: a
+    /// rename is destructive at the source path, so never trust the caller's
+    /// path blindly this close to it. `candidates()` only ever produces
+    /// anchored candidates, but `ProfileDirCandidate` is a public value type
+    /// anyone can construct, so the invariant is checked rather than assumed.
     public func reap(_ candidate: ProfileDirCandidate) async -> ReapRecord? {
+        guard isAnchored(candidate) else {
+            logger.warning("""
+            gc: refusing to quarantine \(candidate.path, privacy: .public) — not a \
+            \(candidate.profileID.uuidString, privacy: .public)-named immediate child of \
+            \(self.base.path, privacy: .public)
+            """)
+            return nil
+        }
         let reapedAt = now()
         // Measure before the rename — the last moment the size is readable at
         // the original path, which is the path the record names.
@@ -183,6 +197,22 @@ public struct ProfileDirCollector: Sendable {
         }
         logger.info("gc: purged expired quarantine \(quarantinePath, privacy: .public)")
         return true
+    }
+
+    /// The candidate names an immediate child of `base` whose own name parses
+    /// as the candidate's `profileID` — exactly what `candidates()` produces.
+    ///
+    /// Stricter than `purge`'s prefix check on purpose, and it has to be: a
+    /// bare prefix test would also accept `<base>/.reaped/<entry>` (already
+    /// quarantined) and `<base>/a/b` (something nested), neither of which this
+    /// collector owns. Requiring the parent to *equal* `base` rejects both,
+    /// along with any `..` in the path, which no longer resolves to `base`
+    /// once the last component is dropped. Matching the name back to the
+    /// candidate's UUID is what keeps `.reaped` itself out.
+    private func isAnchored(_ candidate: ProfileDirCandidate) -> Bool {
+        let url = URL(fileURLWithPath: candidate.path)
+        guard url.deletingLastPathComponent().path == base.path else { return false }
+        return UUID(uuidString: url.lastPathComponent) == candidate.profileID
     }
 
     // MARK: - Quarantine naming

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -172,6 +172,19 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the profile-dir collector gate — the default-off soak switch for
+    /// reclaiming orphaned `~/tbd/profiles/<uuid>/` directories, read on top of
+    /// the GC master switch. Like that master switch, flipping it off does not
+    /// cancel an in-progress sweep: `OrphanGC.sweep` re-reads the flag on its
+    /// next pass.
+    func handleConfigSetGCProfileDirsEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetGCProfileDirsEnabledParams.self, from: paramsData)
+        try await db.config.setGCProfileDirsEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the fleet supervision brake (design 2026-07-26 §3, §7) — the
     /// fleet-wide on/off switch for supervision. Shipped OFF; nothing in the
     /// daemon reads this column to gate an actuation yet, because the acting

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -201,15 +201,19 @@ extension RPCRouter {
         try await db.repos.clearProfileOverride(matching: params.id)
 
         try await db.modelProfileUsage.deleteForProfile(id: params.id)
-        try await db.modelProfiles.delete(id: params.id)
 
         // NOTE: We deliberately do NOT touch terminal.profile_id here.
         // Running terminals keep the env var that was injected at spawn time;
         // mutating their stored profile id would mislead the UI about what the
         // already-running claude process is actually using.
-        // DB row deletion is the source of truth — don't fail the RPC if the
-        // on-disk secret file delete fails (permission, missing, disk error).
-        // Log so an orphan file isn't completely silent.
+        //
+        // Cleanup order is load-bearing: the `model_profiles` row is the ONLY
+        // pointer to `~/tbd/profiles/<uuid>/`, so it is deleted LAST. A daemon
+        // killed partway now leaves "row present, directory gone or present" —
+        // both benign — instead of a directory nothing will ever reclaim.
+        // Individual cleanup failures stay log-only and non-fatal: the user
+        // asked for the profile to be gone, and the profile-dir collector
+        // reclaims whatever is left behind.
         // Only API-key profiles store a Keychain entry; OAuth and Bedrock profiles do not.
         if profile.kind == .apiKey {
             do {
@@ -248,6 +252,9 @@ extension RPCRouter {
                 logger.warning("Failed to delete config directory for \(params.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
+
+        // Last DB mutation: everything keyed by the row has now been cleaned.
+        try await db.modelProfiles.delete(id: params.id)
 
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -580,6 +580,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetAutoTrustWorktrees(request.paramsData)
             case RPCMethod.configSetGCEnabled:
                 return try await handleConfigSetGCEnabled(request.paramsData)
+            case RPCMethod.configSetGCProfileDirsEnabled:
+                return try await handleConfigSetGCProfileDirsEnabled(request.paramsData)
             case RPCMethod.configSetSupervisionEnabled:
                 return try await handleConfigSetSupervisionEnabled(request.paramsData)
             case RPCMethod.remoteProviders:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1468,6 +1468,17 @@ public enum ReapKind: String, Codable, Sendable {
     /// A TBD worktree directory reclaimed after its archive failed to remove
     /// it, or drained from a pool's `.deleting/` queue.
     case archivedWorktree
+    /// A per-profile config directory under `~/tbd/profiles/<uuid>/` whose
+    /// `model_profiles` row is gone.
+    ///
+    /// Reaped by **quarantine**, not deletion: the directory is renamed into
+    /// `.reaped/` and `quarantinePath` records where, so its credentials and
+    /// user content stay hand-recoverable until the retention window expires.
+    /// It is **not restorable** — `OrphanGC.restore` accepts `.agentWorktree`
+    /// only, and must keep doing so: the profile row this directory depends on
+    /// is already gone, so renaming it back would just recreate an orphan for
+    /// the next sweep.
+    case profileDir
 }
 
 /// Record of a directory the daemon-owned orphan GC swept and (optionally)
@@ -1488,12 +1499,18 @@ public struct ReapRecord: Codable, Sendable, Identifiable, Equatable {
     public var snapshotRef: String?
     /// `du -sk` * 1024 at reap time.
     public var apparentBytes: Int64?
+    /// Where a quarantined reap parked the directory (`profileDir` only).
+    /// `nil` for kinds that delete outright. Not a restore pointer —
+    /// `OrphanGC.restore` rejects `.profileDir` — but the path a user needs to
+    /// retrieve anything by hand before the retention window expires.
+    public var quarantinePath: String?
     public var reapedAt: Date
     public var restoredAt: Date?
 
     public init(id: UUID = UUID(), kind: ReapKind, repoPath: String, worktreePath: String,
                 branch: String? = nil, headSHA: String? = nil, snapshotRef: String? = nil,
-                apparentBytes: Int64? = nil, reapedAt: Date = Date(), restoredAt: Date? = nil) {
+                apparentBytes: Int64? = nil, quarantinePath: String? = nil,
+                reapedAt: Date = Date(), restoredAt: Date? = nil) {
         self.id = id
         self.kind = kind
         self.repoPath = repoPath
@@ -1502,6 +1519,7 @@ public struct ReapRecord: Codable, Sendable, Identifiable, Equatable {
         self.headSHA = headSHA
         self.snapshotRef = snapshotRef
         self.apparentBytes = apparentBytes
+        self.quarantinePath = quarantinePath
         self.reapedAt = reapedAt
         self.restoredAt = restoredAt
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1180,6 +1180,21 @@ public struct Config: Codable, Sendable, Equatable {
     /// "never chose" and follows the shipped default wherever it goes; `0`/`1`
     /// is an explicit gesture and is honored forever.
     public var supervisionEnabled: Bool
+    /// Gate for the orphan-GC phase that reclaims per-profile config
+    /// directories under `~/tbd/profiles/`
+    /// (`docs/specs/2026-08-15-profile-dir-gc-design.md`). Read on top of
+    /// `gcEnabled`: both must be on for the phase to run. It ships OFF because
+    /// those directories hold per-profile credentials and user content with no
+    /// other copy, so a brand-new orphan classifier over them soaks behind its
+    /// own switch rather than riding the default-ON master switch.
+    ///
+    /// **Resolved, not stored**, like `supervisionEnabled`: the backing column
+    /// carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `gc_profile_dirs_enabled ?? Config.gcProfileDirsEnabledDefault`. NULL
+    /// means "never chose" and follows the shipped default wherever it goes;
+    /// `0`/`1` is an explicit gesture and is honored forever.
+    public var gcProfileDirsEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -1205,6 +1220,11 @@ public struct Config: Codable, Sendable, Equatable {
     /// change to this constant — no forcing `UPDATE` migration, and an explicit
     /// opt-out is left alone.
     public static let supervisionEnabledDefault = false
+    /// The shipped default for `gcProfileDirsEnabled`, and the single place it
+    /// lives. The profile-dir collector ships off; graduating it is a change to
+    /// this constant — no forcing `UPDATE` migration, and an explicit opt-out
+    /// is left alone.
+    public static let gcProfileDirsEnabledDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1232,7 +1252,8 @@ public struct Config: Codable, Sendable, Equatable {
                 remoteBackendsEnabled: Bool = false,
                 deliveryVerificationEnabled: Bool = false,
                 queuedPromptEnabled: Bool = Config.queuedPromptDefault,
-                supervisionEnabled: Bool = Config.supervisionEnabledDefault) {
+                supervisionEnabled: Bool = Config.supervisionEnabledDefault,
+                gcProfileDirsEnabled: Bool = Config.gcProfileDirsEnabledDefault) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -1260,6 +1281,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.deliveryVerificationEnabled = deliveryVerificationEnabled
         self.queuedPromptEnabled = queuedPromptEnabled
         self.supervisionEnabled = supervisionEnabled
+        self.gcProfileDirsEnabled = gcProfileDirsEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1323,6 +1345,11 @@ public struct Config: Codable, Sendable, Equatable {
         // default rather than hardcoding `false` here as well.
         supervisionEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .supervisionEnabled) ?? Config.supervisionEnabledDefault
+        // Same tri-state again: absent means the sender knew nothing about the
+        // flag, which is the NULL column's situation — follow the shipped
+        // default rather than hardcoding `false`.
+        gcProfileDirsEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .gcProfileDirsEnabled) ?? Config.gcProfileDirsEnabledDefault
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -275,6 +275,7 @@ public enum RPCMethod {
     public static let gcRestore = "gc.restore"
     public static let gcSweepNow = "gc.sweepNow"
     public static let configSetGCEnabled = "config.setGCEnabled"
+    public static let configSetGCProfileDirsEnabled = "config.setGCProfileDirsEnabled"
     public static let remoteProviders = "remote.providers"
     public static let remoteSessions = "remote.sessions"
     public static let remoteCreate = "remote.create"
@@ -2494,6 +2495,14 @@ public struct ConfigSetAutoTrustWorktreesParams: Codable, Sendable {
 
 /// Params for `config.setGCEnabled` — the orphan-GC master switch.
 public struct ConfigSetGCEnabledParams: Codable, Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setGCProfileDirsEnabled` — the gate for the profile-dir
+/// collector, which reclaims orphaned `~/tbd/profiles/<uuid>/` directories
+/// (default OFF during soak, on top of the GC master switch).
+public struct ConfigSetGCProfileDirsEnabledParams: Codable, Sendable {
     public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -1,10 +1,17 @@
 import Testing
 import Foundation
+import GRDB
 @testable import TBDDaemonLib
 @testable import TBDShared
 
 @Suite("ConfigStore")
 struct ConfigStoreTests {
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
     @Test func defaultsToNil() async throws {
         let db = try TBDDatabase(inMemory: true)
         let cfg = try await db.config.get()
@@ -237,5 +244,129 @@ struct ConfigStoreTests {
         #expect(try await db.config.get().autoTrustWorktrees == false)
         try await db.config.setAutoTrustWorktrees(enabled: true)
         #expect(try await db.config.get().autoTrustWorktrees == true)
+    }
+
+    // MARK: - v78: `gc_profile_dirs_enabled` is genuinely tri-state
+
+    /// **The storage guard.** The `config` singleton row is inserted by v1, so
+    /// every install — fresh or years old — has a row that predates v78. After
+    /// v78 that row's `gc_profile_dirs_enabled` must read NULL, not `0`: a SQL
+    /// default would backfill it and make "never chose" indistinguishable from
+    /// a deliberate opt-out, which is what the no-default convention exists to
+    /// prevent. If someone adds `defaults:` to
+    /// `v78_config_gc_profile_dirs`, this goes red — that is its only job.
+    @Test func gcProfileDirsIsNullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.gc_profile_dirs_enabled == nil,
+            """
+            config.gc_profile_dirs_enabled must be NULL until the toggle is \
+            touched — read back \
+            \(String(describing: record.gc_profile_dirs_enabled)). A non-nil \
+            value here means v78_config_gc_profile_dirs grew a `defaults:` \
+            argument; remove it.
+            """
+        )
+    }
+
+    /// The same guard against a row written by a real pre-v78 daemon: migrate
+    /// only through v77, write to the config row, then finish migrating.
+    @Test func rowWrittenBeforeV78StillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v77_config_supervision_enabled")
+
+        // A pre-v78 daemon touching config: the row exists and has been written
+        // to, but knows nothing about the new column.
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID]
+            )
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["gc_profile_dirs_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before v78 must read NULL, not \(raw)"
+            )
+            // The pre-existing write survived — v78 is purely additive.
+            #expect(row["gc_enabled"] == true)
+        }
+    }
+
+    /// NULL follows `Config.gcProfileDirsEnabledDefault` wherever it goes; an
+    /// explicit `false` does not. That property is what makes graduation a
+    /// one-line constant change with no forcing `UPDATE` migration. Exercised
+    /// against BOTH possible default values, so it fails if the resolution is
+    /// ever wired as `?? false`.
+    @Test func gcProfileDirsExplicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.gc_profile_dirs_enabled == nil)
+        #expect(untouched.toModel(gcProfileDirsDefault: false).gcProfileDirsEnabled == false)
+        #expect(
+            untouched.toModel(gcProfileDirsDefault: true).gcProfileDirsEnabled == true,
+            "a never-chosen row must pick up a changed shipped default"
+        )
+
+        try await db.config.setGCProfileDirsEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.gc_profile_dirs_enabled == false)
+        #expect(explicitlyOff.toModel(gcProfileDirsDefault: false).gcProfileDirsEnabled == false)
+        #expect(
+            explicitlyOff.toModel(gcProfileDirsDefault: true).gcProfileDirsEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes"
+        )
+    }
+
+    /// Mirrored for an explicit `true`: an operator who opted into the soak
+    /// stays opted in even if the shipped default never moves.
+    @Test func gcProfileDirsExplicitTrueSticks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.gc_profile_dirs_enabled == true)
+        #expect(explicitlyOn.toModel(gcProfileDirsDefault: false).gcProfileDirsEnabled == true)
+        #expect(explicitlyOn.toModel(gcProfileDirsDefault: true).gcProfileDirsEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard (`toModel()`'s
+    /// `?? gcProfileDirsDefault`) from the STORAGE guard (the migration's
+    /// no-SQL-default) by constructing a `ConfigRecord` directly — no database,
+    /// no migration. It catches a hardening of `?? gcProfileDirsDefault` into
+    /// `?? false` even if the migration guard were broken at the same time.
+    @Test func gcProfileDirsToModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", gc_profile_dirs_enabled: nil)
+        #expect(record.toModel(gcProfileDirsDefault: false).gcProfileDirsEnabled == false)
+        #expect(
+            record.toModel(gcProfileDirsDefault: true).gcProfileDirsEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false"
+        )
+    }
+
+    /// The shipped default today: OFF. The collector quarantines directories
+    /// holding per-profile credentials, so it soaks behind its own switch.
+    /// Graduation edits this constant and nothing else.
+    @Test func gcProfileDirsShipsOff() async throws {
+        #expect(Config.gcProfileDirsEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().gcProfileDirsEnabled == false)
+    }
+
+    @Test func setGCProfileDirsEnabledRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        #expect(try await db.config.get().gcProfileDirsEnabled == true)
+        try await db.config.setGCProfileDirsEnabled(false)
+        #expect(try await db.config.get().gcProfileDirsEnabled == false)
     }
 }

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import GRDB
+import Security
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -25,6 +27,49 @@ final class StubClaudeUsageFetcher: ClaudeUsageFetcher, @unchecked Sendable {
             return .networkError("no stub response queued")
         }
         return responses.removeFirst()
+    }
+}
+
+/// Keychain seam that samples the database from *inside* the delete handler's
+/// cleanup block, recording whether the `model_profiles` row still existed at
+/// that moment.
+///
+/// The row is the only pointer to `~/tbd/profiles/<uuid>/`, so every artifact
+/// keyed by it must be cleaned while it is still there: a daemon killed
+/// between the row delete and the directory removal would otherwise leave a
+/// directory nothing can ever attribute or reclaim. The probe is what pins
+/// that ordering — it cannot `await`, so it reads the writer synchronously.
+final class ProfileRowPresenceProbe: ClaudeCredentialsKeychainDeleting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _rowPresentAtKeychainDelete: Bool?
+    private var _probe: (@Sendable () -> Bool)?
+
+    /// `nil` when the handler never reached the Keychain cleanup at all.
+    var rowPresentAtKeychainDelete: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _rowPresentAtKeychainDelete
+    }
+
+    /// Installed after the router is built, because the sample reads the very
+    /// database the router owns.
+    func onDelete(_ probe: @escaping @Sendable () -> Bool) {
+        lock.lock()
+        _probe = probe
+        lock.unlock()
+    }
+
+    func deleteGenericPassword(service: String) -> OSStatus {
+        lock.lock()
+        let probe = _probe
+        lock.unlock()
+        let present = probe?()
+        lock.lock()
+        _rowPresentAtKeychainDelete = present
+        lock.unlock()
+        // Nothing was ever stored for a temp-dir profile; the handler treats
+        // this as success.
+        return errSecItemNotFound
     }
 }
 
@@ -56,7 +101,8 @@ struct ModelProfileRPCTests {
 
     private func makeRouter(
         stub: StubClaudeUsageFetcher = StubClaudeUsageFetcher(),
-        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager()
+        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
+        claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain()
     )
         -> (RPCRouter, TBDDatabase, StubClaudeUsageFetcher)
     {
@@ -72,6 +118,7 @@ struct ModelProfileRPCTests {
             startTime: Date(),
             usageFetcher: stub,
             configDirManager: configDirManager,
+            claudeCredentialsKeychain: claudeCredentialsKeychain,
             actuationLog: makeTestActuationLog()
         )
         return (router, db, stub)
@@ -440,6 +487,55 @@ struct ModelProfileRPCTests {
         #expect(try await db.modelProfiles.list().isEmpty)
         // Verify the config directory was deleted
         #expect(!FileManager.default.fileExists(atPath: profileDir.path))
+    }
+
+    @Test("delete: artifact cleanup runs while the profile row still exists")
+    func deleteCleansArtifactsBeforeRemovingRow() async throws {
+        let tempBaseDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("profile-delete-order-\(UUID().uuidString)", isDirectory: true)
+        let tempHostDir = tempBaseDir.appendingPathComponent("host-claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempHostDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempBaseDir) }
+
+        let manager = ClaudeProfileConfigDirManager(
+            baseDirectory: tempBaseDir.appendingPathComponent("profiles", isDirectory: true),
+            hostBaseDirectory: tempHostDir
+        )
+        let probe = ProfileRowPresenceProbe()
+        let (router, db, _) = makeRouter(configDirManager: manager, claudeCredentialsKeychain: probe)
+
+        let profile = try await db.modelProfiles.create(name: "OrderCanary", kind: .oauth)
+        _ = try manager.ensureOAuthDir(forProfileID: profile.id)
+        let profileDir = manager.profileDirectory(forProfileID: profile.id)
+        #expect(FileManager.default.fileExists(atPath: profileDir.path))
+
+        // The probe runs synchronously inside the handler, so it reads the
+        // writer directly rather than awaiting a store call.
+        let writer = db.writerForTests
+        let idString = profile.id.uuidString
+        probe.onDelete {
+            let count = try? writer.read { db in
+                try Int.fetchOne(
+                    db,
+                    sql: "SELECT COUNT(*) FROM model_profiles WHERE id = ?",
+                    arguments: [idString]
+                )
+            }
+            return (count ?? 0) > 0
+        }
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.modelProfileDelete,
+            params: ModelProfileDeleteParams(id: profile.id)
+        ))
+        #expect(resp.success)
+
+        // Row-keyed cleanup must happen while the row still exists; otherwise a
+        // crash mid-handler leaves a profile directory nothing points at.
+        #expect(probe.rowPresentAtKeychainDelete == true)
+        // The reorder must not weaken the outcome: both artifacts still go.
+        #expect(!FileManager.default.fileExists(atPath: profileDir.path))
+        #expect(try await db.modelProfiles.get(id: profile.id) == nil)
     }
 
     @Test("delete preserves host mirror targets across multiple slots and removes sidecars")

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -42,13 +42,32 @@ final class StubClaudeUsageFetcher: ClaudeUsageFetcher, @unchecked Sendable {
 final class ProfileRowPresenceProbe: ClaudeCredentialsKeychainDeleting, @unchecked Sendable {
     private let lock = NSLock()
     private var _rowPresentAtKeychainDelete: Bool?
+    private var _dirPresentAtKeychainDelete: Bool?
     private var _probe: (@Sendable () -> Bool)?
+    private var _directoryPath: String?
 
     /// `nil` when the handler never reached the Keychain cleanup at all.
     var rowPresentAtKeychainDelete: Bool? {
         lock.lock()
         defer { lock.unlock() }
         return _rowPresentAtKeychainDelete
+    }
+
+    /// The other half of the ordering: the directory removal is the step whose
+    /// crash-safety the reorder exists for, and it runs *after* this one. If it
+    /// had already happened, the sampled row presence would say nothing about
+    /// it.
+    var directoryPresentAtKeychainDelete: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _dirPresentAtKeychainDelete
+    }
+
+    /// Sampled alongside the row at Keychain-delete time.
+    func watchDirectory(_ path: String) {
+        lock.lock()
+        _directoryPath = path
+        lock.unlock()
     }
 
     /// Installed after the router is built, because the sample reads the very
@@ -62,10 +81,13 @@ final class ProfileRowPresenceProbe: ClaudeCredentialsKeychainDeleting, @uncheck
     func deleteGenericPassword(service: String) -> OSStatus {
         lock.lock()
         let probe = _probe
+        let directoryPath = _directoryPath
         lock.unlock()
         let present = probe?()
+        let directoryPresent = directoryPath.map { FileManager.default.fileExists(atPath: $0) }
         lock.lock()
         _rowPresentAtKeychainDelete = present
+        _dirPresentAtKeychainDelete = directoryPresent
         lock.unlock()
         // Nothing was ever stored for a temp-dir profile; the handler treats
         // this as success.
@@ -513,6 +535,7 @@ struct ModelProfileRPCTests {
         // writer directly rather than awaiting a store call.
         let writer = db.writerForTests
         let idString = profile.id.uuidString
+        probe.watchDirectory(profileDir.path)
         probe.onDelete {
             let count = try? writer.read { db in
                 try Int.fetchOne(
@@ -533,8 +556,58 @@ struct ModelProfileRPCTests {
         // Row-keyed cleanup must happen while the row still exists; otherwise a
         // crash mid-handler leaves a profile directory nothing points at.
         #expect(probe.rowPresentAtKeychainDelete == true)
+        // And the sample has to precede the directory removal for that to mean
+        // anything — otherwise the observed "row present" could be true of a
+        // handler that had already unlinked the directory.
+        #expect(probe.directoryPresentAtKeychainDelete == true)
         // The reorder must not weaken the outcome: both artifacts still go.
         #expect(!FileManager.default.fileExists(atPath: profileDir.path))
+        #expect(try await db.modelProfiles.get(id: profile.id) == nil)
+    }
+
+    /// The other half of the reorder's contract, and the reason a collector is
+    /// needed at all: a directory removal that fails is log-only and must NOT
+    /// abort the delete. The user asked for the profile to be gone, so the row
+    /// still goes — and the leftover directory becomes `ProfileDirCollector`'s
+    /// problem rather than the RPC's.
+    @Test("delete: a failed directory removal still deletes the profile row")
+    func deleteSurvivesAFailedDirectoryRemoval() async throws {
+        let tempBaseDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("profile-delete-rmfail-\(UUID().uuidString)", isDirectory: true)
+        let tempHostDir = tempBaseDir.appendingPathComponent("host-claude", isDirectory: true)
+        let profilesDir = tempBaseDir.appendingPathComponent("profiles", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempHostDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: profilesDir, withIntermediateDirectories: true)
+        defer {
+            // Restore write permission first, or the teardown cannot remove the
+            // tree it just made unwritable.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: profilesDir.path)
+            try? FileManager.default.removeItem(at: tempBaseDir)
+        }
+
+        let manager = ClaudeProfileConfigDirManager(
+            baseDirectory: profilesDir, hostBaseDirectory: tempHostDir)
+        let (router, db, _) = makeRouter(
+            configDirManager: manager, claudeCredentialsKeychain: ProfileRowPresenceProbe())
+
+        let profile = try await db.modelProfiles.create(name: "RmFailCanary", kind: .oauth)
+        _ = try manager.ensureOAuthDir(forProfileID: profile.id)
+        let profileDir = manager.profileDirectory(forProfileID: profile.id)
+
+        // Unlinking a child needs write permission on the parent, so this makes
+        // the handler's `removeItem` fail without touching the child itself.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o555], ofItemAtPath: profilesDir.path)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.modelProfileDelete,
+            params: ModelProfileDeleteParams(id: profile.id)
+        ))
+
+        #expect(resp.success, "a best-effort cleanup failure must not fail the RPC")
+        #expect(FileManager.default.fileExists(atPath: profileDir.path),
+                "the removal really did fail — otherwise this test proves nothing")
         #expect(try await db.modelProfiles.get(id: profile.id) == nil)
     }
 

--- a/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
@@ -126,7 +126,7 @@ struct OrphanGCProfileDirTests: ~Copyable {
 
     // MARK: - Flag gates
 
-    @Test("the profile-dir flag ships off: an aged orphan is untouched")
+    @Test("the profile-dir flag ships off: a real sweep leaves an aged orphan untouched")
     func flagOffIsNoOp() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setGCEnabled(true)
@@ -138,6 +138,27 @@ struct OrphanGCProfileDirTests: ~Copyable {
         #expect(fm.fileExists(atPath: dir.path))
         #expect(!result.planned.contains { $0.hasPrefix("REAP profile-dir ") })
         #expect(!result.planned.contains { $0.contains(dir.path) })
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    @Test("with the flag off a dry run still plans what enabling it would reclaim")
+    func flagOffDryRunStillPlans() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let dir = try makeProfileDir(UUID())
+        let expired = try makeQuarantineEntry(age: 40 * 86_400)
+        let keychain = RecordingKeychain()
+
+        let result = await makeGC(db: db, keychain: keychain).sweep(dryRun: true)
+
+        // The whole point of the bypass: a user deciding whether to flip a
+        // default-off flag can preview exactly what it would reclaim.
+        #expect(result.planned.contains("REAP profile-dir \(dir.path)"))
+        #expect(result.planned.contains("PURGE quarantine \(expired.path)"))
+        #expect(result.reaped == 0)
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(fm.fileExists(atPath: expired.path))
         #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
         #expect(keychain.services.isEmpty)
     }
@@ -319,7 +340,7 @@ struct OrphanGCProfileDirTests: ~Copyable {
         #expect(fm.fileExists(atPath: fresh.path))
     }
 
-    @Test("the flag also gates quarantine expiry")
+    @Test("the flag also gates quarantine expiry in a real sweep")
     func flagOffKeepsExpiredQuarantine() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setGCEnabled(true)

--- a/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Security
 import Testing
 @testable import TBDDaemonLib
@@ -169,12 +170,16 @@ struct OrphanGCProfileDirTests: ~Copyable {
         try await db.config.setGCEnabled(false)
         try await db.config.setGCProfileDirsEnabled(true)
         let dir = try makeProfileDir(UUID())
+        // The master switch stops quarantine expiry too — it is the one gate
+        // that governs the whole sweep, unlike the classifier flag.
+        let expired = try makeQuarantineEntry(age: 40 * 86_400)
         let keychain = RecordingKeychain()
 
         let result = await makeGC(db: db, keychain: keychain).sweep()
 
         #expect(result.planned == ["gc disabled"])
         #expect(fm.fileExists(atPath: dir.path))
+        #expect(fm.fileExists(atPath: expired.path))
         #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
         #expect(keychain.services.isEmpty)
     }
@@ -340,15 +345,60 @@ struct OrphanGCProfileDirTests: ~Copyable {
         #expect(fm.fileExists(atPath: fresh.path))
     }
 
-    @Test("the flag also gates quarantine expiry in a real sweep")
-    func flagOffKeepsExpiredQuarantine() async throws {
+    @Test("quarantine expiry is not gated by the classifier flag")
+    func flagOffStillPurgesExpiredQuarantine() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setGCEnabled(true)
         let expired = try makeQuarantineEntry(age: 40 * 86_400)
+        let fresh = try makeQuarantineEntry(age: 1 * 86_400)
+        // An orphan the classifier would reap if it were on — it must stay put,
+        // proving the flag still gates classification and only classification.
+        let orphan = try makeProfileDir(UUID())
+        let keychain = RecordingKeychain()
 
-        let result = await makeGC(db: db, keychain: RecordingKeychain()).sweep()
+        let result = await makeGC(db: db, keychain: keychain).sweep()
 
-        #expect(!result.planned.contains { $0.hasPrefix("PURGE quarantine ") })
-        #expect(fm.fileExists(atPath: expired.path))
+        // Purging `.reaped/` is cleanup of GC's own artifacts, not a
+        // classification of a user resource: an operator who ends a soak by
+        // turning the flag off must not strand credentials in quarantine past
+        // the retention window.
+        #expect(result.planned.contains("PURGE quarantine \(expired.path)"))
+        #expect(!fm.fileExists(atPath: expired.path))
+        #expect(fm.fileExists(atPath: fresh.path))
+
+        #expect(!result.planned.contains { $0.hasPrefix("REAP profile-dir ") })
+        #expect(fm.fileExists(atPath: orphan.path))
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    // MARK: - Pre-reap re-read failures
+
+    @Test("a throwing pre-reap re-read keeps the directory")
+    func preReapReadFailureKeepsDirectory() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let dir = try makeProfileDir(UUID())
+        let keychain = RecordingKeychain()
+
+        // Close the connection inside the pre-reap window, so the re-read
+        // *throws* rather than returning nil. No production error-injection
+        // seam: the store genuinely has no connection left, which is the same
+        // shape a real read failure takes.
+        let gc = makeGC(db: db, keychain: keychain, beforeProfileDirReap: {
+            try? db.writerForTests.close()
+        })
+        let result = await gc.sweep()
+
+        #expect(result.planned.contains("KEEP row-read-failed \(dir.path)"))
+        #expect(result.reaped == 0)
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(fm.fileExists(atPath: dir.path + "/claude"))
+        // Nothing was moved aside, and the path-keyed credentials item — which
+        // only the rename makes unreachable — was left alone.
+        let quarantined = (try? fm.contentsOfDirectory(atPath: quarantineBase.path)) ?? []
+        #expect(quarantined.isEmpty)
+        #expect(keychain.services.isEmpty)
     }
 }

--- a/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
@@ -1,0 +1,333 @@
+import Foundation
+import Security
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Records every path-keyed Claude credentials delete the sweep requests, so a
+/// test can assert the item keyed on the *original* config dir path is cleaned
+/// up — the one the quarantine rename just made unreachable. Never touches the
+/// real login keychain.
+private final class RecordingKeychain: ClaudeCredentialsKeychainDeleting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedServices: [String] = []
+    /// Status returned to the caller; `errSecItemNotFound` is the "nothing to
+    /// clean" leg, which the sweep must also treat as success.
+    let status: OSStatus
+
+    init(status: OSStatus = errSecSuccess) {
+        self.status = status
+    }
+
+    var services: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return storedServices
+    }
+
+    func deleteGenericPassword(service: String) -> OSStatus {
+        lock.lock()
+        storedServices.append(service)
+        lock.unlock()
+        return status
+    }
+}
+
+/// Tier 2: real filesystem plus an in-memory database, no `~/tbd` and no real
+/// keychain. The profiles base, the scratchpad base, the clock and the keychain
+/// are all injected; nothing here resolves a production path.
+@Suite("OrphanGC reclaims orphaned profile dirs")
+struct OrphanGCProfileDirTests: ~Copyable {
+    let fm = FileManager.default
+    /// Sandbox root for this test instance; everything lives under it.
+    let sandbox: URL
+    /// Injected profiles base (`OrphanGC(profileDirBase:)`).
+    let profileBase: URL
+    /// Injected scratchpad base, so the sweep's scratchpad phase can never
+    /// reach the developer's real Claude store.
+    let scratchpadBase: URL
+    /// Fixed sweep clock, far enough past every fixture's creation date that
+    /// the one-hour grace window has elapsed without backdating anything.
+    let clock = Date(timeIntervalSince1970: 1_800_000_000)
+
+    init() {
+        sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-profile-dir-\(UUID().uuidString)", isDirectory: true)
+        profileBase = sandbox.appendingPathComponent("profiles", isDirectory: true)
+        scratchpadBase = sandbox.appendingPathComponent("scratchpads", isDirectory: true)
+        try? fm.createDirectory(at: profileBase, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: scratchpadBase, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? fm.removeItem(at: sandbox)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeGC(
+        db: TBDDatabase,
+        keychain: any ClaudeCredentialsKeychainDeleting,
+        beforeProfileDirReap: (@Sendable () async -> Void)? = nil
+    ) -> OrphanGC {
+        let fixed = clock
+        return OrphanGC(
+            db: db, git: GitManager(),
+            broadcast: { _ in },
+            liveCWDsProvider: { [] },
+            scratchpadBase: scratchpadBase,
+            now: { fixed },
+            beforeInterruptedArchiveReap: nil,
+            profileDirBase: profileBase,
+            credentialsKeychain: keychain,
+            beforeProfileDirReap: beforeProfileDirReap
+        )
+    }
+
+    /// A profile config dir named for `id`, with a `claude/` subdirectory —
+    /// the shape `ClaudeProfileConfigDirManager` creates, and the path the
+    /// keychain item is keyed on.
+    @discardableResult
+    private func makeProfileDir(_ id: UUID) throws -> URL {
+        let url = profileBase.appendingPathComponent(id.uuidString.lowercased(), isDirectory: true)
+        try fm.createDirectory(
+            at: url.appendingPathComponent("claude", isDirectory: true),
+            withIntermediateDirectories: true)
+        return url
+    }
+
+    private var quarantineBase: URL {
+        profileBase.appendingPathComponent(
+            ProfileDirCollector.quarantineDirName, isDirectory: true)
+    }
+
+    /// A quarantine entry stamped `age` before the sweep clock.
+    @discardableResult
+    private func makeQuarantineEntry(age: TimeInterval) throws -> URL {
+        let stamp = ProfileDirCollector.stamp(clock.addingTimeInterval(-age))
+        let url = quarantineBase.appendingPathComponent(
+            "\(UUID().uuidString.lowercased())-\(stamp)", isDirectory: true)
+        try fm.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Inserts a `model_profiles` row with a caller-chosen id, which
+    /// `ModelProfileStore.create` cannot do (it mints its own UUID) — and the
+    /// id has to match the directory name for any of these gates to engage.
+    private func insertProfileRow(id: UUID, db: TBDDatabase) async throws {
+        let profile = ModelProfile(id: id, name: "acme-\(id.uuidString.prefix(8))", kind: .oauth)
+        try await db.modelProfiles.writer.write { db in
+            try ModelProfileRecord(from: profile).insert(db)
+        }
+    }
+
+    private func expectedKeychainService(forProfileDir path: String) -> String {
+        ClaudeCodeCredentialsKeychain.serviceName(forConfigDirPath: path + "/claude")
+    }
+
+    // MARK: - Flag gates
+
+    @Test("the profile-dir flag ships off: an aged orphan is untouched")
+    func flagOffIsNoOp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let dir = try makeProfileDir(UUID())
+        let keychain = RecordingKeychain()
+
+        let result = await makeGC(db: db, keychain: keychain).sweep()
+
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(!result.planned.contains { $0.hasPrefix("REAP profile-dir ") })
+        #expect(!result.planned.contains { $0.contains(dir.path) })
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    @Test("gcEnabled off keeps everything even with the profile-dir flag on")
+    func masterSwitchStillGoverns() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let dir = try makeProfileDir(UUID())
+        let keychain = RecordingKeychain()
+
+        let result = await makeGC(db: db, keychain: keychain).sweep()
+
+        #expect(result.planned == ["gc disabled"])
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    // MARK: - Reaping
+
+    @Test("flag on: an aged orphan is quarantined, recorded, and its keychain item deleted")
+    func flagOnQuarantines() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let id = UUID()
+        let dir = try makeProfileDir(id)
+        let keychain = RecordingKeychain()
+
+        let result = await makeGC(db: db, keychain: keychain).sweep()
+
+        #expect(result.planned.contains("REAP profile-dir \(dir.path)"))
+        #expect(result.reaped == 1)
+        #expect(!fm.fileExists(atPath: dir.path))
+
+        let records = try await db.reapRecords.list(repoPath: nil)
+        let record = try #require(records.first { $0.kind == .profileDir })
+        #expect(record.worktreePath == dir.path)
+        let quarantine = try #require(record.quarantinePath)
+        #expect(fm.fileExists(atPath: quarantine))
+        #expect(quarantine.hasPrefix(quarantineBase.path + "/"))
+        #expect(fm.fileExists(atPath: quarantine + "/claude"), "the directory moved, not deleted")
+
+        // Keyed on the ORIGINAL config dir path — the rename invalidated it.
+        #expect(keychain.services == [expectedKeychainService(forProfileDir: dir.path)])
+    }
+
+    @Test("errSecItemNotFound from the keychain is success, not a refusal to reap")
+    func missingKeychainItemStillReaps() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let dir = try makeProfileDir(UUID())
+        let keychain = RecordingKeychain(status: errSecItemNotFound)
+
+        let result = await makeGC(db: db, keychain: keychain).sweep()
+
+        #expect(result.planned.contains("REAP profile-dir \(dir.path)"))
+        #expect(!fm.fileExists(atPath: dir.path))
+        #expect(try await db.reapRecords.list(repoPath: nil).count == 1)
+    }
+
+    // MARK: - Keep gates
+
+    @Test("a dir whose profile row exists is kept")
+    func keepsLiveProfile() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let id = UUID()
+        try await insertProfileRow(id: id, db: db)
+        let dir = try makeProfileDir(id)
+        let keychain = RecordingKeychain()
+
+        let result = await makeGC(db: db, keychain: keychain).sweep()
+
+        #expect(result.planned.contains("KEEP row-exists \(dir.path)"))
+        #expect(!result.planned.contains("REAP profile-dir \(dir.path)"))
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    @Test("a dir referenced by a terminal row is kept even with no profile row")
+    func keepsTerminalReferenced() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let id = UUID()
+        let dir = try makeProfileDir(id)
+
+        let repoPath = sandbox.appendingPathComponent("acme", isDirectory: true)
+        try fm.createDirectory(at: repoPath, withIntermediateDirectories: true)
+        let repo = try await db.repos.create(
+            path: repoPath.path, displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "wt",
+            path: repoPath.appendingPathComponent("wt").path, tmuxServer: "tbd-test")
+        _ = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1", profileID: id)
+
+        let keychain = RecordingKeychain()
+        let result = await makeGC(db: db, keychain: keychain).sweep()
+
+        #expect(result.planned.contains("KEEP terminal-reference \(dir.path)"))
+        #expect(!result.planned.contains("REAP profile-dir \(dir.path)"))
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    @Test("a row that appears after the candidate listing keeps its directory")
+    func keepsRowThatAppearedMidSweep() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let id = UUID()
+        let dir = try makeProfileDir(id)
+        let keychain = RecordingKeychain()
+
+        // Lands in the window between the candidate/row snapshot and the reap
+        // — the exact staleness the pre-reap re-read closes.
+        let gc = makeGC(db: db, keychain: keychain, beforeProfileDirReap: {
+            try? await db.modelProfiles.writer.write { db in
+                try ModelProfileRecord(
+                    from: ModelProfile(id: id, name: "acme-recreated", kind: .oauth)
+                ).insert(db)
+            }
+        })
+        let result = await gc.sweep()
+
+        #expect(result.planned.contains("KEEP row-appeared \(dir.path)"))
+        #expect(result.reaped == 0)
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    // MARK: - Dry run
+
+    @Test("dry run plans without touching disk, the DB or the keychain")
+    func dryRunPlansOnly() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let dir = try makeProfileDir(UUID())
+        let expired = try makeQuarantineEntry(age: 40 * 86_400)
+        let keychain = RecordingKeychain()
+
+        let result = await makeGC(db: db, keychain: keychain).sweep(dryRun: true)
+
+        #expect(result.planned.contains("REAP profile-dir \(dir.path)"))
+        #expect(result.planned.contains("PURGE quarantine \(expired.path)"))
+        #expect(result.reaped == 0)
+        #expect(fm.fileExists(atPath: dir.path))
+        #expect(fm.fileExists(atPath: expired.path))
+        #expect(try await db.reapRecords.list(repoPath: nil).isEmpty)
+        #expect(keychain.services.isEmpty)
+    }
+
+    // MARK: - Quarantine expiry
+
+    @Test("expired quarantine entries are purged; unexpired ones survive")
+    func purgesExpiredQuarantine() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCProfileDirsEnabled(true)
+        let expired = try makeQuarantineEntry(age: 40 * 86_400)
+        let fresh = try makeQuarantineEntry(age: 1 * 86_400)
+        let keychain = RecordingKeychain()
+
+        let result = await makeGC(db: db, keychain: keychain).sweep()
+
+        #expect(result.planned.contains("PURGE quarantine \(expired.path)"))
+        #expect(!result.planned.contains("PURGE quarantine \(fresh.path)"))
+        #expect(!fm.fileExists(atPath: expired.path))
+        #expect(fm.fileExists(atPath: fresh.path))
+    }
+
+    @Test("the flag also gates quarantine expiry")
+    func flagOffKeepsExpiredQuarantine() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let expired = try makeQuarantineEntry(age: 40 * 86_400)
+
+        let result = await makeGC(db: db, keychain: RecordingKeychain()).sweep()
+
+        #expect(!result.planned.contains { $0.hasPrefix("PURGE quarantine ") })
+        #expect(fm.fileExists(atPath: expired.path))
+    }
+}

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -233,6 +233,33 @@ struct OrphanGCTests {
         #expect(fetched.first?.worktreePath == record.worktreePath)
     }
 
+    /// `.profileDir` must stay un-restorable, and that is a contract rather
+    /// than an oversight: the `model_profiles` row the directory depends on is
+    /// already gone by the time the collector runs, so renaming it back out of
+    /// quarantine would recreate an orphan for the very next sweep. Recovery is
+    /// by hand, from the `quarantinePath` this record carries.
+    @Test("restore refuses a profileDir record and leaves the quarantine in place")
+    func restoreRejectsProfileDirRecords() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = ReapRecord(
+            kind: .profileDir,
+            repoPath: "",
+            worktreePath: "/tmp/acme/profiles/1f2e3d4c-0000-0000-0000-000000000002",
+            quarantinePath: "/tmp/acme/profiles/.reaped/1f2e3d4c-0000-0000-0000-000000000002-20260815T101500Z"
+        )
+        try await db.reapRecords.insert(record)
+        let gc = OrphanGC(db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] })
+
+        await #expect(throws: OrphanGCError.unsupportedKind(.profileDir)) {
+            try await gc.restore(recordID: record.id)
+        }
+        // A refused restore must not consume the record: the quarantine path is
+        // still the user's only handle on the data.
+        let fetched = try await db.reapRecords.get(id: record.id)
+        #expect(fetched?.restoredAt == nil)
+        #expect(fetched?.quarantinePath == record.quarantinePath)
+    }
+
     /// Every other kind deletes outright, so the column stays NULL for them —
     /// and a record written without one must decode as `nil`, not as "".
     @Test("a non-quarantined reap record round-trips with a nil quarantine path")

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -208,6 +208,43 @@ struct OrphanGCTests {
         #expect(changedCount == 2, "expected one broadcast from sweep + one from restore")
     }
 
+    // MARK: - profileDir reap records
+
+    /// The quarantine path is the only handle a user has on a reaped profile
+    /// directory — `.profileDir` has no restore path — so it must survive the
+    /// round trip through the store alongside the new kind.
+    @Test("a profileDir reap record round-trips through the store with its quarantine path")
+    func profileDirRecordRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = ReapRecord(
+            kind: .profileDir,
+            repoPath: "",
+            worktreePath: "/tmp/acme/profiles/1f2e3d4c-0000-0000-0000-000000000001",
+            apparentBytes: 4096,
+            quarantinePath: "/tmp/acme/profiles/.reaped/1f2e3d4c-0000-0000-0000-000000000001-20260815T101500Z",
+            reapedAt: Date(timeIntervalSince1970: 1_760_000_000)
+        )
+        try await db.reapRecords.insert(record)
+
+        let fetched = try await db.reapRecords.list(repoPath: nil)
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.kind == .profileDir)
+        #expect(fetched.first?.quarantinePath == record.quarantinePath)
+        #expect(fetched.first?.worktreePath == record.worktreePath)
+    }
+
+    /// Every other kind deletes outright, so the column stays NULL for them —
+    /// and a record written without one must decode as `nil`, not as "".
+    @Test("a non-quarantined reap record round-trips with a nil quarantine path")
+    func nonQuarantinedRecordHasNilQuarantinePath() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.reapRecords.insert(
+            ReapRecord(kind: .scratchpad, repoPath: "", worktreePath: "/tmp/acme/scratch-1")
+        )
+        let fetched = try await db.reapRecords.list(repoPath: nil)
+        #expect(fetched.first?.quarantinePath == nil)
+    }
+
     // MARK: - Snapshot retention (anchor rule)
 
     @Test func snapshotRetentionDeletesOldRefs() async throws {

--- a/Tests/TBDDaemonTests/ProfileDirCollectorTests.swift
+++ b/Tests/TBDDaemonTests/ProfileDirCollectorTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Tier 2: real filesystem, no database, no `~/tbd`. Everything lives under a
+/// per-instance sandbox in `NSTemporaryDirectory()`, and every clock read goes
+/// through the collector's injected `now`.
+@Suite("ProfileDirCollector enumerates, gates, quarantines and expires profile dirs")
+struct ProfileDirCollectorTests: ~Copyable {
+    let fm = FileManager.default
+    /// Sandbox root for this test instance; everything lives under it.
+    let sandbox: URL
+    /// Injected profiles base (`ProfileDirCollector(base:)`).
+    let base: URL
+
+    init() {
+        sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("profile-dir-gc-\(UUID().uuidString)", isDirectory: true)
+        base = sandbox.appendingPathComponent("profiles", isDirectory: true)
+        try? fm.createDirectory(at: base, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? fm.removeItem(at: sandbox)
+    }
+
+    /// Creates UUID-named directories under the injected base and returns them.
+    @discardableResult
+    private func makeProfileDirs(_ ids: [UUID]) throws -> [URL] {
+        try ids.map { id in
+            let url = base.appendingPathComponent(id.uuidString.lowercased(), isDirectory: true)
+            try fm.createDirectory(at: url, withIntermediateDirectories: true)
+            return url
+        }
+    }
+
+    private var quarantineBase: URL {
+        base.appendingPathComponent(ProfileDirCollector.quarantineDirName, isDirectory: true)
+    }
+
+    // MARK: - Enumeration
+
+    @Test("candidates lists UUID-named dirs and skips everything else")
+    func candidatesSkipsNonUUIDEntries() throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        try fm.createDirectory(
+            at: base.appendingPathComponent("not-a-uuid", isDirectory: true),
+            withIntermediateDirectories: true)
+        try fm.createDirectory(at: quarantineBase, withIntermediateDirectories: true)
+        // A file whose *name* is a UUID is not a config directory.
+        try "x".write(
+            to: base.appendingPathComponent(UUID().uuidString.lowercased()),
+            atomically: true, encoding: .utf8)
+
+        let found = ProfileDirCollector(base: base).candidates()
+
+        #expect(found.map(\.profileID) == [id])
+        #expect(found.first?.path == base.appendingPathComponent(
+            id.uuidString.lowercased(), isDirectory: true).path)
+        #expect(found.first?.createdAt != nil, "a just-created dir must have a readable creation date")
+    }
+
+    @Test("candidates is empty when the profiles base does not exist")
+    func candidatesEmptyWhenBaseMissing() {
+        let missing = sandbox.appendingPathComponent("no-such-base", isDirectory: true)
+        #expect(ProfileDirCollector(base: missing).candidates().isEmpty)
+    }
+
+    // MARK: - Gates
+
+    @Test("a dir with a live row is kept")
+    func keepsKnownProfile() throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        let collector = ProfileDirCollector(base: base)
+        let candidate = try #require(collector.candidates().first)
+
+        #expect(collector.decide(candidate, knownProfileIDs: [id], referencedProfileIDs: [],
+                                 graceSeconds: 0) == .keep(reason: "row-exists"))
+    }
+
+    @Test("an orphan referenced by a terminal row is kept")
+    func keepsTerminalReferenced() throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        let collector = ProfileDirCollector(base: base)
+        let candidate = try #require(collector.candidates().first)
+
+        #expect(collector.decide(candidate, knownProfileIDs: [], referencedProfileIDs: [id],
+                                 graceSeconds: 0) == .keep(reason: "terminal-reference"))
+    }
+
+    @Test("a young orphan is kept by the grace window")
+    func keepsYoungOrphan() throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        let collector = ProfileDirCollector(base: base)
+        let candidate = try #require(collector.candidates().first)
+
+        #expect(collector.decide(candidate, knownProfileIDs: [], referencedProfileIDs: [],
+                                 graceSeconds: 3600) == .keep(reason: "grace"))
+    }
+
+    @Test("an orphan whose age cannot be read is kept")
+    func keepsUnknownAge() {
+        let collector = ProfileDirCollector(base: base)
+        let candidate = ProfileDirCandidate(
+            profileID: UUID(), path: base.appendingPathComponent("x").path, createdAt: nil)
+
+        #expect(collector.decide(candidate, knownProfileIDs: [], referencedProfileIDs: [],
+                                 graceSeconds: 0) == .keep(reason: "unknown-age"))
+    }
+
+    @Test("an aged, unreferenced orphan is reapable")
+    func reapsAgedOrphan() throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        let collector = ProfileDirCollector(base: base)
+        let candidate = try #require(collector.candidates().first)
+
+        #expect(collector.decide(candidate, knownProfileIDs: [], referencedProfileIDs: [],
+                                 graceSeconds: 0) == .reap)
+    }
+
+    // MARK: - Reap
+
+    @Test("reap renames into .reaped and records both paths")
+    func reapQuarantines() async throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        let dir = base.appendingPathComponent(id.uuidString.lowercased(), isDirectory: true)
+        try "secret".write(
+            to: dir.appendingPathComponent(".credentials.json"), atomically: true, encoding: .utf8)
+
+        let fixed = Date(timeIntervalSince1970: 1_760_000_000)
+        let collector = ProfileDirCollector(base: base, now: { fixed })
+        let candidate = try #require(collector.candidates().first)
+
+        let record = try #require(await collector.reap(candidate))
+
+        #expect(record.kind == .profileDir)
+        #expect(record.repoPath == "")
+        #expect(record.worktreePath == candidate.path)
+        #expect(record.reapedAt == fixed)
+        #expect(!fm.fileExists(atPath: candidate.path), "the rename is the commit point")
+
+        let quarantine = try #require(record.quarantinePath)
+        #expect(quarantine.hasPrefix(quarantineBase.path + "/"))
+        #expect(fm.fileExists(atPath: quarantine))
+        #expect(fm.fileExists(atPath: quarantine + "/.credentials.json"),
+                "quarantine must preserve the directory's contents, not just its name")
+        #expect(collector.candidates().isEmpty, "the quarantine is never a candidate")
+    }
+
+    @Test("a failed quarantine keeps the directory and reports no record")
+    func reapFailureKeepsDirectory() async throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        // A regular file where the quarantine directory belongs: creating the
+        // quarantine base fails, so the rename never happens.
+        try "not a directory".write(to: quarantineBase, atomically: true, encoding: .utf8)
+
+        let collector = ProfileDirCollector(base: base)
+        let candidate = try #require(collector.candidates().first)
+
+        #expect(await collector.reap(candidate) == nil)
+        #expect(fm.fileExists(atPath: candidate.path), "a failed reap must leave the candidate untouched")
+    }
+
+    // MARK: - Quarantine expiry
+
+    @Test("quarantine entries expire only after the retention window")
+    func expiryRespectsRetention() async throws {
+        let id = UUID()
+        try makeProfileDirs([id])
+        let reapedAt = Date(timeIntervalSince1970: 1_760_000_000)
+        let atReap = ProfileDirCollector(base: base, now: { reapedAt })
+        let candidate = try #require(atReap.candidates().first)
+        let record = try #require(await atReap.reap(candidate))
+        let quarantine = try #require(record.quarantinePath)
+
+        let day: TimeInterval = 86_400
+        let early = ProfileDirCollector(base: base, now: { reapedAt.addingTimeInterval(29 * day) })
+        #expect(early.expiredQuarantineEntries(retentionDays: 30).isEmpty)
+
+        let late = ProfileDirCollector(base: base, now: { reapedAt.addingTimeInterval(31 * day) })
+        #expect(late.expiredQuarantineEntries(retentionDays: 30) == [quarantine])
+        #expect(late.purge(quarantinePath: quarantine))
+        #expect(!fm.fileExists(atPath: quarantine))
+    }
+
+    @Test("expiry is empty when there is no quarantine directory")
+    func expiryEmptyWithoutQuarantine() {
+        #expect(ProfileDirCollector(base: base).expiredQuarantineEntries(retentionDays: 30).isEmpty)
+    }
+
+    @Test("an entry whose name carries no timestamp falls back to the directory's own dates")
+    func expiryFallsBackToDirectoryDates() throws {
+        try fm.createDirectory(at: quarantineBase, withIntermediateDirectories: true)
+        let stale = quarantineBase.appendingPathComponent("no-stamp-here", isDirectory: true)
+        let fresh = quarantineBase.appendingPathComponent("also-unparseable", isDirectory: true)
+        try fm.createDirectory(at: stale, withIntermediateDirectories: true)
+        try fm.createDirectory(at: fresh, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_760_000_000)
+        let old = now.addingTimeInterval(-90 * 86_400)
+        try fm.setAttributes([.creationDate: old, .modificationDate: old], ofItemAtPath: stale.path)
+        try fm.setAttributes([.creationDate: now, .modificationDate: now], ofItemAtPath: fresh.path)
+
+        let collector = ProfileDirCollector(base: base, now: { now })
+
+        #expect(collector.expiredQuarantineEntries(retentionDays: 30) == [stale.path])
+    }
+
+    // MARK: - Purge
+
+    @Test("purge refuses a path outside the quarantine directory")
+    func purgeRefusesOutsidePaths() throws {
+        let victim = base.appendingPathComponent("victim", isDirectory: true)
+        try fm.createDirectory(at: victim, withIntermediateDirectories: true)
+
+        #expect(!ProfileDirCollector(base: base).purge(quarantinePath: victim.path))
+        #expect(fm.fileExists(atPath: victim.path))
+    }
+
+    @Test("purge refuses the quarantine directory itself")
+    func purgeRefusesQuarantineRoot() throws {
+        try fm.createDirectory(at: quarantineBase, withIntermediateDirectories: true)
+
+        #expect(!ProfileDirCollector(base: base).purge(quarantinePath: quarantineBase.path))
+        #expect(fm.fileExists(atPath: quarantineBase.path))
+    }
+
+    @Test("purge reports failure when the entry cannot be removed")
+    func purgeReportsRemovalFailure() {
+        let ghost = quarantineBase.appendingPathComponent("gone-already", isDirectory: true)
+
+        #expect(!ProfileDirCollector(base: base).purge(quarantinePath: ghost.path))
+    }
+}

--- a/Tests/TBDDaemonTests/ProfileDirCollectorTests.swift
+++ b/Tests/TBDDaemonTests/ProfileDirCollectorTests.swift
@@ -169,6 +169,45 @@ struct ProfileDirCollectorTests: ~Copyable {
         #expect(fm.fileExists(atPath: candidate.path), "a failed reap must leave the candidate untouched")
     }
 
+    @Test("reap refuses a candidate that does not live directly under the base")
+    func reapRefusesUnanchoredCandidate() async throws {
+        let victim = sandbox.appendingPathComponent("victim", isDirectory: true)
+        try fm.createDirectory(at: victim, withIntermediateDirectories: true)
+        let candidate = ProfileDirCandidate(
+            profileID: UUID(), path: victim.path, createdAt: Date(timeIntervalSince1970: 0))
+
+        #expect(await ProfileDirCollector(base: base).reap(candidate) == nil)
+        #expect(fm.fileExists(atPath: victim.path), "a rename is destructive at the source path too")
+        #expect(!fm.fileExists(atPath: quarantineBase.path), "nothing should have been created")
+    }
+
+    @Test("reap refuses a candidate nested below the base rather than directly under it")
+    func reapRefusesNestedCandidate() async throws {
+        // The shape a bare `hasPrefix(base)` guard would wave through: already
+        // quarantined, and re-quarantining it would bury it a level deeper and
+        // restamp its age.
+        let id = UUID()
+        let nested = quarantineBase.appendingPathComponent(
+            id.uuidString.lowercased(), isDirectory: true)
+        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
+        let candidate = ProfileDirCandidate(
+            profileID: id, path: nested.path, createdAt: Date(timeIntervalSince1970: 0))
+
+        #expect(await ProfileDirCollector(base: base).reap(candidate) == nil)
+        #expect(fm.fileExists(atPath: nested.path))
+    }
+
+    @Test("reap refuses a candidate whose path does not match its own profile id")
+    func reapRefusesMismatchedName() async throws {
+        let dir = base.appendingPathComponent("not-a-uuid", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let candidate = ProfileDirCandidate(
+            profileID: UUID(), path: dir.path, createdAt: Date(timeIntervalSince1970: 0))
+
+        #expect(await ProfileDirCollector(base: base).reap(candidate) == nil)
+        #expect(fm.fileExists(atPath: dir.path))
+    }
+
     // MARK: - Quarantine expiry
 
     @Test("quarantine entries expire only after the retention window")
@@ -201,13 +240,22 @@ struct ProfileDirCollectorTests: ~Copyable {
         try fm.createDirectory(at: quarantineBase, withIntermediateDirectories: true)
         let stale = quarantineBase.appendingPathComponent("no-stamp-here", isDirectory: true)
         let fresh = quarantineBase.appendingPathComponent("also-unparseable", isDirectory: true)
-        try fm.createDirectory(at: stale, withIntermediateDirectories: true)
-        try fm.createDirectory(at: fresh, withIntermediateDirectories: true)
+        // Old creation, recent modification: the fallback takes the NEWER of the
+        // two, so this one is kept. Reading only `creationDate` — or the older
+        // of the pair — would expire a directory somebody touched yesterday,
+        // which is the wrong direction for a fallback that exists because the
+        // real reap timestamp is unavailable.
+        let touched = quarantineBase.appendingPathComponent("touched-recently", isDirectory: true)
+        for url in [stale, fresh, touched] {
+            try fm.createDirectory(at: url, withIntermediateDirectories: true)
+        }
 
         let now = Date(timeIntervalSince1970: 1_760_000_000)
         let old = now.addingTimeInterval(-90 * 86_400)
         try fm.setAttributes([.creationDate: old, .modificationDate: old], ofItemAtPath: stale.path)
         try fm.setAttributes([.creationDate: now, .modificationDate: now], ofItemAtPath: fresh.path)
+        try fm.setAttributes(
+            [.creationDate: old, .modificationDate: now], ofItemAtPath: touched.path)
 
         let collector = ProfileDirCollector(base: base, now: { now })
 

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -150,10 +150,13 @@ and the `.reaped/` quarantine are never candidates. Directories are enumerated *
 the rows are read, so a profile created mid-sweep is always in the row set and can never
 be classified as an orphan.
 
-**Flag: `gc_profile_dirs_enabled`, default off.** The phase runs only when `gcEnabled`
-**and** this flag are both on; with the flag off it is skipped entirely, dry run
-included (a dry run bypasses `gcEnabled` as it does for the rest of the sweep, but never
-this flag). Enable it for a soak with `tbd gc profile-dirs on` (RPC
+**Flag: `gc_profile_dirs_enabled`, default off.** The phase reclaims only when `gcEnabled`
+**and** this flag are both on. A dry run bypasses both, exactly as it does for the rest
+of the sweep: `tbd gc sweep --dry-run` prints the `REAP profile-dir` and
+`PURGE quarantine` lines this phase *would* act on with the flag off, so the decision to
+enable a default-off switch can be made against real candidates rather than blind.
+Planning touches neither disk nor the database. Enable it for a soak with
+`tbd gc profile-dirs on` (RPC
 `config.setGCProfileDirsEnabled`); there is no Settings toggle. The column carries no SQL
 default, so an install nobody has touched reads NULL and resolves through
 `Config.gcProfileDirsEnabledDefault` — graduation is a one-line change to that constant,
@@ -255,11 +258,11 @@ The sweep itself runs:
 
 For an ad-hoc look without waiting for the clock, use `tbd gc sweep --dry-run` — it
 computes and prints the identical plan without touching disk or the DB, regardless of
-`gcEnabled`. One under-report to know about: a companion scratchpad reap for an
-agent worktree that's only *planned* (not actually reaped) in a dry run isn't planned
-either, since it's only computed once the agent worktree itself has actually been
-removed — a real (non-dry) sweep will report more scratchpad reaps than the preceding
-dry run predicted.
+`gcEnabled` or `gc_profile_dirs_enabled`. One under-report to know about: a companion
+scratchpad reap for an agent worktree that's only *planned* (not actually reaped) in a
+dry run isn't planned either, since it's only computed once the agent worktree itself
+has actually been removed — a real (non-dry) sweep will report more scratchpad reaps
+than the preceding dry run predicted.
 
 ## Config knobs
 

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -187,7 +187,11 @@ the empty result as "everything is an orphan".
 **Quarantine, not delete.** A reap renames the directory into
 `~/tbd/profiles/.reaped/<uuid>-<UTC timestamp>/`. The rename is the commit point: a
 failure leaves the candidate exactly where it was for the next sweep to reconsider
-(`quarantine-failed`). Apparent size is measured just before the rename, while it is
+(`quarantine-failed`). Both destructive filesystem calls are anchored first, and to the
+collector's own base rather than to whatever the caller passed: a reap refuses any
+candidate that is not a UUID-named *immediate* child of `~/tbd/profiles/` (so an
+already-quarantined entry can never be re-quarantined a level deeper), and a purge
+refuses any path not strictly under `.reaped/`. Apparent size is measured just before the rename, while it is
 still readable at the original path. Immediately after, the path-keyed Claude Code
 login-keychain item for the *original* config dir (`<uuid>/claude`) is deleted — the
 rename invalidated the path its service name is derived from, so it is unreachable
@@ -208,8 +212,7 @@ recoverable, so reaping parks the data instead of destroying it.
 disease it treats. Age comes from the timestamp this collector stamped into the entry's
 own name; an entry whose name carries no parsable stamp falls back to the newer of its
 own creation and modification dates, and one with no readable date at all is kept rather
-than guessed at. A purge refuses any path not strictly under `.reaped/`. Expiry writes
-no new reap record — the entry already has one.
+than guessed at. Expiry writes no new reap record — the entry already has one.
 
 **No restore path, recovery by hand.** `tbd gc restore` accepts `.agentWorktree` records
 only and rejects `.profileDir`. By the time the collector runs, the profile row — its

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -1,6 +1,7 @@
 # Orphan GC (product feature)
 
-Daemon-owned garbage collection for Claude Code agent worktrees and their scratchpads.
+Daemon-owned garbage collection for Claude Code agent worktrees, their scratchpads, and
+orphaned per-profile Claude config directories.
 **Shipped product**, unlike `scripts/reclaim-build.sh`/`sweep-scratchpads.sh` (see
 [`docs/reclaim-build.md`](reclaim-build.md) for the dev-script sibling and the boundary
 between the two). Design background:
@@ -17,11 +18,15 @@ auto-removes one if it ended unchanged — the moment an agent commits, the work
 Code's own 30-day sweep permanently exempts anything with unpushed commits. Nothing
 else ever cleans these up.
 
-Two things get reaped:
+Three things get reaped:
 - **Agent worktrees** — `<repo>/.claude/worktrees/agent-*` and `wf_*` whose run has
   ended (see gates below).
 - **Attributable scratchpads** — `/private/tmp/claude-<uid>/<slug>` directories TBD can
   tie to a worktree path it knows about (its own, or an agent worktree it just reaped).
+- **Orphaned profile config directories** — `~/tbd/profiles/<uuid>/` directories whose
+  `model_profiles` row is gone; `ProfileDirCollector` is the named reconciler for that
+  resource class, alongside the agent-worktree and scratchpad collectors, and it
+  quarantines rather than deletes (see below).
 
 ## Philosophy: orphaned, not idle
 
@@ -123,6 +128,96 @@ Non-goals: scratchpads of non-TBD projects, and scratchpads left behind by agent
 worktrees Claude Code itself removed before TBD ever swept them. That residue is
 `scripts/sweep-scratchpads.sh`'s territory (`docs/reclaim-build.md`).
 
+## Profile config directories
+
+Every non-Bedrock model profile gets an isolated Claude config directory at
+`~/tbd/profiles/<uuid>/`, created lazily — on session spawn, when the profile's
+`CLAUDE_CONFIG_DIR` is resolved, and on OAuth login prep
+(`modelProfile.prepareConfigDir`, called before `tbd profile login`). Exactly one
+`model_profiles` row points at it, and it is the *only* pointer: nothing on disk records
+which profile a directory belongs to beyond the UUID in its name.
+
+That makes deletion the risk. `modelProfile.delete` cleans the Keychain items and the
+directory before deleting the row — deliberately, so a daemon killed partway leaves "row
+present, directory gone or present", both benign — but each cleanup step is log-only and
+non-fatal. A `removeItem` that fails still deletes the row, and the row is what would
+have named the leftover directory. Without a sweep, a single failed removal orphans that
+directory permanently. `ProfileDirCollector` is the backstop.
+
+**Orphan definition.** An immediate child of `~/tbd/profiles/` whose name parses as a
+UUID, is a directory, and matches no `model_profiles` row. Non-UUID entries, plain files
+and the `.reaped/` quarantine are never candidates. Directories are enumerated *before*
+the rows are read, so a profile created mid-sweep is always in the row set and can never
+be classified as an orphan.
+
+**Flag: `gc_profile_dirs_enabled`, default off.** The phase runs only when `gcEnabled`
+**and** this flag are both on; with the flag off it is skipped entirely, dry run
+included (a dry run bypasses `gcEnabled` as it does for the rest of the sweep, but never
+this flag). Enable it for a soak with `tbd gc profile-dirs on` (RPC
+`config.setGCProfileDirsEnabled`); there is no Settings toggle. The column carries no SQL
+default, so an install nobody has touched reads NULL and resolves through
+`Config.gcProfileDirsEnabledDefault` — graduation is a one-line change to that constant,
+reaching everyone who never flipped the switch while preserving every explicit opt-out.
+
+**Gates**, in order. Like the agent-worktree gates, every one fails toward keeping, and
+each keep is reported in the sweep plan with its reason:
+
+1. **Row exists** (`row-exists`) — a `model_profiles` row with this UUID is present.
+2. **Terminal reference** (`terminal-reference`) — any `terminal` row's `profile_id`
+   matches the UUID. `modelProfile.delete` deliberately leaves `profile_id` on terminals
+   spawned with that profile's env, so a live (or hibernated, resumable) session may
+   still be pointing `CLAUDE_CONFIG_DIR` at the directory. Terminal rows disappear when
+   terminals close, so this converges. It is deliberately stricter than the interactive
+   delete path: a background sweep yanking credentials out from under a running session
+   is worse than a user doing it knowingly.
+3. **Grace window** (`grace`) — the directory's creation date is younger than
+   `gcGraceSeconds` (default 3600s / 1h). An unreadable creation date keeps too
+   (`unknown-age`).
+4. **Pre-reap re-read** (`row-appeared`) — immediately before the rename, `model_profiles`
+   is re-read for the UUID. The candidate list and the row snapshot are both taken at
+   the top of the phase, so a profile recreated with this UUID in between must not have
+   its directory pulled out from under it; a failed read reads as "keep".
+
+A failed `model_profiles` or `terminal` read skips the whole phase rather than treating
+the empty result as "everything is an orphan".
+
+**Quarantine, not delete.** A reap renames the directory into
+`~/tbd/profiles/.reaped/<uuid>-<UTC timestamp>/`. The rename is the commit point: a
+failure leaves the candidate exactly where it was for the next sweep to reconsider
+(`quarantine-failed`). Apparent size is measured just before the rename, while it is
+still readable at the original path. Immediately after, the path-keyed Claude Code
+login-keychain item for the *original* config dir (`<uuid>/claude`) is deleted — the
+rename invalidated the path its service name is derived from, so it is unreachable
+garbage either way; `errSecItemNotFound` counts as success. A `.profileDir` reap record
+is then written, carrying the original path and the quarantine path.
+
+The other collectors can delete outright because what they remove is recoverable by
+other means, or was never precious: an agent worktree replays from a verified snapshot
+ref, and a scratchpad is disposable tmp. A profile directory is neither. It holds `.claude.json` (login identity, onboarding
+state, per-profile settings), `.credentials.json` (fallback OAuth credentials when the
+Keychain is unavailable), and `<slot>.profile-local` sidecars holding real pre-existing
+user content that was moved aside when a slot became a host symlink — none of which has
+another copy once the row is gone. A misclassification therefore has to stay
+recoverable, so reaping parks the data instead of destroying it.
+
+**Quarantine expiry.** The same phase deletes `.reaped/` entries older than
+`gcSnapshotRetentionDays` (default 30), which keeps the quarantine from growing into the
+disease it treats. Age comes from the timestamp this collector stamped into the entry's
+own name; an entry whose name carries no parsable stamp falls back to the newer of its
+own creation and modification dates, and one with no readable date at all is kept rather
+than guessed at. A purge refuses any path not strictly under `.reaped/`. Expiry writes
+no new reap record — the entry already has one.
+
+**No restore path, recovery by hand.** `tbd gc restore` accepts `.agentWorktree` records
+only and rejects `.profileDir`. By the time the collector runs, the profile row — its
+name, kind, endpoint — is already gone, so renaming the directory back would only
+recreate an orphan for the next sweep to find. Recovery is manual and lasts as long as
+the retention window: `tbd gc list` prints the quarantine location next to each record
+(`quarantined→ <path>`), and the user copies out whatever they need, or recreates a
+profile and moves the directory into the new UUID. The app's Reclaimed section does not
+surface these records — it is per-repo, and a profile directory belongs to no repo — so
+the CLI is where a quarantine path is read.
+
 ## Cadence and the `gcEnabled` gate
 
 `gcEnabled` (config-table boolean, **default on**) is the single master switch — it
@@ -171,6 +266,7 @@ dry run predicted.
 | Key | Default | Where |
 |---|---|---|
 | `gcEnabled` | `true` | Settings toggle + `config.setGCEnabled` RPC |
+| `gcProfileDirsEnabled` | `false` | `tbd gc profile-dirs on\|off` + `config.setGCProfileDirsEnabled` RPC, no UI |
 | `gcGraceSeconds` | `3600` (1h) | config table only, no UI |
 | `gcSnapshotRetentionDays` | `30` | config table only, no UI |
 
@@ -196,9 +292,10 @@ Restore is available for `agentWorktree` records only.
 ## CLI
 
 ```sh
-tbd gc list [--repo <path>] [--json]   # list reap records (id, kind, path, size, snapshot state, restored)
+tbd gc list [--repo <path>] [--json]   # list reap records (id, kind, path, size, snapshot state, restored, quarantine path)
 tbd gc restore <uuid>                  # restore a reaped agent worktree
 tbd gc sweep [--dry-run]               # run a sweep now; --dry-run prints the plan, mutates nothing
+tbd gc profile-dirs on|off             # gate the profile-config-dir collector (ships off)
 ```
 
 ## Non-goals (from the design spec)

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -150,9 +150,15 @@ and the `.reaped/` quarantine are never candidates. Directories are enumerated *
 the rows are read, so a profile created mid-sweep is always in the row set and can never
 be classified as an orphan.
 
-**Flag: `gc_profile_dirs_enabled`, default off.** The phase reclaims only when `gcEnabled`
-**and** this flag are both on. A dry run bypasses both, exactly as it does for the rest
-of the sweep: `tbd gc sweep --dry-run` prints the `REAP profile-dir` and
+**Flag: `gc_profile_dirs_enabled`, default off.** The flag gates *classification*: a
+directory is enumerated, gated and quarantined only when `gcEnabled` **and** this flag
+are both on. It does **not** gate quarantine expiry, which runs under `gcEnabled` alone —
+purging `.reaped/` is cleanup of GC's own artifacts, of data the sweep already moved
+aside, not a judgement about a user's resource. That split is what makes quarantining
+safer than deleting: an operator who ends a soak by turning the flag off (or backs out
+after a suspected misclassification) must not thereby strand credentials on disk forever,
+well past the retention window. A dry run bypasses both switches, exactly as it does for
+the rest of the sweep: `tbd gc sweep --dry-run` prints the `REAP profile-dir` and
 `PURGE quarantine` lines this phase *would* act on with the flag off, so the decision to
 enable a default-off switch can be made against real candidates rather than blind.
 Planning touches neither disk nor the database. Enable it for a soak with
@@ -176,13 +182,16 @@ each keep is reported in the sweep plan with its reason:
 3. **Grace window** (`grace`) — the directory's creation date is younger than
    `gcGraceSeconds` (default 3600s / 1h). An unreadable creation date keeps too
    (`unknown-age`).
-4. **Pre-reap re-read** (`row-appeared`) — immediately before the rename, `model_profiles`
-   is re-read for the UUID. The candidate list and the row snapshot are both taken at
-   the top of the phase, so a profile recreated with this UUID in between must not have
-   its directory pulled out from under it; a failed read reads as "keep".
+4. **Pre-reap re-read** (`row-appeared`, `row-read-failed`) — immediately before the
+   rename, `model_profiles` is re-read for the UUID. The candidate list and the row
+   snapshot are both taken at the top of the phase, so a profile recreated with this
+   UUID in between must not have its directory pulled out from under it. A row that is
+   found again keeps as `row-appeared`; a read that *throws* keeps as `row-read-failed`,
+   distinct on purpose — "no answer" is not "no row", and collapsing the two would reap
+   on the one piece of evidence that says nothing.
 
-A failed `model_profiles` or `terminal` read skips the whole phase rather than treating
-the empty result as "everything is an orphan".
+A failed `model_profiles` or `terminal` read skips the whole classification arm rather
+than treating the empty result as "everything is an orphan".
 
 **Quarantine, not delete.** A reap renames the directory into
 `~/tbd/profiles/.reaped/<uuid>-<UTC timestamp>/`. The rename is the commit point: a
@@ -209,7 +218,9 @@ recoverable, so reaping parks the data instead of destroying it.
 
 **Quarantine expiry.** The same phase deletes `.reaped/` entries older than
 `gcSnapshotRetentionDays` (default 30), which keeps the quarantine from growing into the
-disease it treats. Age comes from the timestamp this collector stamped into the entry's
+disease it treats. It runs on every sweep `gcEnabled` allows, whatever
+`gc_profile_dirs_enabled` says, so nothing this collector parked can outlive the
+retention window. Age comes from the timestamp this collector stamped into the entry's
 own name; an entry whose name carries no parsable stamp falls back to the newer of its
 own creation and modification dates, and one with no readable date at all is kept rather
 than guessed at. Expiry writes no new reap record — the entry already has one.

--- a/docs/specs/2026-08-15-profile-dir-gc-design.md
+++ b/docs/specs/2026-08-15-profile-dir-gc-design.md
@@ -173,18 +173,21 @@ Every gate fails toward keeping and appends a KEEP reason to the sweep plan:
 4. Persist a `ReapRecord` with a new `ReapKind.profileDir`, `repoPath: ""`,
    `worktreePath` = the original directory path, and the quarantine location
    in a new optional `quarantine_path` column on `reap_records` (migration +
-   GRDB record + shared model, one commit; the app's kind rendering gains the
-   new case — daemon and app ship together via `scripts/restart.sh`).
+   GRDB record + shared model, one commit). The record's audience is
+   `tbd gc list`: the app's Reclaimed section fetches records per repo and
+   summarizes only the kinds it knows, and a profile directory belongs to no
+   repo, so `.profileDir` records deliberately do not surface there.
 
 ### No restore path
 
 `OrphanGC.restore` stays unsupported for `.profileDir`, like scratchpads. By
 the time the collector runs, the profile row — the name, kind, endpoint —
 is already gone, so renaming the directory back would only recreate an orphan
-for the next sweep. Recovery is manual: the quarantine path is visible in the
-reap history (`tbd gc list` and the History UI), and the user retrieves
-whatever they need (or recreates a profile and moves the directory into its
-UUID) by hand within the retention window.
+for the next sweep. Recovery is manual: `tbd gc list` prints the quarantine
+path next to each record, and the user retrieves whatever they need (or
+recreates a profile and moves the directory into its UUID) by hand within the
+retention window. The CLI is the recovery surface — the app's per-repo
+Reclaimed section does not show `.profileDir` records.
 
 ### Quarantine expiry
 
@@ -203,8 +206,9 @@ write additional ReapRecords — the quarantine entry's record already exists.
   terminal-referenced dir kept; pre-reap re-read keeps a just-recreated row;
   quarantine entry expires after retention and survives before it; dry run
   plans without touching disk or DB.
-- Flag: both branches (off = no-op even with orphans present, on = reaps),
-  plus the three NULL/false/true states.
+- Flag: both branches (off = a real sweep is a no-op even with orphans
+  present, while a dry run still plans them; on = reaps), plus the three
+  NULL/false/true states.
 - All tests use injection seams (`ClaudeProfileConfigDirManager(baseDirectory:)`,
   `OrphanGC`'s injected `now`/`db`), never the real `~/tbd`.
 

--- a/docs/specs/2026-08-15-profile-dir-gc-design.md
+++ b/docs/specs/2026-08-15-profile-dir-gc-design.md
@@ -54,11 +54,13 @@ data. That asymmetry drives the quarantine decision below.
 Three questions were put to a human; each answer below is theirs.
 
 - **Own default-off flag, not a rider on `gcEnabled`.** A new config column
-  `gc_profile_dirs_enabled`, shipped default OFF; the collector runs only when
-  `gcEnabled` AND this flag are both on. `gcEnabled` shipped default-ON for
-  reclaims that are restorable or disposable; a new collector over
-  directories holding credentials and user content warrants its own soak.
-  Graduation is a one-line flip of the Swift default constant.
+  `gc_profile_dirs_enabled`, shipped default OFF; the collector *classifies*
+  only when `gcEnabled` AND this flag are both on. `gcEnabled` shipped
+  default-ON for reclaims that are restorable or disposable; a new classifier
+  over directories holding credentials and user content warrants its own soak.
+  Graduation is a one-line flip of the Swift default constant. The flag's scope
+  ends at classification: quarantine expiry answers to `gcEnabled` alone, so
+  ending a soak never strands data the sweep already moved aside.
 - **Quarantine, then expire — not delete outright.** Reaping renames the
   directory into `~/tbd/profiles/.reaped/<uuid>-<timestamp>/` (rename as the
   atomic commit point, the same pattern as `WorktreeDeletionQueue`) and
@@ -148,9 +150,9 @@ legitimate young directory exists before its row.
 
 Every gate fails toward keeping and appends a KEEP reason to the sweep plan:
 
-- **Flag** — skip the whole phase unless `gcEnabled` and
+- **Flag** — skip the classification arm unless `gcEnabled` and
   `gcProfileDirsEnabled` are both on (dry-run plans regardless, like the
-  other arms).
+  other arms). Quarantine expiry sits outside this gate; see below.
 - **Grace** — keep directories whose creation date is younger than
   `gcGraceSeconds` (default 1 h). Belt-and-braces against any future
   creation-order change.
@@ -158,7 +160,11 @@ Every gate fails toward keeping and appends a KEEP reason to the sweep plan:
   the UUID.
 - **Pre-reap re-read** — immediately before renaming, re-check that no
   `model_profiles` row with the UUID exists (the same
-  snapshot-staleness close as the deletion-queue collector's row re-read).
+  snapshot-staleness close as the deletion-queue collector's row re-read). A
+  row that is found again and a read that throws are separate keeps
+  (`row-appeared`, `row-read-failed`): a thrown read is the absence of
+  evidence, not evidence of absence, and reaping on it would invert the
+  fail-toward-keeping direction the rest of the sweep takes.
 
 ### Reap mechanics
 
@@ -193,7 +199,11 @@ Reclaimed section does not show `.profileDir` records.
 
 The same sweep phase deletes `.reaped/` entries older than
 `gcSnapshotRetentionDays` (default 30 d), reusing the retention knob that
-already governs how long reaped state stays recoverable. Age comes from the
+already governs how long reaped state stays recoverable. Expiry runs under
+`gcEnabled` alone, outside the classifier flag: purging the quarantine is
+cleanup of GC's own artifacts rather than a judgement about a user's resource,
+and a flag that could strand credentials in `.reaped/` indefinitely would
+dissolve the very property that made quarantining preferable to deleting. Age comes from the
 timestamp embedded in the entry's name; an unparseable name falls back to the
 directory's own dates, and any read failure keeps the entry. Expiry does not
 write additional ReapRecords — the quarantine entry's record already exists.
@@ -204,11 +214,14 @@ write additional ReapRecords — the quarantine entry's record already exists.
 - Collector: orphan reaped into quarantine; row-matched dir kept; non-UUID
   entry untouched; `.reaped/` never a candidate; grace keeps a young dir;
   terminal-referenced dir kept; pre-reap re-read keeps a just-recreated row;
-  quarantine entry expires after retention and survives before it; dry run
-  plans without touching disk or DB.
-- Flag: both branches (off = a real sweep is a no-op even with orphans
+  a *throwing* pre-reap re-read keeps the directory, writes no record and
+  leaves the keychain item alone; quarantine entry expires after retention and
+  survives before it; dry run plans without touching disk or DB.
+- Flag: both branches (off = a real sweep reaps nothing even with orphans
   present, while a dry run still plans them; on = reaps), plus the three
-  NULL/false/true states.
+  NULL/false/true states. Its scope too: with the flag off a real sweep still
+  purges an expired quarantine entry, while `gcEnabled` off stops that as
+  well.
 - All tests use injection seams (`ClaudeProfileConfigDirManager(baseDirectory:)`,
   `OrphanGC`'s injected `now`/`db`), never the real `~/tbd`.
 

--- a/docs/specs/2026-08-15-profile-dir-gc-design.md
+++ b/docs/specs/2026-08-15-profile-dir-gc-design.md
@@ -232,6 +232,14 @@ write additional ReapRecords — the quarantine entry's record already exists.
 ## Reconciler doctrine
 
 `ProfileDirCollector` is the named reconciler for the durable resource class
-"per-profile config directories under `~/tbd/profiles/`". Every durable
-external resource TBD creates needs exactly such a named reconciler; this
-collector closes the last known class that had none.
+"per-profile config directories under `~/tbd/profiles/`", the answer this
+design owes to CLAUDE.md's "Every durable external resource needs a named
+reconciler". It arrives as an extension of `OrphanGC`, the reconciler that
+rule already names for filesystem resources, rather than as a fourth sweep.
+
+The class qualified for that question the moment the directories started
+outliving the request that created them: they are created lazily at spawn,
+and the only thing that ever pointed at one was a `model_profiles` row whose
+deletion was not, and cannot be, transactional with the directory's removal.
+That is the same shape as the leaks the doctrine cites as its field evidence
+— best-effort cleanup on the deletion path, no sweep behind it.

--- a/docs/specs/2026-08-15-profile-dir-gc-design.md
+++ b/docs/specs/2026-08-15-profile-dir-gc-design.md
@@ -1,0 +1,233 @@
+# Profile-dir GC: a reconciler for `~/tbd/profiles/`
+
+## Problem
+
+Every non-bedrock model profile gets an isolated config directory at
+`~/tbd/profiles/<uuid>/` (created lazily by
+`ClaudeProfileConfigDirManager.ensureAPIKeyDir`/`ensureOAuthDir` on session
+spawn or OAuth login prep). The only deletion path is the `modelProfile.delete`
+RPC, and it deletes the DB row — the sole pointer to the directory — *before*
+its best-effort Keychain and directory cleanup, each of which only logs on
+failure. A daemon crash or a failed `removeItem` between the row delete and the
+directory removal orphans the directory permanently: no row will ever reference
+it again, and nothing sweeps `~/tbd/profiles/`.
+
+This is the same failure shape that produced the tmux-socket and per-attempt
+branch leaks: a best-effort delete on the happy path with no compensating
+sweep. Profile config directories are the one durable resource class with no
+named reconciler. This design closes that gap with two changes of different
+kinds:
+
+1. **Bug fix** — reorder `modelProfile.delete` so the row outlives the
+   directory. This restores the existing theory (deletes should not orphan)
+   and would not need a spec on its own.
+2. **Feature** — a new OrphanGC collector, `ProfileDirCollector`, the named
+   reconciler for `~/tbd/profiles/`. It reclaims directories with no matching
+   `model_profiles` row. Because it deletes persisted state autonomously and
+   the directories can contain user data, it ships behind its own default-off
+   flag.
+
+## What a profile directory contains
+
+The stakes differ from the existing collectors. Most slots inside
+`<uuid>/claude/` are symlinks into the host `~/.claude` store (`projects/`,
+`plugins/`, `skills/`, …), but the directory also holds real per-profile
+data:
+
+- `.claude.json` — login identity, onboarding state, per-profile settings.
+- `.credentials.json` — fallback OAuth credentials when the Keychain is
+  unavailable. A secret.
+- `<slot>.profile-local` sidecars — real pre-existing user content moved
+  aside when a slot was converted to a symlink.
+
+There is also a paired login-Keychain item
+(`Claude Code-credentials-<sha256-prefix-of-configDir-path>`) keyed by the
+directory's absolute path.
+
+Agent worktrees reap safely because a git snapshot ref makes them restorable;
+scratchpads reap safely because they are disposable tmp. An orphaned profile
+dir has neither property: once the row is gone there is no other copy of this
+data. That asymmetry drives the quarantine decision below.
+
+## Decisions
+
+Three questions were put to a human; each answer below is theirs.
+
+- **Own default-off flag, not a rider on `gcEnabled`.** A new config column
+  `gc_profile_dirs_enabled`, shipped default OFF; the collector runs only when
+  `gcEnabled` AND this flag are both on. `gcEnabled` shipped default-ON for
+  reclaims that are restorable or disposable; a new collector over
+  directories holding credentials and user content warrants its own soak.
+  Graduation is a one-line flip of the Swift default constant.
+- **Quarantine, then expire — not delete outright.** Reaping renames the
+  directory into `~/tbd/profiles/.reaped/<uuid>-<timestamp>/` (rename as the
+  atomic commit point, the same pattern as `WorktreeDeletionQueue`) and
+  deletes the quarantined copy only after the existing
+  `gcSnapshotRetentionDays` window (default 30 days). A misclassification is
+  recoverable for a month; the quarantine cannot grow unboundedly because the
+  same sweep expires it.
+- **Liveness gate: keep while any terminal row references the profile.**
+  `modelProfile.delete` deliberately leaves `terminal.profile_id` on
+  terminals whose sessions were spawned with the profile's env, so a live (or
+  hibernated, resumable) session can still be using the directory via
+  `CLAUDE_CONFIG_DIR`. The collector keeps any candidate whose UUID appears
+  in any terminal row. Terminal rows are removed when terminals close, so
+  this converges; it is deliberately stricter than the interactive delete
+  path, because a background sweep yanking credentials from a running session
+  is worse than a user-initiated delete doing so.
+
+## Bug-fix half: deletion order in `modelProfile.delete`
+
+Reorder `handleModelProfileDelete`
+(`Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift`) so
+everything keyed by the row happens while the row still exists:
+
+1. Clear the default-profile pointer and repo overrides (unchanged).
+2. Delete the usage row (unchanged).
+3. Delete the API-key Keychain entry and the path-keyed login-Keychain item
+   (moved earlier; still log-only on failure).
+4. Remove the profile directory (moved earlier; still log-only on failure).
+5. Delete the `model_profiles` row (moved last).
+
+A directory-removal failure still proceeds to delete the row — the user asked
+for the profile to be gone, and the collector is now the backstop for the
+leftover directory. What the reorder buys is crash-safety: a daemon killed
+mid-handler now leaves "row present, directory gone or present", both benign
+(the directory is recreated lazily on next spawn; the user retries the
+delete), instead of an unreferenced directory nothing will ever reclaim.
+
+Interactive delete keeps outright removal rather than routing through
+quarantine: the user explicitly asked for deletion, and keeping their
+credentials on disk for another 30 days after an explicit delete would be
+worse, not safer.
+
+A regression test pins the order — the directory removal must be observed
+before the row delete — and fails against the pre-fix handler.
+
+## Feature half: `ProfileDirCollector`
+
+A new collector in `Sources/TBDDaemon/GC/`, run as an additional phase of
+`OrphanGC.sweep()`. It follows the established division of labor: the
+collector owns filesystem enumeration and mutation; `OrphanGC` owns every DB
+read (row listing, terminal references, the pre-reap re-read), mirroring how
+`DeletionQueueCollector` stays database-free.
+
+### Flag mechanics
+
+- Migration adds `gc_profile_dirs_enabled` to `config` via
+  `addColumnIfMissing(table:column:type:)` with **no SQL default**, so NULL
+  remains the third state ("nobody has chosen").
+- The shipped default lives in exactly one place:
+  `?? Config.gcProfileDirsEnabledDefault` (= `false`) in
+  `ConfigStore.toModel()`.
+- Same-commit updates to the GRDB record and the Codable `Config` model in
+  `Sources/TBDShared/Models.swift` (optional with default, so existing rows
+  and JSON decode).
+- A config RPC setter mirroring `setGCEnabled`, reachable from the CLI, is
+  the soak-time enablement path. No app UI toggle until graduation.
+- Tests cover the three states: a pre-migration row reads NULL (not `0`); an
+  explicit `false` survives a change to the default constant; NULL follows
+  the constant.
+
+### Orphan definition
+
+A candidate is an immediate child of the profiles base directory
+(`ClaudeProfileConfigDirManager.baseDirectory`, which honors `TBD_HOME`)
+whose name parses as a UUID and which matches no `model_profiles` row. Rows
+are read *after* the directory enumeration, so a profile created mid-sweep is
+always in the row set. Non-UUID entries and the `.reaped/` quarantine are
+never candidates. All profile kinds share one namespace: any UUID directory
+with a row is kept regardless of kind.
+
+The creation path makes this definition sound: directories are only ever
+created from an already-fetched row (`resolveConfigDir` at spawn,
+`modelProfile.prepareConfigDir` at login prep), so there is no window where a
+legitimate young directory exists before its row.
+
+### Keep gates
+
+Every gate fails toward keeping and appends a KEEP reason to the sweep plan:
+
+- **Flag** — skip the whole phase unless `gcEnabled` and
+  `gcProfileDirsEnabled` are both on (dry-run plans regardless, like the
+  other arms).
+- **Grace** — keep directories whose creation date is younger than
+  `gcGraceSeconds` (default 1 h). Belt-and-braces against any future
+  creation-order change.
+- **Terminal reference** — keep while any terminal row's `profile_id` matches
+  the UUID.
+- **Pre-reap re-read** — immediately before renaming, re-check that no
+  `model_profiles` row with the UUID exists (the same
+  snapshot-staleness close as the deletion-queue collector's row re-read).
+
+### Reap mechanics
+
+1. Measure `apparentBytes` before the rename (last moment the size is
+   readable at the original path).
+2. `mkdir -p <base>/.reaped/`, then atomically rename the directory to
+   `<base>/.reaped/<uuid>-<timestamp>/`. Rename is the commit point; a
+   failure leaves the candidate untouched for the next sweep.
+3. Delete the path-keyed login-Keychain item for the *original* path — the
+   rename just invalidated its key, so it is unreachable garbage either way.
+   `errSecItemNotFound` is success.
+4. Persist a `ReapRecord` with a new `ReapKind.profileDir`, `repoPath: ""`,
+   `worktreePath` = the original directory path, and the quarantine location
+   in a new optional `quarantine_path` column on `reap_records` (migration +
+   GRDB record + shared model, one commit; the app's kind rendering gains the
+   new case — daemon and app ship together via `scripts/restart.sh`).
+
+### No restore path
+
+`OrphanGC.restore` stays unsupported for `.profileDir`, like scratchpads. By
+the time the collector runs, the profile row — the name, kind, endpoint —
+is already gone, so renaming the directory back would only recreate an orphan
+for the next sweep. Recovery is manual: the quarantine path is visible in the
+reap history (`tbd gc list` and the History UI), and the user retrieves
+whatever they need (or recreates a profile and moves the directory into its
+UUID) by hand within the retention window.
+
+### Quarantine expiry
+
+The same sweep phase deletes `.reaped/` entries older than
+`gcSnapshotRetentionDays` (default 30 d), reusing the retention knob that
+already governs how long reaped state stays recoverable. Age comes from the
+timestamp embedded in the entry's name; an unparseable name falls back to the
+directory's own dates, and any read failure keeps the entry. Expiry does not
+write additional ReapRecords — the quarantine entry's record already exists.
+
+### Testing
+
+- Delete-order regression test (fails without the bug fix).
+- Collector: orphan reaped into quarantine; row-matched dir kept; non-UUID
+  entry untouched; `.reaped/` never a candidate; grace keeps a young dir;
+  terminal-referenced dir kept; pre-reap re-read keeps a just-recreated row;
+  quarantine entry expires after retention and survives before it; dry run
+  plans without touching disk or DB.
+- Flag: both branches (off = no-op even with orphans present, on = reaps),
+  plus the three NULL/false/true states.
+- All tests use injection seams (`ClaudeProfileConfigDirManager(baseDirectory:)`,
+  `OrphanGC`'s injected `now`/`db`), never the real `~/tbd`.
+
+## Rejected alternatives
+
+- **Riding `gcEnabled` with no new flag** — simpler, but puts a brand-new
+  orphan classifier over credential-bearing directories live on every install
+  the day it ships; the default-ON decision for `gcEnabled` was made for
+  restorable or disposable reclaims.
+- **Delete outright (scratchpad-style)** — no retention bookkeeping, but a
+  misclassification permanently destroys credentials and user content, with
+  the flag soak as the only safety net.
+- **Quarantine forever with manual purge** — safest per-reap, but recreates
+  the unbounded-growth disease one level down.
+- **Quarantine for the interactive delete too** — rejected above: an explicit
+  user delete should not leave secrets on disk for another month.
+- **A rename-back restore for `.profileDir` records** — the row the directory
+  depends on is unrecoverable, so restore would produce an orphan, not a
+  profile.
+
+## Reconciler doctrine
+
+`ProfileDirCollector` is the named reconciler for the durable resource class
+"per-profile config directories under `~/tbd/profiles/`". Every durable
+external resource TBD creates needs exactly such a named reconciler; this
+collector closes the last known class that had none.


### PR DESCRIPTION
## Summary

Every non-bedrock model profile owns an isolated Claude config directory at `~/tbd/profiles/<uuid>/` — its own `.claude.json`, its own login identity, a `.credentials.json` fallback when the Keychain is unavailable, and any `<slot>.profile-local` sidecar holding real user content that was moved aside when a slot became a symlink. The directory is created lazily the first time a session spawns against that profile, and exactly one thing ever points at it: the profile's `model_profiles` row.

Deleting a profile deleted that row first, then tried to clean the Keychain and the directory on a best-effort basis, logging on failure. So any interruption after the row delete — a daemon crash, a failed `removeItem`, a permissions error — stranded the directory permanently. Nothing referenced it, and no sweep looked at `~/tbd/profiles/` at all. It was the one durable resource class in the daemon with no reconciler behind it.

This PR fixes the ordering so an interruption can no longer strand anything, and adds the sweep that reclaims what earlier interruptions already stranded.

## Why this shape

Spec: [`docs/specs/2026-08-15-profile-dir-gc-design.md`](../blob/profile-dir-gc/docs/specs/2026-08-15-profile-dir-gc-design.md).

Three decisions shaped it, all made because these directories are not like the things the existing collectors reap:

- **Its own default-off flag, rather than riding `gcEnabled`.** `gcEnabled` ships ON because agent worktrees are restorable from a snapshot ref and scratchpads are disposable tmp. A profile directory is neither — once the row is gone there is no other copy of the credentials or user content inside it. A brand-new orphan classifier over that deserves a soak before it runs on every install.
- **Reaping quarantines, it does not delete.** The directory is renamed into `~/tbd/profiles/.reaped/<uuid>-<timestamp>/`, with the rename as the atomic commit point (the pattern `WorktreeDeletionQueue` already uses), and the quarantined copy is deleted only after the existing `gcSnapshotRetentionDays` window. A misclassification stays recoverable for a month, and the quarantine cannot itself become the next leak because the same sweep expires it.
- **A profile UUID still named by any terminal row is kept.** Deleting a profile deliberately leaves `terminal.profile_id` in place on sessions that were spawned with that profile's environment, because the running `claude` process really is still using the directory via `CLAUDE_CONFIG_DIR`. This is stricter than the interactive delete path, and intentionally so: a background sweep pulling credentials out from under a running session is worse than a user doing it on purpose.

The interactive delete keeps deleting outright rather than routing through quarantine — when someone explicitly deletes a profile, leaving their credentials on disk for another 30 days is not the safer choice.

Rejected alternatives are recorded in the spec: deleting outright scratchpad-style, quarantining forever with a manual purge, and a rename-back restore path (the row it would need is already unrecoverable, so restoring would only produce a fresh orphan).

## What this PR does

- **`RPCRouter+ModelProfileHandlers.swift`** — `handleModelProfileDelete` now deletes the `model_profiles` row **last**, after the Keychain and directory cleanup. Cleanup failures stay log-only and non-fatal; what changes is that an interruption now leaves "row present, directory gone or present", both benign, instead of an unreferenced directory.
- **`Sources/TBDDaemon/GC/ProfileDirCollector.swift`** (new) — enumerates UUID-named children of the profiles base, gates them, quarantines by rename, and expires quarantine entries. It touches no database; the caller supplies what it needs to judge an orphan. Every failure path — unreadable listing, unreadable creation date, failed rename, unparseable quarantine stamp — fails toward keeping.
- **`OrphanGC.swift`** — a `reclaimProfileDirs` phase running inside the existing hourly sweep. It enumerates directories *before* reading rows, so a profile created mid-sweep is always in the row set and can never be classified an orphan, then gates on: a live `model_profiles` row, a terminal reference, the `gcGraceSeconds` window, an unreadable age, and a final row re-read immediately before the rename. A failed DB read skips the whole phase. After a successful quarantine it deletes the path-keyed Claude Code Keychain item, which the rename has just made unreachable.
- **Migrations `v78`/`v79`** — the `gc_profile_dirs_enabled` config column and a nullable `quarantinePath` on `reap_records`, each with its GRDB record and shared model updated in the same commit. `ReapKind` gains `.profileDir`; `OrphanGC.restore` continues to accept only `.agentWorktree`.
- **CLI** — `tbd gc profile-dirs on|off`, and `tbd gc list` prints the quarantine location so a reclaimed directory can be found by hand.
- **Docs** — [`docs/orphan-gc.md`](../blob/profile-dir-gc/docs/orphan-gc.md) gains the collector, and CLAUDE.md's named-reconciler list records that `OrphanGC` now covers this resource class, which is the answer this PR owes that doctrine.

## Flag & rollout

`gc_profile_dirs_enabled`, default **OFF**, layered on top of the `gcEnabled` master switch. Added with no SQL default, so NULL genuinely means "nobody has chosen" and resolves through `Config.gcProfileDirsEnabledDefault` — the single place graduation changes.

The flag's scope ends at *classification*. Deciding that a directory is an orphan and quarantining it happens only when the flag is on; expiring the quarantine answers to `gcEnabled` alone. That split matters at the moment a soak ends: turning the flag back off must not strand data the sweep already moved aside, and "the same sweep expires it" is the whole reason quarantining beat deleting.

Enable for the soak with `tbd gc profile-dirs on`. `tbd gc sweep --dry-run` previews what enabling it would reclaim **even while the flag is off**, so the census can be inspected before anything is trusted to act on it.

Graduation: after a soak with no misclassification, flip `Config.gcProfileDirsEnabledDefault` to `true`. That reaches everyone who never touched the toggle while preserving every explicit opt-out, and the flag can be deleted later.

## Assumptions

- **Terminal rows are removed when their terminals close.** The keep-gate relies on that for convergence; a permanently leaked terminal row would keep its profile directory forever. That is over-retention, not data loss, and the failure direction is deliberate.
- **A profile directory is only ever created from an already-fetched row** (`resolveConfigDir` at spawn, `modelProfile.prepareConfigDir` at login prep). This is what makes "directory present, row absent" a sound orphan definition. If a future path creates the directory before its row, the grace window is the only thing standing between that directory and a reap.

## Evidence & verification

- **Both flag branches tested**, plus the third state: a pre-migration row reads NULL rather than `0`, an explicit `false` survives a change to the default constant while NULL follows it, a real sweep with the flag off is a no-op, and a dry run with the flag off still plans.
- **Discriminating tests, mutation-checked.** The delete-order regression test fails against the old handler (`rowPresentAtKeychainDelete → false`). The collector's guards were each weakened deliberately to confirm the tests go red: a prefix-only anchor check lets `purge` delete a fixture outside the quarantine, dropping the filesystem-date fallback breaks expiry, removing the flag guard breaks the no-op tests, and emptying the terminal-reference set turns a KEEP into a REAP. All reverted afterwards.
- **Coverage of the fail-toward-keeping paths**: a missing base directory, an unreadable creation date, a failed rename, a `purge` aimed outside `.reaped/` or at the quarantine root itself, and a `model_profiles` row appearing between the enumeration and the rename.
- Full suite green (6,643 tests). `swiftlint --strict` clean. Reviewed across two rounds by independent reviewers; the round-one findings — most notably a missing anchor guard in front of the quarantine rename, echoing PR #604's finding on `WorktreeDeletionQueue.drain` — are fixed in `bb4736bc`.
- Not yet dogfooded against a live daemon: the daemon binary changed, so this needs `scripts/restart.sh` before the soak begins.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=23174083-8F61-4396-AA36-69D1B78C502C)
