### PR TITLE
Fix: Reclaim the orphaned build waiters that starved a lane for two hours

### DIFF
--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -135,6 +135,12 @@ commands do not enter the governor.
 - `TBD_SWIFT_LOCK_PATH` overrides the shared lock path for isolated testing.
 - `TBD_SWIFT_ALLOW_HIGH_JOBS=1` permits an explicit higher job count on an
   otherwise idle machine.
+- `TBD_SWIFT_ALLOW_ORPHAN=1` keeps a queued build waiting even after the
+  process that requested it exits. A queued wrapper otherwise gives up when it
+  is reparented, because killing a shell or an agent session signals only that
+  process: the wrapper it started is never told, and left waiting it eventually
+  takes the machine-global slot to compile a tree nobody will read. Set this
+  only for a build deliberately launched detached.
 
 The repository guardrail rejects raw `swift build`, `swift test`, and `swift
 run` commands issued by agents. CI and non-compiling package commands remain

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -136,11 +136,17 @@ commands do not enter the governor.
 - `TBD_SWIFT_ALLOW_HIGH_JOBS=1` permits an explicit higher job count on an
   otherwise idle machine.
 - `TBD_SWIFT_ALLOW_ORPHAN=1` keeps a queued build waiting even after the
-  process that requested it exits. A queued wrapper otherwise gives up when it
-  is reparented, because killing a shell or an agent session signals only that
-  process: the wrapper it started is never told, and left waiting it eventually
-  takes the machine-global slot to compile a tree nobody will read. Set this
-  only for a build deliberately launched detached.
+  process that requested it exits. A queued wrapper otherwise records its
+  ancestor chain at startup and gives up as soon as any of those processes
+  dies, because killing a shell or an agent session signals only that process:
+  the wrapper it started is never told, and left waiting it eventually takes
+  the machine-global slot to compile a tree nobody will read. The whole chain
+  is watched, not just the direct parent, because the requester usually is not
+  the parent — `scripts/test.sh` reaches the wrapper through `env`, which
+  execs, so a killed agent shell leaves test.sh alive in between. Set this for
+  a build deliberately detached from a shell that will exit later
+  (`nohup scripts/swift-safe build &`); a build launched from something already
+  parented to pid 1 needs no opt-out, since it records no ancestor that can die.
 
 The repository guardrail rejects raw `swift build`, `swift test`, and `swift
 run` commands issued by agents. CI and non-compiling package commands remain

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -350,23 +350,20 @@ def _acquire(
     timeout_seconds: float,
     heartbeat_seconds: float,
     *,
+    requester: int,
+    ancestors: tuple[int, ...],
     monotonic=time.monotonic,
     sleep=time.sleep,
     report=_report,
     getppid=os.getppid,
-    requester: int | None = None,
-    ancestors: tuple[int, ...] = (),
 ) -> None:
+    # Who asked for this build, and the chain above them: `main` records both
+    # before any other work (see the comment there). They are required and
+    # keyword-only on purpose — a default would let a future call site drop the
+    # abandonment check silently, with nothing to compile against or test.
     start = monotonic()
     deadline = start + timeout_seconds
     watch_requester = os.environ.get("TBD_SWIFT_ALLOW_ORPHAN") != "1"
-    if not watch_requester:
-        ancestors = ()
-    # Who asked for this build: `main` records it before any other work (see
-    # the comment there). Falling back to reading it here keeps `_acquire`
-    # callable on its own.
-    if requester is None:
-        requester = getppid() if watch_requester else 0
     announced = False
     next_heartbeat = 0.0
     while True:
@@ -380,6 +377,14 @@ def _acquire(
             # moves this process's own ppid at all. A dead pid that has been
             # reused reads as alive and we keep waiting — the behavior that
             # shipped before this check, so the failure is the safe one.
+            #
+            # The zombie immunity covers only the direct parent, whose death
+            # reparents us regardless of when it is reaped. A *higher* ancestor
+            # left unreaped still answers `kill(pid, 0)`, so a chain whose
+            # middle is an un-waited-for zombie reads as alive and that wait
+            # runs to the timeout. Closing it would need `ps -o stat=` in the
+            # poll loop; the design rejects that cost for a narrow case whose
+            # failure mode is only the pre-existing one.
             if watch_requester and (
                 getppid() != requester
                 or not all(_process_is_alive(pid) for pid in ancestors)
@@ -412,6 +417,11 @@ def main(arguments: list[str]) -> int:
     # then never fire. Python's own startup is still outside this point, so
     # the window shrinks rather than closes — but do not tidy this back down
     # into `_acquire`, which is where it used to sit.
+    #
+    # No test pins that position: every end-to-end case kills its requester
+    # only after the wrapper has reached the wait loop, and there is no clean
+    # seam to delay argument parsing, so moving the capture back down leaves
+    # the suite green. Treat this as a deliberate choice, not a verified one.
     #
     # `TBD_SWIFT_ALLOW_ORPHAN=1` disables the check, and with it the one `ps`
     # this costs. The case it serves is `nohup scripts/swift-safe build &`

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -12,6 +12,14 @@ output sees nothing from this wrapper.  The holder writes ``pid``/``cwd``/
 say who it is queued behind; a heartbeat then repeats the wait's elapsed time
 so a human can tell a queued build from a hung one and an automated caller's
 stall watchdog sees liveness.
+
+A wait also ends when the process that requested the build goes away, which
+shows up as this wrapper being reparented off the pid it was started under.
+Killing a shell or an agent session signals only that process, so a wrapper
+queued behind the lock is never told; left waiting it stays in the queue and
+in time takes the machine-global slot and compiles a tree nobody will read,
+while a real requester waits behind it.  Set ``TBD_SWIFT_ALLOW_ORPHAN=1`` to
+keep waiting anyway, for a build deliberately launched detached.
 """
 
 from __future__ import annotations
@@ -70,6 +78,10 @@ RUN_OPTIONS_WITH_VALUES = {
     "-debug-info-format",
     "-j",
 }
+
+
+class Abandoned(Exception):
+    """The requester exited while we were queued, so the wait has no reader."""
 
 
 def _positive_number(name: str, default: float) -> float:
@@ -271,9 +283,15 @@ def _acquire(
     monotonic=time.monotonic,
     sleep=time.sleep,
     report=_report,
+    getppid=os.getppid,
 ) -> None:
     start = monotonic()
     deadline = start + timeout_seconds
+    # Who asked for this build. A run that was launched detached is already
+    # parented to pid 1 and has no requester to lose, so the signal is the
+    # move away from this recorded value, not the value 1 itself.
+    watch_requester = os.environ.get("TBD_SWIFT_ALLOW_ORPHAN") != "1"
+    requester = getppid() if watch_requester else 0
     announced = False
     next_heartbeat = 0.0
     while True:
@@ -281,6 +299,8 @@ def _acquire(
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             return
         except BlockingIOError:
+            if watch_requester and getppid() != requester:
+                raise Abandoned
             now = monotonic()
             if not announced:
                 report(
@@ -340,6 +360,14 @@ def main(arguments: list[str]) -> int:
     with path.open("a+", encoding="utf-8") as lock_file:
         try:
             _acquire(lock_file, path, timeout, heartbeat)
+        except Abandoned:
+            print(
+                "swift-safe: the process that requested this build exited while "
+                f"it was queued for {path}; abandoning the wait without starting "
+                "a build",
+                file=sys.stderr,
+            )
+            return 75
         except TimeoutError:
             print(
                 f"swift-safe: timed out after {timeout:g}s waiting for {path} "

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -13,13 +13,22 @@ say who it is queued behind; a heartbeat then repeats the wait's elapsed time
 so a human can tell a queued build from a hung one and an automated caller's
 stall watchdog sees liveness.
 
-A wait also ends when the process that requested the build goes away, which
-shows up as this wrapper being reparented off the pid it was started under.
-Killing a shell or an agent session signals only that process, so a wrapper
-queued behind the lock is never told; left waiting it stays in the queue and
-in time takes the machine-global slot and compiles a tree nobody will read,
-while a real requester waits behind it.  Set ``TBD_SWIFT_ALLOW_ORPHAN=1`` to
-keep waiting anyway, for a build deliberately launched detached.
+A wait also ends when whoever requested the build goes away.  Killing a shell
+or an agent session signals only that process, so a wrapper queued behind the
+lock is never told; left waiting it stays in the queue and in time takes the
+machine-global slot and compiles a tree nobody will read, while a real
+requester waits behind it.  The whole ancestor chain is recorded at startup
+and any of those processes dying ends the wait, because the requester is
+rarely the direct parent: ``scripts/test.sh`` runs this wrapper through
+``env``, which execs, so killing the agent's shell leaves test.sh alive and
+blocked in ``wait`` and a direct-parent check would never fire.  Set
+``TBD_SWIFT_ALLOW_ORPHAN=1`` to keep waiting anyway, for a build deliberately
+launched detached from a shell that will exit later.
+
+An abandoned wait and a timed-out wait both exit 75 (``EX_TEMPFAIL``); only
+the stderr line distinguishes them.  Nothing branches on the code today, and
+the shared value says the same thing to a caller that does: the slot was not
+obtained, nothing was compiled, retrying later is reasonable.
 """
 
 from __future__ import annotations
@@ -29,6 +38,7 @@ import math
 import os
 from pathlib import Path
 import shutil
+import subprocess
 import sys
 import time
 
@@ -243,6 +253,66 @@ def _process_is_alive(pid: int) -> bool:
     return True
 
 
+def _process_table() -> dict[int, int]:
+    """child pid -> parent pid for every visible process, from one `ps`.
+
+    macOS has no ``/proc``, so an ancestor walk needs the process table, and
+    one ``ps`` call answers every step of it.  Best effort: a table we could
+    not read leaves the caller with the direct parent alone, which is the
+    behavior that shipped before the walk existed.
+    """
+    try:
+        completed = subprocess.run(
+            ["ps", "-Ao", "pid=,ppid="],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    table: dict[int, int] = {}
+    for line in completed.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            child, parent = int(fields[0]), int(fields[1])
+        except ValueError:
+            continue
+        table[child] = parent
+    return table
+
+
+def _ancestor_pids(
+    *, getppid=os.getppid, process_table=_process_table
+) -> tuple[int, ...]:
+    """This process's ancestors, nearest first, ending at pid 1 if reachable.
+
+    Walked once, at startup: afterwards liveness is `kill(pid, 0)` per poll,
+    with no further subprocesses.  A run launched detached records a short
+    chain — possibly just pid 1 — and so is never abandoned by it.
+    """
+    parent = getppid()
+    if parent <= 0:
+        return ()
+    chain = [parent]
+    seen = {parent}
+    table = process_table()
+    current = parent
+    while current > 1:
+        # A missing entry (the process table raced us, or `ps` failed) or a
+        # cycle (impossible, but a corrupt table must not hang the build)
+        # ends the walk with whatever was recorded so far.
+        nextpid = table.get(current)
+        if nextpid is None or nextpid <= 0 or nextpid in seen:
+            break
+        chain.append(nextpid)
+        seen.add(nextpid)
+        current = nextpid
+    return tuple(chain)
+
+
 def _holder_description(lock_path: Path) -> str:
     """Describe the lock holder without ever claiming one we cannot see."""
     fields = _holder_fields(lock_path)
@@ -284,14 +354,19 @@ def _acquire(
     sleep=time.sleep,
     report=_report,
     getppid=os.getppid,
+    requester: int | None = None,
+    ancestors: tuple[int, ...] = (),
 ) -> None:
     start = monotonic()
     deadline = start + timeout_seconds
-    # Who asked for this build. A run that was launched detached is already
-    # parented to pid 1 and has no requester to lose, so the signal is the
-    # move away from this recorded value, not the value 1 itself.
     watch_requester = os.environ.get("TBD_SWIFT_ALLOW_ORPHAN") != "1"
-    requester = getppid() if watch_requester else 0
+    if not watch_requester:
+        ancestors = ()
+    # Who asked for this build: `main` records it before any other work (see
+    # the comment there). Falling back to reading it here keeps `_acquire`
+    # callable on its own.
+    if requester is None:
+        requester = getppid() if watch_requester else 0
     announced = False
     next_heartbeat = 0.0
     while True:
@@ -299,7 +374,16 @@ def _acquire(
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             return
         except BlockingIOError:
-            if watch_requester and getppid() != requester:
+            # Two readings of the same fact, because neither covers the other:
+            # a reparent is visible even while the old parent lingers as an
+            # unreaped zombie, and a dead ancestor further up the chain never
+            # moves this process's own ppid at all. A dead pid that has been
+            # reused reads as alive and we keep waiting — the behavior that
+            # shipped before this check, so the failure is the safe one.
+            if watch_requester and (
+                getppid() != requester
+                or not all(_process_is_alive(pid) for pid in ancestors)
+            ):
                 raise Abandoned
             now = monotonic()
             if not announced:
@@ -322,6 +406,23 @@ def _acquire(
 
 
 def main(arguments: list[str]) -> int:
+    # Recorded here, before argument parsing, `shutil.which` and opening the
+    # lock file: a requester that dies during that window would otherwise be
+    # recorded after the reparent has already happened, and the check could
+    # then never fire. Python's own startup is still outside this point, so
+    # the window shrinks rather than closes — but do not tidy this back down
+    # into `_acquire`, which is where it used to sit.
+    #
+    # `TBD_SWIFT_ALLOW_ORPHAN=1` disables the check, and with it the one `ps`
+    # this costs. The case it serves is `nohup scripts/swift-safe build &`
+    # from a live shell that exits later: that shell is a recorded ancestor,
+    # so its exit would otherwise end a wait that was meant to outlive it. A
+    # run already parented to pid 1 needs no hatch — it records no ancestor
+    # that can die, and a test in scripts/test-swift-safe.py pins that.
+    watching_requester = os.environ.get("TBD_SWIFT_ALLOW_ORPHAN") != "1"
+    requester = os.getppid() if watching_requester else 0
+    ancestors = _ancestor_pids() if watching_requester else ()
+
     if not arguments or arguments[0] not in SUPPORTED_SUBCOMMANDS:
         supported = "|".join(sorted(SUPPORTED_SUBCOMMANDS))
         print(
@@ -359,7 +460,14 @@ def main(arguments: list[str]) -> int:
 
     with path.open("a+", encoding="utf-8") as lock_file:
         try:
-            _acquire(lock_file, path, timeout, heartbeat)
+            _acquire(
+                lock_file,
+                path,
+                timeout,
+                heartbeat,
+                requester=requester,
+                ancestors=ancestors,
+            )
         except Abandoned:
             print(
                 "swift-safe: the process that requested this build exited while "

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -13,10 +13,14 @@ import importlib.machinery
 import importlib.util
 import os
 from pathlib import Path
+import shlex
+import signal
 import subprocess
 import tempfile
 import textwrap
+import time
 import unittest
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -415,6 +419,238 @@ class WaitReportingTests(unittest.TestCase):
         first = self.wait_messages()[0]
         self.assertIn("...", first)
         self.assertLess(len(first), 400)
+
+
+class AbandonedWaitTests(unittest.TestCase):
+    """Drive `_acquire`'s requester check with a fake clock and a fake getppid.
+
+    The flock underneath is really contended, as in `WaitReportingTests`, so a
+    wait that fails to notice its requester runs on to the full timeout.
+    """
+
+    INITIAL_PARENT = 4242
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.lock_path = Path(self.temp.name) / "swift-build.lock"
+        self.holder = self.lock_path.open("a+", encoding="utf-8")
+        fcntl.flock(self.holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def tearDown(self):
+        self.holder.close()
+        self.temp.cleanup()
+
+    def slot_is_free(self) -> bool:
+        """Whether nobody — the waiter included — holds the lock right now."""
+        with self.lock_path.open("a+", encoding="utf-8") as probe:
+            try:
+                fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return False
+            fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
+            return True
+
+    def wait(self, parents, *, release_slot=False, timeout=125.0):
+        """One wait over the `parents` getppid readings; the last one repeats.
+
+        Returns the exception type that ended it, the virtual seconds it
+        lasted, and whether the slot was left untaken.
+        """
+        clock = FakeClock()
+        readings = list(parents)
+
+        def getppid() -> int:
+            value = readings.pop(0) if len(readings) > 1 else readings[0]
+            if release_slot and value != parents[0]:
+                # Free the slot at the moment the requester goes away, so a
+                # wait that failed to stop would take it and return happily.
+                fcntl.flock(self.holder.fileno(), fcntl.LOCK_UN)
+            return value
+
+        start = clock.monotonic()
+        with self.lock_path.open("a+", encoding="utf-8") as waiter:
+            outcome: BaseException | None = None
+            try:
+                swift_safe._acquire(
+                    waiter,
+                    self.lock_path,
+                    timeout,
+                    60.0,
+                    monotonic=clock.monotonic,
+                    sleep=clock.sleep,
+                    report=lambda *_: None,
+                    getppid=getppid,
+                )
+            except (swift_safe.Abandoned, TimeoutError) as error:
+                outcome = error
+            self.assertIsNotNone(outcome, "the wait acquired the build slot")
+            # Probed while the waiter's descriptor is still open, so a slot it
+            # had taken would still read as busy.
+            free = self.slot_is_free()
+        return type(outcome), clock.monotonic() - start, free
+
+    def test_the_wait_ends_when_the_requester_goes_away(self):
+        outcome, elapsed, _ = self.wait([self.INITIAL_PARENT, self.INITIAL_PARENT, 1])
+        self.assertIs(outcome, swift_safe.Abandoned)
+        # Promptly: within a poll or two, not at the far-off timeout.
+        self.assertLess(elapsed, 1.0)
+
+    def test_an_abandoned_wait_leaves_the_freed_slot_untaken(self):
+        outcome, _, free = self.wait([self.INITIAL_PARENT, 1], release_slot=True)
+        self.assertIs(outcome, swift_safe.Abandoned)
+        self.assertTrue(free, "the abandoned wait took the slot on its way out")
+
+    def test_a_wait_whose_requester_stays_runs_to_the_timeout(self):
+        """Mutation guard: the check must not fire while somebody is waiting."""
+        outcome, elapsed, _ = self.wait([self.INITIAL_PARENT])
+        self.assertIs(outcome, TimeoutError)
+        self.assertGreaterEqual(elapsed, 125.0)
+
+    def test_a_wait_that_started_detached_is_never_abandoned(self):
+        """Reparenting is the signal; being parented to pid 1 all along is not."""
+        outcome, elapsed, _ = self.wait([1])
+        self.assertIs(outcome, TimeoutError)
+        self.assertGreaterEqual(elapsed, 125.0)
+
+    def test_allow_orphan_keeps_a_reparented_wait_queued(self):
+        with mock.patch.dict(os.environ, {"TBD_SWIFT_ALLOW_ORPHAN": "1"}):
+            outcome, elapsed, _ = self.wait([self.INITIAL_PARENT, 1])
+        self.assertIs(outcome, TimeoutError)
+        self.assertGreaterEqual(elapsed, 125.0)
+
+
+class OrphanedWrapperTests(unittest.TestCase):
+    """End to end: kill a queued wrapper's requester, through the real script.
+
+    A killer signals the process it knows about, so the wrapper it started is
+    never told.  Each case runs a real intermediate shell that forks a real
+    `swift-safe` against a real contended lock, then SIGKILLs that shell only.
+    """
+
+    DEADLINE_SECONDS = 3.0
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        root = Path(self.temp.name)
+        self.lock_path = root / "swift-build.lock"
+        self.compiled_marker = root / "swift-ran"
+        self.wrapper_stderr = root / "wrapper.stderr"
+        self.wrapper_pid_file = root / "wrapper.pid"
+        self.fake_swift = root / "swift"
+        self.fake_swift.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                printf '%s\\n' "$*" > {shlex.quote(str(self.compiled_marker))}
+                sleep 30
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.fake_swift.chmod(0o755)
+        # This process keeps the slot for the whole test, so the wrapper below
+        # genuinely queues instead of compiling straight away.
+        self.holder = self.lock_path.open("a+", encoding="utf-8")
+        fcntl.flock(self.holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        self.shells: list[subprocess.Popen] = []
+        self.wrappers: list[int] = []
+        self.wrapper_pid = 0
+
+    def tearDown(self):
+        # Unconditional: a failed assertion must not strand a queued wrapper.
+        for pid in self.wrappers:
+            with contextlib.suppress(OSError):
+                os.kill(pid, signal.SIGKILL)
+        for shell in self.shells:
+            with contextlib.suppress(OSError):
+                shell.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                shell.wait(timeout=5)
+        self.holder.close()
+        self.temp.cleanup()
+
+    def until(self, condition) -> bool:
+        """Poll `condition` up to the deadline rather than sleeping blind."""
+        deadline = time.monotonic() + self.DEADLINE_SECONDS
+        while time.monotonic() < deadline:
+            if condition():
+                return True
+            time.sleep(0.02)
+        return condition()
+
+    def start_queued_wrapper(self, **extra_env) -> subprocess.Popen:
+        env = os.environ.copy()
+        env.update(
+            {
+                "TBD_HOME": str(Path(self.temp.name) / "tbd"),
+                "TBD_SWIFT_LOCK_PATH": str(self.lock_path),
+                "TBD_SWIFT_BIN": str(self.fake_swift),
+                "TBD_SWIFT_LOCK_TIMEOUT_SECONDS": "60",
+                "TBD_SWIFT_HEARTBEAT_SECONDS": "0.05",
+                **extra_env,
+            }
+        )
+        # `&` so the shell forks the wrapper: killing the shell then leaves a
+        # live wrapper behind, which is the leak being reproduced.
+        script = (
+            f"{shlex.quote(str(RUNNER))} build "
+            f"2> {shlex.quote(str(self.wrapper_stderr))} & "
+            f"echo $! > {shlex.quote(str(self.wrapper_pid_file))}; wait"
+        )
+        shell = subprocess.Popen(["/bin/sh", "-c", script], env=env)
+        self.shells.append(shell)
+        def pid_reported() -> bool:
+            try:
+                return self.wrapper_pid_file.read_text().strip().isdigit()
+            except OSError:
+                return False
+
+        self.assertTrue(
+            self.until(pid_reported),
+            "the intermediate shell never reported the wrapper's pid",
+        )
+        self.wrapper_pid = int(self.wrapper_pid_file.read_text().strip())
+        self.wrappers.append(self.wrapper_pid)
+        # Only once it is queued has it captured the requester it will lose.
+        self.assertTrue(
+            self.until(lambda: "waiting for the shared build slot" in self.reported()),
+            "the wrapper never reached the wait",
+        )
+        return shell
+
+    def reported(self) -> str:
+        """Everything the wrapper has said on stderr so far."""
+        try:
+            return self.wrapper_stderr.read_text(errors="replace")
+        except OSError:
+            return ""
+
+    def kill_the_requester(self, shell: subprocess.Popen) -> None:
+        shell.kill()
+        shell.wait(timeout=5)
+
+    def test_a_wrapper_whose_requester_is_killed_stops_competing(self):
+        shell = self.start_queued_wrapper()
+        self.kill_the_requester(shell)
+        self.assertTrue(
+            self.until(lambda: not swift_safe._process_is_alive(self.wrapper_pid)),
+            "the orphaned wrapper kept waiting for the shared build slot",
+        )
+        self.assertFalse(
+            self.compiled_marker.exists(), "the orphan started a build nobody reads"
+        )
+        # The slot record still names this test's holder, never the orphan.
+        self.assertNotIn(f"pid={self.wrapper_pid}", self.lock_path.read_text())
+        self.assertIn("exited while it was queued", self.reported())
+
+    def test_allow_orphan_keeps_a_deliberately_detached_wrapper_waiting(self):
+        shell = self.start_queued_wrapper(TBD_SWIFT_ALLOW_ORPHAN="1")
+        self.kill_the_requester(shell)
+        self.assertFalse(
+            self.until(lambda: not swift_safe._process_is_alive(self.wrapper_pid)),
+            "the escape hatch did not keep the detached wrapper waiting",
+        )
+        self.assertNotIn("exited while it was queued", self.reported())
 
 
 if __name__ == "__main__":

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -295,6 +295,11 @@ class WaitReportingTests(unittest.TestCase):
                     self.lock_path,
                     timeout,
                     heartbeat,
+                    # This process's own live ancestry, as `main` would record
+                    # it: nothing here goes away, so the wait runs to timeout
+                    # and the reporting is what is under test.
+                    requester=os.getppid(),
+                    ancestors=(),
                     monotonic=clock.monotonic,
                     sleep=clock.sleep,
                     report=report,
@@ -463,6 +468,11 @@ class AbandonedWaitTests(unittest.TestCase):
         `ancestors` is the chain recorded at startup, given as real pids so
         the shipped `kill(pid, 0)` liveness check is the one under test.
 
+        The requester passed is `parents[0]`, the first reading — the same
+        value `main` would have captured at startup. The escape-hatch cases
+        pass it too, rather than production's zero, so that they still red if
+        `_acquire`'s own `TBD_SWIFT_ALLOW_ORPHAN` gate is removed.
+
         Returns the exception type that ended it, the virtual seconds it
         lasted, and whether the slot was left untaken.
         """
@@ -486,11 +496,12 @@ class AbandonedWaitTests(unittest.TestCase):
                     self.lock_path,
                     timeout,
                     60.0,
+                    requester=parents[0],
+                    ancestors=tuple(ancestors),
                     monotonic=clock.monotonic,
                     sleep=clock.sleep,
                     report=lambda *_: None,
                     getppid=getppid,
-                    ancestors=tuple(ancestors),
                 )
             except (swift_safe.Abandoned, TimeoutError) as error:
                 outcome = error

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -431,6 +431,13 @@ class AbandonedWaitTests(unittest.TestCase):
     INITIAL_PARENT = 4242
 
     def setUp(self):
+        # `_acquire` reads the escape hatch from the ambient environment, and
+        # docs/reclaim-build.md invites a developer to export it. Every case
+        # below states for itself whether the hatch is set.
+        patcher = mock.patch.dict(os.environ)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        os.environ.pop("TBD_SWIFT_ALLOW_ORPHAN", None)
         self.temp = tempfile.TemporaryDirectory()
         self.lock_path = Path(self.temp.name) / "swift-build.lock"
         self.holder = self.lock_path.open("a+", encoding="utf-8")
@@ -450,8 +457,11 @@ class AbandonedWaitTests(unittest.TestCase):
             fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
             return True
 
-    def wait(self, parents, *, release_slot=False, timeout=125.0):
+    def wait(self, parents, *, ancestors=(), release_slot=False, timeout=125.0):
         """One wait over the `parents` getppid readings; the last one repeats.
+
+        `ancestors` is the chain recorded at startup, given as real pids so
+        the shipped `kill(pid, 0)` liveness check is the one under test.
 
         Returns the exception type that ended it, the virtual seconds it
         lasted, and whether the slot was left untaken.
@@ -480,6 +490,7 @@ class AbandonedWaitTests(unittest.TestCase):
                     sleep=clock.sleep,
                     report=lambda *_: None,
                     getppid=getppid,
+                    ancestors=tuple(ancestors),
                 )
             except (swift_safe.Abandoned, TimeoutError) as error:
                 outcome = error
@@ -518,13 +529,116 @@ class AbandonedWaitTests(unittest.TestCase):
         self.assertIs(outcome, TimeoutError)
         self.assertGreaterEqual(elapsed, 125.0)
 
+    def test_a_dead_grandparent_ends_the_wait_though_the_parent_lives(self):
+        """The requester is rarely the direct parent — `env` execs in between.
+
+        The parent reading never moves here: only the recorded chain shows
+        that the process this build was being run for has gone.
+        """
+        # A live stand-in for the direct parent, then the dead grandparent.
+        outcome, elapsed, _ = self.wait(
+            [self.INITIAL_PARENT], ancestors=(os.getpid(), _dead_pid(), 1)
+        )
+        self.assertIs(outcome, swift_safe.Abandoned)
+        self.assertLess(elapsed, 1.0)
+
+    def test_a_wait_whose_whole_chain_lives_runs_to_the_timeout(self):
+        """Mutation guard: a living ancestry must never fire the check."""
+        outcome, elapsed, _ = self.wait(
+            [self.INITIAL_PARENT], ancestors=(os.getpid(), os.getppid(), 1)
+        )
+        self.assertIs(outcome, TimeoutError)
+        self.assertGreaterEqual(elapsed, 125.0)
+
+    def test_an_unavailable_chain_falls_back_to_the_direct_parent(self):
+        """A walk that failed records nothing, and must still behave."""
+        outcome, elapsed, _ = self.wait([self.INITIAL_PARENT, 1], ancestors=())
+        self.assertIs(outcome, swift_safe.Abandoned)
+        self.assertLess(elapsed, 1.0)
+
+        outcome, elapsed, _ = self.wait([self.INITIAL_PARENT], ancestors=())
+        self.assertIs(outcome, TimeoutError)
+        self.assertGreaterEqual(elapsed, 125.0)
+
+    def test_allow_orphan_keeps_waiting_though_a_recorded_ancestor_died(self):
+        with mock.patch.dict(os.environ, {"TBD_SWIFT_ALLOW_ORPHAN": "1"}):
+            outcome, elapsed, _ = self.wait(
+                [self.INITIAL_PARENT], ancestors=(os.getpid(), _dead_pid(), 1)
+            )
+        self.assertIs(outcome, TimeoutError)
+        self.assertGreaterEqual(elapsed, 125.0)
+
+
+class AncestorChainTests(unittest.TestCase):
+    """The startup walk that records who a build is being run for."""
+
+    def test_the_real_walk_reaches_pid_one_from_this_process(self):
+        chain = swift_safe._ancestor_pids()
+        self.assertEqual(chain[0], os.getppid())
+        self.assertEqual(chain[-1], 1)
+        self.assertEqual(len(set(chain)), len(chain), "the walk repeated a pid")
+        self.assertTrue(all(swift_safe._process_is_alive(pid) for pid in chain))
+
+    def test_the_real_process_table_maps_this_process_to_its_parent(self):
+        self.assertEqual(swift_safe._process_table().get(os.getpid()), os.getppid())
+
+    def test_the_walk_follows_the_table_up_to_pid_one(self):
+        chain = swift_safe._ancestor_pids(
+            getppid=lambda: 10, process_table=lambda: {10: 20, 20: 30, 30: 1, 1: 0}
+        )
+        self.assertEqual(chain, (10, 20, 30, 1))
+
+    def test_a_missing_table_entry_ends_the_walk_at_the_direct_parent(self):
+        chain = swift_safe._ancestor_pids(getppid=lambda: 10, process_table=dict)
+        self.assertEqual(chain, (10,))
+
+    def test_a_cyclic_table_terminates_the_walk(self):
+        chain = swift_safe._ancestor_pids(
+            getppid=lambda: 10, process_table=lambda: {10: 20, 20: 10}
+        )
+        self.assertEqual(chain, (10, 20))
+
+    def test_a_detached_process_records_only_pid_one(self):
+        chain = swift_safe._ancestor_pids(getppid=lambda: 1, process_table=dict)
+        self.assertEqual(chain, (1,))
+
+    def test_an_unusable_parent_records_nothing(self):
+        self.assertEqual(
+            swift_safe._ancestor_pids(getppid=lambda: 0, process_table=dict), ()
+        )
+
+    def test_an_unavailable_ps_leaves_an_empty_table(self):
+        """No table means no chain, which is the pre-walk behavior, not a crash."""
+        for failure in (
+            OSError("no ps here"),
+            subprocess.CalledProcessError(1, "ps"),
+            subprocess.TimeoutExpired("ps", 10),
+        ):
+            with self.subTest(failure=type(failure).__name__):
+                with mock.patch.object(
+                    swift_safe.subprocess, "run", side_effect=failure
+                ):
+                    self.assertEqual(swift_safe._process_table(), {})
+                    self.assertEqual(
+                        swift_safe._ancestor_pids(getppid=lambda: 10), (10,)
+                    )
+
+    def test_unparsable_process_table_rows_are_skipped(self):
+        completed = subprocess.CompletedProcess(
+            ["ps"], 0, stdout="  1     0\nnot a row\n7 x\n8\n 9 10 11\n", stderr=""
+        )
+        with mock.patch.object(swift_safe.subprocess, "run", return_value=completed):
+            self.assertEqual(swift_safe._process_table(), {1: 0})
+
 
 class OrphanedWrapperTests(unittest.TestCase):
     """End to end: kill a queued wrapper's requester, through the real script.
 
     A killer signals the process it knows about, so the wrapper it started is
-    never told.  Each case runs a real intermediate shell that forks a real
-    `swift-safe` against a real contended lock, then SIGKILLs that shell only.
+    never told.  Each case runs real shells that fork a real `swift-safe`
+    against a real contended lock, then SIGKILLs one of them — by a pid this
+    test recorded at spawn, never by a pattern, which once matched and killed
+    unrelated live sessions.
     """
 
     DEADLINE_SECONDS = 3.0
@@ -536,6 +650,7 @@ class OrphanedWrapperTests(unittest.TestCase):
         self.compiled_marker = root / "swift-ran"
         self.wrapper_stderr = root / "wrapper.stderr"
         self.wrapper_pid_file = root / "wrapper.pid"
+        self.intermediate_pid_file = root / "intermediate.pid"
         self.fake_swift = root / "swift"
         self.fake_swift.write_text(
             textwrap.dedent(
@@ -553,12 +668,14 @@ class OrphanedWrapperTests(unittest.TestCase):
         self.holder = self.lock_path.open("a+", encoding="utf-8")
         fcntl.flock(self.holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         self.shells: list[subprocess.Popen] = []
-        self.wrappers: list[int] = []
+        # Only pids these tests recorded at spawn are ever signalled: a
+        # pattern kill here once matched, and killed, unrelated live sessions.
+        self.recorded_pids: list[int] = []
         self.wrapper_pid = 0
 
     def tearDown(self):
         # Unconditional: a failed assertion must not strand a queued wrapper.
-        for pid in self.wrappers:
+        for pid in self.recorded_pids:
             with contextlib.suppress(OSError):
                 os.kill(pid, signal.SIGKILL)
         for shell in self.shells:
@@ -578,8 +695,12 @@ class OrphanedWrapperTests(unittest.TestCase):
             time.sleep(0.02)
         return condition()
 
-    def start_queued_wrapper(self, **extra_env) -> subprocess.Popen:
+    def wrapper_env(self, **extra_env) -> dict[str, str]:
         env = os.environ.copy()
+        # A developer who exported the escape hatch — docs/reclaim-build.md
+        # invites it — must not silently disarm the check under test. The
+        # hatch case below sets it back explicitly.
+        env.pop("TBD_SWIFT_ALLOW_ORPHAN", None)
         env.update(
             {
                 "TBD_HOME": str(Path(self.temp.name) / "tbd"),
@@ -590,33 +711,88 @@ class OrphanedWrapperTests(unittest.TestCase):
                 **extra_env,
             }
         )
-        # `&` so the shell forks the wrapper: killing the shell then leaves a
-        # live wrapper behind, which is the leak being reproduced.
-        script = (
-            f"{shlex.quote(str(RUNNER))} build "
-            f"2> {shlex.quote(str(self.wrapper_stderr))} & "
-            f"echo $! > {shlex.quote(str(self.wrapper_pid_file))}; wait"
-        )
-        shell = subprocess.Popen(["/bin/sh", "-c", script], env=env)
-        self.shells.append(shell)
+        return env
+
+    def reported_pid(self, pid_file: Path, description: str) -> int:
+        """The pid a shell wrote for the child it forked, once it appears."""
+
         def pid_reported() -> bool:
             try:
-                return self.wrapper_pid_file.read_text().strip().isdigit()
+                return pid_file.read_text().strip().isdigit()
             except OSError:
                 return False
 
         self.assertTrue(
-            self.until(pid_reported),
-            "the intermediate shell never reported the wrapper's pid",
+            self.until(pid_reported), f"no pid was reported for {description}"
         )
-        self.wrapper_pid = int(self.wrapper_pid_file.read_text().strip())
-        self.wrappers.append(self.wrapper_pid)
+        pid = int(pid_file.read_text().strip())
+        self.recorded_pids.append(pid)
+        return pid
+
+    def parent_of(self, pid: int) -> int:
+        """This pid's parent, straight from `ps`, to verify the process tree."""
+        completed = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return int(completed.stdout.strip() or -1)
+
+    def await_queued_wrapper(self) -> None:
         # Only once it is queued has it captured the requester it will lose.
         self.assertTrue(
             self.until(lambda: "waiting for the shared build slot" in self.reported()),
             "the wrapper never reached the wait",
         )
+
+    def wrapper_script(self) -> str:
+        """Fork the wrapper, report its pid, and stay alive around it.
+
+        `&` so the shell forks rather than exec-optimizing the wrapper into
+        itself: killing the shell then leaves a live wrapper behind, which is
+        the leak being reproduced.
+        """
+        return (
+            f"{shlex.quote(str(RUNNER))} build "
+            f"2> {shlex.quote(str(self.wrapper_stderr))} & "
+            f"echo $! > {shlex.quote(str(self.wrapper_pid_file))}; wait"
+        )
+
+    def start_queued_wrapper(self, **extra_env) -> subprocess.Popen:
+        shell = subprocess.Popen(
+            ["/bin/sh", "-c", self.wrapper_script()], env=self.wrapper_env(**extra_env)
+        )
+        self.shells.append(shell)
+        self.wrapper_pid = self.reported_pid(self.wrapper_pid_file, "the wrapper")
+        self.await_queued_wrapper()
         return shell
+
+    def start_queued_wrapper_under_a_grandparent(self) -> subprocess.Popen:
+        """grandparent shell -> intermediate shell -> queued wrapper.
+
+        The shape `scripts/test.sh` produces: the wrapper's direct parent is
+        an intermediate that outlives whoever asked for the build.  Every
+        level must genuinely fork — a shell exec-optimizes the last simple
+        command of `-c`, which would collapse the tree and make the test
+        vacuous — so each backgrounds its child with `&` and stays in `wait`.
+        """
+        outer = (
+            f"/bin/sh -c {shlex.quote(self.wrapper_script())} & "
+            f"echo $! > {shlex.quote(str(self.intermediate_pid_file))}; wait"
+        )
+        grandparent = subprocess.Popen(["/bin/sh", "-c", outer], env=self.wrapper_env())
+        self.shells.append(grandparent)
+        intermediate_pid = self.reported_pid(
+            self.intermediate_pid_file, "the intermediate shell"
+        )
+        self.wrapper_pid = self.reported_pid(self.wrapper_pid_file, "the wrapper")
+        self.await_queued_wrapper()
+        # Prove the three levels are distinct processes before killing any.
+        self.assertEqual(self.parent_of(self.wrapper_pid), intermediate_pid)
+        self.assertEqual(self.parent_of(intermediate_pid), grandparent.pid)
+        self.assertNotIn(grandparent.pid, (intermediate_pid, self.wrapper_pid))
+        return grandparent
 
     def reported(self) -> str:
         """Everything the wrapper has said on stderr so far."""
@@ -640,6 +816,25 @@ class OrphanedWrapperTests(unittest.TestCase):
             self.compiled_marker.exists(), "the orphan started a build nobody reads"
         )
         # The slot record still names this test's holder, never the orphan.
+        self.assertNotIn(f"pid={self.wrapper_pid}", self.lock_path.read_text())
+        self.assertIn("exited while it was queued", self.reported())
+
+    def test_a_wrapper_whose_grandparent_is_killed_stops_competing(self):
+        """The direct parent survives, so only the recorded chain can notice.
+
+        `scripts/test.sh` reaches the wrapper through `env`, which execs: kill
+        the agent's shell and test.sh stays alive, blocked in `wait`.
+        """
+        grandparent = self.start_queued_wrapper_under_a_grandparent()
+        # Exactly one pid, recorded when this test spawned it.
+        self.kill_the_requester(grandparent)
+        self.assertTrue(
+            self.until(lambda: not swift_safe._process_is_alive(self.wrapper_pid)),
+            "the wrapper kept waiting because its direct parent was still alive",
+        )
+        self.assertFalse(
+            self.compiled_marker.exists(), "the orphan started a build nobody reads"
+        )
         self.assertNotIn(f"pid={self.wrapper_pid}", self.lock_path.read_text())
         self.assertIn("exited while it was queued", self.reported())
 


### PR DESCRIPTION
## What's broken

Every TBD worktree's build and test run goes through `scripts/swift-safe`, a machine-global admission lock that holds one slot so concurrent compiler swarms can't exhaust the laptop. When a run is killed, its wrapper is orphaned and **keeps competing for that slot forever, producing nothing**.

The parent — a `scripts/test.sh` invocation, or an agent's shell — dies. The Python wrapper is reparented to launchd and goes on polling until its timeout: 30 minutes by default. Measured today, all from one worktree in a single session: pid 73179 competing for 15m54s at `ppid=1`, pid 60009 for 22m17s, and pid 58431 left behind when its parent `test.sh` was killed. That last one is the mechanism in miniature — killing the parent alone leaks the wrapper, so every agent that kills a stuck-looking run creates one unless it knows to kill the whole tree.

The cost is not tidiness. The lock has no queue and no fairness: `LOCK_NB` polled in a loop means whoever polls at the right moment wins, so each orphan is a permanent extra contender in a lottery on a machine that routinely has 5–7 real lanes. A lane in that session waited over two hours across five attempts and never acquired the slot. Two of the contenders it was losing to were its own orphans.

And an orphan does not merely wait. Reproduced here: when the holder released, the orphan **took the machine-global slot and exec'd the compiler**, building a tree nobody would ever read while real requesters queued behind it.

## Why it happens

The wrapper has no notion of whether anyone still wants the result. It polls for the lock until a deadline, and nothing ties its lifetime to its requester's.

Signals are not the gap, which is worth stating because it looks like the obvious cause. SIGTERM to the wrapper already kills it cleanly and the kernel releases the flock — verified. The gap is that a killer signals only the process it knows about, so the child is never told at all. Adding signal handlers would be decorative.

## When it broke

The hazard is as old as the lock: #576 introduced both the polling wait and the 1800s default timeout, and before it there was no slot to queue for. #647 later added the heartbeat that reports who you're queued behind, which makes an orphan visible in a way it wasn't, but did not cause it. Nothing tested the abandoned-requester path because the wrapper had no concept of a requester to abandon.

## What this PR does

The wait ends when the process that asked for the build goes away.

At startup the wrapper records its ancestor chain — one `ps -Ao pid=,ppid=` call walked from its parent up to pid 1 — and while queued it abandons the wait if its parent changes **or** any recorded ancestor is no longer alive. After the initial walk this is pure `kill(pid, 0)` per poll, so no further subprocesses. It exits without starting a build.

Two design points worth flagging:

- **The comparison is against the pid recorded at start, not against `1`.** A build launched detached is already parented to pid 1 and has no requester to lose; it must keep working. A test pins this so a later simplification to `== 1` reddens.
- **The ancestor chain, not just the direct parent, is what matters.** An earlier revision of this fix checked only `getppid()`. Review caught that this misses the repo's own main entry point: `scripts/test.sh` runs `env … scripts/swift-safe test`, and `env` execs, so the wrapper's parent is test.sh's own bash, with the harness shell one level above. Killing that harness leaves test.sh alive and blocked in `wait`, and the wrapper never notices. The mandated test entry point, running the longest builds, was exactly the uncovered shape — reproduced, then closed.

`TBD_SWIFT_ALLOW_ORPHAN=1` opts out, for a build deliberately launched with `nohup … &` from a shell that exits later.

**Who reclaims the orphans** (per CLAUDE.md's named-reconciler doctrine): the wrapper reclaims itself, and this is genuinely a self-reclaiming resource rather than a sweep dodge. The check runs on every poll of a loop that already spins every 0.25s, so reclamation is on a timer independent of whichever failure path stranded it — the property the doctrine actually asks for. No new durable resource is created: `ps` reads OS state, and the flock is kernel-managed and released on exit whatever kills the process. The lock file persists but is only a description; a record naming a dead pid never blocks anyone, and `_holder_description` already reports it honestly.

**No spec.** This restores the system to its existing theory rather than revising it — the wrapper exists to admit *waiting* callers, and admitting one that no longer exists violates its own purpose. The separate defect that the lock is unfair by construction, so a newcomer to a busy machine can starve for hours, **is** a design change; it is deliberately not bundled here and needs its own brainstorm and spec.

## Assumptions

- **Reparenting is the signal that a requester is gone.** Assumes orphans reparent to pid 1, true on darwin. A subreaper would break the inference — the ancestor-liveness half still covers it.
- **Pid reuse over a long wait could make a dead ancestor read as alive.** This fails safe: the wrapper keeps waiting, which is today's behavior, so the worst case is the bug we started with rather than a wrongly-aborted build.
- **An unreaped zombie ancestor reads as alive** under `kill(pid, 0)`. The direct-parent clause is immune (reparenting happens at exit, not at reap), but a *higher* ancestor left unreaped still waits out its timeout. Closing that would need `ps -o stat=` in the poll loop, rejected on cost. Both clauses are kept for this reason and each is separately load-bearing.
- **The `ps` fork costs ~20–30ms on every invocation**, including the uncontended fast path that never reads the chain. Deliberate: deferring it to first contention reopens the gap for the setup window. It is noise against a Swift build, but #576 justified making this lock mandatory partly on the flock being invisible when uncontended, so the new cost is recorded here rather than hidden.
- **The tmux server is now a recorded ancestor**, so `tmux kill-server` abandons every queued build on the machine. That is correct abandonment, but a wider blast radius than the direct-parent check had.

## Evidence & verification

**The repro, written before the fix and re-run against it.** A holder takes a scratch lock; a parent shell runs the real wrapper as a child; the parent is SIGKILLed. Before: the wrapper survived at `ppid=1`, kept polling, and on release took the slot and ran the compiler. After: it exits with its parent and the stub compiler never runs. A second probe builds a genuine three-level tree (grandparent → intermediate → wrapper, ppid links asserted before any kill) and kills only the grandparent: before the ancestor change both survived; after, both are gone and the compiler never runs.

**Discriminating tests, not just a green suite.** 50 tests in `scripts/test-swift-safe.py` (29 before this work), wired into the `lint` CI job. The new cases fail against the pre-fix script. Mutation-checked twice, by the implementer and independently by me: neutering the ancestor clause reds 2 tests, neutering the ppid clause reds 3 — so neither is dead code — and both restore green.

`scripts/test.test.sh` stays green; `scripts/test.sh` is untouched, so no case is owed there.

**One caveat recorded honestly:** the baseline capture sits at the top of `main()` deliberately, above argument parsing and the lock-file open, but no test pins that *position* — moving it back down leaves all 50 green, since every end-to-end case kills its requester after the wrapper reaches the wait loop. There is no clean seam to inject a delay into argument parsing. The comment there says so, rather than implying the constraint is enforced.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=68C0F549-84E5-44B9-A1CF-6642C94CAC12)
