### PR TITLE
Feat: Stop the first-message "Send immediately" box forgetting every time

### DIFF
--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -38,6 +38,8 @@ struct GeneralSettingsTab: View {
     @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = AppState.enableTranscriptDefault
     @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
+    @AppStorage(QueuedPromptComposer.sendImmediatelyKey)
+    private var sendFirstMessageImmediately: Bool = QueuedPromptComposer.sendImmediatelyDefault
     @AppStorage(AppState.showClaudeTabUsageTooltipKey) private var showClaudeTabUsageTooltip: Bool = true
     @AppStorage(AppState.usageResetTimeStyleKey)
     private var usageResetTimeStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset
@@ -157,6 +159,9 @@ struct GeneralSettingsTab: View {
 
                 Toggle("Show Scratch section", isOn: $showScratchSection)
                     .help("Hide the repo-less Scratch section. Existing scratch spaces and their terminals keep running.")
+
+                Toggle("Send first messages immediately", isOn: $sendFirstMessageImmediately)
+                    .help("On: TBD presses Return, and the agent starts working the moment the first message is in. Off: the text waits in the composer for you to read and send. The checkbox in the first-message sheet changes this too.")
 
                 Toggle("Automatically clean up orphaned agent worktrees", isOn: Binding(
                     get: { appState.gcEnabled },

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -161,7 +161,7 @@ struct GeneralSettingsTab: View {
                     .help("Hide the repo-less Scratch section. Existing scratch spaces and their terminals keep running.")
 
                 Toggle("Send first messages immediately", isOn: $sendFirstMessageImmediately)
-                    .help("On: TBD presses Return, and the agent starts working the moment the first message is in. Off: the text waits in the composer for you to read and send. The checkbox in the first-message sheet changes this too.")
+                    .help("Default for first messages you write while a new worktree is coming up. On: TBD presses Return, and the agent starts working the moment the message is in. Off: the text waits in the composer for you to read and send. The \"Send immediately\" checkbox in that creation sheet changes this too; the identical-looking checkbox on an already-parked message edits only that message.")
 
                 Toggle("Automatically clean up orphaned agent worktrees", isOn: Binding(
                     get: { appState.gcEnabled },

--- a/Sources/TBDApp/Worktree/QueuedPromptModal.swift
+++ b/Sources/TBDApp/Worktree/QueuedPromptModal.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 import TBDShared
 
@@ -63,7 +64,15 @@ final class QueuedPromptTarget: ObservableObject, Identifiable {
 /// the read-back — which must agree, because the toggle means the same thing in
 /// both and an operator meets them a minute apart.
 enum QueuedPromptComposer {
-    /// Whether a NEW first message sends itself once it reaches the composer.
+    /// `UserDefaults` key holding the operator's remembered answer for new
+    /// first messages (`docs/specs/2026-08-16-send-immediately-preference-design.md`).
+    /// Written by the creation modal's checkbox and by the Settings ▸ General ▸
+    /// Worktrees row, which are two views onto this one key.
+    static let sendImmediatelyKey = "queuedPromptSendImmediately"
+
+    /// Whether a NEW first message sends itself once it reaches the composer,
+    /// for an operator who has never answered. The choice persists once made,
+    /// so this is the value they meet the first time and never again.
     ///
     /// OFF. Delivery types the message in and stops there unless the operator
     /// ticks the box, because sending is what starts a turn nobody watched
@@ -76,6 +85,30 @@ enum QueuedPromptComposer {
     /// An EXISTING parked message ignores this and shows the bit stored with
     /// it, so the composer never misreports what delivery will do.
     static let sendImmediatelyDefault = false
+
+    /// Resolve the remembered answer, keeping "never chose" distinct from
+    /// "chose off".
+    ///
+    /// The `object(forKey:) as? Bool ??` shape is the point, not a style echo:
+    /// `UserDefaults.bool(forKey:)` collapses absent into `false`, and once
+    /// those read alike a later change to `sendImmediatelyDefault` either
+    /// reaches nobody or overrides deliberate opt-outs — the same destroyed
+    /// distinction that made `auto_hibernate_enabled` unflippable.
+    ///
+    /// `shippedDefault` is a defaulted test seam, not a production knob: it
+    /// lets a test prove the absent case *follows* the default rather than
+    /// coincidentally matching today's `false`.
+    ///
+    /// The views read the key through `@AppStorage`, which applies this same
+    /// rule internally. This is that rule in assertable form — `@AppStorage`
+    /// lives in a `View` and cannot be unit-tested — and the read site for any
+    /// future non-view caller.
+    static func resolveSendImmediately(
+        defaults: UserDefaults,
+        shippedDefault: Bool = sendImmediatelyDefault
+    ) -> Bool {
+        defaults.object(forKey: sendImmediatelyKey) as? Bool ?? shippedDefault
+    }
 }
 
 /// Sheet for the prompt an operator composes while a freshly created worktree
@@ -91,7 +124,14 @@ struct QueuedPromptModal: View {
     @ObservedObject var target: QueuedPromptTarget
 
     @State private var draft: String = ""
-    @State private var sendImmediately = QueuedPromptComposer.sendImmediatelyDefault
+
+    /// Remembered across composers, and written the moment the box is ticked —
+    /// including when the sheet is then dismissed with Escape. That is what the
+    /// gesture means: "I want this on", not "I want this on if I also send this
+    /// particular message". Settings ▸ General ▸ Worktrees is where the
+    /// preference is audited and reversed.
+    @AppStorage(QueuedPromptComposer.sendImmediatelyKey)
+    private var sendImmediately = QueuedPromptComposer.sendImmediatelyDefault
 
     private var isBlank: Bool {
         draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/Sources/TBDApp/Worktree/QueuedPromptModal.swift
+++ b/Sources/TBDApp/Worktree/QueuedPromptModal.swift
@@ -60,14 +60,28 @@ final class QueuedPromptTarget: ObservableObject, Identifiable {
     }
 }
 
-/// Shared settings for the two first-message composers — the creation modal and
-/// the read-back — which must agree, because the toggle means the same thing in
-/// both and an operator meets them a minute apart.
+/// The home for what a NEW first message starts from — the creation modal's
+/// checkbox and the Settings ▸ General ▸ Worktrees row, which are two views
+/// onto the key below.
+///
+/// The read-back composer (`ParkedPromptReadbackView`) deliberately does NOT
+/// read this key, and must not be wired to it "for consistency": it seeds from
+/// the `submit` bit stored with the message on screen, so it can never
+/// misreport what delivery will do for that particular message.
 enum QueuedPromptComposer {
     /// `UserDefaults` key holding the operator's remembered answer for new
     /// first messages (`docs/specs/2026-08-16-send-immediately-preference-design.md`).
     /// Written by the creation modal's checkbox and by the Settings ▸ General ▸
     /// Worktrees row, which are two views onto this one key.
+    ///
+    /// Never register a default for this key. The three-state distinction below
+    /// holds against the *persistent* domain only, so a
+    /// `UserDefaults.register(defaults:)` entry — a natural-looking addition,
+    /// since the app already calls that in `TBDApp.swift` and
+    /// `TableTranscriptView.swift` — would make `object(forKey:)` answer for a
+    /// key nobody chose, collapsing "never chose" back into "chose off". The
+    /// tests cannot catch that: they use isolated `UserDefaults(suiteName:)`,
+    /// whose registration domains are empty.
     static let sendImmediatelyKey = "queuedPromptSendImmediately"
 
     /// Whether a NEW first message sends itself once it reaches the composer,
@@ -99,10 +113,10 @@ enum QueuedPromptComposer {
     /// lets a test prove the absent case *follows* the default rather than
     /// coincidentally matching today's `false`.
     ///
-    /// The views read the key through `@AppStorage`, which applies this same
-    /// rule internally. This is that rule in assertable form — `@AppStorage`
-    /// lives in a `View` and cannot be unit-tested — and the read site for any
-    /// future non-view caller.
+    /// The shipped views read the key through `@AppStorage` and never call
+    /// this, so a test here asserts the contract, not those views. This is the
+    /// contract in assertable form, and the read site for any future non-view
+    /// caller.
     static func resolveSendImmediately(
         defaults: UserDefaults,
         shippedDefault: Bool = sendImmediatelyDefault
@@ -155,7 +169,7 @@ struct QueuedPromptModal: View {
             .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
 
             Toggle("Send immediately", isOn: $sendImmediately)
-                .help("On: TBD presses Return, and the agent starts working the moment the message is in. Off: the text waits in the composer for you to read and send.")
+                .help("On: TBD presses Return, and the agent starts working the moment the message is in. Off: the text waits in the composer for you to read and send. Remembered for future worktrees — change it in Settings ▸ General ▸ Worktrees.")
 
             HStack {
                 Text("↩ to \(sendImmediately ? "send" : "queue") · ⇧↩ or ⌥↩ for a new line")

--- a/Tests/TBDAppTests/ParkedPromptReadbackTests.swift
+++ b/Tests/TBDAppTests/ParkedPromptReadbackTests.swift
@@ -334,11 +334,12 @@ struct ParkedPromptReadbackTests {
 
     // MARK: - Sending is opt-in
 
-    @Test("A new first message does not send itself")
+    @Test("Sending is opt-in: the shipped default is off")
     func sendingIsOptIn() {
-        // Delivery types the message into the composer and stops. Sending
-        // starts a turn nobody watched begin, and is the one half TBD cannot
-        // report on afterwards — so it is the operator's to ask for.
+        // Until an operator opts in, delivery types the message into the
+        // composer and stops. Sending starts a turn nobody watched begin, and
+        // is the one half TBD cannot report on afterwards — so it is the
+        // operator's to ask for.
         #expect(QueuedPromptComposer.sendImmediatelyDefault == false)
     }
 

--- a/Tests/TBDAppTests/SendImmediatelyPreferenceTests.swift
+++ b/Tests/TBDAppTests/SendImmediatelyPreferenceTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import SwiftUI
 @testable import TBDApp
 
 /// The three states `QueuedPromptComposer.resolveSendImmediately` must keep
@@ -10,6 +11,12 @@ import Foundation
 /// is asserted against an explicitly-supplied shipped default rather than
 /// against the constant, which today happens to be `false` and would let a
 /// collapsing resolver pass by coincidence.
+///
+/// The resolver is the contract in assertable form; the shipped surfaces read
+/// the key through `@AppStorage` instead. So the last three tests cover the
+/// mechanism rather than the statement of it: `@AppStorage`'s resolution and
+/// write-back are pinned to the resolver's answer on the same store, and the
+/// modal's checkbox is checked to still be `@AppStorage`-backed.
 ///
 /// Tier 1. Each test gets its own `UserDefaults(suiteName:)` and tears it down;
 /// `UserDefaults.standard` on this unbundled executable is the developer's real
@@ -63,5 +70,127 @@ struct SendImmediatelyPreferenceTests {
         #expect(QueuedPromptComposer.resolveSendImmediately(defaults: defaults))
         #expect(
             QueuedPromptComposer.resolveSendImmediately(defaults: defaults, shippedDefault: false))
+    }
+
+    /// The shipped surfaces — the modal's checkbox and the Settings row — read
+    /// the key through `@AppStorage`, never through `resolveSendImmediately`.
+    /// So the three tests above prove a contract, and this one proves the
+    /// mechanism actually in the binary satisfies it: for every one of the three
+    /// states, against the same store, `AppStorage.wrappedValue` and the
+    /// resolver must agree. A divergence in either direction reddens — SwiftUI
+    /// changing how it resolves an absent key, or the resolver drifting away
+    /// from what the views do.
+    ///
+    /// `AppStorage` is a property wrapper struct, so it can be built and read
+    /// outside a `View` as long as the store is injected. It must be: the
+    /// storeless form resolves against `UserDefaults.standard`, which on this
+    /// unbundled executable is the developer's real `TBDApp.plist`.
+    ///
+    /// Both polarities of the shipped default are exercised for the absent
+    /// case, for the same reason the resolver's own test does it — today's
+    /// `false` would let a resolution that collapses absent into `false` pass by
+    /// coincidence.
+    ///
+    /// Tier 1.
+    @Test("@AppStorage resolves the key the way the contract says it does")
+    func appStorageAgreesWithResolverAcrossAllThreeStates() {
+        let suiteName = "send-immediately-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let key = QueuedPromptComposer.sendImmediatelyKey
+
+        // Absent. Asserted against both shipped defaults, so the key genuinely
+        // follows the default rather than matching today's `false` by accident.
+        for shippedDefault in [false, true] {
+            let storage = AppStorage(wrappedValue: shippedDefault, key, store: defaults)
+            #expect(defaults.object(forKey: key) == nil)
+            #expect(
+                storage.wrappedValue
+                    == QueuedPromptComposer.resolveSendImmediately(
+                        defaults: defaults, shippedDefault: shippedDefault))
+            #expect(storage.wrappedValue == shippedDefault)
+        }
+
+        // Chose off. A deliberate opt-out must survive a shipped default of
+        // `true` on the `@AppStorage` side as well, which is where a collapsing
+        // resolution would show up.
+        defaults.set(false, forKey: key)
+        let storedFalse = AppStorage(wrappedValue: true, key, store: defaults)
+        #expect(
+            storedFalse.wrappedValue
+                == QueuedPromptComposer.resolveSendImmediately(
+                    defaults: defaults, shippedDefault: true))
+        #expect(!storedFalse.wrappedValue)
+
+        // Chose on.
+        defaults.set(true, forKey: key)
+        let storedTrue = AppStorage(wrappedValue: false, key, store: defaults)
+        #expect(
+            storedTrue.wrappedValue
+                == QueuedPromptComposer.resolveSendImmediately(
+                    defaults: defaults, shippedDefault: false))
+        #expect(storedTrue.wrappedValue)
+    }
+
+    /// Ticking the box has to persist, not just move the on-screen toggle —
+    /// "remembered for future worktrees" is the whole feature, and the modal
+    /// writes it the moment the box is ticked, even if the sheet is then
+    /// dismissed with Escape. This asserts the write half of the same seam: a
+    /// value set through `wrappedValue` lands in the store, and the resolver
+    /// reads it back as a stored choice rather than as the absent case.
+    ///
+    /// Tier 1.
+    @Test("writing through @AppStorage persists the choice to the store")
+    func appStorageWriteReachesTheStore() {
+        let suiteName = "send-immediately-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let key = QueuedPromptComposer.sendImmediatelyKey
+        let storage = AppStorage(wrappedValue: false, key, store: defaults)
+        #expect(defaults.object(forKey: key) == nil)
+
+        storage.wrappedValue = true
+
+        #expect(defaults.object(forKey: key) as? Bool == true)
+        #expect(QueuedPromptComposer.resolveSendImmediately(defaults: defaults))
+        // And back off — an opt-out is a stored choice too, not a return to
+        // "never chose", or a later default flip would silently re-enable it.
+        storage.wrappedValue = false
+        #expect(defaults.object(forKey: key) as? Bool == false)
+        #expect(
+            !QueuedPromptComposer.resolveSendImmediately(defaults: defaults, shippedDefault: true))
+    }
+
+    /// The modal's checkbox must stay bound to the persisted key. Reverting
+    /// `@AppStorage` to `@State` — the shape it had before this feature, and the
+    /// shape a future merge conflict resolves back to most easily — would leave
+    /// every assertion above passing while the box forgot the operator's answer
+    /// the moment the sheet closed.
+    ///
+    /// The property wrapper's backing storage is reflectable, so the guard is
+    /// the declared TYPE of the `_sendImmediately` child. Its `wrappedValue` is
+    /// deliberately never read and the view is never rendered: this instance's
+    /// `@AppStorage` has no injected store, so it resolves against
+    /// `UserDefaults.standard` — the developer's real `TBDApp.plist` on this
+    /// unbundled executable. Constructing the wrapper neither reads the key nor
+    /// writes to that store; only touching `wrappedValue` would.
+    ///
+    /// Tier 1.
+    @Test("the modal's checkbox is bound to the persisted key, not to view state")
+    func modalCheckboxIsBackedByAppStorage() {
+        let target = QueuedPromptTarget(
+            placeholderID: UUID(), repoID: UUID(), worktreeName: "acme-feature")
+        let modal = QueuedPromptModal(target: target)
+
+        let backing = Mirror(reflecting: modal).children
+            .first { $0.label == "_sendImmediately" }
+        #expect(backing != nil, "QueuedPromptModal no longer has a sendImmediately property")
+        if let backing {
+            #expect(
+                String(describing: type(of: backing.value)) == "AppStorage<Bool>",
+                "expected @AppStorage-backed storage, found \(type(of: backing.value))")
+        }
     }
 }

--- a/Tests/TBDAppTests/SendImmediatelyPreferenceTests.swift
+++ b/Tests/TBDAppTests/SendImmediatelyPreferenceTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import TBDApp
+
+/// The three states `QueuedPromptComposer.resolveSendImmediately` must keep
+/// distinct (`docs/specs/2026-08-16-send-immediately-preference-design.md`):
+/// never chose, chose off, chose on. `UserDefaults.bool(forKey:)` collapses the
+/// first two into `false`, which is the destroyed distinction that made
+/// `auto_hibernate_enabled` unflippable on the daemon side — so the absent case
+/// is asserted against an explicitly-supplied shipped default rather than
+/// against the constant, which today happens to be `false` and would let a
+/// collapsing resolver pass by coincidence.
+///
+/// Tier 1. Each test gets its own `UserDefaults(suiteName:)` and tears it down;
+/// `UserDefaults.standard` on this unbundled executable is the developer's real
+/// `TBDApp.plist`.
+@MainActor
+@Suite("Send immediately preference")
+struct SendImmediatelyPreferenceTests {
+    @Test("an absent key follows the shipped default, whatever it is")
+    func absentKeyResolvesToShippedDefault() {
+        let suiteName = "send-immediately-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(defaults.object(forKey: QueuedPromptComposer.sendImmediatelyKey) == nil)
+        #expect(
+            QueuedPromptComposer.resolveSendImmediately(defaults: defaults)
+                == QueuedPromptComposer.sendImmediatelyDefault)
+        // The discriminating pair: absent must follow the default in BOTH
+        // directions. A `defaults.bool(forKey:)` resolver fails the `true` arm.
+        #expect(
+            QueuedPromptComposer.resolveSendImmediately(defaults: defaults, shippedDefault: true))
+        #expect(
+            !QueuedPromptComposer.resolveSendImmediately(defaults: defaults, shippedDefault: false))
+    }
+
+    @Test("an explicit false is a stored choice, not the absent case")
+    func explicitFalseIsDistinctFromAbsent() {
+        let suiteName = "send-immediately-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: QueuedPromptComposer.sendImmediatelyKey)
+
+        #expect(defaults.object(forKey: QueuedPromptComposer.sendImmediatelyKey) != nil)
+        #expect(!QueuedPromptComposer.resolveSendImmediately(defaults: defaults))
+        // A deliberate opt-out must survive a future flip of the shipped
+        // default, so this is asserted against `true` rather than against the
+        // constant.
+        #expect(
+            !QueuedPromptComposer.resolveSendImmediately(defaults: defaults, shippedDefault: true))
+    }
+
+    @Test("an explicit true reads true")
+    func explicitTrueReadsTrue() {
+        let suiteName = "send-immediately-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: QueuedPromptComposer.sendImmediatelyKey)
+
+        #expect(QueuedPromptComposer.resolveSendImmediately(defaults: defaults))
+        #expect(
+            QueuedPromptComposer.resolveSendImmediately(defaults: defaults, shippedDefault: false))
+    }
+}

--- a/docs/specs/2026-08-16-send-immediately-preference-design.md
+++ b/docs/specs/2026-08-16-send-immediately-preference-design.md
@@ -33,15 +33,16 @@ written by both.
 ### Where the setting lives
 
 `QueuedPromptComposer` — the enum in `Sources/TBDApp/Worktree/QueuedPromptModal.swift`
-that already declares itself the shared home for settings the two first-message
-composers must agree on — gains three members alongside the existing default:
+that holds what a new first message starts from — carries three members, two of
+them new:
 
 - **`sendImmediatelyKey`** — `"queuedPromptSendImmediately"`, the `UserDefaults`
-  key.
+  key. New.
 - **`sendImmediatelyDefault`** — unchanged at `false`. Still the single place
   the shipped default lives.
-- **`resolveSendImmediately(defaults:)`** — `defaults.object(forKey:) as? Bool
-  ?? sendImmediatelyDefault`.
+- **`resolveSendImmediately(defaults:shippedDefault:)`** —
+  `defaults.object(forKey:) as? Bool ?? shippedDefault`, with `shippedDefault`
+  defaulted to `sendImmediatelyDefault`. New.
 
 The resolver's `object(forKey:) as? Bool ??` shape, matching
 `AppState.enableTranscript` (`AppState.swift`), is the point rather than a
@@ -52,6 +53,14 @@ explicitly-off read alike, a later change to the shipped default either skips
 everyone or overrides deliberate opt-outs. Reading the raw object keeps three
 states, so flipping `sendImmediatelyDefault` later reaches everyone who never
 touched the toggle and preserves everyone who did.
+
+`shippedDefault` is a defaulted test seam, not a production knob — every real
+caller takes the default and reads `sendImmediatelyDefault`. It exists so a
+test can prove the absent case *follows* the shipped default rather than
+coincidentally matching today's `false`: without it, the absent-key assertion
+degenerates to `false == false`, which a resolver that collapsed absent into
+`false` — the exact defect this shape exists to prevent — would pass by
+accident.
 
 ### Who reads and writes it
 
@@ -76,9 +85,18 @@ message, and nothing else.
 
 **Settings ▸ General ▸ Worktrees** gains a row bound to the same key by
 `@AppStorage`, next to the other defaults that apply to newly created
-worktrees: "Send first messages immediately", carrying the same help text the
-composer's toggle uses. That placement is what makes the preference
-discoverable and resettable without opening a composer.
+worktrees: "Send first messages immediately". That placement is what makes the
+preference discoverable and resettable without opening a composer.
+
+The two surfaces do not share help text, because each has a different thing to
+add. The composer's toggle explains what ticking the box does to the message
+being written, then says the tick is remembered and points at Settings. The
+Settings row explains the default it sets and names the surface that also
+writes it — specifically the sheet that opens while a new worktree comes up,
+because a *second* sheet carries the identical title (`First message for
+<name>`) and the identical checkbox label, and that one reads back an
+already-parked message and edits only that message. Naming which sheet is what
+stops an operator reading the row as a claim about the read-back.
 
 ### What does not change
 
@@ -101,7 +119,9 @@ never `UserDefaults.standard`, which on this unbundled executable is the
 developer's real `TBDApp.plist`. Three cases, one per state the resolver must
 keep distinct:
 
-- An absent key resolves to `sendImmediatelyDefault`.
+- An absent key resolves to `sendImmediatelyDefault` — asserted through
+  `shippedDefault` in both positions, so the case proves the fallback is
+  *followed* rather than agreeing with it by coincidence.
 - An explicit `false` reads `false` and stays `false` regardless of what the
   default constant says — the assertion that a future graduation cannot
   override a deliberate opt-out.

--- a/docs/specs/2026-08-16-send-immediately-preference-design.md
+++ b/docs/specs/2026-08-16-send-immediately-preference-design.md
@@ -1,0 +1,131 @@
+# Remembering "Send immediately"
+
+Status: design, approved. App-only preference, ships resolving to OFF.
+
+## The problem
+
+The first-message composer that opens on worktree creation
+(`QueuedPromptModal`, from
+[`2026-08-10-queued-prompt-on-create-design.md`](2026-08-10-queued-prompt-on-create-design.md))
+carries a "Send immediately" checkbox. It starts unticked every time, because
+its `@State` is seeded from the compiled constant
+`QueuedPromptComposer.sendImmediatelyDefault`. There is nowhere for a decision
+about it to live.
+
+An operator who wants first messages to send has to make that choice again on
+every worktree they create. The choice is stable — someone who wants the agent
+to start working the moment the message lands wants it on the tenth worktree
+too — so re-asking is pure friction, and a checkbox that forgets reads as
+broken rather than cautious.
+
+The original OFF default was not arbitrary, and this design keeps its
+reasoning: submitting starts a turn nobody watched begin, and it is the half
+TBD cannot report on afterwards, since an unsubmitted draft leaves no
+machine-readable trace. That argues for making the operator *opt in*. It does
+not argue for making them opt in repeatedly. An opt-in that persists is still
+an opt-in.
+
+## The design
+
+One `UserDefaults` key, read by the new-message composer and by a Settings row,
+written by both.
+
+### Where the setting lives
+
+`QueuedPromptComposer` — the enum in `Sources/TBDApp/Worktree/QueuedPromptModal.swift`
+that already declares itself the shared home for settings the two first-message
+composers must agree on — gains three members alongside the existing default:
+
+- **`sendImmediatelyKey`** — `"queuedPromptSendImmediately"`, the `UserDefaults`
+  key.
+- **`sendImmediatelyDefault`** — unchanged at `false`. Still the single place
+  the shipped default lives.
+- **`resolveSendImmediately(defaults:)`** — `defaults.object(forKey:) as? Bool
+  ?? sendImmediatelyDefault`.
+
+The resolver's `object(forKey:) as? Bool ??` shape, matching
+`AppState.enableTranscript` (`AppState.swift`), is the point rather than a
+stylistic echo. `UserDefaults.bool(forKey:)` collapses "never chose" into
+`false`, which is the same destroyed distinction that made
+`auto_hibernate_enabled` unflippable on the daemon side: once absent and
+explicitly-off read alike, a later change to the shipped default either skips
+everyone or overrides deliberate opt-outs. Reading the raw object keeps three
+states, so flipping `sendImmediatelyDefault` later reaches everyone who never
+touched the toggle and preserves everyone who did.
+
+### Who reads and writes it
+
+**`QueuedPromptModal`** replaces its `@State private var sendImmediately` with
+`@AppStorage(QueuedPromptComposer.sendImmediatelyKey)`, defaulted to
+`sendImmediatelyDefault`. Ticking the box writes the key immediately, so the
+next composer opens ticked.
+
+Writing on tick rather than on submit is deliberate. "Check it once and it
+stays checked" is what a preference means, and the alternative — commit only if
+the message is also sent — makes the setting silently conditional on an
+unrelated later gesture. The cost is that ticking the box and then pressing
+Escape still changes the preference; that is the correct reading of the
+gesture, and the Settings row makes it visible and reversible.
+
+**`ParkedPromptReadbackView`** is untouched. It keeps seeding its checkbox from
+`readback.submit` — the bit stored with that particular parked prompt — and
+never writes the key. Its job is to state what delivery will actually do for
+the message in front of the operator, so it cannot show a global preference
+that may disagree with the parked bit. Toggling it there edits that one
+message, and nothing else.
+
+**Settings ▸ General ▸ Worktrees** gains a row bound to the same key by
+`@AppStorage`, next to the other defaults that apply to newly created
+worktrees: "Send first messages immediately", carrying the same help text the
+composer's toggle uses. That placement is what makes the preference
+discoverable and resettable without opening a composer.
+
+### What does not change
+
+Nothing crosses the RPC boundary. `worktree.setPendingPrompt` still carries an
+explicit `submit` bit per prompt, and the daemon never learns this preference
+exists — it sees only a per-message choice, exactly as before. No schema
+change, no shared model change, no daemon-side default.
+
+No new feature flag either. The key resolves to `false` until an operator
+chooses otherwise, which is already the OFF-first shape a flag would impose,
+and the composer itself remains gated behind the daemon's
+`queued_prompt_enabled`. Adding a flag to gate a default-off preference would
+be flag sprawl guarding nothing.
+
+## Testing
+
+A suite in `Tests/TBDAppTests/`, following `ShowScratchSectionSettingTests` —
+`UserDefaults(suiteName:)` with `removePersistentDomain(forName:)` teardown,
+never `UserDefaults.standard`, which on this unbundled executable is the
+developer's real `TBDApp.plist`. Three cases, one per state the resolver must
+keep distinct:
+
+- An absent key resolves to `sendImmediatelyDefault`.
+- An explicit `false` reads `false` and stays `false` regardless of what the
+  default constant says — the assertion that a future graduation cannot
+  override a deliberate opt-out.
+- An explicit `true` reads `true`.
+
+## Rejected alternatives
+
+**Settings-only, with the composer's checkbox as a one-shot override.** The
+preference would live solely in Settings and merely supply the composer's
+starting value; ticking the box in the composer would affect that message
+alone. This is safer in the narrow sense that a one-off tick cannot change
+future behavior — but it answers the wrong complaint. The operator's gesture is
+already "I want this on", made at the checkbox; sending them to a Settings
+window to make it stick adds a step to the exact interaction the design exists
+to shorten.
+
+**Sticky checkbox with no Settings row.** The smallest diff: persist the
+composer's own value and stop. Rejected because the preference would then be
+invisible — changeable only by creating a worktree, and undiscoverable by
+anyone who has not already noticed the box remembering. A persisted setting
+with no home in Settings is state the operator cannot audit.
+
+**Feeding the preference from the read-back composer too.** Consistent in the
+shallow sense that the box would remember wherever it is ticked, but the
+read-back is editing one already-parked message; giving that edit a global
+side effect means an operator adjusting a single prompt silently changes what
+every future worktree does.


### PR DESCRIPTION
## Summary

Creating a worktree opens a sheet for the first message you want the agent to work on, with a **Send immediately** checkbox: ticked, TBD presses Return and the agent starts as soon as the text lands; unticked, the message waits in the composer for you to read and send.

That box started unticked every single time. Someone who wants their first messages to send — a stable preference, not a per-message judgement — had to re-tick it on every worktree they created. A checkbox that forgets reads as broken rather than cautious.

Now the choice sticks. Tick it once and the next composer opens ticked, and there's a matching row in **Settings ▸ General ▸ Worktrees** so the preference is visible and reversible without creating a worktree to get at it.

## Why this shape

Spec: [`docs/specs/2026-08-16-send-immediately-preference-design.md`](docs/specs/2026-08-16-send-immediately-preference-design.md).

The OFF default was a deliberate decision in the [original queued-prompt design](docs/specs/2026-08-10-queued-prompt-on-create-design.md), and it survives here intact: submitting starts a turn nobody watched begin, and it's the half TBD can't report on afterwards, since an unsubmitted draft leaves no machine-readable trace. That argues for making the operator opt *in*. It doesn't argue for making them opt in repeatedly. An opt-in that persists is still an opt-in.

Three decisions worth naming:

- **The checkbox writes the preference itself, rather than Settings owning it and the checkbox being a one-shot override.** The gesture "I want this on" already happens at the checkbox; sending someone to a Settings window to make it stick adds a step to the exact interaction this exists to shorten. The cost is that ticking the box and then pressing Escape still changes the preference — accepted, because the next composer opens *visibly* ticked before anything can send.
- **`ParkedPromptReadbackView` deliberately does not read the key.** It seeds from the `submit` bit stored with that particular parked message, so it can never misreport what delivery will actually do for the message on screen. Wiring it to the preference "for consistency" is explicitly rejected in the spec, and the enum's doc comment now says so at the edit site.
- **The read goes through `object(forKey:) as? Bool ?? shippedDefault`, never `bool(forKey:)`.** That keeps "never chose" distinct from "chose off". Collapsing them is what left `auto_hibernate_enabled` unflippable: once absent and explicitly-off read alike, a later change to the shipped default either reaches nobody or overrides deliberate opt-outs.

## What this PR does

- `QueuedPromptModal.swift` — `@State` becomes `@AppStorage` on a new `queuedPromptSendImmediately` key; adds the key, a `resolveSendImmediately(defaults:shippedDefault:)` helper stating the three-state contract, and a `.help` clause telling the operator the tick is remembered.
- `SettingsView.swift` — a "Send first messages immediately" row in the Worktrees section, bound to the same key.
- `SendImmediatelyPreferenceTests.swift` — six cases: three on the resolver, one per state it must keep distinct, plus three on the mechanism the shipped views actually use — `@AppStorage`'s resolution and its write-back pinned to the resolver's answer on the same store, and a reflection check that the modal's checkbox is still `@AppStorage`-backed.
- `ParkedPromptReadbackTests.swift` — retitles a neighbouring test whose title this change falsified ("A new first message does not send itself" is no longer true for someone who opted in; the body only ever asserted the shipped default).

No flag, migration, or wire change. The key resolves OFF until someone chooses otherwise — already the OFF-first shape a flag would impose — and the composer stays gated behind the daemon's `queued_prompt_enabled`. `worktree.setPendingPrompt` still carries an explicit per-message `submit` bit; the daemon never learns this preference exists.

## Assumptions

- **Nothing registers a default for `queuedPromptSendImmediately`.** The three-state distinction holds against the persistent domain only. A future `UserDefaults.register(defaults:)` for this key would make "never chose" and "chose off" read alike again, and the tests could not catch it — they use isolated `UserDefaults(suiteName:)` instances with empty registration domains. Nothing registers it today; there's a comment on the key saying not to start.
- **Two sheets share a title and a checkbox label.** Both the creation modal and the read-back are headed "First message for `<name>`" with a "Send immediately" box, and only the first writes the preference. The Settings help text names which one; if either sheet's copy changes, that disambiguation has to keep up.

## Evidence & verification

- `scripts/test.sh --filter "^TBDAppTests\."` → **2210 tests in 232 suites passed**, 0 `error:` lines (2207 before the three `@AppStorage` cases were added).
- `swiftlint --strict` → 0 violations in 758 files.
- **Discriminating evidence.** The suite was run against a deliberately weakened resolver (`defaults.bool(forKey:)`, the collapsing read this design exists to prevent) and went red on the `shippedDefault: true` arm of `absentKeyResolvesToShippedDefault`, then green again once restored. Without that arm the absent-key case degenerates to `false == false`, which the broken resolver passes by accident.

- **Live-verified in the running app.** Built and installed via `scripts/restart.sh` (the running bundle confirmed byte-identical to this worktree's build by SHA-256, so the check was against this code and not a stale install), then driven by hand: the Settings ▸ General ▸ Worktrees row appears unticked; ticking **Send immediately** in a creation sheet and dismissing it with Escape leaves the preference set; the next creation sheet opens already ticked, and the Settings row agrees. That covers the path the tests deliberately do not reach — the real sheet, the real binding, the real write on tick.

One limit, stated rather than papered over:

- **The binding is covered by proxy, not by rendering.** `resolveSendImmediately` still has no production callers — both surfaces use `@AppStorage`, whose semantics are Apple's, not this helper's — so three tests reach the mechanism instead of the statement. `AppStorage` is a property wrapper struct, so it can be built with an injected store outside a `View`: two tests assert its `wrappedValue` agrees with the resolver on the same store across all three states (absent under both shipped-default polarities, chose-off, chose-on) and that a write through `wrappedValue` lands in the store as a stored choice. A divergence in either direction now reddens. A third mirrors a constructed `QueuedPromptModal` and asserts the `_sendImmediately` child's type is `AppStorage<Bool>`, so a merge conflict restoring `@State` fails rather than passing silently — it reads the declared type only, never `wrappedValue`, which without an injected store would resolve against the developer's real `TBDApp.plist`. What remains uncovered *by tests*: nothing renders the view or drives the real sheet, so the checkbox's binding to `$sendImmediately`, the toggle's write on tick, and the Settings row's binding rest on the live check above and on reading the source — a regression in any of them would land silently in CI.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=791069BC-9B69-466A-8B6B-945895D172E6)

