### PR TITLE
Retire a remote lane, or say plainly why you cannot

### DIFF
--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -127,6 +127,33 @@ enum ArchivedSearchDisplay {
     }
 }
 
+/// Whether a row survives the archived list's "Hide worktrees with no
+/// conversations" filter.
+///
+/// A remote lane stores a synthetic `remote://<provider>/<sessionID>` path
+/// rather than a filesystem path, which `ClaudeProjectDirectory.resolve(
+/// worktreePath:)` cannot resolve — so its session count is structurally
+/// zero, always. Left to `effectiveSessionCount` alone, every archived
+/// remote lane would be hidden: archived successfully and then invisible,
+/// indistinguishable from the archive having failed. The remote arm admits a
+/// row on being remote instead of on a count it can never have.
+///
+/// Extracted from the view's `rows` computed property so it is unit-testable
+/// without SwiftUI or `@AppStorage` (same pattern as
+/// `ArchivedWorktreeSearchFilter`) — `hideEmpty` is threaded through as a
+/// parameter rather than read from `UserDefaults.standard` directly.
+enum ArchivedHideEmptyFilter {
+    static func keep(
+        hideEmpty: Bool,
+        location: WorktreeLocation,
+        hasReviveState: Bool,
+        effectiveSessionCount: Int
+    ) -> Bool {
+        guard hideEmpty else { return true }
+        return hasReviveState || !location.isLocal || effectiveSessionCount > 0
+    }
+}
+
 struct ArchivedWorktreesView: View {
     let repoID: UUID
     @EnvironmentObject var appState: AppState
@@ -249,9 +276,13 @@ struct ArchivedWorktreesView: View {
     /// Visible rows after applying every filter. Lingering revives always pass
     /// the `hideEmpty` filter so a just-revived row doesn't vanish mid-flight.
     private var rows: [ArchivedRow] {
-        guard hideEmpty else { return searchedRows }
-        return searchedRows.filter { row in
-            row.reviveState != nil || row.effectiveSessionCount > 0
+        searchedRows.filter { row in
+            ArchivedHideEmptyFilter.keep(
+                hideEmpty: hideEmpty,
+                location: row.worktree.location,
+                hasReviveState: row.reviveState != nil,
+                effectiveSessionCount: row.effectiveSessionCount
+            )
         }
     }
 

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -158,6 +158,14 @@ enum RowActionMenu {
         /// `archive` cannot retire the lane on the backend, so the action stays
         /// disabled until it does.
         var providerCapabilities: Set<String>
+        /// The provider has stopped enumerating this lane's session
+        /// (`RemoteSessionInfo.gone`). The `gone` exemption is the only route
+        /// out for a lane whose provider cannot archive
+        /// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Archive"),
+        /// and the daemon takes it — so the menu must not disable the one
+        /// gesture the daemon will still perform. Always `false` for a local
+        /// row.
+        var isGone: Bool
 
         init(hasHibernatableClaude: Bool = false,
              hasHibernatedClaude: Bool = false,
@@ -177,7 +185,8 @@ enum RowActionMenu {
              hasPreSessionHook: Bool = false,
              location: WorktreeLocation = .local,
              provider: String? = nil,
-             providerCapabilities: Set<String> = []) {
+             providerCapabilities: Set<String> = [],
+             isGone: Bool = false) {
             self.hasHibernatableClaude = hasHibernatableClaude
             self.hasHibernatedClaude = hasHibernatedClaude
             self.hasUnpinnedClaude = hasUnpinnedClaude
@@ -197,6 +206,7 @@ enum RowActionMenu {
             self.location = location
             self.provider = provider
             self.providerCapabilities = providerCapabilities
+            self.isGone = isGone
         }
     }
 
@@ -394,7 +404,17 @@ enum RowActionMenu {
         // user can act on right now (archive the children), while a missing
         // provider capability is not something a gesture here can fix. Order
         // in the `if`/`else if` below is the precedence.
+        //
+        // A `gone` lane is exempt from the capability gate entirely. The spec
+        // calls the `gone` exemption "the only route out for a lane whose
+        // provider cannot archive", and the daemon takes it — `archivePlan`
+        // returns `.rowOnlyGone` for exactly this shape and files the row
+        // without invoking any verb. Disabling Archive here would leave the
+        // surface blocking the one gesture the daemon will still perform, with
+        // no other way out. The exemption is narrow: a lane the provider still
+        // enumerates stays disabled, and active children still win above it.
         let missingArchiveCapability = !context.location.isLocal
+            && !context.isGone
             && !context.providerCapabilities.contains("archive")
         let archiveBlocked = context.hasActiveChildren || missingArchiveCapability
         let archiveTitle: String

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -144,6 +144,20 @@ enum RowActionMenu {
         /// re-run and create items. Resolved by the surface via the shared
         /// `HookResolver`, so `items(...)` stays pure.
         var hasPreSessionHook: Bool
+        /// Where this worktree's files live. `.local` is unaffected by the
+        /// capability gate below; a `.remote` row is the one Archive checks
+        /// `providerCapabilities` for.
+        var location: WorktreeLocation
+        /// The remote lane's provider name (`location`'s associated
+        /// `provider`), or nil for a local row.
+        var provider: String?
+        /// Capabilities the row's provider has declared (`describe.capabilities`,
+        /// read by the surface via `AppState.remoteProviders`). Empty for a
+        /// local row, or a remote one whose provider hasn't answered `describe`
+        /// yet. Gates Archive: a remote lane whose provider has not declared
+        /// `archive` cannot retire the lane on the backend, so the action stays
+        /// disabled until it does.
+        var providerCapabilities: Set<String>
 
         init(hasHibernatableClaude: Bool = false,
              hasHibernatedClaude: Bool = false,
@@ -160,7 +174,10 @@ enum RowActionMenu {
              isPromoted: Bool = false,
              branch: String = "",
              claudeSessions: [ClaudeSessionRef] = [],
-             hasPreSessionHook: Bool = false) {
+             hasPreSessionHook: Bool = false,
+             location: WorktreeLocation = .local,
+             provider: String? = nil,
+             providerCapabilities: Set<String> = []) {
             self.hasHibernatableClaude = hasHibernatableClaude
             self.hasHibernatedClaude = hasHibernatedClaude
             self.hasUnpinnedClaude = hasUnpinnedClaude
@@ -177,6 +194,9 @@ enum RowActionMenu {
             self.branch = branch
             self.claudeSessions = claudeSessions
             self.hasPreSessionHook = hasPreSessionHook
+            self.location = location
+            self.provider = provider
+            self.providerCapabilities = providerCapabilities
         }
     }
 
@@ -189,6 +209,14 @@ enum RowActionMenu {
     /// stays visible (and destructive-styled) but is disabled, and the title
     /// itself explains why, since menu tooltips are easy to miss.
     static let archiveHasChildrenLabel = "Archive (has children)"
+    /// Archive title for a remote lane whose provider has not declared the
+    /// `archive` capability: same visible-but-disabled treatment as
+    /// `archiveHasChildrenLabel`, naming what's missing rather than
+    /// implying anything about the user or the session's own state.
+    static let archiveProviderCannotArchiveLabel = "Archive (provider can't archive)"
+    /// Disabled-help paired with `archiveProviderCannotArchiveLabel`: names the
+    /// capability that would need to exist, not an action for the user to take.
+    static let archiveNeedsProviderCapabilityHelp = "This provider hasn't implemented the archive capability yet"
     static let forkSessionLabel = "Fork session"
     static let newWorktreeFromBranchLabel = "New worktree from this branch…"
     static let hibernateNowLabel = "Hibernate now"
@@ -215,7 +243,10 @@ enum RowActionMenu {
     /// and scratch branches share a sectioned layout, top to bottom:
     ///
     /// 1. Identity — Rename, then Archive (destructive; disabled + retitled
-    ///    "Archive (has children)" for a regular row with active children).
+    ///    "Archive (has children)" for a regular row with active children, or
+    ///    "Archive (provider can't archive)" for a remote lane whose provider
+    ///    has not declared the `archive` capability — active children wins
+    ///    when a remote row hits both).
     /// 2. Hibernation — Wake / Hibernate now / keep-warm toggle (conditional).
     /// 3. Sessions & spawning — per-session Fork entries, plus (regular only)
     ///    Create Nested Worktree / New worktree from this branch.
@@ -355,7 +386,29 @@ enum RowActionMenu {
     }
 
     private static func regularItems(context: Context) -> [Item] {
-        let archiveBlocked = context.hasActiveChildren
+        // A remote lane whose provider has not declared `archive` cannot be
+        // retired on the backend (docs/specs/2026-08-16-remote-lane-archive-design.md
+        // "Archive"), so Archive gates on two independent conditions. When
+        // both apply — a remote lane with active children AND no `archive`
+        // capability — active children wins the title: it is the reason the
+        // user can act on right now (archive the children), while a missing
+        // provider capability is not something a gesture here can fix. Order
+        // in the `if`/`else if` below is the precedence.
+        let missingArchiveCapability = !context.location.isLocal
+            && !context.providerCapabilities.contains("archive")
+        let archiveBlocked = context.hasActiveChildren || missingArchiveCapability
+        let archiveTitle: String
+        let archiveHelp: String?
+        if context.hasActiveChildren {
+            archiveTitle = archiveHasChildrenLabel
+            archiveHelp = archiveNeedsChildrenGoneHelp
+        } else if missingArchiveCapability {
+            archiveTitle = archiveProviderCannotArchiveLabel
+            archiveHelp = archiveNeedsProviderCapabilityHelp
+        } else {
+            archiveTitle = "Archive"
+            archiveHelp = nil
+        }
 
         // Sessions & spawning: per-session fork entries, then the
         // nested-worktree creators.
@@ -375,10 +428,10 @@ enum RowActionMenu {
                 .action(Action(kind: .rename, title: "Rename...")),
                 .action(Action(
                     kind: .archive,
-                    title: archiveBlocked ? archiveHasChildrenLabel : "Archive",
+                    title: archiveTitle,
                     role: .destructive,
                     isEnabled: !archiveBlocked,
-                    disabledHelp: archiveBlocked ? archiveNeedsChildrenGoneHelp : nil
+                    disabledHelp: archiveHelp
                 )),
             ],
             pinActions(context: context).map(Item.action),

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -65,6 +65,17 @@ struct RowActionMenuActions {
         ) != nil
     }
 
+    /// Capabilities the row's provider has declared, keyed by provider name —
+    /// the same idiom `AppState.pushRemoteRenameIfSupported` and
+    /// `RemoteSectionView` use. Empty for a local row or one whose provider
+    /// hasn't answered `describe` yet.
+    private var providerCapabilities: Set<String> {
+        guard let provider = worktree.providerBinding?.provider else { return [] }
+        let capabilities = appState.remoteProviders
+            .first { $0.config.name == provider }?.describe?.capabilities ?? []
+        return Set(capabilities)
+    }
+
     /// Build the pure model context from live `AppState`. Mirrors exactly the
     /// inputs the old `SidebarContextMenu` read inline.
     func context() -> RowActionMenu.Context {
@@ -90,7 +101,10 @@ struct RowActionMenuActions {
             isPromoted: worktree.promotedToRepoID != nil,
             branch: worktree.branch,
             claudeSessions: claudeSessions,
-            hasPreSessionHook: hasPreSessionHook
+            hasPreSessionHook: hasPreSessionHook,
+            location: worktree.location,
+            provider: worktree.providerBinding?.provider,
+            providerCapabilities: providerCapabilities
         )
     }
 

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -76,6 +76,23 @@ struct RowActionMenuActions {
         return Set(capabilities)
     }
 
+    /// Has the provider stopped enumerating this row's session? Read off the
+    /// mirror (`RemoteSessionInfo.gone`), the same source
+    /// `RemoteSessionDetailView` reads it from, rather than off the worktree
+    /// row — the row carries no such fact. `false` for a local row, which has
+    /// no mirror entry at all.
+    ///
+    /// This is what makes the menu's `gone` exemption reachable: the daemon
+    /// archives such a lane through `.rowOnlyGone` whatever the provider
+    /// declares, so a menu reading a hardcoded `false` here would disable the
+    /// one gesture the daemon will still perform.
+    private var isGone: Bool {
+        guard let binding = worktree.providerBinding else { return false }
+        return appState.remoteSessions.first {
+            $0.provider == binding.provider && $0.payload.id == binding.sessionID
+        }?.gone ?? false
+    }
+
     /// Build the pure model context from live `AppState`. Mirrors exactly the
     /// inputs the old `SidebarContextMenu` read inline.
     func context() -> RowActionMenu.Context {
@@ -104,7 +121,8 @@ struct RowActionMenuActions {
             hasPreSessionHook: hasPreSessionHook,
             location: worktree.location,
             provider: worktree.providerBinding?.provider,
-            providerCapabilities: providerCapabilities
+            providerCapabilities: providerCapabilities,
+            isGone: isGone
         )
     }
 

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -104,6 +104,17 @@ enum ActuationSurface: CaseIterable, Sendable {
     case remoteCreate
     case remoteStop
     case remoteSend
+    /// Retires a remote session from the working inventory
+    /// (`docs/remote-provider-contract.md` § `archive <id>`) — same shape as
+    /// `worktreeArchive`'s `dispose`, one level down: this is the provider
+    /// verb the daemon-side worktree archive path (Task 5) invokes underneath
+    /// its own row, not a second row for the same act.
+    case remoteArchive
+    /// Returns an archived remote session to the working inventory
+    /// (`docs/remote-provider-contract.md` § `unarchive <id>`) — `spawn`,
+    /// matching `worktreeRevive`'s kind for the same reason: it brings a
+    /// retired lane back into use.
+    case remoteUnarchive
 
     /// The exact public method name that carries this surface's requests.
     var method: String {
@@ -134,6 +145,8 @@ enum ActuationSurface: CaseIterable, Sendable {
         case .remoteCreate: return RPCMethod.remoteCreate
         case .remoteStop: return RPCMethod.remoteStop
         case .remoteSend: return RPCMethod.remoteSend
+        case .remoteArchive: return RPCMethod.remoteArchive
+        case .remoteUnarchive: return RPCMethod.remoteUnarchive
         }
     }
 
@@ -146,9 +159,9 @@ enum ActuationSurface: CaseIterable, Sendable {
         case .terminalCreate, .terminalRecreateWindow, .terminalSwapProfile,
              .terminalContinueInCodex, .terminalHistoryRevive, .worktreeCreate,
              .scratchCreate, .worktreeRevive, .worktreeReviveConversationFresh,
-             .worktreeRerunPreSession, .remoteCreate: return .spawn
+             .worktreeRerunPreSession, .remoteCreate, .remoteUnarchive: return .spawn
         case .terminalDelete, .worktreeArchive, .worktreeForget, .repoRemove,
-             .scratchDelete, .scratchArchive, .remoteStop: return .dispose
+             .scratchDelete, .scratchArchive, .remoteStop, .remoteArchive: return .dispose
         case .terminalHibernate, .terminalSuspend, .worktreeSuspend: return .hibernate
         case .terminalWake, .terminalResume, .worktreeResume: return .wake
         }

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -230,4 +230,8 @@ enum ActuationRail {
     /// typing the operator's own words into the primary agent once its
     /// `SessionStart` hook has fired.
     static let queuedPrompt = "queued-prompt"
+    /// `RemoteProviderManager`'s filing sync: a provider's own `archived`
+    /// report moving a bound remote worktree row out of — or back into — the
+    /// active list. No RPC carried it, so the sync writes its own row.
+    static let remoteFilingSync = "remote-filing-sync"
 }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -492,11 +492,20 @@ public final class Daemon: Sendable {
         // Assigning only after an awaited `start()` would leave a mid-start
         // shutdown request with nothing to call, orphaning the manager and
         // any provider child processes it spawned.
+        // One `ActuationLog` for the whole daemon: the router hands it to the
+        // hibernation coordinator, and it is passed to every daemon-internal
+        // rail below, so all of them append to the same file through the same
+        // actor (which is what serializes the appends). Constructed here
+        // rather than beside the router because the remote manager's filing
+        // sync is one of those rails and is built first.
+        let actuationLog = ActuationLog(path: TBDConstants.actuationLogPath)
+
         var remoteManager: RemoteProviderManager?
         if mockMode == nil, (try? await database.config.get())?.remoteBackendsEnabled == true {
             let manager = RemoteProviderManager(
                 db: database, subscriptions: subs, runner: ProviderRunner(),
-                registryURL: URL(fileURLWithPath: TBDConstants.agentProvidersPath))
+                registryURL: URL(fileURLWithPath: TBDConstants.agentProvidersPath),
+                actuationLog: actuationLog)
             self.remoteManager = manager
             remoteManager = manager
         }
@@ -522,11 +531,6 @@ public final class Daemon: Sendable {
 
         // 8. Initialize RPC router.
         //
-        // One `ActuationLog` for the whole daemon: the router hands it to the
-        // hibernation coordinator, and it is passed to every daemon-internal
-        // rail below, so all of them append to the same file through the same
-        // actor (which is what serializes the appends).
-        let actuationLog = ActuationLog(path: TBDConstants.actuationLogPath)
         let rpcRouter = RPCRouter(
             db: database,
             lifecycle: lifecycle,

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -584,7 +584,8 @@ public final class Daemon: Sendable {
         // merged move. `PRPoller` is the only thing that calls into that funnel
         // on a timer; `pr.list` serves the snapshot and never fetches.
         let autoArchiveCoordinator = AutoArchiveOnMergeCoordinator(
-            db: database, lifecycle: lifecycle, subscriptions: subs, actuationLog: actuationLog)
+            db: database, lifecycle: lifecycle, subscriptions: subs, actuationLog: actuationLog,
+            remoteManager: remoteManager)
         let autoHibernateCoordinator = AutoHibernateOnMergeCoordinator(
             db: database, hibernation: rpcRouter.hibernationCoordinator, subscriptions: subs)
         let mergedTransitionDispatcher = MergedTransitionDispatcher(

--- a/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
@@ -16,17 +16,24 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
     /// the `worktree.archive` handler calls that same method after writing its
     /// own row, and a row there would double-count every manual archive.
     let actuationLog: ActuationLog
+    /// The remote-backends actor, when the subsystem is on. `nil` when the
+    /// flag was off at boot (`Daemon.swift` only constructs it then) and in
+    /// tests that have no remote lanes — in which case the rail simply
+    /// declines a remote lane, as it did before it had a remote path at all.
+    let remoteManager: RemoteProviderManager?
 
     public init(
         db: TBDDatabase,
         lifecycle: WorktreeLifecycle,
         subscriptions: StateSubscriptionManager,
-        actuationLog: ActuationLog
+        actuationLog: ActuationLog,
+        remoteManager: RemoteProviderManager? = nil
     ) {
         self.db = db
         self.lifecycle = lifecycle
         self.subscriptions = subscriptions
         self.actuationLog = actuationLog
+        self.remoteManager = remoteManager
     }
 
     /// Returns `true` ONLY when it actually began archiving the worktree (i.e.
@@ -41,21 +48,6 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
         do {
             guard let wt = try await db.worktrees.get(id: worktreeID), wt.status == .active else { return false }
 
-            // A remote lane is not auto-archivable, and is refused here rather
-            // than allowed to fail downstream. Archiving a remote worktree
-            // would mean stopping the provider's session — deliberately
-            // unimplemented, not an oversight — so `beginArchiveWorktree`
-            // resolves through `getLocal` and throws for a remote row. Reaching
-            // it would mean the rail had already written a `.dispose` request
-            // for an act it structurally cannot perform, and rewritten it on
-            // every merged transition observed for that lane. The record may
-            // only claim acts that were attempted, so the gate belongs above
-            // the row, not in the catch below it.
-            guard wt.location.isLocal else {
-                logger.debug("auto-archive skipped (remote lane): \(worktreeID, privacy: .public)")
-                return false
-            }
-
             let config = try await db.config.get()
             let effective = wt.autoArchiveOnMerge ?? config.autoArchiveOnMergeDefault
             guard effective else { return false }
@@ -68,6 +60,18 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
             } catch WorktreeArchiveError.hasActiveChildren {
                 logger.info("auto-archive skipped (active children): \(worktreeID, privacy: .public)")
                 return false
+            }
+
+            // A remote lane retires down the provider path instead — the same
+            // act on the same code as a manual archive, under the opt-in this
+            // rail already has. A second switch would gate a switch, so there
+            // is no separate flag: the rail is off by default, per-worktree
+            // overridable, and armed by a deliberate gesture, and it declines
+            // by itself when the provider declares no `archive`
+            // (`docs/specs/2026-08-16-remote-lane-archive-design.md`
+            // §"Auto-archive on merge").
+            if !wt.location.isLocal {
+                return await archiveRemoteLane(wt, prNumber: prNumber)
             }
 
             // The rail's own row, written at its act moment — after the gates
@@ -121,5 +125,90 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
             logger.error("auto-archive failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
             return false
         }
+    }
+
+    /// The remote lane's half of the rail. Same routing, same guards and the
+    /// same record shape as the manual `worktree.archive` remote branch — the
+    /// only differences are this rail's own actuation actor and its
+    /// notification, both of which it already writes for a local worktree.
+    ///
+    /// A refusal — no manager, no declared `archive` on a lane that is not
+    /// `gone`, an agent still working, a provider-reported dirty checkout —
+    /// returns `false` and writes **no** actuation row. Nothing was attempted,
+    /// and a background rail that rewrote a `.dispose` request on every merged
+    /// transition it observed for an unretireable lane would fill the record
+    /// with acts that never happened. Logged at debug, not surfaced: this is a
+    /// background rail, and declining is its ordinary behavior.
+    private func archiveRemoteLane(_ wt: Worktree, prNumber: Int) async -> Bool {
+        guard let remoteManager else {
+            logger.debug("auto-archive skipped (remote backends off): \(wt.id, privacy: .public)")
+            return false
+        }
+        let lanes = RemoteLaneLifecycle(
+            db: db, subscriptions: subscriptions, manager: remoteManager)
+        let step: RemoteLaneLifecycle.ArchiveStep
+        do {
+            switch try await lanes.archiveDecision(for: wt, force: false) {
+            case .refused(let message):
+                logger.debug(
+                    "auto-archive skipped for \(wt.id, privacy: .public): \(message, privacy: .public)")
+                return false
+            case .proceed(let decided):
+                step = decided
+            }
+        } catch {
+            logger.error(
+                "auto-archive could not route \(wt.id, privacy: .public): \(error, privacy: .public)")
+            return false
+        }
+
+        // Fail-closed exactly as the local path is: an unrecordable archive
+        // does not happen, and the worktree survives for the next merged
+        // transition to retry.
+        var request = ActuationRow(
+            actor: .daemon(rail: ActuationRail.autoArchiveOnMerge), kind: .dispose)
+        request.target = ActuationTarget(worktree: wt.id.uuidString)
+        let actuationID: String
+        do {
+            actuationID = try await actuationLog.appendRequest(request)
+        } catch {
+            logger.warning("auto-archive skipped (record unwritable): \(wt.id, privacy: .public): \(error, privacy: .public)")
+            return false
+        }
+
+        do {
+            if let failure = try await lanes.performArchive(step, worktree: wt) {
+                await actuationLog.appendOutcome(
+                    confirms: actuationID, result: .transportFailed, error: failure)
+                logger.error(
+                    "auto-archive failed for \(wt.id, privacy: .public): \(failure, privacy: .public)")
+                return false
+            }
+        } catch {
+            await actuationLog.appendOutcome(
+                confirms: actuationID, result: .transportFailed, error: "\(error)")
+            logger.error("auto-archive failed for \(wt.id, privacy: .public): \(error, privacy: .public)")
+            return false
+        }
+        await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
+
+        // Same notification the local path creates: a worktree retired without
+        // the user asking at that moment has to say why.
+        do {
+            let notification = try await db.notifications.create(
+                worktreeID: wt.id,
+                type: .taskComplete,
+                message: "Archived \(wt.displayName) — PR #\(prNumber) merged",
+                terminalID: nil)
+            subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
+                notificationID: notification.id, worktreeID: notification.worktreeID,
+                type: notification.type, message: notification.message,
+                terminalID: notification.terminalID, activate: false)))
+        } catch {
+            logger.error(
+                "auto-archived \(wt.id, privacy: .public) but could not record a notification: \(error, privacy: .public)")
+        }
+        logger.info("auto-archived remote lane \(wt.id, privacy: .public) on PR #\(prNumber, privacy: .public) merge")
+        return true
     }
 }

--- a/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
+++ b/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
@@ -169,6 +169,13 @@ actor ProviderEventsSupervisor {
     /// cycle on the same instance.
     private var generation = 0
     private var lastActivity = Date()
+    /// When the current `events` connection was opened. This is the request
+    /// start for every `snapshot` event that arrives on it: the provider
+    /// composes its reconnect snapshot from what it knew when TBD asked, so a
+    /// snapshot on a connection opened before a local filing decision cannot
+    /// have accounted for that decision. See
+    /// `RemoteProviderManager.syncFilingDecisions`.
+    private var connectionOpenedAt = Date()
 
     /// Injectable timing so the live test runs in seconds, not minutes.
     let silenceLimit: TimeInterval
@@ -274,6 +281,7 @@ actor ProviderEventsSupervisor {
         process.terminationHandler = { _ in exitGate.markExited() }
 
         do {
+            connectionOpenedAt = Date()
             try process.run()
         } catch {
             remoteLogger.error(
@@ -379,7 +387,9 @@ actor ProviderEventsSupervisor {
         case .hello, .ping:
             break   // activity timestamp already updated by the caller
         case .snapshot(let sessions):
-            try? await manager.apply(snapshot: sessions, provider: config.name)
+            try? await manager.apply(
+                snapshot: sessions, provider: config.name,
+                requestStartedAt: connectionOpenedAt)
         case .session(let session):
             await manager.applyUpsert(session, provider: config.name)
         case .removed(let id):

--- a/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
+++ b/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
@@ -175,13 +175,24 @@ actor ProviderEventsSupervisor {
     /// snapshot on a connection opened before a local filing decision cannot
     /// have accounted for that decision. See
     /// `RemoteProviderManager.syncFilingDecisions`.
-    private var connectionOpenedAt = Date()
+    ///
+    /// Internal rather than private so a test can read what the date seam
+    /// stamped; nothing in production reads it from outside this actor.
+    private(set) var connectionOpenedAt: Date
 
     /// Injectable timing so the live test runs in seconds, not minutes.
     let silenceLimit: TimeInterval
     let backoffCap: TimeInterval
     let healthyResetUptime: TimeInterval
     private let clock: any Clock<Duration>
+    /// The date seam. Separate from `clock` on purpose: `connectionOpenedAt`
+    /// is persisted-shaped data that gets **compared** against a filing
+    /// decision, not a delay — `Duration` is behavior, `Date` is data
+    /// (root `CLAUDE.md`, "New delays and timers take an injected clock").
+    /// The watchdog's own elapsed-time arithmetic deliberately stays on the
+    /// wall clock: it measures how long a child has been silent, which a
+    /// frozen date would disable outright.
+    private let now: @Sendable () -> Date
 
     /// Grace between SIGTERM and SIGKILL, and between observing the child's
     /// exit and finishing the line stream (so late bytes still get applied).
@@ -191,13 +202,16 @@ actor ProviderEventsSupervisor {
     init(config: RemoteProviderConfig, manager: RemoteProviderManager,
          silenceLimit: TimeInterval = 90, backoffCap: TimeInterval = 60,
          healthyResetUptime: TimeInterval = 300,
-         clock: any Clock<Duration> = ContinuousClock()) {
+         clock: any Clock<Duration> = ContinuousClock(),
+         now: @Sendable @escaping () -> Date = { Date() }) {
         self.config = config
         self.manager = manager
         self.silenceLimit = silenceLimit
         self.backoffCap = backoffCap
         self.healthyResetUptime = healthyResetUptime
         self.clock = clock
+        self.now = now
+        self.connectionOpenedAt = now()
     }
 
     func start() {
@@ -281,7 +295,7 @@ actor ProviderEventsSupervisor {
         process.terminationHandler = { _ in exitGate.markExited() }
 
         do {
-            connectionOpenedAt = Date()
+            connectionOpenedAt = now()
             try process.run()
         } catch {
             remoteLogger.error(

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
@@ -1,0 +1,217 @@
+import Foundation
+import TBDShared
+import os
+
+private let remoteLaneLogger = Logger(subsystem: "com.tbd.daemon", category: "remoteLane")
+
+/// Carrying a remote lane's archive or revive out, once
+/// `RemoteLaneLifecycle`'s pure decisions have said what to do
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Archive",
+/// §"Revive", §"The record").
+///
+/// The split between deciding and acting is the record's shape, not a style
+/// preference. **A refusal happens above the actuation row** — nothing was
+/// attempted, and the record may claim solely acts that were attempted — so
+/// callers ask for a decision first, return the refusal if that is what comes
+/// back, and only then write their row and call the `perform` half. The `gone`
+/// path does write a row: no provider call was made, but the row genuinely
+/// changed status, and that is the act the record names.
+///
+/// Nothing here reaches `beginArchiveWorktree`, `completeArchiveWorktree`,
+/// tmux teardown, scrollback capture, or directory removal. A remote lane's
+/// files are on another machine; there is nothing local to tear down.
+extension RemoteLaneLifecycle {
+
+    // MARK: - Decisions, with the guards applied
+
+    /// A remote archive, decided: either refused above the record, or a step
+    /// to carry out below it.
+    enum ArchiveDecision: Equatable {
+        case refused(String)
+        case proceed(ArchiveStep)
+    }
+
+    /// The act itself, once the capability routing and the guards have both
+    /// passed.
+    enum ArchiveStep: Equatable {
+        /// Call `archive <id>`, then mark the row archived.
+        case invokeVerb(provider: String, sessionID: String)
+        /// Mark the row archived and call nothing — the `gone` exemption.
+        case rowOnly
+    }
+
+    /// A remote revive, decided. Same shape and the same reason as
+    /// `ArchiveDecision`.
+    enum ReviveDecision: Equatable {
+        case refused(String)
+        case proceed(ReviveStep)
+    }
+
+    enum ReviveStep: Equatable {
+        case invokeUnarchive(provider: String, sessionID: String)
+        case rowOnly
+    }
+
+    /// Routes an archive of `worktree`, applying the verb path's two guards.
+    ///
+    /// The capability routing is `archivePlan`'s, unchanged — this only adds
+    /// the guards, and only on the verb path. The `gone` path touches nothing
+    /// on the provider and so has nothing to defend, which is why the guards
+    /// sit inside the `.invokeVerb` arm rather than ahead of the switch.
+    /// `force` overrides both.
+    func archiveDecision(for worktree: Worktree, force: Bool) async throws -> ArchiveDecision {
+        guard case .remote(let provider, let sessionID) = worktree.location else {
+            return .refused("Cannot archive \(worktree.name) through the remote path: it is a local worktree.")
+        }
+        let row = try await db.remoteSessions.row(provider: provider, sessionID: sessionID)
+        let payload = row?.decodedPayload
+        let capabilities = await manager.declaredCapabilities(provider: provider)
+        switch Self.archivePlan(capabilities: capabilities, isGone: row?.gone ?? false) {
+        case .refused(let message):
+            return .refused("Cannot archive \(worktree.name): \(message)")
+        case .rowOnlyGone:
+            return .proceed(.rowOnly)
+        case .invokeVerb:
+            if !force {
+                if payload?.agentState == .working {
+                    return .refused(Self.workingGuardRefusal(worktree.name))
+                }
+                if Self.metaReportsDirtyWorkspace(payload?.meta) {
+                    return .refused(Self.dirtyWorkspaceGuardRefusal(worktree.name))
+                }
+            }
+            return .proceed(.invokeVerb(provider: provider, sessionID: sessionID))
+        }
+    }
+
+    /// Routes a revive of `worktree`.
+    ///
+    /// `providerReportsArchived` is what the provider reports **right now**,
+    /// read from the mirror's current payload — not how the row came to be
+    /// archived, so no provenance has to be persisted. An absent `archived`
+    /// reads as `false` here (`isArchived`, the contract's display reading):
+    /// a provider that made no claim is not one asserting a retirement this
+    /// flip would fight with.
+    func reviveDecision(for worktree: Worktree) async throws -> ReviveDecision {
+        guard case .remote(let provider, let sessionID) = worktree.location else {
+            return .refused("Cannot revive \(worktree.name) through the remote path: it is a local worktree.")
+        }
+        let row = try await db.remoteSessions.row(provider: provider, sessionID: sessionID)
+        let capabilities = await manager.declaredCapabilities(provider: provider)
+        switch Self.revivePlan(
+            capabilities: capabilities,
+            providerReportsArchived: row?.decodedPayload?.isArchived ?? false
+        ) {
+        case .refusedNoUnarchive(let message):
+            return .refused("Cannot revive \(worktree.name): \(message)")
+        case .rowOnly:
+            return .proceed(.rowOnly)
+        case .invokeUnarchive:
+            return .proceed(.invokeUnarchive(provider: provider, sessionID: sessionID))
+        }
+    }
+
+    // MARK: - Acting
+
+    /// Carries out a decided archive. Returns `nil` on success, or the
+    /// message to surface when the provider verb failed — in which case the
+    /// row is left alone, because a retirement TBD did not perform is not one
+    /// it may claim.
+    ///
+    /// `date` is the filing decision's timestamp and is **compared**, not
+    /// displayed: `noteFilingDecision` is what stops a `list` response
+    /// composed before this moment from undoing it on arrival. Skipping that
+    /// call would leave the whole stale-snapshot watermark dead code.
+    func performArchive(
+        _ step: ArchiveStep, worktree: Worktree, date: Date = Date()
+    ) async throws -> String? {
+        if case .invokeVerb(let provider, let sessionID) = step {
+            if let failure = await invokeRetirementVerb(
+                "archive", provider: provider, sessionID: sessionID) {
+                return failure
+            }
+        }
+        try await db.worktrees.archive(id: worktree.id)
+        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: worktree.id)))
+        return nil
+    }
+
+    /// Carries out a decided revive. Returns `nil` on success, or the message
+    /// to surface when the provider verb failed.
+    ///
+    /// The session's condition — running, exited, or no longer there — is
+    /// reported through the mirror: whatever Session object the provider
+    /// hands back is upserted before the row flips, so the lane returns to
+    /// the active list already carrying the provider's current word on it
+    /// rather than the stale payload it was archived with.
+    func performRevive(
+        _ step: ReviveStep, worktree: Worktree, date: Date = Date()
+    ) async throws -> String? {
+        if case .invokeUnarchive(let provider, let sessionID) = step {
+            if let failure = await invokeRetirementVerb(
+                "unarchive", provider: provider, sessionID: sessionID) {
+                return failure
+            }
+        }
+        try await db.worktrees.revive(id: worktree.id)
+        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
+            worktreeID: worktree.id, repoID: worktree.repoID,
+            name: worktree.name, path: worktree.localPath)))
+        return nil
+    }
+
+    /// Invokes `archive` or `unarchive` and mirrors whatever Session object
+    /// comes back. Returns `nil` when the row may now be filed, or the
+    /// message to surface otherwise.
+    ///
+    /// **`not_found` degrades to a row-only filing rather than an error, in
+    /// both directions.** A provider that no longer knows this session cannot
+    /// retire or restore it, and there is no live session left to
+    /// misdescribe — the same reasoning the `gone` exemption rests on. Were
+    /// it an error instead, a `gone` lane whose provider happens to declare
+    /// `archive` would take the verb path, fail, and become unretirable,
+    /// while an identical lane on a provider declaring nothing would file
+    /// cleanly. Both verbs are idempotent per contract, so the attempt costs
+    /// a round trip and never a wrong outcome.
+    ///
+    /// This is deliberately **not** a place `stop` can be reached from. The
+    /// contract names ending compute and retiring a record as separate acts,
+    /// and no path in TBD substitutes one for the other.
+    private func invokeRetirementVerb(
+        _ verb: String, provider: String, sessionID: String
+    ) async -> String? {
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: provider, verb: [verb, sessionID], stdin: nil, timeout: 30)
+        } catch let error as ProviderRunError {
+            remoteLaneLogger.error(
+                "\(verb, privacy: .public) provider=\(provider, privacy: .public) timed out")
+            switch error {
+            case .timeout(let timedOutVerb):
+                return "provider '\(provider)' timed out running '\(timedOutVerb)'"
+            }
+        } catch {
+            remoteLaneLogger.error(
+                "\(verb, privacy: .public) provider=\(provider, privacy: .public) failed: \(String(describing: error), privacy: .public)")
+            return "\(error)"
+        }
+        if result.failureClass != nil {
+            if result.decodedError?.code == "not_found" {
+                remoteLaneLogger.debug(
+                    "\(verb, privacy: .public) on \(provider, privacy: .public)/\(sessionID, privacy: .public) reported not_found; filing the row alone")
+                return nil
+            }
+            let message = result.decodedError?.message ?? "\(verb) failed (exit \(result.exitCode))"
+            remoteLaneLogger.error(
+                "\(verb, privacy: .public) provider=\(provider, privacy: .public) failed: \(message, privacy: .public)")
+            return message
+        }
+        if let session = try? result.decoded(RemoteSessionPayload.self) {
+            await manager.applyUpsert(session, provider: provider)
+        }
+        return nil
+    }
+}

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
@@ -56,15 +56,19 @@ extension RemoteLaneLifecycle {
     ///
     /// The capability routing is `archivePlan`'s, unchanged — this only adds
     /// the guards, and only on the verb path. The `gone` path touches nothing
-    /// on the provider and so has nothing to defend, which is why the guards
-    /// sit inside the `.invokeVerb` arm rather than ahead of the switch.
-    /// `force` overrides both.
+    /// on the provider and so has nothing to defend, which is why all three
+    /// guards sit inside the `.invokeVerb` arm rather than ahead of the switch.
+    /// `force` overrides all three.
+    ///
+    /// The stale-snapshot guard belongs with the other two for the same
+    /// reason: it exists because `agentState` and `meta.workspace_dirty` are
+    /// read out of a mirror a stale inventory makes untrustworthy. The `gone`
+    /// path reads neither, so there is nothing for staleness to make wrong —
+    /// and gating it would leave a lane on a provider that cannot archive
+    /// unretireable for as long as that provider stays unhealthy.
     func archiveDecision(for worktree: Worktree, force: Bool) async throws -> ArchiveDecision {
         guard case .remote(let provider, let sessionID) = worktree.location else {
             return .refused("Cannot archive \(worktree.name) through the remote path: it is a local worktree.")
-        }
-        if !force, await manager.hasStaleSnapshot(provider: provider) {
-            return .refused(Self.staleSnapshotRefusal(worktree.name, provider: provider))
         }
         let row = try await db.remoteSessions.row(provider: provider, sessionID: sessionID)
         let payload = row?.decodedPayload
@@ -76,6 +80,9 @@ extension RemoteLaneLifecycle {
             return .proceed(.rowOnly)
         case .invokeVerb:
             if !force {
+                if await manager.hasStaleSnapshot(provider: provider) {
+                    return .refused(Self.staleSnapshotRefusal(worktree.name, provider: provider))
+                }
                 if payload?.agentState == .working {
                     return .refused(Self.workingGuardRefusal(worktree.name))
                 }
@@ -99,13 +106,6 @@ extension RemoteLaneLifecycle {
         guard case .remote(let provider, let sessionID) = worktree.location else {
             return .refused("Cannot revive \(worktree.name) through the remote path: it is a local worktree.")
         }
-        // Same gate as archive's, and there is no `--force` to lift it:
-        // `worktree.revive` carries no force flag, and neither does the
-        // `remote.unarchive` handler this parallels. The recovery is the
-        // provider's next successful poll.
-        if await manager.hasStaleSnapshot(provider: provider) {
-            return .refused(Self.staleSnapshotRefusal(worktree.name, provider: provider))
-        }
         let row = try await db.remoteSessions.row(provider: provider, sessionID: sessionID)
         let capabilities = await manager.declaredCapabilities(provider: provider)
         switch Self.revivePlan(
@@ -115,8 +115,19 @@ extension RemoteLaneLifecycle {
         case .refusedNoUnarchive(let message):
             return .refused("Cannot revive \(worktree.name): \(message)")
         case .rowOnly:
+            // Not gated on staleness: this path calls nothing and consults
+            // nothing a stale inventory could make wrong. It is also the only
+            // way back for a lane filed under the `gone` exemption, and revive
+            // has no `--force` to lift a refusal with.
             return .proceed(.rowOnly)
         case .invokeUnarchive:
+            // Same gate as archive's verb path, and there is no `--force` to
+            // lift it: `worktree.revive` carries no force flag, and neither
+            // does the `remote.unarchive` handler this parallels. The recovery
+            // is the provider's next successful poll.
+            if await manager.hasStaleSnapshot(provider: provider) {
+                return .refused(Self.staleSnapshotRefusal(worktree.name, provider: provider))
+            }
             return .proceed(.invokeUnarchive(provider: provider, sessionID: sessionID))
         }
     }
@@ -128,12 +139,14 @@ extension RemoteLaneLifecycle {
     /// row is left alone, because a retirement TBD did not perform is not one
     /// it may claim.
     ///
-    /// `date` is the filing decision's timestamp and is **compared**, not
-    /// displayed: `noteFilingDecision` is what stops a `list` response
-    /// composed before this moment from undoing it on arrival. Skipping that
-    /// call would leave the whole stale-snapshot watermark dead code.
+    /// `now` supplies the filing decision's timestamps, which are **compared**,
+    /// not displayed — the date seam rather than the clock seam
+    /// (`Tests/CLAUDE.md`, "Clock and date seams"). `noteFilingDecision` is
+    /// what stops a `list` response composed before this gesture from undoing
+    /// it on arrival; skipping it would leave the whole stale-snapshot
+    /// watermark dead code.
     ///
-    /// **The order of the three writes is load bearing, not incidental.** The
+    /// **The order of the four writes is load bearing, not incidental.** The
     /// contract mandates that `archive` return the updated Session, so a
     /// conforming provider's response carries `archived: true` — and mirroring
     /// it runs the filing sync. Were that mirror to land before the row is
@@ -145,27 +158,52 @@ extension RemoteLaneLifecycle {
     /// 1. record the filing decision, **before** the verb is invoked, so a
     ///    poll already in flight cannot act on the row while the verb runs;
     /// 2. invoke the verb, holding whatever Session came back;
-    /// 3. write the row, and only then mirror the held response — by which
-    ///    time the sync observes a row already in its target state and
-    ///    correctly does nothing.
+    /// 3. write the row, and **stamp the watermark again** — a verb takes real
+    ///    time, and a poll launched after step 1 but before the row landed
+    ///    carries the provider's pre-gesture word while passing a watermark
+    ///    that only covers step 1. Without the second stamp the sync would
+    ///    reverse the row about (verb duration / poll interval) of the time;
+    /// 4. mirror the held response, by which time the sync observes a row
+    ///    already in its target state and correctly does nothing.
     func performArchive(
-        _ step: ArchiveStep, worktree: Worktree, date: Date = Date()
+        _ step: ArchiveStep, worktree: Worktree, now: @Sendable () -> Date = { Date() }
     ) async throws -> String? {
-        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        let decidedAt = now()
+        let prior = await manager.noteFilingDecision(worktreeID: worktree.id, at: decidedAt)
         var mirrored: (session: RemoteSessionPayload, provider: String)?
         if case .invokeVerb(let provider, let sessionID) = step {
             switch await invokeRetirementVerb(
                 "archive", provider: provider, sessionID: sessionID) {
             case .failed(let message):
-                await manager.forgetFilingDecision(worktreeID: worktree.id)
+                await manager.withdrawFilingDecision(
+                    worktreeID: worktree.id, restoring: prior, ifStillAt: decidedAt)
                 return message
             case .succeeded(let session):
                 mirrored = session.map { ($0, provider) }
             }
         }
-        try await db.worktrees.archive(id: worktree.id)
+        do {
+            try await db.worktrees.archive(id: worktree.id)
+        } catch {
+            // The row write is as capable of failing as the verb was, and the
+            // watermark recorded for it is as wrong afterwards. Same treatment.
+            await manager.withdrawFilingDecision(
+                worktreeID: worktree.id, restoring: prior, ifStillAt: decidedAt)
+            throw error
+        }
+        await manager.noteFilingDecision(worktreeID: worktree.id, at: now())
         if let mirrored {
-            await manager.applyUpsert(mirrored.session, provider: mirrored.provider)
+            // A conforming provider's response says `archived: true`, and the
+            // sync reading it against a row already `.archived` does nothing.
+            // A provider that returns `archived: false` from its own `archive`
+            // is contradicting the contract, and the sync will take it at its
+            // word and return the row while this RPC reports success. That is
+            // the deliberate trade: mirroring the provider's current report is
+            // what makes the filing sync authoritative in the first place, and
+            // suppressing it for this one row would mean trusting the response
+            // exactly as far as it agrees with us.
+            await manager.applyUpsert(
+                mirrored.session, provider: mirrored.provider, date: now())
         }
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: worktree.id)))
         return nil
@@ -180,29 +218,42 @@ extension RemoteLaneLifecycle {
     /// carrying the provider's current word on it rather than the stale
     /// payload it was archived with.
     ///
-    /// Same three-step order as `performArchive`, and for the mirror-image
+    /// Same four-step order as `performArchive`, and for the mirror-image
     /// reason: `unarchive` returns `archived: false`, so mirroring it before
     /// the row is written would hand the filing sync an `.archived` row beside
     /// a fresh `archived: false` and earn a second, daemon-rail `.spawn` pair
-    /// for a gesture the user made once.
+    /// for a gesture the user made once. The re-stamp after the row write
+    /// closes the same window on this side: a poll launched while the verb ran
+    /// carries a pre-revive `archived: true` that would otherwise re-file the
+    /// row the user just returned.
     func performRevive(
-        _ step: ReviveStep, worktree: Worktree, date: Date = Date()
+        _ step: ReviveStep, worktree: Worktree, now: @Sendable () -> Date = { Date() }
     ) async throws -> String? {
-        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        let decidedAt = now()
+        let prior = await manager.noteFilingDecision(worktreeID: worktree.id, at: decidedAt)
         var mirrored: (session: RemoteSessionPayload, provider: String)?
         if case .invokeUnarchive(let provider, let sessionID) = step {
             switch await invokeRetirementVerb(
                 "unarchive", provider: provider, sessionID: sessionID) {
             case .failed(let message):
-                await manager.forgetFilingDecision(worktreeID: worktree.id)
+                await manager.withdrawFilingDecision(
+                    worktreeID: worktree.id, restoring: prior, ifStillAt: decidedAt)
                 return message
             case .succeeded(let session):
                 mirrored = session.map { ($0, provider) }
             }
         }
-        try await db.worktrees.revive(id: worktree.id)
+        do {
+            try await db.worktrees.revive(id: worktree.id)
+        } catch {
+            await manager.withdrawFilingDecision(
+                worktreeID: worktree.id, restoring: prior, ifStillAt: decidedAt)
+            throw error
+        }
+        await manager.noteFilingDecision(worktreeID: worktree.id, at: now())
         if let mirrored {
-            await manager.applyUpsert(mirrored.session, provider: mirrored.provider)
+            await manager.applyUpsert(
+                mirrored.session, provider: mirrored.provider, date: now())
         }
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: worktree.id, repoID: worktree.repoID,

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
@@ -63,6 +63,9 @@ extension RemoteLaneLifecycle {
         guard case .remote(let provider, let sessionID) = worktree.location else {
             return .refused("Cannot archive \(worktree.name) through the remote path: it is a local worktree.")
         }
+        if !force, await manager.hasStaleSnapshot(provider: provider) {
+            return .refused(Self.staleSnapshotRefusal(worktree.name, provider: provider))
+        }
         let row = try await db.remoteSessions.row(provider: provider, sessionID: sessionID)
         let payload = row?.decodedPayload
         let capabilities = await manager.declaredCapabilities(provider: provider)
@@ -96,6 +99,13 @@ extension RemoteLaneLifecycle {
         guard case .remote(let provider, let sessionID) = worktree.location else {
             return .refused("Cannot revive \(worktree.name) through the remote path: it is a local worktree.")
         }
+        // Same gate as archive's, and there is no `--force` to lift it:
+        // `worktree.revive` carries no force flag, and neither does the
+        // `remote.unarchive` handler this parallels. The recovery is the
+        // provider's next successful poll.
+        if await manager.hasStaleSnapshot(provider: provider) {
+            return .refused(Self.staleSnapshotRefusal(worktree.name, provider: provider))
+        }
         let row = try await db.remoteSessions.row(provider: provider, sessionID: sessionID)
         let capabilities = await manager.declaredCapabilities(provider: provider)
         switch Self.revivePlan(
@@ -122,17 +132,41 @@ extension RemoteLaneLifecycle {
     /// displayed: `noteFilingDecision` is what stops a `list` response
     /// composed before this moment from undoing it on arrival. Skipping that
     /// call would leave the whole stale-snapshot watermark dead code.
+    ///
+    /// **The order of the three writes is load bearing, not incidental.** The
+    /// contract mandates that `archive` return the updated Session, so a
+    /// conforming provider's response carries `archived: true` — and mirroring
+    /// it runs the filing sync. Were that mirror to land before the row is
+    /// written, the sync would see a row still `.active` beside a fresh
+    /// `archived: true` and file it a second time, on the daemon's own rail,
+    /// with a notification claiming the *provider* retired a session the
+    /// *user* just retired. So:
+    ///
+    /// 1. record the filing decision, **before** the verb is invoked, so a
+    ///    poll already in flight cannot act on the row while the verb runs;
+    /// 2. invoke the verb, holding whatever Session came back;
+    /// 3. write the row, and only then mirror the held response — by which
+    ///    time the sync observes a row already in its target state and
+    ///    correctly does nothing.
     func performArchive(
         _ step: ArchiveStep, worktree: Worktree, date: Date = Date()
     ) async throws -> String? {
+        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        var mirrored: (session: RemoteSessionPayload, provider: String)?
         if case .invokeVerb(let provider, let sessionID) = step {
-            if let failure = await invokeRetirementVerb(
+            switch await invokeRetirementVerb(
                 "archive", provider: provider, sessionID: sessionID) {
-                return failure
+            case .failed(let message):
+                await manager.forgetFilingDecision(worktreeID: worktree.id)
+                return message
+            case .succeeded(let session):
+                mirrored = session.map { ($0, provider) }
             }
         }
         try await db.worktrees.archive(id: worktree.id)
-        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        if let mirrored {
+            await manager.applyUpsert(mirrored.session, provider: mirrored.provider)
+        }
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: worktree.id)))
         return nil
     }
@@ -142,28 +176,53 @@ extension RemoteLaneLifecycle {
     ///
     /// The session's condition — running, exited, or no longer there — is
     /// reported through the mirror: whatever Session object the provider
-    /// hands back is upserted before the row flips, so the lane returns to
-    /// the active list already carrying the provider's current word on it
-    /// rather than the stale payload it was archived with.
+    /// hands back is upserted, so the lane returns to the active list already
+    /// carrying the provider's current word on it rather than the stale
+    /// payload it was archived with.
+    ///
+    /// Same three-step order as `performArchive`, and for the mirror-image
+    /// reason: `unarchive` returns `archived: false`, so mirroring it before
+    /// the row is written would hand the filing sync an `.archived` row beside
+    /// a fresh `archived: false` and earn a second, daemon-rail `.spawn` pair
+    /// for a gesture the user made once.
     func performRevive(
         _ step: ReviveStep, worktree: Worktree, date: Date = Date()
     ) async throws -> String? {
+        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        var mirrored: (session: RemoteSessionPayload, provider: String)?
         if case .invokeUnarchive(let provider, let sessionID) = step {
-            if let failure = await invokeRetirementVerb(
+            switch await invokeRetirementVerb(
                 "unarchive", provider: provider, sessionID: sessionID) {
-                return failure
+            case .failed(let message):
+                await manager.forgetFilingDecision(worktreeID: worktree.id)
+                return message
+            case .succeeded(let session):
+                mirrored = session.map { ($0, provider) }
             }
         }
         try await db.worktrees.revive(id: worktree.id)
-        await manager.noteFilingDecision(worktreeID: worktree.id, at: date)
+        if let mirrored {
+            await manager.applyUpsert(mirrored.session, provider: mirrored.provider)
+        }
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: worktree.id, repoID: worktree.repoID,
             name: worktree.name, path: worktree.localPath)))
         return nil
     }
 
-    /// Invokes `archive` or `unarchive` and mirrors whatever Session object
-    /// comes back. Returns `nil` when the row may now be filed, or the
+    /// What a retirement verb came back with.
+    ///
+    /// The Session object travels out rather than being mirrored here, so the
+    /// caller can write the row first — see `performArchive`'s ordering note.
+    /// A `.succeeded(nil)` is the `not_found` degradation and the row-only
+    /// paths: the row may be filed, and there is nothing to mirror.
+    private enum VerbOutcome {
+        case failed(String)
+        case succeeded(RemoteSessionPayload?)
+    }
+
+    /// Invokes `archive` or `unarchive` and decodes whatever Session object
+    /// comes back. Returns `.succeeded` when the row may now be filed, or the
     /// message to surface otherwise.
     ///
     /// **`not_found` degrades to a row-only filing rather than an error, in
@@ -181,7 +240,7 @@ extension RemoteLaneLifecycle {
     /// and no path in TBD substitutes one for the other.
     private func invokeRetirementVerb(
         _ verb: String, provider: String, sessionID: String
-    ) async -> String? {
+    ) async -> VerbOutcome {
         let result: ProviderResult
         do {
             result = try await manager.invoke(
@@ -191,27 +250,24 @@ extension RemoteLaneLifecycle {
                 "\(verb, privacy: .public) provider=\(provider, privacy: .public) timed out")
             switch error {
             case .timeout(let timedOutVerb):
-                return "provider '\(provider)' timed out running '\(timedOutVerb)'"
+                return .failed("provider '\(provider)' timed out running '\(timedOutVerb)'")
             }
         } catch {
             remoteLaneLogger.error(
                 "\(verb, privacy: .public) provider=\(provider, privacy: .public) failed: \(String(describing: error), privacy: .public)")
-            return "\(error)"
+            return .failed("\(error)")
         }
         if result.failureClass != nil {
             if result.decodedError?.code == "not_found" {
                 remoteLaneLogger.debug(
                     "\(verb, privacy: .public) on \(provider, privacy: .public)/\(sessionID, privacy: .public) reported not_found; filing the row alone")
-                return nil
+                return .succeeded(nil)
             }
             let message = result.decodedError?.message ?? "\(verb) failed (exit \(result.exitCode))"
             remoteLaneLogger.error(
                 "\(verb, privacy: .public) provider=\(provider, privacy: .public) failed: \(message, privacy: .public)")
-            return message
+            return .failed(message)
         }
-        if let session = try? result.decoded(RemoteSessionPayload.self) {
-            await manager.applyUpsert(session, provider: provider)
-        }
-        return nil
+        return .succeeded(try? result.decoded(RemoteSessionPayload.self))
     }
 }

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
@@ -138,6 +138,22 @@ struct RemoteLaneLifecycle: Sendable {
         "Cannot archive \(name): its agent is still working. Re-run with --force to retire it anyway."
     }
 
+    /// The refusal for a lane whose provider's cached inventory has gone
+    /// stale — the same gate every `remote.*` mutation passes, and load
+    /// bearing here for a sharper reason than elsewhere.
+    ///
+    /// Both of archive's guards are read out of the mirror (`agentState`, and
+    /// `meta.workspace_dirty`), and the revive routing reads the provider's
+    /// current `archived` claim from it too. On a stale mirror a session that
+    /// was idle at the last good poll and is working now reads as safe, the
+    /// guards pass, and a mid-task session is retired — exactly what the
+    /// guards exist to prevent. Refusing keeps a mutation from resting on an
+    /// inventory TBD already knows it cannot trust.
+    static func staleSnapshotRefusal(_ name: String, provider: String) -> String {
+        "Cannot act on \(name): provider '\(provider)' inventory is stale; refresh must recover " +
+        "before changing remote sessions."
+    }
+
     /// The refusal for a lane whose provider reports an unclean checkout.
     static func dirtyWorkspaceGuardRefusal(_ name: String) -> String {
         "Cannot archive \(name): its provider reports the session's checkout has uncommitted work " +

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
@@ -143,12 +143,17 @@ struct RemoteLaneLifecycle: Sendable {
     /// bearing here for a sharper reason than elsewhere.
     ///
     /// Both of archive's guards are read out of the mirror (`agentState`, and
-    /// `meta.workspace_dirty`), and the revive routing reads the provider's
-    /// current `archived` claim from it too. On a stale mirror a session that
-    /// was idle at the last good poll and is working now reads as safe, the
-    /// guards pass, and a mid-task session is retired — exactly what the
-    /// guards exist to prevent. Refusing keeps a mutation from resting on an
-    /// inventory TBD already knows it cannot trust.
+    /// `meta.workspace_dirty`). On a stale mirror a session that was idle at
+    /// the last good poll and is working now reads as safe, the guards pass,
+    /// and a mid-task session is retired — exactly what the guards exist to
+    /// prevent. Refusing keeps a *provider call* from resting on an inventory
+    /// TBD already knows it cannot trust.
+    ///
+    /// **It therefore covers the verb paths and nothing else.** The row-only
+    /// paths make no provider call and read nothing out of the mirror they
+    /// could be wrong about; gating them would strand the `gone` exemption —
+    /// the only route out for a lane whose provider cannot archive — behind a
+    /// `--force` that revive does not have and the row menu never sends.
     static func staleSnapshotRefusal(_ name: String, provider: String) -> String {
         "Cannot act on \(name): provider '\(provider)' inventory is stale; refresh must recover " +
         "before changing remote sessions."

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Pure decision functions for retiring and reviving a remote lane
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md`, "Archive" and
+/// "Revive"). No I/O, no actor, no provider calls, no DB access — this type
+/// only turns a provider's declared capabilities (and the row's current
+/// status) into a plan. Callers wire the plan to an actuation.
+enum RemoteLaneLifecycle {
+    /// What `worktree.archive` should do with a remote row, decided purely
+    /// from the provider's declared capabilities and whether the row is
+    /// currently `gone`.
+    enum RemoteLaneArchivePlan: Equatable {
+        /// The provider declares `archive`: call it, then mark the row
+        /// archived. Wins even when the row is `gone` — a `not_found` from
+        /// the provider is handled at the call site, not here.
+        case invokeVerb
+        /// The provider declares no `archive`, but the row is `gone`: mark
+        /// it archived and call nothing. There is no live session to
+        /// misdescribe and no verb that could reach it.
+        case rowOnlyGone
+        /// The provider declares no `archive`, and the row is not `gone`:
+        /// refuse. The message names `archive` as the missing capability.
+        case refused(String)
+    }
+
+    /// What `worktree.revive` should do with a remote row, decided purely
+    /// from the provider's declared capabilities and what the provider
+    /// currently reports about `archived`.
+    enum RemoteLaneRevivePlan: Equatable {
+        /// The provider declares `unarchive`: call it, then flip the row to
+        /// active.
+        case invokeUnarchive
+        /// The provider declares no `unarchive`, and no `archive` decision
+        /// TBD made stands to be reversed by anything but TBD itself: flip
+        /// the row, call nothing. Only reachable for a lane TBD filed under
+        /// the `gone` exemption — the provider never claimed it archived.
+        case rowOnly
+        /// The provider declares no `unarchive`, and currently reports the
+        /// session archived: refuse rather than flip a row the provider
+        /// will keep asserting is archived on the next snapshot. The
+        /// message names `unarchive` and says the retirement stands on the
+        /// backend until it exists.
+        case refusedNoUnarchive(String)
+    }
+
+    /// Decides how `worktree.archive` should treat a remote row.
+    ///
+    /// Order matters: a provider that declares `archive` takes the verb
+    /// path even for a `gone` lane (rule 1 checked before `isGone`). This
+    /// function never inspects `"stop"` — ending compute and retiring a
+    /// record are different acts, and a provider declaring only `stop` must
+    /// fall through to `.refused`.
+    static func archivePlan(capabilities: Set<String>, isGone: Bool) -> RemoteLaneArchivePlan {
+        if capabilities.contains("archive") {
+            return .invokeVerb
+        }
+        if isGone {
+            return .rowOnlyGone
+        }
+        return .refused(
+            "this provider does not declare the \"archive\" capability, so this session " +
+            "cannot be retired from its working inventory; see docs/remote-provider-contract.md"
+        )
+    }
+
+    /// Decides how `worktree.revive` should treat a remote row.
+    ///
+    /// `providerReportsArchived` is the provider's *current* report, not
+    /// how the row came to be archived — that is the discriminator the
+    /// spec calls for, since no provenance is persisted. This function
+    /// never inspects `"stop"`.
+    static func revivePlan(capabilities: Set<String>, providerReportsArchived: Bool) -> RemoteLaneRevivePlan {
+        if capabilities.contains("unarchive") {
+            return .invokeUnarchive
+        }
+        if providerReportsArchived {
+            return .refusedNoUnarchive(
+                "this provider does not declare the \"unarchive\" capability, so this session " +
+                "cannot be returned to its working inventory; the retirement stands on the " +
+                "backend until it does. See docs/remote-provider-contract.md"
+            )
+        }
+        return .rowOnly
+    }
+}

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
@@ -1,11 +1,28 @@
 import Foundation
 
-/// Pure decision functions for retiring and reviving a remote lane
-/// (`docs/specs/2026-08-16-remote-lane-archive-design.md`, "Archive" and
-/// "Revive"). No I/O, no actor, no provider calls, no DB access — this type
-/// only turns a provider's declared capabilities (and the row's current
-/// status) into a plan. Callers wire the plan to an actuation.
-enum RemoteLaneLifecycle {
+/// The remote half of retiring and reviving a lane
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md`, "Archive",
+/// "Revive", and "Where the branches live"). Two layers, deliberately split:
+///
+/// - The **static** members below are pure decisions. No I/O, no actor, no
+///   provider calls, no DB access — they only turn a provider's declared
+///   capabilities (and the row's current status) into a plan, so the routing
+///   rules are testable without a provider process.
+/// - The **instance** members, in `RemoteLaneLifecycle+Actuate.swift`, hold
+///   the provider manager and the worktree store and carry a plan out. The
+///   archive and revive handlers and the merge rail branch into them on
+///   location; the local path beneath `getLocal` is untouched.
+struct RemoteLaneLifecycle: Sendable {
+    let db: TBDDatabase
+    let subscriptions: StateSubscriptionManager
+    let manager: RemoteProviderManager
+
+    init(db: TBDDatabase, subscriptions: StateSubscriptionManager, manager: RemoteProviderManager) {
+        self.db = db
+        self.subscriptions = subscriptions
+        self.manager = manager
+    }
+
     /// What `worktree.archive` should do with a remote row, decided purely
     /// from the provider's declared capabilities and whether the row is
     /// currently `gone`.
@@ -81,5 +98,49 @@ enum RemoteLaneLifecycle {
             )
         }
         return .rowOnly
+    }
+
+    // MARK: - Guards on the verb path
+
+    /// The optional well-known `meta` key through which a provider reports
+    /// that the session's checkout has work that is not committed or not
+    /// pushed (`docs/remote-provider-contract.md` § Session object).
+    ///
+    /// TBD cannot see a remote working tree, and the `working` guard does
+    /// not cover this case: an idle agent sitting on unpushed work looks
+    /// safe to retire. A provider that knows its checkout is dirty says so
+    /// here; one that says nothing degrades to the `working` guard alone.
+    /// **The guard is therefore inert until a provider adopts the key, and
+    /// TBD never fabricates the fact.**
+    static let dirtyWorkspaceMetaKey = "workspace_dirty"
+
+    /// Reads the dirty-checkout claim out of a session's `meta`.
+    ///
+    /// `meta` is a flat string-to-string map, so the claim arrives as text.
+    /// Only `"true"` and `"1"` (trimmed, case-insensitively) are read as a
+    /// claim; an absent key, an empty value, and anything unrecognized all
+    /// mean "no claim was made" and leave the guard inert. Deliberately not
+    /// a permissive truthiness test: this value decides whether a user's
+    /// archive is refused, and inventing a claim out of a value a provider
+    /// meant for display would refuse a gesture nobody asked to block.
+    static func metaReportsDirtyWorkspace(_ meta: [String: String]?) -> Bool {
+        guard let raw = meta?[dirtyWorkspaceMetaKey] else { return false }
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "true", "1": return true
+        default: return false
+        }
+    }
+
+    /// The refusal for a lane whose agent is mid-task. Parallels how local
+    /// archive refuses on uncommitted changes: do not retire a session
+    /// mid-task by accident.
+    static func workingGuardRefusal(_ name: String) -> String {
+        "Cannot archive \(name): its agent is still working. Re-run with --force to retire it anyway."
+    }
+
+    /// The refusal for a lane whose provider reports an unclean checkout.
+    static func dirtyWorkspaceGuardRefusal(_ name: String) -> String {
+        "Cannot archive \(name): its provider reports the session's checkout has uncommitted work " +
+        "(meta.\(dirtyWorkspaceMetaKey)). Re-run with --force to retire it anyway."
     }
 }

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -358,8 +358,16 @@ public actor RemoteProviderManager {
     /// it because something changed just now — so the filing sync takes
     /// arrival as the request start. There is no earlier moment to appeal to
     /// and none is needed: nothing was in flight across a local decision.
-    func applyUpsert(_ session: RemoteSessionPayload, provider: String) async {
-        let arrivedAt = Date()
+    ///
+    /// `date` is arrival, and it is **compared** rather than displayed — it is
+    /// the request start the watermark is measured against — so it comes
+    /// through the date seam rather than a bare `Date()`
+    /// (`Tests/CLAUDE.md`, "Clock and date seams": `Duration` is behavior,
+    /// `Date` is data). Defaulted, so no call site changes.
+    func applyUpsert(
+        _ session: RemoteSessionPayload, provider: String, date: Date = Date()
+    ) async {
+        let arrivedAt = date
         let outcome: SnapshotOutcome
         do {
             outcome = try await db.remoteSessions.upsertOne(
@@ -431,11 +439,31 @@ public actor RemoteProviderManager {
     /// to `worktreeID`, so a provider response composed before `at` cannot
     /// undo it.
     ///
-    /// Called by the worktree archive/revive handlers and the merge rail
-    /// after the row's status is written — every place TBD makes a filing
-    /// decision of its own about a remote lane.
+    /// Called by the worktree archive/revive handlers, the merge rail, and the
+    /// filing sync's own two writing paths, after the row's status is written —
+    /// every place TBD makes a filing decision of its own about a remote lane.
+    /// The sync is not exempt from its own rule: a row it files is as
+    /// reversible by a poll still in flight as one a gesture filed.
     func noteFilingDecision(worktreeID: UUID, at date: Date) {
         filingDecisions[worktreeID] = date
+    }
+
+    /// Drops a watermark recorded in anticipation of a decision that then did
+    /// not happen — a retirement verb that failed, leaving the row untouched.
+    /// Keeping it would suppress a legitimate snapshot-driven flip for two
+    /// poll intervals over a decision TBD never made.
+    func forgetFilingDecision(worktreeID: UUID) {
+        filingDecisions.removeValue(forKey: worktreeID)
+    }
+
+    /// Whether a response whose request began at `requestStartedAt` may still
+    /// move this row: it may, unless TBD made a filing decision of its own
+    /// *after* that request began. The boundary belongs to the response — a
+    /// decision taken at the very instant the request began is one that
+    /// request could have accounted for.
+    private func filingDecisionAllowsFlip(_ worktreeID: UUID, requestStartedAt: Date) -> Bool {
+        guard let decidedAt = filingDecisions[worktreeID] else { return true }
+        return decidedAt <= requestStartedAt
     }
 
     /// Test seam: the watermark on file for one row, or nil when none is (or
@@ -497,18 +525,67 @@ public actor RemoteProviderManager {
             // A row whose files are on this machine takes its status from TBD
             // alone, whatever a provider reports about it.
             guard !row.location.isLocal else { continue }
-            if let decidedAt = filingDecisions[row.id], decidedAt > requestStartedAt {
+            guard filingDecisionAllowsFlip(row.id, requestStartedAt: requestStartedAt) else {
                 remoteLogger.debug(
                     "filing sync skipped \(row.id.uuidString, privacy: .public): response predates the local decision"
                 )
                 continue
             }
             if archived, row.status == .active {
-                await fileRowArchived(row, provider: provider, log: actuationLog)
+                await fileRowArchived(
+                    row, provider: provider, log: actuationLog,
+                    requestStartedAt: requestStartedAt, now: now)
             } else if !archived, row.status == .archived {
-                await returnRowToActive(row, provider: provider, log: actuationLog)
+                await returnRowToActive(
+                    row, provider: provider, log: actuationLog,
+                    requestStartedAt: requestStartedAt, now: now)
             }
         }
+    }
+
+    /// What the re-read immediately before a filing write found.
+    private enum FlipRecheck {
+        /// The world still looks the way it did when the flip was decided.
+        case proceed
+        /// It does not, and the flip must be abandoned rather than restated.
+        /// Carries the vocabulary term and the free-text detail for the record.
+        case abandon(RefusedReason, String)
+        /// The row could not be read back at all.
+        case unreadable(any Error)
+    }
+
+    /// Closes the check-then-act window between `syncFilingDecisions` reading a
+    /// row and one of the two filing paths writing it.
+    ///
+    /// Between those two moments the sync suspends twice — once resolving the
+    /// row, once appending the request row to the record — and a user gesture
+    /// landing in that window writes both the status and a watermark. Acting on
+    /// state read three suspensions ago would reverse the user's own action, so
+    /// both facts are read again here, immediately before the write, and a flip
+    /// that no longer holds is abandoned.
+    ///
+    /// `expecting` is the status the flip was decided against: still holding it
+    /// means nobody else has filed this row in the meantime.
+    private func recheckBeforeFiling(
+        _ worktreeID: UUID, expecting expected: WorktreeStatus, requestStartedAt: Date
+    ) async -> FlipRecheck {
+        let current: Worktree?
+        do {
+            current = try await db.worktrees.get(id: worktreeID)
+        } catch {
+            return .unreadable(error)
+        }
+        guard let current else {
+            return .abandon(.notFound, "the worktree row no longer exists")
+        }
+        guard current.status == expected else {
+            return .abandon(.noop, "the row is already \(current.status)")
+        }
+        guard filingDecisionAllowsFlip(worktreeID, requestStartedAt: requestStartedAt) else {
+            return .abandon(
+                .notEligible, "a local filing decision landed while this flip was being recorded")
+        }
+        return .proceed
     }
 
     /// The provider reports this lane retired: file the row, and say so.
@@ -520,7 +597,10 @@ public actor RemoteProviderManager {
     /// that moment. The daemon-rail actuation row is written first and
     /// fail-closed, for the reason that coordinator spells out: an
     /// unrecordable archive does not happen, and the next snapshot retries it.
-    private func fileRowArchived(_ row: Worktree, provider: String, log: ActuationLog) async {
+    private func fileRowArchived(
+        _ row: Worktree, provider: String, log: ActuationLog,
+        requestStartedAt: Date, now: Date
+    ) async {
         var request = ActuationRow(
             actor: .daemon(rail: ActuationRail.remoteFilingSync), kind: .dispose)
         request.target = ActuationTarget(worktree: row.id.uuidString)
@@ -530,6 +610,25 @@ public actor RemoteProviderManager {
         } catch {
             remoteLogger.warning(
                 "filing sync skipped \(row.id.uuidString, privacy: .public) (record unwritable): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        switch await recheckBeforeFiling(
+            row.id, expecting: .active, requestStartedAt: requestStartedAt) {
+        case .proceed:
+            break
+        case .abandon(let reason, let detail):
+            await log.appendOutcome(
+                confirms: actuationID, result: .refused(reason), error: detail)
+            remoteLogger.debug(
+                "filing sync abandoned archiving \(row.id.uuidString, privacy: .public): \(detail, privacy: .public)"
+            )
+            return
+        case .unreadable(let error):
+            await log.appendOutcome(
+                confirms: actuationID, result: .transportFailed, error: "\(error)")
+            remoteLogger.error(
+                "filing sync could not re-read \(row.id.uuidString, privacy: .public): \(String(describing: error), privacy: .public)"
             )
             return
         }
@@ -543,6 +642,11 @@ public actor RemoteProviderManager {
             )
             return
         }
+        // The watermark goes on before anything else observes the write, so a
+        // poll already in flight with the provider's pre-archive word cannot
+        // un-file what this sync just filed. Every write to a remote row's
+        // status is watermarked, whichever path made it.
+        noteFilingDecision(worktreeID: row.id, at: now)
         await log.appendOutcome(confirms: actuationID, result: .dispatched)
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: row.id)))
         do {
@@ -570,7 +674,10 @@ public actor RemoteProviderManager {
     /// and the obligation the spec places on this sync is on the direction
     /// that makes a lane vanish. The actuation row is still written — the
     /// daemon acted, and the record names acts it performed.
-    private func returnRowToActive(_ row: Worktree, provider: String, log: ActuationLog) async {
+    private func returnRowToActive(
+        _ row: Worktree, provider: String, log: ActuationLog,
+        requestStartedAt: Date, now: Date
+    ) async {
         var request = ActuationRow(
             actor: .daemon(rail: ActuationRail.remoteFilingSync), kind: .spawn)
         request.target = ActuationTarget(worktree: row.id.uuidString)
@@ -580,6 +687,25 @@ public actor RemoteProviderManager {
         } catch {
             remoteLogger.warning(
                 "filing sync skipped \(row.id.uuidString, privacy: .public) (record unwritable): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        switch await recheckBeforeFiling(
+            row.id, expecting: .archived, requestStartedAt: requestStartedAt) {
+        case .proceed:
+            break
+        case .abandon(let reason, let detail):
+            await log.appendOutcome(
+                confirms: actuationID, result: .refused(reason), error: detail)
+            remoteLogger.debug(
+                "filing sync abandoned returning \(row.id.uuidString, privacy: .public) to active: \(detail, privacy: .public)"
+            )
+            return
+        case .unreadable(let error):
+            await log.appendOutcome(
+                confirms: actuationID, result: .transportFailed, error: "\(error)")
+            remoteLogger.error(
+                "filing sync could not re-read \(row.id.uuidString, privacy: .public): \(String(describing: error), privacy: .public)"
             )
             return
         }
@@ -593,6 +719,10 @@ public actor RemoteProviderManager {
             )
             return
         }
+        // Same watermark obligation as the archive direction: the un-filing is
+        // a local filing decision too, and an in-flight poll carrying the
+        // provider's pre-return word must not reverse it.
+        noteFilingDecision(worktreeID: row.id, at: now)
         await log.appendOutcome(confirms: actuationID, result: .dispatched)
         subscriptions.broadcast(
             delta: .worktreeRevived(

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -444,16 +444,49 @@ public actor RemoteProviderManager {
     /// every place TBD makes a filing decision of its own about a remote lane.
     /// The sync is not exempt from its own rule: a row it files is as
     /// reversible by a poll still in flight as one a gesture filed.
-    func noteFilingDecision(worktreeID: UUID, at date: Date) {
+    /// **The map only ever moves forward.** The instants arriving here are not
+    /// ordered by the order of the calls: the sync stamps a snapshot's
+    /// *arrival*, which precedes its own write by an adoption and an actuation
+    /// append, so a sync that started before a gesture can finish after it
+    /// carrying the older instant. A blind assignment would then hand a
+    /// still-outstanding poll a watermark it predates, which is exactly the
+    /// window this map exists to close. Keeping the later of the two is always
+    /// sound: every recorded instant belongs to a decision that really was
+    /// made, and the newest one bounds them all.
+    ///
+    /// Returns whatever was on file before, so a caller whose decision then
+    /// fails can put it back through `withdrawFilingDecision`.
+    @discardableResult
+    func noteFilingDecision(worktreeID: UUID, at date: Date) -> Date? {
+        let prior = filingDecisions[worktreeID]
+        if let prior, prior >= date { return prior }
         filingDecisions[worktreeID] = date
+        return prior
     }
 
-    /// Drops a watermark recorded in anticipation of a decision that then did
-    /// not happen — a retirement verb that failed, leaving the row untouched.
-    /// Keeping it would suppress a legitimate snapshot-driven flip for two
-    /// poll intervals over a decision TBD never made.
-    func forgetFilingDecision(worktreeID: UUID) {
-        filingDecisions.removeValue(forKey: worktreeID)
+    /// Takes back a watermark recorded in anticipation of a decision that then
+    /// did not happen — a retirement verb that failed, or a row write that
+    /// threw — leaving the row untouched. Keeping it would suppress a
+    /// legitimate snapshot-driven flip for two poll intervals over a decision
+    /// TBD never made.
+    ///
+    /// **Restoring, not deleting.** A row can carry a watermark from an
+    /// earlier decision that did happen, and that decision's window is still
+    /// open; dropping the entry outright would reopen it because a later
+    /// gesture failed, which has nothing to do with it.
+    ///
+    /// **And only while the map still holds what this caller wrote.** If
+    /// another path has recorded its own decision in the meantime, that
+    /// decision is newer than both and its watermark is the one that must
+    /// survive — including the case where `noteFilingDecision` declined to
+    /// write at all because a newer instant was already there.
+    func withdrawFilingDecision(worktreeID: UUID, restoring prior: Date?, ifStillAt written: Date) {
+        guard filingDecisions[worktreeID] == written else { return }
+        if let prior {
+            filingDecisions[worktreeID] = prior
+        } else {
+            filingDecisions.removeValue(forKey: worktreeID)
+        }
     }
 
     /// Whether a response whose request began at `requestStartedAt` may still
@@ -554,8 +587,8 @@ public actor RemoteProviderManager {
         case unreadable(any Error)
     }
 
-    /// Closes the check-then-act window between `syncFilingDecisions` reading a
-    /// row and one of the two filing paths writing it.
+    /// Narrows the check-then-act window between `syncFilingDecisions` reading
+    /// a row and one of the two filing paths writing it.
     ///
     /// Between those two moments the sync suspends twice — once resolving the
     /// row, once appending the request row to the record — and a user gesture
@@ -564,10 +597,21 @@ public actor RemoteProviderManager {
     /// both facts are read again here, immediately before the write, and a flip
     /// that no longer holds is abandoned.
     ///
-    /// `expecting` is the status the flip was decided against: still holding it
-    /// means nobody else has filed this row in the meantime.
+    /// **It narrows the window rather than closing it.** `db.worktrees.archive`
+    /// is itself a suspension point on this actor, so a gesture can still land
+    /// between this re-read and that write — what shrinks is the exposure, from
+    /// two awaits plus a record append down to one DB write. The watermark is
+    /// what makes the remainder safe: a gesture landing in that last sliver
+    /// stamps a decision later than this response's request start, and the poll
+    /// carrying the reversal is refused at the outer gate on its next arrival.
+    ///
+    /// `expecting` is the status the flip was decided against — still holding
+    /// it means nobody else has filed this row in the meantime — and `becoming`
+    /// is the status it was going to write, which is what tells an idempotent
+    /// no-op apart from a row this act may not touch at all.
     private func recheckBeforeFiling(
-        _ worktreeID: UUID, expecting expected: WorktreeStatus, requestStartedAt: Date
+        _ worktreeID: UUID, expecting expected: WorktreeStatus, becoming target: WorktreeStatus,
+        requestStartedAt: Date
     ) async -> FlipRecheck {
         let current: Worktree?
         do {
@@ -579,7 +623,16 @@ public actor RemoteProviderManager {
             return .abandon(.notFound, "the worktree row no longer exists")
         }
         guard current.status == expected else {
-            return .abandon(.noop, "the row is already \(current.status)")
+            // Only the flip's own target is a genuine no-op — somebody else
+            // did exactly what this flip was about to do. `main`, `creating`
+            // and `failed` are not that: they are states the sync may not file
+            // at all, and recording them as `noop` would put "already done" in
+            // the record over a row that was never eligible.
+            guard current.status == target else {
+                return .abandon(
+                    .notEligible, "the row is \(current.status.rawValue), which the sync may not file")
+            }
+            return .abandon(.noop, "the row is already \(current.status.rawValue)")
         }
         guard filingDecisionAllowsFlip(worktreeID, requestStartedAt: requestStartedAt) else {
             return .abandon(
@@ -614,7 +667,8 @@ public actor RemoteProviderManager {
             return
         }
         switch await recheckBeforeFiling(
-            row.id, expecting: .active, requestStartedAt: requestStartedAt) {
+            row.id, expecting: .active, becoming: .archived,
+            requestStartedAt: requestStartedAt) {
         case .proceed:
             break
         case .abandon(let reason, let detail):
@@ -691,7 +745,8 @@ public actor RemoteProviderManager {
             return
         }
         switch await recheckBeforeFiling(
-            row.id, expecting: .archived, requestStartedAt: requestStartedAt) {
+            row.id, expecting: .archived, becoming: .active,
+            requestStartedAt: requestStartedAt) {
         case .proceed:
             break
         case .abandon(let reason, let detail):

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -650,6 +650,20 @@ public actor RemoteProviderManager {
         if health[config.name] == nil { health[config.name] = (.ok, nil, nil) }
     }
 
+    /// The capability set a provider declared in its cached `describe`
+    /// response, or the empty set when no describe was ever recorded for that
+    /// name (an unknown provider, or one whose describe failed).
+    ///
+    /// A caller MUST NOT invoke a verb whose capability a provider has not
+    /// declared (`docs/remote-provider-contract.md`), so this is the one read
+    /// every capability gate goes through — the router's `remote.*` handlers
+    /// and the remote lane's archive/revive routing alike. Failing closed on
+    /// an absent describe is deliberate: an unknown capability set is not
+    /// permission to try the verb and see.
+    func declaredCapabilities(provider: String) -> Set<String> {
+        Set(describes[provider]?.capabilities ?? [])
+    }
+
     func providerStatuses() async -> [RemoteProviderStatus] {
         for name in providers.keys {
             await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -18,6 +18,13 @@ public actor RemoteProviderManager {
     private let runner: any RemoteProviderInvoking
     private let registryURL: URL
     private let clock: any Clock<Duration>
+    /// Where the filing sync records the archives and revives it performs.
+    /// Optional only so the many fixtures that construct this actor for
+    /// mirror/adoption coverage need not supply one; the daemon always does.
+    /// The sync FAILS CLOSED without it — an act nobody can record does not
+    /// happen (`docs/specs/2026-08-16-remote-lane-archive-design.md`
+    /// §"Never silent").
+    private let actuationLog: ActuationLog?
     static let pollInterval: TimeInterval = 60
 
     private var providers: [String: RemoteProviderConfig] = [:]
@@ -47,10 +54,24 @@ public actor RemoteProviderManager {
     /// never cleared — shutdown is terminal for this actor's lifetime. See
     /// `shutdown()`'s doc comment for the race this closes.
     private var shuttingDown = false
+    /// Worktree id → the moment TBD last locally archived or revived that
+    /// remote row. The stale-snapshot watermark: a provider response whose
+    /// request began *before* one of these entries provably could not have
+    /// accounted for it, so the filing sync abstains rather than reversing a
+    /// decision the user just made.
+    ///
+    /// In memory on purpose. The window it defends is open only while a
+    /// provider request is outstanding, and no such request survives a
+    /// restart — after one, every request start is later than every prior
+    /// decision, so there is nothing left to suppress
+    /// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Stale
+    /// snapshots"). Swept on every apply so it cannot grow without bound.
+    private var filingDecisions: [UUID: Date] = [:]
 
     init(
         db: TBDDatabase, subscriptions: StateSubscriptionManager,
         runner: any RemoteProviderInvoking, registryURL: URL,
+        actuationLog: ActuationLog? = nil,
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.db = db
@@ -58,6 +79,7 @@ public actor RemoteProviderManager {
         self.adopter = RemoteSessionAdopter(db: db)
         self.runner = runner
         self.registryURL = registryURL
+        self.actuationLog = actuationLog
         self.clock = clock
         // RPC becomes available before `start()` runs, so seed the registry
         // synchronously. The first status or mutation-gate read can then recover
@@ -256,6 +278,11 @@ public actor RemoteProviderManager {
         // both call it directly) — register on first use so providerStatuses()
         // reflects it.
         registerIfNeeded(provider)
+        // Stamped BEFORE the provider is asked anything. `snapshotAt` below is
+        // arrival — it says when this response landed, not when the question
+        // was posed, and only the latter can prove a response could not have
+        // accounted for a local filing decision. See `syncFilingDecisions`.
+        let requestStartedAt = Date()
         do {
             let result = try await runner.run(provider, verb: ["list"], stdin: nil, timeout: 30)
             if let failure = result.failureClass {
@@ -264,7 +291,9 @@ public actor RemoteProviderManager {
             }
             let envelope = try result.decoded(RemoteSessionListEnvelope.self)
             let snapshotAt = Date()
-            try await apply(snapshot: envelope.sessions, provider: provider.name, now: snapshotAt)
+            try await apply(
+                snapshot: envelope.sessions, provider: provider.name, now: snapshotAt,
+                requestStartedAt: requestStartedAt)
         } catch {
             remoteLogger.debug(
                 "poll \(provider.name, privacy: .public) failed: \(String(describing: error), privacy: .public)"
@@ -275,9 +304,19 @@ public actor RemoteProviderManager {
     }
 
     /// Shared by the poll path and the events snapshot path (Task 6).
-    func apply(snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date())
-        async throws
-    {
+    ///
+    /// `now` is arrival — when this response landed. `requestStartedAt` is
+    /// when the question behind it was posed: the poll stamps it before
+    /// `runner.run`, and the events supervisor supplies the moment it opened
+    /// the connection the `snapshot` event arrived on. The filing sync needs
+    /// the second, not the first (see `syncFilingDecisions`). It defaults to
+    /// arrival so a caller with a response that is fresh by construction —
+    /// `applyUpsert`'s pushed `session` line — reads correctly without
+    /// inventing a start time.
+    func apply(
+        snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date(),
+        requestStartedAt: Date? = nil
+    ) async throws {
         let outcome = try await db.remoteSessions.applySnapshot(
             provider: provider, sessions: sessions, now: now)
         // After the mirror, never before: adoption reads the repo association
@@ -287,6 +326,12 @@ public actor RemoteProviderManager {
         // mirror re-attempts resolution on every poll while its pin is null,
         // and the poll after the user registers the repo is exactly that case.
         broadcastAdoptions(await adopter.adopt(sessions: sessions, provider: provider))
+        // After adoption, never before: a session first sighted in this very
+        // snapshot already reporting `archived: true` must be filed on the
+        // row adoption just minted, not skipped for lack of one.
+        await syncFilingDecisions(
+            sessions: sessions, provider: provider,
+            requestStartedAt: requestStartedAt ?? now, now: now)
         lastSuccessfulSnapshotAt[provider] = now
         // A live snapshot supersedes whatever the persisted row would have
         // said, so an earlier unreadable read no longer gates anything.
@@ -308,11 +353,17 @@ public actor RemoteProviderManager {
     /// Single-session upsert from an events `session` line. No absence
     /// bookkeeping happens here — only `apply(snapshot:)` drives the
     /// two-absence rule, since only a full snapshot can tell what's missing.
+    ///
+    /// A pushed `session` line is fresh by construction — the provider wrote
+    /// it because something changed just now — so the filing sync takes
+    /// arrival as the request start. There is no earlier moment to appeal to
+    /// and none is needed: nothing was in flight across a local decision.
     func applyUpsert(_ session: RemoteSessionPayload, provider: String) async {
+        let arrivedAt = Date()
         let outcome: SnapshotOutcome
         do {
             outcome = try await db.remoteSessions.upsertOne(
-                provider: provider, session: session, now: Date())
+                provider: provider, session: session, now: arrivedAt)
         } catch {
             remoteLogger.error(
                 "events upsert failed for \(provider, privacy: .public)/\(session.id, privacy: .public): \(String(describing: error), privacy: .public)"
@@ -325,6 +376,9 @@ public actor RemoteProviderManager {
         if let created = await adopter.adopt(session: session, provider: provider) {
             broadcastAdoptions([created])
         }
+        await syncFilingDecisions(
+            sessions: [session], provider: provider,
+            requestStartedAt: arrivedAt, now: arrivedAt)
         if outcome.changed {
             subscriptions.broadcast(delta: .remoteSessionsChanged)
         }
@@ -369,6 +423,191 @@ public actor RemoteProviderManager {
         if changed {
             subscriptions.broadcast(delta: .remoteSessionsChanged)
         }
+    }
+
+    // MARK: - The filing decision travels back
+
+    /// Records that TBD itself just archived or revived the remote row bound
+    /// to `worktreeID`, so a provider response composed before `at` cannot
+    /// undo it.
+    ///
+    /// Called by the worktree archive/revive handlers and the merge rail
+    /// after the row's status is written — every place TBD makes a filing
+    /// decision of its own about a remote lane.
+    func noteFilingDecision(worktreeID: UUID, at date: Date) {
+        filingDecisions[worktreeID] = date
+    }
+
+    /// Test seam: the watermark on file for one row, or nil when none is (or
+    /// none survived the sweep). Nothing in production reads this.
+    func filingDecision(for worktreeID: UUID) -> Date? {
+        filingDecisions[worktreeID]
+    }
+
+    /// Applies the provider's own `archived` claims to the worktree rows
+    /// bound to its sessions, so a lane retired on the provider's surface or
+    /// from another machine leaves TBD's active list too, and one returned to
+    /// the inventory comes back
+    /// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"The filing
+    /// decision travels back").
+    ///
+    /// Three gates, none of them removable:
+    ///
+    /// - **Capability.** `archived` is read only from a provider that
+    ///   declares `archive`. The contract makes an absent field read as
+    ///   `false`, so without this a provider with no archiving concept would
+    ///   carry an implicit "not archived" on every snapshot and drag archived
+    ///   rows back into the active list about once a minute, forever.
+    /// - **Presence.** A provider that declares the capability and omits the
+    ///   field anyway made no claim, and silence must not overwrite the
+    ///   user's own filing decision. Display still reads absent as `false`
+    ///   via `isArchived`; only the sync abstains.
+    /// - **Watermark.** A response whose request began before a local filing
+    ///   decision provably could not have accounted for it, in either
+    ///   direction, so it is dropped rather than allowed to reverse the user.
+    ///
+    /// `state` is never touched here. Filing and liveness are separate axes,
+    /// and the mirror already owns the second.
+    private func syncFilingDecisions(
+        sessions: [RemoteSessionPayload], provider: String,
+        requestStartedAt: Date, now: Date
+    ) async {
+        defer { sweepFilingDecisions(now: now) }
+        guard describes[provider]?.capabilities.contains("archive") == true else { return }
+        guard let actuationLog else {
+            remoteLogger.debug(
+                "filing sync skipped for \(provider, privacy: .public): no actuation log on this manager"
+            )
+            return
+        }
+        for session in sessions {
+            // Presence gate: nil is "no claim", which is not the same fact as
+            // an explicit `false` and must not move anything.
+            guard let archived = session.archived else { continue }
+            let row: Worktree?
+            do {
+                row = try await db.worktrees.findRemote(provider: provider, sessionID: session.id)
+            } catch {
+                remoteLogger.error(
+                    "filing sync could not resolve \(provider, privacy: .public)/\(session.id, privacy: .public): \(String(describing: error), privacy: .public)"
+                )
+                continue
+            }
+            guard let row else { continue }
+            // A row whose files are on this machine takes its status from TBD
+            // alone, whatever a provider reports about it.
+            guard !row.location.isLocal else { continue }
+            if let decidedAt = filingDecisions[row.id], decidedAt > requestStartedAt {
+                remoteLogger.debug(
+                    "filing sync skipped \(row.id.uuidString, privacy: .public): response predates the local decision"
+                )
+                continue
+            }
+            if archived, row.status == .active {
+                await fileRowArchived(row, provider: provider, log: actuationLog)
+            } else if !archived, row.status == .archived {
+                await returnRowToActive(row, provider: provider, log: actuationLog)
+            }
+        }
+    }
+
+    /// The provider reports this lane retired: file the row, and say so.
+    ///
+    /// A lane that leaves the active list without a gesture has to explain
+    /// itself, so this writes a notification record as well as broadcasting
+    /// the delta — the shape `AutoArchiveOnMergeCoordinator` established for
+    /// the other case where a worktree is retired without the user asking at
+    /// that moment. The daemon-rail actuation row is written first and
+    /// fail-closed, for the reason that coordinator spells out: an
+    /// unrecordable archive does not happen, and the next snapshot retries it.
+    private func fileRowArchived(_ row: Worktree, provider: String, log: ActuationLog) async {
+        var request = ActuationRow(
+            actor: .daemon(rail: ActuationRail.remoteFilingSync), kind: .dispose)
+        request.target = ActuationTarget(worktree: row.id.uuidString)
+        let actuationID: String
+        do {
+            actuationID = try await log.appendRequest(request)
+        } catch {
+            remoteLogger.warning(
+                "filing sync skipped \(row.id.uuidString, privacy: .public) (record unwritable): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        do {
+            try await db.worktrees.archive(id: row.id)
+        } catch {
+            await log.appendOutcome(
+                confirms: actuationID, result: .transportFailed, error: "\(error)")
+            remoteLogger.error(
+                "filing sync could not archive \(row.id.uuidString, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        await log.appendOutcome(confirms: actuationID, result: .dispatched)
+        subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: row.id)))
+        do {
+            let notification = try await db.notifications.create(
+                worktreeID: row.id, type: .taskComplete,
+                message: "Archived \(row.displayName) — \(provider) reports this session retired",
+                terminalID: nil)
+            subscriptions.broadcast(
+                delta: .notificationReceived(
+                    NotificationDelta(
+                        notificationID: notification.id, worktreeID: notification.worktreeID,
+                        type: notification.type, message: notification.message,
+                        terminalID: notification.terminalID, activate: false)))
+        } catch {
+            remoteLogger.error(
+                "filing sync archived \(row.id.uuidString, privacy: .public) but could not record a notification: \(String(describing: error), privacy: .public)"
+            )
+        }
+    }
+
+    /// The provider reports this lane back in its working inventory: return
+    /// the row to the active list.
+    ///
+    /// No notification: a lane reappearing in the list is visible on its own,
+    /// and the obligation the spec places on this sync is on the direction
+    /// that makes a lane vanish. The actuation row is still written — the
+    /// daemon acted, and the record names acts it performed.
+    private func returnRowToActive(_ row: Worktree, provider: String, log: ActuationLog) async {
+        var request = ActuationRow(
+            actor: .daemon(rail: ActuationRail.remoteFilingSync), kind: .spawn)
+        request.target = ActuationTarget(worktree: row.id.uuidString)
+        let actuationID: String
+        do {
+            actuationID = try await log.appendRequest(request)
+        } catch {
+            remoteLogger.warning(
+                "filing sync skipped \(row.id.uuidString, privacy: .public) (record unwritable): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        do {
+            try await db.worktrees.revive(id: row.id)
+        } catch {
+            await log.appendOutcome(
+                confirms: actuationID, result: .transportFailed, error: "\(error)")
+            remoteLogger.error(
+                "filing sync could not revive \(row.id.uuidString, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        await log.appendOutcome(confirms: actuationID, result: .dispatched)
+        subscriptions.broadcast(
+            delta: .worktreeRevived(
+                WorktreeDelta(
+                    worktreeID: row.id, repoID: row.repoID, name: row.name,
+                    path: row.localPath, status: .active)))
+    }
+
+    /// Drops watermarks older than two poll intervals. Nothing needs them
+    /// past that: a provider request outstanding for longer has already
+    /// timed out (`list` is bounded at 30s), so no response can still be in
+    /// flight from before them.
+    private func sweepFilingDecisions(now: Date) {
+        let cutoff = now.addingTimeInterval(-2 * Self.pollInterval)
+        filingDecisions = filingDecisions.filter { $0.value >= cutoff }
     }
 
     /// Test seam: whether a supervisor currently exists for `name` — used

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -505,6 +505,25 @@ public actor RemoteProviderManager {
         filingDecisions[worktreeID]
     }
 
+    /// Test seam: awaited inside the check-then-act window, immediately before
+    /// `recheckBeforeFiling` re-reads the row and the watermark. Nil in
+    /// production; nothing outside the suite ever sets it.
+    private var midFlipHook: (@Sendable () async -> Void)?
+
+    /// Test seam: installs `midFlipHook`.
+    ///
+    /// The window it opens onto is reachable only from *inside* the sync, and
+    /// every other seam within it — the actuation log's `write` syscall, its
+    /// `now` closure — is synchronous, so a test that waited from one would
+    /// park a cooperative-pool thread until a second task released it. Under a
+    /// narrow pool shared with the rest of the suite, nothing is left to do the
+    /// releasing and the run wedges with no failing test. A gesture run inline
+    /// on the sync's own task needs no second task at all, so it is exactly as
+    /// deterministic and cannot starve.
+    func setMidFlipHook(_ hook: (@Sendable () async -> Void)?) {
+        midFlipHook = hook
+    }
+
     /// Applies the provider's own `archived` claims to the worktree rows
     /// bound to its sessions, so a lane retired on the provider's surface or
     /// from another machine leaves TBD's active list too, and one returned to
@@ -613,6 +632,7 @@ public actor RemoteProviderManager {
         _ worktreeID: UUID, expecting expected: WorktreeStatus, becoming target: WorktreeStatus,
         requestStartedAt: Date
     ) async -> FlipRecheck {
+        await midFlipHook?()
         let current: Worktree?
         do {
             current = try await db.worktrees.get(id: worktreeID)

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -4,6 +4,37 @@ import TBDShared
 
 private let remoteHandlerLogger = Logger(subsystem: "com.tbd.daemon", category: "remote")
 
+/// A filing decision recorded in anticipation of a retirement verb, held across
+/// the call so it can be re-stamped when the verb returns or taken back when it
+/// fails.
+///
+/// It carries `prior` and `decidedAt` because withdrawal is conditional on
+/// both: the map may hold an earlier decision that did happen and must survive,
+/// and a decision recorded by some other path after this one was written is
+/// newer than both and must not be clobbered by a late withdrawal. Deciding
+/// that at the withdrawal site would mean re-deriving what
+/// `noteFilingDecision` already told us.
+struct RemoteFilingWatermark {
+    let manager: RemoteProviderManager
+    let worktreeID: UUID
+    /// The instant written before the verb was invoked.
+    let decidedAt: Date
+    /// Whatever the map held before `decidedAt` was written, if anything.
+    let prior: Date?
+
+    /// The verb did not happen: put back what was there before.
+    func withdraw() async {
+        await manager.withdrawFilingDecision(
+            worktreeID: worktreeID, restoring: prior, ifStillAt: decidedAt)
+    }
+
+    /// The verb returned: move the watermark forward past every poll that could
+    /// have been launched while it ran.
+    func restamp(at date: Date) async {
+        await manager.noteFilingDecision(worktreeID: worktreeID, at: date)
+    }
+}
+
 /// RPC handlers for remote agent backends (`docs/remote-provider-contract.md`).
 /// Every `remote.*` verb gates on `config.remoteBackendsEnabled` AND on the
 /// `remoteManager` actor existing — the daemon only constructs it at boot
@@ -217,95 +248,156 @@ extension RPCRouter {
     /// hands back — so the row reflects the new `archived` value immediately
     /// rather than waiting for the next poll.
     ///
-    /// The one addition is the capability check below. `archive` is
+    /// The one addition is the capability check in `retire`. `archive` is
     /// optional, and the contract states a caller "MUST NOT invoke a verb
     /// whose capability the provider has not declared" — unlike `rename`
     /// (whose doc comment explains why it skips this check: the app already
     /// decides there), nothing upstream of this handler is trusted to have
     /// checked, so it refuses before any process is spawned rather than
     /// letting the refusal masquerade as an ordinary provider failure.
+    ///
+    /// The gate runs here rather than inside `retire` so a request arriving
+    /// with the subsystem off is refused before its params are decoded:
+    /// "remote backends disabled" is the truthful answer to a malformed
+    /// request too, and the decode would otherwise throw first.
+    ///
+    /// `now` supplies the filing watermark's instants, which are **compared**
+    /// against a poll's request start rather than displayed — the date seam
+    /// rather than the clock seam (`Tests/CLAUDE.md`, "Clock and date seams").
+    /// Defaulted, so no call site changes.
     func handleRemoteArchive(
-        _ paramsData: Data, actor: ActuationActor? = nil
+        _ paramsData: Data, actor: ActuationActor? = nil,
+        now: @Sendable () -> Date = { Date() }
     ) async throws -> RPCResponse {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteArchiveParams.self, from: paramsData)
-        if await manager.hasStaleSnapshot(provider: params.provider) {
-            return Self.staleSnapshotMutationResponse(provider: params.provider)
-        }
-        guard await declaredCapabilities(manager, provider: params.provider).contains("archive") else {
-            return Self.missingCapabilityResponse(provider: params.provider, capability: "archive")
-        }
-        let actuationID = try await beginActuation(
-            .remoteArchive, actor: actor,
-            target: .remote(provider: params.provider, session: params.sessionID))
-        let result: ProviderResult
-        do {
-            result = try await manager.invoke(
-                providerName: params.provider, verb: ["archive", params.sessionID], stdin: nil, timeout: 30)
-        } catch let error as ProviderRunError {
-            remoteHandlerLogger.error("remote.archive provider=\(params.provider, privacy: .public) timed out")
-            let message = Self.friendlyMessage(for: error, provider: params.provider)
-            await finishActuation(actuationID, .transportFailed, error: message)
-            return RPCResponse(error: message)
-        }
-        if result.failureClass != nil {
-            let message = result.decodedError?.message ?? "archive failed (exit \(result.exitCode))"
-            remoteHandlerLogger.error(
-                "remote.archive provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
-            await finishActuation(actuationID, .transportFailed, error: message)
-            return RPCResponse(error: message)
-        }
-        if let session = try? result.decoded(RemoteSessionPayload.self) {
-            await manager.applyUpsert(session, provider: params.provider)
-        }
-        await finishActuation(actuationID, .dispatched)
-        return .ok()
+        return try await retire(
+            verb: "archive", surface: .remoteArchive, manager: manager,
+            provider: params.provider, sessionID: params.sessionID, actor: actor, now: now)
     }
 
     /// Returns an archived session to the working inventory. See
     /// `handleRemoteArchive`'s doc comment for the shared shape and the
-    /// capability-check rationale; this differs only in verb and capability
-    /// name.
+    /// capability-check rationale; this differs only in verb and surface.
     func handleRemoteUnarchive(
-        _ paramsData: Data, actor: ActuationActor? = nil
+        _ paramsData: Data, actor: ActuationActor? = nil,
+        now: @Sendable () -> Date = { Date() }
     ) async throws -> RPCResponse {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteUnarchiveParams.self, from: paramsData)
-        if await manager.hasStaleSnapshot(provider: params.provider) {
-            return Self.staleSnapshotMutationResponse(provider: params.provider)
+        return try await retire(
+            verb: "unarchive", surface: .remoteUnarchive, manager: manager,
+            provider: params.provider, sessionID: params.sessionID, actor: actor, now: now)
+    }
+
+    /// The body both retirement handlers share. One implementation rather than
+    /// two near-identical ones, because everything the two verbs differ by is a
+    /// name: the verb word doubles as the capability the contract requires be
+    /// declared, and the surface names the actuation.
+    ///
+    /// **The filing watermark is the reason this is not just `handleRemoteStop`
+    /// with another verb.** `archive` and `unarchive` move a session's filing
+    /// status, and every write to a remote row's status is watermarked
+    /// whichever path made it — the same obligation
+    /// `RemoteLaneLifecycle.performArchive` carries, discharged in the same
+    /// order and for the same reasons:
+    ///
+    /// 1. stamp **before** the verb, so a `list` already in flight cannot act on
+    ///    the bound row while the verb runs. The provider commits the retirement
+    ///    partway through a call that takes up to 30 seconds, and a poll landing
+    ///    in that window would otherwise read the provider's already-committed
+    ///    `archived: true` against a row nothing had watermarked and file it on
+    ///    the daemon's own `remote-filing-sync` rail — an extra actuation row,
+    ///    and a notification crediting the provider for the user's own gesture;
+    /// 2. stamp again once the verb has returned, before the response is
+    ///    mirrored. A poll launched *after* step 1 but before the verb returned
+    ///    still carries the provider's pre-gesture word, and a watermark that
+    ///    only covers step 1 does not cover it;
+    /// 3. mirror the response, whose `applyUpsert` runs the filing sync with an
+    ///    arrival later than both stamps — so this gesture's own report is the
+    ///    one the sync acts on.
+    ///
+    /// A verb that fails withdraws the watermark rather than deleting it
+    /// (`withdrawFilingDecision(worktreeID:restoring:ifStillAt:)`): the row may
+    /// carry an earlier decision that did happen and whose window is still
+    /// open, and a gesture that failed has no business closing it.
+    ///
+    /// Unlike the lane path there is no row write here — this surface is
+    /// addressed by `(provider, sessionID)`, not by worktree — so a session
+    /// nobody has adopted has no bound row, nothing to watermark, and takes the
+    /// unwatermarked path cleanly rather than erroring.
+    private func retire(
+        verb: String, surface: ActuationSurface, manager: RemoteProviderManager,
+        provider: String, sessionID: String, actor: ActuationActor?,
+        now: @Sendable () -> Date = { Date() }
+    ) async throws -> RPCResponse {
+        if await manager.hasStaleSnapshot(provider: provider) {
+            return Self.staleSnapshotMutationResponse(provider: provider)
         }
-        guard await declaredCapabilities(manager, provider: params.provider).contains("unarchive") else {
-            return Self.missingCapabilityResponse(provider: params.provider, capability: "unarchive")
+        guard await declaredCapabilities(manager, provider: provider).contains(verb) else {
+            return Self.missingCapabilityResponse(provider: provider, capability: verb)
         }
         let actuationID = try await beginActuation(
-            .remoteUnarchive, actor: actor,
-            target: .remote(provider: params.provider, session: params.sessionID))
+            surface, actor: actor, target: .remote(provider: provider, session: sessionID))
+        let watermark = await beginFilingWatermark(
+            manager: manager, provider: provider, sessionID: sessionID, at: now())
         let result: ProviderResult
         do {
             result = try await manager.invoke(
-                providerName: params.provider, verb: ["unarchive", params.sessionID], stdin: nil, timeout: 30)
+                providerName: provider, verb: [verb, sessionID], stdin: nil, timeout: 30)
         } catch let error as ProviderRunError {
-            remoteHandlerLogger.error("remote.unarchive provider=\(params.provider, privacy: .public) timed out")
-            let message = Self.friendlyMessage(for: error, provider: params.provider)
+            remoteHandlerLogger.error(
+                "remote.\(verb, privacy: .public) provider=\(provider, privacy: .public) timed out")
+            let message = Self.friendlyMessage(for: error, provider: provider)
+            await watermark?.withdraw()
             await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
         if result.failureClass != nil {
-            let message = result.decodedError?.message ?? "unarchive failed (exit \(result.exitCode))"
+            let message = result.decodedError?.message ?? "\(verb) failed (exit \(result.exitCode))"
             remoteHandlerLogger.error(
-                "remote.unarchive provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+                "remote.\(verb, privacy: .public) provider=\(provider, privacy: .public) failed: \(message, privacy: .public)")
+            await watermark?.withdraw()
             await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
+        await watermark?.restamp(at: now())
         if let session = try? result.decoded(RemoteSessionPayload.self) {
-            await manager.applyUpsert(session, provider: params.provider)
+            await manager.applyUpsert(session, provider: provider)
         }
         await finishActuation(actuationID, .dispatched)
         return .ok()
+    }
+
+    /// Resolves the worktree row bound to `(provider, sessionID)` and records a
+    /// filing decision against it, returning the handle a caller withdraws or
+    /// re-stamps through.
+    ///
+    /// `nil` means there is nothing to watermark, and it is a normal outcome
+    /// twice over: a session nobody adopted has no bound row, and a row this
+    /// daemon cannot read right now is one no watermark could protect anyway.
+    /// Neither may fail the gesture — the provider verb is the act the user
+    /// asked for, and refusing it because a mirror lookup failed would trade a
+    /// working retirement for a bookkeeping detail.
+    private func beginFilingWatermark(
+        manager: RemoteProviderManager, provider: String, sessionID: String, at date: Date
+    ) async -> RemoteFilingWatermark? {
+        let bound: Worktree?
+        do {
+            bound = try await db.worktrees.findRemote(provider: provider, sessionID: sessionID)
+        } catch {
+            remoteHandlerLogger.warning(
+                "could not resolve the row bound to \(provider, privacy: .public)/\(sessionID, privacy: .public); proceeding unwatermarked: \(String(describing: error), privacy: .public)")
+            return nil
+        }
+        guard let bound else { return nil }
+        let prior = await manager.noteFilingDecision(worktreeID: bound.id, at: date)
+        return RemoteFilingWatermark(
+            manager: manager, worktreeID: bound.id, decidedAt: date, prior: prior)
     }
 
     func handleRemoteSend(

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -367,7 +367,7 @@ extension RPCRouter {
         }
         await watermark?.restamp(at: now())
         if let session = try? result.decoded(RemoteSessionPayload.self) {
-            await manager.applyUpsert(session, provider: provider)
+            await manager.applyUpsert(session, provider: provider, date: now())
         }
         await finishActuation(actuationID, .dispatched)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -186,6 +186,122 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// The provider's declared capability set, read from the cached
+    /// `describe` response `providerStatuses()` already exposes — the same
+    /// data the app reads client-side via
+    /// `remoteProviders.first { ... }?.describe?.capabilities`
+    /// (`AppState+Remote.swift`). No new manager surface: this is a read of
+    /// existing state, not a probe.
+    private func declaredCapabilities(_ manager: RemoteProviderManager, provider: String) async -> Set<String> {
+        let status = await manager.providerStatuses().first { $0.config.name == provider }
+        return Set(status?.describe?.capabilities ?? [])
+    }
+
+    private static func missingCapabilityResponse(provider: String, capability: String) -> RPCResponse {
+        RPCResponse(error:
+            "provider '\(provider)' has not declared capability '\(capability)' " +
+            "(docs/remote-provider-contract.md § \(capability) <id>)")
+    }
+
+    /// Retires a session from the working inventory
+    /// (`docs/remote-provider-contract.md` § `archive <id>` / `unarchive
+    /// <id>`). Mirrors `handleRemoteStop`'s shape exactly: same gate, same
+    /// stale-snapshot guard, same timeout/failureClass handling, same
+    /// best-effort mirror upsert of whatever session object the provider
+    /// hands back — so the row reflects the new `archived` value immediately
+    /// rather than waiting for the next poll.
+    ///
+    /// The one addition is the capability check below. `archive` is
+    /// optional, and the contract states a caller "MUST NOT invoke a verb
+    /// whose capability the provider has not declared" — unlike `rename`
+    /// (whose doc comment explains why it skips this check: the app already
+    /// decides there), nothing upstream of this handler is trusted to have
+    /// checked, so it refuses before any process is spawned rather than
+    /// letting the refusal masquerade as an ordinary provider failure.
+    func handleRemoteArchive(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteArchiveParams.self, from: paramsData)
+        if await manager.hasStaleSnapshot(provider: params.provider) {
+            return Self.staleSnapshotMutationResponse(provider: params.provider)
+        }
+        guard await declaredCapabilities(manager, provider: params.provider).contains("archive") else {
+            return Self.missingCapabilityResponse(provider: params.provider, capability: "archive")
+        }
+        let actuationID = try await beginActuation(
+            .remoteArchive, actor: actor,
+            target: .remote(provider: params.provider, session: params.sessionID))
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: params.provider, verb: ["archive", params.sessionID], stdin: nil, timeout: 30)
+        } catch let error as ProviderRunError {
+            remoteHandlerLogger.error("remote.archive provider=\(params.provider, privacy: .public) timed out")
+            let message = Self.friendlyMessage(for: error, provider: params.provider)
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
+        }
+        if result.failureClass != nil {
+            let message = result.decodedError?.message ?? "archive failed (exit \(result.exitCode))"
+            remoteHandlerLogger.error(
+                "remote.archive provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
+        }
+        if let session = try? result.decoded(RemoteSessionPayload.self) {
+            await manager.applyUpsert(session, provider: params.provider)
+        }
+        await finishActuation(actuationID, .dispatched)
+        return .ok()
+    }
+
+    /// Returns an archived session to the working inventory. See
+    /// `handleRemoteArchive`'s doc comment for the shared shape and the
+    /// capability-check rationale; this differs only in verb and capability
+    /// name.
+    func handleRemoteUnarchive(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteUnarchiveParams.self, from: paramsData)
+        if await manager.hasStaleSnapshot(provider: params.provider) {
+            return Self.staleSnapshotMutationResponse(provider: params.provider)
+        }
+        guard await declaredCapabilities(manager, provider: params.provider).contains("unarchive") else {
+            return Self.missingCapabilityResponse(provider: params.provider, capability: "unarchive")
+        }
+        let actuationID = try await beginActuation(
+            .remoteUnarchive, actor: actor,
+            target: .remote(provider: params.provider, session: params.sessionID))
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: params.provider, verb: ["unarchive", params.sessionID], stdin: nil, timeout: 30)
+        } catch let error as ProviderRunError {
+            remoteHandlerLogger.error("remote.unarchive provider=\(params.provider, privacy: .public) timed out")
+            let message = Self.friendlyMessage(for: error, provider: params.provider)
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
+        }
+        if result.failureClass != nil {
+            let message = result.decodedError?.message ?? "unarchive failed (exit \(result.exitCode))"
+            remoteHandlerLogger.error(
+                "remote.unarchive provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
+        }
+        if let session = try? result.decoded(RemoteSessionPayload.self) {
+            await manager.applyUpsert(session, provider: params.provider)
+        }
+        await finishActuation(actuationID, .dispatched)
+        return .ok()
+    }
+
     func handleRemoteSend(
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -16,13 +16,18 @@ extension RPCRouter {
     /// a single shared value (rather than re-typed at each call site) so the
     /// exact string — which tests assert equality against — can't drift if
     /// one call site is edited and the others aren't.
-    private static let remoteBackendsDisabledResponse = RPCResponse(error: "remote backends disabled")
+    /// Internal rather than private because `worktree.archive` /
+    /// `worktree.revive` branch into the remote path too and must refuse with
+    /// the same words when the subsystem is off.
+    static let remoteBackendsDisabledResponse = RPCResponse(error: "remote backends disabled")
 
     private static func staleSnapshotMutationResponse(provider: String) -> RPCResponse {
         RPCResponse(error: "provider '\(provider)' inventory is stale; refresh must recover before changing remote sessions")
     }
 
-    private func remoteGate() async throws -> RemoteProviderManager? {
+    /// Internal for the same reason as `remoteBackendsDisabledResponse` above:
+    /// the worktree handlers' remote branches pass through the same gate.
+    func remoteGate() async throws -> RemoteProviderManager? {
         guard try await db.config.get().remoteBackendsEnabled else { return nil }
         return remoteManager
     }
@@ -187,14 +192,15 @@ extension RPCRouter {
     }
 
     /// The provider's declared capability set, read from the cached
-    /// `describe` response `providerStatuses()` already exposes — the same
-    /// data the app reads client-side via
+    /// `describe` response — the same data the app reads client-side via
     /// `remoteProviders.first { ... }?.describe?.capabilities`
-    /// (`AppState+Remote.swift`). No new manager surface: this is a read of
-    /// existing state, not a probe.
+    /// (`AppState+Remote.swift`). A read of existing state, not a probe.
+    ///
+    /// Delegates to the manager rather than deriving it a second time, so
+    /// this gate and the remote lane's archive/revive routing can never
+    /// disagree about what a provider declared.
     private func declaredCapabilities(_ manager: RemoteProviderManager, provider: String) async -> Set<String> {
-        let status = await manager.providerStatuses().first { $0.config.name == provider }
-        return Set(status?.describe?.capabilities ?? [])
+        await manager.declaredCapabilities(provider: provider)
     }
 
     private static func missingCapabilityResponse(provider: String, capability: String) -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -207,27 +207,19 @@ extension RPCRouter {
     ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeArchiveParams.self, from: paramsData)
 
-        // A remote lane is not archivable, and is refused here rather than
-        // allowed to fail downstream. Archiving a remote worktree would mean
-        // stopping the provider's session — deliberately unimplemented, not an
-        // oversight — so `beginArchiveWorktree` resolves its row through
-        // `getLocal` and throws for a remote one. Reaching it would mean this
-        // handler had already written a `.dispose` request for an act it
-        // structurally cannot perform, and the record may only claim acts that
-        // were attempted, so the gate belongs above the row.
-        //
-        // Loud, unlike the auto-archive rail's silent `false`: that is a
-        // background rail, this is a deliberate user gesture, and a gesture
-        // that does nothing deserves an answer saying so. This is a plain DB
-        // read, so it is pre-row validation — the same shape as the
-        // worktree-not-found guards on the sibling handlers. A *missing* row is
-        // deliberately not handled here: that stays `beginArchiveWorktree`'s
-        // throw, recorded as transport-failed, unchanged.
+        // A remote lane takes an entirely different path: its files are on
+        // another machine, so nothing below — `beginArchiveWorktree` (which
+        // resolves through `getLocal` and throws for a remote row), tmux
+        // teardown, scrollback capture, the directory removal in phase 2 —
+        // has any meaning for it. See `archiveRemoteLane` for the routing and
+        // the guards. This is a plain DB read, so it is pre-row validation,
+        // the same shape as the worktree-not-found guards on the sibling
+        // handlers. A *missing* row is deliberately not handled here: that
+        // stays `beginArchiveWorktree`'s throw, recorded as transport-failed,
+        // unchanged.
         if let existing = try await db.worktrees.get(id: params.worktreeID),
            !existing.location.isLocal {
-            logger.debug("worktree.archive refused (remote lane): \(params.worktreeID, privacy: .public)")
-            return RPCResponse(
-                error: "Cannot archive \(existing.name): it is a remote lane, and archiving one is not supported.")
+            return try await archiveRemoteLane(existing, force: params.force, actor: actor)
         }
 
         // One row per call, naming the worktree and no terminal: the caller
@@ -263,6 +255,96 @@ extension RPCRouter {
         }
 
         return .ok()
+    }
+
+    // MARK: - The remote branches of archive and revive
+
+    /// Retires a remote lane
+    /// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Archive").
+    ///
+    /// Two things about the shape are load bearing. **Every refusal returns
+    /// above `beginActuation`** — the capability refusal, the two guards, and
+    /// the subsystem gate alike — because nothing was attempted and the record
+    /// may claim solely acts that were attempted; this is the same pre-row
+    /// shape the local handler's not-found guard uses. And the `gone` path
+    /// *does* write a row: no provider call was made, but the row genuinely
+    /// changed status, and that is the act the record names.
+    ///
+    /// `stop` is never reached from here. A provider declaring only `stop` is
+    /// refused, because ending compute and retiring a record are different
+    /// acts and TBD does not decide that a kill is a good enough synonym for a
+    /// filing decision.
+    private func archiveRemoteLane(
+        _ worktree: Worktree, force: Bool, actor: ActuationActor?
+    ) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let lanes = RemoteLaneLifecycle(db: db, subscriptions: subscriptions, manager: manager)
+        let step: RemoteLaneLifecycle.ArchiveStep
+        switch try await lanes.archiveDecision(for: worktree, force: force) {
+        case .refused(let message):
+            logger.debug("worktree.archive refused: \(message, privacy: .public)")
+            return RPCResponse(error: message)
+        case .proceed(let decided):
+            step = decided
+        }
+        let actuationID = try await beginActuation(
+            .worktreeArchive, actor: actor,
+            target: ActuationTarget(worktree: worktree.id.uuidString))
+        let failure: String?
+        do {
+            failure = try await lanes.performArchive(step, worktree: worktree)
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
+        if let failure {
+            await finishActuation(actuationID, .transportFailed, error: failure)
+            return RPCResponse(error: failure)
+        }
+        await finishActuation(actuationID, .dispatched)
+        return .ok()
+    }
+
+    /// Returns a remote lane to the working set
+    /// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Revive").
+    /// Same record shape as `archiveRemoteLane`: refusals above the row, acts
+    /// below it. Returns the refreshed worktree, exactly as the local path
+    /// does, so the caller sees the row it asked for rather than the archived
+    /// snapshot it passed in.
+    private func reviveRemoteLane(
+        _ worktree: Worktree, actor: ActuationActor?
+    ) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let lanes = RemoteLaneLifecycle(db: db, subscriptions: subscriptions, manager: manager)
+        let step: RemoteLaneLifecycle.ReviveStep
+        switch try await lanes.reviveDecision(for: worktree) {
+        case .refused(let message):
+            logger.debug("worktree.revive refused: \(message, privacy: .public)")
+            return RPCResponse(error: message)
+        case .proceed(let decided):
+            step = decided
+        }
+        let actuationID = try await beginActuation(
+            .worktreeRevive, actor: actor,
+            target: ActuationTarget(worktree: worktree.id.uuidString))
+        let failure: String?
+        do {
+            failure = try await lanes.performRevive(step, worktree: worktree)
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
+        if let failure {
+            await finishActuation(actuationID, .transportFailed, error: failure)
+            return RPCResponse(error: failure)
+        }
+        await finishActuation(actuationID, .dispatched)
+        let revived = try await db.worktrees.get(id: worktree.id) ?? worktree
+        return try RPCResponse(result: revived)
     }
 
     /// Re-run the worktree's `preSession` hook. Returns as soon as the hook's
@@ -320,20 +402,29 @@ extension RPCRouter {
         let existing = try await db.worktrees.get(id: params.worktreeID)
         let path = existing?.localPath
 
-        // Same gate, and for the same reason, as `worktree.archive` above.
-        // Forget means "stop tracking this checkout but leave its files
-        // alone", and a remote lane has no checkout here to leave alone:
-        // `forgetWorktree` resolves its row through `getLocal` and throws
-        // `worktreeNotFound` for a remote one. Without this gate the handler
-        // would write a `.worktreeForget` request and then a `.transportFailed`
-        // outcome for an act it structurally cannot perform, and the record may
-        // only claim acts that were attempted — so the gate belongs above the
-        // row, not in the catch below it. A *missing* row stays
-        // `forgetWorktree`'s throw, unchanged.
+        // Forget keeps refusing a remote lane, and that is a scope decision
+        // rather than an unimplemented gap. Forget means "stop tracking this
+        // checkout but leave its files alone", and a remote lane has no
+        // checkout on this machine to leave alone; retiring a lane is
+        // `worktree.archive`'s job, which now has a remote path of its own
+        // (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Where the
+        // branches live"). Forget is also the wrong shape for the job: it
+        // hard-deletes the row, and adoption re-creates a row for any session
+        // it sees without one, so a forgotten lane would simply return on the
+        // next poll.
+        //
+        // Mechanically the gate is still necessary: `forgetWorktree` resolves
+        // its row through `getLocal` and throws `worktreeNotFound` for a
+        // remote one, so without it this handler would write a
+        // `.worktreeForget` request and a `.transportFailed` outcome for an
+        // act it structurally cannot perform — and the record may only claim
+        // acts that were attempted. A *missing* row stays `forgetWorktree`'s
+        // throw, unchanged.
         if let existing, !existing.location.isLocal {
             logger.debug("worktree.forget refused (remote lane): \(params.worktreeID, privacy: .public)")
             return RPCResponse(
-                error: "Cannot forget \(existing.name): it is a remote lane, and forgetting one is not supported.")
+                error: "Cannot forget \(existing.name): it is a remote lane, with no checkout on this "
+                    + "machine to leave alone. Archive it instead — that is what retires a lane.")
         }
 
         // Forget kills the same windows archive does, so it records the same
@@ -367,6 +458,17 @@ extension RPCRouter {
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeReviveParams.self, from: paramsData)
+
+        // A remote lane takes the provider path instead: there is nothing to
+        // spawn on this machine, and `beginReviveWorktree` resolves through
+        // `getLocal` and would throw for it. Pre-row validation, like
+        // archive's branch above; a *missing* row still falls through to the
+        // lifecycle's own throw.
+        if let existing = try await db.worktrees.get(id: params.worktreeID),
+           !existing.location.isLocal {
+            return try await reviveRemoteLane(existing, actor: actor)
+        }
+
         // The row names the worktree, not a terminal: revive spawns its
         // primary terminals inside the lifecycle's own (possibly detached,
         // pre-session-gated) phase, so no terminal ID exists to name yet.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -601,6 +601,10 @@ public final class RPCRouter: Sendable {
                 return try await handleRemoteCreate(request.paramsData, actor: request.actor)
             case RPCMethod.remoteStop:
                 return try await handleRemoteStop(request.paramsData, actor: request.actor)
+            case RPCMethod.remoteArchive:
+                return try await handleRemoteArchive(request.paramsData, actor: request.actor)
+            case RPCMethod.remoteUnarchive:
+                return try await handleRemoteUnarchive(request.paramsData, actor: request.actor)
             case RPCMethod.remoteSend:
                 return try await handleRemoteSend(request.paramsData, actor: request.actor)
             case RPCMethod.remoteLog:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -283,6 +283,8 @@ public enum RPCMethod {
     public static let remoteSessions = "remote.sessions"
     public static let remoteCreate = "remote.create"
     public static let remoteStop = "remote.stop"
+    public static let remoteArchive = "remote.archive"
+    public static let remoteUnarchive = "remote.unarchive"
     public static let remoteSend = "remote.send"
     public static let remoteLog = "remote.log"
     public static let remoteRename = "remote.rename"
@@ -1403,6 +1405,22 @@ public struct RemoteCreateParams: Codable, Sendable {
 }
 
 public struct RemoteStopParams: Codable, Sendable {
+    public let provider: String
+    public let sessionID: String
+    public init(provider: String, sessionID: String) {
+        self.provider = provider; self.sessionID = sessionID
+    }
+}
+
+public struct RemoteArchiveParams: Codable, Sendable {
+    public let provider: String
+    public let sessionID: String
+    public init(provider: String, sessionID: String) {
+        self.provider = provider; self.sessionID = sessionID
+    }
+}
+
+public struct RemoteUnarchiveParams: Codable, Sendable {
     public let provider: String
     public let sessionID: String
     public init(provider: String, sessionID: String) {

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -115,9 +115,19 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
     public let agentStateReason: String?
     public let agentStateAt: String?
     public let meta: [String: String]?
+    /// Retirement-from-inventory claim, per the provider contract's
+    /// `archived` field. `nil` means the provider made no claim (absent);
+    /// `.some(false)`/`.some(true)` is an explicit claim. Deliberately NOT
+    /// collapsed to a non-optional `Bool` — the filing-sync authority rule
+    /// (docs/specs/2026-08-16-remote-lane-archive-design.md §"Whose report
+    /// counts") must distinguish "no claim" from "explicit false", and
+    /// collapsing this at decode would destroy that distinction. Use
+    /// `isArchived` for display, which supplies the contract's
+    /// absent-reads-as-false semantics.
+    public let archived: Bool?
 
     enum CodingKeys: String, CodingKey {
-        case id, title, state, meta
+        case id, title, state, meta, archived
         case createdAt = "created_at"
         case exitCode = "exit_code"
         case agentState = "agent_state"
@@ -129,11 +139,11 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
                 state: RemoteProcessState, exitCode: Int? = nil,
                 agentState: RemoteAgentState = .unknown,
                 agentStateReason: String? = nil, agentStateAt: String? = nil,
-                meta: [String: String]? = nil) {
+                meta: [String: String]? = nil, archived: Bool? = nil) {
         self.id = id; self.title = title; self.createdAt = createdAt
         self.state = state; self.exitCode = exitCode
         self.agentState = agentState; self.agentStateReason = agentStateReason
-        self.agentStateAt = agentStateAt; self.meta = meta
+        self.agentStateAt = agentStateAt; self.meta = meta; self.archived = archived
     }
 
     public init(from decoder: Decoder) throws {
@@ -147,7 +157,13 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
         agentStateReason = try c.decodeIfPresent(String.self, forKey: .agentStateReason)
         agentStateAt = try c.decodeIfPresent(String.self, forKey: .agentStateAt)
         meta = try c.decodeIfPresent([String: String].self, forKey: .meta)
+        archived = try c.decodeIfPresent(Bool.self, forKey: .archived)
     }
+
+    /// The contract's absent-reads-as-`false` display semantics. The sync
+    /// path must NOT use this — it needs to distinguish "no claim" (nil) from
+    /// an explicit `false`, so it reads `archived` directly.
+    public var isArchived: Bool { archived ?? false }
 
     /// A presentation-safe projection for a cached row whose provider has
     /// failed to produce a fresh inventory. The mirror keeps the last good

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -174,12 +174,22 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
     /// only non-terminal/unknown rows are demoted. In every demoted case the
     /// agent axis also becomes unknown so a cached `working` or
     /// `waiting_input` value cannot keep rendering as current activity.
+    ///
+    /// This projection demotes only the liveness axis (`state`,
+    /// `agentState`, `agentStateReason`) to `.unknown` — the fact this
+    /// snapshot is stale says nothing about the filing axis, so `archived`
+    /// must be threaded through unchanged. Filing and liveness are separate
+    /// axes throughout this feature; a field that collapses them here lies
+    /// about one of them. When adding a field to this type, decide which
+    /// axis it belongs to before deciding whether it survives this
+    /// projection.
     public func projectedForStaleSnapshot() -> RemoteSessionPayload {
         guard state != .exited else { return self }
         return RemoteSessionPayload(
             id: id, title: title, createdAt: createdAt,
             state: .unknown, exitCode: exitCode, agentState: .unknown,
-            agentStateReason: nil, agentStateAt: agentStateAt, meta: meta)
+            agentStateReason: nil, agentStateAt: agentStateAt, meta: meta,
+            archived: archived)
     }
 }
 

--- a/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
+++ b/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
@@ -62,6 +62,86 @@ struct ArchivedWorktreeSearchFilterTests {
     }
 }
 
+/// Tier 1. The `hideEmpty` predicate behind the archived list's "Hide
+/// worktrees with no conversations" filter.
+///
+/// A remote lane stores a synthetic `remote://<provider>/<sessionID>` path,
+/// which `ClaudeProjectDirectory.resolve(worktreePath:)` cannot resolve, so
+/// its session count is structurally zero — always. Filtering purely on
+/// `effectiveSessionCount` would therefore hide every archived remote lane,
+/// indistinguishable from the archive having failed. The remote arm admits a
+/// row on its location instead of a count it can never have.
+///
+/// Extracted from the view's `rows` computed property (a `@AppStorage`-backed
+/// `View` is not directly unit-testable) so both halves of the fix are
+/// pinned in one assertion: a remote row with zero conversations survives,
+/// and a LOCAL row with zero conversations still does not — a filter that
+/// simply stopped filtering would satisfy only the first half.
+@Suite("Archived hide-empty filter")
+struct ArchivedHideEmptyFilterTests {
+    private struct Candidate {
+        let id: String
+        let location: WorktreeLocation
+        let hasReviveState: Bool
+        let effectiveSessionCount: Int
+    }
+
+    private func keep(_ c: Candidate, hideEmpty: Bool) -> Bool {
+        ArchivedHideEmptyFilter.keep(
+            hideEmpty: hideEmpty,
+            location: c.location,
+            hasReviveState: c.hasReviveState,
+            effectiveSessionCount: c.effectiveSessionCount
+        )
+    }
+
+    /// The critical case: composed-output assertion, not presence-only, so a
+    /// filter that stopped filtering entirely cannot pass this test.
+    @Test("hideEmpty ON keeps an empty remote lane and drops an empty local worktree")
+    func remoteEmptyKeptLocalEmptyDropped() {
+        let remoteEmpty = Candidate(
+            id: "remote", location: .remote(provider: "acme", sessionID: "s1"),
+            hasReviveState: false, effectiveSessionCount: 0
+        )
+        let localEmpty = Candidate(
+            id: "local", location: .local, hasReviveState: false, effectiveSessionCount: 0
+        )
+        let survivors = [remoteEmpty, localEmpty].filter { keep($0, hideEmpty: true) }.map(\.id)
+        #expect(survivors == ["remote"])
+    }
+
+    @Test("hideEmpty OFF keeps everything, remote or local, empty or not")
+    func hideEmptyOffKeepsEverything() {
+        let candidates = [
+            Candidate(id: "remote-empty", location: .remote(provider: "acme", sessionID: "s1"),
+                      hasReviveState: false, effectiveSessionCount: 0),
+            Candidate(id: "local-empty", location: .local, hasReviveState: false, effectiveSessionCount: 0),
+            Candidate(id: "local-nonempty", location: .local, hasReviveState: false, effectiveSessionCount: 3),
+        ]
+        let survivors = candidates.filter { keep($0, hideEmpty: false) }.map(\.id)
+        #expect(Set(survivors) == Set(candidates.map(\.id)))
+    }
+
+    @Test("hideEmpty ON still keeps a local row with conversations")
+    func localWithConversationsSurvives() {
+        let candidate = Candidate(
+            id: "local", location: .local, hasReviveState: false, effectiveSessionCount: 2
+        )
+        #expect(keep(candidate, hideEmpty: true))
+    }
+
+    @Test("hideEmpty ON keeps a row with a revive in flight regardless of location")
+    func reviveInFlightSurvivesRegardlessOfLocation() {
+        let remote = Candidate(
+            id: "remote", location: .remote(provider: "acme", sessionID: "s1"),
+            hasReviveState: true, effectiveSessionCount: 0
+        )
+        let local = Candidate(id: "local", location: .local, hasReviveState: true, effectiveSessionCount: 0)
+        #expect(keep(remote, hideEmpty: true))
+        #expect(keep(local, hideEmpty: true))
+    }
+}
+
 /// Tier 1. Which row set the archived list renders for a given query, given
 /// the query the results in hand actually answer.
 ///

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -651,3 +651,127 @@ struct RowActionMenuPinTests {
         #expect(!kinds(items).contains(.unpin))
     }
 }
+
+// MARK: - The real call site
+
+/// Every suite above hands `RowActionMenu.items` a hand-built `Context`, which
+/// says what the pure function does with the inputs it is given and nothing at
+/// all about what the app actually gives it. These tests go through
+/// `RowActionMenuActions.context()` — the ONE place in `Sources/` that builds a
+/// `Context` — so a field the production call site never populates fails here
+/// rather than passing everywhere.
+///
+/// The gap this closes was live: `isGone` defaulted to `false` at the call
+/// site, so the `gone` exemption's whole surface half was unreachable in the
+/// running app while three tests over a hand-built `Context` stayed green.
+@MainActor
+@Suite("RowActionMenu — built from live AppState")
+struct RowActionMenuCallSiteTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.RowActionMenuCallSite.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func remoteWorktree(sessionID: String = "s1") -> Worktree {
+        Worktree(
+            repoID: UUID(), name: "acme-lane", displayName: "acme lane",
+            branch: "acme-branch", path: "remote://fake/\(sessionID)",
+            tmuxServer: "unused",
+            location: .remote(provider: "fake", sessionID: sessionID))
+    }
+
+    private func session(_ sessionID: String, gone: Bool) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: "fake",
+            payload: RemoteSessionPayload(id: sessionID, state: .running),
+            gone: gone, dismissed: false, lastSeen: Date())
+    }
+
+    private func provider(capabilities: [String]) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: "fake", exec: "/nonexistent"),
+            describe: ProviderDescribe(
+                contractVersions: [1], name: "fake", capabilities: capabilities),
+            health: .ok, errorMessage: nil,
+            remediationLabel: nil, remediationCommand: nil)
+    }
+
+    private func actions(_ state: AppState, _ worktree: Worktree) -> RowActionMenuActions {
+        RowActionMenuActions(appState: state, worktree: worktree, onRename: {})
+    }
+
+    @Test("the built context carries the mirror's `gone` flag")
+    func contextCarriesGone() {
+        withState { state in
+            let worktree = remoteWorktree()
+            state.remoteProviders = [provider(capabilities: ["stop"])]
+            state.remoteSessions = [session("s1", gone: true)]
+            #expect(actions(state, worktree).context().isGone)
+        }
+    }
+
+    /// The bug the `gone` exemption's menu half exists to prevent, asserted
+    /// end-to-end from `AppState`: the daemon WILL archive this lane through
+    /// `.rowOnlyGone`, so the menu must not be the thing that blocks it.
+    @Test("a gone lane on a provider that cannot archive still offers Archive")
+    func goneLaneOffersArchiveThroughTheCallSite() {
+        withState { state in
+            let worktree = remoteWorktree()
+            state.remoteProviders = [provider(capabilities: ["stop"])]
+            state.remoteSessions = [session("s1", gone: true)]
+            let archive = actions(state, worktree).items()
+                .compactMap(\.action).first { $0.kind == .archive }
+            #expect(archive?.title == "Archive")
+            #expect(archive?.isEnabled == true)
+        }
+    }
+
+    /// The discriminating half: the same wiring with the mirror reporting the
+    /// session still enumerated must stay disabled, so a call site that
+    /// hardcoded `isGone: true` could not pass either.
+    @Test("a lane the provider still enumerates stays disabled through the call site")
+    func enumeratedLaneStaysDisabledThroughTheCallSite() {
+        withState { state in
+            let worktree = remoteWorktree()
+            state.remoteProviders = [provider(capabilities: ["stop"])]
+            state.remoteSessions = [session("s1", gone: false)]
+            let built = actions(state, worktree).context()
+            #expect(!built.isGone)
+            let archive = actions(state, worktree).items()
+                .compactMap(\.action).first { $0.kind == .archive }
+            #expect(archive?.title == RowActionMenu.archiveProviderCannotArchiveLabel)
+            #expect(archive?.isEnabled == false)
+        }
+    }
+
+    /// A local row has no mirror entry to consult and must read `false`
+    /// regardless of what the mirror holds for some other session.
+    @Test("a local row is never gone")
+    func localRowIsNeverGone() {
+        withState { state in
+            let local = Worktree(
+                repoID: UUID(), name: "local", displayName: "local",
+                branch: "b", path: "/tmp/x", tmuxServer: "t")
+            state.remoteSessions = [session("s1", gone: true)]
+            #expect(!actions(state, local).context().isGone)
+        }
+    }
+
+    /// The other two remote fields the call site populates, pinned here for the
+    /// same reason `isGone` is: nothing else proves they are wired.
+    @Test("the built context carries the row's provider and its capabilities")
+    func contextCarriesProviderAndCapabilities() {
+        withState { state in
+            let worktree = remoteWorktree()
+            state.remoteProviders = [provider(capabilities: ["archive", "stop"])]
+            state.remoteSessions = [session("s1", gone: false)]
+            let built = actions(state, worktree).context()
+            #expect(built.provider == "fake")
+            #expect(built.providerCapabilities == ["archive", "stop"])
+            #expect(built.location == .remote(provider: "fake", sessionID: "s1"))
+        }
+    }
+}

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -277,6 +277,54 @@ struct RowActionMenuRemoteArchiveTests {
         #expect(archive?.disabledHelp == nil)
     }
 
+    /// The `gone` exemption is "the only route out for a lane whose provider
+    /// cannot archive" (spec §"Archive"), and the daemon takes it happily —
+    /// `archivePlan` returns `.rowOnlyGone` for exactly this shape. A menu that
+    /// disabled Archive here would be the surface blocking the one gesture the
+    /// daemon is willing to perform.
+    @Test func archiveEnabledForAGoneLaneWhoseProviderCannotArchive() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["stop"],
+                                        isGone: true)
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == "Archive")
+        #expect(archive?.isEnabled == true)
+        #expect(archive?.disabledHelp == nil)
+    }
+
+    /// `gone` is not a blanket override of the other gate: a lane that is still
+    /// enumerated stays disabled, which is what makes the exemption narrow
+    /// rather than a way around the capability entirely.
+    @Test func archiveStaysDisabledForALaneThatIsNotGone() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["stop"],
+                                        isGone: false)
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == RowActionMenu.archiveProviderCannotArchiveLabel)
+        #expect(archive?.isEnabled == false)
+    }
+
+    /// Active children still win over `gone`: that is a reason the user can act
+    /// on right now, and it is not what the exemption is about.
+    @Test func activeChildrenStillBlockAGoneLane() {
+        let ctx = RowActionMenu.Context(hasActiveChildren: true,
+                                        hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: [],
+                                        isGone: true)
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == RowActionMenu.archiveHasChildrenLabel)
+        #expect(archive?.isEnabled == false)
+    }
+
     @Test func activeChildrenTakePrecedenceOverMissingCapabilityOnRemoteLane() {
         // Both gates apply: a remote lane with active children AND no
         // `archive` capability. Documented precedence lives in

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -229,6 +229,72 @@ struct RowActionMenuRegularTests {
 
 }
 
+// MARK: - Remote lane archive capability
+
+@Suite("RowActionMenu — remote archive capability")
+struct RowActionMenuRemoteArchiveTests {
+    private static let remoteLocation = WorktreeLocation.remote(provider: "acme", sessionID: "s1")
+
+    @Test func archiveDisabledWithReasonWhenProviderLacksArchiveCapability() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["stop"])
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == RowActionMenu.archiveProviderCannotArchiveLabel)
+        #expect(archive?.title == "Archive (provider can't archive)")
+        #expect(archive?.isEnabled == false)
+        #expect(archive?.role == .destructive)
+        #expect(archive?.disabledHelp == RowActionMenu.archiveNeedsProviderCapabilityHelp)
+    }
+
+    @Test func archiveEnabledWhenProviderDeclaresArchiveCapability() {
+        // If the capability gate were dropped, this and the test above would
+        // both show "Archive"/enabled — this is the one that proves the gate
+        // actually discriminates on the declared capability set.
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["archive", "stop"])
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == "Archive")
+        #expect(archive?.isEnabled == true)
+        #expect(archive?.disabledHelp == nil)
+    }
+
+    @Test func localRowUnaffectedByCapabilitySet() {
+        // Regression guard: a local row (default `.local` location) ignores
+        // `providerCapabilities` entirely — Archive stays enabled even with an
+        // empty capability set, exactly as before this gate existed.
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b")
+        #expect(ctx.location.isLocal)
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == "Archive")
+        #expect(archive?.isEnabled == true)
+        #expect(archive?.disabledHelp == nil)
+    }
+
+    @Test func activeChildrenTakePrecedenceOverMissingCapabilityOnRemoteLane() {
+        // Both gates apply: a remote lane with active children AND no
+        // `archive` capability. Documented precedence lives in
+        // `RowActionMenu.regularItems`: active children wins the title because
+        // it's the reason the user can act on right now.
+        let ctx = RowActionMenu.Context(hasActiveChildren: true,
+                                        hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: [])
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == RowActionMenu.archiveHasChildrenLabel)
+        #expect(archive?.disabledHelp == RowActionMenu.archiveNeedsChildrenGoneHelp)
+        #expect(archive?.isEnabled == false)
+    }
+}
+
 // MARK: - Scratch branch
 
 @Suite("RowActionMenu — scratch")

--- a/Tests/TBDDaemonTests/AutoArchiveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveRemoteLaneTests.swift
@@ -165,6 +165,35 @@ struct AutoArchiveRemoteLaneTests {
         #expect(try fixture.actuationRows().isEmpty)
     }
 
+    /// The rail reads the same guards out of the same mirror, so it inherits
+    /// the same refusal: a stale inventory is no basis for retiring a lane,
+    /// and the rail has no `--force` to reach for. It declines and writes no
+    /// row, exactly as it does for a missing capability.
+    @Test("an armed remote lane is left alone while the provider's inventory is stale")
+    func staleInventoryDeclinesTheRail() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [
+                RemoteLaneFixture.failingList,
+                // A spare, so a regressed gate fails by assertion rather than
+                // by exhausting the invoker's script (a `precondition`).
+                providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#),
+            ],
+            tag: "rail-stale")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: lane.id, value: true)
+        try await fixture.markSnapshotStale()
+
+        let archived = await fixture.coordinator().handleMergedTransition(
+            worktreeID: lane.id, prNumber: 7)
+
+        #expect(!archived)
+        #expect(!fixture.invoker.calls.contains { $0.first == "archive" })
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
     // MARK: - The local path, unchanged
 
     @Test("a local worktree armed the same way still auto-archives and records its act")

--- a/Tests/TBDDaemonTests/AutoArchiveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveRemoteLaneTests.swift
@@ -4,87 +4,203 @@ import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
 
-/// Tier 1 — in-memory database, dry-run tmux, a real actuation log in a temp
-/// directory. No `TBD_HOME`, no subprocesses.
+/// Tier 2 — in-memory database, dry-run tmux, a scripted fake provider, and a
+/// real actuation log in a temp directory. No `TBD_HOME`, no subprocesses.
 ///
-/// The auto-archive-on-merge rail refuses a remote lane before it writes its
-/// `.dispose` request: a remote worktree cannot be archived today, so a request
-/// row for one would claim an act that was never attempted. Both arms are here
-/// — the refusal, and a local worktree with the identical arming still
-/// archiving, which is what proves the fence did not disarm the feature.
+/// The auto-archive-on-merge rail reaches remote lanes
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Auto-archive on
+/// merge"). It performs the same act on the same code as a manual archive,
+/// under the opt-in it already has — there is no second flag, because a
+/// second switch would gate a switch. It declines by itself when the provider
+/// declares no `archive`, and a decline writes no actuation row: a background
+/// rail that rewrote a `.dispose` request on every merged transition it
+/// observed for an unretireable lane would fill the record with acts that
+/// never happened.
 @Suite("Auto-archive on merge: remote lanes")
 struct AutoArchiveRemoteLaneTests {
 
-    private func makeLogPath() throws -> String {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tbd-autoarchive-remote-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return directory.appendingPathComponent("actuations.jsonl").path
+    @Test("an armed remote lane whose provider declares archive is retired on merge")
+    func armedRemoteLaneWithCapabilityIsArchived() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "rail-armed")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: lane.id, value: true)
+
+        let archived = await fixture.coordinator().handleMergedTransition(
+            worktreeID: lane.id, prNumber: 7)
+
+        #expect(archived)
+        #expect(fixture.invoker.calls == [["describe"], ["archive", "sess-1"]])
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(await fixture.manager.filingDecision(for: lane.id) != nil)
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["kind"] as? String == "dispose")
+        #expect(rows.first?["method"] == nil, "a daemon rail's row carries no RPC method")
+        #expect(rows.last?["result"] as? String == "dispatched")
     }
 
-    private func rows(at path: String) throws -> [[String: Any]] {
-        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
-        return try contents
-            .split(separator: "\n", omittingEmptySubsequences: true)
-            .map { line in
-                try #require(
-                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
-            }
+    /// The same notification the local path creates. A worktree that leaves
+    /// the active list without the user asking at that moment has to say why.
+    @Test("a rail-driven remote archive records a notification naming the PR")
+    func railRecordsANotification() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "rail-notification")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: lane.id, value: true)
+
+        _ = await fixture.coordinator().handleMergedTransition(worktreeID: lane.id, prNumber: 42)
+
+        let notifications = try await fixture.db.notifications.unread(worktreeID: lane.id)
+        let messages = notifications.compactMap(\.message)
+        #expect(messages.contains { $0.contains("PR #42") },
+                "no notification named the merge: \(messages)")
     }
 
-    private func makeFixture(
-        logPath: String
-    ) async throws -> (coordinator: AutoArchiveOnMergeCoordinator, db: TBDDatabase, repo: Repo) {
-        let db = try TBDDatabase(inMemory: true)
-        let subscriptions = StateSubscriptionManager()
-        let lifecycle = WorktreeLifecycle(
-            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
-            hooks: HookResolver(), subscriptions: subscriptions)
-        let repo = try await db.repos.create(
-            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
-        let coordinator = AutoArchiveOnMergeCoordinator(
-            db: db, lifecycle: lifecycle, subscriptions: subscriptions,
-            actuationLog: ActuationLog(path: logPath))
-        return (coordinator, db, repo)
-    }
+    @Test("an armed remote lane whose provider declares no archive is not retired")
+    func armedRemoteLaneWithoutCapabilityIsDeclined() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["stop"], tag: "rail-nocap")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: lane.id, value: true)
 
-    @Test("an armed remote worktree is refused, and no actuation row is written for it")
-    func remoteLaneIsRefusedAndRecordsNothing() async throws {
-        let logPath = try makeLogPath()
-        let fixture = try await makeFixture(logPath: logPath)
-        let worktree = try await fixture.db.worktrees.createRemote(
-            repoID: fixture.repo.id, name: "acme-remote", branch: "acme-branch",
-            provider: "acme-provider", sessionID: "sess-1")
-        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: worktree.id, value: true)
-
-        let archived = await fixture.coordinator.handleMergedTransition(
-            worktreeID: worktree.id, prNumber: 7)
+        let archived = await fixture.coordinator().handleMergedTransition(
+            worktreeID: lane.id, prNumber: 7)
 
         #expect(!archived)
-        #expect(try await fixture.db.worktrees.get(id: worktree.id)?.status == .active)
-        // Not "no dispose row" but no row of any kind: the rail never reached
-        // its act moment, so it has nothing to record — neither a request nor
-        // the transport-failed outcome the downstream throw used to produce.
-        #expect(try rows(at: logPath).isEmpty)
+        // `stop` is never substituted for a missing `archive`, on any path.
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty, "a decline must write no actuation row")
     }
+
+    /// The opt-in is the only gate. A remote lane that was never armed is
+    /// left alone even where the provider could archive it — otherwise the
+    /// remote path would be auto-archiving lanes the user never opted in.
+    @Test("an unarmed remote lane is left alone even when the provider can archive")
+    func unarmedRemoteLaneIsLeftAlone() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], tag: "rail-unarmed")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: lane.id, value: false)
+
+        let archived = await fixture.coordinator().handleMergedTransition(
+            worktreeID: lane.id, prNumber: 7)
+
+        #expect(!archived)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    /// A lane that inherits its arming from the repo-wide default rather than
+    /// from a per-worktree override still retires — the rail reads the same
+    /// effective value it always did.
+    @Test("a remote lane armed only by the global default is retired")
+    func remoteLaneArmedByTheDefaultIsArchived() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "rail-default-on")
+        defer { fixture.cleanup() }
+        try await fixture.db.config.setAutoArchiveOnMergeDefault(true)
+        let lane = try await fixture.seedLane()
+
+        let archived = await fixture.coordinator().handleMergedTransition(
+            worktreeID: lane.id, prNumber: 7)
+
+        #expect(archived)
+        #expect(try await fixture.status(of: lane) == .archived)
+    }
+
+    /// The rail carries the guards too: it is the same archive on the same
+    /// path, and retiring a lane whose agent is mid-task by accident is
+    /// exactly what the guard exists to stop. The rail has no `--force`.
+    @Test("a remote lane whose agent is still working is not retired on merge")
+    func workingRemoteLaneIsNotRetired() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], tag: "rail-working")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(agentState: .working)
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: lane.id, value: true)
+
+        let archived = await fixture.coordinator().handleMergedTransition(
+            worktreeID: lane.id, prNumber: 7)
+
+        #expect(!archived)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    /// With no remote manager — the shape every install has while
+    /// `remote_backends_enabled` is off — the rail declines exactly as it did
+    /// before it had a remote path at all.
+    @Test("with remote backends off the rail declines a remote lane silently")
+    func remoteLaneDeclinedWithoutAManager() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: ["archive"], tag: "rail-nomanager")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: lane.id, value: true)
+        let coordinator = AutoArchiveOnMergeCoordinator(
+            db: fixture.db,
+            lifecycle: WorktreeLifecycle(
+                db: fixture.db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver(), subscriptions: fixture.subscriptions),
+            subscriptions: fixture.subscriptions,
+            actuationLog: ActuationLog(path: fixture.logPath))
+
+        let archived = await coordinator.handleMergedTransition(worktreeID: lane.id, prNumber: 7)
+
+        #expect(!archived)
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    // MARK: - The local path, unchanged
 
     @Test("a local worktree armed the same way still auto-archives and records its act")
     func localLaneStillArchives() async throws {
-        let logPath = try makeLogPath()
-        let fixture = try await makeFixture(logPath: logPath)
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "rail-local")
+        defer { fixture.cleanup() }
         let worktree = try await fixture.db.worktrees.create(
             repoID: fixture.repo.id, name: "acme-local", branch: "acme-branch",
             path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
         try await fixture.db.worktrees.setAutoArchiveOnMerge(id: worktree.id, value: true)
 
-        let archived = await fixture.coordinator.handleMergedTransition(
+        let archived = await fixture.coordinator().handleMergedTransition(
             worktreeID: worktree.id, prNumber: 7)
 
         #expect(archived)
-        #expect(try await fixture.db.worktrees.get(id: worktree.id)?.status == .archived)
-        let written = try rows(at: logPath)
-        #expect(written.count == 2)
-        #expect(written.first?["kind"] as? String == "dispose")
-        #expect(written.last?["result"] as? String == "dispatched")
+        #expect(try await fixture.status(of: worktree) == .archived)
+        #expect(fixture.invoker.calls == [["describe"]], "a local archive must call no provider")
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["kind"] as? String == "dispose")
+        #expect(rows.last?["result"] as? String == "dispatched")
+    }
+
+    @Test("an unarmed local worktree is still left alone")
+    func unarmedLocalLaneIsLeftAlone() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "rail-local-unarmed")
+        defer { fixture.cleanup() }
+        let worktree = try await fixture.db.worktrees.create(
+            repoID: fixture.repo.id, name: "acme-local", branch: "acme-branch",
+            path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
+
+        let archived = await fixture.coordinator().handleMergedTransition(
+            worktreeID: worktree.id, prNumber: 7)
+
+        #expect(!archived)
+        #expect(try await fixture.status(of: worktree) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
     }
 }

--- a/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
@@ -1,0 +1,179 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// `remote.archive` / `remote.unarchive` — Task 2 of
+/// `docs/plans/2026-08-16-remote-lane-archive.md`. Tier 2: in-memory GRDB + a
+/// fake provider invoker, no real subprocess. Mirrors the shape of
+/// `RPCRouterRemoteTests`'s `remote.stop`/`remote.rename` coverage; kept in
+/// its own file rather than appended there because a sibling task is also
+/// touching this worktree concurrently.
+@Suite("RPCRouter remote.archive / remote.unarchive")
+struct RPCRouterRemoteArchiveTests: ~Copyable {
+    let db: TBDDatabase
+    let subs: StateSubscriptionManager
+    let dir: URL
+    let registryURL: URL
+
+    init() throws {
+        let localDB = try TBDDatabase(inMemory: true)
+        let localDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpc-remote-archive-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: localDir, withIntermediateDirectories: true)
+        let localRegistryURL = localDir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent"}]"#
+            .write(to: localRegistryURL, atomically: true, encoding: .utf8)
+        db = localDB
+        subs = StateSubscriptionManager()
+        dir = localDir
+        registryURL = localRegistryURL
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func router(manager: RemoteProviderManager?) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs,
+            remoteManager: manager, actuationLog: makeTestActuationLog())
+    }
+
+    /// `describeOutcome` is popped FIRST by the fake invoker (`loadRegistryAndDescribe`
+    /// runs before the verb under test), so callers order their script
+    /// `[describe, verb...]`.
+    private func router(invoker: FakeProviderInvoker) async -> RPCRouter {
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        await manager.loadRegistryAndDescribe()
+        return router(manager: manager)
+    }
+
+    private func call(_ router: RPCRouter, _ method: String, _ params: String = "{}") async -> RPCResponse {
+        await router.handle(RPCRequest(method: method, params: params))
+    }
+
+    private func describeDeclaring(_ capabilities: [String]) -> ProviderResult {
+        let caps = capabilities.map { "\"\($0)\"" }.joined(separator: ", ")
+        return providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": [\#(caps)]}"#)
+    }
+
+    // MARK: - flag off / no manager
+
+    @Test func archiveAndUnarchiveErrorWhenFlagOff() async throws {
+        let invoker = FakeProviderInvoker(script: [])
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        let r = router(manager: manager)
+        for method in ["remote.archive", "remote.unarchive"] {
+            let response = await call(r, method, #"{"provider": "fake", "sessionID": "a"}"#)
+            #expect(response.success == false, "expected \(method) to be gated")
+            #expect(response.error == "remote backends disabled")
+        }
+        #expect(invoker.callsSnapshot().isEmpty)
+    }
+
+    @Test func archiveAndUnarchiveErrorWhenManagerNilEvenIfFlagOn() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let r = router(manager: nil)
+        for method in ["remote.archive", "remote.unarchive"] {
+            let response = await call(r, method, #"{"provider": "fake", "sessionID": "a"}"#)
+            #expect(response.success == false, "expected \(method) to be gated")
+            #expect(response.error == "remote backends disabled")
+        }
+    }
+
+    // MARK: - declared capability: invokes and upserts
+
+    @Test func archiveInvokesVerbAndAdoptsReturnedSessionWhenDeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive", "unarchive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": true}"#),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.archive", #"{"provider": "fake", "sessionID": "a"}"#)
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["archive", "a"]])
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.first?.decodedPayload?.isArchived == true)
+    }
+
+    @Test func unarchiveInvokesVerbAndAdoptsReturnedSessionWhenDeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive", "unarchive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": false}"#),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.unarchive", #"{"provider": "fake", "sessionID": "a"}"#)
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["unarchive", "a"]])
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.first?.decodedPayload?.isArchived == false)
+    }
+
+    // MARK: - undeclared capability: refused, provider never spawned
+
+    @Test func archiveRefusesAndNeverSpawnsWhenCapabilityUndeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["unarchive"]),
+        ])
+        let r = await router(invoker: invoker)
+        #expect(invoker.calls == [["describe"]], "sanity: only describe ran so far")
+        let response = await call(r, "remote.archive", #"{"provider": "fake", "sessionID": "a"}"#)
+        #expect(response.success == false)
+        #expect(response.error?.contains("archive") == true)
+        // The refusal must not spawn the provider — no "archive" call recorded,
+        // only the earlier "describe".
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    @Test func unarchiveRefusesAndNeverSpawnsWhenCapabilityUndeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive"]),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.unarchive", #"{"provider": "fake", "sessionID": "a"}"#)
+        #expect(response.success == false)
+        #expect(response.error?.contains("unarchive") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    /// A provider declaring only `stop` must also be refused for archive —
+    /// the plan's explicit warning that `stop` is never substituted for a
+    /// missing `archive`.
+    @Test func archiveRefusesWhenOnlyStopIsDeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["stop"]),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.archive", #"{"provider": "fake", "sessionID": "a"}"#)
+        #expect(response.success == false)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    /// No `describe` was ever recorded for this provider name at all (e.g.
+    /// describe failed or the provider is unknown) — capabilities read as
+    /// empty, so both verbs refuse rather than crash or fail open.
+    @Test func archiveRefusesWhenProviderHasNoCachedDescribe() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 1, stdout: Data(), stderr: "describe failed"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.archive", #"{"provider": "fake", "sessionID": "a"}"#)
+        #expect(response.success == false)
+        #expect(invoker.calls == [["describe"]])
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
@@ -445,6 +445,44 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
         #expect(await manager.filingDecision(for: laneID) == earlier)
     }
 
+    /// The watermark tests above prove `now()` is on file *while the verb
+    /// runs*, but that only exercises `beginFilingWatermark`'s call to
+    /// `now()` — it says nothing about whether the restamp
+    /// (`watermark?.restamp(at: now())`) and the mirror
+    /// (`manager.applyUpsert(session, provider:, date: now())`) share that
+    /// same instant. `call`/`router.handle` always supply the real-clock
+    /// default, so this calls `handleRemoteArchive` directly with an
+    /// injected `now` — the only way to reach that seam — and checks the
+    /// mirror's `firstSeen` (set from `applyUpsert`'s `date`) against the
+    /// watermark (set from the same call's restamp) for exact equality
+    /// rather than mere proximity. A build that reverts to `applyUpsert`'s
+    /// `Date()` default would still pass every test above (both stamps are
+    /// "recent") but fail this one, because `injected` is nowhere near the
+    /// real clock.
+    @Test("archive threads the same injected `now` through the restamp and the mirror")
+    func archiveThreadsInjectedNowThroughRestampAndMirror() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .active)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive", "unarchive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": true}"#),
+        ])
+        let (r, manager) = await wiring(invoker: invoker)
+        let laneID = lane.id
+        let injected = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01, far from real "now"
+
+        let response = try await r.handleRemoteArchive(
+            Data(remoteParams().utf8), actor: nil, now: { injected })
+
+        #expect(response.success)
+        let watermark = await manager.filingDecision(for: laneID)
+        #expect(watermark == injected, "the restamp did not use the injected `now`")
+        let rows = try await db.remoteSessions.list()
+        #expect(
+            rows.first?.firstSeen == injected,
+            "the mirror's applyUpsert did not use the injected `now`")
+    }
+
     /// This surface is addressed by `(provider, sessionID)`, not by worktree, so
     /// it reaches sessions nobody has adopted. There is no row to watermark
     /// then, and that is an ordinary outcome rather than an error: the verb

--- a/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
@@ -16,6 +16,11 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
     let subs: StateSubscriptionManager
     let dir: URL
     let registryURL: URL
+    /// The suite owns the log path rather than taking `makeTestActuationLog`'s
+    /// hidden one, because half the watermark tests below assert on what the
+    /// record *does not* contain — an extra daemon-rail row filed by a poll
+    /// that interleaved with the verb — and that is unreadable without the path.
+    let logPath: String
 
     init() throws {
         let localDB = try TBDDatabase(inMemory: true)
@@ -29,6 +34,7 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
         subs = StateSubscriptionManager()
         dir = localDir
         registryURL = localRegistryURL
+        logPath = localDir.appendingPathComponent("actuations.jsonl").path
     }
 
     deinit {
@@ -60,12 +66,20 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
     /// side effect the handlers' `applyUpsert` reaches, leaving the mirror
     /// payload (which updates unconditionally) as the only observable.
     private func router(invoker: FakeProviderInvoker) async -> RPCRouter {
-        let log = makeTestActuationLog(tag: "rpc-remote-archive")
+        await wiring(invoker: invoker).router
+    }
+
+    /// The same wiring, with the manager handed back — the watermark tests read
+    /// `filingDecision(for:)` off it and drive a competing poll through it.
+    private func wiring(
+        invoker: FakeProviderInvoker
+    ) async -> (router: RPCRouter, manager: RemoteProviderManager) {
+        let log = ActuationLog(path: logPath)
         let manager = RemoteProviderManager(
             db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
             actuationLog: log)
         await manager.loadRegistryAndDescribe()
-        return router(manager: manager, actuationLog: log)
+        return (router(manager: manager, actuationLog: log), manager)
     }
 
     /// Pre-adopts the remote worktree row bound to the session under test.
@@ -216,4 +230,274 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
         #expect(response.success == false)
         #expect(invoker.calls == [["describe"]])
     }
+
+    // MARK: - The filing watermark
+
+    private func remoteParams(_ sessionID: String = "a") -> String {
+        #"{"provider": "fake", "sessionID": "\#(sessionID)"}"#
+    }
+
+    private func payload(archived: Bool) -> RemoteSessionPayload {
+        RemoteSessionPayload(
+            id: "a", state: .running, agentState: .idle, meta: nil, archived: archived)
+    }
+
+    /// The provider commits the retirement partway through a call that may take
+    /// 30 seconds, so the watermark has to be on file before the verb is
+    /// invoked — not after it returns. Read from inside the call itself, which
+    /// is the only moment at which "before it returns" is a fact rather than an
+    /// inference.
+    @Test("archive stamps the bound row's watermark before the verb returns")
+    func archiveWatermarksTheBoundRowBeforeTheVerbReturns() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .active)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive", "unarchive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": true}"#),
+        ])
+        let (r, manager) = await wiring(invoker: invoker)
+        let observed = MidVerbObservation()
+        let laneID = lane.id
+        let startedAt = Date()
+        invoker.onCall = { [manager] verb in
+            guard verb.first == "archive" else { return }
+            observed.watermark = await manager.filingDecision(for: laneID)
+        }
+
+        let response = await call(r, "remote.archive", remoteParams())
+
+        #expect(response.success)
+        let stamped = try #require(
+            observed.watermark, "no filing watermark was on file while `archive` was still running")
+        #expect(stamped >= startedAt)
+    }
+
+    /// Same obligation in the other direction. See
+    /// `archiveWatermarksTheBoundRowBeforeTheVerbReturns`.
+    @Test("unarchive stamps the bound row's watermark before the verb returns")
+    func unarchiveWatermarksTheBoundRowBeforeTheVerbReturns() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .archived)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive", "unarchive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": false}"#),
+        ])
+        let (r, manager) = await wiring(invoker: invoker)
+        let observed = MidVerbObservation()
+        let laneID = lane.id
+        let startedAt = Date()
+        invoker.onCall = { [manager] verb in
+            guard verb.first == "unarchive" else { return }
+            observed.watermark = await manager.filingDecision(for: laneID)
+        }
+
+        let response = await call(r, "remote.unarchive", remoteParams())
+
+        #expect(response.success)
+        let stamped = try #require(
+            observed.watermark,
+            "no filing watermark was on file while `unarchive` was still running")
+        #expect(stamped >= startedAt)
+    }
+
+    /// The failure the watermark exists to prevent, driven end to end: a `list`
+    /// posed before the gesture lands while the verb is still outstanding,
+    /// carrying the provider's already-committed `archived: true`. Unwatermarked
+    /// it files the row on the daemon's own `remote-filing-sync` rail and
+    /// announces that the *provider* retired a session the *user* just retired.
+    ///
+    /// The discriminating assertions are the ones read mid-verb. By the time the
+    /// RPC returns the row is archived either way — what differs is who filed
+    /// it, and only the record and the notification taken at that moment can
+    /// tell them apart.
+    @Test("a poll landing while `archive` runs does not file the bound row itself")
+    func pollDuringArchiveDoesNotFileTheRow() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .active)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive", "unarchive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": true}"#),
+        ])
+        let (r, manager) = await wiring(invoker: invoker)
+        // The poll's request went out before the gesture did, so its response
+        // provably could not have accounted for this archive — however fresh
+        // the `archived: true` it carries.
+        let pollStartedAt = Date()
+        let observed = MidVerbObservation()
+        let laneID = lane.id
+        let path = logPath
+        let archivedPayload = payload(archived: true)
+        invoker.onCall = { [db, manager] verb in
+            guard verb.first == "archive" else { return }
+            try? await manager.apply(
+                snapshot: [archivedPayload], provider: "fake", now: Date(),
+                requestStartedAt: pollStartedAt)
+            await observed.capture(db: db, worktreeID: laneID, logPath: path)
+        }
+
+        let response = await call(r, "remote.archive", remoteParams())
+
+        #expect(response.success)
+        #expect(
+            observed.status == .active,
+            "the interleaved poll filed a row the user's own gesture was already retiring")
+        #expect(observed.notifications == 0)
+        #expect(observed.filingSyncRails == 0)
+        // The gesture's own mirrored response is what files it, once.
+        #expect(try await status(of: lane) == .archived)
+    }
+
+    /// The mirror image: a stale `list` carrying `archived: false` arriving
+    /// while `unarchive` runs would return the row on the daemon rail, earning a
+    /// second actuation for a gesture the user made once.
+    @Test("a poll landing while `unarchive` runs does not return the bound row itself")
+    func pollDuringUnarchiveDoesNotReturnTheRow() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .archived)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive", "unarchive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": false}"#),
+        ])
+        let (r, manager) = await wiring(invoker: invoker)
+        let pollStartedAt = Date()
+        let observed = MidVerbObservation()
+        let laneID = lane.id
+        let path = logPath
+        let returnedPayload = payload(archived: false)
+        invoker.onCall = { [db, manager] verb in
+            guard verb.first == "unarchive" else { return }
+            try? await manager.apply(
+                snapshot: [returnedPayload], provider: "fake", now: Date(),
+                requestStartedAt: pollStartedAt)
+            await observed.capture(db: db, worktreeID: laneID, logPath: path)
+        }
+
+        let response = await call(r, "remote.unarchive", remoteParams())
+
+        #expect(response.success)
+        #expect(
+            observed.status == .archived,
+            "the interleaved poll returned a row the user's own gesture was already returning")
+        #expect(observed.filingSyncRails == 0)
+        #expect(try await status(of: lane) == .active)
+    }
+
+    /// A verb that failed did not happen, and a watermark recorded for it is as
+    /// wrong afterwards as the retirement would have been. Both halves are under
+    /// test: it must be there while the verb runs, and gone once it fails.
+    @Test("a failed archive withdraws the watermark it wrote")
+    func failedArchiveWithdrawsItsOwnWatermark() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .active)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive"]),
+            ProviderResult(
+                exitCode: 1,
+                stdout: Data(#"{"error": {"code": "busy", "message": "session is busy"}}"#.utf8),
+                stderr: ""),
+        ])
+        let (r, manager) = await wiring(invoker: invoker)
+        let observed = MidVerbObservation()
+        let laneID = lane.id
+        invoker.onCall = { [manager] verb in
+            guard verb.first == "archive" else { return }
+            observed.watermark = await manager.filingDecision(for: laneID)
+        }
+
+        let response = await call(r, "remote.archive", remoteParams())
+
+        #expect(response.success == false)
+        #expect(
+            observed.watermark != nil,
+            "no filing watermark was on file while `archive` was still running")
+        #expect(await manager.filingDecision(for: laneID) == nil)
+        #expect(try await status(of: lane) == .active)
+    }
+
+    /// Withdrawal restores, it does not delete: the row may carry an earlier
+    /// decision that did happen and whose window is still open, and a gesture
+    /// that failed has no business closing it.
+    @Test("a timed-out unarchive restores an earlier watermark rather than deleting it")
+    func failedUnarchiveRestoresTheEarlierWatermark() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .archived)
+        let invoker = FakeProviderInvoker(outcomes: [
+            .result(describeDeclaring(["unarchive"])),
+            .timeout,
+        ])
+        let (r, manager) = await wiring(invoker: invoker)
+        let laneID = lane.id
+        let earlier = Date().addingTimeInterval(-5)
+        await manager.noteFilingDecision(worktreeID: laneID, at: earlier)
+        let observed = MidVerbObservation()
+        invoker.onCall = { [manager] verb in
+            guard verb.first == "unarchive" else { return }
+            observed.watermark = await manager.filingDecision(for: laneID)
+        }
+
+        let response = await call(r, "remote.unarchive", remoteParams())
+
+        #expect(response.success == false)
+        let duringVerb = try #require(
+            observed.watermark,
+            "no filing watermark was on file while `unarchive` was still running")
+        #expect(duringVerb > earlier, "the gesture's own decision never moved the watermark forward")
+        #expect(await manager.filingDecision(for: laneID) == earlier)
+    }
+
+    /// This surface is addressed by `(provider, sessionID)`, not by worktree, so
+    /// it reaches sessions nobody has adopted. There is no row to watermark
+    /// then, and that is an ordinary outcome rather than an error: the verb
+    /// still runs and the response is still mirrored.
+    @Test("a session with no bound worktree row archives cleanly, unwatermarked")
+    func archiveWithNoBoundRowIsACleanNoOp() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["archive"]),
+            providerOK(#"{"id": "a", "state": "running", "archived": true}"#),
+        ])
+        let (r, _) = await wiring(invoker: invoker)
+
+        let response = await call(r, "remote.archive", remoteParams())
+
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["archive", "a"]])
+        #expect(try await db.worktrees.findRemote(provider: "fake", sessionID: "a") == nil)
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.first?.decodedPayload?.isArchived == true)
+    }
+}
+
+/// Capture point for facts read from inside a provider call, where a `@Sendable`
+/// closure cannot write to a local `var`. Written and read on the one task that
+/// runs the hook inline, so it needs no lock of its own.
+private final class MidVerbObservation: @unchecked Sendable {
+    var watermark: Date?
+    var status: WorktreeStatus?
+    var notifications = 0
+    /// Actuation requests the filing sync wrote on the daemon's own rail.
+    var filingSyncRails = 0
+
+    func capture(db: TBDDatabase, worktreeID: UUID, logPath: String) async {
+        status = ((try? await db.worktrees.get(id: worktreeID)) ?? nil)?.status
+        notifications = ((try? await db.notifications.unread(worktreeID: worktreeID)) ?? []).count
+        filingSyncRails = decodedActuationRows(at: logPath).count {
+            ($0["actor"] as? [String: Any])?["rail"] as? String == ActuationRail.remoteFilingSync
+        }
+    }
+}
+
+/// The actuation log as decoded rows, readable from a `@Sendable` context —
+/// the suite's own helper cannot be, since it is a method on a `~Copyable`
+/// struct.
+private func decodedActuationRows(at path: String) -> [[String: Any]] {
+    guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+    return contents
+        .split(separator: "\n", omittingEmptySubsequences: true)
+        .compactMap { line -> [String: Any]? in
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)) else {
+                return nil
+            }
+            return object as? [String: Any]
+        }
 }

--- a/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteArchiveTests.swift
@@ -35,25 +35,55 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
         try? FileManager.default.removeItem(at: dir)
     }
 
-    private func router(manager: RemoteProviderManager?) -> RPCRouter {
+    private func router(
+        manager: RemoteProviderManager?, actuationLog: ActuationLog = makeTestActuationLog()
+    ) -> RPCRouter {
         RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
-                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver(),
+                subscriptions: subs),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
             subscriptions: subs,
-            remoteManager: manager, actuationLog: makeTestActuationLog())
+            remoteManager: manager, actuationLog: actuationLog)
     }
 
     /// `describeOutcome` is popped FIRST by the fake invoker (`loadRegistryAndDescribe`
     /// runs before the verb under test), so callers order their script
     /// `[describe, verb...]`.
+    ///
+    /// The manager gets the SAME actuation log as the router, exactly as
+    /// `Daemon.swift` shares one — and, like `RemoteLaneFixture`, it gets one
+    /// at all. `syncFilingDecisions` fails closed when the manager's log is
+    /// nil, so a manager built without one silently disables every row-filing
+    /// side effect the handlers' `applyUpsert` reaches, leaving the mirror
+    /// payload (which updates unconditionally) as the only observable.
     private func router(invoker: FakeProviderInvoker) async -> RPCRouter {
+        let log = makeTestActuationLog(tag: "rpc-remote-archive")
         let manager = RemoteProviderManager(
-            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: log)
         await manager.loadRegistryAndDescribe()
-        return router(manager: manager)
+        return router(manager: manager, actuationLog: log)
+    }
+
+    /// Pre-adopts the remote worktree row bound to the session under test.
+    ///
+    /// Without it `findRemote(provider:sessionID:)` resolves nothing and the
+    /// filing sync skips the session entirely — so the row-status assertions
+    /// below would be vacuous and only the mirror payload would be under test.
+    @discardableResult
+    private func seedLane(sessionID: String = "a", status: WorktreeStatus) async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        return try await db.worktrees.createRemote(
+            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
+            provider: "fake", sessionID: sessionID, status: status)
+    }
+
+    private func status(of worktree: Worktree) async throws -> WorktreeStatus? {
+        try await db.worktrees.get(id: worktree.id)?.status
     }
 
     private func call(_ router: RPCRouter, _ method: String, _ params: String = "{}") async -> RPCResponse {
@@ -92,8 +122,13 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
 
     // MARK: - declared capability: invokes and upserts
 
+    /// Two observables, and only the second can regress silently: the mirror
+    /// payload records what the provider said (`applyUpsert` writes it
+    /// unconditionally), while the worktree row's status is the filing
+    /// decision travelling back through `syncFilingDecisions`. Assert both.
     @Test func archiveInvokesVerbAndAdoptsReturnedSessionWhenDeclared() async throws {
         try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .active)
         let invoker = FakeProviderInvoker(script: [
             describeDeclaring(["archive", "unarchive"]),
             providerOK(#"{"id": "a", "state": "running", "archived": true}"#),
@@ -104,10 +139,14 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
         #expect(invoker.calls == [["describe"], ["archive", "a"]])
         let rows = try await db.remoteSessions.list()
         #expect(rows.first?.decodedPayload?.isArchived == true)
+        #expect(try await status(of: lane) == .archived)
     }
 
+    /// The mirror-plus-row pair again, in the other direction. See
+    /// `archiveInvokesVerbAndAdoptsReturnedSessionWhenDeclared`.
     @Test func unarchiveInvokesVerbAndAdoptsReturnedSessionWhenDeclared() async throws {
         try await db.config.setRemoteBackendsEnabled(true)
+        let lane = try await seedLane(status: .archived)
         let invoker = FakeProviderInvoker(script: [
             describeDeclaring(["archive", "unarchive"]),
             providerOK(#"{"id": "a", "state": "running", "archived": false}"#),
@@ -118,6 +157,7 @@ struct RPCRouterRemoteArchiveTests: ~Copyable {
         #expect(invoker.calls == [["describe"], ["unarchive", "a"]])
         let rows = try await db.remoteSessions.list()
         #expect(rows.first?.decodedPayload?.isArchived == false)
+        #expect(try await status(of: lane) == .active)
     }
 
     // MARK: - undeclared capability: refused, provider never spawned

--- a/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
+++ b/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
@@ -52,12 +52,13 @@ struct RemoteFilingSyncTests {
     /// A manager whose cached `describe` declares `capabilities`, with a real
     /// actuation log wired in — the sync fails closed without one.
     private func manager(
-        declaring capabilities: [String], runner: (any RemoteProviderInvoking)? = nil
+        declaring capabilities: [String], runner: (any RemoteProviderInvoking)? = nil,
+        log: ActuationLog? = nil
     ) async -> RemoteProviderManager {
         let invoker = runner ?? FakeProviderInvoker(script: [describeDeclaring(capabilities)])
         let m = RemoteProviderManager(
             db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
-            actuationLog: ActuationLog(path: logPath))
+            actuationLog: log ?? ActuationLog(path: logPath))
         await m.loadRegistryAndDescribe()
         return m
     }
@@ -295,6 +296,233 @@ struct RemoteFilingSyncTests {
         #expect(try await status(row.id) == .archived)
     }
 
+    /// The rule is "no later than the request start", so the boundary belongs
+    /// to the response: a decision taken at the very instant the request began
+    /// is one that request could have accounted for. Both directions are here
+    /// because the comparison is one line and a suite that only pinned the
+    /// strict cases would survive swapping `>` for `>=`.
+    @Test("a decision taken exactly at the request start does not suppress the flip")
+    func watermarkBoundaryIsExclusiveAtEquality() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let toFile = try await adoptedRow(m, sessionID: "to-file")
+        let toReturn = try await adoptedRow(m, sessionID: "to-return")
+        try await db.worktrees.archive(id: toReturn.id)
+        let boundary = Date(timeIntervalSince1970: 1_000)
+        await m.noteFilingDecision(worktreeID: toFile.id, at: boundary)
+        await m.noteFilingDecision(worktreeID: toReturn.id, at: boundary)
+
+        try await m.apply(
+            snapshot: [
+                session("to-file", archived: true),
+                session("to-return", archived: false),
+            ],
+            provider: "fake",
+            now: Date(timeIntervalSince1970: 1_002), requestStartedAt: boundary)
+
+        #expect(try await status(toFile.id) == .archived)
+        #expect(try await status(toReturn.id) == .active)
+    }
+
+    /// One second the other side of the same boundary, so the pair pins the
+    /// comparison rather than one of its arms.
+    @Test("a decision taken one instant after the request start does suppress the flip")
+    func watermarkBoundaryIsInclusiveOneInstantLater() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+        let boundary = Date(timeIntervalSince1970: 1_000)
+        await m.noteFilingDecision(worktreeID: row.id, at: boundary.addingTimeInterval(0.001))
+
+        try await m.apply(
+            snapshot: [session("a", archived: true)], provider: "fake",
+            now: Date(timeIntervalSince1970: 1_002), requestStartedAt: boundary)
+
+        #expect(try await status(row.id) == .active)
+    }
+
+    // MARK: - Every write to a remote row's status is watermarked
+
+    /// Not only the verb paths. A row filed by the sync itself — which is how
+    /// a Provider-Desk `remote.archive` reaches the worktree row, since that
+    /// handler never touches the row — must leave a watermark too, or a poll
+    /// already in flight carrying the pre-archive `archived: false` un-files it
+    /// moments later.
+    @Test("a sync-driven archive is watermarked, and an in-flight poll cannot undo it")
+    func syncDrivenArchiveIsWatermarked() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+
+        try await m.apply(
+            snapshot: [session("a", archived: true)], provider: "fake",
+            now: Date(timeIntervalSince1970: 2_000),
+            requestStartedAt: Date(timeIntervalSince1970: 2_000))
+        #expect(try await status(row.id) == .archived)
+        #expect(await m.filingDecision(for: row.id) != nil, "the sync left no watermark")
+
+        // A `list` launched before that decision lands afterwards, still
+        // carrying the provider's pre-archive word.
+        try await m.apply(
+            snapshot: [session("a", archived: false)], provider: "fake",
+            now: Date(timeIntervalSince1970: 2_002),
+            requestStartedAt: Date(timeIntervalSince1970: 1_999))
+
+        #expect(try await status(row.id) == .archived)
+    }
+
+    @Test("a sync-driven return to active is watermarked, and an in-flight poll cannot undo it")
+    func syncDrivenReturnIsWatermarked() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+        try await db.worktrees.archive(id: row.id)
+
+        try await m.apply(
+            snapshot: [session("a", archived: false)], provider: "fake",
+            now: Date(timeIntervalSince1970: 2_000),
+            requestStartedAt: Date(timeIntervalSince1970: 2_000))
+        #expect(try await status(row.id) == .active)
+        #expect(await m.filingDecision(for: row.id) != nil, "the sync left no watermark")
+
+        try await m.apply(
+            snapshot: [session("a", archived: true)], provider: "fake",
+            now: Date(timeIntervalSince1970: 2_002),
+            requestStartedAt: Date(timeIntervalSince1970: 1_999))
+
+        #expect(try await status(row.id) == .active)
+    }
+
+    // MARK: - Check-then-act across the suspensions
+
+    /// The row and the watermark are read once, and then two awaits follow —
+    /// the record append and the status write. A gesture landing in that
+    /// window makes the decision stale before it is carried out, so the sync
+    /// re-reads both and abandons rather than restating an act somebody else
+    /// already performed.
+    ///
+    /// The interleave is exact rather than raced: the actuation log's own
+    /// `write` syscall is the seam. It hands control to the racing gesture and
+    /// blocks until that gesture has finished, so the sync always resumes into
+    /// a world it has not looked at since it decided.
+    @Test("a gesture landing mid-sync abandons the flip instead of restating it")
+    func aGestureLandingMidSyncAbandonsTheFlip() async throws {
+        let handshake = MidAppendHandshake()
+        let log = ActuationLog(
+            path: logPath, now: { Date() },
+            syscalls: ActuationLogSyscalls(
+                write: { descriptor, buffer, count in
+                    handshake.pauseOnFirstWrite()
+                    return Foundation.write(descriptor, buffer, count)
+                },
+                fsync: { Foundation.fsync($0) }))
+        let m = await manager(declaring: ["archive", "unarchive"], log: log)
+        let row = try await adoptedRow(m)
+
+        // The user's own archive, waiting for the sync to reach its record.
+        let gesture = Task { [db] in
+            await handshake.awaitSyncAtRecord()
+            try? await db.worktrees.archive(id: row.id)
+            await m.noteFilingDecision(worktreeID: row.id, at: Date(timeIntervalSince1970: 3_000))
+            handshake.releaseSync()
+        }
+
+        try await m.apply(
+            snapshot: [session("a", archived: true)], provider: "fake",
+            now: Date(timeIntervalSince1970: 2_001),
+            requestStartedAt: Date(timeIntervalSince1970: 2_000))
+        await gesture.value
+
+        #expect(try await status(row.id) == .archived, "the user's own archive stands")
+        // The gesture is the author of this filing, so nothing may say the
+        // provider retired the session.
+        #expect(try await db.notifications.unread(worktreeID: row.id).isEmpty)
+        let rows = try actuationRows()
+        let request = try #require(rows.first { $0["kind"] as? String == "dispose" })
+        let requestID = try #require(request["id"] as? String)
+        let outcome = try #require(rows.first { $0["confirms"] as? String == requestID })
+        #expect(
+            outcome["result"] as? String == "refused",
+            "the sync carried out a decision that had gone stale: \(outcome)")
+    }
+
+    // MARK: - The two events paths
+
+    /// A pushed `session` line is fresh by construction — the provider wrote it
+    /// because something changed just now — so the sync takes its arrival as
+    /// the request start and files the row.
+    @Test("a pushed session line reporting archived: true files its row")
+    func eventsPushedSessionFilesTheRow() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+
+        await m.applyUpsert(
+            session("a", archived: true), provider: "fake",
+            date: Date(timeIntervalSince1970: 5_000))
+
+        #expect(try await status(row.id) == .archived)
+        #expect(try await mirrorState("a") == RemoteProcessState.running.rawValue)
+    }
+
+    /// "Fresh by construction" is a claim about the line, not a licence to
+    /// overwrite a decision taken after it arrived. The injected arrival date
+    /// is what the watermark is compared against, so a decision stamped later
+    /// than the line still wins — and the seam is what makes that assertable
+    /// without wall time.
+    @Test("a pushed session line does not reverse a decision taken after it arrived")
+    func eventsPushedSessionRespectsALaterDecision() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+        try await db.worktrees.archive(id: row.id)
+        await m.noteFilingDecision(worktreeID: row.id, at: Date(timeIntervalSince1970: 5_001))
+
+        await m.applyUpsert(
+            session("a", archived: false), provider: "fake",
+            date: Date(timeIntervalSince1970: 5_000))
+
+        #expect(try await status(row.id) == .archived)
+    }
+
+    /// The reconnect snapshot arm. The supervisor supplies the moment it opened
+    /// the connection as the request start, because the provider composes that
+    /// snapshot from what it knew when TBD asked — so a snapshot on a
+    /// connection opened before a local decision cannot account for it, and one
+    /// on a connection opened after it can.
+    @Test("an events snapshot is judged by when its connection opened")
+    func eventsSnapshotIsJudgedByConnectionOpenTime() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let stale = try await adoptedRow(m, sessionID: "stale-connection")
+        let fresh = try await adoptedRow(m, sessionID: "fresh-connection")
+        try await db.worktrees.archive(id: stale.id)
+        try await db.worktrees.archive(id: fresh.id)
+        await m.noteFilingDecision(worktreeID: stale.id, at: Date(timeIntervalSince1970: 6_000))
+        await m.noteFilingDecision(worktreeID: fresh.id, at: Date(timeIntervalSince1970: 6_000))
+
+        // One connection opened before both decisions, one after.
+        try await m.apply(
+            snapshot: [session("stale-connection", archived: false)], provider: "fake",
+            now: Date(timeIntervalSince1970: 6_002),
+            requestStartedAt: Date(timeIntervalSince1970: 5_999))
+        try await m.apply(
+            snapshot: [session("fresh-connection", archived: false)], provider: "fake",
+            now: Date(timeIntervalSince1970: 6_003),
+            requestStartedAt: Date(timeIntervalSince1970: 6_001))
+
+        #expect(try await status(stale.id) == .archived)
+        #expect(try await status(fresh.id) == .active)
+    }
+
+    /// The supervisor stamps that connection-open time through an injected date
+    /// seam rather than a bare `Date()`, because the value is **compared**
+    /// (Tests/CLAUDE.md, "Clock and date seams": `Duration` is behavior,
+    /// `Date` is data).
+    @Test("the events supervisor stamps its connection-open time through the date seam")
+    func eventsSupervisorTakesADateSeam() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let fixed = Date(timeIntervalSince1970: 7_000)
+        let supervisor = ProviderEventsSupervisor(
+            config: RemoteProviderConfig(name: "fake", exec: "/nonexistent"), manager: m,
+            now: { fixed })
+
+        #expect(await supervisor.connectionOpenedAt == fixed)
+    }
+
     // MARK: - The sweep
 
     @Test("the sweep drops watermarks older than two poll intervals")
@@ -312,6 +540,23 @@ struct RemoteFilingSyncTests {
 
         #expect(await m.filingDecision(for: fresh) != nil)
         #expect(await m.filingDecision(for: stale) == nil)
+    }
+
+    /// The cutoff itself is kept. A watermark exactly two poll intervals old is
+    /// still older than nothing in flight, and pinning the boundary is what
+    /// stops the comparison drifting between `>` and `>=` unnoticed.
+    @Test("a watermark exactly at the sweep cutoff survives")
+    func sweepKeepsTheWatermarkOnTheCutoff() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let now = Date(timeIntervalSince1970: 10_000)
+        let onTheCutoff = UUID()
+        await m.noteFilingDecision(
+            worktreeID: onTheCutoff,
+            at: now.addingTimeInterval(-2 * RemoteProviderManager.pollInterval))
+
+        try await m.apply(snapshot: [], provider: "fake", now: now, requestStartedAt: now)
+
+        #expect(await m.filingDecision(for: onTheCutoff) != nil)
     }
 
     // MARK: - Never silent
@@ -335,6 +580,48 @@ struct RemoteFilingSyncTests {
         let requestID = try #require(request["id"] as? String)
         let outcome = try #require(rows.first { $0["confirms"] as? String == requestID })
         #expect(outcome["result"] as? String == "dispatched")
+    }
+}
+
+/// Rendezvous between the filing sync — paused inside the actuation log's
+/// first `write` syscall — and a gesture racing it. Two semaphores rather than
+/// one: the gesture must not start before the sync has committed to its
+/// decision, and the sync must not resume before the gesture has landed.
+///
+/// The blocking `wait` on the sync's side parks the actuation log's executor
+/// thread, which is exactly the point; the gesture's side never blocks a
+/// cooperative thread, since it waits on a global dispatch queue and resumes
+/// through a continuation.
+private final class MidAppendHandshake: @unchecked Sendable {
+    private let syncReachedRecord = DispatchSemaphore(value: 0)
+    private let gestureLanded = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var paused = false
+
+    /// Called from the log's `write` syscall. Only the first append pauses:
+    /// the outcome row is written after the decision has been re-confirmed and
+    /// has nothing left to race.
+    func pauseOnFirstWrite() {
+        lock.lock()
+        let alreadyPaused = paused
+        paused = true
+        lock.unlock()
+        guard !alreadyPaused else { return }
+        syncReachedRecord.signal()
+        gestureLanded.wait()
+    }
+
+    func awaitSyncAtRecord() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async { [syncReachedRecord] in
+                syncReachedRecord.wait()
+                continuation.resume()
+            }
+        }
+    }
+
+    func releaseSync() {
+        gestureLanded.signal()
     }
 }
 

--- a/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
+++ b/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
@@ -14,7 +14,15 @@ import Testing
 /// Every timestamp these tests care about is passed in explicitly. Nothing
 /// sleeps: the rule under test is an ordering between two `Date`s, so wall
 /// time would only make the assertions slower and flakier.
-@Suite("Remote filing sync")
+///
+/// The time limit is a hang-catcher, not a budget. Three of these tests drive a
+/// competing gesture into the sync's check-then-act window, and an earlier
+/// rendezvous that blocked a cooperative-pool thread there wedged a CI run for
+/// its whole 30-minute step timeout with no failing test and no output. Two
+/// minutes turns any future recurrence into a named red instead, with headroom
+/// for the scheduling latency a ~4500-test parallel pass adds to a trivial test
+/// (`Tests/CLAUDE.md`, "Population is the scheduler").
+@Suite("Remote filing sync", .timeLimit(.minutes(2)))
 struct RemoteFilingSyncTests {
     let db: TBDDatabase
     let subs: StateSubscriptionManager
@@ -51,14 +59,11 @@ struct RemoteFilingSyncTests {
 
     /// A manager whose cached `describe` declares `capabilities`, with a real
     /// actuation log wired in — the sync fails closed without one.
-    private func manager(
-        declaring capabilities: [String], runner: (any RemoteProviderInvoking)? = nil,
-        log: ActuationLog? = nil
-    ) async -> RemoteProviderManager {
-        let invoker = runner ?? FakeProviderInvoker(script: [describeDeclaring(capabilities)])
+    private func manager(declaring capabilities: [String]) async -> RemoteProviderManager {
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(capabilities)])
         let m = RemoteProviderManager(
             db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
-            actuationLog: log ?? ActuationLog(path: logPath))
+            actuationLog: ActuationLog(path: logPath))
         await m.loadRegistryAndDescribe()
         return m
     }
@@ -397,37 +402,27 @@ struct RemoteFilingSyncTests {
     /// re-reads both and abandons rather than restating an act somebody else
     /// already performed.
     ///
-    /// The interleave is exact rather than raced: the actuation log's own
-    /// `write` syscall is the seam. It hands control to the racing gesture and
-    /// blocks until that gesture has finished, so the sync always resumes into
-    /// a world it has not looked at since it decided.
+    /// The interleave is exact rather than raced, and it costs no second task:
+    /// the gesture runs inline on the sync's own task, through the manager's
+    /// `midFlipHook`, at the one moment that lands it after the sync decided
+    /// and before the recheck re-reads. Nothing blocks a cooperative-pool
+    /// thread, so a narrow pool shared with the rest of the suite cannot wedge
+    /// it.
     @Test("a gesture landing mid-sync abandons the flip instead of restating it")
     func aGestureLandingMidSyncAbandonsTheFlip() async throws {
-        let handshake = MidAppendHandshake()
-        let log = ActuationLog(
-            path: logPath, now: { Date() },
-            syscalls: ActuationLogSyscalls(
-                write: { descriptor, buffer, count in
-                    handshake.pauseOnFirstWrite()
-                    return Foundation.write(descriptor, buffer, count)
-                },
-                fsync: { Foundation.fsync($0) }))
-        let m = await manager(declaring: ["archive", "unarchive"], log: log)
+        let m = await manager(declaring: ["archive", "unarchive"])
         let row = try await adoptedRow(m)
 
-        // The user's own archive, waiting for the sync to reach its record.
-        let gesture = Task { [db] in
-            await handshake.awaitSyncAtRecord()
+        // The user's own archive, landing while the sync is recording its own.
+        await m.setMidFlipHook { [db] in
             try? await db.worktrees.archive(id: row.id)
             await m.noteFilingDecision(worktreeID: row.id, at: Date(timeIntervalSince1970: 3_000))
-            handshake.releaseSync()
         }
 
         try await m.apply(
             snapshot: [session("a", archived: true)], provider: "fake",
             now: Date(timeIntervalSince1970: 2_001),
             requestStartedAt: Date(timeIntervalSince1970: 2_000))
-        await gesture.value
 
         #expect(try await status(row.id) == .archived, "the user's own archive stands")
         // The gesture is the author of this filing, so nothing may say the
@@ -449,29 +444,17 @@ struct RemoteFilingSyncTests {
     /// record over a row that was never eligible.
     @Test("a row that became ineligible mid-sync is recorded not-eligible, not noop")
     func ineligibleRowMidSyncIsNotRecordedAsANoop() async throws {
-        let handshake = MidAppendHandshake()
-        let log = ActuationLog(
-            path: logPath, now: { Date() },
-            syscalls: ActuationLogSyscalls(
-                write: { descriptor, buffer, count in
-                    handshake.pauseOnFirstWrite()
-                    return Foundation.write(descriptor, buffer, count)
-                },
-                fsync: { Foundation.fsync($0) }))
-        let m = await manager(declaring: ["archive", "unarchive"], log: log)
+        let m = await manager(declaring: ["archive", "unarchive"])
         let row = try await adoptedRow(m)
 
-        let gesture = Task { [db] in
-            await handshake.awaitSyncAtRecord()
+        await m.setMidFlipHook { [db] in
             try? await db.worktrees.updateStatus(id: row.id, status: .failed)
-            handshake.releaseSync()
         }
 
         try await m.apply(
             snapshot: [session("a", archived: true)], provider: "fake",
             now: Date(timeIntervalSince1970: 2_001),
             requestStartedAt: Date(timeIntervalSince1970: 2_000))
-        await gesture.value
 
         #expect(try await status(row.id) == .failed, "the sync filed a row it may not touch")
         let rows = try actuationRows()
@@ -488,29 +471,17 @@ struct RemoteFilingSyncTests {
     /// to the flip's own target really is a no-op.
     @Test("a row already at the flip's target is recorded noop")
     func alreadyFiledRowIsRecordedNoop() async throws {
-        let handshake = MidAppendHandshake()
-        let log = ActuationLog(
-            path: logPath, now: { Date() },
-            syscalls: ActuationLogSyscalls(
-                write: { descriptor, buffer, count in
-                    handshake.pauseOnFirstWrite()
-                    return Foundation.write(descriptor, buffer, count)
-                },
-                fsync: { Foundation.fsync($0) }))
-        let m = await manager(declaring: ["archive", "unarchive"], log: log)
+        let m = await manager(declaring: ["archive", "unarchive"])
         let row = try await adoptedRow(m)
 
-        let gesture = Task { [db] in
-            await handshake.awaitSyncAtRecord()
+        await m.setMidFlipHook { [db] in
             try? await db.worktrees.archive(id: row.id)
-            handshake.releaseSync()
         }
 
         try await m.apply(
             snapshot: [session("a", archived: true)], provider: "fake",
             now: Date(timeIntervalSince1970: 2_001),
             requestStartedAt: Date(timeIntervalSince1970: 2_000))
-        await gesture.value
 
         let rows = try actuationRows()
         let request = try #require(rows.first { $0["kind"] as? String == "dispose" })
@@ -657,48 +628,6 @@ struct RemoteFilingSyncTests {
         let requestID = try #require(request["id"] as? String)
         let outcome = try #require(rows.first { $0["confirms"] as? String == requestID })
         #expect(outcome["result"] as? String == "dispatched")
-    }
-}
-
-/// Rendezvous between the filing sync — paused inside the actuation log's
-/// first `write` syscall — and a gesture racing it. Two semaphores rather than
-/// one: the gesture must not start before the sync has committed to its
-/// decision, and the sync must not resume before the gesture has landed.
-///
-/// The blocking `wait` on the sync's side parks the actuation log's executor
-/// thread, which is exactly the point; the gesture's side never blocks a
-/// cooperative thread, since it waits on a global dispatch queue and resumes
-/// through a continuation.
-private final class MidAppendHandshake: @unchecked Sendable {
-    private let syncReachedRecord = DispatchSemaphore(value: 0)
-    private let gestureLanded = DispatchSemaphore(value: 0)
-    private let lock = NSLock()
-    private var paused = false
-
-    /// Called from the log's `write` syscall. Only the first append pauses:
-    /// the outcome row is written after the decision has been re-confirmed and
-    /// has nothing left to race.
-    func pauseOnFirstWrite() {
-        lock.lock()
-        let alreadyPaused = paused
-        paused = true
-        lock.unlock()
-        guard !alreadyPaused else { return }
-        syncReachedRecord.signal()
-        gestureLanded.wait()
-    }
-
-    func awaitSyncAtRecord() async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global().async { [syncReachedRecord] in
-                syncReachedRecord.wait()
-                continuation.resume()
-            }
-        }
-    }
-
-    func releaseSync() {
-        gestureLanded.signal()
     }
 }
 

--- a/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
+++ b/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
@@ -1,0 +1,369 @@
+import Foundation
+import TestSupport
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The filing sync — Task 7 of `docs/plans/2026-08-16-remote-lane-archive.md`,
+/// spec §"The filing decision travels back".
+///
+/// Tier 1: in-memory GRDB, a fake provider invoker, and a real actuation log
+/// in a temp directory. No subprocesses, no network, no `TBD_HOME`.
+///
+/// Every timestamp these tests care about is passed in explicitly. Nothing
+/// sleeps: the rule under test is an ordering between two `Date`s, so wall
+/// time would only make the assertions slower and flakier.
+@Suite("Remote filing sync")
+struct RemoteFilingSyncTests {
+    let db: TBDDatabase
+    let subs: StateSubscriptionManager
+    let dir: URL
+    let registryURL: URL
+    let logPath: String
+    /// One repo for the whole suite: every fixture session reports the same
+    /// `meta["repo"]`, and a second registration of the same remote would make
+    /// that resolution ambiguous rather than more realistic.
+    let repo: Repo
+
+    init() async throws {
+        db = try TBDDatabase(inMemory: true)
+        subs = StateSubscriptionManager()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-filing-sync-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        dir = directory
+        registryURL = directory.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        logPath = directory.appendingPathComponent("actuations.jsonl").path
+        repo = try await db.repos.create(
+            path: "/tmp/filing-sync-\(UUID().uuidString)", displayName: "api",
+            defaultBranch: "main", remoteURL: "https://github.com/acme/api")
+    }
+
+    // MARK: - Fixtures
+
+    private func describeDeclaring(_ capabilities: [String]) -> ProviderResult {
+        let caps = capabilities.map { "\"\($0)\"" }.joined(separator: ", ")
+        return providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": [\#(caps)]}"#)
+    }
+
+    /// A manager whose cached `describe` declares `capabilities`, with a real
+    /// actuation log wired in — the sync fails closed without one.
+    private func manager(
+        declaring capabilities: [String], runner: (any RemoteProviderInvoking)? = nil
+    ) async -> RemoteProviderManager {
+        let invoker = runner ?? FakeProviderInvoker(script: [describeDeclaring(capabilities)])
+        let m = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: ActuationLog(path: logPath))
+        await m.loadRegistryAndDescribe()
+        return m
+    }
+
+    private func session(
+        _ id: String, archived: Bool?, state: RemoteProcessState = .running,
+        meta: [String: String]? = ["repo": "acme/api"]
+    ) -> RemoteSessionPayload {
+        RemoteSessionPayload(
+            id: id, state: state, agentState: .working, meta: meta, archived: archived)
+    }
+
+    /// Adopts one session into a worktree row and returns it, using a payload
+    /// that makes no `archived` claim so the adoption itself never files
+    /// anything.
+    private func adoptedRow(
+        _ m: RemoteProviderManager, sessionID: String = "a"
+    ) async throws -> Worktree {
+        try await m.apply(snapshot: [session(sessionID, archived: nil)], provider: "fake")
+        return try #require(
+            try await db.worktrees.findRemote(provider: "fake", sessionID: sessionID))
+    }
+
+    private func status(_ id: UUID) async throws -> WorktreeStatus? {
+        try await db.worktrees.get(id: id)?.status
+    }
+
+    private func mirrorState(_ sessionID: String) async throws -> String? {
+        try await db.remoteSessions.list().first { $0.sessionID == sessionID }?.state
+    }
+
+    private func actuationRows() throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: logPath, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    // MARK: - Both directions flip, and neither touches `state`
+
+    @Test("a provider reporting archived: true files the bound row, leaving state alone")
+    func archivedTrueFilesTheRow() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+        #expect(try await status(row.id) == .active)
+
+        try await m.apply(snapshot: [session("a", archived: true)], provider: "fake")
+
+        #expect(try await status(row.id) == .archived)
+        // Filing and liveness are separate axes: the mirror still reports the
+        // session running, because the sync never writes `state`.
+        #expect(try await mirrorState("a") == RemoteProcessState.running.rawValue)
+    }
+
+    @Test("a provider reporting archived: false returns the row, leaving state alone")
+    func archivedFalseReturnsTheRow() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+        try await db.worktrees.archive(id: row.id)
+        #expect(try await status(row.id) == .archived)
+
+        try await m.apply(snapshot: [session("a", archived: false)], provider: "fake")
+
+        #expect(try await status(row.id) == .active)
+        #expect(try await mirrorState("a") == RemoteProcessState.running.rawValue)
+    }
+
+    // MARK: - Gate 1: the provider must declare `archive`
+
+    /// Without this gate every provider with no archiving concept would carry
+    /// an implicit "not archived" on each snapshot (the contract reads an
+    /// absent field as `false`) and drag archived rows back into the active
+    /// list about once a minute, forever. Both directions are exercised, so a
+    /// sync that only ignored one of them still fails.
+    @Test("a provider that does not declare archive moves no row, whatever it reports")
+    func undeclaredArchiveCapabilityMovesNothing() async throws {
+        let m = await manager(declaring: ["stop", "unarchive"])
+        let active = try await adoptedRow(m, sessionID: "active-one")
+        let filed = try await adoptedRow(m, sessionID: "filed-one")
+        try await db.worktrees.archive(id: filed.id)
+
+        try await m.apply(
+            snapshot: [
+                session("active-one", archived: true),
+                session("filed-one", archived: false),
+            ],
+            provider: "fake")
+
+        #expect(try await status(active.id) == .active)
+        #expect(try await status(filed.id) == .archived)
+        #expect(try actuationRows().isEmpty)
+    }
+
+    // MARK: - Gate 2: the field must be present
+
+    /// Absent means no claim was made; explicit `false` is a claim. Display
+    /// still reads absent as `false` — only the sync abstains.
+    @Test("an absent archived field moves no row, while isArchived still reads false")
+    func absentArchivedMovesNothingButStillDisplaysAsNotArchived() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let active = try await adoptedRow(m, sessionID: "active-one")
+        let filed = try await adoptedRow(m, sessionID: "filed-one")
+        try await db.worktrees.archive(id: filed.id)
+
+        try await m.apply(
+            snapshot: [
+                session("active-one", archived: nil),
+                session("filed-one", archived: nil),
+            ],
+            provider: "fake")
+
+        #expect(try await status(active.id) == .active)
+        #expect(try await status(filed.id) == .archived)
+        #expect(try actuationRows().isEmpty)
+
+        let mirrored = try await db.remoteSessions.list()
+        #expect(mirrored.count == 2)
+        for row in mirrored {
+            let payload = try #require(row.decodedPayload)
+            #expect(payload.archived == nil)
+            #expect(payload.isArchived == false)
+        }
+    }
+
+    // MARK: - A local row takes its status from TBD alone
+
+    @Test("a local worktree is never moved by any provider report")
+    func aLocalWorktreeIsNeverMoved() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let local = try await db.worktrees.create(
+            repoID: repo.id, name: "local-lane", branch: "local-branch",
+            path: "/tmp/local-lane-\(UUID().uuidString)", tmuxServer: "tbd-test")
+
+        // The provider names the local row outright, echoing its id back the
+        // way a TBD-created session does, and claims it is archived.
+        try await m.apply(
+            snapshot: [
+                session(
+                    "a", archived: true,
+                    meta: ["repo": "acme/api", "tbd_worktree_id": local.id.uuidString])
+            ],
+            provider: "fake")
+
+        #expect(try await status(local.id) == .active)
+        // …and the run did move something, so a sync that moved nothing at
+        // all cannot pass this by doing nothing.
+        let adopted = try #require(try await db.worktrees.findRemote(provider: "fake", sessionID: "a"))
+        #expect(adopted.id != local.id)
+        #expect(try await status(adopted.id) == .archived)
+    }
+
+    // MARK: - The stale-snapshot watermark, both directions
+
+    @Test("a response whose request began before a local archive does not reverse it")
+    func staleResponseDoesNotUndoALocalArchive() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+        let requestStartedAt = Date(timeIntervalSince1970: 1_000)
+        // The user archives while that `list` is still in flight.
+        try await db.worktrees.archive(id: row.id)
+        await m.noteFilingDecision(worktreeID: row.id, at: Date(timeIntervalSince1970: 1_001))
+
+        try await m.apply(
+            snapshot: [session("a", archived: false)], provider: "fake",
+            now: Date(timeIntervalSince1970: 1_002), requestStartedAt: requestStartedAt)
+
+        #expect(try await status(row.id) == .archived)
+    }
+
+    @Test("a response whose request began before a local revive does not re-file it")
+    func staleResponseDoesNotUndoALocalRevive() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+        let requestStartedAt = Date(timeIntervalSince1970: 1_000)
+        // The row is active because the user just revived it, mid-flight.
+        await m.noteFilingDecision(worktreeID: row.id, at: Date(timeIntervalSince1970: 1_001))
+
+        try await m.apply(
+            snapshot: [session("a", archived: true)], provider: "fake",
+            now: Date(timeIntervalSince1970: 1_002), requestStartedAt: requestStartedAt)
+
+        #expect(try await status(row.id) == .active)
+    }
+
+    @Test("a response whose request began after the local decision does apply, both directions")
+    func freshResponseAppliesInBothDirections() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let toFile = try await adoptedRow(m, sessionID: "to-file")
+        let toReturn = try await adoptedRow(m, sessionID: "to-return")
+        try await db.worktrees.archive(id: toReturn.id)
+        await m.noteFilingDecision(worktreeID: toFile.id, at: Date(timeIntervalSince1970: 1_000))
+        await m.noteFilingDecision(worktreeID: toReturn.id, at: Date(timeIntervalSince1970: 1_000))
+
+        try await m.apply(
+            snapshot: [
+                session("to-file", archived: true),
+                session("to-return", archived: false),
+            ],
+            provider: "fake",
+            now: Date(timeIntervalSince1970: 1_002),
+            requestStartedAt: Date(timeIntervalSince1970: 1_001))
+
+        #expect(try await status(toFile.id) == .archived)
+        #expect(try await status(toReturn.id) == .active)
+    }
+
+    /// `pollOnce` must stamp the request start BEFORE it asks the provider
+    /// anything. The invoker files the row locally while its `list` call is
+    /// still outstanding, so a manager that stamped arrival time instead
+    /// would treat the decision as older than the response and hand the row
+    /// straight back to the active list.
+    @Test("pollOnce stamps the request start before invoking the provider")
+    func pollOnceStampsRequestStartBeforeTheCall() async throws {
+        let row = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote-a", branch: "b", provider: "fake", sessionID: "a")
+        let invoker = MidCallFilingInvoker(
+            script: [
+                describeDeclaring(["archive", "unarchive"]),
+                providerOK(#"{"sessions": [{"id": "a", "state": "running", "archived": false}]}"#),
+            ])
+        let m = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: ActuationLog(path: logPath))
+        await m.loadRegistryAndDescribe()
+        invoker.onListCall = { [db] in
+            try? await db.worktrees.archive(id: row.id)
+            await m.noteFilingDecision(worktreeID: row.id, at: Date())
+        }
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        #expect(try await status(row.id) == .archived)
+    }
+
+    // MARK: - The sweep
+
+    @Test("the sweep drops watermarks older than two poll intervals")
+    func sweepDropsStaleWatermarks() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let now = Date(timeIntervalSince1970: 10_000)
+        let fresh = UUID()
+        let stale = UUID()
+        await m.noteFilingDecision(
+            worktreeID: fresh, at: now.addingTimeInterval(-2 * RemoteProviderManager.pollInterval + 1))
+        await m.noteFilingDecision(
+            worktreeID: stale, at: now.addingTimeInterval(-2 * RemoteProviderManager.pollInterval - 1))
+
+        try await m.apply(snapshot: [], provider: "fake", now: now, requestStartedAt: now)
+
+        #expect(await m.filingDecision(for: fresh) != nil)
+        #expect(await m.filingDecision(for: stale) == nil)
+    }
+
+    // MARK: - Never silent
+
+    @Test("a sync-driven archive writes a notification record and an actuation row")
+    func syncDrivenArchiveIsNeverSilent() async throws {
+        let m = await manager(declaring: ["archive", "unarchive"])
+        let row = try await adoptedRow(m)
+
+        try await m.apply(snapshot: [session("a", archived: true)], provider: "fake")
+
+        let notifications = try await db.notifications.unread(worktreeID: row.id)
+        #expect(notifications.count == 1)
+        #expect(notifications.first?.message?.contains("Archived") == true)
+
+        let rows = try actuationRows()
+        let request = try #require(rows.first { $0["kind"] as? String == "dispose" })
+        #expect((request["actor"] as? [String: Any])?["rail"] as? String == "remote-filing-sync")
+        #expect((request["target"] as? [String: Any])?["worktree"] as? String == row.id.uuidString)
+        #expect(request["method"] == nil)
+        let requestID = try #require(request["id"] as? String)
+        let outcome = try #require(rows.first { $0["confirms"] as? String == requestID })
+        #expect(outcome["result"] as? String == "dispatched")
+    }
+}
+
+/// A provider invoker that runs a caller-supplied action in the middle of its
+/// `list` call — the only way to construct "a local filing decision made while
+/// this request was outstanding" without sleeping.
+private final class MidCallFilingInvoker: RemoteProviderInvoking, @unchecked Sendable {
+    private let lock = NSLock()
+    private var script: [ProviderResult]
+    /// Runs after `list` is asked for and before its result is returned.
+    var onListCall: (@Sendable () async -> Void)?
+
+    init(script: [ProviderResult]) {
+        self.script = script
+    }
+
+    func run(
+        _ config: RemoteProviderConfig, verb: [String], stdin: Data?, timeout: TimeInterval
+    ) async throws -> ProviderResult {
+        if verb.first == "list", let onListCall {
+            await onListCall()
+        }
+        return pop()
+    }
+
+    private func pop() -> ProviderResult {
+        lock.lock()
+        defer { lock.unlock() }
+        precondition(!script.isEmpty, "MidCallFilingInvoker script exhausted")
+        return script.removeFirst()
+    }
+}

--- a/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
+++ b/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
@@ -442,6 +442,83 @@ struct RemoteFilingSyncTests {
             "the sync carried out a decision that had gone stale: \(outcome)")
     }
 
+    /// The recheck's vocabulary has to stay faithful. A row that reached the
+    /// flip's own target is an idempotent no-op — somebody did exactly this.
+    /// A row that moved to `failed` (or `main`, or `creating`) is not: the
+    /// sync may not file it at all, and `noop` would put "already done" in the
+    /// record over a row that was never eligible.
+    @Test("a row that became ineligible mid-sync is recorded not-eligible, not noop")
+    func ineligibleRowMidSyncIsNotRecordedAsANoop() async throws {
+        let handshake = MidAppendHandshake()
+        let log = ActuationLog(
+            path: logPath, now: { Date() },
+            syscalls: ActuationLogSyscalls(
+                write: { descriptor, buffer, count in
+                    handshake.pauseOnFirstWrite()
+                    return Foundation.write(descriptor, buffer, count)
+                },
+                fsync: { Foundation.fsync($0) }))
+        let m = await manager(declaring: ["archive", "unarchive"], log: log)
+        let row = try await adoptedRow(m)
+
+        let gesture = Task { [db] in
+            await handshake.awaitSyncAtRecord()
+            try? await db.worktrees.updateStatus(id: row.id, status: .failed)
+            handshake.releaseSync()
+        }
+
+        try await m.apply(
+            snapshot: [session("a", archived: true)], provider: "fake",
+            now: Date(timeIntervalSince1970: 2_001),
+            requestStartedAt: Date(timeIntervalSince1970: 2_000))
+        await gesture.value
+
+        #expect(try await status(row.id) == .failed, "the sync filed a row it may not touch")
+        let rows = try actuationRows()
+        let request = try #require(rows.first { $0["kind"] as? String == "dispose" })
+        let requestID = try #require(request["id"] as? String)
+        let outcome = try #require(rows.first { $0["confirms"] as? String == requestID })
+        #expect(outcome["result"] as? String == "refused")
+        #expect(
+            outcome["reason"] as? String == "not-eligible",
+            "an ineligible row was recorded as an idempotent no-op: \(outcome)")
+    }
+
+    /// The other arm, so the mapping discriminates: a row somebody else filed
+    /// to the flip's own target really is a no-op.
+    @Test("a row already at the flip's target is recorded noop")
+    func alreadyFiledRowIsRecordedNoop() async throws {
+        let handshake = MidAppendHandshake()
+        let log = ActuationLog(
+            path: logPath, now: { Date() },
+            syscalls: ActuationLogSyscalls(
+                write: { descriptor, buffer, count in
+                    handshake.pauseOnFirstWrite()
+                    return Foundation.write(descriptor, buffer, count)
+                },
+                fsync: { Foundation.fsync($0) }))
+        let m = await manager(declaring: ["archive", "unarchive"], log: log)
+        let row = try await adoptedRow(m)
+
+        let gesture = Task { [db] in
+            await handshake.awaitSyncAtRecord()
+            try? await db.worktrees.archive(id: row.id)
+            handshake.releaseSync()
+        }
+
+        try await m.apply(
+            snapshot: [session("a", archived: true)], provider: "fake",
+            now: Date(timeIntervalSince1970: 2_001),
+            requestStartedAt: Date(timeIntervalSince1970: 2_000))
+        await gesture.value
+
+        let rows = try actuationRows()
+        let request = try #require(rows.first { $0["kind"] as? String == "dispose" })
+        let requestID = try #require(request["id"] as? String)
+        let outcome = try #require(rows.first { $0["confirms"] as? String == requestID })
+        #expect(outcome["reason"] as? String == "noop", "\(outcome)")
+    }
+
     // MARK: - The two events paths
 
     /// A pushed `session` line is fresh by construction — the provider wrote it

--- a/Tests/TBDDaemonTests/RemoteLaneArchiveTestSupport.swift
+++ b/Tests/TBDDaemonTests/RemoteLaneArchiveTestSupport.swift
@@ -1,0 +1,132 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Shared fixture for the remote halves of `worktree.archive`,
+/// `worktree.revive` and the auto-archive-on-merge rail
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md`). Tier 2:
+/// in-memory GRDB, dry-run tmux, a real actuation log in a temp directory,
+/// and a scripted fake provider invoker — no subprocess, no network, no
+/// `TBD_HOME`.
+///
+/// One fixture rather than three copies, because every one of these tests
+/// asks the same two questions of the same wiring: which provider verbs ran,
+/// and what landed in the record.
+struct RemoteLaneFixture {
+    let db: TBDDatabase
+    let subscriptions: StateSubscriptionManager
+    let manager: RemoteProviderManager
+    let invoker: FakeProviderInvoker
+    let logPath: String
+    let repo: Repo
+    private let dir: URL
+
+    /// - Parameters:
+    ///   - capabilities: what the provider's `describe` declares.
+    ///   - verbs: canned results for the verb calls that follow `describe`,
+    ///     in order. Empty means the test expects no verb to be invoked —
+    ///     the invoker's script is then exhausted and any call trips its
+    ///     `precondition`, which is a stronger statement than an assertion
+    ///     after the fact.
+    static func make(
+        capabilities: [String], verbs: [ProviderResult] = [], tag: String
+    ) async throws -> RemoteLaneFixture {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteBackendsEnabled(true)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-\(tag)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let registryURL = dir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+
+        let caps = capabilities.map { "\"\($0)\"" }.joined(separator: ", ")
+        let describe = providerOK(
+            #"{"contract_versions": [1], "name": "fake", "capabilities": [\#(caps)]}"#)
+        let invoker = FakeProviderInvoker(script: [describe] + verbs)
+        let subscriptions = StateSubscriptionManager()
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subscriptions, runner: invoker, registryURL: registryURL)
+        await manager.loadRegistryAndDescribe()
+
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        return RemoteLaneFixture(
+            db: db, subscriptions: subscriptions, manager: manager, invoker: invoker,
+            logPath: dir.appendingPathComponent("actuations.jsonl").path,
+            repo: repo, dir: dir)
+    }
+
+    func router() -> RPCRouter {
+        let tmux = TmuxManager(dryRun: true)
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                subscriptions: subscriptions),
+            tmux: tmux,
+            startTime: Date(),
+            subscriptions: subscriptions,
+            remoteManager: manager,
+            actuationLog: ActuationLog(path: logPath))
+    }
+
+    func coordinator() -> AutoArchiveOnMergeCoordinator {
+        AutoArchiveOnMergeCoordinator(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver(), subscriptions: subscriptions),
+            subscriptions: subscriptions,
+            actuationLog: ActuationLog(path: logPath),
+            remoteManager: manager)
+    }
+
+    /// A remote worktree row plus the mirror row it is bound to, so the
+    /// routing can read the provider's own report about the session.
+    @discardableResult
+    func seedLane(
+        sessionID: String = "sess-1",
+        name: String = "acme-remote",
+        status: WorktreeStatus = .active,
+        state: RemoteProcessState = .running,
+        agentState: RemoteAgentState = .idle,
+        meta: [String: String]? = nil,
+        archived: Bool? = nil,
+        gone: Bool = false
+    ) async throws -> Worktree {
+        let worktree = try await db.worktrees.createRemote(
+            repoID: repo.id, name: name, branch: "acme-branch",
+            provider: "fake", sessionID: sessionID, status: status)
+        _ = try await db.remoteSessions.upsertOne(
+            provider: "fake",
+            session: RemoteSessionPayload(
+                id: sessionID, state: state, agentState: agentState,
+                meta: meta, archived: archived),
+            now: Date())
+        if gone {
+            try await db.remoteSessions.markGone(provider: "fake", sessionID: sessionID)
+        }
+        return worktree
+    }
+
+    /// Every actuation row written so far, decoded.
+    func actuationRows() throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: logPath, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    func status(of worktree: Worktree) async throws -> WorktreeStatus? {
+        try await db.worktrees.get(id: worktree.id)?.status
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: dir)
+    }
+}

--- a/Tests/TBDDaemonTests/RemoteLaneArchiveTestSupport.swift
+++ b/Tests/TBDDaemonTests/RemoteLaneArchiveTestSupport.swift
@@ -20,6 +20,12 @@ struct RemoteLaneFixture {
     let manager: RemoteProviderManager
     let invoker: FakeProviderInvoker
     let logPath: String
+    /// The ONE actuation log, shared by the manager, the router and the merge
+    /// coordinator exactly as `Daemon.swift` shares it. Wiring it into the
+    /// manager is what makes the filing sync live here: a fixture that left
+    /// the manager's log nil would fail the sync closed and hide every way a
+    /// verb path can re-enter it.
+    let actuationLog: ActuationLog
     let repo: Repo
     private let dir: URL
 
@@ -47,16 +53,18 @@ struct RemoteLaneFixture {
             #"{"contract_versions": [1], "name": "fake", "capabilities": [\#(caps)]}"#)
         let invoker = FakeProviderInvoker(script: [describe] + verbs)
         let subscriptions = StateSubscriptionManager()
+        let logPath = dir.appendingPathComponent("actuations.jsonl").path
+        let actuationLog = ActuationLog(path: logPath)
         let manager = RemoteProviderManager(
-            db: db, subscriptions: subscriptions, runner: invoker, registryURL: registryURL)
+            db: db, subscriptions: subscriptions, runner: invoker, registryURL: registryURL,
+            actuationLog: actuationLog)
         await manager.loadRegistryAndDescribe()
 
         let repo = try await db.repos.create(
             path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
         return RemoteLaneFixture(
             db: db, subscriptions: subscriptions, manager: manager, invoker: invoker,
-            logPath: dir.appendingPathComponent("actuations.jsonl").path,
-            repo: repo, dir: dir)
+            logPath: logPath, actuationLog: actuationLog, repo: repo, dir: dir)
     }
 
     func router() -> RPCRouter {
@@ -70,7 +78,7 @@ struct RemoteLaneFixture {
             startTime: Date(),
             subscriptions: subscriptions,
             remoteManager: manager,
-            actuationLog: ActuationLog(path: logPath))
+            actuationLog: actuationLog)
     }
 
     func coordinator() -> AutoArchiveOnMergeCoordinator {
@@ -80,7 +88,7 @@ struct RemoteLaneFixture {
                 db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
                 hooks: HookResolver(), subscriptions: subscriptions),
             subscriptions: subscriptions,
-            actuationLog: ActuationLog(path: logPath),
+            actuationLog: actuationLog,
             remoteManager: manager)
     }
 
@@ -125,6 +133,32 @@ struct RemoteLaneFixture {
     func status(of worktree: Worktree) async throws -> WorktreeStatus? {
         try await db.worktrees.get(id: worktree.id)?.status
     }
+
+    /// Notifications recorded against this lane. A verb-path archive must
+    /// produce none: the user watched themselves retire it, and a "the
+    /// provider reports this session retired" note would be a false claim.
+    func notifications(for worktree: Worktree) async throws -> [TBDNotification] {
+        try await db.notifications.unread(worktreeID: worktree.id)
+    }
+
+    /// Puts the provider's cached inventory into the state the mutation gate
+    /// reads as stale: one accepted full inventory (which stamps the persisted
+    /// freshness row) followed by a failing poll (which moves health off
+    /// `.ok`). `isStaleSnapshot` needs both, and fails open on either alone.
+    ///
+    /// Consumes ONE scripted verb result — the failing `list` — so callers
+    /// script it. The empty inventory leaves already-seeded mirror rows in
+    /// place: one absence is not two, so nothing is marked gone.
+    func markSnapshotStale() async throws {
+        try await manager.apply(snapshot: [], provider: "fake")
+        await manager.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/nonexistent"))
+    }
+
+    /// A canned failing `list`, for `markSnapshotStale`'s poll.
+    static let failingList = ProviderResult(
+        exitCode: 1,
+        stdout: Data(#"{"error": {"code": "unreachable", "message": "host is down"}}"#.utf8),
+        stderr: "")
 
     func cleanup() {
         try? FileManager.default.removeItem(at: dir)

--- a/Tests/TBDDaemonTests/RemoteLaneArchiveTestSupport.swift
+++ b/Tests/TBDDaemonTests/RemoteLaneArchiveTestSupport.swift
@@ -81,6 +81,13 @@ struct RemoteLaneFixture {
             actuationLog: actuationLog)
     }
 
+    /// The lane lifecycle the router and the merge rail both build, for tests
+    /// that need to drive `performArchive`/`performRevive` with an injected
+    /// clock rather than through an RPC that supplies its own.
+    func lanes() -> RemoteLaneLifecycle {
+        RemoteLaneLifecycle(db: db, subscriptions: subscriptions, manager: manager)
+    }
+
     func coordinator() -> AutoArchiveOnMergeCoordinator {
         AutoArchiveOnMergeCoordinator(
             db: db,

--- a/Tests/TBDDaemonTests/RemoteLaneLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/RemoteLaneLifecycleTests.swift
@@ -184,6 +184,40 @@ struct RemoteLaneLifecycleTests {
         #expect(plan == .rowOnly)
     }
 
+    // MARK: - The dirty-checkout claim, read out of `meta`
+
+    /// `meta` is a flat string-to-string map, so the claim arrives as text and
+    /// the contract names exactly two spellings — `"true"` and `"1"`, trimmed
+    /// and case-insensitively. Each arm of that reading is pinned: drop the
+    /// `"1"` case, the trim, or the lowercasing and one of these goes red.
+    @Test("only the contract's two spellings are read as a dirty-checkout claim")
+    func dirtyWorkspaceReadingIsExactlyTheContractsTwoSpellings() {
+        let claims = ["true", "1", "TRUE", "True", " true ", "\t1\n", "  TRUE  "]
+        for raw in claims {
+            #expect(
+                RemoteLaneLifecycle.metaReportsDirtyWorkspace(
+                    [RemoteLaneLifecycle.dirtyWorkspaceMetaKey: raw]),
+                "\(raw.debugDescription) should be read as a claim")
+        }
+    }
+
+    /// Everything else is silence, deliberately: this value decides whether a
+    /// user's archive is refused, and inventing a claim out of a string the
+    /// provider meant for display would block a gesture nobody asked to block.
+    @Test("no other value is read as a dirty-checkout claim")
+    func dirtyWorkspaceReadingRejectsEverythingElse() {
+        let nonClaims = ["", " ", "yes", "y", "on", "0", "false", "dirty", "2", "true-ish", "1.0"]
+        for raw in nonClaims {
+            #expect(
+                !RemoteLaneLifecycle.metaReportsDirtyWorkspace(
+                    [RemoteLaneLifecycle.dirtyWorkspaceMetaKey: raw]),
+                "\(raw.debugDescription) should not be read as a claim")
+        }
+        #expect(!RemoteLaneLifecycle.metaReportsDirtyWorkspace(nil))
+        #expect(!RemoteLaneLifecycle.metaReportsDirtyWorkspace([:]))
+        #expect(!RemoteLaneLifecycle.metaReportsDirtyWorkspace(["repo": "acme/api"]))
+    }
+
     // MARK: - Global negative property
 
     @Test("no plan anywhere ever invokes or references stop")

--- a/Tests/TBDDaemonTests/RemoteLaneLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/RemoteLaneLifecycleTests.swift
@@ -1,0 +1,230 @@
+import Testing
+@testable import TBDDaemonLib
+
+/// Pure decision-function tests for `RemoteLaneLifecycle`
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md`, "Archive" and
+/// "Revive"). No fixtures, no stub provider, no `TBD_HOME` — these are plain
+/// functions over a capability set and a boolean.
+@Suite("RemoteLaneLifecycle")
+struct RemoteLaneLifecycleTests {
+    // MARK: - Archive
+
+    @Test("archive: declares archive -> invokeVerb, regardless of isGone")
+    func archiveDeclaresArchiveInvokesVerb() {
+        for isGone in [false, true] {
+            let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["archive"], isGone: isGone)
+            #expect(plan == .invokeVerb)
+        }
+    }
+
+    @Test("archive: declares archive+stop -> invokeVerb, regardless of isGone")
+    func archiveDeclaresArchiveAndStopInvokesVerb() {
+        for isGone in [false, true] {
+            let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["archive", "stop"], isGone: isGone)
+            #expect(plan == .invokeVerb)
+        }
+    }
+
+    @Test("archive: declares archive+unarchive -> invokeVerb, regardless of isGone")
+    func archiveDeclaresArchiveAndUnarchiveInvokesVerb() {
+        for isGone in [false, true] {
+            let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["archive", "unarchive"], isGone: isGone)
+            #expect(plan == .invokeVerb)
+        }
+    }
+
+    @Test("archive: ordering — declaring archive wins over a gone row (not rowOnlyGone)")
+    func archiveOrderingArchiveBeatsGone() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["archive"], isGone: true)
+        #expect(plan == .invokeVerb)
+        if case .rowOnlyGone = plan {
+            Issue.record("expected invokeVerb to win over rowOnlyGone when archive is declared")
+        }
+    }
+
+    @Test("archive: no capabilities, gone -> rowOnlyGone")
+    func archiveNoCapabilitiesGoneRowOnlyGone() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: [], isGone: true)
+        #expect(plan == .rowOnlyGone)
+    }
+
+    @Test("archive: unarchive only, gone -> rowOnlyGone")
+    func archiveUnarchiveOnlyGoneRowOnlyGone() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["unarchive"], isGone: true)
+        #expect(plan == .rowOnlyGone)
+    }
+
+    @Test("archive: unrelated capabilities, gone -> rowOnlyGone")
+    func archiveUnrelatedCapabilitiesGoneRowOnlyGone() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["log", "send", "attach"], isGone: true)
+        #expect(plan == .rowOnlyGone)
+    }
+
+    @Test("archive: no capabilities, not gone -> refused")
+    func archiveNoCapabilitiesNotGoneRefused() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: [], isGone: false)
+        guard case .refused(let message) = plan else {
+            Issue.record("expected refused, got \(plan)")
+            return
+        }
+        #expect(message.contains("archive"))
+        #expect(message.contains("docs/remote-provider-contract.md"))
+    }
+
+    @Test("archive: stop only, not gone -> refused, and stop is never the reason")
+    func archiveStopOnlyNotGoneRefused() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["stop"], isGone: false)
+        guard case .refused(let message) = plan else {
+            Issue.record("expected refused for a provider declaring only stop, got \(plan)")
+            return
+        }
+        #expect(message.contains("archive"))
+        // The single most important negative property: stop is never
+        // substituted for a missing archive, and never named as if it were
+        // the fix.
+        #expect(!message.contains("stop"))
+    }
+
+    @Test("archive: stop only, gone -> rowOnlyGone (still not invokeVerb, stop is irrelevant)")
+    func archiveStopOnlyGoneRowOnlyGone() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["stop"], isGone: true)
+        #expect(plan == .rowOnlyGone)
+    }
+
+    @Test("archive: unrelated capabilities, not gone -> refused")
+    func archiveUnrelatedCapabilitiesNotGoneRefused() {
+        let plan = RemoteLaneLifecycle.archivePlan(capabilities: ["log", "send", "attach"], isGone: false)
+        guard case .refused(let message) = plan else {
+            Issue.record("expected refused, got \(plan)")
+            return
+        }
+        #expect(message.contains("archive"))
+    }
+
+    // MARK: - Revive
+
+    @Test("revive: declares unarchive -> invokeUnarchive, regardless of providerReportsArchived")
+    func reviveDeclaresUnarchiveInvokesUnarchive() {
+        for archived in [false, true] {
+            let plan = RemoteLaneLifecycle.revivePlan(capabilities: ["unarchive"], providerReportsArchived: archived)
+            #expect(plan == .invokeUnarchive)
+        }
+    }
+
+    @Test("revive: declares archive+unarchive -> invokeUnarchive, regardless of providerReportsArchived")
+    func reviveDeclaresArchiveAndUnarchiveInvokesUnarchive() {
+        for archived in [false, true] {
+            let plan = RemoteLaneLifecycle.revivePlan(
+                capabilities: ["archive", "unarchive"],
+                providerReportsArchived: archived
+            )
+            #expect(plan == .invokeUnarchive)
+        }
+    }
+
+    @Test("revive: no capabilities, providerReportsArchived false -> rowOnly (anti-stranding)")
+    func reviveNoCapabilitiesNotArchivedRowOnly() {
+        let plan = RemoteLaneLifecycle.revivePlan(capabilities: [], providerReportsArchived: false)
+        #expect(plan == .rowOnly)
+    }
+
+    @Test("revive: archive only, providerReportsArchived true -> refusedNoUnarchive")
+    func reviveArchiveOnlyArchivedRefused() {
+        let plan = RemoteLaneLifecycle.revivePlan(capabilities: ["archive"], providerReportsArchived: true)
+        guard case .refusedNoUnarchive(let message) = plan else {
+            Issue.record("expected refusedNoUnarchive, got \(plan)")
+            return
+        }
+        #expect(message.contains("unarchive"))
+        #expect(message.contains("docs/remote-provider-contract.md"))
+    }
+
+    @Test("revive: archive only, providerReportsArchived false -> rowOnly")
+    func reviveArchiveOnlyNotArchivedRowOnly() {
+        let plan = RemoteLaneLifecycle.revivePlan(capabilities: ["archive"], providerReportsArchived: false)
+        #expect(plan == .rowOnly)
+    }
+
+    @Test("revive: stop only, providerReportsArchived true -> refusedNoUnarchive, and stop is never the reason")
+    func reviveStopOnlyArchivedRefused() {
+        let plan = RemoteLaneLifecycle.revivePlan(capabilities: ["stop"], providerReportsArchived: true)
+        guard case .refusedNoUnarchive(let message) = plan else {
+            Issue.record("expected refusedNoUnarchive, got \(plan)")
+            return
+        }
+        #expect(message.contains("unarchive"))
+        #expect(!message.contains("stop"))
+    }
+
+    @Test("revive: stop only, providerReportsArchived false -> rowOnly")
+    func reviveStopOnlyNotArchivedRowOnly() {
+        let plan = RemoteLaneLifecycle.revivePlan(capabilities: ["stop"], providerReportsArchived: false)
+        #expect(plan == .rowOnly)
+    }
+
+    @Test("revive: unrelated capabilities, providerReportsArchived true -> refusedNoUnarchive")
+    func reviveUnrelatedCapabilitiesArchivedRefused() {
+        let plan = RemoteLaneLifecycle.revivePlan(
+            capabilities: ["log", "send", "attach"],
+            providerReportsArchived: true
+        )
+        guard case .refusedNoUnarchive(let message) = plan else {
+            Issue.record("expected refusedNoUnarchive, got \(plan)")
+            return
+        }
+        #expect(message.contains("unarchive"))
+    }
+
+    @Test("revive: unrelated capabilities, providerReportsArchived false -> rowOnly")
+    func reviveUnrelatedCapabilitiesNotArchivedRowOnly() {
+        let plan = RemoteLaneLifecycle.revivePlan(
+            capabilities: ["log", "send", "attach"],
+            providerReportsArchived: false
+        )
+        #expect(plan == .rowOnly)
+    }
+
+    // MARK: - Global negative property
+
+    @Test("no plan anywhere ever invokes or references stop")
+    func stopIsNeverInvokedAcrossFullPowerset() {
+        // Exhaustive over the capability powerset the spec calls out, crossed
+        // with every relevant boolean. Nowhere does "stop" appearing in the
+        // capability set change the outcome relative to it being absent,
+        // and no refusal message ever names "stop".
+        let capabilitySets: [Set<String>] = [
+            [],
+            ["stop"],
+            ["archive"],
+            ["archive", "stop"],
+            ["archive", "unarchive"],
+            ["unarchive"],
+            ["log", "send", "attach"],
+        ]
+
+        for capabilities in capabilitySets {
+            let withoutStop = capabilities.subtracting(["stop"])
+
+            for isGone in [false, true] {
+                let plan = RemoteLaneLifecycle.archivePlan(capabilities: capabilities, isGone: isGone)
+                let planWithoutStop = RemoteLaneLifecycle.archivePlan(capabilities: withoutStop, isGone: isGone)
+                #expect(plan == planWithoutStop)
+                if case .refused(let message) = plan {
+                    #expect(!message.contains("stop"))
+                }
+            }
+
+            for archived in [false, true] {
+                let plan = RemoteLaneLifecycle.revivePlan(capabilities: capabilities, providerReportsArchived: archived)
+                let planWithoutStop = RemoteLaneLifecycle.revivePlan(
+                    capabilities: withoutStop,
+                    providerReportsArchived: archived
+                )
+                #expect(plan == planWithoutStop)
+                if case .refusedNoUnarchive(let message) = plan {
+                    #expect(!message.contains("stop"))
+                }
+            }
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/RemoteLaneWatermarkTests.swift
+++ b/Tests/TBDDaemonTests/RemoteLaneWatermarkTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The stale-snapshot watermark, from the gesture side
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Stale snapshots").
+///
+/// Tier 1: in-memory GRDB, a scripted fake provider, a real actuation log in a
+/// temp directory, and every timestamp passed in explicitly. Nothing sleeps —
+/// the rule under test is an ordering between `Date`s, and wall time would
+/// only make it slower and flakier.
+///
+/// The property these tests exist for: **a gesture's watermark must cover the
+/// moment its row was written, not the moment the gesture began.** A verb takes
+/// real time, and a poll launched during it carries the provider's pre-gesture
+/// word; a watermark stamped only at the start lets that response through the
+/// gate and reverses the row the user just filed.
+@Suite("Remote lane filing watermark")
+struct RemoteLaneWatermarkTests {
+
+    /// A `now` seam that hands out the given instants in order, then repeats
+    /// the last one. Deliberately explicit rather than a monotonic `Date()`:
+    /// the assertion is *which* instant was recorded, and a real clock cannot
+    /// tell the pre-verb stamp from the post-write one.
+    private final class Instants: @unchecked Sendable {
+        private let values: [Date]
+        private var index = 0
+        private let lock = NSLock()
+        init(_ values: [Date]) { self.values = values }
+        var next: @Sendable () -> Date {
+            { [self] in
+                lock.lock()
+                defer { lock.unlock() }
+                let value = values[min(index, values.count - 1)]
+                index += 1
+                return value
+            }
+        }
+    }
+
+    private static func at(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: 1_000_000 + seconds)
+    }
+
+    private static let archived = providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)
+    private static let unarchived = providerOK(#"{"id": "sess-1", "state": "running", "archived": false}"#)
+    private static let unreachable = ProviderResult(
+        exitCode: 1,
+        stdout: Data(#"{"error": {"code": "unreachable", "message": "host is down"}}"#.utf8),
+        stderr: "")
+
+    // MARK: - The gesture paths re-stamp after the row write
+
+    @Test("archive stamps the watermark again once the row is written")
+    func archiveRestampsAfterTheRowWrite() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], verbs: [Self.archived], tag: "watermark-archive-restamp")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        // Gesture at T0; the verb runs; the row lands at T10.
+        let clock = Instants([Self.at(0), Self.at(10), Self.at(11)])
+
+        let failure = try await fixture.lanes().performArchive(
+            .invokeVerb(provider: "fake", sessionID: "sess-1"), worktree: lane, now: clock.next)
+
+        #expect(failure == nil)
+        #expect(try await fixture.status(of: lane) == .archived)
+        let recorded = try #require(await fixture.manager.filingDecision(for: lane.id))
+        #expect(
+            recorded == Self.at(10),
+            "the watermark stopped at the gesture's start, so a poll launched during the verb still passes the gate")
+    }
+
+    @Test("revive stamps the watermark again once the row is written")
+    func reviveRestampsAfterTheRowWrite() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"], verbs: [Self.unarchived],
+            tag: "watermark-revive-restamp")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+        let clock = Instants([Self.at(0), Self.at(10), Self.at(11)])
+
+        let failure = try await fixture.lanes().performRevive(
+            .invokeUnarchive(provider: "fake", sessionID: "sess-1"), worktree: lane, now: clock.next)
+
+        #expect(failure == nil)
+        #expect(try await fixture.status(of: lane) == .active)
+        let recorded = try #require(await fixture.manager.filingDecision(for: lane.id))
+        #expect(recorded == Self.at(10))
+    }
+
+    /// The scenario in full, with the sync driven for real: the user archives
+    /// at T0, a poll launched at T5 (while the verb was still running) returns
+    /// the provider's pre-archive `archived: false`, and lands at T20. Only a
+    /// watermark covering the row write at T10 refuses it.
+    @Test("a poll launched during the archive verb cannot un-file the row")
+    func pollLaunchedDuringTheVerbDoesNotUnfileTheRow() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], verbs: [Self.archived], tag: "watermark-archive-race")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        let clock = Instants([Self.at(0), Self.at(10), Self.at(11)])
+
+        _ = try await fixture.lanes().performArchive(
+            .invokeVerb(provider: "fake", sessionID: "sess-1"), worktree: lane, now: clock.next)
+        #expect(try await fixture.status(of: lane) == .archived)
+
+        try await fixture.manager.apply(
+            snapshot: [RemoteSessionPayload(id: "sess-1", state: .running, archived: false)],
+            provider: "fake", now: Self.at(20), requestStartedAt: Self.at(5))
+
+        #expect(
+            try await fixture.status(of: lane) == .archived,
+            "the stale poll returned the row the user just archived")
+    }
+
+    /// The mirror image: revive at T0, a poll launched at T5 carrying the
+    /// provider's pre-revive `archived: true`, arriving at T20.
+    @Test("a poll launched during the unarchive verb cannot re-file the row")
+    func pollLaunchedDuringTheVerbDoesNotRefileTheRow() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"], verbs: [Self.unarchived],
+            tag: "watermark-revive-race")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+        let clock = Instants([Self.at(0), Self.at(10), Self.at(11)])
+
+        _ = try await fixture.lanes().performRevive(
+            .invokeUnarchive(provider: "fake", sessionID: "sess-1"), worktree: lane, now: clock.next)
+        #expect(try await fixture.status(of: lane) == .active)
+
+        try await fixture.manager.apply(
+            snapshot: [RemoteSessionPayload(id: "sess-1", state: .running, archived: true)],
+            provider: "fake", now: Self.at(20), requestStartedAt: Self.at(5))
+
+        #expect(
+            try await fixture.status(of: lane) == .active,
+            "the stale poll re-filed the row the user just revived")
+    }
+
+    // MARK: - The map is monotonic
+
+    @Test("an older instant never displaces a newer watermark")
+    func noteIsMonotonic() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "watermark-monotonic")
+        defer { fixture.cleanup() }
+        let id = UUID()
+
+        await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(20))
+        await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(5))
+
+        #expect(
+            await fixture.manager.filingDecision(for: id) == Self.at(20),
+            "a late-arriving older stamp moved the watermark backwards")
+    }
+
+    @Test("a newer instant still advances the watermark")
+    func noteAdvances() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "watermark-advance")
+        defer { fixture.cleanup() }
+        let id = UUID()
+
+        await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(5))
+        await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(20))
+
+        #expect(await fixture.manager.filingDecision(for: id) == Self.at(20))
+    }
+
+    // MARK: - Withdrawal restores rather than deletes
+
+    @Test("withdrawing a failed decision puts the prior watermark back")
+    func withdrawRestoresThePrior() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "watermark-withdraw")
+        defer { fixture.cleanup() }
+        let id = UUID()
+
+        await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(5))
+        let prior = await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(20))
+        #expect(prior == Self.at(5))
+        await fixture.manager.withdrawFilingDecision(
+            worktreeID: id, restoring: prior, ifStillAt: Self.at(20))
+
+        #expect(
+            await fixture.manager.filingDecision(for: id) == Self.at(5),
+            "a later failed verb destroyed an earlier legitimate filing decision")
+    }
+
+    @Test("withdrawal leaves a decision another path made in the meantime alone")
+    func withdrawDefersToANewerDecision() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "watermark-withdraw-newer")
+        defer { fixture.cleanup() }
+        let id = UUID()
+
+        let prior = await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(5))
+        // Another path files this row while the verb is out.
+        await fixture.manager.noteFilingDecision(worktreeID: id, at: Self.at(30))
+        await fixture.manager.withdrawFilingDecision(
+            worktreeID: id, restoring: prior, ifStillAt: Self.at(5))
+
+        #expect(await fixture.manager.filingDecision(for: id) == Self.at(30))
+    }
+
+    /// End to end through `performArchive`: a lane that already carries a
+    /// legitimate watermark from an earlier decision, whose verb then fails,
+    /// must keep it.
+    @Test("a failing archive verb does not destroy an earlier watermark")
+    func failingVerbKeepsTheEarlierWatermark() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], verbs: [Self.unreachable], tag: "watermark-verb-failure")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        await fixture.manager.noteFilingDecision(worktreeID: lane.id, at: Self.at(1))
+
+        let failure = try await fixture.lanes().performArchive(
+            .invokeVerb(provider: "fake", sessionID: "sess-1"), worktree: lane,
+            now: Instants([Self.at(5), Self.at(10), Self.at(11)]).next)
+
+        #expect(failure == "host is down")
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(
+            await fixture.manager.filingDecision(for: lane.id) == Self.at(1),
+            "the failed verb dropped a watermark an earlier decision had legitimately left")
+    }
+
+    // MARK: - The row write can fail too
+
+    /// The verb succeeds and the DB write throws. The watermark was recorded
+    /// for a filing that never happened, so it has to come back off — the same
+    /// treatment the verb-failure path gets, on the path that was left out.
+    @Test("a failing row write withdraws the watermark it recorded")
+    func failingRowWriteWithdrawsTheWatermark() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], verbs: [Self.archived], tag: "watermark-db-failure")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        // Deleting the row makes `db.worktrees.archive` throw "Worktree not
+        // found" — a DB failure arriving after the verb already succeeded.
+        try await fixture.db.worktrees.delete(id: lane.id)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await fixture.lanes().performArchive(
+                .invokeVerb(provider: "fake", sessionID: "sess-1"), worktree: lane,
+                now: Instants([Self.at(5), Self.at(10), Self.at(11)]).next)
+        }
+
+        #expect(
+            await fixture.manager.filingDecision(for: lane.id) == nil,
+            "a watermark survives for a filing that never happened, suppressing real snapshots for two poll intervals")
+    }
+
+    @Test("a failing revive row write withdraws the watermark it recorded")
+    func failingReviveRowWriteWithdrawsTheWatermark() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"], verbs: [Self.unarchived],
+            tag: "watermark-db-failure-revive")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+        try await fixture.db.worktrees.delete(id: lane.id)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await fixture.lanes().performRevive(
+                .invokeUnarchive(provider: "fake", sessionID: "sess-1"), worktree: lane,
+                now: Instants([Self.at(5), Self.at(10), Self.at(11)]).next)
+        }
+
+        #expect(await fixture.manager.filingDecision(for: lane.id) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -25,6 +25,16 @@ final class FakeProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
     /// stdin bytes for each call, same index as `calls`. `nil` entries are
     /// calls made with no stdin (e.g. `stop`/`log`).
     private(set) var stdins: [Data?] = []
+    /// Runs after a verb is asked for and before its canned outcome is
+    /// returned — the seam for observing daemon state *mid-flight*, while the
+    /// provider call is still outstanding, without sleeping. Same shape as
+    /// `MidCallFilingInvoker.onListCall` in `RemoteFilingSyncTests`, generalized
+    /// to any verb: the caller reads `verb` and decides whether this is the call
+    /// it wants to interleave with. Nil for every test that does not.
+    ///
+    /// The action runs inline on the calling task, so nothing has to be
+    /// released by a second task and it cannot starve the cooperative pool.
+    var onCall: (@Sendable ([String]) async -> Void)?
 
     init(script: [ProviderResult]) {
         self.script = script.map { .result($0) }
@@ -39,7 +49,8 @@ final class FakeProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
         _ config: RemoteProviderConfig, verb: [String], stdin: Data?,
         timeout: TimeInterval
     ) async throws -> ProviderResult {
-        try popScript(verb, stdin: stdin)
+        if let onCall { await onCall(verb) }
+        return try popScript(verb, stdin: stdin)
     }
 
     /// Synchronous helper so the NSLock critical section isn't taken from an

--- a/Tests/TBDDaemonTests/WorktreeArchiveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveRemoteLaneTests.swift
@@ -4,180 +4,400 @@ import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
 
-/// Tier 2 — in-memory database, dry-run tmux, a real actuation log in a temp
-/// directory. No `TBD_HOME`, no subprocesses.
+/// Tier 2 — in-memory database, dry-run tmux, a scripted fake provider, and a
+/// real actuation log in a temp directory. No `TBD_HOME`, no subprocesses.
 ///
-/// `worktree.archive` refuses a remote lane before it writes its `.dispose`
-/// request. A remote worktree cannot be archived today — `beginArchiveWorktree`
-/// resolves through `getLocal` and throws for one — so a request row for it
-/// would claim an act that was never attempted. Unlike the auto-archive rail's
-/// silent skip, this path is a deliberate user gesture, so the refusal comes
-/// back as an RPC error the caller can show.
+/// `worktree.archive` on a remote lane
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Archive"). Three
+/// routes out of the same handler — the verb, the `gone` exemption, and a
+/// refusal — plus the two guards on the verb path, and the record shape that
+/// separates them: **a refusal writes no actuation row at all**, because
+/// nothing was attempted and the record may claim solely acts that were
+/// attempted.
 ///
-/// Both arms are here: the refusal, and a local worktree archiving exactly as
-/// before, which is what proves the fence did not disarm the surface.
+/// The local arms are here for the same reason they always were: this is a
+/// shared handler, and a run that showed the remote path working while
+/// quietly breaking the local one must not pass.
 @Suite("worktree.archive: remote lanes")
 struct WorktreeArchiveRemoteLaneTests {
 
-    // MARK: - Fixture
-
-    private func makeLogPath() throws -> String {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tbd-archive-remote-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return directory.appendingPathComponent("actuations.jsonl").path
-    }
-
-    private func rows(at path: String) throws -> [[String: Any]] {
-        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
-        return try contents
-            .split(separator: "\n", omittingEmptySubsequences: true)
-            .map { line in
-                try #require(
-                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
-            }
-    }
-
-    private func makeRouter(db: TBDDatabase, logPath: String) -> RPCRouter {
-        let tmux = TmuxManager(dryRun: true)
-        return RPCRouter(
-            db: db,
-            lifecycle: WorktreeLifecycle(
-                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
-            tmux: tmux,
-            startTime: Date(),
-            actuationLog: ActuationLog(path: logPath))
-    }
-
-    private func makeRepo(in db: TBDDatabase) async throws -> Repo {
-        try await db.repos.create(
-            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
-    }
-
-    // MARK: - Tests
-
-    @Test("archiving a remote lane is refused, and writes no actuation row for it")
-    func remoteLaneIsRefusedAndRecordsNothing() async throws {
-        let logPath = try makeLogPath()
-        let db = try TBDDatabase(inMemory: true)
-        let router = makeRouter(db: db, logPath: logPath)
-        let repo = try await makeRepo(in: db)
-        let worktree = try await db.worktrees.createRemote(
-            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
-            provider: "acme-provider", sessionID: "sess-1")
-
-        let response = await router.handle(try RPCRequest(
+    private func archive(
+        _ router: RPCRouter, _ worktree: Worktree, force: Bool = false
+    ) async throws -> RPCResponse {
+        await router.handle(try RPCRequest(
             method: RPCMethod.worktreeArchive,
-            params: WorktreeArchiveParams(worktreeID: worktree.id),
+            params: WorktreeArchiveParams(worktreeID: worktree.id, force: force),
             actor: .app))
+    }
+
+    // MARK: - The verb path
+
+    @Test("a provider declaring archive is invoked, and the row is filed")
+    func declaredArchiveInvokesTheVerb() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "stop"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "archive-verb")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(response.success, "the archive was refused: \(response.error ?? "no error")")
+        #expect(fixture.invoker.calls == [["describe"], ["archive", "sess-1"]])
+        #expect(try await fixture.status(of: lane) == .archived)
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["kind"] as? String == "dispose")
+        #expect(rows.first?["method"] as? String == RPCMethod.worktreeArchive)
+        #expect(rows.last?["result"] as? String == "dispatched")
+    }
+
+    /// The watermark that stops a `list` response composed before this
+    /// gesture from undoing it on arrival. Discriminating by construction:
+    /// the manager records nothing on its own, so this reads `nil` the moment
+    /// the `noteFilingDecision` call is deleted.
+    @Test("archiving a remote lane records the local filing decision")
+    func archiveRecordsTheFilingDecision() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "archive-watermark")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        #expect(await fixture.manager.filingDecision(for: lane.id) == nil, "sanity: nothing recorded yet")
+
+        let before = Date()
+        let response = try await archive(fixture.router(), lane)
+        let after = Date()
+
+        #expect(response.success)
+        let recorded = try #require(await fixture.manager.filingDecision(for: lane.id))
+        #expect(recorded >= before && recorded <= after)
+    }
+
+    /// The provider no longer knows this session. That is the case the `gone`
+    /// exemption exists for, so it files the row rather than failing — a lane
+    /// on a capable provider must not be harder to retire than one on a
+    /// provider that declares nothing.
+    @Test("a not_found from the archive verb degrades to a row-only filing")
+    func notFoundDegradesToARowFlip() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [ProviderResult(
+                exitCode: 1,
+                stdout: Data(#"{"error": {"code": "not_found", "message": "gone"}}"#.utf8),
+                stderr: "")],
+            tag: "archive-notfound")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(response.success, "not_found should not surface as an error: \(response.error ?? "")")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(try fixture.actuationRows().last?["result"] as? String == "dispatched")
+    }
+
+    @Test("a failing archive verb leaves the row alone and records transport-failed")
+    func failingVerbLeavesTheRowAlone() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [ProviderResult(
+                exitCode: 1,
+                stdout: Data(#"{"error": {"code": "unreachable", "message": "host is down"}}"#.utf8),
+                stderr: "")],
+            tag: "archive-failure")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+
+        let response = try await archive(fixture.router(), lane)
 
         #expect(!response.success)
-        #expect(response.error?.contains("remote lane") == true,
+        #expect(response.error == "host is down")
+        // A retirement TBD did not perform is not one it may claim.
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(await fixture.manager.filingDecision(for: lane.id) == nil)
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.last?["result"] as? String == "transport-failed")
+    }
+
+    // MARK: - The gone exemption
+
+    @Test("a gone lane is filed with no provider call, and still records its act")
+    func goneLaneIsFiledWithoutTheProvider() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: [], tag: "archive-gone")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(gone: true)
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(response.success, "the archive was refused: \(response.error ?? "no error")")
+        #expect(fixture.invoker.calls == [["describe"]], "the gone path must call no verb")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(await fixture.manager.filingDecision(for: lane.id) != nil)
+        // A row genuinely changed status, so the record names that act —
+        // unlike a refusal, which writes nothing.
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.last?["result"] as? String == "dispatched")
+    }
+
+    /// The guards defend the verb path. The `gone` path touches nothing on
+    /// the provider and has nothing to defend, so a working agent and a dirty
+    /// checkout both file cleanly there.
+    @Test("the guards do not apply to the gone path")
+    func guardsDoNotApplyToTheGonePath() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: [], tag: "archive-gone-guards")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(
+            agentState: .working, meta: ["workspace_dirty": "true"], gone: true)
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(response.success, "the archive was refused: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(fixture.invoker.calls == [["describe"]])
+    }
+
+    // MARK: - Refusals
+
+    @Test("a provider declaring neither archive nor a gone session is refused")
+    func undeclaredCapabilityIsRefused() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: [], tag: "archive-refused")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("archive") == true,
+                "the refusal did not name the capability: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try fixture.actuationRows().isEmpty, "a refusal must write no actuation row")
+    }
+
+    /// `stop` is never substituted for a missing `archive`. Ending compute
+    /// and retiring a record are different acts, and the assertion is on the
+    /// invoker rather than on the response: a refusal that had quietly killed
+    /// the session first would still look like a refusal from the outside.
+    @Test("a provider declaring only stop is refused, and stop is never invoked")
+    func stopIsNeverSubstituted() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["stop"], tag: "archive-stop-only")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(!fixture.invoker.calls.contains { $0.first == "stop" })
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    /// Even forced. `--force` overrides the guards, which are about the
+    /// session's condition; it cannot conjure a capability the provider does
+    /// not have.
+    @Test("force does not override a missing archive capability")
+    func forceDoesNotOverrideAMissingCapability() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["stop"], tag: "archive-force-nocap")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+
+        let response = try await archive(fixture.router(), lane, force: true)
+
+        #expect(!response.success)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    @Test("archiving a remote lane is refused when remote backends are off")
+    func refusedWhenSubsystemDisabled() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], tag: "archive-flag-off")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.db.config.setRemoteBackendsEnabled(false)
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error == "remote backends disabled")
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    // MARK: - Guards on the verb path
+
+    @Test("a lane whose agent is working is refused, and the verb never runs")
+    func workingAgentIsRefused() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], tag: "archive-working")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(agentState: .working)
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("working") == true,
                 "the refusal did not say why: \(response.error ?? "no error")")
-        #expect(try await db.worktrees.get(id: worktree.id)?.status == .active)
-        // Not "no dispose row" but no row of any kind: the handler never
-        // reached its act moment, so it has nothing to record — neither a
-        // request nor the transport-failed outcome the downstream throw used to
-        // produce.
-        #expect(try rows(at: logPath).isEmpty)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
     }
 
-    /// The CLI's `--force` reaches the same handler, and force is about phase 2
-    /// (skipping the dirty-tree check on `git worktree remove`), not about
-    /// locality — there is still no provider session teardown to run.
-    @Test("a forced archive of a remote lane is refused the same way")
-    func forcedRemoteLaneIsAlsoRefused() async throws {
-        let logPath = try makeLogPath()
-        let db = try TBDDatabase(inMemory: true)
-        let router = makeRouter(db: db, logPath: logPath)
-        let repo = try await makeRepo(in: db)
-        let worktree = try await db.worktrees.createRemote(
-            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
-            provider: "acme-provider", sessionID: "sess-1")
+    @Test("a provider-reported dirty checkout is refused, and the verb never runs")
+    func dirtyCheckoutIsRefused() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], tag: "archive-dirty")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(
+            agentState: .idle, meta: [RemoteLaneLifecycle.dirtyWorkspaceMetaKey: "true"])
 
-        let response = await router.handle(try RPCRequest(
-            method: RPCMethod.worktreeArchive,
-            params: WorktreeArchiveParams(worktreeID: worktree.id, force: true),
-            actor: .app))
+        let response = try await archive(fixture.router(), lane)
 
         #expect(!response.success)
-        #expect(try await db.worktrees.get(id: worktree.id)?.status == .active)
-        #expect(try rows(at: logPath).isEmpty)
+        #expect(response.error?.contains(RemoteLaneLifecycle.dirtyWorkspaceMetaKey) == true,
+                "the refusal did not name the key: \(response.error ?? "no error")")
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().isEmpty)
     }
+
+    /// The guard is inert until a provider adopts the key. A session that
+    /// says nothing about its checkout — the overwhelmingly common case —
+    /// must archive exactly as it would have before the guard existed, and a
+    /// value that is not a claim must not be read as one.
+    @Test("a provider that reports nothing about its checkout is not guarded")
+    func absentDirtyKeyLeavesTheGuardInert() async throws {
+        for meta in [nil, [:], ["workspace_dirty": ""], ["workspace_dirty": "unknown"],
+                     ["repo": "acme/api"]] as [[String: String]?] {
+            let fixture = try await RemoteLaneFixture.make(
+                capabilities: ["archive"],
+                verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+                tag: "archive-dirty-inert")
+            defer { fixture.cleanup() }
+            let lane = try await fixture.seedLane(meta: meta)
+
+            let response = try await archive(fixture.router(), lane)
+
+            #expect(response.success, "meta \(String(describing: meta)) was guarded: \(response.error ?? "")")
+            #expect(try await fixture.status(of: lane) == .archived)
+        }
+    }
+
+    @Test("force overrides the working guard")
+    func forceOverridesTheWorkingGuard() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "archive-force-working")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(agentState: .working)
+
+        let response = try await archive(fixture.router(), lane, force: true)
+
+        #expect(response.success, "force did not override the guard: \(response.error ?? "no error")")
+        #expect(fixture.invoker.calls == [["describe"], ["archive", "sess-1"]])
+        #expect(try await fixture.status(of: lane) == .archived)
+    }
+
+    @Test("force overrides the dirty-checkout guard")
+    func forceOverridesTheDirtyGuard() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "archive-force-dirty")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(
+            meta: [RemoteLaneLifecycle.dirtyWorkspaceMetaKey: "true"])
+
+        let response = try await archive(fixture.router(), lane, force: true)
+
+        #expect(response.success, "force did not override the guard: \(response.error ?? "no error")")
+        #expect(fixture.invoker.calls == [["describe"], ["archive", "sess-1"]])
+        #expect(try await fixture.status(of: lane) == .archived)
+    }
+
+    // MARK: - The local path, unchanged
 
     @Test("a local worktree still archives and records its act")
     func localWorktreeStillArchives() async throws {
-        let logPath = try makeLogPath()
-        let db = try TBDDatabase(inMemory: true)
-        let router = makeRouter(db: db, logPath: logPath)
-        let repo = try await makeRepo(in: db)
-        let worktree = try await db.worktrees.create(
-            repoID: repo.id, name: "acme-local", branch: "acme-branch",
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "archive-local")
+        defer { fixture.cleanup() }
+        let worktree = try await fixture.db.worktrees.create(
+            repoID: fixture.repo.id, name: "acme-local", branch: "acme-branch",
             path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
 
-        let response = await router.handle(try RPCRequest(
-            method: RPCMethod.worktreeArchive,
-            params: WorktreeArchiveParams(worktreeID: worktree.id),
-            actor: .app))
+        let response = try await archive(fixture.router(), worktree)
 
         #expect(response.success, "the archive was refused: \(response.error ?? "no error")")
-        #expect(try await db.worktrees.get(id: worktree.id)?.status == .archived)
-        let written = try rows(at: logPath)
-        #expect(written.count == 2)
-        #expect(written.first?["kind"] as? String == "dispose")
-        #expect(written.first?["method"] as? String == RPCMethod.worktreeArchive)
-        #expect(written.last?["result"] as? String == "dispatched")
+        #expect(try await fixture.status(of: worktree) == .archived)
+        #expect(fixture.invoker.calls == [["describe"]], "a local archive must call no provider")
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["kind"] as? String == "dispose")
+        #expect(rows.first?["method"] as? String == RPCMethod.worktreeArchive)
+        #expect(rows.last?["result"] as? String == "dispatched")
     }
 
-    /// The pre-row read must not swallow the not-found case: an unknown id still
-    /// reaches `beginArchiveWorktree` and still records a transport-failed
-    /// outcome, exactly as it did before the fence.
+    /// The pre-row read must not swallow the not-found case: an unknown id
+    /// still reaches `beginArchiveWorktree` and still records a
+    /// transport-failed outcome, exactly as it did before the branch.
     @Test("an unknown worktree id still throws and records transport-failed")
     func unknownWorktreeStillRecordsTransportFailure() async throws {
-        let logPath = try makeLogPath()
-        let db = try TBDDatabase(inMemory: true)
-        let router = makeRouter(db: db, logPath: logPath)
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "archive-unknown")
+        defer { fixture.cleanup() }
 
-        let response = await router.handle(try RPCRequest(
+        let response = await fixture.router().handle(try RPCRequest(
             method: RPCMethod.worktreeArchive,
             params: WorktreeArchiveParams(worktreeID: UUID()),
             actor: .app))
 
         #expect(!response.success)
-        let written = try rows(at: logPath)
-        #expect(written.count == 2)
-        #expect(written.first?["kind"] as? String == "dispose")
-        #expect(written.last?["result"] as? String == "transport-failed")
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["kind"] as? String == "dispose")
+        #expect(rows.last?["result"] as? String == "transport-failed")
     }
 
     // MARK: - worktree.forget, the sibling surface
 
-    /// `forget` is the other verb that resolves its row through `getLocal` and
-    /// so throws for a remote lane. It records ahead of the act like archive
-    /// does, which is what makes the gate necessary rather than cosmetic: the
-    /// unfenced handler wrote a `.worktreeForget` request and a
-    /// transport-failed outcome for an act it structurally cannot perform.
+    /// Forget keeps refusing a remote lane, and that is a scope decision:
+    /// forget means "leave the files alone", a remote lane has no files here,
+    /// and retiring a lane is archive's job. The gate is still mechanically
+    /// necessary — `forgetWorktree` resolves through `getLocal` and would
+    /// throw beneath an already-written row.
     @Test("forgetting a remote lane is refused, and writes no actuation row for it")
     func forgetOnARemoteLaneIsRefusedAndRecordsNothing() async throws {
-        let logPath = try makeLogPath()
-        let db = try TBDDatabase(inMemory: true)
-        let router = makeRouter(db: db, logPath: logPath)
-        let repo = try await makeRepo(in: db)
-        let worktree = try await db.worktrees.createRemote(
-            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
-            provider: "acme-provider", sessionID: "sess-1")
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"], tag: "forget-remote")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
 
-        let response = await router.handle(try RPCRequest(
+        let response = await fixture.router().handle(try RPCRequest(
             method: RPCMethod.worktreeForget,
-            params: WorktreeForgetParams(worktreeID: worktree.id),
+            params: WorktreeForgetParams(worktreeID: lane.id),
             actor: .app))
 
         #expect(!response.success)
         #expect(response.error?.contains("remote lane") == true,
                 "the refusal did not say why: \(response.error ?? "no error")")
+        #expect(response.error?.contains("Archive") == true,
+                "the refusal did not name the alternative: \(response.error ?? "no error")")
         // The row survives: a refused forget must not half-delete the lane.
-        #expect(try await db.worktrees.get(id: worktree.id) != nil)
-        #expect(try rows(at: logPath).isEmpty)
+        #expect(try await fixture.db.worktrees.get(id: lane.id) != nil)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try fixture.actuationRows().isEmpty)
     }
 
     /// The gate reads locality, not "the row exists": an unknown id must keep
@@ -185,19 +405,18 @@ struct WorktreeArchiveRemoteLaneTests {
     /// transport-failed outcome.
     @Test("an unknown id still reaches forget and records transport-failed")
     func forgetOnAnUnknownWorktreeStillRecordsTransportFailure() async throws {
-        let logPath = try makeLogPath()
-        let db = try TBDDatabase(inMemory: true)
-        let router = makeRouter(db: db, logPath: logPath)
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "forget-unknown")
+        defer { fixture.cleanup() }
 
-        let response = await router.handle(try RPCRequest(
+        let response = await fixture.router().handle(try RPCRequest(
             method: RPCMethod.worktreeForget,
             params: WorktreeForgetParams(worktreeID: UUID()),
             actor: .app))
 
         #expect(!response.success)
-        let written = try rows(at: logPath)
-        #expect(written.count == 2)
-        #expect(written.first?["kind"] as? String == "dispose")
-        #expect(written.last?["result"] as? String == "transport-failed")
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["kind"] as? String == "dispose")
+        #expect(rows.last?["result"] as? String == "transport-failed")
     }
 }

--- a/Tests/TBDDaemonTests/WorktreeArchiveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveRemoteLaneTests.swift
@@ -53,6 +53,40 @@ struct WorktreeArchiveRemoteLaneTests {
         #expect(rows.last?["result"] as? String == "dispatched")
     }
 
+    /// The contract mandates that `archive` return the updated Session, so
+    /// every conforming provider hands back `archived: true`. Mirroring that
+    /// response before the row is written would hand the filing sync a row
+    /// still `.active` alongside a fresh `archived: true` — and the sync would
+    /// file the row a second time, on the daemon's own rail, with a
+    /// notification claiming the *provider* retired a session the *user* just
+    /// retired.
+    ///
+    /// So the shape is asserted, not just the outcome: exactly the two rows
+    /// this one gesture is entitled to, none of them on the sync's rail, and
+    /// no notification at all.
+    @Test("the verb's own response does not re-enter the filing sync")
+    func verbResponseDoesNotReenterTheFilingSync() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "archive-no-resync")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(response.success, "the archive was refused: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .archived)
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2, "one gesture must write one request and one outcome, got \(rows.count)")
+        #expect(
+            rows.allSatisfy { ($0["actor"] as? [String: Any])?["rail"] as? String != "remote-filing-sync" },
+            "the filing sync wrote a row for a gesture the user made")
+        #expect(
+            try await fixture.notifications(for: lane).isEmpty,
+            "the user archived this lane themselves; nothing may claim the provider did")
+    }
+
     /// The watermark that stops a `list` response composed before this
     /// gesture from undoing it on arrival. Discriminating by construction:
     /// the manager records nothing on its own, so this reads `nil` the moment
@@ -234,6 +268,80 @@ struct WorktreeArchiveRemoteLaneTests {
         #expect(response.error == "remote backends disabled")
         #expect(try await fixture.status(of: lane) == .active)
         #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    // MARK: - The stale-snapshot gate
+
+    /// The same gate every `remote.*` mutation passes, for the same reason and
+    /// with sharper stakes here. Both of archive's guards are read out of the
+    /// mirror — `agentState` and `meta.workspace_dirty` — so on a stale mirror
+    /// a session that was idle at the last good poll and is working now reads
+    /// as safe, the guards pass, and a mid-task session is retired.
+    @Test("a stale provider inventory refuses the archive above the record")
+    func staleInventoryRefusesTheArchive() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [
+                RemoteLaneFixture.failingList,
+                // A spare, so a regressed gate fails this test by assertion
+                // rather than by exhausting the invoker's script — which is a
+                // `precondition` and would abort the whole test process.
+                providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#),
+            ],
+            tag: "archive-stale")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.markSnapshotStale()
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("stale") == true,
+                "the refusal did not say why: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(!fixture.invoker.calls.contains { $0.first == "archive" })
+        #expect(try fixture.actuationRows().isEmpty, "a refusal must write no actuation row")
+    }
+
+    /// `--force` overrides it, exactly as it overrides the two guards: the user
+    /// has been told the inventory is stale and is asking anyway.
+    @Test("force overrides the stale-snapshot gate")
+    func forceOverridesTheStaleGate() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [
+                RemoteLaneFixture.failingList,
+                providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#),
+            ],
+            tag: "archive-stale-force")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.markSnapshotStale()
+
+        let response = try await archive(fixture.router(), lane, force: true)
+
+        #expect(response.success, "force did not override the gate: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(fixture.invoker.calls.last == ["archive", "sess-1"])
+    }
+
+    /// A fresh inventory is the ordinary case, so the gate must not fire when
+    /// nothing is wrong — otherwise a run that refused everything would pass
+    /// the arm above by doing nothing.
+    @Test("a healthy provider inventory does not trip the stale gate")
+    func healthyInventoryArchivesNormally() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": true}"#)],
+            tag: "archive-fresh")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane()
+        try await fixture.manager.apply(snapshot: [], provider: "fake")
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(response.success, "the archive was refused: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .archived)
     }
 
     // MARK: - Guards on the verb path

--- a/Tests/TBDDaemonTests/WorktreeArchiveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveRemoteLaneTests.swift
@@ -344,6 +344,27 @@ struct WorktreeArchiveRemoteLaneTests {
         #expect(try await fixture.status(of: lane) == .archived)
     }
 
+    /// The gate defends the verb path, and only that. The `gone` path makes no
+    /// provider call and reads nothing out of the mirror it could be wrong
+    /// about — it consults the row's own `gone` flag, which a stale inventory
+    /// does not put in doubt. Gating it would leave a lane whose provider
+    /// cannot archive unretireable for as long as that provider is unhealthy,
+    /// with `--force` the only way out and the row menu never sending one.
+    @Test("a stale inventory does not gate the gone path")
+    func staleInventoryDoesNotGateTheGonePath() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: [], verbs: [RemoteLaneFixture.failingList], tag: "archive-stale-gone")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(gone: true)
+        try await fixture.markSnapshotStale()
+
+        let response = try await archive(fixture.router(), lane)
+
+        #expect(response.success, "the gone path was gated on staleness: \(response.error ?? "")")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(!fixture.invoker.calls.contains { $0.first == "archive" })
+    }
+
     // MARK: - Guards on the verb path
 
     @Test("a lane whose agent is working is refused, and the verb never runs")

--- a/Tests/TBDDaemonTests/WorktreeReviveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveRemoteLaneTests.swift
@@ -1,0 +1,244 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — in-memory database, dry-run tmux, a scripted fake provider, and a
+/// real actuation log in a temp directory. No `TBD_HOME`, no subprocesses.
+///
+/// `worktree.revive` on a remote lane
+/// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Revive"). The
+/// discriminator is what the provider reports **right now**, not how the row
+/// came to be archived — so a lane filed under the `gone` exemption is
+/// reversible by the same gesture that filed it, while one the provider still
+/// asserts is archived is refused rather than flipped into a row the next
+/// snapshot would re-file.
+@Suite("worktree.revive: remote lanes")
+struct WorktreeReviveRemoteLaneTests {
+
+    private func revive(_ router: RPCRouter, _ worktree: Worktree) async throws -> RPCResponse {
+        await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: worktree.id),
+            actor: .app))
+    }
+
+    // MARK: - The verb path
+
+    @Test("a provider declaring unarchive is invoked, and the row returns to active")
+    func declaredUnarchiveInvokesTheVerb() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": false}"#)],
+            tag: "revive-verb")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(response.success, "the revive was refused: \(response.error ?? "no error")")
+        #expect(fixture.invoker.calls == [["describe"], ["unarchive", "sess-1"]])
+        #expect(try await fixture.status(of: lane) == .active)
+        let returned = try response.decodeResult(Worktree.self)
+        #expect(returned.id == lane.id)
+        #expect(returned.status == .active, "the handler returned the pre-flip snapshot")
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["method"] as? String == RPCMethod.worktreeRevive)
+        #expect(rows.last?["result"] as? String == "dispatched")
+    }
+
+    /// The session's condition comes back through the mirror rather than
+    /// through a second call: an exited session flips just as cleanly, and
+    /// the lane returns to the list already carrying the provider's current
+    /// word on it.
+    @Test("an exited session flips cleanly and its condition reaches the mirror")
+    func exitedSessionFlipsCleanly() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["unarchive"],
+            verbs: [providerOK(
+                #"{"id": "sess-1", "state": "exited", "exit_code": 3, "archived": false}"#)],
+            tag: "revive-exited")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(response.success, "the revive was refused: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .active)
+        let mirrored = try await fixture.db.remoteSessions.row(provider: "fake", sessionID: "sess-1")
+        #expect(mirrored?.decodedPayload?.state == .exited)
+        #expect(mirrored?.decodedPayload?.exitCode == 3)
+    }
+
+    /// A `gone` session may be listed again, and an exited one may still be a
+    /// record the provider can unarchive — so the verb is worth attempting.
+    /// What comes back when it is not there is `not_found`, and that degrades
+    /// to a plain row flip rather than an error: the user asked for the lane
+    /// back, and TBD's own filing decision is TBD's to reverse.
+    @Test("a not_found response degrades to a row flip rather than an error")
+    func notFoundDegradesToARowFlip() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["unarchive"],
+            verbs: [ProviderResult(
+                exitCode: 1,
+                stdout: Data(#"{"error": {"code": "not_found", "message": "no such session"}}"#.utf8),
+                stderr: "")],
+            tag: "revive-notfound")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true, gone: true)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(response.success, "not_found should not surface as an error: \(response.error ?? "")")
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(try fixture.actuationRows().last?["result"] as? String == "dispatched")
+    }
+
+    @Test("a failing unarchive verb leaves the row archived and records transport-failed")
+    func failingVerbLeavesTheRowArchived() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["unarchive"],
+            verbs: [ProviderResult(
+                exitCode: 1,
+                stdout: Data(#"{"error": {"code": "unreachable", "message": "host is down"}}"#.utf8),
+                stderr: "")],
+            tag: "revive-failure")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error == "host is down")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(await fixture.manager.filingDecision(for: lane.id) == nil)
+        #expect(try fixture.actuationRows().last?["result"] as? String == "transport-failed")
+    }
+
+    /// Same watermark as archive, in the other direction — the one a
+    /// timestamp on the row itself could not cover, since revive clears
+    /// `archivedAt` and leaves nothing to appeal to.
+    @Test("reviving a remote lane records the local filing decision")
+    func reviveRecordsTheFilingDecision() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["unarchive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": false}"#)],
+            tag: "revive-watermark")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+        #expect(await fixture.manager.filingDecision(for: lane.id) == nil, "sanity: nothing recorded yet")
+
+        let before = Date()
+        let response = try await revive(fixture.router(), lane)
+        let after = Date()
+
+        #expect(response.success)
+        let recorded = try #require(await fixture.manager.filingDecision(for: lane.id))
+        #expect(recorded >= before && recorded <= after)
+    }
+
+    // MARK: - The row-only path
+
+    /// The lane filed under the `gone` exemption: TBD's own decision, which a
+    /// TBD gesture reverses. Nothing will arrive to undo it, because the
+    /// filing sync reads `archived` only from a provider declaring `archive`.
+    @Test("a lane no provider reports archived flips with no provider call")
+    func rowOnlyFlipCallsNothing() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: [], tag: "revive-rowonly")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: nil, gone: true)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(response.success, "the revive was refused: \(response.error ?? "no error")")
+        #expect(fixture.invoker.calls == [["describe"]], "the row-only path must call no verb")
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(await fixture.manager.filingDecision(for: lane.id) != nil)
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.last?["result"] as? String == "dispatched")
+    }
+
+    // MARK: - The refusal
+
+    /// With no verb to call and the provider still asserting `archived:
+    /// true`, a row-only flip would be re-filed by the sync on the next
+    /// snapshot, and again on every snapshot after. Refusing is what keeps
+    /// the two records from fighting.
+    @Test("a lane the provider still reports archived, with no unarchive, is refused")
+    func refusedWhenProviderStillReportsArchived() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive"], tag: "revive-refused")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("unarchive") == true,
+                "the refusal did not name the capability: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(fixture.invoker.calls == [["describe"]])
+        #expect(try fixture.actuationRows().isEmpty, "a refusal must write no actuation row")
+    }
+
+    @Test("reviving a remote lane is refused when remote backends are off")
+    func refusedWhenSubsystemDisabled() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["unarchive"], tag: "revive-flag-off")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+        try await fixture.db.config.setRemoteBackendsEnabled(false)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error == "remote backends disabled")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    // MARK: - The local path, unchanged
+
+    /// A local worktree still resolves through the lifecycle, which rejects
+    /// an active row — and it does so **beneath** an already-written request
+    /// row. That two-row shape is what discriminates: had the new branch
+    /// captured a local worktree, the remote path would have refused above
+    /// the row and written none.
+    @Test("a local worktree still reaches the lifecycle and records its request row")
+    func localWorktreeStillReachesTheLifecycle() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "revive-local")
+        defer { fixture.cleanup() }
+        let worktree = try await fixture.db.worktrees.create(
+            repoID: fixture.repo.id, name: "acme-local", branch: "acme-branch",
+            path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
+
+        let response = try await revive(fixture.router(), worktree)
+
+        #expect(!response.success, "an active local worktree is not revivable")
+        #expect(fixture.invoker.calls == [["describe"]], "a local revive must call no provider")
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?["method"] as? String == RPCMethod.worktreeRevive)
+        #expect(rows.last?["result"] as? String == "transport-failed")
+    }
+
+    @Test("an unknown worktree id still throws and records transport-failed")
+    func unknownWorktreeStillRecordsTransportFailure() async throws {
+        let fixture = try await RemoteLaneFixture.make(capabilities: [], tag: "revive-unknown")
+        defer { fixture.cleanup() }
+
+        let response = await fixture.router().handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: UUID()),
+            actor: .app))
+
+        #expect(!response.success)
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2)
+        #expect(rows.last?["result"] as? String == "transport-failed")
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeReviveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveRemoteLaneTests.swift
@@ -278,6 +278,25 @@ struct WorktreeReviveRemoteLaneTests {
         #expect(try await fixture.status(of: lane) == .active)
     }
 
+    /// The gate defends the verb path alone. A lane filed under the `gone`
+    /// exemption takes the row-only flip, which calls nothing and asks the
+    /// mirror nothing — and there is no `--force` on revive, so gating it
+    /// would strand the lane for as long as its provider stays unhealthy.
+    @Test("a stale inventory does not gate the row-only revive")
+    func staleInventoryDoesNotGateTheRowOnlyPath() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: [], verbs: [RemoteLaneFixture.failingList], tag: "revive-stale-rowonly")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, gone: true)
+        try await fixture.markSnapshotStale()
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(response.success, "the row-only path was gated on staleness: \(response.error ?? "")")
+        #expect(try await fixture.status(of: lane) == .active)
+        #expect(!fixture.invoker.calls.contains { $0.first == "unarchive" })
+    }
+
     // MARK: - The local path, unchanged
 
     /// A local worktree still resolves through the lifecycle, which rejects

--- a/Tests/TBDDaemonTests/WorktreeReviveRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveRemoteLaneTests.swift
@@ -49,6 +49,31 @@ struct WorktreeReviveRemoteLaneTests {
         #expect(rows.last?["result"] as? String == "dispatched")
     }
 
+    /// The mirror image of the archive path's re-entrancy: `unarchive` returns
+    /// the updated Session with `archived: false`, and mirroring that before
+    /// the row is written would leave the sync looking at an `.archived` row
+    /// alongside a fresh `archived: false` — a second, daemon-rail `.spawn`
+    /// pair for a gesture the user made once.
+    @Test("the unarchive verb's own response does not re-enter the filing sync")
+    func unarchiveResponseDoesNotReenterTheFilingSync() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": false}"#)],
+            tag: "revive-no-resync")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(response.success, "the revive was refused: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .active)
+        let rows = try fixture.actuationRows()
+        #expect(rows.count == 2, "one gesture must write one request and one outcome, got \(rows.count)")
+        #expect(
+            rows.allSatisfy { ($0["actor"] as? [String: Any])?["rail"] as? String != "remote-filing-sync" },
+            "the filing sync wrote a row for a gesture the user made")
+    }
+
     /// The session's condition comes back through the mirror rather than
     /// through a second call: an exited session flips just as cleanly, and
     /// the lane returns to the list already carrying the provider's current
@@ -199,6 +224,58 @@ struct WorktreeReviveRemoteLaneTests {
         #expect(response.error == "remote backends disabled")
         #expect(try await fixture.status(of: lane) == .archived)
         #expect(try fixture.actuationRows().isEmpty)
+    }
+
+    // MARK: - The stale-snapshot gate
+
+    /// The same gate `remote.unarchive` passes. Revive's routing reads what
+    /// the provider reports *right now* out of the mirror, so a stale mirror
+    /// picks the wrong branch: a lane the provider still holds archived can
+    /// read as unarchived and take a row-only flip the next snapshot re-files.
+    /// There is no `--force` on revive anywhere in TBD, here or on the
+    /// `remote.unarchive` handler; the recovery is the provider's next
+    /// successful poll.
+    @Test("a stale provider inventory refuses the revive above the record")
+    func staleInventoryRefusesTheRevive() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"],
+            verbs: [
+                RemoteLaneFixture.failingList,
+                // A spare, so a regressed gate fails by assertion rather than
+                // by exhausting the invoker's script (a `precondition`).
+                providerOK(#"{"id": "sess-1", "state": "running", "archived": false}"#),
+            ],
+            tag: "revive-stale")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+        try await fixture.markSnapshotStale()
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("stale") == true,
+                "the refusal did not say why: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .archived)
+        #expect(!fixture.invoker.calls.contains { $0.first == "unarchive" })
+        #expect(try fixture.actuationRows().isEmpty, "a refusal must write no actuation row")
+    }
+
+    /// The ordinary case still works, so a run that refused everything cannot
+    /// pass the arm above by doing nothing.
+    @Test("a healthy provider inventory does not trip the stale gate")
+    func healthyInventoryRevivesNormally() async throws {
+        let fixture = try await RemoteLaneFixture.make(
+            capabilities: ["archive", "unarchive"],
+            verbs: [providerOK(#"{"id": "sess-1", "state": "running", "archived": false}"#)],
+            tag: "revive-fresh")
+        defer { fixture.cleanup() }
+        let lane = try await fixture.seedLane(status: .archived, archived: true)
+        try await fixture.manager.apply(snapshot: [], provider: "fake")
+
+        let response = try await revive(fixture.router(), lane)
+
+        #expect(response.success, "the revive was refused: \(response.error ?? "no error")")
+        #expect(try await fixture.status(of: lane) == .active)
     }
 
     // MARK: - The local path, unchanged

--- a/Tests/TBDSharedTests/RemoteProviderTests.swift
+++ b/Tests/TBDSharedTests/RemoteProviderTests.swift
@@ -32,6 +32,81 @@ struct RemoteProviderTests {
         #expect(s.agentState == .unknown)
     }
 
+    // MARK: - RemoteSessionPayload — archived field (nil vs. false vs. true)
+    //
+    // The filing-sync authority rule (docs/specs/2026-08-16-remote-lane-archive-design.md
+    // §"Whose report counts") depends on distinguishing an absent `archived`
+    // (no claim made) from an explicit `false` (a claim). These tests would
+    // pass on a collapsed `archived: Bool = false` EXCEPT for
+    // `archivedFieldRoundTripsAllThreeStatesDistinctly`, which fails outright
+    // if `archived` is not `Bool?` — that is the one load-bearing case.
+
+    @Test func archivedAbsentDecodesAsNilAndIsArchivedReadsFalse() throws {
+        let json = #"{"id": "x", "state": "running"}"#.data(using: .utf8)!
+        let s = try JSONDecoder().decode(RemoteSessionPayload.self, from: json)
+        #expect(s.archived == nil)
+        #expect(s.isArchived == false)
+    }
+
+    @Test func archivedExplicitFalseDecodesAsSomeFalse() throws {
+        let json = #"{"id": "x", "state": "running", "archived": false}"#.data(using: .utf8)!
+        let s = try JSONDecoder().decode(RemoteSessionPayload.self, from: json)
+        #expect(s.archived == .some(false))
+        #expect(s.isArchived == false)
+    }
+
+    @Test func archivedTrueDecodesAsSomeTrue() throws {
+        let json = #"{"id": "x", "state": "running", "archived": true}"#.data(using: .utf8)!
+        let s = try JSONDecoder().decode(RemoteSessionPayload.self, from: json)
+        #expect(s.archived == .some(true))
+        #expect(s.isArchived == true)
+    }
+
+    /// The load-bearing case: if `archived` were collapsed to a non-optional
+    /// `Bool` defaulting to `false`, the absent and explicit-`false` states
+    /// would decode and re-encode identically and this test would fail to
+    /// distinguish them on round-trip.
+    @Test func archivedFieldRoundTripsAllThreeStatesDistinctly() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let absent = RemoteSessionPayload(id: "x", state: .running)
+        let explicitFalse = RemoteSessionPayload(id: "x", state: .running, archived: false)
+        let explicitTrue = RemoteSessionPayload(id: "x", state: .running, archived: true)
+
+        let decodedAbsent = try decoder.decode(RemoteSessionPayload.self, from: try encoder.encode(absent))
+        let decodedFalse = try decoder.decode(RemoteSessionPayload.self, from: try encoder.encode(explicitFalse))
+        let decodedTrue = try decoder.decode(RemoteSessionPayload.self, from: try encoder.encode(explicitTrue))
+
+        #expect(decodedAbsent.archived == nil)
+        #expect(decodedFalse.archived == .some(false))
+        #expect(decodedTrue.archived == .some(true))
+        // All three must be pairwise distinguishable — a collapsed `Bool`
+        // would make the first two equal.
+        #expect(decodedAbsent.archived != decodedFalse.archived)
+        #expect(decodedFalse.archived != decodedTrue.archived)
+
+        #expect(decodedAbsent.isArchived == false)
+        #expect(decodedFalse.isArchived == false)
+        #expect(decodedTrue.isArchived == true)
+    }
+
+    /// A realistic payload fixture that predates the `archived` field (same
+    /// shape as `sessionPayloadDecodesSnakeCaseAndTolerantEnums` above) must
+    /// still decode — the field is additive.
+    @Test func realisticFixtureWithoutArchivedStillDecodes() throws {
+        let json = """
+        {"id": "fix-ci", "title": "fix CI", "created_at": "2026-07-24T18:02:11Z",
+         "state": "running", "agent_state": "waiting_input",
+         "agent_state_reason": "permission_prompt", "agent_state_at": "2026-07-24T18:40:00Z",
+         "meta": {"repo": "acme/api"}}
+        """.data(using: .utf8)!
+        let s = try JSONDecoder().decode(RemoteSessionPayload.self, from: json)
+        #expect(s.id == "fix-ci")
+        #expect(s.archived == nil)
+        #expect(s.isArchived == false)
+    }
+
     @Test func staleProjectionDemotesActiveStateWithoutMutatingTheSnapshot() {
         let original = RemoteSessionPayload(
             id: "x", title: "worker", state: .running,

--- a/Tests/TBDSharedTests/RemoteProviderTests.swift
+++ b/Tests/TBDSharedTests/RemoteProviderTests.swift
@@ -126,6 +126,24 @@ struct RemoteProviderTests {
         #expect(exited.projectedForStaleSnapshot() == exited)
     }
 
+    /// Filing and liveness are separate axes (docs/specs/2026-08-16-remote-lane-archive-design.md,
+    /// "The filing decision travels back"). This projection demotes only the
+    /// liveness axis — an archived-but-not-exited session must still read as
+    /// archived after projection, even though its state and agent state are
+    /// demoted to `.unknown`. Asserting both halves in one test means it
+    /// cannot pass by the projection simply doing nothing.
+    @Test func staleProjectionPreservesArchivedWhileDemotingLiveness() {
+        let original = RemoteSessionPayload(
+            id: "x", title: "worker", state: .running,
+            agentState: .working, agentStateReason: "tool", archived: true)
+        let projected = original.projectedForStaleSnapshot()
+
+        #expect(projected.archived == .some(true))
+        #expect(projected.isArchived == true)
+        #expect(projected.state == .unknown)
+        #expect(projected.agentState == .unknown)
+    }
+
     @Test func providerStatusWithoutNewTimestampStillDecodes() throws {
         let json = #"{"config":{"name":"acme","exec":"/x"},"health":"ok"}"#.data(using: .utf8)!
         let status = try JSONDecoder().decode(RemoteProviderStatus.self, from: json)

--- a/docs/remote-provider-contract.md
+++ b/docs/remote-provider-contract.md
@@ -62,6 +62,10 @@ Other fields:
 
 The condition worth notifying a human about is an **edge** in `agent_state` — a transition into `waiting_input` or `exited` — not the value in isolation.
 
+### Unclean-checkout key (optional)
+
+One further `meta` key is well-known, on the same terms as the keys above: `workspace_dirty`. A provider that knows the session's checkout carries work which is not committed or not pushed sets it to `"true"`; anything else, including an absent key, means no claim was made. A caller MAY refuse a destructive gesture — retiring the session, say — on a session that claims it, and MUST degrade to its ordinary behavior when the key is absent, since most providers cannot see that fact and none is required to report it. Only `"true"` and `"1"` are read as a claim, trimmed and case-insensitively; a caller MUST NOT read an arbitrary value as one. Optional and purely additive at either contract major, like the identity keys below.
+
 ### Worktree identity keys (optional)
 
 Two further `meta` keys are well-known, on the same terms as `repo`, `branch`, and `profile`: `tbd_worktree_id` and `tbd_parent_worktree_id`. They are how a session tells TBD which lane it *is* and which lane spawned it. Both are optional and purely additive — a provider that sets neither is fully conformant and behaves exactly as it does without them — and both are readable at either contract major. They ride inside `meta`, which is a provider-defined map at every major, and a caller with no handling for a key simply renders it as an opaque detail row, so populating them is not a v2 feature and needs no change to a provider's declared `contract_versions`.

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -442,7 +442,8 @@ The discriminator is what the provider reports now, not how the row came to be
 archived, so nothing about the archive has to be persisted to decide it.
 
 **Attempting the verb is worth a call TBD expects to fail.** `gone` means only
-that a session missed two consecutive snapshots, and a provider may list it
+that a session stopped being enumerated — after two consecutive absences from a
+snapshot, or at once on an explicit `removed` event — and a provider may list it
 again; an exited session may still be a record the provider can unarchive. What
 comes back is better evidence than what TBD believed beforehand, and idempotence
 means the attempt costs a round trip and never a wrong outcome.

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -9,11 +9,10 @@ to a registered repo becomes a worktree row, nested under the lane named by
 carries a badge and the sidebar renders one surface per lane rather than two.
 Unbuilt: the CLI provider path (`--provider`, `--param`), provider default
 resolution inside `remote.create`, the outbound worktree id on `create`'s stdin,
-the retirement of the sidebar's flat `RemoteSectionView`, and the archive and
-revive semantics below — `worktree.archive`, `worktree.forget`, and the
-auto-archive-on-merge rail each refuse a remote row rather than acting on one,
-so an adopted lane cannot yet leave the active list.
-**Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md) (contract v2 — the `stop`, `archive`, and `unarchive` capabilities archive composes over),
+and the retirement of the sidebar's flat `RemoteSectionView`. The archive and
+revive semantics below are carried into code paths, wire surface, and UI by
+[`2026-08-16-remote-lane-archive-design.md`](2026-08-16-remote-lane-archive-design.md).
+**Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md) (contract v2 — the `archive` and `unarchive` capabilities archive and revive compose over),
 [`2026-07-24-remote-agent-backends-design.md`](2026-07-24-remote-agent-backends-design.md) (mirror, RPC family, provider manager),
 [`2026-08-01-provider-desk-read-only-design.md`](2026-08-01-provider-desk-read-only-design.md) (Provider Desk).
 
@@ -349,23 +348,33 @@ actually declares:
 - **Provider declares `archive`** — call it, then mark the row `archived`. The
   retirement is then a fact on the backend rather than TBD's private
   bookkeeping, so every other client of that backend sees it too.
-- **Provider declares `stop` but not `archive`** — stop the session, then mark
-  the row `archived`. Ending the compute is the closest such a backend comes to
-  retiring, and TBD's row carries the rest.
-- **Provider declares neither** — mark the row `archived` and do nothing else.
-  The provider-side session keeps running, and the UI says so rather than
-  implying a teardown that never happened.
+- **The session is `gone`** — mark the row `archived` and call nothing. A
+  session the provider has stopped enumerating cannot be reached by a verb, and
+  there is no live session for the row to misdescribe.
+- **Neither** — refused, naming `archive` as the capability the provider needs
+  to implement.
 
-`stop` and `archive` are both idempotent per contract, so archiving an
+`archive` and `unarchive` are both idempotent per contract, so archiving an
 already-archived or already-exited lane flips the row and nothing else.
 
+**TBD does not file a row for a lane it could not retire.** A row marked
+archived while the provider still reports the session active leaves two records
+disagreeing, and the one the user reads claims a retirement that did not happen.
+A provider may define archiving as narrowly as it likes — retiring an entry in
+its own inventory is enough, since `archived` is retirement from the working
+inventory rather than a statement about liveness — but it declares the
+capability and reports the result through `list`, so the claim sits where
+another client can verify it.
+
 **Terminating compute and retiring from inventory are separate acts, and the
-contract names them separately.** Fusing them would be sound only for a provider
-that can perform both in one call. A platform that reclaims idle sessions on its
+contract names them separately.** A platform that reclaims idle sessions on its
 own schedule, exposing no client-facing kill, can retire a session but cannot
 terminate one; another backend can kill a process and has no durable inventory
-to retire it from. Archive therefore reaches for whichever act a provider has,
-and where it has neither, the row state alone is the honest whole of it.
+to retire it from. So archive reaches for `archive` and for nothing else.
+Substituting `stop` where `archive` is undeclared would decide that a kill is a
+good enough synonym for a filing decision, discarding at the moment it matters
+the distinction the contract draws. `stop` stays available as its own gesture,
+asked for by name.
 
 The filing decision travels the other way too: a session the provider reports as
 `archived: true` flips its row to `archived`, and one reported back to
@@ -375,87 +384,74 @@ and it is the one fact both sides hold — so a lane retired on the provider's o
 surface or from another laptop leaves TBD's active list too, instead of
 persisting as a lane nobody will use.
 
+TBD reads that field only from a provider that declares `archive`, and only when
+it is present. A provider with no archiving concept never sets it, and an absent
+`archived` reads as `false` per contract, so an ungated reading would have every
+such snapshot carry an implicit "not archived" that returned rows to the active
+list about once a minute. Display still reads absent as `false`; only the filing
+sync abstains, because a rule about overwriting the user's own filing decision
+has to tell silence apart from denial.
+
 This holds while the row's location is remote, which is what makes it safe. A row
 whose files are on this machine takes its status from TBD alone, whatever a
 provider later says about a session that row once ran on.
 
-Where archive ends the session, it refuses on an active lane unless forced,
+Where archive invokes the verb, it refuses on an unsafe lane unless forced,
 paralleling how local archive refuses on uncommitted changes. Two guards:
 
-- `agentState == .working` — do not tear down a session mid-task by accident.
+- `agentState == .working` — do not retire a session mid-task by accident.
 - A dirty remote checkout, reported through an optional well-known `meta` key.
 
-The second guard exists because TBD cannot see a remote working tree. Ending a
+The second guard exists because TBD cannot see a remote working tree. Retiring a
 box session can destroy work that was never pushed, and the `working` guard does
-not help: an idle agent sitting on a dirty tree looks safe to stop. A provider
+not help: an idle agent sitting on a dirty tree looks safe to retire. A provider
 that knows its checkout is dirty reports it; TBD then treats the lane like a
-local one with uncommitted changes. Providers that report nothing degrade to a
-warning, so the guard is inert until a provider adopts it. It is additive at
-either contract major, which lets providers add response fields at any time.
+local one with uncommitted changes. Providers that report nothing degrade to the
+`working` guard alone, so the guard is inert until a provider adopts it. It is
+additive at either contract major, which lets providers add response fields at
+any time.
 
-**Both guards apply only where archive actually ends the session,** because
-destroying unpushed work is the only thing they defend against. A retire-only
-archive destroys nothing: the session keeps running, `unarchive` brings it back
-where the provider declares it, and refusing it would block a harmless gesture on
-a hazard that is not present. So:
-
-- **The `stop` path is always guarded.** TBD is asking for termination.
-- **The `archive`-verb path is guarded when the same provider also declares
-  `stop`.** The contract does not require `archive` to terminate anything, but it
-  permits termination as a side effect of retiring, and a provider whose one
-  operation does both is the common shape — it declares `stop` and `archive`
-  pointed at that single operation. Declared `stop` is the observable that says
-  this backend can end compute, so TBD treats its archive as possibly doing so.
-- **A provider that declares `archive` without `stop` is taken at its word.**
-  It has said it cannot terminate a session; archiving through it is a filing
-  change, and TBD does not guard it. Withholding `stop` while archiving tears the
-  box down is a misdeclaration, not a case this design defends against.
-- **The row-state-only path is never refused.** Nothing on the box is touched.
+**Both guards apply to the verb path alone.** The `gone` path calls nothing and
+touches nothing on the provider, so it has nothing to defend against. The
+contract permits termination as a side effect of retiring, so a declared
+`archive` is reason enough to check — one rule for both locations, rather than an
+inference drawn from which other capabilities a provider happens to declare.
 
 `--force` overrides both.
 
 ### Revive
 
-Revive returns a lane to the working set, and how far it reaches is decided by
-what archive did to the session.
+Revive returns a lane to the working set. It attempts the verb where one is
+declared, degrades on what comes back, and reports it. Two cases:
 
-**A `gone` row is checked first, before any of the cases below.** A row that is
-both `archived` and `gone` has a session the provider has stopped listing, so
-there is nothing to unarchive whatever the provider declares — reviving it flips
-the row alone and says the session is no longer there. Without that precedence
-such a row would fall into a capability-keyed case and issue a provider call
-that can only come back `not_found`: not a data-loss risk, but a confusing
-error where a plain statement belongs. This is the same precedence the
-terminated case already takes, for the same reason — what happened to the
-session outranks what the provider can be asked.
+- **Provider declares `unarchive`** — call it, flip the row back to `active`, and
+  report the session's condition: running, exited, or no longer there. Both verbs
+  are idempotent, so an already-active session, an exited one, and a `gone` one
+  all flip cleanly, with a `not_found` response degrading to a row-only flip
+  rather than surfacing an error.
+- **No `unarchive`, and the provider still reports the session archived** — the
+  retirement stands on the backend and TBD cannot lift it. The contract declares
+  the two verbs separately precisely because a backend may retire without being
+  able to restore, so revive is unavailable and says which half is missing.
+- **No `unarchive`, and the provider does not report it archived** — flip the
+  row and call nothing. This is a lane filed under the `gone` exemption: TBD's
+  own decision, which a TBD gesture reverses, so a `gone` archive is never a
+  one-way door.
 
-Four cases then remain, mirroring archive's own:
+The discriminator is what the provider reports now, not how the row came to be
+archived, so nothing about the archive has to be persisted to decide it.
 
-- **Nothing was retired on the provider** — archive flipped the row alone. Revive
-  flips it back. The session never left the provider's working set, so there is
-  nothing to undo there.
-- **Provider declares `unarchive`** — call it, then flip the row back to
-  `active`. This restores the lane whole: the session is still there, and both
-  sides agree it is back in play.
-- **The session was terminated** — archive took the `stop` path, or the
-  provider's archive tore down the compute as a side effect. There is nothing to
-  return to, and revive says so. Recreating a session on the same branch and
-  rebinding the row — the shape `ReviveFresh` already uses locally — is additive
-  and needs no model change, so it can follow if the absence chafes.
-- **Provider declares `archive` without `unarchive`, and the session still
-  exists** — the retirement stands on the backend and TBD cannot lift it. The
-  contract declares the two verbs separately precisely because a backend may
-  retire without being able to restore, so revive is unavailable and says which
-  half is missing.
+**Attempting the verb is worth a call TBD expects to fail.** `gone` means only
+that a session missed two consecutive snapshots, and a provider may list it
+again; an exited session may still be a record the provider can unarchive. What
+comes back is better evidence than what TBD believed beforehand, and idempotence
+means the attempt costs a round trip and never a wrong outcome.
 
-**These are evaluated in order, and termination is checked before capability.**
-The common `archive`+`stop`-without-`unarchive` shape satisfies both of the last
-two conditions at once, so the order is what decides which message the user sees.
-Termination wins because it is the stronger fact: if the compute is gone, an
-`unarchive` verb would not have helped either, and telling someone which half of
-a verb pair is missing invites them to go looking for a restore that could not
-work. "There is nothing to return to" is the accurate answer whenever it is
-true, whatever the provider declares.
+**The refusal is mechanical rather than a matter of taste.** With no verb to
+call and the provider still reporting `archived: true`, a row-only flip would be
+re-archived by the filing sync on the next snapshot, and again on every snapshot
+after. Refusing keeps the two records from fighting. Where the provider reports
+nothing, no such contradiction exists to create.
 
 ### `gone` and `archived` compose
 
@@ -604,23 +600,27 @@ Behavior:
 
 - Parameter resolution honors all four layers, including a user default beating
   ambient derivation.
-- Archive takes each of its three paths against the capabilities declared: a
-  provider declaring `archive` is archived through the verb, one declaring only
-  `stop` is stopped, and one declaring neither has its row flipped with no
-  provider call at all. Each ends with the row `archived`, and an
-  already-archived or already-exited lane flips without error.
-- The guards are scoped to the terminating paths: archive refuses on `working`
-  and on a provider-reported dirty checkout when the path is `stop`, and when it
-  is the `archive` verb from a provider that also declares `stop`; it refuses on
-  neither when the provider declares `archive` without `stop`, nor when no verb
-  is called at all. `--force` overrides both wherever they apply.
+- Archive takes each of its paths against the capabilities declared: a provider
+  declaring `archive` is archived through the verb, a `gone` lane has its row
+  flipped with no provider call, and a provider declaring neither is refused with
+  the row untouched. A provider declaring only `stop` is refused too, and `stop`
+  is never invoked. An already-archived or already-exited lane flips without
+  error.
+- The guards are scoped to the verb path: archive refuses on `working` and on a
+  provider-reported dirty checkout when it calls `archive`, and refuses on
+  neither when it files a `gone` lane. `--force` overrides both wherever they
+  apply.
 - A session reported `archived: true` flips its row to `archived`, and one
   reported back to `archived: false` returns it to `active`, without either
-  touching `state`.
-- Revive takes each of its four cases: it flips the row back alone where archive
-  called nothing, unarchives through the verb where it is declared, and reports
-  the reason it cannot proceed both where `archive` was declared without
-  `unarchive` and where the session was terminated.
+  touching `state`. A provider that does not declare `archive` moves no row
+  whatever it reports, and an absent `archived` moves no row while still reading
+  as not-archived for display.
+- Revive takes each of its cases: it unarchives through the verb where declared —
+  for a running, an exited, and a `gone` session alike, with `not_found`
+  degrading to a row-only flip; it reports which half is missing where `archive`
+  was declared without `unarchive` and the session is still reported archived;
+  and it flips the row alone for a `gone`-exemption lane whose provider declares
+  neither verb.
 - Adoption places an unparented session at top level in its matched repo,
   creates no row for an unmatched session, and does not re-derive an existing
   row.

--- a/docs/specs/2026-08-16-remote-lane-archive-design.md
+++ b/docs/specs/2026-08-16-remote-lane-archive-design.md
@@ -1,10 +1,10 @@
 # Retiring a remote lane
 
 **Date:** 2026-08-16
-**Status:** Approved, unbuilt.
+**Status:** Approved, built.
 **Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md)
-(the `archive`, `unarchive`, and `stop` capabilities, and the `archived` field
-on the Session object),
+(the `archive` and `unarchive` capabilities, the `archived` field on the Session
+object, and the optional `meta.workspace_dirty` key),
 [`2026-08-10-remote-sessions-in-worktree-tree-design.md`](2026-08-10-remote-sessions-in-worktree-tree-design.md)
 (the local/remote boundary, adoption, and the archive and revive semantics this
 design implements).
@@ -273,10 +273,13 @@ static func revivePlan(capabilities: Set<String>, providerReportsArchived: Bool)
     -> RemoteLaneRevivePlan
 ```
 
-Capabilities are read from the provider manager's cached `describe` response.
-No contract negotiation is involved: `describe.capabilities` already carries
-`archive` and `unarchive`, and a caller must not invoke a verb whose capability
-a provider has not declared.
+Capabilities come from the provider manager's cached `describe` response,
+reached through its public `providerStatuses()` rather than the private
+`describes` map — the same door the app already uses client-side, so daemon and
+app derive a provider's capabilities identically instead of through two paths
+that can drift. No contract negotiation is involved: `describe.capabilities`
+already carries `archive` and `unarchive`, and a caller must not invoke a verb
+whose capability a provider has not declared.
 
 `worktree.forget` keeps its refusal for a remote lane. Forget means "stop
 tracking this checkout but leave its files alone", and a remote lane has no

--- a/docs/specs/2026-08-16-remote-lane-archive-design.md
+++ b/docs/specs/2026-08-16-remote-lane-archive-design.md
@@ -83,13 +83,21 @@ The `gone` exemption is the only route out for a lane whose provider cannot
 archive, and it is deliberately narrow. A lane whose session is still enumerated
 stays in the active list until its provider implements the capability.
 
+A declared `archive` wins over the exemption, so a `gone` lane on a capable
+provider still takes the verb path — and a `not_found` response there degrades
+to the same row-only filing rather than an error. A session the provider no
+longer knows is exactly the case the exemption covers, and treating it as a
+failure would leave a lane unretireable on a provider that declares *more* than
+one whose lane files cleanly. Revive has the mirror-image degradation.
+
 ### Guards
 
 Where archive invokes the verb, it refuses on an unsafe lane unless forced,
 paralleling how local archive refuses on uncommitted changes:
 
 - `agentState == .working` — do not retire a session mid-task by accident.
-- A dirty remote checkout, reported through an optional well-known `meta` key.
+- A dirty remote checkout, reported through the optional well-known `meta` key
+  `workspace_dirty`.
 
 The second guard exists because TBD cannot see a remote working tree, and the
 `working` guard does not cover it: an idle agent sitting on unpushed work looks
@@ -97,6 +105,14 @@ safe to retire. A provider that knows its checkout is dirty reports it; one that
 reports nothing degrades to the `working` guard alone, so the guard is inert
 until a provider adopts it and TBD never fabricates the fact. It is additive at
 either contract major.
+
+`meta` is a flat string-to-string map, so the claim arrives as text, and only
+`"true"` and `"1"` — trimmed, case-insensitively — are read as one. An absent
+key, an empty value, and any unrecognized value all mean no claim was made.
+The reading is deliberately narrow rather than a permissive truthiness test:
+this value decides whether a user's archive is refused, and inventing a claim
+out of a string a provider meant for display would block a gesture nobody asked
+to block.
 
 Both guards apply to the verb path alone. The `gone` path touches nothing on the
 provider and has nothing to defend. `--force` overrides both.

--- a/docs/specs/2026-08-16-remote-lane-archive-design.md
+++ b/docs/specs/2026-08-16-remote-lane-archive-design.md
@@ -1,0 +1,448 @@
+# Retiring a remote lane
+
+**Date:** 2026-08-16
+**Status:** Approved, unbuilt.
+**Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md)
+(the `archive`, `unarchive`, and `stop` capabilities, and the `archived` field
+on the Session object),
+[`2026-08-10-remote-sessions-in-worktree-tree-design.md`](2026-08-10-remote-sessions-in-worktree-tree-design.md)
+(the local/remote boundary, adoption, and the archive and revive semantics this
+design implements).
+
+## Summary
+
+A remote agent session that TBD has adopted as a worktree row cannot be retired.
+Every path that would retire a row refuses a remote one, and the code beneath
+those refusals resolves rows through `WorktreeStore.getLocal`, which returns
+nothing for a remote row. Adopted lanes are therefore permanent: they accumulate
+in the active sidebar and no gesture removes them.
+
+This gives a remote lane its own retirement path. Archive composes over the
+capabilities a provider declares rather than over a fixed teardown, because what
+retiring means on the far side is the provider's to define. Where a provider
+declares nothing, TBD refuses rather than filing a row it cannot stand behind —
+a retirement TBD did not perform is not a retirement it may claim.
+
+## The gap
+
+Four paths are structurally local, and the first three carry an explicit refusal
+while the fourth would fail beneath one:
+
+- `handleWorktreeArchive` returns an error for a row whose location is not local.
+- `handleWorktreeForget` does the same.
+- `AutoArchiveOnMergeCoordinator.handleMergedTransition` returns `false`
+  silently, which is right for a background rail.
+- `handleWorktreeRerunPreSession`'s sibling `beginReviveWorktree` carries no
+  refusal at all, and resolves through `getLocal` like the others.
+
+Lifting the refusals alone would not work. `beginArchiveWorktree`,
+`forgetWorktree`, and `beginReviveWorktree` each obtain their row through
+`getLocal`, and `LocalWorktree.init?` rejects a remote row before anything else.
+Beneath them the local archive path captures scrollback, kills tmux windows,
+runs git checks, and removes a directory — work that has no meaning for a lane
+whose files are on another machine. A remote lane needs a different path, not an
+unfenced one.
+
+The merged-transition rail reaches remote lanes today, so its refusal is load
+bearing rather than theoretical: PR polling was re-keyed on the branch when
+adoption shipped, and `pollableWorktrees` admits remote rows so a lane carries a
+PR badge like any other.
+
+## Archive
+
+Archive retires a lane from the working set. It has one success path and one
+exemption.
+
+- **The provider declares `archive`** — guard, invoke `archive <id>`, then mark
+  the row archived. The retirement is a fact on the backend rather than TBD's
+  private bookkeeping, so every other client of that backend sees it.
+- **The session is `gone`** — mark the row archived and call nothing. A `gone`
+  session is one the provider has stopped enumerating, so there is no live
+  session to misdescribe and no verb that could reach it.
+- **Neither** — refused, naming `archive` as the capability the provider needs
+  to implement.
+
+**Refusing is the point, not a gap in coverage.** Filing a row while the
+provider still reports the session active leaves two records disagreeing, and
+the one the user reads says a retirement happened that did not. A provider is
+free to define archiving as it likes — retiring an entry in its own inventory is
+enough, and the contract defines `archived` as retirement from the working
+inventory rather than as a statement about liveness — but it must say so through
+the capability and report it back through `list`. What TBD will not do is
+synthesize that claim on a provider's behalf.
+
+**TBD does not substitute `stop` for a missing `archive`.** The contract names
+the two verbs separately because ending compute and retiring a record are
+different acts, and a provider that declared only `stop` has said it can do the
+first. Reaching for it when the user asked for the second would be TBD deciding
+that a kill is a good enough synonym for a filing decision. `stop` remains
+available as its own gesture on the Provider Desk, where the user asks for it by
+name.
+
+The `gone` exemption is the only route out for a lane whose provider cannot
+archive, and it is deliberately narrow. A lane whose session is still enumerated
+stays in the active list until its provider implements the capability.
+
+### Guards
+
+Where archive invokes the verb, it refuses on an unsafe lane unless forced,
+paralleling how local archive refuses on uncommitted changes:
+
+- `agentState == .working` — do not retire a session mid-task by accident.
+- A dirty remote checkout, reported through an optional well-known `meta` key.
+
+The second guard exists because TBD cannot see a remote working tree, and the
+`working` guard does not cover it: an idle agent sitting on unpushed work looks
+safe to retire. A provider that knows its checkout is dirty reports it; one that
+reports nothing degrades to the `working` guard alone, so the guard is inert
+until a provider adopts it and TBD never fabricates the fact. It is additive at
+either contract major.
+
+Both guards apply to the verb path alone. The `gone` path touches nothing on the
+provider and has nothing to defend. `--force` overrides both.
+
+Guarding the verb unconditionally, rather than inferring from a provider's other
+capabilities whether its archive might end compute, keeps one rule for both
+locations. The contract permits termination as a side effect of retiring, so a
+declared `archive` is reason enough to check.
+
+### Auto-archive on merge
+
+The merged-transition rail participates under the opt-in it already has. The
+rail is off by default, per-worktree overridable, and armed by a deliberate
+gesture; the act it performs is the same archive on the same path, and it
+declines by itself when the provider declares no `archive`, exactly as a manual
+archive would. A second switch would gate a switch.
+
+## Revive
+
+Revive returns a lane to the working set. It attempts the verb where one is
+declared, degrades on what comes back, and reports it:
+
+- **The provider declares `unarchive`** — invoke it, flip the row to active, and
+  report the session's condition: running, exited, or no longer there. `archive`
+  and `unarchive` are idempotent per contract, so an already-active session, an
+  exited one, and a `gone` one all flip cleanly, with `not_found` degrading to a
+  row-only flip rather than surfacing an error.
+- **No `unarchive`, and the provider currently reports the session archived** —
+  refused, naming `unarchive` as the missing half and saying the retirement
+  stands on the backend until it exists.
+- **No `unarchive`, and the provider does not report it archived** — flip the
+  row, call nothing. This is the lane filed under the `gone` exemption: TBD's own
+  decision, which a TBD gesture reverses.
+
+The discriminator is what the provider reports right now, not how the row came to
+be archived, so no provenance has to be persisted. A lane the provider still
+reports archived is one TBD retired through the verb; a lane it does not report
+at all, or reports unarchived, is one TBD filed on its own.
+
+Attempting the verb even for a lane that looks dead is worth a call TBD expects
+to fail. `gone` means only that a session missed two consecutive snapshots, and
+a provider may list it again; an exited session may still be a record the
+provider can unarchive. The verb is idempotent, so the attempt costs a round
+trip and never a wrong outcome, and what comes back is better evidence than what
+TBD believed beforehand.
+
+**The refusal is mechanical rather than a matter of taste.** With no verb to
+call and the provider still reporting `archived: true`, a row-only flip would be
+re-archived by the filing sync on the next snapshot, and again on every snapshot
+after. Refusing is what keeps the two records from fighting. Where the provider
+reports nothing, there is no such contradiction to create: the sync reads
+`archived` only from a provider declaring `archive`, and only when present, so
+nothing will arrive to undo the flip.
+
+## The filing decision travels back
+
+A session the provider reports as archived leaves TBD's active list, and one
+reported back to unarchived returns to it, so a lane retired on the provider's
+own surface or from another machine does not persist as a lane nobody will use.
+This holds only while a row's location is remote. A row whose files are on this
+machine takes its status from TBD alone.
+
+Neither direction touches `state`. Filing and liveness are separate axes, and a
+row that collapses them lies about one of them.
+
+### Whose report counts
+
+TBD reads `archived` **only from a provider that declares `archive`, and only
+when the field is present**.
+
+The capability half is what makes the exemption durable. A provider with no
+archiving concept never sets the field, and the contract requires an absent
+`archived` to be read as `false` — so without the gate, every snapshot from such
+a provider would carry an implicit "not archived" that returned rows to the
+active list about once a minute, forever.
+
+The presence half defends against a provider that declares the capability and
+omits the field anyway. Absent means no claim was made; explicit `false` is a
+claim. Display still reads absent as `false`, exactly as the contract says; only
+the sync abstains, because a rule about whether to overwrite the user's own
+filing decision needs to distinguish silence from denial.
+
+`RemoteSessionPayload.archived` is therefore stored as `Bool?` and never
+collapsed at decode. A computed reading supplies the contract's absent-is-false
+semantics wherever display needs it.
+
+### Stale snapshots
+
+The payload carries no provider-side timestamp or sequence number, and the
+mirror stamps arrival time from TBD's own clock, so a response composed before a
+local filing decision is indistinguishable on its face from one composed after.
+A `list` launched half a second before an archive and returning after it carries
+a pre-archive `archived: false`, which passes both gates above and returns the
+row the user just retired.
+
+The consequence is worse than a brief flicker, because the app's archive
+tombstone defers it. A tombstone is dropped early only when the daemon reports
+the row archived or absent; over a row the daemon reports active it is held to
+its TTL. So the lane disappears on archive, stays hidden while the tombstone
+lives, reappears when it expires, and files itself again on the next clean poll.
+The symptom presents as a lane returning unbidden some seconds after being
+archived, which reads as a persistence bug rather than a stale read. Revive has
+the mirror-image case.
+
+TBD therefore records when it last made a filing decision on a remote row, and
+suppresses a snapshot-driven flip whose request began earlier:
+
+- `pollOnce` captures the request start before invoking the provider and carries
+  it to the apply, alongside the arrival time the mirror already stamps. The
+  events path supplies the connection-open time for a `snapshot`, and arrival
+  for a pushed `session`, which is fresh by construction.
+- The provider manager holds an in-memory map of worktree id to filing time,
+  written whenever TBD locally archives or revives a remote row, and swept of
+  entries older than two poll intervals.
+- A flip applies only when the row's recorded decision is no later than the
+  request start.
+
+This is exact rather than a tuned window: a response to a request sent before a
+decision provably could not have accounted for it. It covers both directions,
+which a timestamp on the row itself cannot — revive clears `archivedAt`, leaving
+the un-archive direction with nothing to appeal to.
+
+Holding the map in memory rather than in a column is what the durability is
+worth. The window it defends is open only while a provider request is
+outstanding, and such a request dies with the process; after a restart every
+request start is later than every prior decision, so there is nothing left to
+suppress. A persisted column would buy survival of a window that cannot survive.
+
+### Never silent
+
+A sync-driven archive writes a notification record rather than only broadcasting
+a delta, so a lane that leaves the active list without a gesture says why. The
+merge rail already establishes this shape for the other case where a worktree is
+retired without the user asking at that moment.
+
+The same obligation covers the refusals. A refused archive names `archive` as
+the capability to implement, and a refused revive names `unarchive` and says the
+retirement stands until it exists. Both point at the provider contract. Telling
+someone an action is unavailable without telling them what would make it
+available leaves them with a dead control and no next step.
+
+## Where the branches live
+
+`RemoteLaneLifecycle` owns the remote path, holding the provider manager and the
+worktree store. The archive and revive handlers and the merge rail branch into
+it on location; the local path beneath `getLocal` is untouched, and the boundary
+`LocalWorktree` draws stays exactly where it is.
+
+Capability routing is a pure function over the declared capability set and the
+row's `gone` flag, so the decision is testable without a provider process:
+
+```swift
+enum RemoteLaneArchivePlan { case invokeVerb, rowOnlyGone, refused(String) }
+enum RemoteLaneRevivePlan  { case invokeUnarchive, rowOnly, refusedNoUnarchive(String) }
+
+static func archivePlan(capabilities: Set<String>, isGone: Bool) -> RemoteLaneArchivePlan
+static func revivePlan(capabilities: Set<String>, providerReportsArchived: Bool)
+    -> RemoteLaneRevivePlan
+```
+
+Capabilities are read from the provider manager's cached `describe` response.
+No contract negotiation is involved: `describe.capabilities` already carries
+`archive` and `unarchive`, and a caller must not invoke a verb whose capability
+a provider has not declared.
+
+`worktree.forget` keeps its refusal for a remote lane. Forget means "stop
+tracking this checkout but leave its files alone", and a remote lane has no
+checkout here to leave alone. Its message changes from describing an
+unimplemented gap to stating that retiring a lane is archive's job.
+
+## Wire surface
+
+Two RPC methods, mirroring `remote.stop`'s shape:
+
+```swift
+static let remoteArchive   = "remote.archive"
+static let remoteUnarchive = "remote.unarchive"
+
+public struct RemoteArchiveParams: Codable, Sendable {
+    public let provider: String
+    public let sessionID: String
+}
+public struct RemoteUnarchiveParams: Codable, Sendable { /* same shape */ }
+```
+
+And one field on the Session payload:
+
+```swift
+public let archived: Bool?          // nil = absent = no claim made
+public var isArchived: Bool { archived ?? false }
+```
+
+Both verbs return the updated Session object per contract. Both are idempotent,
+so archiving an already-archived lane or unarchiving one that is not archived
+succeeds and changes nothing.
+
+## Surfaces
+
+`RowActionMenu.Context` gains the row's location, its provider name, and the
+provider's declared capability set. Archive stays visible and destructive-styled
+for a lane whose provider cannot archive, but disabled, with the reason in the
+item's own title — the same treatment the menu already gives a row with active
+children, and for the same reason: a tooltip on a disabled menu item is easy to
+miss. Hiding the item instead would leave the absence unexplained and give a
+provider author no signal that a capability is missing.
+
+`ArchivedWorktreesView`'s hide-empty filter admits a remote lane on its location.
+The filter keeps a row when it has conversations or a revive in flight, and a
+remote lane's synthetic `remote://` path resolves to no Claude project
+directory, so its session count is structurally zero. Left alone, the filter is
+on by default and every archived lane would be invisible — archived successfully
+and then hidden, which is indistinguishable from the archive having failed.
+
+## The record
+
+A refusal happens above the actuation row. Nothing was attempted, and the record
+may claim solely acts that were attempted, so a refused archive writes no
+request and no outcome — the same shape the current location gates use, and the
+same reason `repo.remove` writes no dispose row for a lane it never tore down.
+
+The `gone` path does write a row and confirm it dispatched. No provider call was
+made, but the row genuinely changed status, and that is the act the record names.
+
+A sync-driven archive writes its own row with the daemon actor and a rail name,
+as the merge coordinator does, because no RPC carried it.
+
+## Flag, migration, and reconciliation
+
+**No new flag.** Everything here is inert unless `remote_backends_enabled` is on
+and a provider is registered, and a remote row cannot exist otherwise. The
+filing sync is background behavior that mutates persisted state, which ordinarily
+argues for its own default-off gate, but the subsystem it belongs to is already
+behind exactly such a gate and a second one would gate a flag.
+
+**No migration.** `archived` rides the existing payload blob the mirror already
+stores, and the stale-snapshot watermark is in-memory.
+
+**Reconciliation.** This creates no durable external resource: it mutates rows
+that already exist and calls verbs the contract defines as idempotent. The one
+divergence it can produce is a verb that succeeded against a row that was never
+written, leaving TBD active and the backend archived. The filing sync reconciles
+that on the next snapshot, and is the named answer for it. No new sweep is
+required.
+
+## Testing
+
+All tests run against the existing stub provider fixture, with no network, under
+`TBD_HOME` isolation.
+
+Archive:
+
+- Each plan is taken against the capabilities declared: a provider declaring
+  `archive` is archived through the verb, a `gone` lane is filed with no provider
+  call, and a provider declaring neither is refused with the row untouched.
+- A provider declaring only `stop` is refused, and `stop` is never invoked.
+- The guards refuse on `working` and on a provider-reported dirty checkout for
+  the verb path, refuse on neither for the `gone` path, and both yield to
+  `--force`.
+- An already-archived and an already-exited lane each flip without error.
+- The merge rail archives an armed remote lane whose provider declares `archive`,
+  and declines one whose provider does not, without writing an actuation row for
+  the decline.
+
+Revive:
+
+- A provider declaring `unarchive` returns the lane whether the session is
+  running, exited, or gone, and a `not_found` response degrades to a row-only
+  flip rather than an error.
+- A provider declaring `archive` without `unarchive`, still reporting the session
+  archived, is refused, and the message names `unarchive`.
+- A lane filed under the `gone` exemption by a provider declaring neither verb is
+  revived by a row-only flip, with no provider call — so a `gone` archive is
+  never a one-way door.
+
+Filing sync:
+
+- A session reported `archived: true` files its row; one reported back to
+  `false` returns it; neither changes `state`.
+- A provider that does not declare `archive` moves no row whatever it reports.
+- An absent `archived` moves no row, while still reading as not-archived for
+  display.
+- A response whose request began before a local filing decision does not reverse
+  it, in both the archive and the revive direction; one whose request began after
+  does apply.
+- A local worktree's status is never moved by any provider report.
+
+Surfaces and record:
+
+- The row menu disables Archive with a reason for a lane whose provider cannot
+  archive, and enables it where the capability is declared.
+- An archived remote lane appears in the archived list with the hide-empty
+  filter at its default, alongside a local archived worktree with no
+  conversations that the filter still hides — so a run that showed everything
+  cannot pass by doing nothing.
+- A refused archive and a refused revive each write no actuation row; a `gone`
+  archive and a sync-driven archive each write one.
+
+## Rejected alternatives
+
+**Filing the row anyway when a provider cannot archive, and explaining
+afterwards.** The gesture would always succeed and the archived row would carry a
+standing note that the session is still running. Rejected because it makes TBD
+the author of a retirement no other client of that backend can see, and the
+record the user reads is the one that overstates what happened. A provider that
+wants a filing-only archive can implement exactly that and report it through
+`list`, which keeps the claim where it can be verified.
+
+**Substituting `stop` where `archive` is undeclared.** Rejected above: the
+contract separates ending compute from retiring a record precisely because a
+backend may have one and not the other, and inferring a retirement from a kill
+discards that distinction at the moment it matters.
+
+**`worktree.forget` as a general escape hatch for a lane that cannot be
+archived.** Attractive, because forget already means "stop tracking this, leave
+the thing alone" and makes no claim about the backend. Rejected because
+adoption re-creates a row for any session it sees without one, so a forgotten
+lane would return on the next poll; making it stick would need a persisted
+do-not-adopt fact and a way to reverse it, which is a second retirement concept
+alongside archive.
+
+**A persisted column for the stale-snapshot watermark.** Rejected on what the
+durability buys: the window it protects is open only while a provider request is
+outstanding, and no such request survives a restart.
+
+**Reading `archived` from any provider, gated only on the field's presence.**
+Simpler to state, and defensible — the field is plain Session data the contract
+does not gate on a capability. Rejected because a provider with no archiving
+concept can still emit `archived: false` for tidiness, and TBD would then let a
+backend that cannot archive anything overwrite a filing decision the user made.
+
+**A monotonic sync that files rows but never returns them.** This would remove
+the stale-snapshot race outright, since the only direction it moves is one a
+stale response cannot fabricate. Rejected because it breaks revive instead: a
+stale `archived: true` arriving after a revive would re-file the row, and the
+later corrected `false` would be ignored, leaving the row archived permanently
+and the user's revive silently undone.
+
+**Its own default-off flag for the filing sync.** Rejected because the
+subsystem is already behind `remote_backends_enabled` and a remote row cannot
+exist without it.
+
+## Deliberate cuts
+
+No recreation of a session for a lane whose session was terminated, so revive
+reaches only as far as `unarchive` does. No `delete` verb, and no mapping of any
+TBD gesture onto one — retiring and destroying are different acts and the
+contract names only the first. No per-repo policy for which providers may be
+archived automatically. No change to attach, log, send, stop, or the reconnect
+policy.

--- a/docs/specs/2026-08-16-remote-lane-archive-design.md
+++ b/docs/specs/2026-08-16-remote-lane-archive-design.md
@@ -153,11 +153,12 @@ reports archived is one TBD retired through the verb; a lane it does not report
 at all, or reports unarchived, is one TBD filed on its own.
 
 Attempting the verb even for a lane that looks dead is worth a call TBD expects
-to fail. `gone` means only that a session missed two consecutive snapshots, and
-a provider may list it again; an exited session may still be a record the
-provider can unarchive. The verb is idempotent, so the attempt costs a round
-trip and never a wrong outcome, and what comes back is better evidence than what
-TBD believed beforehand.
+to fail. `gone` means only that a session stopped being enumerated — it is set
+after two consecutive absences from a snapshot, or at once on an explicit
+`removed` event — and a provider may list it again; an exited session may still
+be a record the provider can unarchive. The verb is idempotent, so the attempt
+costs a round trip and never a wrong outcome, and what comes back is better
+evidence than what TBD believed beforehand.
 
 **The refusal is mechanical rather than a matter of taste.** With no verb to
 call and the provider still reporting `archived: true`, a row-only flip would be
@@ -274,12 +275,12 @@ static func revivePlan(capabilities: Set<String>, providerReportsArchived: Bool)
 ```
 
 Capabilities come from the provider manager's cached `describe` response,
-reached through its public `providerStatuses()` rather than the private
-`describes` map — the same door the app already uses client-side, so daemon and
-app derive a provider's capabilities identically instead of through two paths
-that can drift. No contract negotiation is involved: `describe.capabilities`
-already carries `archive` and `unarchive`, and a caller must not invoke a verb
-whose capability a provider has not declared.
+through a single derivation on the manager itself so the RPC gate and the lane
+routing cannot drift apart. Daemon-side callers are inside the actor and read
+the cached map directly; the app, being outside it, reads the same values off
+the `describe` carried on `providerStatuses()`. No contract negotiation is
+involved: `describe.capabilities` already carries `archive` and `unarchive`, and
+a caller must not invoke a verb whose capability a provider has not declared.
 
 `worktree.forget` keeps its refusal for a remote lane. Forget means "stop
 tracking this checkout but leave its files alone", and a remote lane has no
@@ -311,6 +312,16 @@ public var isArchived: Bool { archived ?? false }
 Both verbs return the updated Session object per contract. Both are idempotent,
 so archiving an already-archived lane or unarchiving one that is not archived
 succeeds and changes nothing.
+
+**These two RPCs are the direct verb surface, and they carry no lane guards.**
+They name a provider and a session, invoke the verb, and mirror the result —
+the shape `remote.stop` already established, where the user asks for an act on a
+session by name. The guarded path is `worktree.archive`, which reasons about a
+lane: it consults capabilities, applies the `working` and dirty-checkout guards,
+honors `--force`, and files the row. A control that means "retire this lane"
+belongs on that path. Wiring such a control to `remote.archive` instead would
+skip every guard this design rests on, which is why the distinction is stated
+here rather than left to be inferred from which surface was closer to hand.
 
 ## Surfaces
 

--- a/docs/specs/2026-08-16-remote-lane-archive-design.md
+++ b/docs/specs/2026-08-16-remote-lane-archive-design.md
@@ -114,8 +114,44 @@ this value decides whether a user's archive is refused, and inventing a claim
 out of a string a provider meant for display would block a gesture nobody asked
 to block.
 
-Both guards apply to the verb path alone. The `gone` path touches nothing on the
-provider and has nothing to defend. `--force` overrides both.
+A third refusal joins them, on the same path and for the same reason: **a
+provider whose cached inventory has gone stale refuses the verb.** Both guards
+above are read out of the mirror, and a stale mirror is one TBD already knows it
+cannot trust — a session idle at the last good poll and working now reads as
+safe, both guards pass, and a mid-task session is retired, which is the outcome
+the guards exist to prevent. Refusing keeps a provider call from resting on an
+inventory that may be wrong about exactly the facts being consulted. It is the
+same gate every `remote.*` mutation passes.
+
+All three apply to the verb path alone. The `gone` archive and the row-only
+revive touch nothing on the provider, consult nothing but the row's own `gone`
+flag, and so have nothing to defend. Gating them would be worse than useless: the
+`gone` exemption is the only route out for a lane whose provider cannot archive,
+and revive has no `--force` at all, so a lane could be stranded in the archived
+list for as long as its provider stayed unhealthy. `--force` overrides all three
+where they apply.
+
+The row-only revive does carry a residual, stated rather than defended away: its
+branch is chosen from the provider's `archived` claim as the mirror last saw it,
+so a stale mirror can route a lane the provider still holds archived down the
+row-only flip instead of the refusal. The next good snapshot re-files it, which
+is a visible correction rather than a lost gesture, and that is the better half
+of the trade against stranding the exemption.
+
+### The rail declines on a stale inventory, and that edge is lost
+
+`AutoArchiveOnMergeCoordinator` reaches a remote lane through the same routing
+and inherits the same refusal, with no `--force` to reach for. That is the right
+default — autonomously retiring a possibly-working session on the strength of an
+inventory known to be wrong is worse than not retiring it — but the cost is worth
+recording, because the trigger it declines is not one it will see again.
+
+The merged transition is edge-triggered and unpersisted: the dispatcher re-arms
+only when a worktree returns to unresolved, so a provider hiccup at the moment a
+merge is observed drops that lane's auto-archive for the rest of the daemon run.
+The recovery is a manual archive. Persisting the pending edge would fix it, and
+is deliberately not done here: it is a change to the rail's own trigger model
+rather than to remote archiving, and it belongs with the rail.
 
 Guarding the verb unconditionally, rather than inferring from a provider's other
 capabilities whether its archive might end compute, keeps one rule for both
@@ -230,6 +266,31 @@ suppresses a snapshot-driven flip whose request began earlier:
   entries older than two poll intervals.
 - A flip applies only when the row's recorded decision is no later than the
   request start.
+
+Three properties of that map are what make it hold, and each closes a way the
+window reopens.
+
+- **The decision is stamped after the row is written, not only before it.** A
+  gesture that invokes a provider verb stamps twice: once before the call, so a
+  poll already outstanding cannot act on the row while the verb runs, and again
+  once the row lands. Only the second covers the verb's own duration — a `list`
+  launched after the gesture began but before the row was written carries the
+  provider's pre-gesture word and would otherwise pass the gate, reversing the
+  row roughly (verb duration / poll interval) of the time. The sync's own two
+  writing paths stamp after their write for the same reason.
+- **The map only moves forward.** Instants do not arrive in the order the calls
+  are made: the sync stamps a snapshot's *arrival*, which precedes its own write
+  by an adoption and a record append, so a sync that began before a gesture can
+  finish after it holding the older instant. Keeping the later of the two is
+  always sound, since every recorded instant belongs to a decision that really
+  was made and the newest bounds them all.
+- **A decision that fails restores what was there, rather than deleting.** A
+  verb that fails, or a row write that throws, leaves a watermark recorded for a
+  filing that never happened, and it has to come back off — but the row may
+  carry an earlier watermark from a decision that did happen, whose window is
+  still open. The withdrawal puts that one back, and stands down entirely if
+  another path has recorded its own decision in the meantime, since that one is
+  newer than both.
 
 This is exact rather than a tuned window: a response to a request sent before a
 decision provably could not have accounted for it. It covers both directions,
@@ -411,12 +472,27 @@ Filing sync:
 - A response whose request began before a local filing decision does not reverse
   it, in both the archive and the revive direction; one whose request began after
   does apply.
+- A poll launched *while a gesture's verb was running* reverses neither an
+  archive nor a revive, which is the case only the post-write stamp covers.
+- An older instant does not displace a newer watermark, and a withdrawal
+  restores the previous one rather than dropping the entry.
+- A row that became ineligible while a flip was being recorded is refused as
+  `not-eligible`, and one already at the flip's own target as `noop`.
 - A local worktree's status is never moved by any provider report.
+
+Guards:
+
+- The stale-inventory refusal covers the verb paths and leaves the `gone`
+  archive and the row-only revive alone, so a lane on an unhealthy provider is
+  still retireable and revivable by the path that calls nothing.
 
 Surfaces and record:
 
 - The row menu disables Archive with a reason for a lane whose provider cannot
   archive, and enables it where the capability is declared.
+- Those menu assertions run through the app's own context builder rather than a
+  hand-built context, so a field the running app never populates — as `isGone`
+  once was not — fails the suite instead of passing it.
 - An archived remote lane appears in the archived list with the hide-empty
   filter at its default, alongside a local archived worktree with no
   conversations that the filter still hides — so a run that showed everything


### PR DESCRIPTION
## Summary

A remote agent session that TBD has adopted as a worktree row could not be retired. Archive, forget, and the auto-archive-on-merge rail each refused a remote row, and revive would have thrown beneath its own resolver. So an adopted lane was permanent: it sat in the active sidebar and no gesture removed it.

Now a lane can be retired, and what that means is the provider's to define. Where a provider declares the `archive` capability, TBD invokes it and files the row, so the retirement is a fact on the backend that every other client of it sees. Where a provider declares nothing and the session is still being enumerated, TBD **refuses** and says which capability would make it work — rather than filing a row and quietly implying a teardown that never happened.

## Why this shape

Spec: [`docs/specs/2026-08-16-remote-lane-archive-design.md`](docs/specs/2026-08-16-remote-lane-archive-design.md), brainstormed and committed before implementation. It also amends [`2026-08-10-remote-sessions-in-worktree-tree-design.md`](docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md) in the same PR, so the two documents do not disagree about a question only one of them can own.

Three decisions carried the design:

**Refusing beats pretending.** The earlier design let archive fall back to `stop` when `archive` was undeclared, and to a row-only filing when neither existed. Both are gone. The contract names ending compute and retiring a record separately because a backend may have one and not the other, and substituting a kill for a filing decision discards that distinction exactly where it matters. A row marked archived while the provider still reports the session active leaves two records disagreeing, and the one the user reads is the one that overstates what happened.

**A `gone` session is the one honest exemption.** A session the provider has stopped enumerating cannot be reached by a verb and has no live state to misdescribe, so its row files on TBD's own authority. This is deliberately narrow: a lane whose session is still listed stays in the active list until its provider implements the capability.

**Filing is a two-way fact, but only from a provider that can file.** A session reported `archived: true` files its row and one reported back to `false` returns it, so a lane retired from another machine leaves the active list here too. TBD reads that field only from a provider declaring `archive`, and only when it is actually present. Both gates are load-bearing: the contract requires an absent `archived` to read as `false`, so without them every provider with no archiving concept would carry an implicit "not archived" on every poll and return archived rows to the active list about once a minute, forever.

## What this PR does

- `RemoteLaneLifecycle` — pure planners (`archivePlan`, `revivePlan`) plus the actuation half. All routing decisions go through the planners; nothing re-derives the rules inline.
- `remote.archive` / `remote.unarchive` RPC handlers, mirroring `remote.stop`. These are the direct "ask by name" surface and carry no lane guards; the guarded path is `worktree.archive`, and the spec states the distinction so a later UI control is not wired to the wrong one.
- Remote branches in `worktree.archive` and `worktree.revive`, and in `AutoArchiveOnMergeCoordinator` under its existing opt-in. `worktree.forget` still refuses a remote lane — retiring is archive's job.
- Guards on the verb path: `agentState == .working`, and a provider-reported dirty checkout via the optional well-known `meta.workspace_dirty` key (inert until a provider sets it; only `"true"`/`"1"` count, so a display string cannot fabricate a refusal). `--force` overrides both. A stale provider snapshot also refuses, matching the `remote.*` handlers.
- Provider → TBD filing sync, with an in-memory watermark so a `list` already in flight cannot reverse a filing decision made after it was sent. Every write to a remote row's status is watermarked, whichever path made it.
- `RemoteSessionPayload.archived: Bool?` — kept optional on purpose. Collapsing absent into `false` at decode destroys the distinction the sync's authority rule depends on.
- Row menu gates Archive on capability, staying visible-but-disabled with the reason in its title; a `gone` lane is not disabled, because the daemon will archive it.
- The archived list's hide-empty filter admits a remote lane on its location. Its conversation count is structurally zero, so without this every archived lane would be filed and then invisible.

**Reconciler:** this introduces no new durable external resource. It mutates rows that already exist and calls verbs the contract defines as idempotent. The one divergence it can produce — a verb that succeeded against a row that was never written — is reconciled by the filing sync itself on the next snapshot. No new sweep.

**No flag, no migration.** The subsystem is already behind `remote_backends_enabled` and a remote row cannot exist without it; a second flag would gate a flag. `archived` rides the existing payload blob and the watermark is in memory.

## Assumptions

- A provider that declares `archive` actually sets `archived: true` on the session it returns, as the contract mandates. If it declares the capability and omits the field, the sync abstains (the presence gate) rather than flapping — but its lane will not file from the provider side.
- `meta.workspace_dirty` is absent for every provider today, so the dirty-checkout guard is inert until one adopts it. It never fabricates the fact.
- The watermark is in-memory and lost on daemon restart. That costs nothing, because the window it defends is only open while a provider request is outstanding, and such a request dies with the process.

## Evidence & verification

**Live, against real adopted lanes** (the installed agent-box provider genuinely declares no `archive`, so this is the true refusal case):

- `tbd worktree archive <remote lane>` → exit 1, `this provider does not declare the "archive" capability, so this session cannot be retired from its working inventory; see docs/remote-provider-contract.md`, row still `active`.
- `tbd worktree forget <remote lane>` → `it is a remote lane, with no checkout on this machine to leave alone. Archive it instead — that is what retires a lane.`
- 111 active local worktrees unaffected.

The verb *success* path is not live-verified here: it needs the provider-side change, which is a separate PR in its own repo and not yet installed. It is covered by tests on both sides.

**Suite:** 6878 tests pass (70 known `commit.gpgsign` failures, pre-existing and unrelated). `swiftlint --strict` clean across 759 files.

**Two review passes, and both found real defects.** Worth recording, because the same failure mode produced both.

The first pass found that the verb path mirrored the provider's response *before* writing the row, so the filing sync saw a still-active row carrying a fresh `archived: true` and filed it itself — four actuation rows for one gesture, a duplicate broadcast, and a notification telling the user the *provider* had retired a session the *user* had just retired. Every test missed it because the fixtures built the manager without an actuation log, so the sync hit its fail-closed guard and bailed; production wires one.

The second pass found that the row-menu `gone` fix never executed in the running app — `isGone` was defaulted at the sole call site and never populated — and that the gesture paths recorded the watermark before the verb but never re-stamped after the row write, leaving a window where a poll launched mid-verb could un-file what the user had just archived.

Both bugs were live, and both were invisible for the same reason: **a test fixture that diverged from how production wires the thing.** Once it was the manager built without its actuation log; once it was a `Context` built by hand instead of through the call site. The fixtures now match production, and `RowActionMenuCallSiteTests` exercises the real construction path rather than a hand-assembled value.

Guards are mutation-checked, not assumed: deleting each fix turns specific named assertions red, and the reports record which. One assertion stayed green under mutation because the sync's archive is idempotent — which is exactly why the notification and outcome assertions are the ones carrying that test.

The stale-snapshot guard was added in response to the first review and is now specified in §Guards, including why it covers the verb paths only and the trade it imposes on the auto-archive rail's edge-triggered trigger.

[Remote Lane Archive](https://cheapsteak.github.io/tbd/open/?worktree=6FEAA577-472E-4597-B21D-C2E109016987)


## Known limitation

`remote.archive` / `remote.unarchive` write no worktree row of their own. They invoke the provider verb and mirror the response, and the bound row is then filed by the filing sync that mirroring triggers — on the `remote-filing-sync` daemon rail, carrying the "provider reports this session retired" notification. So a retirement made through those two RPCs is credited to the provider rather than to the person who asked for it.

The watermark added here removes the duplicate filing and the race around it; it does not change who the single remaining filing is attributed to. Closing that means having the handler write the row itself, the way `worktree.archive` does — a behavior change to a surface nothing calls yet, which belongs in a spec rather than in a review-finding fix. Both methods are unreachable from the app and the CLI today, so nothing user-facing is mis-attributed in this PR.
