### PR TITLE
Fix: Collapse the two nil-resolutions of pendingPromptSubmit before one becomes reachable

### DIFF
--- a/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
+++ b/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
@@ -15,11 +15,10 @@ struct ParkedPromptReadback: Identifiable, Equatable {
     /// Whether delivery ends with Enter. Carried through Deliver-now so
     /// re-parking cannot silently flip a staged message into a sent one.
     ///
-    /// Mirrors the column rather than the composer's own default: every row
-    /// that holds a prompt was written with an explicit bit, so the fallback
-    /// below is for rows that have no prompt to show and never fires here.
-    /// Showing anything but the stored bit would misreport what delivery will
-    /// actually do.
+    /// Mirrors the column rather than the composer's own default, and resolves
+    /// an absent bit through `Worktree.pendingPromptSubmitResolved` — the same
+    /// property the daemon's delivery path reads. Showing anything else would
+    /// misreport what delivery will actually do.
     let submit: Bool
     /// Where this message is in its life. The one discriminator behind both
     /// surfaces, computed here so they cannot disagree about the same text.
@@ -50,7 +49,7 @@ struct ParkedPromptReadback: Identifiable, Equatable {
         self.id = worktree.id
         self.worktreeName = worktree.displayName
         self.text = text
-        self.submit = worktree.pendingPromptSubmit ?? true
+        self.submit = worktree.pendingPromptSubmitResolved
         self.worktreeIsArchived = worktree.status == .archived
         self.phase = ParkedPromptPhase.resolve(
             isArchived: worktreeIsArchived, terminals: terminals)

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1337,12 +1337,21 @@ public final class TBDDatabase: Sendable {
         }
 
         // The parked prompt itself. `pending_prompt_submit` DOES carry a SQL
-        // default, and it is unreachable by construction: it is data rather
-        // than a feature gate, and `setPendingPrompt` — the only writer — always
-        // names both columns, so the default can only ever describe a row that
-        // has nothing parked and therefore no submit choice to remember.
-        // Delivery resolves an absent value to "do not press Enter", which is
-        // the shipped behavior; see `PendingPromptCoordinator`.
+        // default, because it is data rather than a feature gate: there is no
+        // third "nobody chose" state worth preserving. That default IS reached
+        // — `ADD COLUMN ... DEFAULT 1` backfills every row that already
+        // existed, which then reads a present `true` rather than NULL
+        // (`QueuedPromptSchemaTests.rowWrittenBeforeV71DecodesWithNothingParked`
+        // pins that). It is inert, not unreachable: the rows it lands on get a
+        // NULL `pending_prompt` in the same breath, so the bit describes a
+        // prompt that does not exist and nobody will ever deliver.
+        //
+        // Both columns are added here together and `setPendingPrompt` — their
+        // only writer — always names both, so a prompt with no recorded submit
+        // bit is a shape no writer produces. Where the bit is genuinely absent
+        // (a row saved from a `Worktree` that never named it),
+        // `Worktree.pendingPromptSubmitResolved` is the one place that decides
+        // what it means, for delivery and for the read-back alike.
         migrator.registerMigration("v74_worktree_pending_prompt") { db in
             try db.addColumnIfMissing(
                 table: "worktree", column: "pending_prompt", type: .text)

--- a/Sources/TBDDaemon/Lifecycle/PendingPromptCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/PendingPromptCoordinator.swift
@@ -532,10 +532,10 @@ actor PendingPromptCoordinator {
     private func deliverParkedPrompt(worktreeID: UUID, terminalID: UUID, armID: UUID) async {
         guard let worktree = try? await db.worktrees.get(id: worktreeID),
               let text = worktree.pendingPrompt, !text.isEmpty else { return }
-        // Submitting is opt-in. A row with nothing recorded is a prompt nobody
-        // asked to send, and staging costs the operator one keypress while an
-        // unasked-for turn cannot be taken back.
-        let submit = worktree.pendingPromptSubmit ?? false
+        // Submitting is opt-in, and `Worktree.pendingPromptSubmitResolved` is
+        // where that is decided once — for this send and for the read-back
+        // sheet that tells the operator what this send will do.
+        let submit = worktree.pendingPromptSubmitResolved
 
         guard let deliver else {
             await notifyIfCurrent(

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -275,13 +275,29 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// Not a queue: parking a second prompt replaces the first.
     public var pendingPrompt: String?
 
-    /// Whether delivering `pendingPrompt` ends with Enter. `nil` on rows
-    /// written before v74 and on rows that never parked anything; consumers
-    /// resolve it to `true`, the shipped behavior the modal's checkbox
-    /// expresses. Unlike `Config.queuedPromptEnabled` this is data rather than
-    /// a feature gate — there is no third state to preserve, so its column
-    /// carries an ordinary SQL default.
+    /// Whether delivering `pendingPrompt` ends with Enter, as recorded. `nil`
+    /// on any row saved without naming the bit — the initializer defaults it to
+    /// nil and `WorktreeRecord` writes that through as SQL NULL, which is what
+    /// an ordinarily created worktree row holds. It is never `nil` alongside a
+    /// prompt: `setPendingPrompt` is the only writer of either column and names
+    /// both. Nobody resolves this optional at a call site: read
+    /// `pendingPromptSubmitResolved` instead.
+    /// Unlike `Config.queuedPromptEnabled` this is data rather than a feature
+    /// gate — there is no third state to preserve, so its column carries an
+    /// ordinary SQL default.
     public var pendingPromptSubmit: Bool?
+
+    /// **The** resolution of `pendingPromptSubmit` — the one the delivery path
+    /// acts on and the one every display surface must state. A single property
+    /// so the two cannot answer differently about the same row: a read-back
+    /// promising Enter over a prompt the daemon will merely stage is precisely
+    /// the misreport the read-back exists to prevent.
+    ///
+    /// Absent resolves to `false`. Submitting is opt-in, and a row with nothing
+    /// recorded is a prompt nobody asked to send; the asymmetry settles it —
+    /// staging costs the operator one keypress, while an unasked-for turn
+    /// cannot be taken back.
+    public var pendingPromptSubmitResolved: Bool { pendingPromptSubmit ?? false }
 
     /// A scratch space is a repo-less worktree. Derived — no separate column.
     public var isScratch: Bool { repoID == nil }
@@ -401,8 +417,11 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         } else {
             location = .local
         }
-        // Absent in JSON written before v74 — nothing was ever parked, and
-        // `nil` submit resolves to the shipped `true`.
+        // The two keys are absent together, or not at all: a daemon old enough
+        // to omit the submit bit omits the prompt too, so an absent bit here
+        // never describes a prompt that is present. Nothing decides the
+        // optional at this site either way — every consumer reads
+        // `pendingPromptSubmitResolved`, which answers `false`.
         pendingPrompt = try c.decodeIfPresent(String.self, forKey: .pendingPrompt)
         pendingPromptSubmit = try c.decodeIfPresent(Bool.self, forKey: .pendingPromptSubmit)
         // Absent in JSON written before the PR-observation column: no attempt

--- a/Tests/TBDAppTests/ParkedPromptReadbackTests.swift
+++ b/Tests/TBDAppTests/ParkedPromptReadbackTests.swift
@@ -154,9 +154,12 @@ struct ParkedPromptReadbackTests {
         #expect(ParkedPromptReadback(worktree: worktree(repoID: repoID, prompt: nil)) == nil)
         // An empty string is not a parked prompt either.
         #expect(ParkedPromptReadback(worktree: worktree(repoID: repoID, prompt: "")) == nil)
-        // A row written before the migration has no submit bit; delivery ends
-        // with Enter, matching the column's own default.
-        #expect(ParkedPromptReadback(worktree: worktree(repoID: repoID, prompt: "x"))?.submit == true)
+        // A row with no submit bit recorded: the sheet must say what delivery
+        // will actually do, and delivery stages without pressing Enter. Both
+        // sides read `Worktree.pendingPromptSubmitResolved`, so this cannot
+        // drift from the daemon — see `resolvedBitIsWhatTheSheetShows`.
+        #expect(ParkedPromptReadback(
+            worktree: worktree(repoID: repoID, prompt: "x", submit: nil))?.submit == false)
     }
 
     // MARK: - Reveal
@@ -352,6 +355,26 @@ struct ParkedPromptReadbackTests {
             worktree: worktree(repoID: repoID, prompt: "x", submit: true))?.submit == true)
         #expect(ParkedPromptReadback(
             worktree: worktree(repoID: repoID, prompt: "x", submit: false))?.submit == false)
+    }
+
+    /// The agreement itself. The sheet's whole job is to state what delivery
+    /// will do, and delivery reads `Worktree.pendingPromptSubmitResolved`
+    /// (`PendingPromptCoordinator.deliverParkedPrompt`). So both are asserted
+    /// against the same *literal* per row shape, the absent bit included —
+    /// comparing the sheet to the resolver instead would be an identity that
+    /// stays green however the resolver is changed, and would pin nothing.
+    @Test("The sheet seeds the same resolution delivery acts on")
+    func resolvedBitIsWhatTheSheetShows() {
+        let repoID = UUID()
+        let contract: [(recorded: Bool?, pressesEnter: Bool)] =
+            [(nil, false), (false, false), (true, true)]
+        for (recorded, pressesEnter) in contract {
+            let wt = worktree(repoID: repoID, prompt: "x", submit: recorded)
+            // What delivery will do with this row.
+            #expect(wt.pendingPromptSubmitResolved == pressesEnter)
+            // And what the sheet tells the operator it will do.
+            #expect(ParkedPromptReadback(worktree: wt)?.submit == pressesEnter)
+        }
     }
 
     // MARK: - Where it surfaces

--- a/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
@@ -1,5 +1,6 @@
 import Clocks
 import Foundation
+import GRDB
 import TestSupport
 import Testing
 @testable import TBDDaemonLib
@@ -759,6 +760,46 @@ struct QueuedPromptDeliveryTests {
             // be known, and it is what the column is cleared on.
             #expect(try await pendingPrompt(fixture.db, fixture.worktree.id) == nil)
         }
+    }
+
+    /// A row holding a prompt with **no** submit bit recorded. Delivery stages
+    /// it: submitting is opt-in, and nothing here asked for it.
+    ///
+    /// **No production writer makes this row.** `setPendingPrompt` names both
+    /// columns on every write, and the two arrived in one migration, so a
+    /// prompt never outlives its submit bit — which is why the column is nulled
+    /// by hand here rather than through `park`. What the test pins is the
+    /// resolution, not a state the daemon can reach: the read-back sheet reads
+    /// that same resolution over that same row shape
+    /// (`ParkedPromptReadbackTests.resolvedBitIsWhatTheSheetShows`), so the two
+    /// surfaces cannot answer differently about it.
+    @Test("a row with no submit bit recorded is staged, not sent")
+    func absentSubmitBitIsStagedNotSent() async throws {
+        let clock = TestClock()
+        let fixture = try await makeSpawnFixture(clock: clock)
+        try await fixture.db.config.setQueuedPrompt(true)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            kind: .claude)
+
+        #expect(await fixture.coordinator.park(
+            worktreeID: fixture.worktree.id, text: "no submit bit on this row",
+            submit: true) == .awaitingReady)
+        try await fixture.db.writerForTests.write { db in
+            try db.execute(
+                sql: "UPDATE worktree SET pending_prompt_submit = NULL WHERE id = ?",
+                arguments: [fixture.worktree.id.uuidString])
+        }
+        let staged = try await fixture.db.worktrees.get(id: fixture.worktree.id)
+        #expect(staged?.pendingPromptSubmit == nil)
+
+        await fixture.coordinator.noteSessionReady(
+            worktreeID: fixture.worktree.id, terminalID: terminal.id)
+        await advancePastSettle(clock, fixture)
+        await awaitDeliveries(fixture.coordinator)
+
+        #expect(fixture.sends.calls == [SendRecorder.Call(
+            terminalID: terminal.id, text: "no submit bit on this row", submit: false)])
     }
 
     // MARK: - Verbatim, with the envelope suppressed

--- a/Tests/TBDDaemonTests/QueuedPromptSchemaTests.swift
+++ b/Tests/TBDDaemonTests/QueuedPromptSchemaTests.swift
@@ -121,8 +121,10 @@ struct QueuedPromptSchemaTests {
 /// `v74_worktree_pending_prompt` — the parked text and its submit bit.
 ///
 /// Unlike the flag above, `pending_prompt_submit` is *data*, not a feature
-/// gate: "deliver with Enter" is the shipped behavior and there is no third
-/// state to preserve, so a SQL default is correct there.
+/// gate: there is no third "nobody chose" state worth preserving, so a SQL
+/// default is correct there. What an absent bit means is settled in exactly one
+/// place — `Worktree.pendingPromptSubmitResolved` — and it means "do not press
+/// Enter".
 @Suite("QueuedPromptWorktreeStore")
 struct QueuedPromptWorktreeStoreTests {
 
@@ -273,9 +275,10 @@ struct QueuedPromptWorktreeStoreTests {
             let model = try #require(record.toModel())
             #expect(model.pendingPrompt == nil)
             // `pending_prompt_submit` IS data, not a feature gate, so its SQL
-            // default is correct — and unreachable, because the row it
-            // backfills has nothing parked and therefore no submit choice to
-            // remember. `setPendingPrompt` always names both columns.
+            // default is correct — and the backfill it performs here is inert,
+            // because the row it lands on has nothing parked and therefore no
+            // submit choice to remember. `setPendingPrompt` always names both
+            // columns.
             #expect(record.pending_prompt_submit == true)
             #expect(model.pendingPromptSubmit == true)
         }

--- a/Tests/TBDSharedTests/PendingPromptSubmitResolutionTests.swift
+++ b/Tests/TBDSharedTests/PendingPromptSubmitResolutionTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Tier 1. `Worktree.pendingPromptSubmitResolved` is the single answer to
+/// "does delivering this prompt press Enter", shared by the daemon's delivery
+/// path and by the read-back sheet that tells the operator what delivery will
+/// do. These pin the answer itself; the two consumers are pinned in
+/// `QueuedPromptDeliveryTests` and `ParkedPromptReadbackTests`.
+@Suite("Pending prompt submit resolution")
+struct PendingPromptSubmitResolutionTests {
+
+    /// Always names `pendingPromptSubmit`, including for the nil case — the
+    /// initializer defaults it to nil, so an omitted argument would make the
+    /// case under test indistinguishable from an oversight.
+    private func worktree(submit: Bool?) -> Worktree {
+        Worktree(
+            repoID: UUID(), name: "wt", displayName: "wt", branch: "tbd/wt",
+            path: "/tmp/wt", tmuxServer: "tbd-test",
+            pendingPrompt: "do the thing",
+            pendingPromptSubmit: submit)
+    }
+
+    @Test("An absent bit resolves to: do not press Enter")
+    func absentResolvesToFalse() {
+        let wt = worktree(submit: nil)
+        #expect(wt.pendingPromptSubmit == nil)
+        #expect(wt.pendingPromptSubmitResolved == false)
+    }
+
+    @Test("An explicit choice is returned as recorded")
+    func explicitChoiceIsReturned() {
+        #expect(worktree(submit: false).pendingPromptSubmitResolved == false)
+        #expect(worktree(submit: true).pendingPromptSubmitResolved == true)
+    }
+
+    /// The same resolution, arrived at through the decoder rather than the
+    /// initializer. The JSON is hand-built and no daemon emits it — one old
+    /// enough to omit the submit key omits `pendingPrompt` with it — so what is
+    /// pinned is that an absent key decodes to nil and resolves exactly as an
+    /// explicit nil does: staged, not sent.
+    @Test("JSON that omits the key resolves to: do not press Enter")
+    func jsonWithoutTheKeyResolvesToFalse() throws {
+        let json = """
+        {"id":"88888888-8888-8888-8888-888888888888","name":"w","displayName":"w",
+         "branch":"b","path":"/tmp/x","status":"active","createdAt":0,
+         "tmuxServer":"srv","pendingPrompt":"do the thing"}
+        """
+        let decoded = try JSONDecoder().decode(Worktree.self, from: Data(json.utf8))
+        #expect(decoded.pendingPromptSubmit == nil)
+        #expect(decoded.pendingPromptSubmitResolved == false)
+    }
+}


### PR DESCRIPTION
## What's broken

`Worktree.pendingPromptSubmit` records whether delivering a parked first message ends with Enter. It is optional, and its two consumers resolved a nil in **opposite** directions:

- The delivery path (`PendingPromptCoordinator.deliverParkedPrompt`) read `?? false` — stage the text, don't press Enter.
- The read-back sheet (`ParkedPromptReadbackView`), whose entire job is to state what delivery will do for the message on screen, read `?? true` — tell the operator it will send.

Two answers to one question, in the one place where disagreeing means lying to the operator.

**No row ever reached either of them, and this PR is not fixing an incident.** `pending_prompt` and `pending_prompt_submit` arrived in the same migration and have a single writer, `setPendingPrompt`, which always names both columns — so a prompt never outlives its submit bit. Wire skew can't produce the shape either: a daemon old enough to omit the submit key from its JSON omits the prompt key with it. What is being closed is an inconsistency, before it becomes reachable.

Alongside it, the comments around the column asserted several things that are not true — including the claim that all consumers resolve nil to `true`, which is what the read-back was faithfully implementing.

## Why it happens

Both fallbacks were authored in the same commit as the feature itself (`03308108`), in different files, and neither review caught that they disagreed. Nothing structural prevented it: the optional was public, and every consumer was free to answer the question locally. A second consumer added later would have picked a side the same way.

## When it broke

Born with the feature, in PR #624 — an authoring slip rather than a considered decision. The commit message for that PR states "Sending is opt-in and off by default", which is the `?? false` answer; the app-side `?? true` contradicted its own PR description. It slipped through because the divergent state is unreachable, so no test and no operator could surface it.

## What this PR does

- Adds `Worktree.pendingPromptSubmitResolved` in `TBDShared` — one resolution, documented next to the stored property, answering `false` for an absent bit. Submitting is opt-in: staging costs the operator one keypress, while an unasked-for turn cannot be taken back.
- Routes both consumers through it, so the two sites can no longer drift.
- Corrects the comments that were wrong. The decode site said an absent bit resolves to the "shipped `true`". The v74 migration called its SQL default "unreachable by construction", when `ADD COLUMN ... DEFAULT 1` **backfills** every pre-existing row with a present `true` — the default is reached and merely *inert*, because the rows it lands on hold no prompt. Three tests narrated version skew for a row shape only a hand-written `UPDATE` or hand-built JSON can produce.

No spec: this restores the system to its documented theory rather than revising it, which is the bug-fix exemption. No schema change, no migration, no wire change — a computed property is excluded from the hand-written `encode(to:)`/`init(from:)`, so there is no daemon-skew consequence.

## Assumptions

- **`setPendingPrompt` remains the only writer of `pending_prompt`.** The unreachability argument rests on it naming both columns together. A second writer that sets a prompt without a submit bit would make the nil case live — at which point the resolver already answers correctly, which is the point of landing this now.
- **A computed property stays out of the Codable surface.** `Worktree` hand-writes `encode(to:)` and `init(from:)`; if either is ever regenerated or replaced with synthesis, `pendingPromptSubmitResolved` must not become a wire field.

## Evidence & verification

- Full suite: **6898 tests in 698 suites passed**, matching the baseline exactly; the 71 `error:` strings in the log are all `EventDrivenTestClockSelfTests` known-issue diagnostics, zero real failures.
- `swiftlint --strict` → 0 violations in 761 files.
- **Discriminating evidence, run twice.** Flipping the shared resolver to `?? true` reddens 4 assertions across 3 suites. Reproducing the *exact* pre-fix state — the view back to an inline `?? true`, the resolver left correct — reddens 2, including the agreement test catching the divergence directly.
- The app-side agreement test was initially tautological: it compared the sheet's bit to the resolver, so both sides moved together and it would have stayed green under any resolution. It now asserts a literal contract table (`nil → false`, `false → false`, `true → true`) against **both** the sheet and the property delivery reads.
- `absentSubmitBitIsStagedNotSent` (daemon) is a contract guard, not a reproduction — it passes against pre-fix code too, since the daemon was already `?? false`. It has to null the column through `writerForTests` because no production writer makes that row. Stated plainly so it isn't mistaken for proof of a live defect.

## Known adjacent issue, deliberately not fixed here

`WorktreeStore.clearPendingPrompt` compare-and-swaps on `... AND pending_prompt_submit = ?`. In SQLite `NULL = 0` is NULL, so for a NULL-submit row the clear matches zero rows and the prompt stays parked for redelivery — and the caller discards the result (`_ =`), so it is silent. It predates this change, is unreachable for the same reason described above, and needs its own decision (COALESCE in the predicate, or normalizing on read). This diff does not make it worse: the coordinator passes the same value it passed before.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=791069BC-9B69-466A-8B6B-945895D172E6)