### PR TITLE
Feat: A project turned on gets a supervisor — the hosted desk, spawned and reclaimable

### DIFF
--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -6,7 +6,10 @@ struct GCCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "gc",
         abstract: "Orphan GC: list reaps, restore a reaped agent worktree, trigger a sweep",
-        subcommands: [GCList.self, GCRestore.self, GCSweep.self, GCProfileDirs.self]
+        subcommands: [
+            GCList.self, GCRestore.self, GCSweep.self, GCProfileDirs.self,
+            GCSupervisionDesks.self,
+        ]
     )
 }
 
@@ -28,6 +31,28 @@ struct GCProfileDirs: AsyncParsableCommand {
         try SocketClient().callVoid(method: RPCMethod.configSetGCProfileDirsEnabled,
                                     params: ConfigSetGCProfileDirsEnabledParams(enabled: enabled))
         print("Profile-dir GC \(enabled ? "enabled" : "disabled").")
+    }
+}
+
+/// The soak switch for the supervision-desk collector. It archives the scratch
+/// space of a hosted supervisor whose session is gone and drops its record, so
+/// it ships off and is opted into by hand — the same shape `profile-dirs` uses.
+struct GCSupervisionDesks: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "supervision-desks",
+        abstract: "Enable or disable reclaiming orphaned supervision desks (default off)")
+    @Argument(help: "on | off") var state: String
+    mutating func run() async throws {
+        let enabled: Bool
+        switch state.lowercased() {
+        case "on", "true", "enable": enabled = true
+        case "off", "false", "disable": enabled = false
+        default: throw ValidationError("Expected 'on' or 'off', got: \(state)")
+        }
+        try SocketClient().callVoid(
+            method: RPCMethod.configSetGCSupervisionDesksEnabled,
+            params: ConfigSetGCSupervisionDesksEnabledParams(enabled: enabled))
+        print("Supervision-desk GC \(enabled ? "enabled" : "disabled").")
     }
 }
 

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -221,6 +221,15 @@ enum ActuationRail {
     /// judge session, and the close that kills that session's windows — all
     /// acts the desk performs on its own, with no RPC behind them.
     static let nightwatchDesk = "nightwatch-desk"
+    /// `SupervisionDeskManager` spawning a project's hosted desk. `on <project>`
+    /// is the gesture behind it, but the desk is TBD's own arrangement rather
+    /// than something the caller asked for by name — the operator asked for
+    /// coverage, and a desk is how coverage is carried out — so it is a rail
+    /// with its own row rather than a branch of the `supervise.*` door. One row
+    /// per spawn, naming the scratch worktree and no terminal, the shape
+    /// `worktree.revive` uses: the terminal is minted inside
+    /// `spawnPrimaryTerminals`.
+    static let supervisionDesk = "supervision-desk"
     /// The boot-time (and post-`cleanup`) reconcile sweep: it kills the windows
     /// of worktrees that left disk, parks sessions whose window is gone, and
     /// reaps orphaned windows and dead servers. One row per act — each is an

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -639,15 +639,32 @@ public final class Daemon: Sendable {
         // Skipped in mock mode like every other rail: a fixture render must not
         // read the operator's real supervision file, and `supervise.*` refuses
         // with a named condition there rather than answering from it.
+        //
+        // The ledger writer is built once and shared by the store and the desk
+        // manager: it is a single-writer append-only file, and two writers on
+        // two descriptors would each be checking a different one against the
+        // path.
+        let supervisionLedger = SupervisionLedgerWriter(
+            path: TBDConstants.supervisionLedgerPath)
         let supervisionStore: SupervisionStore? = mockMode == nil
             ? SupervisionStore(
                 files: SupervisionFileStore(),
-                ledger: SupervisionLedgerWriter(path: TBDConstants.supervisionLedgerPath),
+                ledger: supervisionLedger,
                 fleet: DatabaseSupervisionFleetReader(db: database))
             : nil
         if let supervisionStore {
             self.supervision = supervisionStore
             rpcRouter.supervision = supervisionStore
+            // The hosted-desk lifecycle (design §9). Same mock-mode gate as the
+            // store: a fixture render must never spawn a session.
+            rpcRouter.supervisionDesks = SupervisionDeskManager(
+                db: database,
+                lifecycle: lifecycle,
+                tmux: tmux,
+                desks: SupervisionDesksStore(),
+                ledger: supervisionLedger,
+                actuationLog: actuationLog,
+                subscriptions: subs)
             do {
                 try await supervisionStore.load()
             } catch {

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -62,6 +62,11 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// Resolve it through `Config.gcProfileDirsEnabledDefault`, never through
     /// `?? false`.
     var gc_profile_dirs_enabled: Bool?
+    /// Gate for the supervision-desk collector. Tri-state for the same reason
+    /// and in the same shape as `gc_profile_dirs_enabled`: no SQL default, so
+    /// `nil` means "never chose". Resolve through
+    /// `Config.gcSupervisionDesksEnabledDefault`, never through `?? false`.
+    var gc_supervision_desks_enabled: Bool?
 
     /// - Parameter queuedPromptDefault: the shipped default a NULL
     ///   `queued_prompt_enabled` resolves to. Defaulted to the real constant;
@@ -77,7 +82,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
         supervisionEnabledDefault: Bool = Config.supervisionEnabledDefault,
-        gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault
+        gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault,
+        gcSupervisionDesksDefault: Bool = Config.gcSupervisionDesksEnabledDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -125,7 +131,11 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             supervisionEnabled: supervision_enabled ?? supervisionEnabledDefault,
             // Same reasoning again, for the profile-dir collector's gate —
             // NOT `?? false`.
-            gcProfileDirsEnabled: gc_profile_dirs_enabled ?? gcProfileDirsDefault
+            gcProfileDirsEnabled: gc_profile_dirs_enabled ?? gcProfileDirsDefault,
+            // Same reasoning once more, for the supervision-desk collector's
+            // gate — NOT `?? false`.
+            gcSupervisionDesksEnabled:
+                gc_supervision_desks_enabled ?? gcSupervisionDesksDefault
         )
     }
 }
@@ -452,6 +462,19 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET gc_profile_dirs_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the supervision-desk collector gate (default OFF, soaking) —
+    /// read on top of the GC master switch, so both must be on for the leg to
+    /// reclaim anything. Written on every call, because writing either value is
+    /// the explicit gesture that lifts the column out of NULL forever after.
+    public func setGCSupervisionDesksEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_supervision_desks_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1431,6 +1431,20 @@ public final class TBDDatabase: Sendable {
                 table: "reap_records", column: "quarantinePath", type: .text)
         }
 
+        // Gate for `SupervisionDeskCollector` — the reconciler for a hosted
+        // supervision desk's scratch space and its `desks.json` entry
+        // (docs/specs/2026-07-26-fleet-supervision-design.md §9). Ships OFF and
+        // soaks, following v78: reclaiming a desk archives a worktree and drops
+        // a record, so the classifier proves itself before it graduates.
+        // Tri-state like v70/v77/v78 — no SQL default, so a pre-migration row
+        // reads NULL ("never chose") rather than 0, and NULL resolves through
+        // `Config.gcSupervisionDesksEnabledDefault` in `ConfigRecord.toModel()`,
+        // the single place graduation changes.
+        migrator.registerMigration("v80_config_gc_supervision_desks") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "gc_supervision_desks_enabled", type: .boolean)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -61,6 +61,7 @@ public actor OrphanGC {
     private let scratchpadCollector: ScratchpadCollector
     private let deletionQueueCollector: DeletionQueueCollector
     private let profileDirCollector: ProfileDirCollector
+    private let supervisionDeskCollector: SupervisionDeskCollector
     /// Deletes the path-keyed Claude Code credentials item belonging to a
     /// quarantined profile dir. Injected so tests never reach the real login
     /// keychain, which `scripts/test.sh` cannot fence.
@@ -94,7 +95,8 @@ public actor OrphanGC {
         scratchpadBase: URL? = nil,
         now: (@Sendable () -> Date)? = nil,
         profileDirBase: URL? = nil,
-        credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain()
+        credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
+        supervisionDesks: SupervisionDesksStore? = nil
     ) {
         var wrapped: (@Sendable () async -> [String]?)?
         if let lsofProvider {
@@ -103,7 +105,8 @@ public actor OrphanGC {
         self.init(
             db: db, git: git, broadcast: broadcast, liveCWDsProvider: wrapped,
             scratchpadBase: scratchpadBase, now: now,
-            profileDirBase: profileDirBase, credentialsKeychain: credentialsKeychain
+            profileDirBase: profileDirBase, credentialsKeychain: credentialsKeychain,
+            supervisionDesks: supervisionDesks
         )
     }
 
@@ -122,7 +125,11 @@ public actor OrphanGC {
         beforeInterruptedArchiveReap: (@Sendable () async -> Void)? = nil,
         profileDirBase: URL? = nil,
         credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
-        beforeProfileDirReap: (@Sendable () async -> Void)? = nil
+        beforeProfileDirReap: (@Sendable () async -> Void)? = nil,
+        /// Where the hosted-desk record lives. Defaulted to the real path
+        /// through `TBDConstants`, which honors `TBD_HOME`; tests inject a
+        /// store on a temp directory so a sweep never reads the developer's.
+        supervisionDesks: SupervisionDesksStore? = nil
     ) {
         let resolvedNow = now ?? Date.init
         let resolvedScratchpadBase = scratchpadBase ?? TBDConstants.claudeScratchpadBase
@@ -148,6 +155,10 @@ public actor OrphanGC {
         self.deletionQueueCollector = DeletionQueueCollector(git: git, now: resolvedNow)
         self.profileDirCollector = ProfileDirCollector(
             base: resolvedProfileDirBase, now: resolvedNow)
+        self.supervisionDeskCollector = SupervisionDeskCollector(
+            desks: supervisionDesks ?? SupervisionDesksStore(),
+            scratchBase: TBDConstants.scratchDir,
+            now: resolvedNow)
     }
 
     // MARK: - Sweep
@@ -223,6 +234,10 @@ public actor OrphanGC {
 
         await reclaimProfileDirs(
             config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
+        )
+
+        await reclaimSupervisionDesks(
+            config: config, live: live, dryRun: dryRun, planned: &planned, reaped: &reaped
         )
 
         // Snapshot retention never runs in dryRun; the outer guard already
@@ -625,6 +640,84 @@ public actor OrphanGC {
                 }
                 await insertReapRecord(record)
                 reaped += 1
+            }
+        }
+    }
+
+    /// Reclaims hosted supervision desks whose session is gone: drops the
+    /// `desks.json` entry and hands the scratch worktree to the archive path
+    /// this sweep already runs, by moving its row to `.archived`. The
+    /// deletion-queue and scratchpad legs above then reclaim the directory on
+    /// this or a later sweep, and `WorktreeLifecycle+Reconcile` settles its tmux
+    /// state — this leg deliberately kills no window itself, because an
+    /// archived row is exactly the shape those two already own.
+    ///
+    /// **Gated by `gcSupervisionDesksEnabled` on top of `gcEnabled`**, following
+    /// the profile-dir precedent: the leg archives a worktree and drops a
+    /// record, so it soaks behind its own default-off switch before graduating.
+    /// `dryRun` bypasses the flag exactly as `sweep` lets it bypass `gcEnabled`
+    /// — someone deciding whether to enable a default-off flag needs to see
+    /// what enabling it would reclaim. A NON-dry run still requires the flag.
+    ///
+    /// **A live desk is never reclaimed**, and that is the property the leg is
+    /// tested for in both directions.
+    private func reclaimSupervisionDesks(
+        config: Config, live: [String], dryRun: Bool,
+        planned: inout [String], reaped: inout Int
+    ) async {
+        guard config.gcSupervisionDesksEnabled || dryRun else { return }
+
+        for candidate in supervisionDeskCollector.candidates() {
+            // Both reads fail toward keeping: a nil `terminalExists` is a read
+            // that never answered, kept distinct from a row that is genuinely
+            // gone, and a worktree read failure is indistinguishable from a
+            // missing row only if we collapse them — so it is not collapsed.
+            var terminalExists: Bool?
+            do {
+                terminalExists = try await db.terminals.get(id: candidate.entry.terminal) != nil
+            } catch {
+                terminalExists = nil
+            }
+            let worktree = (try? await db.worktrees.get(id: candidate.entry.worktree)) ?? nil
+
+            switch supervisionDeskCollector.decide(
+                candidate, terminalExists: terminalExists, worktree: worktree,
+                liveCWDs: live, graceSeconds: config.gcGraceSeconds
+            ) {
+            case .keep(let reason):
+                planned.append("KEEP \(reason) desk:\(candidate.project)")
+                logger.debug("""
+                gc: keep \(reason, privacy: .public) desk for \
+                \(candidate.project, privacy: .public)
+                """)
+            case .reap(let reason):
+                planned.append("REAP supervision-desk \(reason) desk:\(candidate.project)")
+                // This leg's guard is `gcSupervisionDesksEnabled || dryRun`, so
+                // every line below runs only with the flag actually on.
+                guard !dryRun else { continue }
+                guard supervisionDeskCollector.forget(project: candidate.project) else {
+                    planned.append("KEEP desk-record-write-failed desk:\(candidate.project)")
+                    continue
+                }
+                reaped += 1
+                if let worktree, worktree.status == .active {
+                    do {
+                        try await db.worktrees.archive(id: worktree.id)
+                        logger.info("""
+                        gc: archived the scratch space of \(candidate.project, privacy: .public)'s \
+                        orphaned desk at \(worktree.localPath, privacy: .public)
+                        """)
+                    } catch {
+                        // The record is already dropped, which is the half that
+                        // stops a second desk from being mistaken for this one.
+                        // The directory stays until someone archives it.
+                        logger.warning("""
+                        gc: dropped the desk record for \(candidate.project, privacy: .public) but \
+                        could not archive \(worktree.localPath, privacy: .public): \
+                        \(String(describing: error), privacy: .public)
+                        """)
+                    }
+                }
             }
         }
     }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -678,10 +678,19 @@ public actor OrphanGC {
             } catch {
                 terminalExists = nil
             }
-            let worktree = (try? await db.worktrees.get(id: candidate.entry.worktree)) ?? nil
+            let lookup: SupervisionDeskCollector.WorktreeLookup
+            do {
+                if let row = try await db.worktrees.get(id: candidate.entry.worktree) {
+                    lookup = .row(row)
+                } else {
+                    lookup = .gone
+                }
+            } catch {
+                lookup = .unreadable
+            }
 
             switch supervisionDeskCollector.decide(
-                candidate, terminalExists: terminalExists, worktree: worktree,
+                candidate, terminalExists: terminalExists, worktree: lookup,
                 liveCWDs: live, graceSeconds: config.gcGraceSeconds
             ) {
             case .keep(let reason):
@@ -695,12 +704,22 @@ public actor OrphanGC {
                 // This leg's guard is `gcSupervisionDesksEnabled || dryRun`, so
                 // every line below runs only with the flag actually on.
                 guard !dryRun else { continue }
-                guard supervisionDeskCollector.forget(project: candidate.project) else {
+                switch supervisionDeskCollector.forget(
+                    project: candidate.project, expecting: candidate.entry) {
+                case .changed:
+                    // A spawn for this project landed while the sweep ran. Its
+                    // desk is live and nothing judged it, so neither the record
+                    // nor the worktree below is touched.
+                    planned.append("KEEP desk-record-changed desk:\(candidate.project)")
+                    continue
+                case .writeFailed:
                     planned.append("KEEP desk-record-write-failed desk:\(candidate.project)")
                     continue
+                case .dropped:
+                    break
                 }
                 reaped += 1
-                if let worktree, worktree.status == .active {
+                if case .row(let worktree) = lookup, worktree.status == .active {
                     do {
                         try await db.worktrees.archive(id: worktree.id)
                         logger.info("""

--- a/Sources/TBDDaemon/GC/SupervisionDeskCollector.swift
+++ b/Sources/TBDDaemon/GC/SupervisionDeskCollector.swift
@@ -65,6 +65,29 @@ public struct SupervisionDeskCollector: Sendable {
         case reap(String)
     }
 
+    /// What the sweep found when it looked a desk's worktree row up.
+    ///
+    /// **A read that did not answer is not a row that is gone**, and collapsing
+    /// the two is how a sweep reaps a live desk on a transient database error.
+    /// The terminal read is kept apart the same way, by its `Bool?`.
+    public enum WorktreeLookup: Sendable, Equatable {
+        case row(Worktree)
+        /// The row is genuinely absent — the read answered, with nothing.
+        case gone
+        /// The read failed. Keeps.
+        case unreadable
+    }
+
+    /// What `forget` did, which is not always "dropped it".
+    public enum ForgetResult: Sendable, Equatable {
+        case dropped
+        /// The record no longer holds the entry this sweep judged — a spawn for
+        /// the same project landed while the sweep ran. Its desk is live and
+        /// nobody judged it, so it is left exactly as it is.
+        case changed
+        case writeFailed
+    }
+
     /// The recorded desks, ordered by project so a plan is stable to diff.
     ///
     /// An unreadable or malformed record yields no candidates rather than an
@@ -91,14 +114,16 @@ public struct SupervisionDeskCollector: Sendable {
     /// - Parameters:
     ///   - terminalExists: whether the desk's terminal row is still in the
     ///     database. Nil means the read failed, which keeps.
-    ///   - worktree: the desk's worktree row, or nil when it is gone.
+    ///   - worktree: what the worktree read answered — a row, a genuine
+    ///     absence, or a read that failed.
     ///   - liveCWDs: the sweep's single `lsof` pass, already canonicalized —
     ///     the same evidence `AgentWorktreeCollector` gates on. A process
-    ///     sitting in the desk's directory is the desk running.
+    ///     sitting in the desk's directory **or anywhere below it** is the desk
+    ///     running.
     ///   - graceSeconds: a desk spawned moments ago may not have shown up in
     ///     the `lsof` pass yet, so a young record is kept regardless.
     public func decide(
-        _ candidate: Candidate, terminalExists: Bool?, worktree: Worktree?,
+        _ candidate: Candidate, terminalExists: Bool?, worktree: WorktreeLookup,
         liveCWDs: [String], graceSeconds: Int
     ) -> Decision {
         let age = now().timeIntervalSince(candidate.entry.spawnedAt.date)
@@ -107,23 +132,32 @@ public struct SupervisionDeskCollector: Sendable {
         }
         guard let terminalExists else { return .keep("desk-row-read-failed") }
 
-        guard let worktree else {
+        let row: Worktree
+        switch worktree {
+        case .unreadable:
+            return .keep("desk-worktree-read-failed")
+        case .gone:
             // The row is gone, so there is nothing to archive and nothing on
             // disk this sweep can attribute. Drop the record only.
             return .reap("desk-worktree-row-gone")
+        case .row(let found):
+            row = found
         }
         // Only a scratch space under the scratch base is a desk's, and only
         // those are this leg's to touch. Anything else in the record is either
         // an older layout or a hand edit, and reclaiming it would be acting on
         // a resource this sweep does not own.
-        guard worktree.repoID == nil,
-              LocalWorktree(worktree)?.path.hasPrefix(scratchBase.path + "/") == true else {
+        guard row.repoID == nil,
+              LocalWorktree(row)?.path.hasPrefix(scratchBase.path + "/") == true else {
             return .keep("desk-not-a-scratch-space")
         }
-        guard worktree.status == .active else { return .keep("desk-already-archived") }
+        guard row.status == .active else { return .keep("desk-already-archived") }
 
-        let canonical = AgentWorktreeCollector.canon(worktree.localPath)
-        if liveCWDs.contains(canonical) {
+        let canonical = AgentWorktreeCollector.canon(row.localPath)
+        // The shared prefix-boundary match, not equality: an agent's own shell
+        // sits in a subdirectory as often as in the root, and equality would
+        // read that as "nothing is running here" and archive a live desk.
+        if AgentWorktreeCollector.liveCWDsContain(liveCWDs, path: canonical) {
             // A process is sitting in the desk's directory. **Never reclaim a
             // live desk**, whatever its terminal row or its project says.
             return .keep("desk-live")
@@ -132,26 +166,38 @@ public struct SupervisionDeskCollector: Sendable {
         return .reap("desk-process-gone")
     }
 
-    /// Drop one project's entry from the record.
+    /// Drop from the record the exact entry this sweep judged.
     ///
     /// Read-modify-write per reap rather than once per sweep: `desks.json` is
     /// also written by `SupervisionDeskManager` when a project is turned on, and
     /// a whole-file rewrite computed at the top of a sweep would clobber a desk
-    /// spawned while the sweep ran. Returns whether the record changed.
+    /// spawned while the sweep ran.
+    ///
+    /// **Re-reading is not enough on its own** — the entry has to match too. A
+    /// spawn for *this* project landing between `candidates()` and this write
+    /// leaves a different entry under the same key, and dropping it would
+    /// unrecord a desk that is live and that nothing judged. That is the same
+    /// resurrection hazard `SupervisionDeskManager` guards on its side, from
+    /// the other end.
     @discardableResult
-    public func forget(project: String) -> Bool {
+    public func forget(project: String, expecting entry: SupervisionDeskEntry) -> ForgetResult {
         do {
             let file = try desks.load()
-            let updated = file.forgetting(project)
-            guard updated != file else { return false }
-            try desks.save(updated)
-            return true
+            guard file.desk(for: project) == entry else {
+                logger.notice("""
+                gc: the desk record for \(project, privacy: .public) changed while the sweep ran; \
+                leaving it alone
+                """)
+                return .changed
+            }
+            try desks.save(file.forgetting(project))
+            return .dropped
         } catch {
             logger.warning("""
             gc: could not drop the desk record for \(project, privacy: .public): \
             \(String(describing: error), privacy: .public)
             """)
-            return false
+            return .writeFailed
         }
     }
 }

--- a/Sources/TBDDaemon/GC/SupervisionDeskCollector.swift
+++ b/Sources/TBDDaemon/GC/SupervisionDeskCollector.swift
@@ -1,0 +1,154 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// Enumerates and gates the hosted supervision desks recorded in
+/// `~/tbd/supervision/desks.json`, so an orphaned one is reclaimed rather than
+/// leaking a scratch space forever.
+///
+/// **Why this exists** (repo `CLAUDE.md`, "Every durable external resource needs
+/// a named reconciler"). A hosted desk is a scratch worktree plus a spawned
+/// process, created before either can be recorded — `SupervisionDeskManager`
+/// makes the directory, makes the row, spawns the session, and only then writes
+/// `desks.json`. A crash, a cancellation, or a failed spawn anywhere in that
+/// sequence leaves a resource nobody owns, and `OrphanGC`'s existing legs do not
+/// cover it: the agent-worktree leg iterates `db.repos.list()` and so only sees
+/// repo-backed worktrees, while the archived legs only touch rows that are
+/// already `.archived`. A live desk is therefore never at risk from those legs,
+/// which is right — and an orphaned one was reclaimed by nothing, which is what
+/// this closes.
+///
+/// **Every failure direction is toward keeping.** A read that does not answer,
+/// a row that cannot be fetched, a path that does not look like a desk's: all
+/// keep. Reclaiming a desk archives a worktree and drops a record; leaving one
+/// costs a directory until the next sweep.
+///
+/// **The decision is liveness, and only liveness.** Three triggers were
+/// considered — the terminal row gone, the tmux window gone, and the project no
+/// longer resolving — and the first two are the same fact from two angles,
+/// while the third turned out to change no outcome. A desk whose project stopped
+/// resolving but whose session is *running* must not be reclaimed: killing a
+/// live agent is exactly what the doctrine forbids, and closing that project's
+/// coverage is the supervision path's job (design §9's recycle), never a
+/// sweep's. Once the desk is not live, it is reclaimed regardless of whether the
+/// project still resolves — so adding the project check would gate nothing and
+/// would need a second reader of `supervision.json`.
+public struct SupervisionDeskCollector: Sendable {
+    let desks: SupervisionDesksStore
+    /// Where a desk's scratch space is allowed to live. A recorded worktree
+    /// outside it is not something this sweep will touch.
+    let scratchBase: URL
+    let now: @Sendable () -> Date
+
+    public init(desks: SupervisionDesksStore, scratchBase: URL,
+                now: @Sendable @escaping () -> Date) {
+        self.desks = desks
+        self.scratchBase = scratchBase
+        self.now = now
+    }
+
+    /// One recorded desk, as the sweep sees it.
+    public struct Candidate: Sendable, Equatable {
+        public let project: String
+        public let entry: SupervisionDeskEntry
+    }
+
+    /// What the sweep should do with one candidate. `keep` carries the reason
+    /// so the plan line says which gate held.
+    public enum Decision: Sendable, Equatable {
+        case keep(String)
+        case reap(String)
+    }
+
+    /// The recorded desks, ordered by project so a plan is stable to diff.
+    ///
+    /// An unreadable or malformed record yields no candidates rather than an
+    /// error: the sweep must not reclaim anything on the strength of a file it
+    /// could not read.
+    public func candidates() -> [Candidate] {
+        let file: SupervisionDesksFile
+        do {
+            file = try desks.load()
+        } catch {
+            logger.warning("""
+            gc: supervision-desk phase skipped — \(self.desks.fileURL.path, privacy: .public) \
+            could not be read: \(String(describing: error), privacy: .public)
+            """)
+            return []
+        }
+        return file.desks
+            .sorted { $0.key < $1.key }
+            .map { Candidate(project: $0.key, entry: $0.value) }
+    }
+
+    /// Gate one candidate.
+    ///
+    /// - Parameters:
+    ///   - terminalExists: whether the desk's terminal row is still in the
+    ///     database. Nil means the read failed, which keeps.
+    ///   - worktree: the desk's worktree row, or nil when it is gone.
+    ///   - liveCWDs: the sweep's single `lsof` pass, already canonicalized —
+    ///     the same evidence `AgentWorktreeCollector` gates on. A process
+    ///     sitting in the desk's directory is the desk running.
+    ///   - graceSeconds: a desk spawned moments ago may not have shown up in
+    ///     the `lsof` pass yet, so a young record is kept regardless.
+    public func decide(
+        _ candidate: Candidate, terminalExists: Bool?, worktree: Worktree?,
+        liveCWDs: [String], graceSeconds: Int
+    ) -> Decision {
+        let age = now().timeIntervalSince(candidate.entry.spawnedAt.date)
+        if age < Double(graceSeconds) {
+            return .keep("desk-within-grace")
+        }
+        guard let terminalExists else { return .keep("desk-row-read-failed") }
+
+        guard let worktree else {
+            // The row is gone, so there is nothing to archive and nothing on
+            // disk this sweep can attribute. Drop the record only.
+            return .reap("desk-worktree-row-gone")
+        }
+        // Only a scratch space under the scratch base is a desk's, and only
+        // those are this leg's to touch. Anything else in the record is either
+        // an older layout or a hand edit, and reclaiming it would be acting on
+        // a resource this sweep does not own.
+        guard worktree.repoID == nil,
+              LocalWorktree(worktree)?.path.hasPrefix(scratchBase.path + "/") == true else {
+            return .keep("desk-not-a-scratch-space")
+        }
+        guard worktree.status == .active else { return .keep("desk-already-archived") }
+
+        let canonical = AgentWorktreeCollector.canon(worktree.localPath)
+        if liveCWDs.contains(canonical) {
+            // A process is sitting in the desk's directory. **Never reclaim a
+            // live desk**, whatever its terminal row or its project says.
+            return .keep("desk-live")
+        }
+        guard terminalExists else { return .reap("desk-terminal-row-gone") }
+        return .reap("desk-process-gone")
+    }
+
+    /// Drop one project's entry from the record.
+    ///
+    /// Read-modify-write per reap rather than once per sweep: `desks.json` is
+    /// also written by `SupervisionDeskManager` when a project is turned on, and
+    /// a whole-file rewrite computed at the top of a sweep would clobber a desk
+    /// spawned while the sweep ran. Returns whether the record changed.
+    @discardableResult
+    public func forget(project: String) -> Bool {
+        do {
+            let file = try desks.load()
+            let updated = file.forgetting(project)
+            guard updated != file else { return false }
+            try desks.save(updated)
+            return true
+        } catch {
+            logger.warning("""
+            gc: could not drop the desk record for \(project, privacy: .public): \
+            \(String(describing: error), privacy: .public)
+            """)
+            return false
+        }
+    }
+}

--- a/Sources/TBDDaemon/GC/SupervisionDeskCollector.swift
+++ b/Sources/TBDDaemon/GC/SupervisionDeskCollector.swift
@@ -10,15 +10,17 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
 ///
 /// **Why this exists** (repo `CLAUDE.md`, "Every durable external resource needs
 /// a named reconciler"). A hosted desk is a scratch worktree plus a spawned
-/// process, created before either can be recorded — `SupervisionDeskManager`
-/// makes the directory, makes the row, spawns the session, and only then writes
-/// `desks.json`. A crash, a cancellation, or a failed spawn anywhere in that
-/// sequence leaves a resource nobody owns, and `OrphanGC`'s existing legs do not
-/// cover it: the agent-worktree leg iterates `db.repos.list()` and so only sees
-/// repo-backed worktrees, while the archived legs only touch rows that are
-/// already `.archived`. A live desk is therefore never at risk from those legs,
-/// which is right — and an orphaned one was reclaimed by nothing, which is what
-/// this closes.
+/// process, and `OrphanGC`'s existing legs cover neither: the agent-worktree leg
+/// iterates `db.repos.list()` and so only sees repo-backed worktrees, while the
+/// archived legs only touch rows that are already `.archived`. A live desk is
+/// therefore never at risk from those legs, which is right — and a desk that
+/// died was reclaimed by nothing, which is what this closes.
+///
+/// **Its subject is a desk that got recorded and then died**, which is the only
+/// orphan shape it can see: it enumerates `desks.json`, so a spawn that failed
+/// before writing an entry is not here at all. That half is
+/// `SupervisionDeskManager`'s own, which archives the scratch row on every
+/// failing exit and so hands it to the deletion-queue leg.
 ///
 /// **Every failure direction is toward keeping.** A read that does not answer,
 /// a row that cannot be fetched, a path that does not look like a desk's: all
@@ -30,11 +32,12 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
 /// longer resolving — and the first two are the same fact from two angles,
 /// while the third turned out to change no outcome. A desk whose project stopped
 /// resolving but whose session is *running* must not be reclaimed: killing a
-/// live agent is exactly what the doctrine forbids, and closing that project's
-/// coverage is the supervision path's job (design §9's recycle), never a
-/// sweep's. Once the desk is not live, it is reclaimed regardless of whether the
-/// project still resolves — so adding the project check would gate nothing and
-/// would need a second reader of `supervision.json`.
+/// live agent is exactly what the doctrine forbids, and design §9 is explicit
+/// that a topology gesture ending a project takes its mark, its mode selection
+/// and its supervisor binding — not the desk, because **no coverage gesture
+/// disposes a desk**. Once the desk is not live, it is reclaimed regardless of
+/// whether the project still resolves — so adding the project check would gate
+/// nothing and would need a second reader of `supervision.json`.
 public struct SupervisionDeskCollector: Sendable {
     let desks: SupervisionDesksStore
     /// Where a desk's scratch space is allowed to live. A recorded worktree

--- a/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
+++ b/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
@@ -79,7 +79,29 @@ struct PluginDirWriter {
         // out of the box. Dormant until its description matches a babysitting task.
         try writeNightwatch(pluginDir: pluginDir)
 
+        // Bundled `supervision` skill: how a supervisor reads a project's
+        // readout, acts through `tbd terminal send`, submits briefings and
+        // reads the ledger back. Written here rather than into a desk's own
+        // directory because this plugin dir is what every TBD Claude spawn
+        // already loads — so the skill is fleet-visible, exactly as the
+        // Nightwatch one is. That is deliberate and not a leak: what makes a
+        // desk a desk is its standing conduct layer and its injected
+        // `TBD_PROJECT`, not exclusive access to a reference file, and every
+        // command the skill names is a public surface.
+        try writeSupervision(pluginDir: pluginDir)
+
         Self.logger.info("Wrote TBD plugin at \(pluginDir, privacy: .public)")
+    }
+
+    /// Install the `supervision` skill. One file, no scripts and no config
+    /// tree — it is reference prose, and the conduct that varies per project
+    /// lives in that project's playbook, never here.
+    private func writeSupervision(pluginDir: String) throws {
+        let root = pluginDir + "/skills/supervision"
+        try FileManager.default.createDirectory(
+            atPath: root, withIntermediateDirectories: true)
+        try SupervisionSkillContent.body.write(
+            toFile: root + "/SKILL.md", atomically: true, encoding: .utf8)
     }
 
     /// Install the `nightwatch` skill into the plugin's skills dir. `tick.py`

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -35,12 +35,26 @@ enum SystemPromptBuilder {
     /// global user-customizable override for the scratch rename-nudge layer
     /// (`Config.scratchRenamePrompt`); `nil` or blank falls back to
     /// `RepoConstants.defaultScratchRenamePrompt`.
+    /// `supervisionPlaybook` is the resolved playbook a hosted desk or an
+    /// appointed supervisor stands on, installed as a **standing conduct
+    /// layer** (fleet-supervision design §5, §9; sweep-program design §8). Nil
+    /// on every ordinary fleet spawn, which is all of them but a desk's.
     static func promptLayers(
-        repo: Repo?, worktree: Worktree, scratchInstructions: String? = nil, scratchRenamePrompt: String? = nil
+        repo: Repo?, worktree: Worktree, scratchInstructions: String? = nil,
+        scratchRenamePrompt: String? = nil, supervisionPlaybook: String? = nil
     ) -> [String: String] {
         var layers: [String: String] = [:]
 
         layers["TBD_PROMPT_CONTEXT"] = builtInTBDContext
+
+        // The supervisor's standing conduct. Installed at launch rather than
+        // sent as a message so compaction cannot eat it: a playbook embedded in
+        // an early turn can be summarized into mush by briefing fifteen, while
+        // a standing layer is re-included by construction.
+        if let playbook = supervisionPlaybook?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !playbook.isEmpty {
+            layers["TBD_PROMPT_SUPERVISION"] = supervisionPlaybook!
+        }
 
         if worktree.isScratch {
             let trimmedCustom = scratchInstructions?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -74,23 +88,42 @@ enum SystemPromptBuilder {
 
     /// Build the combined system prompt for a Claude session.
     /// Returns nil if there's nothing to append (e.g., resume session).
+    ///
+    /// **This function hand-picks the layers it emits, so a layer added to
+    /// `promptLayers` alone reaches the environment and nothing else.** Anything
+    /// missing from the list below is silently dropped from
+    /// `--append-system-prompt` — it compiles, it ships, and it delivers
+    /// nothing. Add to both, and assert on the composed string rather than on
+    /// the map.
+    ///
+    /// **Resume returns nil, and the supervision layer inherits that.** A
+    /// conduct reload — resuming a desk's session with a refreshed playbook
+    /// layer after the operator edits it (sweep-program design §8) — is
+    /// therefore not yet wired: this slice installs the layer at spawn only.
+    /// The shipped mechanism for a playbook edit under a live desk is the
+    /// briefing header's conduct delta, which arrives with delivery. Nothing
+    /// here was overlooked; the reload is deferred deliberately.
     static func build(
         repo: Repo?, worktree: Worktree, isResume: Bool, scratchInstructions: String? = nil,
-        scratchRenamePrompt: String? = nil
+        scratchRenamePrompt: String? = nil, supervisionPlaybook: String? = nil
     ) -> String? {
         if isResume { return nil }
 
         let layers = promptLayers(
             repo: repo, worktree: worktree, scratchInstructions: scratchInstructions,
-            scratchRenamePrompt: scratchRenamePrompt
+            scratchRenamePrompt: scratchRenamePrompt, supervisionPlaybook: supervisionPlaybook
         )
         var parts: [String] = []
 
-        // Order: scratch layer, rename prompt, TBD context, custom instructions
+        // Order: scratch layer, rename prompt, TBD context, custom
+        // instructions, standing supervision conduct. The playbook goes last
+        // so that nothing generic follows the conduct a supervisor is meant to
+        // act under.
         if let scratch = layers["TBD_PROMPT_SCRATCH"] { parts.append(scratch) }
         if let rename = layers["TBD_PROMPT_RENAME"] { parts.append(rename) }
         parts.append(builtInTBDContext)
         if let instructions = layers["TBD_PROMPT_INSTRUCTIONS"] { parts.append(instructions) }
+        if let supervision = layers["TBD_PROMPT_SUPERVISION"] { parts.append(supervision) }
 
         return parts.isEmpty ? nil : parts.joined(separator: "\n\n---\n\n")
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1209,7 +1209,15 @@ extension WorktreeLifecycle {
         /// until the lease store promotes one of them to `.judge` — because at
         /// spawn time no lease has been acquired yet. Every other caller leaves
         /// it nil and gets exactly the overlay it got before the tee existed.
-        watchDeskRole: WatchDeskRole? = nil
+        watchDeskRole: WatchDeskRole? = nil,
+        /// Non-nil when this spawn is a supervision hosted desk. The name is
+        /// injected as `TBD_PROJECT` — the desk's ambient identity, the same
+        /// variable an appointment relaunch injects (design §9) — and the
+        /// playbook is installed as the session's standing conduct layer
+        /// through `SystemPromptBuilder` (sweep-program design §8). Every other
+        /// caller leaves both nil and gets exactly the spawn it got before.
+        supervisionProject: String? = nil,
+        supervisionPlaybook: String? = nil
     ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
@@ -1344,7 +1352,8 @@ extension WorktreeLifecycle {
                 : SystemPromptBuilder.build(
                     repo: repo, worktree: worktree, isResume: false,
                     scratchInstructions: config.scratchInstructions,
-                    scratchRenamePrompt: config.scratchRenamePrompt)
+                    scratchRenamePrompt: config.scratchRenamePrompt,
+                    supervisionPlaybook: supervisionPlaybook)
             let profileConfigDir = configDirManager.resolveConfigDir(for: resolvedProfile)
             // Pre-accept Claude Code's folder-trust dialog. TBD just created
             // this worktree from a repo the operator registered, so the trust
@@ -1419,10 +1428,15 @@ extension WorktreeLifecycle {
                 sessionName: worktree.displayName
             )
             primaryCommand = spawn.command
-            primaryEnv = [
+            var claudeEnv = [
                 "TBD_WORKTREE_ID": worktreeID.uuidString,
                 "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
             ]
+            // A hosted desk's ambient identity, alongside the two ids every TBD
+            // session already carries. Non-sensitive, so it rides the same
+            // inline-exported `env` map (design §9, §5).
+            if let supervisionProject { claudeEnv["TBD_PROJECT"] = supervisionProject }
+            primaryEnv = claudeEnv
             // Layer the builder's auth/routing env ON TOP of free-form overrides
             // so auth/routing stays final and free-form vars can't clobber it.
             primarySensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -185,6 +185,22 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the supervision-desk collector gate — the default-off soak
+    /// switch for reclaiming a hosted desk whose session is gone, read on top
+    /// of the GC master switch. The sweep re-reads it per pass, so flipping it
+    /// off does not cancel one already running.
+    ///
+    /// **This is how the flag is turned on for its soak.** A default-off gate
+    /// with no surface that can set it is not soaking; it is dead code.
+    func handleConfigSetGCSupervisionDesksEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetGCSupervisionDesksEnabledParams.self, from: paramsData)
+        try await db.config.setGCSupervisionDesksEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the fleet supervision brake (design 2026-07-26 §3, §7) — the
     /// fleet-wide on/off switch for supervision. Shipped OFF; nothing in the
     /// daemon reads this column to gate an actuation yet, because the acting

--- a/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
@@ -15,8 +15,31 @@ extension RPCRouter {
             role: valid ? .judge : .readOnlyCoordinator)
     }
 
+    /// `nightwatch.setMode`.
+    ///
+    /// **The single choke point for the coexistence gate**, which is why the
+    /// refusal lives here rather than in the CLI or in `DaywatchRunner`: this is
+    /// the one place ahead of both the DB write and `runner.apply`, so a mode
+    /// that is refused here neither persists nor starts a loop.
+    ///
+    /// Anything but `.off` is refused while any project is under fleet
+    /// supervision — the two paths watch the same fleet and are mutually
+    /// exclusive until Nightwatch is retired. **`.off` is never refused**, in
+    /// this direction or the other: an operator must always be able to stop
+    /// either path.
     func handleSetNightwatchMode(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NightwatchSetModeParams.self, from: data)
+        if params.mode != .off, let supervision {
+            // A store that cannot answer is not evidence that nothing is
+            // supervised, so a throw here propagates rather than being read as
+            // "clear to start". Failing toward refusal is the safe direction:
+            // the remedy is one readable error, and `off` still works.
+            let marked = try await supervision.markedProjects()
+            guard marked.isEmpty else {
+                throw SupervisionNightwatchConflict.nightwatchOnWhileProjectsSupervised(
+                    projects: marked.sorted())
+            }
+        }
         try await db.config.setNightwatchMode(params.mode)
         // Apply the mode to the runner (start/stop the loop).
         if let runner = daywatchRunner {

--- a/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
@@ -27,6 +27,20 @@ extension RPCRouter {
     /// exclusive until Nightwatch is retired. **`.off` is never refused**, in
     /// this direction or the other: an operator must always be able to stop
     /// either path.
+    ///
+    /// **The gate is check-then-act, and nothing serializes it against its twin
+    /// in `handleSuperviseSetProjectMark`.** The two facts live in separate
+    /// stores — the marks in `SupervisionStore`, the mode in a DB config row —
+    /// and each handler reads the other's store before writing its own.
+    /// `RPCRouter` is a plain class, not an actor, so two calls in flight at the
+    /// same instant can both pass their precondition before either write lands,
+    /// and the fleet ends up under both paths at once: precisely the state these
+    /// two gates exist to prevent, and one no later read repairs by itself — an
+    /// operator turns one path off. The window is narrow, because reaching it
+    /// takes two operator gestures in the same instant, one per path. Closing it
+    /// needs a lock shared across both handlers, which is a design decision
+    /// about where supervision's writes serialize rather than a fix, and it is
+    /// deliberately not made here.
     func handleSetNightwatchMode(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NightwatchSetModeParams.self, from: data)
         if params.mode != .off, let supervision {

--- a/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
@@ -1,5 +1,9 @@
 import Foundation
+import os
 import TBDShared
+
+private let supervisionLogger = Logger(
+    subsystem: "com.tbd.daemon", category: "supervision.handlers")
 
 /// RPC handlers for the `supervise.*` surface (`docs/cli-supervise.md`,
 /// `docs/specs/2026-07-26-fleet-supervision-design.md` §10).
@@ -40,11 +44,66 @@ extension RPCRouter {
         return try RPCResponse(result: await store.status(brake: brake))
     }
 
+    /// `supervise.setProjectMark` — `tbd supervise on/off <project>`.
+    ///
+    /// **`on <project>` is ensure-desk** (design §9): the mark is set first,
+    /// then a live supervisor is verified to exist. The two are ordered that
+    /// way deliberately — the mark is what the gesture promises, and a desk that
+    /// could not be spawned is an anomaly, never a refusal of coverage the
+    /// operator asked for.
+    ///
+    /// **`off` disposes nothing.** The mark is a delivery precondition
+    /// rechecked at act time, so a stood-down desk simply receives nothing —
+    /// an idle session holding context that cost real tokens to build. No
+    /// disposal path exists on this surface at all.
+    ///
+    /// **The result line carries the mark and nothing more.** No desk state
+    /// reaches stdout: reporting a fact the command did not establish is the
+    /// invented measurement this design refuses (`docs/cli-supervise.md`).
     func handleSuperviseSetProjectMark(_ paramsData: Data) async throws -> RPCResponse {
         let store = try requireSupervision()
         let params = try decoder.decode(SuperviseSetProjectMarkParams.self, from: paramsData)
-        return try RPCResponse(
-            result: await store.setProjectMark(project: params.project, on: params.on))
+
+        // The Nightwatch coexistence gate. The two supervision paths are
+        // mutually exclusive until Nightwatch is retired, not sequential, so
+        // turning a project on while Nightwatch is running is refused with the
+        // condition named. **Only `on`.** `off` is never refusable in either
+        // direction: an operator who could not turn coverage off while the
+        // other path held it on would be wedged with no way out.
+        if params.on {
+            let mode = try await db.config.get().nightwatchMode
+            guard mode == .off else {
+                throw SupervisionNightwatchConflict.superviseOnWhileNightwatchRunning(mode: mode)
+            }
+        }
+
+        let result = try await store.setProjectMark(project: params.project, on: params.on)
+
+        if params.on {
+            await ensureDesk(project: params.project)
+        }
+        return try RPCResponse(result: result)
+    }
+
+    /// Ensure `project` has a live supervisor, reporting rather than refusing.
+    ///
+    /// Every failure here is an anomaly on the daemon's own record — the log
+    /// and, for a dangling binding, an operator notification — and none of them
+    /// reaches the caller: the mark is already set, and retroactively failing a
+    /// gesture that took effect would be a lie about what happened.
+    private func ensureDesk(project: String) async {
+        guard let desks = supervisionDesks, let store = supervision else { return }
+        do {
+            let inputs = try await store.deskInputs(project: project)
+            _ = try await desks.ensureDesk(project: inputs)
+        } catch {
+            supervisionLogger.error(
+                """
+                Coverage of "\(project, privacy: .public)" is on, but its supervisor could not \
+                be ensured: \(String(describing: error), privacy: .public). The mark stands; \
+                nothing will be delivered until a supervisor exists.
+                """)
+        }
     }
 
     func handleSuperviseSetMode(_ paramsData: Data) async throws -> RPCResponse {
@@ -179,6 +238,41 @@ extension RPCRouter {
             project: params.project, text: params.text, brake: brake,
             deliverer: supervisionBriefingDeliverer))
     }
+}
+
+/// The refusals that keep the two supervision paths apart while both are live.
+///
+/// **Nightwatch stays live until the redesign's cutover, so the two are mutually
+/// exclusive rather than sequential.** Both drive the same fleet through the
+/// same terminals, on different theories of who decides what — running them
+/// together would have two rails nudging one agent with neither aware of the
+/// other. Each direction refuses the *on* gesture and names the condition.
+///
+/// **Neither direction can refuse an `off`**, and that asymmetry is the whole
+/// safety property: turning supervision off, and setting Nightwatch to `.off`,
+/// always work. An operator who ran into a refusal in both directions would be
+/// wedged with the fleet running and no gesture that could stop it.
+enum SupervisionNightwatchConflict: Error, CustomStringConvertible, LocalizedError {
+    case superviseOnWhileNightwatchRunning(mode: NightwatchMode)
+    case nightwatchOnWhileProjectsSupervised(projects: [String])
+
+    var description: String {
+        switch self {
+        case .superviseOnWhileNightwatchRunning(let mode):
+            return "Nightwatch is running (mode: \(mode.rawValue)), and it supervises the same "
+                + "fleet this would. Turn it off first with \"tbd nightwatch mode off\", then "
+                + "turn the project on. Turning projects OFF is never refused."
+        case .nightwatchOnWhileProjectsSupervised(let projects):
+            let named = projects.map { "\"\($0)\"" }.joined(separator: ", ")
+            let verb = projects.count == 1 ? "is" : "are"
+            return "\(named) \(verb) under fleet supervision, which watches the same fleet "
+                + "Nightwatch would. Turn each project off first with "
+                + "\"tbd supervise off <project>\", then set the Nightwatch mode. Setting "
+                + "Nightwatch to off is never refused."
+        }
+    }
+
+    var errorDescription: String? { description }
 }
 
 /// The refusal a `supervise.*` call gets when the daemon has no supervision

--- a/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
@@ -70,6 +70,20 @@ extension RPCRouter {
         // condition named. **Only `on`.** `off` is never refusable in either
         // direction: an operator who could not turn coverage off while the
         // other path held it on would be wedged with no way out.
+        //
+        // **The gate is check-then-act, and nothing serializes it against its
+        // twin in `handleSetNightwatchMode`.** The two facts live in separate
+        // stores — the mode in a DB config row, the marks in `SupervisionStore`
+        // — and each handler reads the other's store before writing its own.
+        // `RPCRouter` is a plain class, not an actor, so two calls in flight at
+        // the same instant can both pass their precondition before either write
+        // lands, and the fleet ends up under both paths at once: precisely the
+        // state these two gates exist to prevent, and one no later read
+        // repairs by itself — an operator turns one path off. The window is
+        // narrow, because reaching it takes two operator gestures in the same
+        // instant, one per path. Closing it needs a lock shared across both
+        // handlers, which is a design decision about where supervision's writes
+        // serialize rather than a fix, and it is deliberately not made here.
         if params.on {
             let mode = try await db.config.get().nightwatchMode
             guard mode == .off else {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -41,6 +41,11 @@ public final class RPCRouter: Sendable {
     /// every router a test constructs would share the developer's real
     /// `~/tbd/supervision`.
     public nonisolated(unsafe) var supervision: SupervisionStore?
+    /// The hosted-desk lifecycle (design §9): `on <project>` ensures a live
+    /// supervisor through it. Wired post-construction beside `supervision` and
+    /// `nil` in mock mode and in tests that do not need it — where `on` still
+    /// sets the mark, which is the half the gesture actually promises.
+    public nonisolated(unsafe) var supervisionDesks: SupervisionDeskManager?
     /// The out-of-band `status.json` heartbeat. The brake handler publishes an
     /// edge through it and arms or disarms its timer to match, so the timer's
     /// lifetime is tied to the brake rather than to daemon boot. Wired

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -596,6 +596,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetGCEnabled(request.paramsData)
             case RPCMethod.configSetGCProfileDirsEnabled:
                 return try await handleConfigSetGCProfileDirsEnabled(request.paramsData)
+            case RPCMethod.configSetGCSupervisionDesksEnabled:
+                return try await handleConfigSetGCSupervisionDesksEnabled(request.paramsData)
             case RPCMethod.configSetSupervisionEnabled:
                 return try await handleConfigSetSupervisionEnabled(request.paramsData)
             case RPCMethod.remoteProviders:

--- a/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
@@ -121,8 +121,9 @@ public typealias SupervisionDeskSpawn = @Sendable (
 /// - *A recorded desk that died* is `SupervisionDeskCollector`'s, run as a leg
 ///   of `OrphanGC`: it prunes the `desks.json` entry and hands the worktree to
 ///   the archive path the sweep already runs, and never touches a live desk.
-/// - *A spawn that failed before the record was written* is invisible to that
-///   collector, which walks `desks.json` and finds no entry — so this type
+/// - *An ensure that ended with no entry written* — the spawn threw, produced
+///   no terminal, or ran and could not be recorded — is invisible to that
+///   collector, which walks `desks.json` and finds nothing. So this type
 ///   archives the scratch row itself on every such exit (`abandon`), which puts
 ///   it under `OrphanGC`'s deletion-queue leg instead.
 public actor SupervisionDeskManager {
@@ -358,8 +359,10 @@ public actor SupervisionDeskManager {
     /// created first because it cannot be created transactionally, then the
     /// record, then the line.
     ///
-    /// **Every exit between the scratch space and the record hands the space
-    /// back.** `SupervisionDeskCollector` walks `desks.json`, so a failure
+    /// **Every failing exit after the scratch space exists hands it back** —
+    /// the spawn that threw, the spawn that produced no terminal, and the desk
+    /// that could not be written to the record.
+    /// `SupervisionDeskCollector` walks `desks.json`, so a failure
     /// before the entry is written is invisible to it — and to every other leg
     /// of the sweep, because a scratch row has no repo and the archived legs
     /// only touch rows already archived. `abandon` archives the row, which is
@@ -432,6 +435,18 @@ public actor SupervisionDeskManager {
             let latest = try desks.load()
             try desks.save(latest.recording(entry, for: inputs.project))
         } catch {
+            // A desk that ran and was never written down is the worst of the
+            // three failing exits, not the mildest: the session is live, so the
+            // next `on` reads no entry and spawns a second one beside it, and
+            // the pile grows one agent per gesture. Nothing else reclaims it —
+            // `SupervisionDeskCollector` enumerates the record this write did
+            // not reach, and the sweep's other legs walk repo-backed or
+            // already-archived rows. So this exit hands the space back too, and
+            // the archived row is what carries the session's own teardown to
+            // `WorktreeLifecycle+Reconcile`.
+            await abandon(
+                worktree, project: inputs.project,
+                because: "its desk could not be written to the record")
             throw SupervisionDeskError.recordFailed(
                 project: inputs.project, detail: String(describing: error))
         }
@@ -439,9 +454,23 @@ public actor SupervisionDeskManager {
         subscriptions?.broadcast(delta: .worktreeCreated(WorktreeDelta(
             worktreeID: worktree.id, repoID: nil, name: worktree.name,
             path: worktree.localPath, status: worktree.status)))
+        for created in created {
+            // The sidebar shows the desk's scratch space the moment the row
+            // broadcast above lands; without this it would sit there tabless
+            // until the next full state refresh. Same pair `scratch.create`
+            // sends, for the same reason.
+            subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
+                terminalID: created.id, worktreeID: worktree.id, label: created.label)))
+        }
 
         let ref = SupervisionDeskRef(terminal: entry.terminal, worktree: entry.worktree)
         if let predecessor {
+            // The desk this one succeeds keeps a scratch space that the record
+            // no longer names, and that nothing else reclaims: the collector
+            // enumerates `desks.json`, where this project's key now holds the
+            // successor. Handing it back here is what keeps a project's
+            // replacements from piling up one dead space per replacement.
+            await abandonPredecessor(predecessor, project: inputs.project)
             await ledger.append(SupervisionLedgerLine.deskReplaced(
                 project: inputs.project, mode: inputs.mode, desk: ref,
                 predecessor: SupervisionDeskRef(
@@ -553,6 +582,27 @@ public actor SupervisionDeskManager {
                 \(String(describing: error), privacy: .public). It is left for a human.
                 """)
         }
+    }
+
+    /// Hand back the scratch space of the desk a replacement just succeeded.
+    ///
+    /// Recording the successor overwrites the project's key, so from that
+    /// moment the predecessor's space is referenced by nothing: the collector
+    /// enumerates `desks.json` and reads the successor there, the
+    /// agent-worktree leg walks only repo-backed worktrees, and the archived
+    /// legs only touch rows already archived. Without this it would leak one
+    /// scratch space per replacement, forever.
+    ///
+    /// Done only **after** the successor is recorded, so a record write that
+    /// failed leaves the predecessor exactly as it was rather than letting go
+    /// of the one desk the project still has. A row that is already archived,
+    /// or gone, is left alone — there is nothing to hand back.
+    private func abandonPredecessor(
+        _ predecessor: SupervisionDeskEntry, project: String
+    ) async {
+        guard let row = ((try? await db.worktrees.get(id: predecessor.worktree)) ?? nil),
+              row.status == .active else { return }
+        await abandon(row, project: project, because: "the desk it held was replaced")
     }
 
     private func notify(_ message: String, worktree: UUID) {

--- a/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
@@ -1,0 +1,473 @@
+import Foundation
+import os
+import TBDShared
+
+private let deskLogger = Logger(subsystem: "com.tbd.daemon", category: "supervision.desk")
+
+// MARK: - What a desk needs to exist
+
+/// Everything `ensureDesk` needs, read once by the one component that owns
+/// `supervision.json`.
+///
+/// The desk manager deliberately resolves no topology of its own:
+/// `SupervisionStore` is the single reader of the operator's file, and a second
+/// resolution would be a second answer to a question with one.
+public struct SupervisionDeskInputs: Sendable, Equatable {
+    public let project: String
+    /// The project's active mode at the moment of the gesture — carried onto
+    /// the lifecycle line, never interpreted.
+    public let mode: String
+    /// The project's resolved playbook: installed verbatim as the desk's
+    /// standing conduct layer, and hashed onto the desk's record.
+    public let playbook: SupervisionPlaybook
+    /// The operator's appointed supervisor, when one is bound. Its presence
+    /// stands the hosted default down entirely (design §9).
+    public let appointed: SupervisionSupervisorBinding?
+
+    public init(project: String, mode: String, playbook: SupervisionPlaybook,
+                appointed: SupervisionSupervisorBinding?) {
+        self.project = project
+        self.mode = mode
+        self.playbook = playbook
+        self.appointed = appointed
+    }
+}
+
+/// What one `ensureDesk` did. Every case is a fact about the world afterwards,
+/// not a status code: callers log it, and the ledger line was already written
+/// by the time it is returned.
+public enum SupervisionDeskOutcome: Sendable, Equatable {
+    /// An appointed binding stands and its session is live. Nothing was
+    /// spawned — a mark is coverage, a binding is selection, and `on` never
+    /// touches the second.
+    case appointed(terminal: UUID)
+    /// An appointed binding stands and names a session that is gone. Reported
+    /// loudly and left alone: the operator chose that supervisor, and TBD does
+    /// not unchoose it (design §9). The resolution is the operator's relieve
+    /// gesture, which is not in this slice.
+    case danglingBinding(terminal: String, detail: String)
+    /// A recorded desk is live; it resumes as it stands and nothing was
+    /// spawned. The quiet path, and the common one.
+    case resumed(SupervisionDeskEntry)
+    /// A project that had no desk got one.
+    case spawned(SupervisionDeskEntry)
+    /// A recorded desk had died and was replaced, with a lifecycle line linking
+    /// successor to predecessor.
+    case replaced(successor: SupervisionDeskEntry, predecessor: SupervisionDeskEntry)
+}
+
+/// Why a desk could not be ensured. A spawn failure is an anomaly, never a
+/// refusal of the mark: `on <project>` sets the mark first and the caller
+/// reports this without failing the gesture (design §9, `docs/cli-supervise.md`).
+public enum SupervisionDeskError: Error, CustomStringConvertible, LocalizedError {
+    case couldNotAllocateDirectory(project: String)
+    case spawnFailed(project: String, detail: String)
+    case recordFailed(project: String, detail: String)
+
+    public var description: String {
+        switch self {
+        case .couldNotAllocateDirectory(let project):
+            return "Could not allocate a scratch directory for \"\(project)\"'s hosted desk."
+        case .spawnFailed(let project, let detail):
+            return "The hosted desk for \"\(project)\" could not be spawned: \(detail)"
+        case .recordFailed(let project, let detail):
+            return "The hosted desk for \"\(project)\" was spawned but could not be recorded: "
+                + "\(detail)"
+        }
+    }
+
+    public var errorDescription: String? { description }
+}
+
+// MARK: - The manager
+
+/// Ensures each supervised project has a live supervisor, per design §9's
+/// hosted-desk lifecycle.
+///
+/// **The whole of the policy, in the order it is applied.**
+///
+/// 1. *An appointed binding wins, always.* Where one stands, no hosted desk is
+///    spawned and none is silently substituted. A binding naming a session that
+///    is gone is a **dangling binding**: reported loudly, never taken over.
+/// 2. *A live recorded desk resumes as it stands.* Liveness is the terminal row
+///    plus its tmux window, read from TBD's own records and tmux's metadata —
+///    never from anything rendered on a screen.
+/// 3. *A recorded desk that died is replaced*, and the lifecycle line links
+///    successor to predecessor so a project's desks read as a chain.
+/// 4. *A project with no desk gets one.*
+///
+/// **A spawn delivers nothing.** No message, no nudge, no opening prompt: the
+/// opening material rides the first briefing, so a quiet project's desk idles at
+/// zero token cost. That is a property this type is tested for, not a detail.
+///
+/// **Who reclaims an orphan** (repo `CLAUDE.md`): `SupervisionDeskCollector`,
+/// run as a leg of `OrphanGC`. A desk is a scratch worktree plus a live process,
+/// and this type creates both before it can record either — so a crash between
+/// the spawn and the `desks.json` write leaves a scratch space nobody owns. The
+/// collector prunes the record and hands the worktree to the archive path the
+/// sweep already runs, and never touches a live desk.
+public actor SupervisionDeskManager {
+    private let db: TBDDatabase
+    private let lifecycle: WorktreeLifecycle
+    private let tmux: TmuxManager
+    private let desks: SupervisionDesksStore
+    private let ledger: SupervisionLedgerWriter
+    private let actuationLog: ActuationLog
+    private let subscriptions: StateSubscriptionManager?
+    /// A persisted, compared timestamp — the date seam, never a `Clock`.
+    /// Nothing here sleeps, debounces, polls, or times out.
+    private let now: @Sendable () -> Date
+
+    /// Serializes the whole read-decide-spawn-record sequence. Actor isolation
+    /// alone is not enough: `ensureDesk` awaits the database and the spawn, and
+    /// an actor releases itself across every suspension, so two concurrent
+    /// ensures for one project would both read "no desk" and both spawn one.
+    private var gateBusy = false
+    private var gateWaiters: [CheckedContinuation<Void, Never>] = []
+
+    private func gateAcquire() async {
+        if gateBusy {
+            await withCheckedContinuation { gateWaiters.append($0) }
+            // Resumed by gateRelease(); `gateBusy` stays true.
+        } else {
+            gateBusy = true
+        }
+    }
+
+    private func gateRelease() {
+        if gateWaiters.isEmpty {
+            gateBusy = false
+        } else {
+            gateWaiters.removeFirst().resume()
+        }
+    }
+
+    public init(
+        db: TBDDatabase,
+        lifecycle: WorktreeLifecycle,
+        tmux: TmuxManager,
+        desks: SupervisionDesksStore,
+        ledger: SupervisionLedgerWriter,
+        actuationLog: ActuationLog,
+        subscriptions: StateSubscriptionManager? = nil,
+        now: @Sendable @escaping () -> Date = { Date() }
+    ) {
+        self.db = db
+        self.lifecycle = lifecycle
+        self.tmux = tmux
+        self.desks = desks
+        self.ledger = ledger
+        self.actuationLog = actuationLog
+        self.subscriptions = subscriptions
+        self.now = now
+    }
+
+    // MARK: - Ensure
+
+    /// Ensure a live supervisor for one project, spawning a hosted desk only
+    /// when that is what the four rules above call for.
+    @discardableResult
+    public func ensureDesk(project inputs: SupervisionDeskInputs) async throws
+        -> SupervisionDeskOutcome {
+        await gateAcquire()
+        defer { gateRelease() }
+
+        if let binding = inputs.appointed {
+            return await evaluateAppointment(binding, project: inputs.project)
+        }
+
+        let file = try desks.load()
+        if let entry = file.desk(for: inputs.project) {
+            if await isLive(entry) {
+                deskLogger.debug(
+                    """
+                    Hosted desk for "\(inputs.project, privacy: .public)" is live; resuming as it \
+                    stands.
+                    """)
+                return .resumed(entry)
+            }
+            // A desk that died while stood down — a death nothing was watching
+            // for, because a stood-down project's sweep is not running — is
+            // detected exactly here and nowhere else.
+            let successor = try await spawn(inputs: inputs, file: file, predecessor: entry)
+            return .replaced(successor: successor, predecessor: entry)
+        }
+
+        let entry = try await spawn(inputs: inputs, file: file, predecessor: nil)
+        return .spawned(entry)
+    }
+
+    // MARK: - Appointment
+
+    /// An appointed binding stands. Verify the session is really there, and say
+    /// so loudly when it is not — the hosted default does **not** step in.
+    private func evaluateAppointment(
+        _ binding: SupervisionSupervisorBinding, project: String
+    ) async -> SupervisionDeskOutcome {
+        guard let terminalID = binding.terminalID else {
+            return dangling(
+                binding.terminal, project: project, worktree: nil,
+                detail: "the binding does not name a terminal id")
+        }
+        let terminal: Terminal?
+        do {
+            terminal = try await db.terminals.get(id: terminalID)
+        } catch {
+            // A read that never answered says nothing about the session, so it
+            // is not evidence of a dangling binding. Report it and change
+            // nothing: the keep-favoring direction, matching the sweeps.
+            deskLogger.warning(
+                """
+                Could not check "\(project, privacy: .public)"'s appointed supervisor \
+                \(terminalID.uuidString, privacy: .public): \
+                \(String(describing: error), privacy: .public). Nothing was spawned.
+                """)
+            return .appointed(terminal: terminalID)
+        }
+        guard let terminal else {
+            return dangling(
+                binding.terminal, project: project, worktree: nil,
+                detail: "that terminal no longer exists")
+        }
+        guard terminal.hibernatedAt == nil, terminal.suspendedAt == nil else {
+            return dangling(
+                binding.terminal, project: project, worktree: terminal.worktreeID,
+                detail: "that session is parked, so nothing can be delivered to it")
+        }
+        guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
+            return dangling(
+                binding.terminal, project: project, worktree: nil,
+                detail: "TBD no longer has the worktree that session lived in")
+        }
+        guard await tmux.windowExists(
+            server: worktree.tmuxServer, windowID: terminal.tmuxWindowID) else {
+            return dangling(
+                binding.terminal, project: project, worktree: terminal.worktreeID,
+                detail: "that session's window is gone")
+        }
+        deskLogger.debug(
+            """
+            "\(project, privacy: .public)" has an appointed supervisor \
+            (\(terminalID.uuidString, privacy: .public)); no hosted desk was spawned.
+            """)
+        return .appointed(terminal: terminalID)
+    }
+
+    /// The loud half of a dangling binding: an error in the log and an operator
+    /// notification. **Never a silent takeover** — the hosted default does not
+    /// step into a role the operator assigned to someone else (design §9).
+    ///
+    /// The matching `anomaly` ledger line is not written here because this build
+    /// has no anomaly payload to write; it arrives with the anomaly kind.
+    /// Nothing about the reporting is silent in the meantime.
+    /// `worktree` is the bound session's, when TBD still has one. A TBD
+    /// notification is worktree-scoped, so a binding whose terminal row is gone
+    /// entirely raises none — the `.error` log line above is written either way,
+    /// and inventing a worktree to hang the notification on would be a fact TBD
+    /// does not have.
+    private func dangling(
+        _ terminal: String, project: String, worktree: UUID?, detail: String
+    ) -> SupervisionDeskOutcome {
+        let message = """
+            Supervision: "\(project)" is bound to supervisor \(terminal), but \(detail). \
+            No hosted desk was spawned in its place — relieve the binding to fall back to the \
+            hosted default.
+            """
+        deskLogger.error("\(message, privacy: .public)")
+        if let worktree { notify(message, worktree: worktree) }
+        return .danglingBinding(terminal: terminal, detail: detail)
+    }
+
+    // MARK: - Liveness
+
+    /// Whether a recorded desk is really there: a terminal row that is not
+    /// parked, its worktree still active, and a tmux window that still exists.
+    ///
+    /// **Read from TBD's records and tmux's own metadata**, never from anything
+    /// rendered in the pane. A screen is a display surface, not an API (root
+    /// `CLAUDE.md`).
+    ///
+    /// Every failure direction is toward *not live*, which costs a replacement
+    /// desk. The opposite direction costs a project with no supervisor and
+    /// nothing to say so.
+    private func isLive(_ entry: SupervisionDeskEntry) async -> Bool {
+        guard let terminal = try? await db.terminals.get(id: entry.terminal),
+              terminal.hibernatedAt == nil, terminal.suspendedAt == nil,
+              let worktree = try? await db.worktrees.getLocal(id: entry.worktree),
+              worktree.status == .active else {
+            return false
+        }
+        return await tmux.windowExists(
+            server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
+    }
+
+    // MARK: - Spawn
+
+    /// Create the scratch space and the desk session in it, record the desk,
+    /// and append the lifecycle line.
+    ///
+    /// The order is deliberate and matches the store's: the external resource is
+    /// created first because it cannot be created transactionally, then the
+    /// record, then the line. A crash in the middle leaves a scratch space with
+    /// no desk entry — which is precisely what `SupervisionDeskCollector`
+    /// reclaims.
+    private func spawn(
+        inputs: SupervisionDeskInputs, file: SupervisionDesksFile,
+        predecessor: SupervisionDeskEntry?
+    ) async throws -> SupervisionDeskEntry {
+        let worktree = try await createScratchSpace(project: inputs.project)
+
+        // The rail spawns an agent session with nobody having asked for a
+        // session by name, so it writes its own row: one naming the scratch
+        // worktree and no terminal, the shape `worktree.revive` uses, because
+        // the terminal is minted inside `spawnPrimaryTerminals`.
+        var row = ActuationRow(
+            actor: .daemon(rail: ActuationRail.supervisionDesk), kind: .spawn)
+        row.target = ActuationTarget(worktree: worktree.id.uuidString)
+        let actuationID = try await actuationLog.appendRequest(row)
+
+        let created: [(id: UUID, label: String)]
+        do {
+            created = try await lifecycle.spawnPrimaryTerminals(
+                worktree: worktree,
+                repo: nil,
+                skipClaude: false,
+                // **Nothing is delivered at spawn.** No opening prompt, no
+                // nudge, no briefing: the opening material rides the first
+                // briefing, so a quiet project's desk costs nothing to have.
+                initialPrompt: nil,
+                preSessionTerminalID: nil,
+                // Forced rather than read from the operator's primary-agent
+                // preference: supervisor capability is a per-adapter
+                // qualification (design §9), and the standing conduct layer
+                // below rides `--append-system-prompt`, which only the Claude
+                // spawn path carries. A Codex desk would launch with no conduct
+                // at all and nothing would say so.
+                primaryAgentPreference: .claude,
+                supervisionProject: inputs.project,
+                supervisionPlaybook: inputs.playbook.text)
+        } catch {
+            await actuationLog.appendOutcome(
+                confirms: actuationID, result: .transportFailed, error: "\(error)")
+            throw SupervisionDeskError.spawnFailed(
+                project: inputs.project, detail: String(describing: error))
+        }
+        await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
+
+        guard let primary = created.first else {
+            throw SupervisionDeskError.spawnFailed(
+                project: inputs.project, detail: "the spawn created no terminal")
+        }
+
+        let at = now()
+        let entry = SupervisionDeskEntry(
+            terminal: primary.id, worktree: worktree.id,
+            spawnedAt: SupervisionInstant(at), conductHash: inputs.playbook.conductHash)
+        do {
+            try desks.save(file.recording(entry, for: inputs.project))
+        } catch {
+            throw SupervisionDeskError.recordFailed(
+                project: inputs.project, detail: String(describing: error))
+        }
+
+        subscriptions?.broadcast(delta: .worktreeCreated(WorktreeDelta(
+            worktreeID: worktree.id, repoID: nil, name: worktree.name,
+            path: worktree.localPath, status: worktree.status)))
+
+        let ref = SupervisionDeskRef(terminal: entry.terminal, worktree: entry.worktree)
+        if let predecessor {
+            await ledger.append(SupervisionLedgerLine.deskReplaced(
+                project: inputs.project, mode: inputs.mode, desk: ref,
+                predecessor: SupervisionDeskRef(
+                    terminal: predecessor.terminal, worktree: predecessor.worktree),
+                conductHash: entry.conductHash, at: at))
+            deskLogger.notice(
+                """
+                Replaced the hosted desk for "\(inputs.project, privacy: .public)": \
+                \(predecessor.terminal.uuidString, privacy: .public) had died; its successor is \
+                \(entry.terminal.uuidString, privacy: .public).
+                """)
+        } else {
+            await ledger.append(SupervisionLedgerLine.deskSpawned(
+                project: inputs.project, mode: inputs.mode, desk: ref,
+                conductHash: entry.conductHash, at: at))
+            deskLogger.notice(
+                """
+                Spawned a hosted desk for "\(inputs.project, privacy: .public)": terminal \
+                \(entry.terminal.uuidString, privacy: .public) in \
+                \(worktree.localPath, privacy: .public).
+                """)
+        }
+        return entry
+    }
+
+    /// A fresh scratch worktree for one desk: a `repoID == nil` row under
+    /// `TBDConstants.scratchDir`, exactly like every other scratch space.
+    ///
+    /// The directory name is derived from the project only as a courtesy to a
+    /// human reading `ls`. **Nothing ever looks a desk up by it** — the record
+    /// is keyed by id, so a rename is free.
+    private func createScratchSpace(project: String) async throws -> Worktree {
+        let fm = FileManager.default
+        let scratchDir = TBDConstants.scratchDir
+        try fm.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+
+        // **Creating the directory IS the allocation.** A check-then-create
+        // would leave a window in which two ensures pick the same free name and
+        // the second one's `createDirectory` throws; `withIntermediateDirectories:
+        // false` fails with `fileWriteFileExists` on an already-taken name, so
+        // the loser simply tries the next candidate. The database check stays,
+        // because a name can be taken by a row whose directory is gone.
+        var path: URL?
+        var name = ""
+        for attempt in 0..<50 {
+            let candidate = attempt == 0
+                ? "supervision-desk"
+                : "supervision-desk-\(UUID().uuidString.prefix(8))"
+            let url = scratchDir.appendingPathComponent(candidate)
+            if try await db.worktrees.findByPath(path: url.path) != nil { continue }
+            do {
+                try fm.createDirectory(at: url, withIntermediateDirectories: false)
+            } catch CocoaError.fileWriteFileExists {
+                continue
+            }
+            name = candidate
+            path = url
+            break
+        }
+        guard let deskPath = path else {
+            throw SupervisionDeskError.couldNotAllocateDirectory(project: project)
+        }
+
+        do {
+            return try await db.worktrees.createScratch(
+                name: name,
+                // A display string for the sidebar and nothing else. The record
+                // is keyed by id precisely so this can be renamed at will.
+                displayName: "Supervisor · \(project)",
+                path: deskPath.path,
+                tmuxServer: TmuxManager.serverName(forRepoPath: scratchDir.path))
+        } catch {
+            // Best-effort, as creation-time rollback always is here. The
+            // standing guarantee is the collector, not this line.
+            try? fm.removeItem(at: deskPath)
+            throw error
+        }
+    }
+
+    private func notify(_ message: String, worktree: UUID) {
+        let db = self.db
+        let subscriptions = self.subscriptions
+        Task {
+            guard let notification = try? await db.notifications.create(
+                worktreeID: worktree, type: .error, message: message) else { return }
+            subscriptions?.broadcast(delta: .notificationReceived(NotificationDelta(
+                notificationID: notification.id,
+                worktreeID: notification.worktreeID,
+                type: notification.type,
+                message: notification.message,
+                terminalID: notification.terminalID,
+                activate: false)))
+        }
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
@@ -126,6 +126,12 @@ public typealias SupervisionDeskSpawn = @Sendable (
 ///   collector, which walks `desks.json` and finds nothing. So this type
 ///   archives the scratch row itself on every such exit (`abandon`), which puts
 ///   it under `OrphanGC`'s deletion-queue leg instead.
+///
+/// One residual is deliberate rather than covered: a predecessor whose liveness
+/// recheck refuses to call it gone is left `.active` and reclaimed by nobody,
+/// because handing back a space whose session is alive costs that session its
+/// terminal on the next reconcile pass. `abandonPredecessor` states the whole
+/// tradeoff, and the operator is told rather than left to find it.
 public actor SupervisionDeskManager {
     private let db: TBDDatabase
     private let spawnSession: SupervisionDeskSpawn
@@ -329,25 +335,74 @@ public actor SupervisionDeskManager {
 
     // MARK: - Liveness
 
-    /// Whether a recorded desk is really there: a terminal row that is not
-    /// parked, its worktree still active, and a tmux window that still exists.
+    /// What one read of a recorded desk found.
+    ///
+    /// The three cases exist because two different decisions act on this answer
+    /// in **opposite** directions, and each needs its own failure direction.
+    /// Deciding whether to *spawn* a replacement fails toward "not live" — a
+    /// spare desk costs tokens, a project with no supervisor costs coverage.
+    /// Deciding whether to *archive* the predecessor fails toward keeping — an
+    /// archived worktree loses its tmux window to the next reconcile pass, so
+    /// getting that one wrong destroys a live agent session. Collapsing "no
+    /// evidence" into "gone", which a `Bool` forces, is precisely how the
+    /// second decision goes wrong; `SupervisionDeskCollector.WorktreeLookup`
+    /// keeps the same two apart for the same reason.
+    private enum DeskLiveness: Equatable {
+        /// The session is there and can be delivered to.
+        case live
+        /// Affirmative evidence the desk is not there: a terminal row that is
+        /// gone, a worktree row that is gone or already archived, or a tmux
+        /// window that is not there.
+        case gone
+        /// Nothing was established. A read that did not answer, or a session
+        /// that is parked — asleep but wakeable, so a record of a session that
+        /// is coming back rather than evidence of one that is not.
+        case undetermined
+    }
+
+    /// Read a recorded desk: a terminal row that is not parked, its worktree
+    /// still active, and a tmux window that still exists.
     ///
     /// **Read from TBD's records and tmux's own metadata**, never from anything
     /// rendered in the pane. A screen is a display surface, not an API (root
     /// `CLAUDE.md`).
     ///
+    /// One limitation is worth stating, because it bounds what `.gone` proves:
+    /// `TmuxManager.windowExists` answers `false` both for a window that is not
+    /// there and for a tmux it could not reach, so an unreachable tmux reads as
+    /// `.gone`. That is the same evidence this type has always decided on, and
+    /// narrowing it needs a distinguishable answer from `TmuxManager` itself.
+    private func liveness(_ entry: SupervisionDeskEntry) async -> DeskLiveness {
+        let terminal: Terminal?
+        do {
+            terminal = try await db.terminals.get(id: entry.terminal)
+        } catch {
+            return .undetermined
+        }
+        guard let terminal else { return .gone }
+        guard terminal.hibernatedAt == nil, terminal.suspendedAt == nil else {
+            return .undetermined
+        }
+        let worktree: LocalWorktree?
+        do {
+            worktree = try await db.worktrees.getLocal(id: entry.worktree)
+        } catch {
+            return .undetermined
+        }
+        guard let worktree, worktree.status == .active else { return .gone }
+        let windowExists = await tmux.windowExists(
+            server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
+        return windowExists ? .live : .gone
+    }
+
+    /// Whether a recorded desk is really there.
+    ///
     /// Every failure direction is toward *not live*, which costs a replacement
     /// desk. The opposite direction costs a project with no supervisor and
     /// nothing to say so.
     private func isLive(_ entry: SupervisionDeskEntry) async -> Bool {
-        guard let terminal = try? await db.terminals.get(id: entry.terminal),
-              terminal.hibernatedAt == nil, terminal.suspendedAt == nil,
-              let worktree = try? await db.worktrees.getLocal(id: entry.worktree),
-              worktree.status == .active else {
-            return false
-        }
-        return await tmux.windowExists(
-            server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
+        let state = await liveness(entry)
+        return state == .live
     }
 
     // MARK: - Spawn
@@ -597,27 +652,89 @@ public actor SupervisionDeskManager {
     /// failed leaves the predecessor exactly as it was rather than letting go
     /// of the one desk the project still has. A row that is already archived,
     /// or gone, is left alone — there is nothing to hand back.
+    ///
+    /// **The predecessor is read again here, and only affirmative evidence that
+    /// it is gone archives it.** The judgement that started this replacement was
+    /// made before a whole spawn — a worktree created, a session started, a
+    /// record written — and it was made by `isLive`, which answers "not live" to
+    /// a read that merely failed. Two paths therefore reach a session that is
+    /// alive: a transient read that glitched the first judgement, and a desk
+    /// that was stood down at the decision and woken before this line (a
+    /// stood-down desk stays wakeable by design). Archiving either is not
+    /// cosmetic: `WorktreeLifecycle+Reconcile` computes its tracked tmux windows
+    /// from non-archived rows, so an archived-but-live desk loses its window on
+    /// the next reconcile pass — a live agent session destroyed through ordinary
+    /// control flow. This recheck is the same shape and the same direction as
+    /// `SupervisionDeskCollector`'s fresh-liveness pass immediately before a
+    /// reap, and it is why every reap direction in this subsystem fails toward
+    /// keeping.
+    ///
+    /// **The tradeoff when the recheck declines is real, and is not papered
+    /// over.** The successor already holds the project's key in `desks.json`, so
+    /// the predecessor is enumerated by nothing: `SupervisionDeskCollector`
+    /// walks that record and reads the successor there, the agent-worktree leg
+    /// walks only repo-backed rows, and the archived legs only touch rows
+    /// already archived. A predecessor kept here is therefore a scratch space no
+    /// reconciler will reclaim later. It is left `.active`, logged, and
+    /// announced to the operator on its own worktree, which makes it the same
+    /// shape as the crash-window residual the spawn path already carries: a
+    /// visible row an operator can see and close. That is strictly better than
+    /// the alternative, which is killing a live agent session.
     private func abandonPredecessor(
         _ predecessor: SupervisionDeskEntry, project: String
     ) async {
         guard let row = ((try? await db.worktrees.get(id: predecessor.worktree)) ?? nil),
               row.status == .active else { return }
+        let state = await liveness(predecessor)
+        guard state == .gone else {
+            let detail = state == .live
+                ? "its session is still live"
+                : "its session could not be confidently read as gone"
+            let message = """
+                Supervision: "\(project)" replaced its hosted desk, and the desk it replaced kept \
+                its scratch space — \(detail). That space at \(row.localPath) is left active, and \
+                no sweep will reclaim it, because the project's record now names the replacement. \
+                Close it by hand once you have confirmed nothing is running in it. Handing it back \
+                would have cost a live session its terminal on the next reconcile pass.
+                """
+            deskLogger.error("\(message, privacy: .public)")
+            await announce(message, worktree: row.id)
+            return
+        }
         await abandon(row, project: project, because: "the desk it held was replaced")
     }
 
+    /// Raise an operator notification from a synchronous caller. Detached
+    /// because the callers that need it return a decision rather than awaiting
+    /// one, and a notification is a report, never a gate.
     private func notify(_ message: String, worktree: UUID) {
         let db = self.db
         let subscriptions = self.subscriptions
         Task {
-            guard let notification = try? await db.notifications.create(
-                worktreeID: worktree, type: .error, message: message) else { return }
-            subscriptions?.broadcast(delta: .notificationReceived(NotificationDelta(
-                notificationID: notification.id,
-                worktreeID: notification.worktreeID,
-                type: notification.type,
-                message: notification.message,
-                terminalID: notification.terminalID,
-                activate: false)))
+            await Self.announce(message, worktree: worktree, db: db, subscriptions: subscriptions)
         }
+    }
+
+    /// The same report, awaited. An async caller uses this so the notification
+    /// has landed by the time the call returns — one less escaping task, and the
+    /// fact is observable at the point it is made.
+    private func announce(_ message: String, worktree: UUID) async {
+        await Self.announce(
+            message, worktree: worktree, db: db, subscriptions: subscriptions)
+    }
+
+    private static func announce(
+        _ message: String, worktree: UUID, db: TBDDatabase,
+        subscriptions: StateSubscriptionManager?
+    ) async {
+        guard let notification = try? await db.notifications.create(
+            worktreeID: worktree, type: .error, message: message) else { return }
+        subscriptions?.broadcast(delta: .notificationReceived(NotificationDelta(
+            notificationID: notification.id,
+            worktreeID: notification.worktreeID,
+            type: notification.type,
+            message: notification.message,
+            terminalID: notification.terminalID,
+            activate: false)))
     }
 }

--- a/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
@@ -79,6 +79,20 @@ public enum SupervisionDeskError: Error, CustomStringConvertible, LocalizedError
     public var errorDescription: String? { description }
 }
 
+/// How a desk's session comes into being: `WorktreeLifecycle`'s
+/// primary-terminal spawn in production, and an injection seam everywhere else.
+///
+/// It exists as a seam because the two failing exits the spawn path cleans up
+/// after are not both reachable through the real one. A thrown spawn is — tmux
+/// refusing the `new-window` produces it — but `spawnPrimaryTerminals` always
+/// returns at least the primary terminal, so "the spawn created no terminal" is
+/// reachable from no input at all. That branch guards against a future
+/// refactor of the spawn path, and this seam is how it is held to its
+/// behaviour.
+public typealias SupervisionDeskSpawn = @Sendable (
+    _ worktree: Worktree, _ inputs: SupervisionDeskInputs
+) async throws -> [(id: UUID, label: String)]
+
 // MARK: - The manager
 
 /// Ensures each supervised project has a live supervisor, per design §9's
@@ -113,7 +127,7 @@ public enum SupervisionDeskError: Error, CustomStringConvertible, LocalizedError
 ///   it under `OrphanGC`'s deletion-queue leg instead.
 public actor SupervisionDeskManager {
     private let db: TBDDatabase
-    private let lifecycle: WorktreeLifecycle
+    private let spawnSession: SupervisionDeskSpawn
     private let tmux: TmuxManager
     private let desks: SupervisionDesksStore
     private let ledger: SupervisionLedgerWriter
@@ -155,16 +169,45 @@ public actor SupervisionDeskManager {
         ledger: SupervisionLedgerWriter,
         actuationLog: ActuationLog,
         subscriptions: StateSubscriptionManager? = nil,
+        spawnSession: SupervisionDeskSpawn? = nil,
         now: @Sendable @escaping () -> Date = { Date() }
     ) {
         self.db = db
-        self.lifecycle = lifecycle
+        self.spawnSession = spawnSession ?? Self.lifecycleSpawn(lifecycle)
         self.tmux = tmux
         self.desks = desks
         self.ledger = ledger
         self.actuationLog = actuationLog
         self.subscriptions = subscriptions
         self.now = now
+    }
+
+    /// The production spawn: one agent session in the desk's scratch space.
+    private static func lifecycleSpawn(
+        _ lifecycle: WorktreeLifecycle
+    ) -> SupervisionDeskSpawn {
+        { worktree, inputs in
+            try await lifecycle.spawnPrimaryTerminals(
+                worktree: worktree,
+                repo: nil,
+                skipClaude: false,
+                // **Nothing is delivered at spawn.** No opening prompt, no
+                // nudge, no briefing: the opening material rides the first
+                // briefing, so a quiet project's desk costs nothing to have.
+                initialPrompt: nil,
+                preSessionTerminalID: nil,
+                // Forced rather than read from the operator's primary-agent
+                // preference: supervisor capability is a per-adapter
+                // qualification (design §9), and the standing conduct layer
+                // below rides `--append-system-prompt`, which only the Claude
+                // spawn path carries. A Codex desk would launch with no conduct
+                // at all and nothing would say so — `spawn` logs the
+                // substitution so a Codex-preferring fleet is told rather than
+                // left to read a tab label.
+                primaryAgentPreference: .claude,
+                supervisionProject: inputs.project,
+                supervisionPlaybook: inputs.playbook.text)
+        }
     }
 
     // MARK: - Ensure
@@ -355,24 +398,7 @@ public actor SupervisionDeskManager {
 
         let created: [(id: UUID, label: String)]
         do {
-            created = try await lifecycle.spawnPrimaryTerminals(
-                worktree: worktree,
-                repo: nil,
-                skipClaude: false,
-                // **Nothing is delivered at spawn.** No opening prompt, no
-                // nudge, no briefing: the opening material rides the first
-                // briefing, so a quiet project's desk costs nothing to have.
-                initialPrompt: nil,
-                preSessionTerminalID: nil,
-                // Forced rather than read from the operator's primary-agent
-                // preference: supervisor capability is a per-adapter
-                // qualification (design §9), and the standing conduct layer
-                // below rides `--append-system-prompt`, which only the Claude
-                // spawn path carries. A Codex desk would launch with no conduct
-                // at all and nothing would say so.
-                primaryAgentPreference: .claude,
-                supervisionProject: inputs.project,
-                supervisionPlaybook: inputs.playbook.text)
+            created = try await spawnSession(worktree, inputs)
         } catch {
             await actuationLog.appendOutcome(
                 confirms: actuationID, result: .transportFailed, error: "\(error)")

--- a/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionDeskManager.swift
@@ -100,12 +100,17 @@ public enum SupervisionDeskError: Error, CustomStringConvertible, LocalizedError
 /// opening material rides the first briefing, so a quiet project's desk idles at
 /// zero token cost. That is a property this type is tested for, not a detail.
 ///
-/// **Who reclaims an orphan** (repo `CLAUDE.md`): `SupervisionDeskCollector`,
-/// run as a leg of `OrphanGC`. A desk is a scratch worktree plus a live process,
-/// and this type creates both before it can record either — so a crash between
-/// the spawn and the `desks.json` write leaves a scratch space nobody owns. The
-/// collector prunes the record and hands the worktree to the archive path the
-/// sweep already runs, and never touches a live desk.
+/// **Who reclaims an orphan** (repo `CLAUDE.md`), in two halves, because a desk
+/// is a scratch worktree plus a live process and this type creates both before
+/// it can record either.
+///
+/// - *A recorded desk that died* is `SupervisionDeskCollector`'s, run as a leg
+///   of `OrphanGC`: it prunes the `desks.json` entry and hands the worktree to
+///   the archive path the sweep already runs, and never touches a live desk.
+/// - *A spawn that failed before the record was written* is invisible to that
+///   collector, which walks `desks.json` and finds no entry — so this type
+///   archives the scratch row itself on every such exit (`abandon`), which puts
+///   it under `OrphanGC`'s deletion-queue leg instead.
 public actor SupervisionDeskManager {
     private let db: TBDDatabase
     private let lifecycle: WorktreeLifecycle
@@ -189,11 +194,11 @@ public actor SupervisionDeskManager {
             // A desk that died while stood down — a death nothing was watching
             // for, because a stood-down project's sweep is not running — is
             // detected exactly here and nowhere else.
-            let successor = try await spawn(inputs: inputs, file: file, predecessor: entry)
+            let successor = try await spawn(inputs: inputs, predecessor: entry)
             return .replaced(successor: successor, predecessor: entry)
         }
 
-        let entry = try await spawn(inputs: inputs, file: file, predecessor: nil)
+        let entry = try await spawn(inputs: inputs, predecessor: nil)
         return .spawned(entry)
     }
 
@@ -308,14 +313,36 @@ public actor SupervisionDeskManager {
     ///
     /// The order is deliberate and matches the store's: the external resource is
     /// created first because it cannot be created transactionally, then the
-    /// record, then the line. A crash in the middle leaves a scratch space with
-    /// no desk entry — which is precisely what `SupervisionDeskCollector`
-    /// reclaims.
+    /// record, then the line.
+    ///
+    /// **Every exit between the scratch space and the record hands the space
+    /// back.** `SupervisionDeskCollector` walks `desks.json`, so a failure
+    /// before the entry is written is invisible to it — and to every other leg
+    /// of the sweep, because a scratch row has no repo and the archived legs
+    /// only touch rows already archived. `abandon` archives the row, which is
+    /// exactly the shape `OrphanGC`'s deletion-queue leg reclaims. A crash
+    /// (rather than a thrown error) in the same window still leaves an
+    /// unreferenced scratch space, and that one nothing reclaims; the doctrine's
+    /// answer is that a crash there is not silent — the row is `.active` and
+    /// visible in the sidebar.
     private func spawn(
-        inputs: SupervisionDeskInputs, file: SupervisionDesksFile,
-        predecessor: SupervisionDeskEntry?
+        inputs: SupervisionDeskInputs, predecessor: SupervisionDeskEntry?
     ) async throws -> SupervisionDeskEntry {
         let worktree = try await createScratchSpace(project: inputs.project)
+
+        // Say so when the desk's forced adapter is not the operator's pick.
+        // A Codex-preferring fleet would otherwise discover its supervisors are
+        // Claude sessions only by reading a tab label.
+        if let preference = try? await db.config.get().primaryAgentPreference,
+           preference != .claude {
+            deskLogger.notice(
+                """
+                The hosted desk for "\(inputs.project, privacy: .public)" launches Claude, not \
+                \(preference.rawValue, privacy: .public): a supervisor's standing conduct rides \
+                --append-system-prompt, which only the Claude spawn path carries. The fleet's \
+                primary-agent preference is unchanged and still applies to every other session.
+                """)
+        }
 
         // The rail spawns an agent session with nobody having asked for a
         // session by name, so it writes its own row: one naming the scratch
@@ -349,12 +376,15 @@ public actor SupervisionDeskManager {
         } catch {
             await actuationLog.appendOutcome(
                 confirms: actuationID, result: .transportFailed, error: "\(error)")
+            await abandon(worktree, project: inputs.project, because: "its session never started")
             throw SupervisionDeskError.spawnFailed(
                 project: inputs.project, detail: String(describing: error))
         }
         await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
 
         guard let primary = created.first else {
+            await abandon(
+                worktree, project: inputs.project, because: "the spawn created no terminal")
             throw SupervisionDeskError.spawnFailed(
                 project: inputs.project, detail: "the spawn created no terminal")
         }
@@ -364,7 +394,17 @@ public actor SupervisionDeskManager {
             terminal: primary.id, worktree: worktree.id,
             spawnedAt: SupervisionInstant(at), conductHash: inputs.playbook.conductHash)
         do {
-            try desks.save(file.recording(entry, for: inputs.project))
+            // **Re-read, never write back the copy read before the spawn.**
+            // Spawning a session takes seconds, and `SupervisionDeskCollector`
+            // rewrites this same file per reap while the hourly sweep runs. A
+            // save built on the pre-spawn copy would resurrect an entry the
+            // sweep had just dropped — and a resurrected entry whose worktree
+            // the sweep already archived is kept by every later sweep
+            // (`desk-already-archived`), so it would never be reclaimed again.
+            // `SupervisionStore` guards the identical shape by re-reading
+            // before it commits.
+            let latest = try desks.load()
+            try desks.save(latest.recording(entry, for: inputs.project))
         } catch {
             throw SupervisionDeskError.recordFailed(
                 project: inputs.project, detail: String(describing: error))
@@ -452,6 +492,40 @@ public actor SupervisionDeskManager {
             // standing guarantee is the collector, not this line.
             try? fm.removeItem(at: deskPath)
             throw error
+        }
+    }
+
+    /// Hand a scratch space back when the desk that was to live in it never
+    /// started.
+    ///
+    /// Archiving the row is the whole act, and it is deliberately not a
+    /// delete: an archived scratch row is exactly the shape `OrphanGC`'s
+    /// deletion-queue leg already reclaims, so this moves the directory from
+    /// "covered by no reconciler" to "covered by one that has run hourly for
+    /// months". Nothing here removes the directory itself — that sweep does,
+    /// after its own grace and liveness gates.
+    ///
+    /// Best-effort, as creation-time cleanup always is (repo `CLAUDE.md`): if
+    /// the archive does not land, the row stays `.active` and an operator sees
+    /// a stray scratch space, which is the visible failure rather than the
+    /// silent one.
+    private func abandon(_ worktree: Worktree, project: String, because reason: String) async {
+        do {
+            try await db.worktrees.archive(id: worktree.id)
+            deskLogger.notice(
+                """
+                Handed back the scratch space for "\(project, privacy: .public)"'s hosted desk at \
+                \(worktree.localPath, privacy: .public) — \(reason, privacy: .public). It is \
+                archived, and the orphan sweep reclaims it from there.
+                """)
+        } catch {
+            deskLogger.error(
+                """
+                The hosted desk for "\(project, privacy: .public)" could not be spawned \
+                (\(reason, privacy: .public)) and its scratch space at \
+                \(worktree.localPath, privacy: .public) could not be archived either: \
+                \(String(describing: error), privacy: .public). It is left for a human.
+                """)
         }
     }
 

--- a/Sources/TBDDaemon/Supervision/SupervisionLedgerWriter.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionLedgerWriter.swift
@@ -178,7 +178,8 @@ public actor SupervisionLedgerWriter {
             case .projectOff: open.removeValue(forKey: project)
             // A line of a kind this build does not recognize neither opens a
             // span nor closes one. It is somebody else's record, read past.
-            case .brakeEngaged, .brakeReleased, .modeChanged, .unrecognized: break
+            case .brakeEngaged, .brakeReleased, .modeChanged, .deskSpawned, .deskReplaced,
+                 .unrecognized: break
             }
         }
         if skipped > 0 {

--- a/Sources/TBDDaemon/Supervision/SupervisionStore.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionStore.swift
@@ -726,6 +726,42 @@ public actor SupervisionStore {
             playbooks.resolve(project: resolved, in: file, repos: repos))
     }
 
+    /// Everything `SupervisionDeskManager.ensureDesk` needs, read in one pass
+    /// through the file this store owns: the project's active mode, its
+    /// resolved playbook, and its appointed supervisor binding if one stands.
+    ///
+    /// Exists so the desk manager resolves no topology of its own. This store is
+    /// the single reader of `supervision.json`, and a second reader would be a
+    /// second answer to a question with exactly one.
+    public func deskInputs(project: String) async throws -> SupervisionDeskInputs {
+        let repos = try await prepare()
+        let file = try freshFile()
+        let projects = try SupervisionTopology.resolve(file: file, repos: repos)
+        guard let resolved = projects.first(where: { $0.name == project }) else {
+            throw SupervisionStoreError.unknownProject(project)
+        }
+        return SupervisionDeskInputs(
+            project: project,
+            mode: resolved.activeMode,
+            playbook: playbooks.resolve(project: resolved, in: file, repos: repos),
+            appointed: file.supervisors[project])
+    }
+
+    /// The names of every project whose mark stands right now.
+    ///
+    /// Read-only, and it exists for exactly one caller: the Nightwatch
+    /// coexistence gate, which must refuse turning Nightwatch on while any
+    /// project is supervised. Kept narrow deliberately — `status` computes
+    /// warnings and a whole readout, none of which that gate has any business
+    /// evaluating.
+    public func markedProjects() async throws -> [String] {
+        let repos = try await prepare()
+        let file = try freshFile()
+        return try SupervisionTopology.resolve(file: file, repos: repos)
+            .filter(\.mark)
+            .map(\.name)
+    }
+
     /// The "Customize playbook…" gesture: copy the current shipped default into
     /// one level, once.
     ///

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -361,6 +361,22 @@ public enum TBDConstants {
         supervisionStatusPath(environment: ProcessInfo.processInfo.environment)
     }
 
+    /// The hosted desks TBD is running: `~/tbd/supervision/desks.json`.
+    ///
+    /// **Derived state TBD owns, deliberately not beside the operator's
+    /// selections.** `supervision.json` holds what an operator chose and
+    /// nothing else (design §7, §8) — its `supervisors` map is the *appointed*
+    /// binding, a selection. Which terminal TBD spawned to serve as a project's
+    /// hosted desk is TBD's own bookkeeping, rewritten without an operator
+    /// gesture, so it lives in its own file where a hand edit to one can never
+    /// clobber the other.
+    public static func supervisionDesksPath(environment: [String: String]) -> String {
+        supervisionDir(environment: environment).appendingPathComponent("desks.json").path
+    }
+    public static var supervisionDesksPath: String {
+        supervisionDesksPath(environment: ProcessInfo.processInfo.environment)
+    }
+
     /// A project's own directory: `~/tbd/supervision/projects/<name>`. Holds
     /// the operator-level playbook, the journal, the proposals doc, and any
     /// customized sweep or transition program.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1195,6 +1195,11 @@ public struct Config: Codable, Sendable, Equatable {
     /// means "never chose" and follows the shipped default wherever it goes;
     /// `0`/`1` is an explicit gesture and is honored forever.
     public var gcProfileDirsEnabled: Bool
+    /// Gate for the supervision-desk collector, resolved as
+    /// `gc_supervision_desks_enabled ?? Config.gcSupervisionDesksEnabledDefault`.
+    /// NULL means nobody chose, `0`/`1` mean somebody did — the third state the
+    /// column has no SQL default in order to keep.
+    public var gcSupervisionDesksEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -1226,6 +1231,16 @@ public struct Config: Codable, Sendable, Equatable {
     /// is left alone.
     public static let gcProfileDirsEnabledDefault = false
 
+    /// The shipped default for `gcSupervisionDesksEnabled`, and the single
+    /// place it lives.
+    ///
+    /// Ships OFF and soaks, following the profile-dir precedent: reclaiming a
+    /// desk archives a worktree and drops its record, so the classifier proves
+    /// itself against real fleets before it graduates. Graduation is a one-line
+    /// change here — it reaches every install whose operator never touched the
+    /// toggle and preserves every explicit opt-out.
+    public static let gcSupervisionDesksEnabledDefault = false
+
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
                 envSettingOverrides: [String: ClaudeEnvValue] = [:],
@@ -1253,7 +1268,9 @@ public struct Config: Codable, Sendable, Equatable {
                 deliveryVerificationEnabled: Bool = false,
                 queuedPromptEnabled: Bool = Config.queuedPromptDefault,
                 supervisionEnabled: Bool = Config.supervisionEnabledDefault,
-                gcProfileDirsEnabled: Bool = Config.gcProfileDirsEnabledDefault) {
+                gcProfileDirsEnabled: Bool = Config.gcProfileDirsEnabledDefault,
+                gcSupervisionDesksEnabled: Bool =
+                    Config.gcSupervisionDesksEnabledDefault) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -1282,6 +1299,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.queuedPromptEnabled = queuedPromptEnabled
         self.supervisionEnabled = supervisionEnabled
         self.gcProfileDirsEnabled = gcProfileDirsEnabled
+        self.gcSupervisionDesksEnabled = gcSupervisionDesksEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1350,6 +1368,9 @@ public struct Config: Codable, Sendable, Equatable {
         // default rather than hardcoding `false`.
         gcProfileDirsEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .gcProfileDirsEnabled) ?? Config.gcProfileDirsEnabledDefault
+        gcSupervisionDesksEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .gcSupervisionDesksEnabled)
+            ?? Config.gcSupervisionDesksEnabledDefault
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -281,6 +281,8 @@ public enum RPCMethod {
     public static let gcSweepNow = "gc.sweepNow"
     public static let configSetGCEnabled = "config.setGCEnabled"
     public static let configSetGCProfileDirsEnabled = "config.setGCProfileDirsEnabled"
+    public static let configSetGCSupervisionDesksEnabled =
+        "config.setGCSupervisionDesksEnabled"
     public static let remoteProviders = "remote.providers"
     public static let remoteSessions = "remote.sessions"
     public static let remoteCreate = "remote.create"
@@ -2526,6 +2528,15 @@ public struct ConfigSetGCEnabledParams: Codable, Sendable {
 /// collector, which reclaims orphaned `~/tbd/profiles/<uuid>/` directories
 /// (default OFF during soak, on top of the GC master switch).
 public struct ConfigSetGCProfileDirsEnabledParams: Codable, Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setGCSupervisionDesksEnabled` — the gate for the
+/// supervision-desk collector, which reclaims the scratch space and the
+/// `desks.json` entry of a hosted desk whose session is gone (default OFF
+/// during soak, on top of the GC master switch).
+public struct ConfigSetGCSupervisionDesksEnabledParams: Codable, Sendable {
     public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Sources/TBDShared/Supervision/SupervisionDesks.swift
+++ b/Sources/TBDShared/Supervision/SupervisionDesks.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+// MARK: - One desk
+
+/// The hosted desk TBD is running for one project: the session it spawned, the
+/// scratch space that session lives in, when it was spawned, and the conduct
+/// hash of the playbook it stands on.
+///
+/// **Tracked by id, never by display string.** A desk is found again by its
+/// terminal and worktree ids, so renaming the scratch space — an operator
+/// gesture, or the agent's own rename nudge — cannot orphan it. The Watch
+/// Desk's `displayName == "Watch Desk"` lookup is exactly the shape this
+/// avoids: the moment somebody renames that space, the desk becomes
+/// unreclaimable and the next ensure spawns a second one beside it.
+///
+/// `conductHash` is the SHA-256 of the playbook bytes installed as this
+/// session's standing layer at spawn (`SupervisionPlaybook.conductHash`). It is
+/// recorded so a later build can tell that the file has moved on from what this
+/// session stands on; nothing in this slice reads it to make a decision.
+public struct SupervisionDeskEntry: Codable, Sendable, Equatable {
+    /// The TBD terminal running the desk agent.
+    public let terminal: UUID
+    /// The scratch worktree that terminal lives in.
+    public let worktree: UUID
+    public let spawnedAt: SupervisionInstant
+    /// SHA-256, lowercase hex, of the playbook installed at spawn.
+    public let conductHash: String
+
+    public init(terminal: UUID, worktree: UUID, spawnedAt: SupervisionInstant,
+                conductHash: String) {
+        self.terminal = terminal
+        self.worktree = worktree
+        self.spawnedAt = spawnedAt
+        self.conductHash = conductHash
+    }
+}
+
+// MARK: - The file
+
+/// `~/tbd/supervision/desks.json` — which hosted desk serves which project.
+///
+/// **This is TBD-owned derived state, not operator selections, and that is
+/// exactly why it is not in `supervision.json`.** That file holds what an
+/// operator chose (design §7, §8): the topology, the marks, the mode
+/// selections, and the *appointed* supervisor bindings. A hosted desk is
+/// nobody's choice — TBD spawns one because a project was turned on and no
+/// supervisor stood — and it is rewritten by the daemon with no gesture behind
+/// it. Keeping the two apart means a hand edit to the operator's file can never
+/// be clobbered by a desk spawn, and a corrupt desks file can never take the
+/// fleet's topology offline.
+///
+/// An absent file is the empty value, not an error: a fleet that has never
+/// turned a project on has no desks, and so does one whose desks all died.
+public struct SupervisionDesksFile: Codable, Sendable, Equatable {
+    /// The only version this build reads and writes.
+    public static let currentVersion = 1
+
+    public var version: Int
+    /// Hosted desks by project name.
+    public var desks: [String: SupervisionDeskEntry]
+
+    public init(version: Int = SupervisionDesksFile.currentVersion,
+                desks: [String: SupervisionDeskEntry] = [:]) {
+        self.version = version
+        self.desks = desks
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case desks
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? Self.currentVersion
+        desks = try container.decodeIfPresent(
+            [String: SupervisionDeskEntry].self, forKey: .desks) ?? [:]
+    }
+
+    /// An empty map is omitted, so an installation with no desks keeps a
+    /// one-line file rather than accumulating scaffolding it never asked for —
+    /// the same shape `SupervisionFile` writes.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        if !desks.isEmpty { try container.encode(desks, forKey: .desks) }
+    }
+
+    /// The desk serving a project, if one is recorded.
+    public func desk(for project: String) -> SupervisionDeskEntry? { desks[project] }
+
+    /// The same file with a project's desk recorded.
+    public func recording(_ entry: SupervisionDeskEntry, for project: String)
+        -> SupervisionDesksFile {
+        var copy = self
+        copy.desks[project] = entry
+        return copy
+    }
+
+    /// The same file with a project's desk forgotten. Forgetting one that is
+    /// not there returns an equal value, so a caller can decline to write.
+    public func forgetting(_ project: String) -> SupervisionDesksFile {
+        guard desks[project] != nil else { return self }
+        var copy = self
+        copy.desks.removeValue(forKey: project)
+        return copy
+    }
+
+    public func validate() throws {
+        guard version == Self.currentVersion else {
+            throw SupervisionDesksError.unsupportedVersion(
+                found: version, supported: Self.currentVersion)
+        }
+    }
+}
+
+// MARK: - The store
+
+/// Reads and writes `desks.json`, with the same durability `SupervisionFileStore`
+/// gives `supervision.json`: a fresh temporary in the **same directory**,
+/// flushed, `rename(2)` over the target, then the directory flushed.
+///
+/// The store holds the file URL it was given. There is deliberately **no static
+/// helper that builds its own path**: a static twin added "for convenience"
+/// makes every caller's injected seam decorative, which is how a test suite ends
+/// up writing into the developer's real `~/tbd` (root `CLAUDE.md`).
+public struct SupervisionDesksStore: Sendable {
+    public let fileURL: URL
+
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// Resolves `~/tbd/supervision/desks.json` through `TBDConstants`, honoring
+    /// `TBD_HOME`.
+    public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.init(fileURL: URL(
+            fileURLWithPath: TBDConstants.supervisionDesksPath(environment: environment)))
+    }
+
+    public var directoryURL: URL { fileURL.deletingLastPathComponent() }
+
+    /// The recorded desks, or the empty value when there is no file.
+    public func load() throws -> SupervisionDesksFile {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return SupervisionDesksFile()
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch {
+            throw SupervisionDesksError.malformed(
+                path: fileURL.path, detail: error.localizedDescription)
+        }
+        let file: SupervisionDesksFile
+        do {
+            file = try JSONDecoder().decode(SupervisionDesksFile.self, from: data)
+        } catch let error as DecodingError {
+            throw SupervisionDesksError.malformed(
+                path: fileURL.path, detail: String(describing: error))
+        }
+        try file.validate()
+        return file
+    }
+
+    /// Writes durably: temp in the same directory, `fsync`, `rename(2)`, then
+    /// `fsync` on the directory. A crash mid-write leaves the previous bytes;
+    /// power loss after the rename leaves either the previous file or the whole
+    /// new one, never an empty file where the desk record used to be.
+    public func save(_ file: SupervisionDesksFile) throws {
+        try file.validate()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(file)
+        data.append(0x0A)
+
+        try FileManager.default.createDirectory(
+            at: directoryURL, withIntermediateDirectories: true)
+
+        let temporary = temporaryURL()
+        do {
+            guard FileManager.default.createFile(atPath: temporary.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            let handle = try FileHandle(forWritingTo: temporary)
+            do {
+                try handle.write(contentsOf: data)
+                try handle.synchronize()
+                try handle.close()
+            } catch {
+                try? handle.close()
+                throw error
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: temporary)
+            throw error
+        }
+
+        guard rename(temporary.path, fileURL.path) == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            try? FileManager.default.removeItem(at: temporary)
+            throw POSIXError(code)
+        }
+
+        let directory = open(directoryURL.path, O_RDONLY)
+        if directory >= 0 {
+            fsync(directory)
+            close(directory)
+        }
+    }
+
+    /// The write-temp for one save, in the target's own directory: `rename(2)`
+    /// is atomic only within a filesystem.
+    func temporaryURL() -> URL {
+        directoryURL.appendingPathComponent(
+            ".\(fileURL.lastPathComponent).\(UUID().uuidString).tmp")
+    }
+}
+
+// MARK: - Errors
+
+/// Why the desk record was refused. Reaches a human through the daemon log and,
+/// for a spawn that could not be recorded, an operator notification.
+public enum SupervisionDesksError: Error, Equatable, CustomStringConvertible, LocalizedError {
+    case unsupportedVersion(found: Int, supported: Int)
+    case malformed(path: String, detail: String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedVersion(let found, let supported):
+            return "The hosted-desk record is version \(found); this build reads version "
+                + "\(supported)."
+        case .malformed(let path, let detail):
+            return "The hosted-desk record at \(path) could not be read: \(detail)"
+        }
+    }
+
+    public var errorDescription: String? { description }
+}

--- a/Sources/TBDShared/Supervision/SupervisionLedger.swift
+++ b/Sources/TBDShared/Supervision/SupervisionLedger.swift
@@ -16,6 +16,28 @@ public enum SupervisionLifecycleEvent: String, Codable, Sendable {
     case brakeEngaged
     case brakeReleased
     case modeChanged
+    /// A hosted desk was spawned for a project that had none.
+    case deskSpawned
+    /// A hosted desk was spawned to replace one that had died — the successor
+    /// line names its predecessor, so a reader can follow one project's desks
+    /// back through every replacement.
+    case deskReplaced
+}
+
+/// The desk a lifecycle line is about: the session TBD spawned and the scratch
+/// space it lives in, both by id.
+///
+/// **Ids, never display strings.** A line that named "Watch Desk" would stop
+/// resolving the moment somebody renamed the space; a terminal id resolves for
+/// as long as the row exists and is unambiguous after it does not.
+public struct SupervisionDeskRef: Codable, Sendable, Equatable {
+    public let terminal: UUID
+    public let worktree: UUID
+
+    public init(terminal: UUID, worktree: UUID) {
+        self.terminal = terminal
+        self.worktree = worktree
+    }
 }
 
 /// One agent inside a project's perimeter, as the `projectOn` roster snapshot
@@ -107,6 +129,14 @@ public enum SupervisionLedgerPayload: Sendable, Equatable {
     case brakeEngaged
     case brakeReleased
     case modeChanged(from: String, to: String)
+    /// A hosted desk spawned for a project that had none, and the conduct hash
+    /// of the playbook installed as its standing layer.
+    case deskSpawned(desk: SupervisionDeskRef, conductHash: String)
+    /// A hosted desk spawned to replace one that had died. `predecessor` is the
+    /// desk this one succeeds, which is what makes a project's desk history a
+    /// chain rather than a set of unrelated spawns.
+    case deskReplaced(
+        desk: SupervisionDeskRef, predecessor: SupervisionDeskRef, conductHash: String)
     /// A line whose envelope this build understands and whose body it does
     /// not — a `delivery`, `enrollment` or `anomaly` line, or a lifecycle event
     /// a later build writes.
@@ -127,6 +157,8 @@ public enum SupervisionLedgerPayload: Sendable, Equatable {
         case .brakeEngaged: return .brakeEngaged
         case .brakeReleased: return .brakeReleased
         case .modeChanged: return .modeChanged
+        case .deskSpawned: return .deskSpawned
+        case .deskReplaced: return .deskReplaced
         case .unrecognized: return nil
         }
     }
@@ -198,6 +230,32 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
             kind: .lifecycle, payload: .modeChanged(from: from, to: to))
     }
 
+    /// A hosted desk spawned for a project that had none.
+    public static func deskSpawned(
+        project: String, mode: String, desk: SupervisionDeskRef, conductHash: String,
+        at date: Date, id: String = SupervisionLedgerLine.newID()
+    ) -> SupervisionLedgerLine {
+        SupervisionLedgerLine(
+            id: id, ts: SupervisionInstant(date), mode: mode, project: project,
+            kind: .lifecycle, payload: .deskSpawned(desk: desk, conductHash: conductHash))
+    }
+
+    /// A hosted desk spawned to replace one that died, linking successor to
+    /// predecessor. Both are required: a replacement line that could omit its
+    /// predecessor would be indistinguishable from a first spawn, and "which
+    /// desk did this one succeed" is the question the line exists to answer.
+    public static func deskReplaced(
+        project: String, mode: String, desk: SupervisionDeskRef,
+        predecessor: SupervisionDeskRef, conductHash: String,
+        at date: Date, id: String = SupervisionLedgerLine.newID()
+    ) -> SupervisionLedgerLine {
+        SupervisionLedgerLine(
+            id: id, ts: SupervisionInstant(date), mode: mode, project: project,
+            kind: .lifecycle,
+            payload: .deskReplaced(
+                desk: desk, predecessor: predecessor, conductHash: conductHash))
+    }
+
     /// Fleet-wide: takes no project and no mode, because the brake has neither.
     public static func brakeEngaged(
         at date: Date, id: String = SupervisionLedgerLine.newID()
@@ -221,6 +279,7 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case id, ts, mode, project, kind
         case event, roster, coverage, from, to
+        case desk, predecessor, conductHash
     }
 
     /// Encoding a `.unrecognized` line throws rather than writing a line whose
@@ -252,6 +311,15 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
             try container.encode(SupervisionLifecycleEvent.modeChanged, forKey: .event)
             try container.encode(from, forKey: .from)
             try container.encode(to, forKey: .to)
+        case .deskSpawned(let desk, let conductHash):
+            try container.encode(SupervisionLifecycleEvent.deskSpawned, forKey: .event)
+            try container.encode(desk, forKey: .desk)
+            try container.encode(conductHash, forKey: .conductHash)
+        case .deskReplaced(let desk, let predecessor, let conductHash):
+            try container.encode(SupervisionLifecycleEvent.deskReplaced, forKey: .event)
+            try container.encode(desk, forKey: .desk)
+            try container.encode(predecessor, forKey: .predecessor)
+            try container.encode(conductHash, forKey: .conductHash)
         case .unrecognized:
             throw EncodingError.invalidValue(payload, EncodingError.Context(
                 codingPath: container.codingPath,
@@ -295,6 +363,16 @@ public struct SupervisionLedgerLine: Codable, Sendable, Equatable {
             payload = .modeChanged(
                 from: try container.decode(String.self, forKey: .from),
                 to: try container.decode(String.self, forKey: .to))
+        case .deskSpawned:
+            payload = .deskSpawned(
+                desk: try container.decode(SupervisionDeskRef.self, forKey: .desk),
+                conductHash: try container.decode(String.self, forKey: .conductHash))
+        case .deskReplaced:
+            payload = .deskReplaced(
+                desk: try container.decode(SupervisionDeskRef.self, forKey: .desk),
+                predecessor: try container.decode(
+                    SupervisionDeskRef.self, forKey: .predecessor),
+                conductHash: try container.decode(String.self, forKey: .conductHash))
         case nil:
             payload = .unrecognized
         }

--- a/Sources/TBDShared/SupervisionSkillContent.swift
+++ b/Sources/TBDShared/SupervisionSkillContent.swift
@@ -55,13 +55,15 @@ the daemon, not by you.
 
 ```bash
 tbd supervise readout --project "$TBD_PROJECT"
-tbd supervise readout --project "$TBD_PROJECT" --json
+tbd supervise readout --project "$TBD_PROJECT" | jq '.agents[] | {terminal, state}'
 ```
 
 The readout is the project's whole current picture in one call: its agents,
 their session state, what each is waiting on, and the machinery facts
 (mark, mode, brake). Read it before deciding anything — it is free, it makes no
-decision, and it starts nothing.
+decision, and it starts nothing. It prints JSON and only JSON — there is no
+`--json` flag to pass, and no other rendering — so reach for `jq` when you want
+one fact out of it.
 
 Two habits worth keeping:
 

--- a/Sources/TBDShared/SupervisionSkillContent.swift
+++ b/Sources/TBDShared/SupervisionSkillContent.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// Canonical content for the `supervision` skill — the reference a supervisor
+/// reads to work the three public surfaces
+/// (`docs/specs/2026-07-26-fleet-supervision-design.md` §9, §10;
+/// `docs/cli-supervise.md`).
+///
+/// Written by `PluginDirWriter` to
+/// `~/Library/Application Support/TBD/plugin/skills/supervision/SKILL.md`, the
+/// same plugin directory that carries the `tbd` skill.
+///
+/// **That directory is fleet-shared, and this skill is therefore visible
+/// fleet-wide.** Every TBD-spawned Claude session already gets the same
+/// `--plugin-dir`, so an ordinary agent can load this skill exactly as it can
+/// load the Nightwatch one. That is not a leak to plug: a skill is reference
+/// prose, its description keeps it dormant until a supervision task matches,
+/// and none of the commands it names are privileged — they are the public
+/// surfaces, available to every caller by design (§3, §16). **What makes a desk
+/// a desk is its standing conduct layer and its injected `TBD_PROJECT`, not
+/// exclusive access to this file.**
+///
+/// Deliberately shaped after `TBDSkillContent`, not `NightwatchSkillContent`:
+/// one string, no scripts, no config tree, nothing hardcoded about any
+/// particular fleet.
+public enum SupervisionSkillContent {
+
+    public static let body: String = """
+---
+name: supervision
+description: Work a TBD supervision desk — read a project's readout, act on agents through `tbd terminal send`, submit briefings, and read the supervision ledger back. Use when running as a project's supervisor (the `TBD_PROJECT` env var is set), or when asked to inspect what supervision saw or did for a project.
+---
+
+# Supervision desk
+
+TBD's fleet supervision watches a **project** — one or more registered repos —
+and the agent sessions running inside it. A *supervisor* is an ordinary agent
+session bound to one project for its whole life. If `TBD_PROJECT` is set in your
+environment, you are that session and its value is your project's name.
+
+Your standing conduct — what counts as stuck, when to intervene, when to
+escalate, where this project's questions go — is in the **playbook** installed
+as part of your instructions. This file describes the mechanics only. Where the
+two disagree about conduct, the playbook wins; it is the project's, this is the
+tool's.
+
+## What you are for
+
+Agents get stuck, ask questions, and wait. You read the project's state, decide
+whether the smallest intervention that restores progress is worth making, and
+either make it or escalate it. You are not a gate: nothing you do is enforced by
+TBD, and nothing TBD does is enforced by you. Every act you take is recorded by
+the daemon, not by you.
+
+## Reading the project — `tbd supervise readout`
+
+```bash
+tbd supervise readout --project "$TBD_PROJECT"
+tbd supervise readout --project "$TBD_PROJECT" --json
+```
+
+The readout is the project's whole current picture in one call: its agents,
+their session state, what each is waiting on, and the machinery facts
+(mark, mode, brake). Read it before deciding anything — it is free, it makes no
+decision, and it starts nothing.
+
+Two habits worth keeping:
+
+- **Re-derive external state in the same breath as the act.** A readout is a
+  snapshot. Before sending anything that asserts a merge, a review, or a check
+  result, check it live yourself — you are a full session and can run `git` and
+  `gh`.
+- **Read backward before driving past a prompt.** Be able to say *why* an agent
+  is asking, not just what it asks. When you cannot, escalate.
+
+## Acting — `tbd terminal send`
+
+One verb, for every caller, always attributed:
+
+```bash
+tbd terminal send --terminal <id> --text "…" --submit
+tbd terminal send --terminal <id> --keys "…"
+```
+
+`--text` types a message; `--submit` presses Enter after it. `--keys` sends key
+names, for the cases a message cannot express — dismissing a prompt, choosing an
+option. Terminal ids come from the readout.
+
+Rules that hold regardless of the playbook:
+
+- **Write every message as if it will be executed unchecked.** Sessions differ
+  in permission posture and you cannot tell which one you are talking to.
+- **One intervention per agent per wake**, unless the playbook says otherwise.
+  Piling on turns one confused agent into two.
+- A send that answers a pending question is a reply; a send with no pending
+  question is a nudge. Know which one you are making.
+
+## Briefing a supervisor — `tbd supervise brief`
+
+Briefing text arrives on stdin:
+
+```bash
+echo "…" | tbd supervise brief --project <name>
+```
+
+The answer is synchronous and machine-readable: delivered, or refused with the
+reason (the project is off, the fleet brake is engaged, the text is too large,
+or it arrived inside the pacing window). TBD never reads the text — only its
+size — and never retries a briefing. Continuation is the submitting program's
+decision, which is why the refusal names which one it was.
+
+## Reading the record back — `tbd supervise ledger`
+
+```bash
+tbd supervise ledger --project "$TBD_PROJECT" --since 22:00
+```
+
+The ledger is the append-only account of what supervision decided and did:
+coverage turning on and off, mode changes, desk lifecycle, and every actuation
+with its outcome. **The daemon writes it, never you** — which is what makes it
+worth reading. Use it to answer "has this already been asked", "what did I
+already send here", and "what governed that act".
+
+The current standing conduct is readable too:
+
+```bash
+tbd supervise playbook show --project "$TBD_PROJECT" --content
+```
+
+## Where durable things live
+
+Your session's memory is disposable by design. Anything that must outlive this
+conversation goes somewhere else, as it happens:
+
+- **Questions for a human** go to the project's question route, named in the
+  playbook — not into your context, and not only into a terminal.
+- **Learning** goes into the project's journal; **proposals** into its proposals
+  document. Both live under the project's own directory in TBD's supervision
+  record.
+- **What you did** is already in the ledger; you never need to keep a copy.
+
+If an operator answers a question by typing into your tab, act on it — and write
+that answer to the question route with a note saying you are acting on it, so it
+survives you.
+
+## What supervision never does
+
+- It never blocks anything. There is no gate, no approval table, no permission
+  layer. If you need one, escalate to a human instead of simulating one.
+- It never parses your prose or the playbook's. Structure is for readers.
+- It never claims an act landed that it did not observe landing.
+"""
+}

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -369,4 +369,94 @@ struct ConfigStoreTests {
         try await db.config.setGCProfileDirsEnabled(false)
         #expect(try await db.config.get().gcProfileDirsEnabled == false)
     }
+
+    // MARK: - v80: the supervision-desk collector's soak gate
+    //
+    // The same three-state property as v78, for the same reason: the leg
+    // archives a worktree and drops a record, so it ships off and soaks, and
+    // graduation must be a one-line constant change that reaches every
+    // never-chosen install while preserving every explicit opt-out.
+
+    /// A row written by a real pre-v80 daemon must read NULL, not 0.
+    @Test func rowWrittenBeforeV80StillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v79_reap_records_quarantine_path")
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID]
+            )
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["gc_supervision_desks_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before v80 must read NULL, not \(raw)"
+            )
+            #expect(row["gc_enabled"] == true)
+        }
+    }
+
+    /// NULL follows the shipped default wherever it goes; an explicit `false`
+    /// does not. Exercised against BOTH default values, so it fails if the
+    /// resolution is ever wired as `?? false`.
+    @Test func gcSupervisionDesksExplicitFalseSurvivesADefaultFlipWhileNullFollowsIt()
+        async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.gc_supervision_desks_enabled == nil)
+        #expect(
+            untouched.toModel(gcSupervisionDesksDefault: false).gcSupervisionDesksEnabled
+                == false)
+        #expect(
+            untouched.toModel(gcSupervisionDesksDefault: true).gcSupervisionDesksEnabled == true,
+            "a never-chosen row must pick up a changed shipped default"
+        )
+
+        try await db.config.setGCSupervisionDesksEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.gc_supervision_desks_enabled == false)
+        #expect(
+            explicitlyOff.toModel(gcSupervisionDesksDefault: true).gcSupervisionDesksEnabled
+                == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes"
+        )
+    }
+
+    /// Isolates the RESOLUTION guard from the STORAGE guard: no database, no
+    /// migration, just the record's own `??`.
+    @Test func gcSupervisionDesksToModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", gc_supervision_desks_enabled: nil)
+        #expect(
+            record.toModel(gcSupervisionDesksDefault: false).gcSupervisionDesksEnabled == false)
+        #expect(
+            record.toModel(gcSupervisionDesksDefault: true).gcSupervisionDesksEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false"
+        )
+    }
+
+    /// The shipped default today: OFF. Graduation edits this constant and
+    /// nothing else.
+    @Test func gcSupervisionDesksShipsOff() async throws {
+        #expect(Config.gcSupervisionDesksEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().gcSupervisionDesksEnabled == false)
+    }
+
+    @Test func setGCSupervisionDesksEnabledRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCSupervisionDesksEnabled(true)
+        #expect(try await db.config.get().gcSupervisionDesksEnabled == true)
+        try await db.config.setGCSupervisionDesksEnabled(false)
+        #expect(try await db.config.get().gcSupervisionDesksEnabled == false)
+    }
 }

--- a/Tests/TBDDaemonTests/OrphanGCSupervisionDeskTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCSupervisionDeskTests.swift
@@ -103,6 +103,90 @@ struct OrphanGCSupervisionDeskTests: ~Copyable {
         #expect(row?.status == .active)
     }
 
+    @Test("a desk whose only process sits in a subdirectory is live, and survives")
+    func processBelowTheDeskRootIsLive() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: true)
+        let desk = try await makeDesk(project: "acme-web", db: db)
+
+        // An agent's own shell sits below the worktree root as often as in it.
+        // Every other GC leg matches on the prefix boundary for exactly this
+        // reason; exact equality would read this as "nothing is running here".
+        let below = AgentWorktreeCollector.canon(desk.worktree.localPath) + "/src/inner"
+        let result = await makeGC(db: db, liveCWDs: [below]).sweep()
+
+        #expect(result.planned.contains { $0 == "KEEP desk-live desk:acme-web" })
+        #expect(!result.planned.contains { $0.hasPrefix("REAP supervision-desk") })
+        let row = try await db.worktrees.get(id: desk.worktree.id)
+        #expect(row?.status == .active)
+    }
+
+    @Test("a sibling directory sharing the desk's name prefix is not the desk running")
+    func siblingPrefixIsNotLive() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: true)
+        let desk = try await makeDesk(project: "acme-web", db: db)
+
+        // The other half of the prefix-boundary match: `/…/desk-ab` must not
+        // keep `/…/desk-a` alive.
+        let sibling = AgentWorktreeCollector.canon(desk.worktree.localPath) + "-sibling"
+        let result = await makeGC(db: db, liveCWDs: [sibling]).sweep()
+
+        #expect(result.planned.contains {
+            $0 == "REAP supervision-desk desk-process-gone desk:acme-web"
+        })
+    }
+
+    @Test("a worktree read that failed keeps the desk; only a real absence reaps it")
+    func unreadableWorktreeRowKeeps() throws {
+        let fixed = clock
+        let collector = SupervisionDeskCollector(
+            desks: desks, scratchBase: sandbox, now: { fixed })
+        let candidate = SupervisionDeskCollector.Candidate(
+            project: "acme-web",
+            entry: SupervisionDeskEntry(
+                terminal: UUID(), worktree: UUID(),
+                spawnedAt: SupervisionInstant(clock.addingTimeInterval(-86_400)),
+                conductHash: "abc"))
+
+        // A read that never answered says nothing about the desk, so it keeps —
+        // the same direction the terminal read's `nil` already takes. Collapsing
+        // it into "the row is gone" would drop a live desk's record on a
+        // transient database error.
+        #expect(collector.decide(
+            candidate, terminalExists: true, worktree: .unreadable,
+            liveCWDs: [], graceSeconds: 60) == .keep("desk-worktree-read-failed"))
+        #expect(collector.decide(
+            candidate, terminalExists: true, worktree: .gone,
+            liveCWDs: [], graceSeconds: 60) == .reap("desk-worktree-row-gone"))
+    }
+
+    @Test("forget drops only the entry the sweep judged, never one that replaced it")
+    func forgetLeavesAReplacedEntryAlone() throws {
+        let fixed = clock
+        let collector = SupervisionDeskCollector(
+            desks: desks, scratchBase: sandbox, now: { fixed })
+        let judged = SupervisionDeskEntry(
+            terminal: UUID(), worktree: UUID(),
+            spawnedAt: SupervisionInstant(clock), conductHash: "abc")
+        let successor = SupervisionDeskEntry(
+            terminal: UUID(), worktree: UUID(),
+            spawnedAt: SupervisionInstant(clock), conductHash: "abc")
+
+        // A spawn for this same project landed between `candidates()` and the
+        // write. Its desk is live and nothing judged it, so dropping the key
+        // would unrecord a running desk — the resurrection hazard from the
+        // other end.
+        try desks.save(SupervisionDesksFile().recording(successor, for: "acme-web"))
+        #expect(collector.forget(project: "acme-web", expecting: judged) == .changed)
+        #expect(try desks.load().desk(for: "acme-web") == successor)
+
+        // The entry it did judge still goes.
+        try desks.save(SupervisionDesksFile().recording(judged, for: "acme-web"))
+        #expect(collector.forget(project: "acme-web", expecting: judged) == .dropped)
+        #expect(try desks.load().desk(for: "acme-web") == nil)
+    }
+
     @Test("a desk spawned moments ago is kept, however quiet lsof is about it")
     func youngDeskIsKept() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/OrphanGCSupervisionDeskTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCSupervisionDeskTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// `OrphanGC`'s supervision-desk leg: the reconciler that answers "who reclaims
+/// an orphaned hosted desk" (repo `CLAUDE.md`).
+///
+/// The boundary this closes: the sweep's agent-worktree leg iterates
+/// `db.repos.list()`, so it only ever sees repo-backed worktrees, and its
+/// archived legs only touch rows that are already `.archived`. A desk's scratch
+/// space is neither, so a live desk was never at risk from those legs — right —
+/// and an orphaned one was reclaimed by nothing.
+///
+/// Tier 2 — real filesystem plus an in-memory database, the desk record injected
+/// into a sandbox, the clock fixed, and `lsof` replaced by an explicit list.
+@Suite("OrphanGC reclaims orphaned supervision desks")
+struct OrphanGCSupervisionDeskTests: ~Copyable {
+    let fm = FileManager.default
+    let sandbox: URL
+    let desks: SupervisionDesksStore
+    /// Fixed sweep clock, far past every fixture's spawn stamp so the grace
+    /// window has elapsed without backdating anything.
+    let clock = Date(timeIntervalSince1970: 1_800_000_000)
+
+    init() {
+        sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-desk-\(UUID().uuidString)", isDirectory: true)
+        try? fm.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        desks = SupervisionDesksStore(fileURL: sandbox.appendingPathComponent("desks.json"))
+    }
+
+    deinit {
+        try? fm.removeItem(at: sandbox)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeGC(db: TBDDatabase, liveCWDs: [String] = []) -> OrphanGC {
+        let fixed = clock
+        return OrphanGC(
+            db: db, git: GitManager(),
+            broadcast: { _ in },
+            liveCWDsProvider: { liveCWDs },
+            scratchpadBase: sandbox.appendingPathComponent("scratchpads", isDirectory: true),
+            now: { fixed },
+            profileDirBase: sandbox.appendingPathComponent("profiles", isDirectory: true),
+            supervisionDesks: desks)
+    }
+
+    /// A desk on disk: a scratch worktree under the scratch base, a terminal row
+    /// in it, and an entry in the record — the three things a spawn leaves
+    /// behind.
+    private func makeDesk(
+        project: String, db: TBDDatabase, spawnedAgo: TimeInterval = 86_400
+    ) async throws -> (worktree: Worktree, terminal: Terminal) {
+        let base = TBDConstants.scratchDir
+        try fm.createDirectory(at: base, withIntermediateDirectories: true)
+        let path = base.appendingPathComponent("desk-\(UUID().uuidString.prefix(8))")
+        try fm.createDirectory(at: path, withIntermediateDirectories: true)
+
+        let worktree = try await db.worktrees.createScratch(
+            name: path.lastPathComponent, displayName: "Supervisor · \(project)",
+            path: path.path, tmuxServer: "tbd-scratch")
+        let terminal = try await db.terminals.create(
+            id: UUID(), worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, claudeSessionID: nil, profileID: nil, kind: .claude)
+
+        var file = try desks.load()
+        file = file.recording(
+            SupervisionDeskEntry(
+                terminal: terminal.id, worktree: worktree.id,
+                spawnedAt: SupervisionInstant(clock.addingTimeInterval(-spawnedAgo)),
+                conductHash: "abc"),
+            for: project)
+        try desks.save(file)
+        return (worktree, terminal)
+    }
+
+    private func enable(_ db: TBDDatabase, desks: Bool) async throws {
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCSupervisionDesksEnabled(desks)
+    }
+
+    // MARK: - Never reclaim a live desk
+
+    @Test("a live desk survives a sweep: its record and its scratch space are untouched")
+    func liveDeskSurvives() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: true)
+        let desk = try await makeDesk(project: "acme-web", db: db)
+
+        // A process sitting in the desk's directory is the desk running — the
+        // same evidence the agent-worktree leg gates on.
+        let result = await makeGC(
+            db: db, liveCWDs: [AgentWorktreeCollector.canon(desk.worktree.localPath)]
+        ).sweep()
+
+        #expect(result.planned.contains { $0 == "KEEP desk-live desk:acme-web" })
+        #expect(!result.planned.contains { $0.hasPrefix("REAP supervision-desk") })
+        #expect(try desks.load().desk(for: "acme-web") != nil)
+        let row = try await db.worktrees.get(id: desk.worktree.id)
+        #expect(row?.status == .active)
+    }
+
+    @Test("a desk spawned moments ago is kept, however quiet lsof is about it")
+    func youngDeskIsKept() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: true)
+        _ = try await makeDesk(project: "acme-web", db: db, spawnedAgo: 5)
+
+        let result = await makeGC(db: db).sweep()
+        #expect(result.planned.contains { $0 == "KEEP desk-within-grace desk:acme-web" })
+        #expect(try desks.load().desk(for: "acme-web") != nil)
+    }
+
+    // MARK: - Reclaim an orphan
+
+    @Test("an orphaned desk is reclaimed: the record is dropped and the space archived")
+    func orphanedDeskIsReclaimed() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: true)
+        let desk = try await makeDesk(project: "acme-web", db: db)
+
+        // Nothing is running in it any more.
+        let result = await makeGC(db: db).sweep()
+
+        #expect(result.planned.contains {
+            $0 == "REAP supervision-desk desk-process-gone desk:acme-web"
+        })
+        #expect(try desks.load().desk(for: "acme-web") == nil)
+        // Handed to the archive path the sweep already runs; the deletion-queue
+        // and scratchpad legs reclaim the directory from there.
+        let row = try await db.worktrees.get(id: desk.worktree.id)
+        #expect(row?.status == .archived)
+    }
+
+    @Test("a desk whose terminal row is gone is reclaimed too")
+    func terminalRowGoneIsReclaimed() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: true)
+        let desk = try await makeDesk(project: "acme-web", db: db)
+        try await db.terminals.delete(id: desk.terminal.id)
+
+        let result = await makeGC(db: db).sweep()
+        #expect(result.planned.contains {
+            $0.hasPrefix("REAP supervision-desk desk-terminal-row-gone")
+        })
+        #expect(try desks.load().desk(for: "acme-web") == nil)
+    }
+
+    @Test("a record pointing at a worktree row that is gone is dropped, with nothing to archive")
+    func worktreeRowGoneDropsTheRecord() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: true)
+        try desks.save(SupervisionDesksFile(desks: [
+            "acme-web": SupervisionDeskEntry(
+                terminal: UUID(), worktree: UUID(),
+                spawnedAt: SupervisionInstant(clock.addingTimeInterval(-86_400)),
+                conductHash: "abc")
+        ]))
+
+        let result = await makeGC(db: db).sweep()
+        #expect(result.planned.contains {
+            $0.hasPrefix("REAP supervision-desk desk-worktree-row-gone")
+        })
+        #expect(try desks.load().desk(for: "acme-web") == nil)
+    }
+
+    // MARK: - The soak gate
+
+    @Test("the desk flag ships off: a real sweep leaves an orphan untouched")
+    func flagOffIsNoOp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: false)
+        let desk = try await makeDesk(project: "acme-web", db: db)
+
+        let result = await makeGC(db: db).sweep()
+
+        #expect(!result.planned.contains { $0.hasPrefix("REAP supervision-desk") })
+        #expect(try desks.load().desk(for: "acme-web") != nil)
+        let row = try await db.worktrees.get(id: desk.worktree.id)
+        #expect(row?.status == .active)
+    }
+
+    @Test("a dry run plans what enabling the flag would reclaim, and touches nothing")
+    func dryRunPlansPastTheFlag() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await enable(db, desks: false)
+        let desk = try await makeDesk(project: "acme-web", db: db)
+
+        // Someone deciding whether to flip a default-off flag needs to see what
+        // flipping it would reclaim before flipping it.
+        let result = await makeGC(db: db).sweep(dryRun: true)
+
+        #expect(result.planned.contains { $0.hasPrefix("REAP supervision-desk") })
+        #expect(result.reaped == 0)
+        #expect(try desks.load().desk(for: "acme-web") != nil)
+        let row = try await db.worktrees.get(id: desk.worktree.id)
+        #expect(row?.status == .active)
+    }
+
+    @Test("gc disabled wholesale leaves the record alone, flag or no flag")
+    func gcDisabledIsNoOp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        try await db.config.setGCSupervisionDesksEnabled(true)
+        _ = try await makeDesk(project: "acme-web", db: db)
+
+        let result = await makeGC(db: db).sweep()
+        #expect(result.planned == ["gc disabled"])
+        #expect(try desks.load().desk(for: "acme-web") != nil)
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
@@ -38,6 +38,25 @@ struct SupervisionDeskManagerTests {
         func run() { lock.withLock { action }?() }
     }
 
+    /// Every delta a spawn broadcast, decoded. The app builds the sidebar out
+    /// of these, so "the desk appears with its tab" is a property of the pair.
+    private final class DeltaSink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var received: [StateDelta] = []
+        let subscriptions = StateSubscriptionManager()
+
+        init() {
+            subscriptions.addSubscriber { [self] data in
+                if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                    lock.withLock { received.append(delta) }
+                }
+                return true
+            }
+        }
+
+        var deltas: [StateDelta] { lock.withLock { received } }
+    }
+
     private struct Fixture {
         let db: TBDDatabase
         let directory: URL
@@ -61,7 +80,8 @@ struct SupervisionDeskManagerTests {
     private static func makeFixture(
         createWindowError: (@Sendable (String) -> Error?)? = nil,
         duringSpawn: (@Sendable () -> Void)? = nil,
-        spawnSession: SupervisionDeskSpawn? = nil
+        spawnSession: SupervisionDeskSpawn? = nil,
+        subscriptions: StateSubscriptionManager? = nil
     ) throws -> Fixture {
         let db = try TBDDatabase(inMemory: true)
         let directory = FileManager.default.temporaryDirectory
@@ -102,6 +122,7 @@ struct SupervisionDeskManagerTests {
                 desks: desks,
                 ledger: SupervisionLedgerWriter(path: ledgerPath),
                 actuationLog: ActuationLog(path: actuationPath),
+                subscriptions: subscriptions,
                 spawnSession: spawnSession,
                 now: dates.provider))
     }
@@ -195,6 +216,33 @@ struct SupervisionDeskManagerTests {
         let entry = try #require(try fixture.desks.load().desk(for: "acme-web"))
         let worktree = try await fixture.db.worktrees.getLocal(id: entry.worktree)
         #expect(worktree?.worktree.pendingPrompt == nil)
+    }
+
+    @Test("A spawn announces the scratch space AND its terminal")
+    func spawnBroadcastsBothDeltas() async throws {
+        let sink = DeltaSink()
+        let fixture = try Self.makeFixture(subscriptions: sink.subscriptions)
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let entry) = outcome else {
+            Issue.record("expected a spawn, got \(outcome)")
+            return
+        }
+
+        // The row delta alone puts the desk in the sidebar with no tabs under
+        // it until the next full state refresh. `scratch.create` sends the
+        // pair for the same reason.
+        #expect(sink.deltas.contains {
+            if case .worktreeCreated(let delta) = $0 { return delta.worktreeID == entry.worktree }
+            return false
+        })
+        #expect(sink.deltas.contains {
+            if case .terminalCreated(let delta) = $0 {
+                return delta.terminalID == entry.terminal && delta.worktreeID == entry.worktree
+            }
+            return false
+        })
     }
 
     @Test("The desk's conduct hash is the resolved playbook's")

--- a/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
@@ -19,8 +19,24 @@ struct SupervisionDeskManagerTests {
     private final class DeadWindows: @unchecked Sendable {
         private let lock = NSLock()
         private var dead: Set<String> = []
+        private var deadOnce: Set<String> = []
         func markDead(_ windowID: String) { lock.withLock { _ = dead.insert(windowID) } }
-        func isDead(_ windowID: String) -> Bool { lock.withLock { dead.contains(windowID) } }
+
+        /// Report the window dead on the **first** read and alive on every read
+        /// after it. That is the seam that makes two reads of one desk differ:
+        /// `isLive` is documented to answer "not live" to a read that merely
+        /// glitched, and the recheck before the archive then sees the session
+        /// that was there all along.
+        func markDeadUntilFirstRead(_ windowID: String) {
+            lock.withLock { _ = deadOnce.insert(windowID) }
+        }
+
+        func isDead(_ windowID: String) -> Bool {
+            lock.withLock {
+                if dead.contains(windowID) { return true }
+                return deadOnce.remove(windowID) != nil
+            }
+        }
     }
 
     /// Something else touching the desk record, standing by to land mid-spawn.
@@ -484,6 +500,80 @@ struct SupervisionDeskManagerTests {
         // And the desk that now serves the project is untouched.
         let live = try #require(try await fixture.db.worktrees.get(id: successor.worktree))
         #expect(live.status == .active)
+        // Nothing was raised: handing back a desk that really is gone is the
+        // quiet path, and the anomaly notification below must not fire here.
+        let raised = try await fixture.db.notifications.unread(worktreeID: predecessor.worktree)
+        #expect(raised.isEmpty)
+    }
+
+    @Test("A predecessor that reads live at the recheck keeps its scratch space")
+    func livePredecessorIsNotArchived() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let first = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let predecessor) = first else {
+            Issue.record("expected a spawn, got \(first)")
+            return
+        }
+        let terminal = try #require(try await fixture.db.terminals.get(id: predecessor.terminal))
+        // The window reads dead once and alive after: the transient read that
+        // makes `isLive` say "not live" about a session that is running. A
+        // whole spawn happens between that judgement and the archive, so the
+        // archive must not inherit it.
+        fixture.deadWindows.markDeadUntilFirstRead(terminal.tmuxWindowID)
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .replaced(let successor, _) = outcome else {
+            Issue.record("expected a replacement, got \(outcome)")
+            return
+        }
+
+        // Archiving it would have taken the live session's tmux window with it:
+        // `WorktreeLifecycle+Reconcile` computes tracked windows from
+        // non-archived rows and kills the rest.
+        let old = try #require(try await fixture.db.worktrees.get(id: predecessor.worktree))
+        #expect(old.status == .active)
+        // The decline is not silent — the operator is told on the very row that
+        // is left behind, because nothing will reclaim it later.
+        let raised = try await fixture.db.notifications.unread(worktreeID: predecessor.worktree)
+        #expect(raised.count == 1)
+        let message = try #require(raised.first?.message)
+        #expect(message.contains("still live"))
+        // The successor is unaffected either way: the project has a supervisor.
+        let live = try #require(try await fixture.db.worktrees.get(id: successor.worktree))
+        #expect(live.status == .active)
+    }
+
+    @Test("A predecessor that cannot be read as gone keeps its scratch space too")
+    func undeterminedPredecessorIsNotArchived() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let first = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let predecessor) = first else {
+            Issue.record("expected a spawn, got \(first)")
+            return
+        }
+        // A parked desk is not live — nothing can be delivered to it — but it
+        // is wakeable by design, so it is not evidence of a session that is
+        // gone. Replacing it is right; archiving the space it can wake into is
+        // not.
+        try await fixture.db.terminals.setSuspended(
+            id: predecessor.terminal, sessionID: UUID().uuidString)
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .replaced = outcome else {
+            Issue.record("expected a replacement, got \(outcome)")
+            return
+        }
+
+        let old = try #require(try await fixture.db.worktrees.get(id: predecessor.worktree))
+        #expect(old.status == .active)
+        let raised = try await fixture.db.notifications.unread(worktreeID: predecessor.worktree)
+        #expect(raised.count == 1)
+        let message = try #require(raised.first?.message)
+        #expect(message.contains("confidently"))
     }
 
     // MARK: - Appointment

--- a/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
@@ -23,22 +23,19 @@ struct SupervisionDeskManagerTests {
         func isDead(_ windowID: String) -> Bool { lock.withLock { dead.contains(windowID) } }
     }
 
-    /// A `SupervisionDeskCollector` reap, standing by to land mid-spawn. Armed
-    /// after the fixture is built so it fires during one chosen spawn and not
-    /// the one that set the record up.
-    private final class ArmedReap: @unchecked Sendable {
+    /// Something else touching the desk record, standing by to land mid-spawn.
+    /// Armed after the fixture is built, because what it does is written in
+    /// terms of the store the fixture created — and, for the reap, so it fires
+    /// during one chosen spawn and not the one that set the record up.
+    private final class ArmedHook: @unchecked Sendable {
         private let lock = NSLock()
-        private var target: (store: SupervisionDesksStore, project: String)?
+        private var action: (@Sendable () -> Void)?
 
-        func arm(store: SupervisionDesksStore, project: String) {
-            lock.withLock { target = (store, project) }
+        func arm(_ action: @escaping @Sendable () -> Void) {
+            lock.withLock { self.action = action }
         }
 
-        func run() {
-            guard let target = lock.withLock({ target }) else { return }
-            guard let file = try? target.store.load() else { return }
-            try? target.store.save(file.forgetting(target.project))
-        }
+        func run() { lock.withLock { action }?() }
     }
 
     private struct Fixture {
@@ -287,6 +284,27 @@ struct SupervisionDeskManagerTests {
         })
     }
 
+    @Test("A desk that cannot be written to the record hands its scratch space back too")
+    func unrecordableDeskArchivesTheScratchSpace() async throws {
+        // The record goes unreadable while the spawn is in flight, so the
+        // write that follows cannot land. This is the exit that bites hardest:
+        // the session is live and nothing recorded it, so the next `on` would
+        // read no entry and spawn a second desk beside it.
+        let hook = ArmedHook()
+        let fixture = try Self.makeFixture(duringSpawn: { hook.run() })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let url = fixture.desks.fileURL
+        hook.arm { try? Data("{ not json".utf8).write(to: url) }
+
+        await #expect(throws: SupervisionDeskError.self) {
+            try await fixture.manager.ensureDesk(project: Self.inputs())
+        }
+
+        let scratch = try await Self.onlyScratchRow(fixture)
+        #expect(scratch.status == .archived)
+    }
+
     // MARK: - Recording a desk must not resurrect a reaped one
 
     @Test("A reap that lands mid-spawn survives the record: the desk file is re-read")
@@ -296,7 +314,7 @@ struct SupervisionDeskManagerTests {
         // the seconds a spawn takes. Nothing here spawns concurrently: the
         // manager's gate serializes ensures, and the race being reproduced is
         // with the collector, which does not hold that gate.
-        let armed = ArmedReap()
+        let armed = ArmedHook()
         let fixture = try Self.makeFixture(duringSpawn: { armed.run() })
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
 
@@ -309,7 +327,11 @@ struct SupervisionDeskManagerTests {
         #expect(try fixture.desks.load().desk(for: "seed-project") != nil)
 
         // Arm the reap only now, so it lands during the second spawn.
-        armed.arm(store: fixture.desks, project: "seed-project")
+        let desks = fixture.desks
+        armed.arm {
+            guard let file = try? desks.load() else { return }
+            try? desks.save(file.forgetting("seed-project"))
+        }
         let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
         guard case .spawned(let entry) = outcome else {
             Issue.record("expected a spawn, got \(outcome)")
@@ -383,6 +405,37 @@ struct SupervisionDeskManagerTests {
         }
         #expect(desk.terminal == successor.terminal)
         #expect(previous.terminal == predecessor.terminal)
+    }
+
+    @Test("Replacing a desk hands the predecessor's scratch space back")
+    func replacementArchivesThePredecessorsScratchSpace() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let first = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let predecessor) = first else {
+            Issue.record("expected a spawn, got \(first)")
+            return
+        }
+        let terminal = try #require(try await fixture.db.terminals.get(id: predecessor.terminal))
+        fixture.deadWindows.markDead(terminal.tmuxWindowID)
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .replaced(let successor, _) = outcome else {
+            Issue.record("expected a replacement, got \(outcome)")
+            return
+        }
+
+        // Recording the successor overwrites the project's key, so from that
+        // moment nothing references the predecessor's space: the collector
+        // enumerates `desks.json` and reads the successor, and every other
+        // sweep leg walks repo-backed or already-archived rows. Leaving it
+        // `.active` would leak one scratch space per replacement, forever.
+        let old = try #require(try await fixture.db.worktrees.get(id: predecessor.worktree))
+        #expect(old.status == .archived)
+        // And the desk that now serves the project is untouched.
+        let live = try #require(try await fixture.db.worktrees.get(id: successor.worktree))
+        #expect(live.status == .active)
     }
 
     // MARK: - Appointment

--- a/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `SupervisionDeskManager.ensureDesk` — the four branches of design §9's
+/// hosted-desk lifecycle, and the one thing a spawn must never do.
+///
+/// Tier 2 — real filesystem and an in-memory database, tmux in `dryRun`, time
+/// pinned through the date seam. Nothing here waits on wall time and nothing
+/// reaches a real tmux server.
+@Suite("Supervision desk lifecycle")
+struct SupervisionDeskManagerTests {
+
+    // MARK: - Fixture
+
+    /// Thread-safe record of which windows the fixture should call dead.
+    private final class DeadWindows: @unchecked Sendable {
+        private let lock = NSLock()
+        private var dead: Set<String> = []
+        func markDead(_ windowID: String) { lock.withLock { _ = dead.insert(windowID) } }
+        func isDead(_ windowID: String) -> Bool { lock.withLock { dead.contains(windowID) } }
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let directory: URL
+        let desks: SupervisionDesksStore
+        let ledgerPath: String
+        let actuationPath: String
+        let dates: TestDateSource
+        let deadWindows: DeadWindows
+        let manager: SupervisionDeskManager
+    }
+
+    private static func makeFixture() throws -> Fixture {
+        let db = try TBDDatabase(inMemory: true)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-supervision-desk-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let deadWindows = DeadWindows()
+        let tmux = TmuxManager(
+            dryRun: true, dryRunWindowIsDead: { deadWindows.isDead($0) })
+        let desks = SupervisionDesksStore(
+            fileURL: directory.appendingPathComponent("desks.json"))
+        let ledgerPath = directory.appendingPathComponent("ledger.jsonl").path
+        let actuationPath = directory.appendingPathComponent("actuations.jsonl").path
+        let dates = TestDateSource()
+
+        return Fixture(
+            db: db,
+            directory: directory,
+            desks: desks,
+            ledgerPath: ledgerPath,
+            actuationPath: actuationPath,
+            dates: dates,
+            deadWindows: deadWindows,
+            manager: SupervisionDeskManager(
+                db: db,
+                lifecycle: WorktreeLifecycle(
+                    db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+                tmux: tmux,
+                desks: desks,
+                ledger: SupervisionLedgerWriter(path: ledgerPath),
+                actuationLog: ActuationLog(path: actuationPath),
+                now: dates.provider))
+    }
+
+    private static func inputs(
+        project: String = "acme-web", appointed: SupervisionSupervisorBinding? = nil,
+        playbook: String = "# Conduct\n"
+    ) -> SupervisionDeskInputs {
+        SupervisionDeskInputs(
+            project: project, mode: "attended",
+            playbook: SupervisionPlaybook(
+                project: project, tier: .shipped, path: nil, bytes: Data(playbook.utf8)),
+            appointed: appointed)
+    }
+
+    private static func ledgerEvents(_ fixture: Fixture) -> [SupervisionLifecycleEvent] {
+        guard let data = FileManager.default.contents(atPath: fixture.ledgerPath) else { return [] }
+        return data.split(separator: 0x0A, omittingEmptySubsequences: true)
+            .compactMap { try? JSONDecoder().decode(SupervisionLedgerLine.self, from: Data($0)) }
+            .compactMap { $0.payload.event }
+    }
+
+    /// Every actuation row this fixture's rail wrote, as `(kind, result)`. The
+    /// assertion behind "a spawn delivers nothing": a nudge would show up here
+    /// as a `send`.
+    private static func actuationKinds(_ fixture: Fixture) -> [String] {
+        guard let data = FileManager.default.contents(atPath: fixture.actuationPath) else {
+            return []
+        }
+        return data.split(separator: 0x0A, omittingEmptySubsequences: true)
+            .compactMap {
+                try? JSONSerialization.jsonObject(with: Data($0)) as? [String: Any]
+            }
+            .compactMap { $0["kind"] as? String }
+    }
+
+    // MARK: - Spawn
+
+    @Test("A project with no desk gets one, recorded by id, with a spawn line")
+    func spawnsWhenNoDeskExists() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let entry) = outcome else {
+            Issue.record("expected a spawn, got \(outcome)")
+            return
+        }
+        // The record is by id and the terminal really exists.
+        let terminal = try await fixture.db.terminals.get(id: entry.terminal)
+        #expect(terminal != nil)
+        let worktree = try await fixture.db.worktrees.getLocal(id: entry.worktree)
+        #expect(worktree?.worktree.repoID == nil)
+        #expect(worktree?.path.hasPrefix(TBDConstants.scratchDir.path) == true)
+
+        #expect(try fixture.desks.load().desk(for: "acme-web") == entry)
+        #expect(Self.ledgerEvents(fixture) == [.deskSpawned])
+    }
+
+    @Test("A spawn delivers nothing — no message, no nudge, no opening prompt")
+    func spawnDeliversNothing() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        _ = try await fixture.manager.ensureDesk(project: Self.inputs())
+
+        // A quiet project's desk idles at zero token cost: the opening material
+        // rides the first briefing. A nudge would appear here as a `send` row,
+        // because every payload into a session is recorded before it is sent.
+        let kinds = Self.actuationKinds(fixture)
+        #expect(kinds.allSatisfy { $0 == "spawn" || $0 == "outcome" })
+        #expect(!kinds.contains("send"))
+        // And the desk's own worktree row carries no parked prompt.
+        let entry = try #require(try fixture.desks.load().desk(for: "acme-web"))
+        let worktree = try await fixture.db.worktrees.getLocal(id: entry.worktree)
+        #expect(worktree?.worktree.pendingPrompt == nil)
+    }
+
+    @Test("The desk's conduct hash is the resolved playbook's")
+    func recordsTheConductHash() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let playbook = "# Conduct\n\nEscalate instead of guessing.\n"
+        _ = try await fixture.manager.ensureDesk(
+            project: Self.inputs(playbook: playbook))
+        let entry = try #require(try fixture.desks.load().desk(for: "acme-web"))
+        #expect(entry.conductHash == SupervisionPlaybook.hash(of: Data(playbook.utf8)))
+    }
+
+    // MARK: - Resume
+
+    @Test("A live desk resumes as it stands; nothing is spawned and no line is written")
+    func resumesALiveDesk() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let first = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let entry) = first else {
+            Issue.record("expected a spawn, got \(first)")
+            return
+        }
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        #expect(outcome == .resumed(entry))
+        #expect(try fixture.desks.load().desk(for: "acme-web") == entry)
+        // Still exactly one spawn line: resuming is not a decision to record.
+        #expect(Self.ledgerEvents(fixture) == [.deskSpawned])
+    }
+
+    // MARK: - Replace
+
+    @Test("A desk that died is replaced, and the line links successor to predecessor")
+    func replacesADeadDesk() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let first = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let predecessor) = first else {
+            Issue.record("expected a spawn, got \(first)")
+            return
+        }
+        // The death nothing was watching for: a stood-down project's sweep is
+        // not running, so the window simply goes away.
+        let terminal = try #require(try await fixture.db.terminals.get(id: predecessor.terminal))
+        fixture.deadWindows.markDead(terminal.tmuxWindowID)
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .replaced(let successor, let recorded) = outcome else {
+            Issue.record("expected a replacement, got \(outcome)")
+            return
+        }
+        #expect(recorded == predecessor)
+        #expect(successor.terminal != predecessor.terminal)
+        #expect(try fixture.desks.load().desk(for: "acme-web") == successor)
+        #expect(Self.ledgerEvents(fixture) == [.deskSpawned, .deskReplaced])
+
+        // The line really names the predecessor.
+        let data = try #require(FileManager.default.contents(atPath: fixture.ledgerPath))
+        let lines = data.split(separator: 0x0A, omittingEmptySubsequences: true)
+            .compactMap { try? JSONDecoder().decode(SupervisionLedgerLine.self, from: Data($0)) }
+        guard case .deskReplaced(let desk, let previous, _) = lines[1].payload else {
+            Issue.record("expected a deskReplaced payload")
+            return
+        }
+        #expect(desk.terminal == successor.terminal)
+        #expect(previous.terminal == predecessor.terminal)
+    }
+
+    // MARK: - Appointment
+
+    @Test("An appointed binding stands: no desk is spawned and nothing is recorded")
+    func appointedBindingIsHonored() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        // Spawn one desk to borrow a live terminal from, then appoint it.
+        let seeded = try await fixture.manager.ensureDesk(
+            project: Self.inputs(project: "seed"))
+        guard case .spawned(let seedEntry) = seeded else {
+            Issue.record("expected a spawn, got \(seeded)")
+            return
+        }
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs(
+            appointed: SupervisionSupervisorBinding(terminalID: seedEntry.terminal)))
+        #expect(outcome == .appointed(terminal: seedEntry.terminal))
+        // A mark is coverage, a binding is selection: `on` touches neither the
+        // binding nor the hosted record.
+        #expect(try fixture.desks.load().desk(for: "acme-web") == nil)
+    }
+
+    @Test("A dangling binding is reported, never silently replaced by a hosted desk")
+    func danglingBindingIsNotTakenOver() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let gone = UUID()
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs(
+            appointed: SupervisionSupervisorBinding(terminalID: gone)))
+        guard case .danglingBinding(let terminal, _) = outcome else {
+            Issue.record("expected a dangling binding, got \(outcome)")
+            return
+        }
+        #expect(terminal == gone.uuidString)
+        // The operator chose that supervisor and TBD does not unchoose it.
+        #expect(try fixture.desks.load().desk(for: "acme-web") == nil)
+        #expect(Self.ledgerEvents(fixture).isEmpty)
+    }
+
+    @Test("A binding that does not name a terminal id is dangling, not a crash")
+    func bindingWithoutAnIDIsDangling() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs(
+            appointed: SupervisionSupervisorBinding(terminal: "not-a-uuid")))
+        guard case .danglingBinding(let terminal, _) = outcome else {
+            Issue.record("expected a dangling binding, got \(outcome)")
+            return
+        }
+        #expect(terminal == "not-a-uuid")
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
@@ -115,9 +115,13 @@ struct SupervisionDeskManagerTests {
         // The record is by id and the terminal really exists.
         let terminal = try await fixture.db.terminals.get(id: entry.terminal)
         #expect(terminal != nil)
+        // A scratch space: a `repoID == nil` row, named for what it is.
+        // Deliberately not asserted against `TBDConstants.scratchDir` — that
+        // resolver reads `TBD_HOME`, which a serialized suite elsewhere in the
+        // process can move between the spawn and the assertion.
         let worktree = try await fixture.db.worktrees.getLocal(id: entry.worktree)
         #expect(worktree?.worktree.repoID == nil)
-        #expect(worktree?.path.hasPrefix(TBDConstants.scratchDir.path) == true)
+        #expect(worktree?.worktree.name.hasPrefix("supervision-desk") == true)
 
         #expect(try fixture.desks.load().desk(for: "acme-web") == entry)
         #expect(Self.ledgerEvents(fixture) == [.deskSpawned])

--- a/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionDeskManagerTests.swift
@@ -23,6 +23,24 @@ struct SupervisionDeskManagerTests {
         func isDead(_ windowID: String) -> Bool { lock.withLock { dead.contains(windowID) } }
     }
 
+    /// A `SupervisionDeskCollector` reap, standing by to land mid-spawn. Armed
+    /// after the fixture is built so it fires during one chosen spawn and not
+    /// the one that set the record up.
+    private final class ArmedReap: @unchecked Sendable {
+        private let lock = NSLock()
+        private var target: (store: SupervisionDesksStore, project: String)?
+
+        func arm(store: SupervisionDesksStore, project: String) {
+            lock.withLock { target = (store, project) }
+        }
+
+        func run() {
+            guard let target = lock.withLock({ target }) else { return }
+            guard let file = try? target.store.load() else { return }
+            try? target.store.save(file.forgetting(target.project))
+        }
+    }
+
     private struct Fixture {
         let db: TBDDatabase
         let directory: URL
@@ -34,15 +52,37 @@ struct SupervisionDeskManagerTests {
         let manager: SupervisionDeskManager
     }
 
-    private static func makeFixture() throws -> Fixture {
+    /// - Parameters:
+    ///   - createWindowError: makes the real spawn throw, the way tmux refusing
+    ///     a `new-window` does.
+    ///   - duringSpawn: runs while the spawn is in flight — after `ensureDesk`
+    ///     has read `desks.json` and before the record is written. It stands in
+    ///     for a concurrent `SupervisionDeskCollector` reap, which rewrites that
+    ///     same file per reap while the hourly sweep runs.
+    ///   - spawnSession: replaces the spawn outright, for the one failing exit
+    ///     the real one cannot produce.
+    private static func makeFixture(
+        createWindowError: (@Sendable (String) -> Error?)? = nil,
+        duringSpawn: (@Sendable () -> Void)? = nil,
+        spawnSession: SupervisionDeskSpawn? = nil
+    ) throws -> Fixture {
         let db = try TBDDatabase(inMemory: true)
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-supervision-desk-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
         let deadWindows = DeadWindows()
+        let recorder: (@Sendable ([String]) -> Void)?
+        if let duringSpawn {
+            recorder = { _ in duringSpawn() }
+        } else {
+            recorder = nil
+        }
         let tmux = TmuxManager(
-            dryRun: true, dryRunWindowIsDead: { deadWindows.isDead($0) })
+            dryRun: true,
+            dryRunRecorder: recorder,
+            dryRunWindowIsDead: { deadWindows.isDead($0) },
+            dryRunCreateWindowError: createWindowError)
         let desks = SupervisionDesksStore(
             fileURL: directory.appendingPathComponent("desks.json"))
         let ledgerPath = directory.appendingPathComponent("ledger.jsonl").path
@@ -65,6 +105,7 @@ struct SupervisionDeskManagerTests {
                 desks: desks,
                 ledger: SupervisionLedgerWriter(path: ledgerPath),
                 actuationLog: ActuationLog(path: actuationPath),
+                spawnSession: spawnSession,
                 now: dates.provider))
     }
 
@@ -90,6 +131,10 @@ struct SupervisionDeskManagerTests {
     /// assertion behind "a spawn delivers nothing": a nudge would show up here
     /// as a `send`.
     private static func actuationKinds(_ fixture: Fixture) -> [String] {
+        actuationRows(fixture).compactMap { $0["kind"] as? String }
+    }
+
+    private static func actuationRows(_ fixture: Fixture) -> [[String: Any]] {
         guard let data = FileManager.default.contents(atPath: fixture.actuationPath) else {
             return []
         }
@@ -97,7 +142,16 @@ struct SupervisionDeskManagerTests {
             .compactMap {
                 try? JSONSerialization.jsonObject(with: Data($0)) as? [String: Any]
             }
-            .compactMap { $0["kind"] as? String }
+    }
+
+    /// The one scratch row this fixture's spawn created. Read out of the
+    /// database rather than off `TBDConstants.scratchDir`, whose resolver reads
+    /// `TBD_HOME` — a serialized suite elsewhere in the process can move that
+    /// between the spawn and the assertion.
+    private static func onlyScratchRow(_ fixture: Fixture) async throws -> Worktree {
+        let rows = try await fixture.db.worktrees.listScratch()
+        #expect(rows.count == 1)
+        return try #require(rows.first)
     }
 
     // MARK: - Spawn
@@ -156,6 +210,120 @@ struct SupervisionDeskManagerTests {
             project: Self.inputs(playbook: playbook))
         let entry = try #require(try fixture.desks.load().desk(for: "acme-web"))
         #expect(entry.conductHash == SupervisionPlaybook.hash(of: Data(playbook.utf8)))
+    }
+
+    @Test("A Codex-preferring fleet still gets a Claude desk, and keeps its preference")
+    func codexPreferenceStillSpawnsAClaudeDesk() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        // The whole fleet prefers Codex. A supervisor is the one exception:
+        // its standing conduct rides `--append-system-prompt`, which only the
+        // Claude spawn path carries, so a Codex desk would launch with no
+        // conduct at all.
+        try await fixture.db.config.setPrimaryAgentPreference(.codex)
+
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let entry) = outcome else {
+            Issue.record("expected a spawn, got \(outcome)")
+            return
+        }
+        let terminal = try #require(try await fixture.db.terminals.get(id: entry.terminal))
+        #expect(terminal.kind == .claude)
+        #expect(terminal.label == TerminalLabel.claudeCode)
+        // Forcing the adapter for this one session changes nothing about the
+        // fleet: every other spawn still reads Codex out of the config.
+        #expect(try await fixture.db.config.get().primaryAgentPreference == .codex)
+    }
+
+    // MARK: - A spawn that fails hands the scratch space back
+
+    @Test("A spawn that throws archives its scratch row, and still records the outcome")
+    func thrownSpawnArchivesTheScratchSpace() async throws {
+        struct TmuxRefused: Error {}
+        let fixture = try Self.makeFixture(createWindowError: { _ in TmuxRefused() })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        await #expect(throws: SupervisionDeskError.self) {
+            try await fixture.manager.ensureDesk(project: Self.inputs())
+        }
+
+        // `SupervisionDeskCollector` walks `desks.json`, and no entry was ever
+        // written — so unless the row is archived here, nothing reclaims the
+        // directory. `.archived` is exactly the shape `OrphanGC`'s
+        // deletion-queue leg already takes.
+        #expect(try fixture.desks.load().desk(for: "acme-web") == nil)
+        let scratch = try await Self.onlyScratchRow(fixture)
+        #expect(scratch.status == .archived)
+
+        // The rail still says what it tried and what came back.
+        let rows = Self.actuationRows(fixture)
+        #expect(rows.contains { $0["kind"] as? String == "spawn" })
+        #expect(rows.contains {
+            $0["kind"] as? String == "outcome" && $0["result"] as? String == "transport-failed"
+        })
+    }
+
+    @Test("A spawn that creates no terminal archives its scratch row too")
+    func terminallessSpawnArchivesTheScratchSpace() async throws {
+        // The one failing exit the real spawn cannot produce:
+        // `spawnPrimaryTerminals` always returns the primary terminal, so this
+        // branch is held to its behaviour through the spawn seam.
+        let fixture = try Self.makeFixture(spawnSession: { _, _ in [] })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        await #expect(throws: SupervisionDeskError.self) {
+            try await fixture.manager.ensureDesk(project: Self.inputs())
+        }
+
+        #expect(try fixture.desks.load().desk(for: "acme-web") == nil)
+        let scratch = try await Self.onlyScratchRow(fixture)
+        #expect(scratch.status == .archived)
+        // The spawn itself reached the transport and reported no failure — the
+        // outcome row says so, and the anomaly is that it produced nothing.
+        let rows = Self.actuationRows(fixture)
+        #expect(rows.contains {
+            $0["kind"] as? String == "outcome" && $0["result"] as? String == "dispatched"
+        })
+    }
+
+    // MARK: - Recording a desk must not resurrect a reaped one
+
+    @Test("A reap that lands mid-spawn survives the record: the desk file is re-read")
+    func recordingRereadsBeforeSaving() async throws {
+        // Seed a second project's desk, then drop it while `acme-web`'s spawn
+        // is in flight — the sweep's read-modify-write per reap, arriving in
+        // the seconds a spawn takes. Nothing here spawns concurrently: the
+        // manager's gate serializes ensures, and the race being reproduced is
+        // with the collector, which does not hold that gate.
+        let armed = ArmedReap()
+        let fixture = try Self.makeFixture(duringSpawn: { armed.run() })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let seeded = try await fixture.manager.ensureDesk(
+            project: Self.inputs(project: "seed-project"))
+        guard case .spawned = seeded else {
+            Issue.record("expected a spawn, got \(seeded)")
+            return
+        }
+        #expect(try fixture.desks.load().desk(for: "seed-project") != nil)
+
+        // Arm the reap only now, so it lands during the second spawn.
+        armed.arm(store: fixture.desks, project: "seed-project")
+        let outcome = try await fixture.manager.ensureDesk(project: Self.inputs())
+        guard case .spawned(let entry) = outcome else {
+            Issue.record("expected a spawn, got \(outcome)")
+            return
+        }
+
+        let file = try fixture.desks.load()
+        // The concurrent change survives. Writing back the copy read before
+        // the spawn would resurrect it — and a resurrected entry whose worktree
+        // the sweep already archived is kept by every later sweep
+        // (`desk-already-archived`), so it would never be reclaimed again.
+        #expect(file.desk(for: "seed-project") == nil)
+        // And the new desk is recorded on top of the file as it now stands.
+        #expect(file.desk(for: "acme-web") == entry)
     }
 
     // MARK: - Resume

--- a/Tests/TBDDaemonTests/SupervisionNightwatchGateTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionNightwatchGateTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The coexistence gate between the two supervision paths.
+///
+/// Nightwatch stays live until the redesign's cutover, so the two are
+/// **mutually exclusive rather than sequential**: both drive the same fleet
+/// through the same terminals on different theories of who decides what.
+/// Each direction refuses the *on* gesture and names the condition — and
+/// **neither direction can refuse an `off`**, which is the property that keeps
+/// an operator from wedging themselves with the fleet running and no gesture
+/// that stops it.
+///
+/// Tier 2 — in-memory database, tmux in `dryRun`, real filesystem for the
+/// supervision files, no clocks.
+@Suite("Supervision / Nightwatch coexistence")
+struct SupervisionNightwatchGateTests {
+
+    private struct StubFleet: SupervisionFleetReading {
+        var repoList: [SupervisionRepo] = []
+        func repos() async throws -> [SupervisionRepo] { repoList }
+        func agents(inRepos repoIDs: Set<UUID>) async throws -> [SupervisionFleetAgent] { [] }
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let directory: URL
+    }
+
+    private static func makeFixture(repos names: [String] = ["acme-web"]) throws -> Fixture {
+        let db = try TBDDatabase(inMemory: true)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-supervision-gate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+        router.supervision = SupervisionStore(
+            files: SupervisionFileStore(
+                fileURL: directory.appendingPathComponent("supervision.json")),
+            ledger: SupervisionLedgerWriter(
+                path: directory.appendingPathComponent("ledger.jsonl").path),
+            fleet: StubFleet(repoList: names.map { SupervisionRepo(id: UUID(), name: $0) }))
+        // Deliberately no `supervisionDesks`: the gate is about the mark, and
+        // wiring a desk manager here would spawn sessions this suite never
+        // looks at.
+        return Fixture(db: db, router: router, directory: directory)
+    }
+
+    private static func setMark(
+        _ fixture: Fixture, _ project: String, on: Bool
+    ) async throws -> RPCResponse {
+        await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.superviseSetProjectMark,
+            params: SuperviseSetProjectMarkParams(project: project, on: on)))
+    }
+
+    private static func setNightwatch(
+        _ fixture: Fixture, _ mode: NightwatchMode
+    ) async throws -> RPCResponse {
+        await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchSetMode,
+            params: NightwatchSetModeParams(mode: mode)))
+    }
+
+    // MARK: - supervise on, while Nightwatch runs
+
+    @Test("`supervise on <project>` is refused while Nightwatch is running")
+    func superviseOnRefusedWhileNightwatchRuns() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        try await fixture.db.config.setNightwatchMode(.nightwatch)
+        let response = try await Self.setMark(fixture, "acme-web", on: true)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        // Names the condition and the way out, rather than failing opaquely.
+        #expect(error.contains("Nightwatch is running"))
+        #expect(error.contains("tbd nightwatch mode off"))
+
+        // And the mark really did not move: a refusal that half-applied would
+        // be worse than either outcome.
+        let store = try #require(fixture.router.supervision)
+        #expect(try await store.markedProjects().isEmpty)
+    }
+
+    @Test("`supervise on <project>` is allowed once Nightwatch is off")
+    func superviseOnAllowedWhenNightwatchOff() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        try await fixture.db.config.setNightwatchMode(.off)
+        let response = try await Self.setMark(fixture, "acme-web", on: true)
+        #expect(response.success)
+        let store = try #require(fixture.router.supervision)
+        #expect(try await store.markedProjects() == ["acme-web"])
+    }
+
+    @Test("`supervise off <project>` is never refused, whatever Nightwatch is doing")
+    func superviseOffIsNeverRefused() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        #expect(try await Self.setMark(fixture, "acme-web", on: true).success)
+        // Nightwatch comes up out of band — a hand-edited config, an older
+        // build, a race. The operator must still be able to stand down.
+        try await fixture.db.config.setNightwatchMode(.daywatch)
+        let response = try await Self.setMark(fixture, "acme-web", on: false)
+        #expect(response.success)
+        let store = try #require(fixture.router.supervision)
+        #expect(try await store.markedProjects().isEmpty)
+    }
+
+    // MARK: - Nightwatch on, while a project is supervised
+
+    @Test("`nightwatch.setMode` is refused while a project is supervised")
+    func nightwatchRefusedWhileProjectSupervised() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        #expect(try await Self.setMark(fixture, "acme-web", on: true).success)
+        let response = try await Self.setNightwatch(fixture, .nightwatch)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("acme-web"))
+        #expect(error.contains("tbd supervise off"))
+
+        // Gated ahead of the DB write, so a refused mode never persists.
+        #expect(try await fixture.db.config.get().nightwatchMode == .off)
+    }
+
+    @Test("`nightwatch.setMode` is allowed once no project is supervised")
+    func nightwatchAllowedWithNoProjectsOn() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        #expect(try await Self.setMark(fixture, "acme-web", on: true).success)
+        #expect(try await Self.setMark(fixture, "acme-web", on: false).success)
+        #expect(try await Self.setNightwatch(fixture, .daywatch).success)
+        #expect(try await fixture.db.config.get().nightwatchMode == .daywatch)
+    }
+
+    @Test("`nightwatch.setMode off` is never refused, even with projects supervised")
+    func nightwatchOffIsNeverRefused() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        try await fixture.db.config.setNightwatchMode(.nightwatch)
+        // A supervised project alongside a running Nightwatch: reachable
+        // through an older build or a hand edit, and exactly the state where a
+        // symmetric refusal would leave the operator with no way out.
+        let store = try #require(fixture.router.supervision)
+        _ = try await store.setProjectMark(project: "acme-web", on: true)
+
+        #expect(try await Self.setNightwatch(fixture, .off).success)
+        #expect(try await fixture.db.config.get().nightwatchMode == .off)
+    }
+
+    @Test("A daemon with no supervision store does not block Nightwatch")
+    func noSupervisionStoreDoesNotBlock() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        // Mock mode and unit tests run without a store. Nothing is supervised
+        // there by construction, so the gate has nothing to protect.
+        fixture.router.supervision = nil
+        #expect(try await Self.setNightwatch(fixture, .nightwatch).success)
+    }
+
+    // MARK: - A stood-down project is still observable
+
+    @Test("A stood-down project still appears in the readout and the account")
+    func stoodDownProjectStaysVisible() async throws {
+        let fixture = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        #expect(try await Self.setMark(fixture, "acme-web", on: true).success)
+        #expect(try await Self.setMark(fixture, "acme-web", on: false).success)
+
+        // The account: `supervise status` lists it, off, with its mode.
+        let store = try #require(fixture.router.supervision)
+        let status = try await store.status(brake: .released)
+        let project = try #require(status.projects.first { $0.name == "acme-web" })
+        #expect(!project.on)
+        #expect(project.mode == "attended")
+
+        // The readout: refused only for a project that does not exist, never
+        // for one that is merely off — observability is never withheld.
+        let readout = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.superviseReadout,
+            params: SuperviseReadoutParams(project: "acme-web")))
+        #expect(readout.success)
+    }
+}

--- a/Tests/TBDDaemonTests/SupervisionStandingLayerTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionStandingLayerTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The desk's standing conduct layer, `TBD_PROMPT_SUPERVISION`.
+///
+/// **The assertion that matters is the composed string, not the map.**
+/// `SystemPromptBuilder.build` hand-picks the layers it emits, so a layer added
+/// to `promptLayers` alone reaches the environment and is silently dropped from
+/// `--append-system-prompt` — it compiles, it ships, and the desk stands on
+/// nothing. Every test here that could be satisfied by the map is paired with
+/// one that reads the flag the agent actually launches with.
+///
+/// Tier 1 — pure string composition, no filesystem, no clocks.
+@Suite("Supervision standing layer")
+struct SupervisionStandingLayerTests {
+
+    private static let playbook = "# Conduct\n\nEscalate instead of guessing."
+
+    private static func scratch() -> Worktree {
+        Worktree(
+            repoID: nil, name: "supervision-desk", displayName: "Supervisor · acme-web",
+            branch: "", path: "/tmp/x-scratch/supervision-desk", tmuxServer: "tbd-scratch")
+    }
+
+    // MARK: - The layer
+
+    @Test("The playbook becomes the TBD_PROMPT_SUPERVISION layer")
+    func layerIsNamed() {
+        let layers = SystemPromptBuilder.promptLayers(
+            repo: nil, worktree: Self.scratch(), supervisionPlaybook: Self.playbook)
+        #expect(layers["TBD_PROMPT_SUPERVISION"] == Self.playbook)
+    }
+
+    @Test("No playbook, no layer — every ordinary fleet spawn is unchanged")
+    func absentWithoutAPlaybook() {
+        let layers = SystemPromptBuilder.promptLayers(repo: nil, worktree: Self.scratch())
+        #expect(layers["TBD_PROMPT_SUPERVISION"] == nil)
+        let built = SystemPromptBuilder.build(
+            repo: nil, worktree: Self.scratch(), isResume: false)
+        #expect(built?.contains("Escalate instead of guessing") != true)
+    }
+
+    @Test("A blank playbook installs no layer — whitespace is not conduct")
+    func blankPlaybookInstallsNothing() {
+        let layers = SystemPromptBuilder.promptLayers(
+            repo: nil, worktree: Self.scratch(), supervisionPlaybook: "  \n\t ")
+        #expect(layers["TBD_PROMPT_SUPERVISION"] == nil)
+    }
+
+    // MARK: - The trap: it has to reach the composed prompt
+
+    @Test("The playbook text reaches the built system prompt, not just the map")
+    func reachesTheBuiltPrompt() throws {
+        let built = try #require(SystemPromptBuilder.build(
+            repo: nil, worktree: Self.scratch(), isResume: false,
+            supervisionPlaybook: Self.playbook))
+        #expect(built.contains("Escalate instead of guessing"))
+        // The generic layers still ship beside it — the standing layer is
+        // installed, never exclusive.
+        #expect(built.contains("TBD-managed worktree"))
+    }
+
+    @Test("The playbook text reaches the --append-system-prompt flag Claude launches with")
+    func reachesTheSpawnFlag() throws {
+        let appendPrompt = SystemPromptBuilder.build(
+            repo: nil, worktree: Self.scratch(), isResume: false,
+            supervisionPlaybook: Self.playbook)
+        let spawn = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: UUID().uuidString,
+            appendSystemPrompt: appendPrompt,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh")
+        #expect(spawn.command.contains("--append-system-prompt"))
+        #expect(spawn.command.contains("Escalate instead of guessing"))
+    }
+
+    @Test("A resume appends nothing, playbook or not — the conduct reload is deferred")
+    func resumeStillAppendsNothing() {
+        // Not an oversight: this slice installs the layer at spawn only. The
+        // shipped mechanism for a playbook edit under a live desk is the
+        // briefing header's conduct delta, which arrives with delivery.
+        let built = SystemPromptBuilder.build(
+            repo: nil, worktree: Self.scratch(), isResume: true,
+            supervisionPlaybook: Self.playbook)
+        #expect(built == nil)
+    }
+}

--- a/Tests/TBDSharedTests/SupervisionDeskLedgerTests.swift
+++ b/Tests/TBDSharedTests/SupervisionDeskLedgerTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// The two desk lifecycle lines: `deskSpawned` and `deskReplaced`.
+///
+/// Tier 1 — pure encode/decode, no filesystem, no clocks.
+@Suite("Supervision desk lifecycle lines")
+struct SupervisionDeskLedgerTests {
+
+    private static let at = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private static func encode(_ line: SupervisionLedgerLine) throws -> [String: Any] {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let object = try JSONSerialization.jsonObject(with: try encoder.encode(line))
+        return object as? [String: Any] ?? [:]
+    }
+
+    @Test("A spawn line carries the desk by id and the conduct it stands on")
+    func spawnShape() throws {
+        let terminal = UUID()
+        let worktree = UUID()
+        let line = SupervisionLedgerLine.deskSpawned(
+            project: "acme-web", mode: "attended",
+            desk: SupervisionDeskRef(terminal: terminal, worktree: worktree),
+            conductHash: "feed01", at: Self.at, id: "line1")
+        let json = try Self.encode(line)
+
+        #expect(json["kind"] as? String == "lifecycle")
+        #expect(json["event"] as? String == "deskSpawned")
+        #expect(json["project"] as? String == "acme-web")
+        #expect(json["mode"] as? String == "attended")
+        #expect(json["conductHash"] as? String == "feed01")
+        let desk = try #require(json["desk"] as? [String: Any])
+        #expect(desk["terminal"] as? String == terminal.uuidString)
+        #expect(desk["worktree"] as? String == worktree.uuidString)
+        #expect(json["predecessor"] == nil)
+    }
+
+    @Test("A replacement line links successor to predecessor")
+    func replacementLinksPredecessor() throws {
+        let successor = SupervisionDeskRef(terminal: UUID(), worktree: UUID())
+        let predecessor = SupervisionDeskRef(terminal: UUID(), worktree: UUID())
+        let line = SupervisionLedgerLine.deskReplaced(
+            project: "acme-web", mode: "autonomous", desk: successor,
+            predecessor: predecessor, conductHash: "feed02", at: Self.at, id: "line2")
+        let json = try Self.encode(line)
+
+        #expect(json["event"] as? String == "deskReplaced")
+        let recorded = try #require(json["predecessor"] as? [String: Any])
+        #expect(recorded["terminal"] as? String == predecessor.terminal.uuidString)
+        // Successor and predecessor are distinguishable, which is the whole
+        // reason the line exists rather than a second spawn line.
+        let desk = try #require(json["desk"] as? [String: Any])
+        #expect(desk["terminal"] as? String == successor.terminal.uuidString)
+    }
+
+    @Test("Both lines survive a round trip through the record's own coding")
+    func roundTrip() throws {
+        let lines = [
+            SupervisionLedgerLine.deskSpawned(
+                project: "acme-web", mode: "attended",
+                desk: SupervisionDeskRef(terminal: UUID(), worktree: UUID()),
+                conductHash: "aa", at: Self.at),
+            SupervisionLedgerLine.deskReplaced(
+                project: "acme-web", mode: "attended",
+                desk: SupervisionDeskRef(terminal: UUID(), worktree: UUID()),
+                predecessor: SupervisionDeskRef(terminal: UUID(), worktree: UUID()),
+                conductHash: "bb", at: Self.at),
+        ]
+        for line in lines {
+            let decoded = try JSONDecoder().decode(
+                SupervisionLedgerLine.self, from: try JSONEncoder().encode(line))
+            #expect(decoded == line)
+            #expect(decoded.payload.event == line.payload.event)
+        }
+    }
+
+    @Test("A desk event a later build writes decodes as unrecognized, not as damage")
+    func unknownDeskEventIsReadPast() throws {
+        let raw = Data("""
+            {"id":"x","ts":"2027-01-01T00:00:00.000Z","mode":"attended","project":"acme-web",\
+            "kind":"lifecycle","event":"deskRetired"}
+            """.utf8)
+        let line = try JSONDecoder().decode(SupervisionLedgerLine.self, from: raw)
+        #expect(line.payload == .unrecognized)
+        #expect(line.project == "acme-web")
+    }
+}

--- a/Tests/TBDSharedTests/SupervisionDesksTests.swift
+++ b/Tests/TBDSharedTests/SupervisionDesksTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// `~/tbd/supervision/desks.json`: the wire shape a hosted desk is recorded in,
+/// and the store that writes it durably.
+///
+/// Tier 2 — real filesystem, no clocks, no subprocesses. Every path is a temp
+/// directory handed to the store, so nothing here touches `~/tbd`.
+@Suite("Supervision desks file")
+struct SupervisionDesksTests {
+
+    private static func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-supervision-desks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static func entry(
+        terminal: UUID = UUID(), worktree: UUID = UUID(),
+        at seconds: TimeInterval = 1_800_000_000, hash: String = "abc123"
+    ) -> SupervisionDeskEntry {
+        SupervisionDeskEntry(
+            terminal: terminal, worktree: worktree,
+            spawnedAt: SupervisionInstant(Date(timeIntervalSince1970: seconds)),
+            conductHash: hash)
+    }
+
+    // MARK: - Shape
+
+    @Test("A desk entry carries exactly the four fields, keyed by id")
+    func entryShape() throws {
+        let terminal = UUID()
+        let worktree = UUID()
+        let file = SupervisionDesksFile(desks: [
+            "acme-web": Self.entry(terminal: terminal, worktree: worktree, hash: "deadbeef")
+        ])
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let json = try JSONSerialization.jsonObject(with: encoder.encode(file))
+
+        let root = try #require(json as? [String: Any])
+        #expect(root["version"] as? Int == 1)
+        let desks = try #require(root["desks"] as? [String: Any])
+        let acme = try #require(desks["acme-web"] as? [String: Any])
+        #expect(Set(acme.keys) == ["terminal", "worktree", "spawnedAt", "conductHash"])
+        #expect(acme["terminal"] as? String == terminal.uuidString)
+        #expect(acme["worktree"] as? String == worktree.uuidString)
+        #expect(acme["conductHash"] as? String == "deadbeef")
+        // No display string anywhere: a rename must never orphan a desk.
+        #expect(acme["name"] == nil)
+        #expect(acme["displayName"] == nil)
+    }
+
+    @Test("An empty record is one line, not empty scaffolding")
+    func emptyRecordOmitsTheMap() throws {
+        let data = try JSONEncoder().encode(SupervisionDesksFile())
+        let root = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(root["version"] as? Int == 1)
+        #expect(root["desks"] == nil)
+    }
+
+    @Test("An entry survives a round trip unchanged")
+    func roundTrip() throws {
+        let file = SupervisionDesksFile(desks: ["acme-web": Self.entry()])
+        let decoded = try JSONDecoder().decode(
+            SupervisionDesksFile.self, from: try JSONEncoder().encode(file))
+        #expect(decoded == file)
+    }
+
+    @Test("A version this build does not read is refused")
+    func futureVersionRefused() throws {
+        let data = Data(#"{"version": 2}"#.utf8)
+        let file = try JSONDecoder().decode(SupervisionDesksFile.self, from: data)
+        #expect(throws: SupervisionDesksError.self) { try file.validate() }
+    }
+
+    // MARK: - Mutation
+
+    @Test("Recording and forgetting are value transforms; forgetting nothing is a no-op")
+    func mutations() {
+        let entry = Self.entry()
+        let empty = SupervisionDesksFile()
+        let recorded = empty.recording(entry, for: "acme-web")
+        #expect(recorded.desk(for: "acme-web") == entry)
+        #expect(empty.desk(for: "acme-web") == nil)
+
+        // A no-op returns an equal value, which is what lets the collector
+        // decline to write.
+        #expect(empty.forgetting("acme-web") == empty)
+        #expect(recorded.forgetting("acme-web") == empty)
+    }
+
+    // MARK: - Store
+
+    @Test("An absent file loads as the empty record, not an error")
+    func absentFileIsEmpty() throws {
+        let directory = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SupervisionDesksStore(
+            fileURL: directory.appendingPathComponent("desks.json"))
+        #expect(try store.load() == SupervisionDesksFile())
+    }
+
+    @Test("Save then load returns the same record")
+    func saveLoadRoundTrip() throws {
+        let directory = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SupervisionDesksStore(
+            fileURL: directory.appendingPathComponent("desks.json"))
+        let file = SupervisionDesksFile(desks: [
+            "acme-web": Self.entry(), "acme-hooks": Self.entry()
+        ])
+        try store.save(file)
+        #expect(try store.load() == file)
+    }
+
+    @Test("The write leaves no temp file behind, and the temp is in the target's directory")
+    func saveIsAtomicInPlace() throws {
+        let directory = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SupervisionDesksStore(
+            fileURL: directory.appendingPathComponent("desks.json"))
+        // `rename(2)` is atomic only within a filesystem, so the temp has to be
+        // a sibling of the target rather than under `/tmp`.
+        #expect(store.temporaryURL().deletingLastPathComponent().path == directory.path)
+
+        try store.save(SupervisionDesksFile(desks: ["acme-web": Self.entry()]))
+        let left = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        #expect(left == ["desks.json"])
+    }
+
+    @Test("A malformed record is refused by path, naming the file")
+    func malformedIsNamed() throws {
+        let directory = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("desks.json")
+        try Data("{ not json".utf8).write(to: url)
+        let store = SupervisionDesksStore(fileURL: url)
+        #expect(throws: SupervisionDesksError.self) { _ = try store.load() }
+    }
+
+    @Test("The desks path is TBD_HOME-relative, and beside the operator's file")
+    func pathHonorsTBDHome() {
+        let environment = ["TBD_HOME": "/tmp/x-tbd-home"]
+        let desks = TBDConstants.supervisionDesksPath(environment: environment)
+        #expect(desks == "/tmp/x-tbd-home/supervision/desks.json")
+        // Beside `supervision.json`, never inside it: derived state and
+        // operator selections share a directory, not a file.
+        #expect(
+            (desks as NSString).deletingLastPathComponent
+                == (TBDConstants.supervisionFilePath(environment: environment) as NSString)
+                    .deletingLastPathComponent)
+    }
+}

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -214,10 +214,36 @@ cannot take never turns a gesture that succeeded into a nonzero exit — but it
 says on stderr that it could not read the state, rather than falling silent
 and letting silence read as a calm night.
 
-What these gestures do today is the mark, the ledger line, the result and
-that warning. The supervisor half described above — ensuring a hosted desk
-live, standing one down — and the transition hook belong with the
-not-yet-built commands, and arrive with them.
+**`on <project>` really does ensure a desk**, and the order is the mark first,
+the supervisor second. Where an appointed binding stands it is left exactly as
+it is — a mark is coverage, a binding is selection — and a binding naming a
+session that has gone is reported loudly rather than quietly replaced by the
+hosted default. Otherwise a live desk resumes as it stands, a desk that died
+while stood down is replaced with a ledger line linking successor to
+predecessor, and a project that never had one gets it spawned. The spawn
+creates a scratch space, installs the project's playbook as the session's
+standing conduct, gives it the supervision skill, and **sends it nothing**: a
+quiet project's desk idles at zero token cost until its first briefing.
+
+A desk that cannot be spawned is an anomaly, never a refusal — the mark is what
+the gesture promises, and it stands. Nothing about the desk reaches stdout
+either way; the result line carries the mark and nothing more.
+
+**`off <project>` stands the desk down and disposes of nothing.** There is no
+disposal on this surface at all: the mark is a delivery precondition rechecked
+at act time, so a stood-down desk simply receives nothing while keeping context
+that cost real tokens to build, and the next `on` re-verifies it is alive rather
+than paying to rebuild it.
+
+**While Nightwatch is running, `on <project>` is refused**, naming the
+condition. The two supervise the same fleet through the same terminals and are
+mutually exclusive until Nightwatch is retired; the refusal in the other
+direction is symmetric — `tbd nightwatch mode` refuses anything but `off` while
+any project is on. **Neither `off` is ever refusable**, in either direction, so
+an operator can always stand either path down.
+
+The transition hook described above belongs with the not-yet-built commands and
+arrives with them.
 
 Bare: the fleet brake. `off` pauses TBD's authority to act everywhere —
 briefings refused, identified supervisor sends refused from that instant —

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -18,7 +18,7 @@ auto-removes one if it ended unchanged — the moment an agent commits, the work
 Code's own 30-day sweep permanently exempts anything with unpushed commits. Nothing
 else ever cleans these up.
 
-Three things get reaped:
+Four things get reaped:
 - **Agent worktrees** — `<repo>/.claude/worktrees/agent-*` and `wf_*` whose run has
   ended (see gates below).
 - **Attributable scratchpads** — `/private/tmp/claude-<uid>/<slug>` directories TBD can
@@ -27,6 +27,9 @@ Three things get reaped:
   `model_profiles` row is gone; `ProfileDirCollector` is the named reconciler for that
   resource class, alongside the agent-worktree and scratchpad collectors, and it
   quarantines rather than deletes (see below).
+- **Orphaned supervision desks** — the scratch space and `desks.json` entry of a hosted
+  supervisor whose session is gone; `SupervisionDeskCollector` is the named reconciler
+  for that resource class (see below).
 
 ## Philosophy: orphaned, not idle
 
@@ -235,6 +238,56 @@ profile and moves the directory into the new UUID. The app's Reclaimed section d
 surface these records — it is per-repo, and a profile directory belongs to no repo — so
 the CLI is where a quarantine path is read.
 
+## Hosted supervision desks
+
+Turning a project on under fleet supervision spawns a **hosted desk**: a scratch
+worktree with one agent session in it, recorded in `~/tbd/supervision/desks.json`
+(`docs/specs/2026-07-26-fleet-supervision-design.md` §9). Neither half is covered by the
+legs above — the agent-worktree leg walks `db.repos.list()` and so sees only repo-backed
+worktrees, and the archived legs only touch rows already `.archived` — so
+`SupervisionDeskCollector` is that resource class's reconciler.
+
+**Its subject is a desk that got recorded and then died.** It enumerates the record, so
+a spawn that failed before writing an entry is not visible to it at all; that half is
+the spawn path's own, which archives its scratch row on every failing exit and thereby
+hands the directory to the deletion-queue leg.
+
+**Flag: `gc_supervision_desks_enabled`, default off.** Enable it for a soak with
+`tbd gc supervision-desks on` (RPC `config.setGCSupervisionDesksEnabled`); there is no
+Settings toggle. Like the profile-dir flag it carries no SQL default, so an untouched
+install reads NULL and resolves through `Config.gcSupervisionDesksEnabledDefault` —
+graduation is a one-line change to that constant. `tbd gc sweep --dry-run` bypasses the
+flag and prints the `REAP supervision-desk` lines it would act on.
+
+**Gates**, every one failing toward keeping:
+
+1. **Grace** (`desk-within-grace`) — a desk spawned inside `gcGraceSeconds` may not have
+   reached the `lsof` pass yet.
+2. **Terminal read** (`desk-row-read-failed`) — a read that did not answer says nothing
+   about the desk.
+3. **Worktree read** (`desk-worktree-read-failed`) — likewise, and kept distinct from a
+   row that is genuinely absent (`desk-worktree-row-gone`, which reaps the record only,
+   there being nothing on disk this sweep can attribute).
+4. **Shape** (`desk-not-a-scratch-space`) — a recorded worktree that is repo-backed, or
+   outside the scratch base, is not this leg's to touch.
+5. **Already archived** (`desk-already-archived`) — the row is where a reap would put it.
+6. **Live** (`desk-live`) — a process sitting in the desk's directory *or anywhere below
+   it* is the desk running, matched on the same prefix boundary the agent-worktree leg
+   uses. **A live desk is never reclaimed**, whatever its rows or its project say.
+
+Reaping drops the record and moves the worktree row to `.archived`, from where the
+deletion-queue and scratchpad legs reclaim the directory and `WorktreeLifecycle+Reconcile`
+settles its tmux state — this leg kills no window itself. The record write is guarded on
+the entry the sweep judged (`desk-record-changed`): a spawn for the same project landing
+mid-sweep leaves a live desk nobody judged, and dropping its key would unrecord it.
+
+**Liveness is the whole decision.** A desk whose project stopped resolving is not
+reaped on that ground: design §9 is explicit that a topology gesture ending a project
+takes its mark, its mode selection and its supervisor binding, and that no coverage
+gesture disposes a desk. Once the desk is not live it is reclaimed regardless of whether
+the project still resolves, so a project check would gate nothing and would need a
+second reader of `supervision.json`.
+
 ## Cadence and the `gcEnabled` gate
 
 `gcEnabled` (config-table boolean, **default on**) is the single master switch — it
@@ -284,6 +337,7 @@ than the preceding dry run predicted.
 |---|---|---|
 | `gcEnabled` | `true` | Settings toggle + `config.setGCEnabled` RPC |
 | `gcProfileDirsEnabled` | `false` | `tbd gc profile-dirs on\|off` + `config.setGCProfileDirsEnabled` RPC, no UI |
+| `gcSupervisionDesksEnabled` | `false` | `tbd gc supervision-desks on\|off` + `config.setGCSupervisionDesksEnabled` RPC, no UI |
 | `gcGraceSeconds` | `3600` (1h) | config table only, no UI |
 | `gcSnapshotRetentionDays` | `30` | config table only, no UI |
 
@@ -313,6 +367,7 @@ tbd gc list [--repo <path>] [--json]   # list reap records (id, kind, path, size
 tbd gc restore <uuid>                  # restore a reaped agent worktree
 tbd gc sweep [--dry-run]               # run a sweep now; --dry-run prints the plan, mutates nothing
 tbd gc profile-dirs on|off             # gate the profile-config-dir collector (ships off)
+tbd gc supervision-desks on|off        # gate the supervision-desk collector (ships off)
 ```
 
 ## Non-goals (from the design spec)

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -2236,18 +2236,26 @@ the one way to send a desk substance.
   construction — which is why the route and not the desk is the durable
   home for anything needing a human.
 - **An orphaned desk is reclaimed by a named reconciler.** A spawn creates a
-  scratch space and a process before either can be recorded (§7), so a crash
-  or a failed spawn in between leaves a desk nobody owns — and TBD's existing
-  sweeps do not cover it, because the agent-worktree pass only walks
-  repo-backed worktrees and the archived passes only touch rows already
-  archived. A **supervision-desk collector**, run as a leg of the hourly orphan
-  sweep, closes that: it drops the record and hands the scratch worktree to the
-  archive path the sweep already runs. Its reap decision is **liveness and
-  nothing else** — a desk with a process running in its directory is kept
-  whatever its project or its rows say, because a sweep must never kill a
-  running agent, and a project that stopped resolving is closed through the
-  recycle path above rather than by garbage collection. Reclaiming is
-  destructive enough to soak behind its own default-off switch first.
+  scratch space and a process before either can be recorded (§7), and TBD's
+  existing sweeps cover neither: the agent-worktree pass only walks repo-backed
+  worktrees and the archived passes only touch rows already archived. The
+  orphan has two shapes and each gets its own answer.
+  - *A desk that was recorded and then died* is the **supervision-desk
+    collector**'s, run as a leg of the hourly orphan sweep: it drops the record
+    and hands the scratch worktree to the archive path the sweep already runs.
+    Its reap decision is **liveness and nothing else** — a desk with a process
+    running in its directory is kept whatever its project or its rows say,
+    because a sweep must never kill a running agent. A project that stopped
+    resolving therefore never triggers a reap on its own: the topology gesture
+    took that project's mark, mode and binding, and no coverage gesture
+    disposes a desk, so the desk is reclaimed when it dies and not before.
+    Reclaiming is destructive enough to soak behind its own default-off switch
+    first.
+  - *A spawn that failed before the record was written* leaves nothing for that
+    collector to enumerate, so the **spawn path archives the scratch row
+    itself** on every failing exit, which puts the directory under the sweep's
+    deletion-queue pass. Best-effort, as create-time cleanup always is; the
+    standing guarantee remains a sweep, not the rollback.
 - **`off <project>` stands the desk down; it does not dispose of it.** The
   mark is a delivery precondition rechecked at act time (§3, §8), so a
   stood-down desk simply receives nothing — an idle session holding its

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -2251,11 +2251,22 @@ the one way to send a desk substance.
     disposes a desk, so the desk is reclaimed when it dies and not before.
     Reclaiming is destructive enough to soak behind its own default-off switch
     first.
-  - *A spawn that failed before the record was written* leaves nothing for that
+  - *An ensure that ended with no record written* leaves nothing for that
     collector to enumerate, so the **spawn path archives the scratch row
     itself** on every failing exit, which puts the directory under the sweep's
-    deletion-queue pass. Best-effort, as create-time cleanup always is; the
-    standing guarantee remains a sweep, not the rollback.
+    deletion-queue pass. All three exits are covered, including the one that
+    bites hardest — a desk that ran and could not be written down, where the
+    next `on` would otherwise read no entry and spawn a second desk beside a
+    live one. Best-effort, as create-time cleanup always is; the standing
+    guarantee remains a sweep, not the rollback.
+  - *The desk a replacement succeeded* is the third shape, and it is the
+    replacement's own to hand back: recording the successor overwrites the
+    project's entry, so from that moment the predecessor's scratch space is
+    named by nothing the collector enumerates. It is archived once the
+    successor is safely recorded — never before, so a record write that failed
+    leaves the project the one desk it still has. This is not the disposal the
+    rule below forbids: a coverage gesture still disposes of nothing, and what
+    is let go here is a desk already found dead and already replaced.
 - **`off <project>` stands the desk down; it does not dispose of it.** The
   mark is a delivery precondition rechecked at act time (§3, §8), so a
   stood-down desk simply receives nothing — an idle session holding its

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -1297,6 +1297,14 @@ declared project, the operator's copy lives beside the project's definition
 (`~/tbd/supervision/projects/<name>/supervision.md`) and the repo level is
 whichever member repo the project designated.
 
+**Which of those two operator paths applies is decided by whether the project
+is declared, read from `supervision.json` — the one place declarations live.**
+The collapse property holds for the resolved *value*, not for the path lookup:
+a fresh install and one whose file declares a single-repo project per repo
+resolve to equal playbooks, but the two store the operator's copy in different
+places, so a resolved project carries no "is this a singleton" flag and the
+question is asked of the file instead.
+
 **Every desk stands on exactly one playbook**, because a desk supervises
 exactly one project: the whole file is installed as the desk's standing
 conduct at spawn — at the appointment relaunch for an appointed supervisor
@@ -1702,6 +1710,24 @@ account, not a wrong action. The third category is **human-authored process**.
   is the reclamation path, which is the same standing `notes.md` and the
   per-repo hooks already have under `~/tbd/repos/<id>/`. A project directory
   that outlives its project is therefore expected, not a leak.
+- **Derived state TBD owns**, in its own file beside the operator's:
+  - `~/tbd/supervision/desks.json` — which hosted desk serves which project
+    (§9): the terminal, the scratch worktree, when it was spawned, and the
+    conduct hash of the playbook installed as its standing layer. Written with
+    the same atomic temp-and-rename `supervision.json` gets.
+
+    **Separate from `supervision.json` because it is a different kind of
+    fact.** That file holds what an operator *chose*, and its `supervisors`
+    entry is the appointed binding — a selection. A hosted desk is nobody's
+    choice: TBD spawns one because a project was turned on and no supervisor
+    stood, and it rewrites the record with no gesture behind it. Keeping the
+    two apart means a hand edit to the operator's file is never clobbered by a
+    desk spawn, and a damaged desk record can never take the fleet's topology
+    offline.
+
+    **Tracked by id, never by display string**, which is what makes a desk
+    reclaimable after somebody renames its scratch space. A record whose desk
+    is gone is reclaimed by the reconciler §9 names.
 - **In-memory, deliberately not durable**: active one-minute re-check timers
   and the brief pipe's liveness bookkeeping. Timers may live in memory *because*
   everything they encode derives from the durable record — an actuation
@@ -1718,10 +1744,18 @@ account, not a wrong action. The third category is **human-authored process**.
   query-time rule, not a recovery sweep.
 
 Net property: **supervision adds one column to TBD's database** — the fleet
-brake. Everything else it knows is in files a human can open: under
-`~/tbd/supervision/`, in the general actuation log beside TBD's other
-files, and in the playbooks in the repos
-themselves.
+brake. Everything supervision *knows* is in files a human can open: the
+operator's selections, the record, and TBD's own desk bookkeeping under
+`~/tbd/supervision/`, the general actuation log beside TBD's other files, and
+the playbooks in the repos themselves. The one column is the exception because
+it is live coordination state that has to be read at act time and changed
+atomically from two surfaces at once.
+
+The claim is about *state*, not about every boolean the subsystem touches.
+Reclaiming an orphaned desk is garbage collection, and its soak switch is a
+`gc_*` column in the same family as the other collectors' — a gate on TBD's
+housekeeping, carrying no supervision fact and readable as nothing about what
+is covered.
 
 ## 8. Remembered things: advice, selection, and the question route
 
@@ -2201,6 +2235,19 @@ the one way to send a desk substance.
   and in the sweep program's files (§8), which outlive every desk by
   construction — which is why the route and not the desk is the durable
   home for anything needing a human.
+- **An orphaned desk is reclaimed by a named reconciler.** A spawn creates a
+  scratch space and a process before either can be recorded (§7), so a crash
+  or a failed spawn in between leaves a desk nobody owns — and TBD's existing
+  sweeps do not cover it, because the agent-worktree pass only walks
+  repo-backed worktrees and the archived passes only touch rows already
+  archived. A **supervision-desk collector**, run as a leg of the hourly orphan
+  sweep, closes that: it drops the record and hands the scratch worktree to the
+  archive path the sweep already runs. Its reap decision is **liveness and
+  nothing else** — a desk with a process running in its directory is kept
+  whatever its project or its rows say, because a sweep must never kill a
+  running agent, and a project that stopped resolving is closed through the
+  recycle path above rather than by garbage collection. Reclaiming is
+  destructive enough to soak behind its own default-off switch first.
 - **`off <project>` stands the desk down; it does not dispose of it.** The
   mark is a delivery precondition rechecked at act time (§3, §8), so a
   stood-down desk simply receives nothing — an idle session holding its


### PR DESCRIPTION
> Second of four PRs for slice 5 (#633): **1** the playbook (#661, merged) →
> **2 the desk exists** → **3** the desk receives → **4** the desk acts.
> Rebased onto `main` now that #661 has landed, so this targets `main`
> directly.

## Summary

Turning a project on now gives it a supervisor. `tbd supervise on <project>`
ensures a hosted desk — a scratch space with a Claude session in it, standing on
that project's playbook, knowing which project it works for — and
`tbd supervise off <project>` stands that desk down without disposing of it, so
the context it cost real tokens to build survives until the next `on`.

**The desk receives nothing yet.** Delivery, the compiled header, the delivery
ledger line and the `supervisor.live` flip are the next PR's. Until they land,
`supervisor.live` stays `false` and `supervise brief` keeps answering
`no-live-supervisor` — jointly true, because nothing can in fact be delivered to
a desk today. `SupervisionReadoutBuilder` and `SupervisorBriefingDeliverer` are
byte-identical to the base branch, deliberately: a live desk with `live: false`
would make every program's liveness check lie, and the reverse would make the
readout the liar, so they flip together in one commit or not at all.

## Why this shape

**A desk is tracked by ID, never by a display string.** A name-keyed binding is
unreclaimable the moment someone renames the thing it names, which is how
durable resources have leaked in this codebase before. A test asserts the
persisted entry's key set is exactly `{terminal, worktree, spawnedAt,
conductHash}` and that no `name` or `displayName` key exists, so the property is
enforced rather than intended.

**`desks.json` is a new file because the design had nowhere to put this.** §7
pins supervision at exactly one DB column (the fleet brake) with everything else
in files a human can open; `supervision.json` holds operator *selections* only,
and its `supervisors` map is the **appointed** binding, not the hosted desk.
Nothing in the spec said where a hosted desk's terminal ID lives. A new
TBD-owned `~/tbd/supervision/desks.json` keeps the one-column property, stays
operator-readable, and stays out of `supervision.json` precisely because it is
derived state rather than a choice anyone made. §7 is amended to name it.

**Spawn delivers nothing.** No message, nudge, or opening prompt — the opening
material rides the first briefing, so a quiet project's desk idles at zero token
cost. This is a tested property, not a detail.

**`off` stands the desk down; nothing in this PR disposes of a desk.** The mark
is a delivery precondition, so a stood-down desk simply receives nothing while
keeping its context. A stood-down project still appears in the readout —
observability is never withheld.

**The desk forces the Claude adapter.** Standing conduct rides
`--append-system-prompt`, which only the Claude spawn path carries; a Codex desk
would launch with no conduct at all and nothing would say so. Design §9 makes
supervisor capability a per-adapter qualification, so this is that rule applied
rather than a preference — and a Codex-preferring fleet is told in the log
rather than discovering it by reading a tab label.

Spec: [`docs/specs/2026-07-26-fleet-supervision-design.md`](docs/specs/2026-07-26-fleet-supervision-design.md)
§5, §7, §9; standing-conduct mechanics in
[`docs/specs/2026-08-01-fleet-supervision-sweep-program-design.md`](docs/specs/2026-08-01-fleet-supervision-sweep-program-design.md)
§8. Slice 5 is already specced by that set, so no new brainstorm was needed;
the drift this PR does cause is amended in the same diff (below).

## What this PR does

- **`desks.json`** — `SupervisionDesks{File,Entry,Store}`, atomic
  temp-file → `fsync` → `rename(2)` → directory `fsync`, matching
  `SupervisionFileStore`.
- **`SupervisionDeskManager.ensureDesk`** → `.appointed` / `.danglingBinding` /
  `.resumed` / `.spawned` / `.replaced(successor:predecessor:)`. An appointed
  binding is never silently replaced by the hosted default; a dangling one is
  loud. Topology comes from `SupervisionStore.deskInputs(project:)` so
  `supervision.json` keeps exactly one reader.
- **The playbook as a standing layer** — a `TBD_PROMPT_SUPERVISION` layer in
  `SystemPromptBuilder`, plus `TBD_PROJECT` injected following the
  `TBD_WORKTREE_ID` precedent.
- **The supervision skill** in the plugin dir. Note this dir is **fleet-shared**
  — every Claude spawn already gets `--plugin-dir` pointing at it, so the skill
  is visible fleet-wide exactly as the Nightwatch skill is. What makes a desk a
  desk is the standing layer plus `TBD_PROJECT`, never exclusive skill access.
- **Desk lifecycle ledger lines** — spawn, and replacement linking successor to
  predecessor.
- **The Nightwatch mutual exclusion**, both directions.
- **`SupervisionDeskCollector`**, a new `OrphanGC` leg.
- **`tbd gc supervision-desks on|off`** and `docs/orphan-gc.md` coverage.

## Flag & rollout

`gc_supervision_desks_enabled` — daemon config column added by
`v80_config_gc_supervision_desks`, **default OFF**. It carries **no SQL
default**, so NULL ("nobody has chosen") stays distinguishable from an explicit
`0`/`1`, and the shipped default lives in exactly one place,
`?? Config.gcSupervisionDesksEnabledDefault`. Graduation is a one-line change to
that constant, reaching everyone who never touched the toggle while preserving
every explicit opt-out — no forcing migration.

Enable for the soak with `tbd gc supervision-desks on`. Graduate once a soak
shows the collector reclaiming dead desks and never touching live ones. Only the
*reclaiming* is gated; nothing else in this PR is behind a flag, because
spawning a desk happens on an explicit operator gesture.

## Every durable external resource needs a named reconciler

A desk is a scratch space **plus** a live process — the shape that produced this
repo's measured leaks. The orphan has two shapes and each has an owner.

- **A desk that was recorded and then died** → `SupervisionDeskCollector`, a leg
  of the hourly `OrphanGC` sweep. It drops the `desks.json` entry and hands the
  scratch worktree to the archive path the sweep already runs. Its reap decision
  is **liveness and nothing else**: a desk with a process running in its
  directory is kept whatever its project or its rows say. Every failure
  direction is toward keeping — an unreadable file, an unfetchable row, a path
  that does not look like a desk's, all keep.
- **A spawn that failed before the record was written** leaves nothing for that
  collector to enumerate, so the spawn path **archives the scratch row itself**
  on every failing exit, which puts the directory under the sweep's
  deletion-queue leg. Best-effort, as create-time cleanup always is; the
  standing guarantee is still the sweep.

I verified the existing sweeps' boundary rather than assuming it: `OrphanGC`'s
agent-worktree leg iterates `db.repos.list()` and so only walks repo-backed
worktrees, and its archived legs only touch rows already `.archived`. So a
**live** desk was never at risk from them (correct), and an **orphaned** one was
reclaimed by nothing (the gap this closes).

**A project that stops resolving does not trigger a reap**, deliberately. Design
§9 is explicit that a topology gesture ending a project takes its mark, its mode
selection and its supervisor binding — and that no coverage gesture disposes a
desk. Killing a live agent because its project was renamed is precisely what the
doctrine forbids. Once the desk is not live it is reclaimed regardless, so the
check would gate nothing while adding a second reader of `supervision.json`.

**One residual is stated rather than papered over**: a daemon *crash* (as
opposed to a thrown error) between creating the scratch space and writing the
record leaves an unreferenced scratch space that nothing reclaims. It is not
silent — the row is `.active` and visible in the sidebar.

## Assumptions

- **The two exclusion gates are not mutually atomic.** `supervise on` reads the
  Nightwatch mode before writing the mark; `nightwatch.setMode` reads the marked
  projects before writing the mode. Two RPCs issued in the same instant could
  both pass and leave both paths on. Closing it means a lock shared across two
  handlers, which is a design call rather than a fix, and it takes two operator
  gestures at the same moment to reach. If both paths ever are found on
  together, this is why.
- **Desk liveness is a process-in-directory fact**, read through the sweep's
  existing `lsof` cwd set with the same prefix-boundary matching every other leg
  uses. If a desk's process is running with a cwd outside its scratch space, it
  reads as dead.

## Evidence & verification

`scripts/test.sh`: **6846 tests in 697 suites**. `swiftlint --strict`: 0
violations in 766 files. `scripts/swift-safe build`: clean.

Both branches of every new conditional are covered. Highlights:

- Spawn delivers nothing; a stood-down project still appears in the readout.
- Both Nightwatch refusals — and **the wedge state**: with Nightwatch running
  *and* a project marked, setting the mode `off` still succeeds. `off` is
  refusable in neither direction, so an operator can always get out.
- A live desk survives a sweep; a dead one is reclaimed; the flag ships off.
- The three-state flag column: a pre-migration row reads NULL, NULL follows a
  changed default, an explicit `false` survives one.
- A replacement's predecessor is archived, and only after the successor is
  safely recorded.
- A reap landing mid-spawn survives the record write — the test drops a
  *different* project's entry during the spawn and asserts that change is not
  clobbered, so "the new entry is present" cannot pass it.

**Guards were mutation-checked, not merely asserted.** Deleting the
`TBD_PROMPT_SUPERVISION` append from `build()` turned the two composed-string
tests red while the map-only test **stayed green** — `promptLayers` and `build()`
are separately maintained, so a test asserting only the env map would have
shipped a desk with no conduct. Each of the seven review fixes was likewise
reverted, observed red, and restored: the predecessor leak, the record-write
exit, the exact-path liveness match, the failed-read-reads-as-gone collapse, the
`forget` mismatch, and the terminal broadcast.

Two bugs surfaced from writing the tests rather than from reading the code: a
check-then-create race in scratch-space allocation where two concurrent ensures
could pick the same name, and a replacement that orphaned its predecessor's
scratch space permanently — one leaked directory per replacement.

[20260816-lucky-tern](https://cheapsteak.github.io/tbd/open/?worktree=727D12E2-18EB-4259-A6D8-71CDFEBA8DCE)

https://claude.ai/code/session_01PSjtUmDrA4nYbNCAFgz4f3
