### PR TITLE
Fix: Stop the peer-messaging docs reading a live peer as dead

### DIFF
--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -110,11 +110,12 @@ running session can be missing — and `SendMessage` hands one plain text,
 delivered between the recipient's turns. Each row carries a name, a short
 `[ref]`, its kind and its status; TBD-spawned rows also carry a tmux pane. TBD
 sets a session's peer name from the worktree display name at spawn, so rows
-usually match the sidebar — but a row can instead carry the
-working-directory slug plus a short suffix, when the session was spawned
-before the running daemon supported naming, or when the worktree has been
-renamed since (the name is fixed at spawn, and a new one applies at that
-session's next respawn or resume).
+usually match the sidebar — but two things pull them apart. A session spawned
+before the running daemon supported naming carries the
+working-directory slug plus a short suffix instead. And a worktree renamed
+after a session started leaves that session on its spawn-time name, because the
+name is fixed at spawn and a new one applies only at the next respawn or
+resume.
 
 So a `No agent named 'X' is reachable.` refusal usually means the peer is
 listed under a different name, not that it is dead — do not conclude a session

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -107,21 +107,22 @@ Two channels reach another TBD session.
 If `ListAgents` and `SendMessage` are among your tools, sibling sessions on this
 machine should show up in `ListAgents` — registration is best-effort, so a
 running session can be missing — and `SendMessage` hands one plain text,
-delivered between the recipient's turns. Each row carries a name and a short
-`[ref]`, plus its kind, status and tmux pane. TBD sets a session's peer name
-from the worktree display name at spawn, so rows usually match the sidebar —
-but a row can instead carry the working-directory slug plus a short suffix,
-when the session was spawned before the running daemon supported naming, or
-when the worktree has been renamed since (the name is fixed at spawn, and a new
-one applies at that session's next respawn or resume).
+delivered between the recipient's turns. Each row carries a name, a short
+`[ref]`, its kind and its status; TBD-spawned rows also carry a tmux pane. TBD
+sets a session's peer name from the worktree display name at spawn, so rows
+usually match the sidebar — but a row can instead carry the
+working-directory slug plus a short suffix, when the session was spawned
+before the running daemon supported naming, or when the worktree has been
+renamed since (the name is fixed at spawn, and a new one applies at that
+session's next respawn or resume).
 
 So a `No agent named 'X' is reachable.` refusal usually means the peer is
 listed under a different name, not that it is dead — do not conclude a session
-is gone from a failed send. Identify its row by the tmux pane instead: every row
-prints `tmux <server>:<window>.<pane>`, and `tbd terminal list <worktree-id>`
-prints that worktree's own window and pane, so the two join whatever the row is
-named. `tbd worktree list --json` is where the worktree id and the directory
-slug come from.
+is gone from a failed send. Identify its row by the tmux pane instead:
+every TBD-spawned row prints `tmux <server>:<window>.<pane>`, and
+`tbd terminal list <worktree-id>` prints that worktree's own window and pane, so
+the two join whatever the row is named. `tbd worktree list --json` is where the
+worktree id and the directory slug come from.
 
 Address a peer you have not messaged before as `name [ref]`:
 a bare name may be refused with an error naming the ref you need, even when

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -107,15 +107,29 @@ Two channels reach another TBD session.
 If `ListAgents` and `SendMessage` are among your tools, sibling sessions on this
 machine should show up in `ListAgents` — registration is best-effort, so a
 running session can be missing — and `SendMessage` hands one plain text,
-delivered between the recipient's turns. Each row carries the
-worktree display name plus a short `[ref]`. Address a peer you
-have not messaged before as `name [ref]`: a bare name may be refused with an
-error naming the ref you need, even when only one row answers to it, and the
-ref is also how you pick when several rows share a name (several terminals in
-one worktree do, and so can worktrees in different repos). Once a message to
-that peer has gone through, its bare name works. Refs belong to live sessions —
-re-read `ListAgents` instead of reusing an old listing. If those tools aren't
-there, use `tbd terminal send`.
+delivered between the recipient's turns. Each row carries a name and a short
+`[ref]`, plus its kind, status and tmux pane. TBD sets a session's peer name
+from the worktree display name at spawn, so rows usually match the sidebar —
+but a row can instead carry the working-directory slug plus a short suffix,
+when the session was spawned before the running daemon supported naming, or
+when the worktree has been renamed since (the name is fixed at spawn, and a new
+one applies at that session's next respawn or resume).
+
+So a `No agent named 'X' is reachable.` refusal usually means the peer is
+listed under a different name, not that it is dead — do not conclude a session
+is gone from a failed send. Identify its row by the tmux pane instead: every row
+prints `tmux <server>:<window>.<pane>`, and `tbd terminal list <worktree-id>`
+prints that worktree's own window and pane, so the two join whatever the row is
+named. `tbd worktree list --json` is where the worktree id and the directory
+slug come from.
+
+Address a peer you have not messaged before as `name [ref]`:
+a bare name may be refused with an error naming the ref you need, even when
+only one row answers to it, and the ref is also how you pick when several rows
+share a name (several terminals in one worktree do, and so can worktrees in
+different repos). Once a message to that peer has gone through, its bare name
+works. Refs belong to live sessions — re-read `ListAgents` instead of reusing
+an old listing. If those tools aren't there, use `tbd terminal send`.
 
 `tbd terminal send` / `tbd terminal output` (above) is the daemon-mediated
 channel: it works from any harness, and it can also drive input into a

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -43,9 +43,23 @@ import Foundation
     // both names must survive an edit of this section.
     #expect(body.contains("ListAgents"))
     #expect(body.contains("SendMessage"))
-    #expect(body.contains("worktree display name"))
+    #expect(body.contains("worktree display name at spawn"))
     #expect(body.contains("tbd terminal send"))
     #expect(body.contains("tbd terminal output"))
+    // The display-name correspondence is a default, not a guarantee: a row can
+    // carry the cwd slug instead when the session outlived a rename or was
+    // spawned by a daemon without naming. Pin the qualifier, so a rewrite that
+    // restores the unconditional claim reds.
+    #expect(body.contains("working-directory slug plus a short suffix"))
+    // The consequence is the part sessions get wrong in the field: a flat
+    // not-found reads as "the peer is dead" unless the text says otherwise.
+    #expect(body.contains("No agent named 'X' is reachable."))
+    #expect(body.contains("listed under a different name, not that it is dead"))
+    // The recovery is a mechanical join between the row's tmux pane and TBD's
+    // own terminal listing; both halves have to survive.
+    #expect(body.contains("tmux <server>:<window>.<pane>"))
+    #expect(body.contains("tbd terminal list <worktree-id>"))
+    #expect(body.contains("tbd worktree list --json"))
     // The `[ref]` is the address, not merely a tiebreak for ambiguous names:
     // a peer that has not been messaged before must be addressed `name [ref]`,
     // and a bare name is refused even where exactly one row answers to it.

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -46,10 +46,10 @@ import Foundation
     #expect(body.contains("worktree display name at spawn"))
     #expect(body.contains("tbd terminal send"))
     #expect(body.contains("tbd terminal output"))
-    // The display-name correspondence is a default, not a guarantee: a row can
-    // carry the cwd slug instead when the session outlived a rename or was
-    // spawned by a daemon without naming. Pin the qualifier, so a rewrite that
-    // restores the unconditional claim reds.
+    // The display-name correspondence is a default, not a guarantee: a session
+    // spawned by a daemon without naming carries the cwd slug instead, and one
+    // that outlived a rename keeps its spawn-time name. Pin the qualifier, so a
+    // rewrite that restores the unconditional claim reds.
     #expect(body.contains("working-directory slug plus a short suffix"))
     // The consequence is the part sessions get wrong in the field: a flat
     // not-found reads as "the peer is dead" unless the text says otherwise.

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -56,10 +56,15 @@ import Foundation
     #expect(body.contains("No agent named 'X' is reachable."))
     #expect(body.contains("listed under a different name, not that it is dead"))
     // The recovery is a mechanical join between the row's tmux pane and TBD's
-    // own terminal listing; both halves have to survive.
+    // own terminal listing, plus the worktree listing that yields the id the
+    // second one needs; all three legs have to survive.
     #expect(body.contains("tmux <server>:<window>.<pane>"))
     #expect(body.contains("tbd terminal list <worktree-id>"))
     #expect(body.contains("tbd worktree list --json"))
+    // Only rows for sessions running under tmux carry that pane — `cloud` and
+    // remote-control rows do not — so the join is scoped to what TBD spawns.
+    // Pin the scope, so a rewrite that promises it of every row reds.
+    #expect(body.contains("every TBD-spawned row prints"))
     // The `[ref]` is the address, not merely a tiebreak for ambiguous names:
     // a peer that has not been messaged before must be addressed `name [ref]`,
     // and a bare name is refused even where exactly one row answers to it.

--- a/docs/cross-session-messaging.md
+++ b/docs/cross-session-messaging.md
@@ -59,6 +59,11 @@ session's **next respawn or resume**; until then the running session
 still answers to its spawn-time name. Nothing breaks in the meantime —
 the listing tells the two apart, as described next.
 
+A running session is not stuck with that name, though: Claude Code's
+documentation states that a session answers to the name set with the
+`/rename` command as well as the one given by `--name`, so a drifted
+name can be corrected from inside the session without a respawn.
+
 **A stale daemon binary produces the slug fallback fleet-wide.** The flag
 is passed by the daemon, and `scripts/restart.sh` from any worktree
 replaces the one live daemon for the whole machine. Restarting from a
@@ -74,8 +79,9 @@ what the listing shows rather than by what you expect it to show.
 
 ## Addressing a peer
 
-Addressing starts at the listing. Run `/list-agents` — or call the
-`ListAgents` tool. A row looks like this:
+Addressing starts at the listing a session itself receives — the
+**`ListAgents` tool result**, which is the form that matters when a
+session is trying to reach a peer. A row in it looks like this:
 
 ```
 acme-worker [455f3e]  ·  interactive  ·  busy  ·  tmux main:@388.%388  ·  started 5d ago
@@ -83,12 +89,18 @@ acme-worker [455f3e]  ·  interactive  ·  busy  ·  tmux main:@388.%388  ·  st
 
 The fields are the session's name, a short `[ref]` unique to that live
 session, its kind, its status, its tmux server, window and pane, and how
-long ago it started. **The listing row does not carry a working
+long ago it started. **The tool result does not carry a working
 directory** — the tmux pane is the field that ties a row to a specific
 terminal, and the one to reach for whenever the name is not enough. (The
 on-disk registry record described under [The peer
-registry](#the-peer-registry) does hold one; the listing does not print
-it.)
+registry](#the-peer-registry) does hold one; the tool result does not
+print it.)
+
+What a human sees in the TUI is a separate surface with its own field
+set. Claude Code's documentation states that the `/list-agents`
+slash-command view shows each local session's working directory, so do
+not assume the two render the same fields. Everything below — the pane
+join especially — is written for the session-facing tool result.
 
 The tmux field is there only for a session running inside tmux, which
 every TBD session is. A plain-terminal `claude` started outside tmux, and
@@ -97,7 +109,9 @@ and the pane matching described below does not reach them.
 
 The row layout above, and the not-found refusal in
 [When a name is not reachable](#when-a-name-is-not-reachable), were read
-off CLI 2.1.233. The wording is Claude Code's rather than TBD's, so treat
+off the `ListAgents` tool result on CLI 2.1.233; the slash-command
+layout is Claude Code's documented behavior rather than anything
+measured here. The wording is Claude Code's rather than TBD's, so treat
 the field set as the durable part and the exact text as version-bound.
 
 **Address a peer you have not messaged before as `name [ref]`.** A bare

--- a/docs/cross-session-messaging.md
+++ b/docs/cross-session-messaging.md
@@ -83,9 +83,12 @@ acme-worker [455f3e]  ·  interactive  ·  busy  ·  tmux main:@388.%388  ·  st
 
 The fields are the session's name, a short `[ref]` unique to that live
 session, its kind, its status, its tmux server, window and pane, and how
-long ago it started. **The row does not carry a working directory** — the
-tmux pane is the field that ties a row to a specific terminal, and the
-one to reach for whenever the name is not enough.
+long ago it started. **The listing row does not carry a working
+directory** — the tmux pane is the field that ties a row to a specific
+terminal, and the one to reach for whenever the name is not enough. (The
+on-disk registry record described under [The peer
+registry](#the-peer-registry) does hold one; the listing does not print
+it.)
 
 The tmux field is there only for a session running inside tmux, which
 every TBD session is. A plain-terminal `claude` started outside tmux, and
@@ -143,11 +146,11 @@ No agent named 'acme-worker' is reachable.
 This one is a flat not-found: nothing in the listing answers to that
 name. **It usually does not mean the session died.** Far more often the
 session is alive and listed under a different name — the drift described
-in [Naming](#naming), where a session spawned before the running daemon
-supported `--name`, or one whose worktree was renamed after it started,
-carries the working-directory slug instead. Reading the refusal as a
-death notice — and giving up on a peer that is sitting there working —
-is the mistake to avoid.
+in [Naming](#naming). A session spawned before the running daemon
+supported `--name` carries the working-directory slug instead; one whose
+worktree was renamed after it started still answers to its spawn-time
+name. Reading the refusal as a death notice — and giving up on a peer
+that is sitting there working — is the mistake to avoid.
 
 Find the row by its tmux pane instead of by its name. Every TBD-spawned
 row prints its pane as `tmux <server>:<window>.<pane>`, and TBD prints the

--- a/docs/cross-session-messaging.md
+++ b/docs/cross-session-messaging.md
@@ -51,7 +51,7 @@ TBD spawns each Claude session with `--name` set to the worktree's
 names in `/list-agents` are the ones you already know from the sidebar.
 
 Without that flag a session names itself after its working-directory
-folder: a slug plus a random suffix, which never matches a name you chose
+folder: a slug plus a short suffix, which never matches a name you chose
 in the app.
 
 `--name` is fixed at spawn. Renaming a worktree therefore applies at that
@@ -59,12 +59,33 @@ session's **next respawn or resume**; until then the running session
 still answers to its spawn-time name. Nothing breaks in the meantime —
 the listing tells the two apart, as described next.
 
+**A stale daemon binary produces the slug fallback fleet-wide.** The flag
+is passed by the daemon, and `scripts/restart.sh` from any worktree
+replaces the one live daemon for the whole machine. Restarting from a
+branch cut before naming shipped therefore reverts *every* subsequent
+spawn — in every worktree, not just that one — to the self-chosen slug
+name, silently, until the daemon is restarted from a tree that has the
+feature. Sessions spawned during such a window keep their slug name for
+as long as they run, because the name is fixed at spawn.
+
+So a listing can mix named and slug-named rows for reasons that have
+nothing to do with a session's health. Expect it, and address rows by
+what the listing shows rather than by what you expect it to show.
+
 ## Addressing a peer
 
 Addressing starts at the listing. Run `/list-agents` — or call the
-`ListAgents` tool — and each row carries the session's name and a short
-`[ref]`, an identifier unique to that live session, alongside its working
-directory and status.
+`ListAgents` tool. A row looks like this:
+
+```
+acme-worker [455f3e]  ·  interactive  ·  busy  ·  tmux main:@388.%388  ·  started 5d ago
+```
+
+The fields are the session's name, a short `[ref]` unique to that live
+session, its kind, its status, its tmux server, window and pane, and how
+long ago it started. **The row does not carry a working directory** — the
+tmux pane is the field that ties a row to a specific terminal, and the
+one to reach for whenever the name is not enough.
 
 **Address a peer you have not messaged before as `name [ref]`.** A bare
 name may be refused even when exactly one row answers to it, and nothing
@@ -92,12 +113,44 @@ sessions ordinary:
 - **Two worktrees, one name.** Display names are yours to choose and
   nothing stops you reusing one.
 
-The working directory and status in the row are how you tell which is
-which; the `[ref]` is how you say which one you meant.
+The tmux pane in the row is how you tell which is which — it names one
+terminal exactly — and the `[ref]` is how you say which one you meant.
+Status narrows the field but does not identify a row on its own.
 
 Pull a fresh listing rather than reusing one from earlier in a long
 conversation — refs belong to live sessions, and the pool changes as
 sessions spawn, respawn, and exit.
+
+### When a name is not reachable
+
+A send to a name that no row carries fails differently from the
+ambiguity refusal above:
+
+```
+No agent named 'acme-worker' is reachable.
+```
+
+This one is a flat not-found: nothing in the listing answers to that
+name. **It usually does not mean the session died.** Far more often the
+session is alive and listed under a different name — the drift described
+in [Naming](#naming), where a session spawned before the running daemon
+supported `--name`, or one whose worktree was renamed after it started,
+carries the working-directory slug instead. Reading the refusal as a
+death notice — and giving up on a peer that is sitting there working —
+is the mistake to avoid.
+
+Find the row by its tmux pane instead of by its name. Every listing row
+prints its pane as `tmux <server>:<window>.<pane>`, and TBD prints the
+same coordinates from its own side:
+
+```sh
+tbd worktree list --json          # worktree id, displayName, directory name, path
+tbd terminal list <worktree-id>   # WINDOW and PANE columns for that worktree
+```
+
+Join the two on the window and pane (`@388` / `%388` above): the row that
+matches is the lane you meant, whatever it happens to be called. Address
+it as `name [ref]` with the name the listing actually shows.
 
 ## Reach
 

--- a/docs/cross-session-messaging.md
+++ b/docs/cross-session-messaging.md
@@ -87,6 +87,16 @@ long ago it started. **The row does not carry a working directory** — the
 tmux pane is the field that ties a row to a specific terminal, and the
 one to reach for whenever the name is not enough.
 
+The tmux field is there only for a session running inside tmux, which
+every TBD session is. A plain-terminal `claude` started outside tmux, and
+rows of other kinds (`cloud`, remote control), carry no tmux coordinates,
+and the pane matching described below does not reach them.
+
+The row layout above, and the not-found refusal in
+[When a name is not reachable](#when-a-name-is-not-reachable), were read
+off CLI 2.1.233. The wording is Claude Code's rather than TBD's, so treat
+the field set as the durable part and the exact text as version-bound.
+
 **Address a peer you have not messaged before as `name [ref]`.** A bare
 name may be refused even when exactly one row answers to it, and nothing
 is delivered when it is:
@@ -139,8 +149,8 @@ carries the working-directory slug instead. Reading the refusal as a
 death notice — and giving up on a peer that is sitting there working —
 is the mistake to avoid.
 
-Find the row by its tmux pane instead of by its name. Every listing row
-prints its pane as `tmux <server>:<window>.<pane>`, and TBD prints the
+Find the row by its tmux pane instead of by its name. Every TBD-spawned
+row prints its pane as `tmux <server>:<window>.<pane>`, and TBD prints the
 same coordinates from its own side:
 
 ```sh

--- a/docs/specs/2026-08-09-cross-session-messaging-design.md
+++ b/docs/specs/2026-08-09-cross-session-messaging-design.md
@@ -83,11 +83,28 @@ one.
 
 The display name is mutable and `--name` is fixed at spawn, so a rename
 applies at the session's next respawn or resume; until then the running
-session answers to its spawn-time name. This staleness is accepted:
-respawns are frequent in TBD (wake, swap, fresh spawns), renames are
-rare, and the listing carries the working directory and a per-session
-identifier next to the name, so a stale name misleads no one who reads
-the row.
+session answers to its spawn-time name. This staleness is accepted,
+because respawns are frequent in TBD (wake, swap, fresh spawns) and
+renames are rare, so a mismatched row is short-lived.
+
+It is not harmless while it lasts. A listing row carries the name, a
+per-session `[ref]`, the kind, the status, the tmux
+`server:window.pane`, and how long ago the session started — and no
+working directory, so nothing in a stale row spells out the lane a
+sender is looking for. Field use showed the failure mode: a send
+addressed to a renamed lane's current display name returned a flat
+`No agent named 'acme-worker' is reachable.`, the row still listed under
+that session's spawn-time slug went unrecognized, and the sender twice
+concluded that a live session had exited.
+
+The mitigation is the pane, not the name. The `[ref]` addresses a row
+unambiguously once it has been found, and the tmux pane is what finds
+it: `tbd terminal list <worktree-id>` prints the same window and pane
+coordinates from TBD's side, so a TBD-spawned row joins back to its
+worktree whatever name it happens to carry. A stale name therefore costs
+a lookup rather than a peer — for a reader who knows to make it, which
+is why `docs/cross-session-messaging.md` documents the not-found refusal
+and that join.
 
 #### The name is a label; the ref is the address
 

--- a/docs/specs/2026-08-09-cross-session-messaging-design.md
+++ b/docs/specs/2026-08-09-cross-session-messaging-design.md
@@ -87,9 +87,10 @@ session answers to its spawn-time name. This staleness is accepted,
 because respawns are frequent in TBD (wake, swap, fresh spawns) and
 renames are rare, so a mismatched row is short-lived.
 
-It is not harmless while it lasts. A listing row carries the name, a
+It is not harmless while it lasts. A row in the `ListAgents` tool
+result — the listing a session itself receives — carries the name, a
 per-session `[ref]`, the kind, the status, the tmux
-`server:window.pane`, and how long ago the session started — and no
+`server:window.pane`, and how long ago the session started, and no
 working directory, so nothing in a stale row spells out the lane a
 sender is looking for. Field use showed the failure mode: a send
 addressed to a renamed lane's current display name returned a flat


### PR DESCRIPTION
## Summary

TBD passes `--name <worktree display name>` to every `claude` it spawns, so a
session's peers can address it by the name shown in the sidebar. The
documentation that teaches an agent to use that — `docs/cross-session-messaging.md`
and the `tbd` skill body compiled into `TBDSkillContent` — promised more than
the mechanism delivers, and an agent that believed it concluded a live peer was
dead.

Two claims were wrong. The first: that a `ListAgents` row carries a working
directory. It does not. A live row reads

```
acme-worker [455f3e]  ·  interactive  ·  busy  ·  tmux main:@388.%388  ·  started 5d ago
```

— name, ref, kind, status, tmux coordinates, age. The doc's entire
disambiguation-and-recovery story rested on a field that is not there.

The second: that every row carries the worktree display name. Four things break
that correspondence, and none of them means anything is wrong. Two leave the
session self-naming from its working-directory folder — a slug plus a suffix:

- the session was spawned before the running daemon had the flag;
- the running *daemon binary* predates the feature. `scripts/restart.sh` from
  any worktree replaces the one live daemon for the whole machine, so this
  reverts naming fleet-wide, silently, in every worktree at once.

Two leave a real `--name` in place that simply is not the name on screen:

- the worktree was renamed after the session started, since the name is fixed at
  spawn by design and a new one applies at the next respawn or resume;
- the display name truncates, or sanitizes down to something else.

Either way, a send to the sidebar name answers
`No agent named 'X' is reachable.` — a flat not-found with no hint that the peer
is alive under another name. A reader who trusted the docs takes that as a death
notice and abandons a peer that is sitting there working. That is what happened,
and it is why this change exists.

This is a documentation-correctness fix with **no behavior change**: no Swift
logic, no flag, no migration, and nothing under `Sources/TBDDaemon/`. The only
Swift touched is the string literal that holds the skill body.

## Why this shape

The obvious hypothesis was that some spawn path had been missed and was not
passing the flag at all. It was investigated and refuted:
`ClaudeSpawnCommandBuilder.build` has seven call sites — the hibernation
coordinator, two in worktree creation, four in the terminal RPC handlers — and
`git blame` plus `git log -S` show all seven passing
`sessionName: worktree.displayName` since the flag landed. Nothing is missing
from the spawn path; the correspondence it creates is simply weaker than the
docs claimed.

That left the question of what to document in place of a guarantee. The recovery
this PR teaches needs no new code: a row prints its tmux `server:window.pane`,
`tbd terminal list <worktree-id>` prints the same window and pane from TBD's own
side, and the two join exactly. Both halves were verified live before they were
written down.

**Rename drift is deliberately out of scope.** Keeping a *running* session's
registered peer name in sync with its worktree's display name would change TBD's
theory of session identity — today the name is fixed at spawn, and that fixity is
what makes an address stable — so it needs a brainstormed spec with a human
answering the questions, not a doc fix smuggling in a decision. It may also not
be TBD's to change at all: the peer registry row belongs to Claude Code, written
by the Claude process into its own config dir. TBD contributes a spawn-time flag;
it does not own the record.

No spec accompanies this PR because it is a bug fix in the sense the root
`CLAUDE.md` draws: the docs are restored to the system's existing theory rather
than revising it.

## What this PR does

- **`docs/cross-session-messaging.md`** — replaces the working-directory story
  with the row's real field set, shown as a sample row, and marks the listing row
  off from the persisted registry record, which does hold a working directory;
  explains the ways a name drifts from the sidebar, keeping the slug case and the
  stale-name case apart, including the fleet-wide effect of a stale daemon binary;
  adds a "When a name is not reachable" section that distinguishes the flat
  not-found from the ambiguity refusal and gives the pane-join recovery; and
  records which CLI the quoted output was read off, so a later reader can tell
  measured text from remembered text.
- **`Sources/TBDShared/TBDSkillContent.swift`** — the same corrections,
  condensed, in the "Message a sibling session" section of the skill body every
  TBD session is seeded with.
- **`Tests/TBDSharedTests/TBDSkillContentTests.swift`** — pins the qualifiers, so
  a rewrite that restores an unconditional claim reds.

Both surfaces scope the tmux claim rather than universalizing it: `cloud` and
remote-control rows carry no tmux field, and a plain-terminal `claude` started
outside tmux carries none either, so the pane join is stated for the sessions TBD
spawns and the exclusion is named once in the doc.

## Assumptions

- Assumes the row layout and refusal texts quoted here are Claude Code's current
  output. They were read off CLI 2.1.233 and the doc says so; if upstream rewords
  them the quoted strings go stale, while the field set and the pane-join method
  stay true.
- Assumes a session's peer name is fixed for its lifetime. If Claude Code gains a
  way to rename a live session, the drift section overstates the problem.

## Evidence & verification

- **The repro is the reason this exists.** A session addressed a peer by its
  sidebar name, got `No agent named 'X' is reachable.`, and concluded the peer
  was gone. The peer was alive and listed under its cwd slug.
- **The recovery was verified live before being documented.**
  `tbd terminal list <worktree-id>` printed WINDOW and PANE matching the
  `tmux main:@388.%388` in the peer's row exactly, so the join is a real join and
  not a plausible-sounding one.
- **The missing-flag hypothesis was refuted by inspection, not assumed away:**
  seven of seven `ClaudeSpawnCommandBuilder.build` call sites pass
  `sessionName: worktree.displayName`.
- **Discriminating tests.** Each of the eight pinned sentences was
  mutation-checked — deleting it reds `bodyContainsSiblingMessagingSection`. The
  scope pin added during review was checked the same way: relaxing
  `every TBD-spawned row prints` back to `every row prints` reds the suite.
- `scripts/swift-safe build` clean; `scripts/test.sh --filter TBDSkillContentTests`
  runs 7 tests, all passing; `swiftlint --strict` reports 0 violations.

[🏷️ Peer Session Naming](https://cheapsteak.github.io/tbd/open/?worktree=FB61F8F7-62B7-4040-A872-E8BCD1FEDE35)
