### PR TITLE
Fix: Stop the sidebar and transcript panes recomputing the same answer every render

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -1335,11 +1335,13 @@ extension AppState {
     /// spaces can never be children — nesting requires a `repoID`
     /// (`createNestedWorktree` guards on it), and `createScratch` never sets
     /// `parentWorktreeID` — so no child ever lives outside the dict.
+    ///
+    /// Served from the memoized `childrenIndex()` (`AppState.swift`), which the
+    /// `worktrees` `didSet` invalidates. The sidebar calls this once per row
+    /// while rendering, so recomputing the flatMap/filter/sort per call made a
+    /// render pass O(N²).
     func children(of parentID: UUID) -> [Worktree] {
-        worktrees.values
-            .flatMap { $0 }
-            .filter { $0.parentWorktreeID == parentID && ($0.status == .active || $0.status == .creating) }
-            .sorted { $0.sortOrder < $1.sortOrder }
+        childrenIndex()[parentID] ?? []
     }
 
     /// Find a worktree by id across all repos, including repo-less scratch

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -104,10 +104,69 @@ final class AppState: ObservableObject {
     private var themeStoreSubscription: AnyCancellable?
 
     @Published var repos: [Repo] = []
-    @Published var worktrees: [UUID: [Worktree]] = [:]
+    @Published var worktrees: [UUID: [Worktree]] = [:] {
+        didSet {
+            childrenIndexCache = nil
+            allWorktreesCache = nil
+        }
+    }
     /// Repo-less scratch spaces (`Worktree.isScratch`), surfaced separately
     /// in the sidebar's Scratch section rather than under any repo group.
-    @Published var scratchWorktrees: [Worktree] = []
+    @Published var scratchWorktrees: [Worktree] = [] {
+        // Only `allWorktrees` reads this — `childrenIndex()` is dict-only by
+        // design (see `children(of:)`), so its cache survives scratch churn.
+        didSet { allWorktreesCache = nil }
+    }
+
+    // MARK: - Derived worktree caches
+    //
+    // Both are plain stored properties, NOT `@Published`: their getters fill
+    // them lazily, and a `@Published` write from inside a SwiftUI `body`
+    // evaluation would fault with "Modifying state during view update".
+    // `AppState` is `@MainActor`, so plain storage is race-free here.
+    //
+    // Invalidation is the two `didSet`s above. Every mutation site in the app
+    // goes through these stored properties — including in-place element writes
+    // like `worktrees[key]?[idx].pinSortOrder = order`, which are a
+    // get-modify-set on the stored property and therefore fire `didSet` too —
+    // so there is no bypassing path.
+
+    /// Memoized parent-keyed child index; see `childrenIndex()`.
+    private var childrenIndexCache: [UUID: [Worktree]]?
+    /// Memoized flattening for `allWorktrees`.
+    private var allWorktreesCache: [Worktree]?
+
+    /// Every active/creating worktree bucketed by `parentWorktreeID`, in
+    /// `sortOrder`. Backs `children(of:)`, which the sidebar calls once per
+    /// row while rendering — recomputing the O(N) flatMap/filter/sort per call
+    /// made a render pass O(N²) (measured 79.5 ms at 127 worktrees; the index
+    /// costs 1.68 ms cold and ~0 warm).
+    ///
+    /// Deliberately dict-only, never `allWorktrees`: scratch spaces can never
+    /// be children (see `children(of:)`).
+    func childrenIndex() -> [UUID: [Worktree]] {
+        if let cached = childrenIndexCache { return cached }
+        var index: [UUID: [Worktree]] = [:]
+        for rows in worktrees.values {
+            for worktree in rows {
+                guard let parentID = worktree.parentWorktreeID,
+                      worktree.status == .active || worktree.status == .creating else { continue }
+                index[parentID, default: []].append(worktree)
+            }
+        }
+        // Same comparator as the pre-index implementation. `Dictionary.values`
+        // iteration order is nondeterministic and `sort` is not stable, so ties
+        // on equal `sortOrder` were already nondeterministic — deliberately not
+        // "fixed" with an id tie-break, which would change behavior.
+        // `Array(index.keys)` rather than `index.keys`: the lazy view holds a
+        // reference to the dictionary's storage, so mutating `index` inside
+        // the loop would force a full copy-on-write copy on every iteration.
+        for key in Array(index.keys) {
+            index[key]?.sort { $0.sortOrder < $1.sortOrder }
+        }
+        childrenIndexCache = index
+        return index
+    }
     @Published var terminals: [UUID: [Terminal]] = [:]
     @Published var notes: [UUID: [Note]] = [:]
     @Published var focusedTabCloseContext: TabCloseContext?
@@ -207,12 +266,30 @@ final class AppState: ObservableObject {
                 return
             }
 
+            // Rebuild the order in a local, then assign to `selectionOrder`
+            // EXACTLY ONCE. `selectionOrder`'s own `didSet` runs a full
+            // JSONEncoder + UserDefaults write, so mutating it in place — one
+            // `removeAll` plus one `append` per newly-selected id — cost N+1
+            // encodes and writes for a single selection change. The `Set`
+            // membership test also replaces an O(n) `Array.contains` inside
+            // the loop.
+            //
+            // Order semantics are unchanged: surviving ids keep their existing
+            // relative order and newly-selected ids are appended after them.
+            // The append loop still iterates `selectedWorktreeIDs`, a `Set`,
+            // so the relative order of several ids added by one gesture stays
+            // as nondeterministic as it always was — deliberately not
+            // stabilized here.
+            var newOrder = selectionOrder
             // Remove deselected items from order
-            selectionOrder.removeAll { !selectedWorktreeIDs.contains($0) }
+            newOrder.removeAll { !selectedWorktreeIDs.contains($0) }
             // Append newly selected items (maintains insertion order for cmd+click)
-            for id in selectedWorktreeIDs where !selectionOrder.contains(id) {
-                selectionOrder.append(id)
+            let alreadyOrdered = Set(newOrder)
+            for id in selectedWorktreeIDs where !alreadyOrdered.contains(id) {
+                newOrder.append(id)
             }
+            // Skip the write entirely when nothing moved.
+            if newOrder != selectionOrder { selectionOrder = newOrder }
             // When a single worktree becomes the focused selection, the user is
             // now viewing its active tab — clear that tab's unread-completion
             // bold. Single-select only: tab bars only render in single-select.
@@ -2292,8 +2369,15 @@ final class AppState: ObservableObject {
     /// Use this instead of re-flattening `worktrees.values` whenever a lookup
     /// must also resolve scratch spaces (e.g. notification banner titles,
     /// startup selection restore).
+    ///
+    /// Memoized (`allWorktreesCache`, invalidated by the `worktrees` /
+    /// `scratchWorktrees` `didSet`s): `SidebarView` reads it twice per body
+    /// evaluation, and each read was a full copy of every row.
     var allWorktrees: [Worktree] {
-        worktrees.values.flatMap { $0 } + scratchWorktrees
+        if let cached = allWorktreesCache { return cached }
+        let flattened = worktrees.values.flatMap { $0 } + scratchWorktrees
+        allWorktreesCache = flattened
+        return flattened
     }
 
     /// Runs `body` only if no poll cycle is currently in flight. Returns true if

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -374,6 +374,13 @@ struct SessionTranscriptView: View {
     /// streaming update (follow the tail).
     @State private var activityToggleToken: Int = 0
 
+    /// Per-pane memo for `TranscriptPresentation.build`, which is called inline
+    /// in `body` and so re-ran on every body evaluation — and this view observes
+    /// `AppState`, so any unrelated publish paid for it. Per-pane rather than
+    /// the process-wide `.shared` so this pane and the live transcript cannot
+    /// evict each other out of a size-1 cache.
+    @State private var presentationMemo = TranscriptPresentationMemo()
+
     @State private var isFreshBranchReviveInFlight = false
 
     private var messages: [TranscriptItem] {
@@ -451,7 +458,8 @@ struct SessionTranscriptView: View {
             } else {
                 let presentation = TranscriptPresentation.build(
                     items: messages,
-                    expansionOverrides: activityGroupExpansion
+                    expansionOverrides: activityGroupExpansion,
+                    memo: presentationMemo
                 )
                 SessionWorkbenchView(
                     sections: presentation.indexSections,

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -45,6 +45,17 @@ struct TableTranscriptPaneView: View {
     /// streaming update (follow the tail).
     @State private var activityToggleToken: Int = 0
 
+    /// Per-pane memo for `TranscriptPresentation.build`, which is called from
+    /// inside `tableTranscript` and so re-ran on every body evaluation — and
+    /// this view observes `AppState`, so any unrelated publish paid for it.
+    /// A reference-type holder in `@State`, the same shape as `openTiming`
+    /// below: the default expression re-runs on every memberwise init, but
+    /// `@State` keeps the first instance, and allocating an empty box is free
+    /// where recomputing the projection is not. Per-pane rather than the
+    /// process-wide `.shared` so the live pane and Session History cannot
+    /// evict each other out of a size-1 cache.
+    @State private var presentationMemo = TranscriptPresentationMemo()
+
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
 
     /// OPEN-PATH BOUNDARY TIMING (#129 freeze hunt). Permanent-but-off: emitted
@@ -178,7 +189,8 @@ struct TableTranscriptPaneView: View {
     private var tableTranscript: some View {
         let presentation = TranscriptPresentation.build(
             items: displayedMessages,
-            expansionOverrides: activityGroupExpansion
+            expansionOverrides: activityGroupExpansion,
+            memo: presentationMemo
         )
         let cardContext = TranscriptCardContext(
             terminalID: terminalID,

--- a/Sources/TBDApp/Panes/Transcript/TranscriptPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptPresentation.swift
@@ -233,9 +233,31 @@ struct TranscriptPresentation {
         indexSections.reduce(0) { $0 + $1.entries.count }
     }
 
+    /// Memoized entry point. `build` is called from inside two SwiftUI view
+    /// bodies (`TableTranscriptPaneView.tableTranscript` and `HistoryPaneView`),
+    /// each holding the result in a plain `let`, and both views observe
+    /// `AppState` — so an unrelated publish re-ran the whole projection,
+    /// including one `JSONSerialization` parse per tool call. Measured at
+    /// 2.4 ms / 200 items, 11.3 ms / 800, 70.8 ms / 3000, on the main thread.
+    ///
+    /// The memo is keyed on FULL value equality of both inputs, never a cheap
+    /// proxy: a tool call gets its result filled in later without the array
+    /// count or the last item's ID changing, so a count-or-last-ID key would
+    /// serve a stale transcript. Equality is cheap in the common case because
+    /// the same underlying array storage is re-read from
+    /// `appState.sessionTranscripts[sid]`, and `Array.==` short-circuits on
+    /// identical buffers.
     nonisolated static func build(
         items: [TranscriptItem],
-        expansionOverrides: [String: Bool] = [:]
+        expansionOverrides: [String: Bool] = [:],
+        memo: TranscriptPresentationMemo = .shared
+    ) -> TranscriptPresentation {
+        memo.presentation(items: items, expansionOverrides: expansionOverrides, compute: compute)
+    }
+
+    private nonisolated static func compute(
+        items: [TranscriptItem],
+        expansionOverrides: [String: Bool]
     ) -> TranscriptPresentation {
         let baseNodes = transcriptRenderNodes(from: items)
         var projected: [TranscriptRenderNode] = []
@@ -448,12 +470,22 @@ struct TranscriptPresentation {
             }
         }
 
+        // One pass to bucket, then emit. The previous shape rescanned the whole
+        // of `orderedKeys` once per category — O(categories × keys) — which on a
+        // long session was a measurable share of a main-thread rebuild. Ordering
+        // is unchanged and must stay so: sections come out in
+        // `SessionIndexCategory.allCases` order, entries within a section in
+        // first-seen `orderedKeys` order, and an empty category is omitted.
+        var bucketed: [SessionIndexCategory: [SessionIndexEntry]] = [:]
+        for key in orderedKeys {
+            guard let entry = entries[key] else { continue }
+            bucketed[key.category, default: []].append(entry)
+        }
+
         return SessionIndexCategory.allCases.compactMap { category in
-            let categoryEntries = orderedKeys.compactMap { key -> SessionIndexEntry? in
-                guard key.category == category else { return nil }
-                return entries[key]
+            guard let categoryEntries = bucketed[category], !categoryEntries.isEmpty else {
+                return nil
             }
-            guard !categoryEntries.isEmpty else { return nil }
             return SessionIndexSection(category: category, entries: categoryEntries)
         }
     }
@@ -499,5 +531,80 @@ struct TranscriptPresentation {
         return [
             "browser_navigate", "browser_open", "browser_search", "web_fetch", "web_search"
         ].contains(String(leaf))
+    }
+}
+
+/// Size-1 memo behind `TranscriptPresentation.build`.
+///
+/// Only the most recent `(items, expansionOverrides)` pair is retained: the
+/// access pattern is a single view re-reading one session's transcript many
+/// times in a row, so a deeper cache would buy nothing and pin transcript
+/// arrays alive.
+///
+/// Both view call sites hold their OWN instance in `@State` rather than using
+/// `.shared`, so the live pane and Session History cannot evict each other out
+/// of a size-1 cache when both are mounted. `.shared` is the default only for
+/// callers that pass no memo — chiefly tests.
+///
+/// `build` is `nonisolated static`, so the cache must be callable from any
+/// isolation. A lock is used rather than a `@MainActor` holder because a
+/// main-actor-isolated store would be unreachable from a `nonisolated`
+/// function without either an `await` (which `build` cannot introduce — its
+/// call sites are synchronous `let`s inside view bodies) or
+/// `MainActor.assumeIsolated`, which would trap in the many off-main unit
+/// tests that call `build` directly.
+final class TranscriptPresentationMemo: @unchecked Sendable {
+    static let shared = TranscriptPresentationMemo()
+
+    private struct Entry {
+        let items: [TranscriptItem]
+        let expansionOverrides: [String: Bool]
+        let presentation: TranscriptPresentation
+    }
+
+    private let lock = NSLock()
+    private var entry: Entry?
+    private var hitCount = 0
+    private var missCount = 0
+
+    func presentation(
+        items: [TranscriptItem],
+        expansionOverrides: [String: Bool],
+        compute: ([TranscriptItem], [String: Bool]) -> TranscriptPresentation
+    ) -> TranscriptPresentation {
+        lock.lock()
+        let cached = entry
+        lock.unlock()
+
+        // Full value equality on BOTH inputs. A tool call gains its result in
+        // place, leaving `count` and the last item's ID untouched, so any
+        // cheaper key would serve a stale transcript.
+        if let cached,
+           cached.items == items,
+           cached.expansionOverrides == expansionOverrides {
+            lock.lock()
+            hitCount += 1
+            lock.unlock()
+            return cached.presentation
+        }
+
+        // Computed outside the lock: two threads racing here recompute
+        // independently and the loser's identical result is simply discarded,
+        // which is cheaper than serializing a 70 ms projection.
+        let fresh = compute(items, expansionOverrides)
+
+        lock.lock()
+        entry = Entry(items: items, expansionOverrides: expansionOverrides, presentation: fresh)
+        missCount += 1
+        lock.unlock()
+        return fresh
+    }
+
+    /// Hit/miss tallies, for tests. Read under the lock so a test never races
+    /// the counters it is asserting on.
+    var statistics: (hits: Int, misses: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (hitCount, missCount)
     }
 }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -157,7 +157,19 @@ private struct AddTabButton: View {
     let onAddCodex: () -> Void
     let onAddNote: () -> Void
     @State private var isHovering = false
-    @State private var availability = AgentExecutableAvailability.detect()
+    /// Optimistic placeholder, deliberately NOT `.detect()`.
+    ///
+    /// A `@State` default-value expression runs on EVERY call to the memberwise
+    /// initializer — `@State` only preserves the stored value after first
+    /// mount, it does not stop the expression from re-evaluating. `AddTabButton`
+    /// is built inside `TabBar.body`, itself built inside `SingleWorktreeView.body`,
+    /// and `WorktreePager` keeps one of those mounted per kept-alive worktree, all
+    /// observing `AppState` — so any `@Published` change (the 2 s poll, terminal
+    /// churn, `mainAreaSize` during a window resize) re-ran `detect()` for every
+    /// mounted worktree, each doing `2 × (PATH dirs + 8)` synchronous `stat`s on
+    /// the main thread. The two real refresh paths below cover the value: `.task`
+    /// on appear, and a synchronous re-detect in `showMenu()`.
+    @State private var availability = AgentExecutableAvailability.allAvailable
 
     var body: some View {
         Image(systemName: "plus")
@@ -179,7 +191,11 @@ private struct AddTabButton: View {
     }
 
     private func showMenu() {
-        availability = AgentExecutableAvailability.detect()
+        // Re-detect synchronously, and build the menu from the value just
+        // measured rather than reading `availability` back — the menu can never
+        // be built from the optimistic placeholder.
+        let detected = AgentExecutableAvailability.detect()
+        availability = detected
         let coordinator = MenuCoordinator(
             onShell: onAddShell,
             onClaude: onAddClaude,
@@ -190,7 +206,7 @@ private struct AddTabButton: View {
         )
         let menu = AddTabMenu.build(
             profiles: profiles,
-            availability: availability,
+            availability: detected,
             coordinator: coordinator
         )
 

--- a/Tests/TBDAppTests/AppStateDerivedCacheTests.swift
+++ b/Tests/TBDAppTests/AppStateDerivedCacheTests.swift
@@ -1,0 +1,459 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// Tier 1: deterministic, in-process state only. No sleeps, no subprocesses,
+// no `~/tbd`. Every `AppState` here is built against a throwaway
+// `UserDefaults` suite — `UserDefaults.standard` on this unbundled executable
+// is the developer's real `TBDApp.plist`.
+
+private func makeWorktree(
+    id: UUID = UUID(),
+    repoID: UUID?,
+    status: WorktreeStatus = .active,
+    sortOrder: Int = 0,
+    parentWorktreeID: UUID? = nil
+) -> Worktree {
+    Worktree(
+        id: id,
+        repoID: repoID,
+        name: "test-\(id.uuidString.prefix(8))",
+        displayName: "Test \(id.uuidString.prefix(8))",
+        branch: "main",
+        path: "/tmp/test",
+        status: status,
+        tmuxServer: "test-server",
+        sortOrder: sortOrder,
+        parentWorktreeID: parentWorktreeID
+    )
+}
+
+/// The pre-memoization `children(of:)` body, verbatim. Every index assertion
+/// below is stated against this oracle so the memoized index cannot silently
+/// drift from the semantics it replaced.
+@MainActor
+private func referenceChildren(_ state: AppState, of parentID: UUID) -> [Worktree] {
+    state.worktrees.values
+        .flatMap { $0 }
+        .filter { $0.parentWorktreeID == parentID && ($0.status == .active || $0.status == .creating) }
+        .sorted { $0.sortOrder < $1.sortOrder }
+}
+
+@MainActor
+private func withState(_ body: (AppState) -> Void) {
+    let suiteName = "TBDAppTests.AppStateDerivedCache.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    body(AppState(userDefaults: defaults))
+}
+
+/// `children(of:)` is served from a memoized parent-keyed index rather than
+/// re-running an O(N) flatMap/filter/sort per call — the sidebar calls it once
+/// per row, which made a render pass O(N²) (measured 79.5 ms at 127
+/// worktrees). These tests pin both halves: the index must agree with the old
+/// implementation, and it must be invalidated on every `worktrees` mutation.
+@MainActor
+@Suite("children(of:) memoized index")
+struct ChildrenIndexTests {
+
+    @Test func matchesReferenceOnAFreshState() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let parent = makeWorktree(id: parentID, repoID: repoID)
+            let childA = makeWorktree(repoID: repoID, sortOrder: 2, parentWorktreeID: parentID)
+            let childB = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [parent, childA, childB]]
+
+            #expect(state.children(of: parentID).map(\.id) == [childB.id, childA.id])
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+            // A parent with no children resolves to empty, not to some other
+            // bucket's rows.
+            #expect(state.children(of: UUID()).isEmpty)
+        }
+    }
+
+    @Test func reflectsAnAddedChild() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: parentID, repoID: repoID)]]
+            // Warm the cache before mutating — a missing invalidation would
+            // keep serving this empty answer.
+            #expect(state.children(of: parentID).isEmpty)
+
+            let child = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            state.worktrees[repoID]?.append(child)
+
+            #expect(state.children(of: parentID).map(\.id) == [child.id])
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+        }
+    }
+
+    @Test func reflectsARemovedChild() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let child = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [makeWorktree(id: parentID, repoID: repoID), child]]
+            #expect(state.children(of: parentID).count == 1)
+
+            state.worktrees[repoID]?.removeAll { $0.id == child.id }
+
+            #expect(state.children(of: parentID).isEmpty)
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+        }
+    }
+
+    @Test func reflectsAReparent() {
+        withState { state in
+            let repoID = UUID()
+            let firstParent = UUID()
+            let secondParent = UUID()
+            let child = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: firstParent)
+            state.worktrees = [repoID: [
+                makeWorktree(id: firstParent, repoID: repoID),
+                makeWorktree(id: secondParent, repoID: repoID),
+                child
+            ]]
+            #expect(state.children(of: firstParent).map(\.id) == [child.id])
+
+            // In-place element write through the subscript — still a
+            // get-modify-set on the stored property, so `didSet` fires.
+            let index = state.worktrees[repoID]!.firstIndex { $0.id == child.id }!
+            state.worktrees[repoID]?[index].parentWorktreeID = secondParent
+
+            #expect(state.children(of: firstParent).isEmpty)
+            #expect(state.children(of: secondParent).map(\.id) == [child.id])
+            #expect(state.children(of: secondParent) == referenceChildren(state, of: secondParent))
+        }
+    }
+
+    @Test func statusChangeToArchivedDropsTheChild() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let child = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [makeWorktree(id: parentID, repoID: repoID), child]]
+            #expect(state.children(of: parentID).count == 1)
+
+            let index = state.worktrees[repoID]!.firstIndex { $0.id == child.id }!
+            state.worktrees[repoID]?[index].status = .archived
+
+            #expect(state.children(of: parentID).isEmpty)
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+        }
+    }
+
+    @Test func onlyActiveAndCreatingRowsAreIncluded() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let active = makeWorktree(repoID: repoID, status: .active, sortOrder: 1, parentWorktreeID: parentID)
+            let creating = makeWorktree(repoID: repoID, status: .creating, sortOrder: 2, parentWorktreeID: parentID)
+            let archived = makeWorktree(repoID: repoID, status: .archived, sortOrder: 3, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [active, creating, archived]]
+
+            #expect(state.children(of: parentID).map(\.id) == [active.id, creating.id])
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+        }
+    }
+
+    @Test func reflectsASortOrderChange() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let first = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            let second = makeWorktree(repoID: repoID, sortOrder: 2, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [first, second]]
+            #expect(state.children(of: parentID).map(\.id) == [first.id, second.id])
+
+            let index = state.worktrees[repoID]!.firstIndex { $0.id == first.id }!
+            state.worktrees[repoID]?[index].sortOrder = 99
+
+            #expect(state.children(of: parentID).map(\.id) == [second.id, first.id])
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+        }
+    }
+
+    @Test func wholesaleDictReplacementInvalidatesTheIndex() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let child = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [child]]
+            #expect(state.children(of: parentID).count == 1)
+
+            state.worktrees = [:]
+
+            #expect(state.children(of: parentID).isEmpty)
+        }
+    }
+
+    @Test func bucketsChildrenAcrossRepos() {
+        withState { state in
+            let repoA = UUID()
+            let repoB = UUID()
+            let parentID = UUID()
+            // A child of the same parent living under a different repo key —
+            // the index must not be repo-partitioned.
+            let childA = makeWorktree(repoID: repoA, sortOrder: 1, parentWorktreeID: parentID)
+            let childB = makeWorktree(repoID: repoB, sortOrder: 2, parentWorktreeID: parentID)
+            state.worktrees = [repoA: [childA], repoB: [childB]]
+
+            #expect(state.children(of: parentID).map(\.id) == [childA.id, childB.id])
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+        }
+    }
+
+    /// `children(of:)` is dict-only by design: a scratch space can never be a
+    /// child (`createNestedWorktree` requires a `repoID`, `createScratch`
+    /// never sets `parentWorktreeID`). The index must keep that scope even
+    /// when a scratch row is hand-stamped with a parent.
+    @Test func excludesScratchWorktrees() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let realChild = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [realChild]]
+            state.scratchWorktrees = [
+                makeWorktree(repoID: nil, sortOrder: 0, parentWorktreeID: parentID)
+            ]
+
+            #expect(state.children(of: parentID).map(\.id) == [realChild.id])
+            #expect(state.children(of: parentID) == referenceChildren(state, of: parentID))
+        }
+    }
+
+    /// A scratch mutation must not disturb the child index (it invalidates
+    /// only the `allWorktrees` cache), and must still not leak into it.
+    @Test func scratchMutationsNeverEnterTheIndex() {
+        withState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            let realChild = makeWorktree(repoID: repoID, sortOrder: 1, parentWorktreeID: parentID)
+            state.worktrees = [repoID: [realChild]]
+            #expect(state.children(of: parentID).map(\.id) == [realChild.id])
+
+            state.scratchWorktrees.append(
+                makeWorktree(repoID: nil, sortOrder: 0, parentWorktreeID: parentID)
+            )
+
+            #expect(state.children(of: parentID).map(\.id) == [realChild.id])
+        }
+    }
+}
+
+/// `allWorktrees` is memoized behind the same two `didSet`s. It must stay
+/// scratch-inclusive and must follow BOTH sources.
+@MainActor
+@Suite("allWorktrees memoization")
+struct AllWorktreesCacheTests {
+
+    @Test func followsWorktreeDictMutations() {
+        withState { state in
+            let repoID = UUID()
+            let first = makeWorktree(repoID: repoID)
+            state.worktrees = [repoID: [first]]
+            #expect(state.allWorktrees.map(\.id) == [first.id])
+
+            let second = makeWorktree(repoID: repoID)
+            state.worktrees[repoID]?.append(second)
+
+            #expect(Set(state.allWorktrees.map(\.id)) == Set([first.id, second.id]))
+        }
+    }
+
+    @Test func followsScratchMutations() {
+        withState { state in
+            let repoID = UUID()
+            let repoRow = makeWorktree(repoID: repoID)
+            state.worktrees = [repoID: [repoRow]]
+            #expect(state.allWorktrees.map(\.id) == [repoRow.id])
+
+            let scratch = makeWorktree(repoID: nil)
+            state.scratchWorktrees.append(scratch)
+
+            #expect(Set(state.allWorktrees.map(\.id)) == Set([repoRow.id, scratch.id]))
+
+            state.scratchWorktrees.removeAll()
+            #expect(state.allWorktrees.map(\.id) == [repoRow.id])
+        }
+    }
+
+    @Test func followsInPlaceFieldEdits() {
+        withState { state in
+            let repoID = UUID()
+            let row = makeWorktree(repoID: repoID)
+            state.worktrees = [repoID: [row]]
+            #expect(state.allWorktrees.first?.displayName == row.displayName)
+
+            state.worktrees[repoID]?[0].displayName = "Renamed"
+
+            #expect(state.allWorktrees.first?.displayName == "Renamed")
+        }
+    }
+}
+
+/// A `UserDefaults` that counts writes per key, so a test can assert how many
+/// encode+write round-trips one selection change costs.
+private final class WriteCountingUserDefaults: UserDefaults {
+    nonisolated(unsafe) var writesByKey: [String: Int] = [:]
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        writesByKey[defaultName, default: 0] += 1
+        super.set(value, forKey: defaultName)
+    }
+}
+
+/// `selectedWorktreeIDs`'s `didSet` used to mutate `selectionOrder` in place —
+/// one `removeAll` plus one `append` per newly-selected id — and
+/// `selectionOrder`'s own `didSet` runs a full `JSONEncoder` + `UserDefaults`
+/// write. One selection of N worktrees therefore cost N+1 encodes and writes.
+/// The order it produces must be byte-identical to the old behavior.
+@MainActor
+@Suite("Selection order persists once per selection change")
+struct SelectionOrderWriteCoalescingTests {
+
+    /// Key literal, because `AppState.selectionOrderKey` is `private static`.
+    private static let selectionOrderKey = "com.tbd.app.selectionOrder"
+
+    private func withCountingState(_ body: (AppState, WriteCountingUserDefaults) -> Void) {
+        let suiteName = "TBDAppTests.SelectionOrderWrites.\(UUID().uuidString)"
+        let defaults = WriteCountingUserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+        // `persistSelectionOrder` is gated on this; startup must not clobber a
+        // saved value before the restore has run.
+        state.isInitialStateLoaded = true
+        defaults.writesByKey.removeAll()
+        body(state, defaults)
+    }
+
+    private func writes(_ defaults: WriteCountingUserDefaults) -> Int {
+        defaults.writesByKey[Self.selectionOrderKey] ?? 0
+    }
+
+    @Test func selectingFiveWorktreesWritesOnce() {
+        withCountingState { state, defaults in
+            let repoID = UUID()
+            let rows = (0..<5).map { makeWorktree(repoID: repoID, sortOrder: $0) }
+            state.worktrees = [repoID: rows]
+
+            state.selectedWorktreeIDs = Set(rows.map(\.id))
+
+            // Old code: 1 `removeAll` + 5 `append` = 6 writes.
+            #expect(writes(defaults) == 1)
+            #expect(Set(state.selectionOrder) == Set(rows.map(\.id)))
+        }
+    }
+
+    @Test func selectingOneWorktreeWritesOnce() {
+        withCountingState { state, defaults in
+            let repoID = UUID()
+            let row = makeWorktree(repoID: repoID)
+            state.worktrees = [repoID: [row]]
+
+            state.selectedWorktreeIDs = [row.id]
+
+            // Old code: 1 `removeAll` + 1 `append` = 2 writes.
+            #expect(writes(defaults) == 1)
+            #expect(state.selectionOrder == [row.id])
+        }
+    }
+
+    @Test func reassigningTheSameSelectionWritesNothing() {
+        withCountingState { state, defaults in
+            let repoID = UUID()
+            let row = makeWorktree(repoID: repoID)
+            state.worktrees = [repoID: [row]]
+            state.selectedWorktreeIDs = [row.id]
+            #expect(writes(defaults) == 1)
+
+            // A no-op selection change must not re-encode and re-write.
+            state.selectedWorktreeIDs = [row.id]
+
+            #expect(writes(defaults) == 1)
+            #expect(state.selectionOrder == [row.id])
+        }
+    }
+
+    @Test func deselectingWritesOnce() {
+        withCountingState { state, defaults in
+            let repoID = UUID()
+            let rows = (0..<3).map { makeWorktree(repoID: repoID, sortOrder: $0) }
+            state.worktrees = [repoID: rows]
+            state.selectedWorktreeIDs = Set(rows.map(\.id))
+            defaults.writesByKey.removeAll()
+
+            state.selectedWorktreeIDs = [rows[0].id]
+
+            #expect(writes(defaults) == 1)
+            #expect(state.selectionOrder == [rows[0].id])
+        }
+    }
+}
+
+/// The order `selectionOrder` ends up in must be exactly what the in-place
+/// mutation produced: survivors keep their relative order, newly-selected ids
+/// land after them.
+@MainActor
+@Suite("Selection order contents are unchanged")
+struct SelectionOrderSemanticsTests {
+
+    @Test func survivorsKeepRelativeOrderAndNewIDsAppend() {
+        withState { state in
+            let repoID = UUID()
+            let rows = (0..<4).map { makeWorktree(repoID: repoID, sortOrder: $0) }
+            state.worktrees = [repoID: rows]
+            state.isInitialStateLoaded = true
+
+            // Build a deliberate cmd+click order: 2, then 0, then 1.
+            state.selectedWorktreeIDs = [rows[2].id]
+            state.selectedWorktreeIDs = [rows[2].id, rows[0].id]
+            state.selectedWorktreeIDs = [rows[2].id, rows[0].id, rows[1].id]
+            #expect(state.selectionOrder == [rows[2].id, rows[0].id, rows[1].id])
+
+            // Drop the middle survivor and add a brand-new id in one change:
+            // 2 and 1 keep their relative order, 3 is appended after them.
+            state.selectedWorktreeIDs = [rows[2].id, rows[1].id, rows[3].id]
+
+            #expect(state.selectionOrder == [rows[2].id, rows[1].id, rows[3].id])
+        }
+    }
+
+    @Test func clearingSelectionEmptiesTheOrder() {
+        withState { state in
+            let repoID = UUID()
+            let rows = (0..<2).map { makeWorktree(repoID: repoID, sortOrder: $0) }
+            state.worktrees = [repoID: rows]
+            state.isInitialStateLoaded = true
+            state.selectedWorktreeIDs = [rows[0].id]
+            state.selectedWorktreeIDs = [rows[0].id, rows[1].id]
+            #expect(state.selectionOrder == [rows[0].id, rows[1].id])
+
+            state.selectedWorktreeIDs = []
+
+            #expect(state.selectionOrder.isEmpty)
+        }
+    }
+
+    /// The bookkeeping that runs after the loop must still see the final
+    /// `selectionOrder` — `recentWorktreeIDs` is fed from `selectionOrder.last`.
+    @Test func recentWorktreeIDsStillSeeTheFinalOrder() {
+        withState { state in
+            let repoID = UUID()
+            let rows = (0..<2).map { makeWorktree(repoID: repoID, sortOrder: $0) }
+            state.worktrees = [repoID: rows]
+            state.isInitialStateLoaded = true
+
+            state.selectedWorktreeIDs = [rows[0].id]
+            #expect(state.recentWorktreeIDs.first == rows[0].id)
+
+            state.selectedWorktreeIDs = [rows[0].id, rows[1].id]
+            #expect(state.selectionOrder.last == rows[1].id)
+            #expect(state.recentWorktreeIDs.first == rows[1].id)
+        }
+    }
+}

--- a/Tests/TBDAppTests/TranscriptPresentationMemoTests.swift
+++ b/Tests/TBDAppTests/TranscriptPresentationMemoTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// Tier 1 — pure, in-process, no clock and no filesystem.
+///
+/// Covers the two halves of the transcript-presentation perf fix: the
+/// single-pass bucketing inside the session-index builder (output must be
+/// byte-for-byte what the per-category rescan produced) and the size-1 memo in
+/// front of `TranscriptPresentation.build`.
+@Suite("Transcript presentation memo and index ordering")
+struct TranscriptPresentationMemoTests {
+
+    // MARK: - Index section ordering
+
+    @Test("session index keeps category order, first-seen entry order, counts, and omits empties")
+    func indexSectionOrderingIsExact() throws {
+        // Deliberately interleaved so that FIRST-SEEN category order
+        // (web, delegates, sources, changed) is the exact reverse of the
+        // declared `SessionIndexCategory.allCases` order the sections must come
+        // out in — a builder that emitted buckets in encounter order, or in
+        // Dictionary order, cannot pass this.
+        let items: [TranscriptItem] = [
+            tool("w1", "WebSearch", #"{"query":"swift memoization"}"#),
+            tool("d1", "Task", #"{"description":"audit the index"}"#),
+            tool("r1", "Read", #"{"file_path":"/repo/A.swift"}"#),
+            tool("c1", "Write", #"{"file_path":"/repo/B.swift"}"#),
+            tool("r2", "Read", #"{"file_path":"/repo/A.swift"}"#),
+            tool("w2", "WebFetch", #"{"url":"https://example.com/spec"}"#),
+            tool("r3", "Read", #"{"file_path":"/repo/C.swift"}"#),
+            tool("c2", "Edit", #"{"file_path":"/repo/B.swift"}"#),
+            tool("c3", "MultiEdit", #"{"file_path":"/repo/D.swift"}"#)
+        ]
+
+        let sections = TranscriptPresentation.build(
+            items: items,
+            memo: TranscriptPresentationMemo()
+        ).indexSections
+
+        #expect(sections.map(\.category) == [.changed, .sources, .web, .delegates])
+        try #require(sections.count == 4)
+
+        #expect(sections[0].entries.map(\.target) == ["/repo/B.swift", "/repo/D.swift"])
+        #expect(sections[0].entries.map(\.count) == [2, 1])
+        // A repeat bumps the count and re-points at the LATEST occurrence.
+        #expect(sections[0].entries.map(\.transcriptItemID) == ["c2", "c3"])
+
+        #expect(sections[1].entries.map(\.target) == ["/repo/A.swift", "/repo/C.swift"])
+        #expect(sections[1].entries.map(\.count) == [2, 1])
+        #expect(sections[1].entries.map(\.transcriptItemID) == ["r2", "r3"])
+
+        #expect(sections[2].entries.map(\.target) == ["swift memoization", "https://example.com/spec"])
+        #expect(sections[2].entries.map(\.count) == [1, 1])
+        #expect(sections[2].entries.map(\.transcriptItemID) == ["w1", "w2"])
+
+        #expect(sections[3].entries.map(\.target) == ["audit the index"])
+        #expect(sections[3].entries.map(\.transcriptItemID) == ["d1"])
+
+        // Empty categories are omitted entirely, not emitted as empty sections:
+        // this fixture produces `changed` and `web` only.
+        let sparse = TranscriptPresentation.build(
+            items: [
+                tool("w1", "WebFetch", #"{"url":"https://example.com/a"}"#),
+                tool("c1", "Write", #"{"file_path":"/repo/B.swift"}"#)
+            ],
+            memo: TranscriptPresentationMemo()
+        ).indexSections
+        #expect(sparse.map(\.category) == [.changed, .web])
+        #expect(sparse.allSatisfy { !$0.entries.isEmpty })
+    }
+
+    // MARK: - Memo
+
+    @Test("a repeated build with identical inputs is served from the memo")
+    func repeatedBuildHitsMemo() {
+        let memo = TranscriptPresentationMemo()
+        let items = pendingRun
+
+        let first = TranscriptPresentation.build(items: items, memo: memo)
+        let second = TranscriptPresentation.build(items: items, memo: memo)
+
+        #expect(first.nodes == second.nodes)
+        #expect(first.indexSections == second.indexSections)
+        #expect(memo.statistics.hits == 1)
+        #expect(memo.statistics.misses == 1)
+
+        // Value equality, not buffer identity: the same transcript arriving in
+        // fresh storage (the shape a decoded RPC payload has) is still a hit.
+        let rewired = items.map(roundTripped)
+        let third = TranscriptPresentation.build(items: rewired, memo: memo)
+        #expect(third.nodes == first.nodes)
+        #expect(memo.statistics.hits == 2)
+        #expect(memo.statistics.misses == 1)
+    }
+
+    @Test("a tool call gaining its result recomputes, even though the count is unchanged")
+    func inPlaceResultRecomputes() {
+        let memo = TranscriptPresentationMemo()
+        let pending = pendingRun
+        let settled = settledRun
+
+        // The trap a count-or-last-ID cache key falls into: same element count,
+        // same IDs, same last item — only the first item's payload changed.
+        #expect(pending.count == settled.count)
+        #expect(pending.map(\.id) == settled.map(\.id))
+        #expect(pending.last == settled.last)
+
+        let before = TranscriptPresentation.build(items: pending, memo: memo)
+        let after = TranscriptPresentation.build(items: settled, memo: memo)
+
+        #expect(memo.statistics.hits == 0)
+        #expect(memo.statistics.misses == 2)
+        #expect(summary(of: before)?.pendingCount == 1)
+        #expect(summary(of: after)?.pendingCount == 0)
+        #expect(before.nodes != after.nodes)
+    }
+
+    @Test("changing only the expansion overrides recomputes")
+    func expansionOverrideChangeRecomputes() {
+        let memo = TranscriptPresentationMemo()
+        let items = settledRun
+        let groupID = "t1#activity-group"
+
+        let collapsed = TranscriptPresentation.build(items: items, memo: memo)
+        let expanded = TranscriptPresentation.build(
+            items: items,
+            expansionOverrides: [groupID: true],
+            memo: memo
+        )
+
+        #expect(memo.statistics.hits == 0)
+        #expect(memo.statistics.misses == 2)
+        #expect(collapsed.nodes.map(\.id) == [groupID])
+        #expect(expanded.nodes.map(\.id) == [groupID, "t1", "t2"])
+
+        // And going back to the previous overrides is a miss too — the memo
+        // holds one entry, so this proves it is keyed rather than accumulating.
+        let collapsedAgain = TranscriptPresentation.build(items: items, memo: memo)
+        #expect(collapsedAgain.nodes.map(\.id) == [groupID])
+        #expect(memo.statistics.hits == 0)
+        #expect(memo.statistics.misses == 3)
+    }
+
+    // MARK: - Fixtures
+
+    /// Two consecutive tool calls — enough to form an activity group — with the
+    /// first still awaiting its result.
+    private var pendingRun: [TranscriptItem] {
+        [
+            tool("t1", "Bash", #"{"command":"swift build"}"#),
+            succeededTool("t2", "Read", #"{"file_path":"/repo/A.swift"}"#)
+        ]
+    }
+
+    /// The same run one poll later: `t1` has gained its result in place. Same
+    /// count, same IDs, same last element.
+    private var settledRun: [TranscriptItem] {
+        [
+            succeededTool("t1", "Bash", #"{"command":"swift build"}"#),
+            succeededTool("t2", "Read", #"{"file_path":"/repo/A.swift"}"#)
+        ]
+    }
+
+    private func tool(_ id: String, _ name: String, _ input: String) -> TranscriptItem {
+        .toolCall(
+            id: id, name: name, inputJSON: input, inputTruncatedTo: nil,
+            result: nil, subagent: nil, timestamp: nil, usage: nil
+        )
+    }
+
+    private func succeededTool(_ id: String, _ name: String, _ input: String) -> TranscriptItem {
+        .toolCall(
+            id: id, name: name, inputJSON: input, inputTruncatedTo: nil,
+            result: ToolResult(text: "ok", truncatedTo: nil, isError: false),
+            subagent: nil, timestamp: nil, usage: nil
+        )
+    }
+
+    /// Sends an item through the Codable path the app actually receives items
+    /// over, so the resulting array shares no storage with the original.
+    private func roundTripped(_ item: TranscriptItem) -> TranscriptItem {
+        do {
+            let data = try JSONEncoder().encode(item)
+            return try JSONDecoder().decode(TranscriptItem.self, from: data)
+        } catch {
+            Issue.record(error)
+            return item
+        }
+    }
+
+    private func summary(of presentation: TranscriptPresentation) -> ActivityGroupSummary? {
+        for node in presentation.nodes {
+            if case .activityGroupSummary(let summary) = node.kind { return summary }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## What's broken

With a large fleet open, the app burns main-thread CPU doing work that produces
the same answer it produced a moment ago. Scrolling the sidebar, switching
worktrees, and typing into a terminal all feel sluggish, and the sluggishness
scales with how many worktrees you have rather than with anything you are doing.

It is not tmux: server round-trips measured 0.00–0.02 s across four servers with
74 panes and 11 attached clients while the UI was visibly hitching. The cost is
app-side, on the main thread, competing with terminal rendering.

Anyone with a few dozen worktrees hits it continuously — the work reruns on
every state publish, roughly every two seconds at idle, and more often while a
window is being resized or a Claude session is streaming.

## Why it happens

Three separate pieces of derived state are rebuilt from scratch inside SwiftUI
view bodies, so they recompute on every re-render rather than when their inputs
change.

**The sidebar recomputes the whole worktree tree once per row.**
`AppState.children(of:)` flattens every worktree in every repo, filters it, and
sorts it — returning full `Worktree` values. `WorktreeSubtreeView.body` calls it
once per row, recursively. So drawing N rows costs N passes over all N
worktrees: quadratic, and the copies are not cheap because `Worktree` has 28
stored properties of which 11 are refcounted, making every copy a burst of
retain/release traffic. `AppState.allWorktrees` has the same shape — it copies
every row on each access and `SidebarView` reads it twice per body evaluation.

**The transcript pane rebuilds its whole index on every render.**
`TranscriptPresentation.build` walks the entire message array and calls
`makeIndexSections`, which JSON-parses every tool call's input and then rescans
its key list once per category. Neither call site cached the result, and both
views observe `AppState`, so any unrelated publish paid for a full rebuild.

**The add-tab button probes the filesystem while rendering.**
`AgentExecutableAvailability.detect()` sat in the default-value expression of a
`@State` property. A default-value expression runs on *every* call to the
memberwise initializer — `@State` preserves the stored value, not the
expression — and `AddTabButton` is constructed inside `TabBar.body`, itself
inside `SingleWorktreeView.body`, one per kept-alive worktree. Every publish
therefore ran `2 × (PATH entries + 8)` synchronous `stat` calls per mounted
worktree on the main thread.

**Selecting worktrees wrote to disk once per selection.**
`selectedWorktreeIDs`'s `didSet` mutated the `@Published` `selectionOrder` array
once per newly selected id, and that property's own `didSet` runs a full
`JSONEncoder` encode plus a `UserDefaults` write. Selecting N worktrees cost N+1
encodes and writes, with an O(n²) `Array.contains` membership test on top.

## What this PR does

Six changes, all semantics-preserving — same outputs, computed less often.

- `children(of:)` is served from a memoized parent-keyed index on `AppState`,
  invalidated by `worktrees`' `didSet`. Deliberately dictionary-only: scratch
  spaces can never be children, matching the pre-index behaviour exactly.
- `allWorktrees` is memoized, invalidated by both `worktrees` and
  `scratchWorktrees`.
- `makeIndexSections` buckets its keys in one pass instead of rescanning them
  per category. Section order, entry order within a section, counts, and
  omission of empty categories are all unchanged.
- A size-1 `TranscriptPresentationMemo` sits in front of
  `TranscriptPresentation.build`. It is keyed on **full value equality** of both
  inputs rather than a cheap proxy, because a tool call gains its result in
  place without the array count or the last item's ID changing — a
  count-or-last-ID key would serve a stale transcript. Equality stays cheap in
  practice because the same array storage is re-read from
  `sessionTranscripts`, and `Array.==` short-circuits on identical buffers.
- `AgentExecutableAvailability.detect()` no longer runs from a `@State` default.
  The two real refresh paths are unchanged: `.task` on appear, and a synchronous
  re-detect when the menu opens. That call now builds the menu from the value it
  just measured instead of reading `@State` back, which is not reliable within
  the same synchronous call.
- `selectedWorktreeIDs`'s `didSet` builds the new order in a local and assigns
  once, skipping the write entirely when nothing moved, and uses a `Set` for the
  membership test.

Why memoization rather than restructuring: every one of these restores intended
behaviour without changing what the app models or how it renders. The larger
structural question — `AppState` publishes object-wide to 56 observing view
files, so any write re-runs all of them — is deliberately **not** addressed
here. It is tracked in #667 with a measured plan, and it needs its own design
work rather than being smuggled into a bug fix.

## Assumptions

- The children index assumes every child worktree lives in the `worktrees`
  dictionary and never in `scratchWorktrees`. This holds because nesting
  requires a `repoID` and `createScratch` never sets `parentWorktreeID`. If a
  scratch space ever gains a parent, it would silently not render as a child.
- The transcript memo assumes `TranscriptItem`'s `Equatable` conformance is
  exact — that two items comparing equal really are interchangeable for
  rendering. If a future field is added to a case but omitted from equality,
  the memo would serve a stale projection.
- Ties on equal `sortOrder` were already nondeterministic before this change
  (`Dictionary.values` iteration order is unspecified and Swift's sort is not
  stable). The index preserves that rather than "fixing" it, so ordering
  behaviour is unchanged — but nothing guarantees a stable order for equal
  `sortOrder`, and callers should not rely on one.

## Evidence & verification

**Measured before/after, with isolated `swiftc -O` benchmarks** mirroring the
real type shapes, sized to a real working set — 127 worktrees across 11 repos
with 53 nested, plus 154 terminals:

- `children(of:)`, per sidebar render pass: **79.5 ms → 1.68 ms** when the index
  is rebuilt every pass, and **0.004 ms** warm. That is ~16,100 `Worktree`
  copies per pass eliminated.
- `makeIndexSections`, per call: **2.4 ms / 11.3 ms / 70.8 ms** at 200 / 800 /
  3000 transcript items before the change. The cost was superlinear in items.

These are isolated benchmarks, deliberately, because the machine they were found
on was heavily loaded; a live sample there measures the load as much as the app.

**25 tests across 5 suites, each written to fail against the old code** — not
merely to pass against the new:

- `children(of:)` is compared against a reference implementation of the previous
  algorithm across a fresh state, adding a child, removing one, re-parenting,
  a status change to archived, and a `sortOrder` change.
- Index invalidation is tested both for wholesale dictionary replacement and for
  in-place field edits (`worktrees[key]?[idx].field = x`), which is the case a
  naive cache would miss.
- Scratch worktrees with a `parentWorktreeID` are asserted absent from the index.
- The selection-order suite counts actual `UserDefaults` writes through a
  counting subclass and asserts exactly one per selection change — this test
  fails on the old code, which wrote N+1 times.
- The memo suite asserts a repeated build is served from cache, that changing
  only `expansionOverrides` recomputes, and — the discriminating case — that a
  tool call gaining its result **recomputes even though the array count is
  unchanged**. Items are constructed through the production `Codable` path
  rather than hand-rolled.

**Not verified live.** There is no before/after `sample` of the running app in
this PR. The benchmarks above are load-independent and stand on their own, but
the end-to-end effect on perceived latency is unconfirmed, and I would rather
say so than imply a smoothness claim I did not measure. Tracked in #667.

Build clean, SwiftLint clean (0 violations across 759 files).

Refs #667
