### PR TITLE
Feat: Untrack a stale PR from the status bar, and say which PR it is

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3039,11 +3039,18 @@ final class AppState: ObservableObject {
     /// the way out rather than waiting for the next poll, so the chip leaves
     /// the bar as part of the gesture.
     ///
-    /// A `detached: false` result is success, not failure — it says the PR was
-    /// already tombstoned, which from the chips is reachable only by
-    /// double-clicking the same xmark. The user asked for the PR to be gone and
-    /// it is. Only a thrown error is a failure, and that one is worth a toast:
-    /// the chip would otherwise stay put with nothing said.
+    /// Success is judged on the **outcome, not the returned flag**. A
+    /// `detached: false` usually means the PR was already tombstoned — the user
+    /// asked for it to be gone and it is — but the daemon also reports false
+    /// when it declines to record a tombstone for a PR outside the worktree's
+    /// repo, and that one leaves the chip where it was. Rather than teach the
+    /// app which false is which, this re-reads the bindings it just refreshed
+    /// and speaks up only if the chip the user clicked is still there. That
+    /// also covers the case no flag could describe: a concurrent bind putting
+    /// the PR straight back.
+    ///
+    /// A thrown error is the other failure, and it gets the same toast: the
+    /// chip would otherwise stay put with nothing said.
     ///
     /// `url` is optional and `number` is not: a chip lifted from a legacy
     /// cached status can carry a url that will not parse, and the daemon
@@ -3057,11 +3064,18 @@ final class AppState: ObservableObject {
                 \(worktreeID, privacy: .public): \
                 \(String(describing: error), privacy: .public)
                 """)
-            showTransientToast("Could not stop tracking that PR", style: .error)
+            showTransientToast("Could not stop tracking PR #\(number)", style: .error)
             handleConnectionError(error)
             return
         }
         await refreshPRBindings()
+        guard effectivePRBindings(worktreeID: worktreeID).contains(where: { $0.number == number })
+        else { return }
+        logger.error("""
+            Detach of PR #\(number, privacy: .public) from worktree \
+            \(worktreeID, privacy: .public) left the binding in place
+            """)
+        showTransientToast("PR #\(number) is still tracked here", style: .error)
     }
 
     /// Trigger an immediate PR refresh for one worktree (on-select).

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -782,6 +782,9 @@ final class AppState: ObservableObject {
     /// non-zero, which is precisely the signal that suppresses the
     /// legacy-status fallback below.
     @Published var prDetachedCounts: [UUID: Int] = [:]
+    /// Start order for `refreshPRBindings`, so a response that lost the race to
+    /// a later one cannot publish its older snapshot over the newer state.
+    private var prBindingsRefreshSeq = 0
     /// What every PR surface — toolbar split button, sidebar row indicator,
     /// status-bar chips — must read, so they cannot disagree about a worktree.
     /// Bindings when there are any; otherwise the legacy single `prStatuses`
@@ -3034,6 +3037,8 @@ final class AppState: ObservableObject {
     /// are not reliably what this call saw even on success.
     @discardableResult
     func refreshPRBindings() async -> PRBindingRefresh.State? {
+        prBindingsRefreshSeq += 1
+        let seq = prBindingsRefreshSeq
         let result: PRBindingsAllResult
         do {
             result = try await prBindingsFetcher()
@@ -3044,6 +3049,11 @@ final class AppState: ObservableObject {
             return nil
         }
         let next = PRBindingRefresh.state(from: result)
+        // A refresh that started later has already published, so this response
+        // is stale — return it to our own caller, who asked for it, but do not
+        // put an older snapshot back on screen. Without this a poll issued a
+        // moment before an untrack can land after it and bring the chip back.
+        guard seq == prBindingsRefreshSeq else { return next }
         if next.bindings != prBindings { prBindings = next.bindings }
         if next.detachedCounts != prDetachedCounts { prDetachedCounts = next.detachedCounts }
         return next

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3044,12 +3044,16 @@ final class AppState: ObservableObject {
     /// double-clicking the same xmark. The user asked for the PR to be gone and
     /// it is. Only a thrown error is a failure, and that one is worth a toast:
     /// the chip would otherwise stay put with nothing said.
-    func detachPR(worktreeID: UUID, url: String) async {
+    ///
+    /// `url` is optional and `number` is not: a chip lifted from a legacy
+    /// cached status can carry a url that will not parse, and the daemon
+    /// resolves a bare number against the worktree's own repo.
+    func detachPR(worktreeID: UUID, url: String?, number: Int) async {
         do {
-            _ = try await daemonClient.detachPR(worktreeID: worktreeID, url: url)
+            _ = try await daemonClient.detachPR(worktreeID: worktreeID, url: url, number: number)
         } catch {
             logger.error("""
-                Failed to detach PR \(url, privacy: .public) from worktree \
+                Failed to detach PR #\(number, privacy: .public) from worktree \
                 \(worktreeID, privacy: .public): \
                 \(String(describing: error), privacy: .public)
                 """)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3024,12 +3024,16 @@ final class AppState: ObservableObject {
     /// - a worktree ABSENT from a SUCCESSFUL response loses its entry, so a
     ///   `tbd pr detach` is observed. `PRBindingRefresh.state(from:)` owns that,
     ///   which is how it can be asserted without a daemon.
-    /// Returns whether the fetch actually landed. Callers that judge an
-    /// outcome by re-reading these maps must check it: on failure the maps
-    /// still hold the pre-call values, which look identical to "the write did
-    /// nothing".
+    /// Returns **the state this call fetched**, or nil when the fetch failed.
+    ///
+    /// A caller that judges an outcome must read the returned value rather than
+    /// the published maps, for two reasons. On failure the maps still hold the
+    /// pre-call values, which look identical to "the write did nothing". And
+    /// these maps are whole-fleet: another refresh already in flight can resolve
+    /// after this one and publish its older snapshot over the top, so the maps
+    /// are not reliably what this call saw even on success.
     @discardableResult
-    func refreshPRBindings() async -> Bool {
+    func refreshPRBindings() async -> PRBindingRefresh.State? {
         let result: PRBindingsAllResult
         do {
             result = try await prBindingsFetcher()
@@ -3037,12 +3041,12 @@ final class AppState: ObservableObject {
             // Leave the previous values in place — a failed fetch is not
             // evidence that any worktree lost its PRs.
             logger.error("Failed to list PR bindings: \(String(describing: error), privacy: .public)")
-            return false
+            return nil
         }
         let next = PRBindingRefresh.state(from: result)
         if next.bindings != prBindings { prBindings = next.bindings }
         if next.detachedCounts != prDetachedCounts { prDetachedCounts = next.detachedCounts }
-        return true
+        return next
     }
 
     /// Untrack one PR from one worktree — the status bar chip's xmark.
@@ -3081,13 +3085,20 @@ final class AppState: ObservableObject {
             handleConnectionError(error)
             return
         }
-        // Only a refresh that LANDED is evidence. A failed one leaves the maps
-        // holding their pre-call values, which read exactly like a detach that
-        // did nothing — and reporting a landed detach as a failure is its own
-        // kind of lie.
-        guard await refreshPRBindings(),
-              effectivePRBindings(worktreeID: worktreeID).contains(where: { $0.number == number })
-        else { return }
+        // Judged on WHAT THIS CALL FETCHED, never on the published maps. A
+        // failed refresh leaves them holding their pre-call values, which read
+        // exactly like a detach that did nothing; and a whole-fleet refresh
+        // already in flight can land afterwards and publish its older snapshot
+        // over the top. Either would report a detach that succeeded as a
+        // failure, which is its own kind of lie.
+        guard let refreshed = await refreshPRBindings() else { return }
+        let stillTracked = PRBindingPresentation.effectiveBindings(
+            refreshed.bindings[worktreeID] ?? [],
+            legacyStatus: prStatuses[worktreeID],
+            worktreeID: worktreeID,
+            detachedCount: refreshed.detachedCounts[worktreeID] ?? 0
+        ).contains { $0.number == number }
+        guard stillTracked else { return }
         logger.error("""
             Detach of PR #\(number, privacy: .public) from worktree \
             \(worktreeID, privacy: .public) left the binding in place

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1379,6 +1379,13 @@ final class AppState: ObservableObject {
     /// without a daemon.
     lazy var prBindingsFetcher: @MainActor () async throws -> PRBindingsAllResult =
         { [daemonClient] in try await daemonClient.listAllPRBindings() }
+    /// How `detachPR` untracks one PR — injectable for the same reason as
+    /// `prBindingsFetcher`, so the status bar's untrack gesture and each of its
+    /// outcomes can be driven without a daemon.
+    lazy var prDetacher: @MainActor (UUID, String?, Int) async throws -> PRDetachResult =
+        { [daemonClient] worktreeID, url, number in
+            try await daemonClient.detachPR(worktreeID: worktreeID, url: url, number: number)
+        }
     /// How `loadTabStates` fetches a worktree's persisted tab order / labels /
     /// active tab — injectable for the same reason as `daemonCapabilitiesFetcher`
     /// (`DaemonClient` is concrete, no protocol), so hydration tests can drive
@@ -3063,7 +3070,7 @@ final class AppState: ObservableObject {
     /// resolves a bare number against the worktree's own repo.
     func detachPR(worktreeID: UUID, url: String?, number: Int) async {
         do {
-            _ = try await daemonClient.detachPR(worktreeID: worktreeID, url: url, number: number)
+            _ = try await prDetacher(worktreeID, url, number)
         } catch {
             logger.error("""
                 Failed to detach PR #\(number, privacy: .public) from worktree \

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -782,9 +782,15 @@ final class AppState: ObservableObject {
     /// non-zero, which is precisely the signal that suppresses the
     /// legacy-status fallback below.
     @Published var prDetachedCounts: [UUID: Int] = [:]
-    /// Start order for `refreshPRBindings`, so a response that lost the race to
-    /// a later one cannot publish its older snapshot over the newer state.
+    /// Start order for `refreshPRBindings`: every call takes the next ticket
+    /// before it fetches, so the two counters below can be compared to tell an
+    /// older snapshot from a newer one.
     private var prBindingsRefreshSeq = 0
+    /// The highest ticket that has actually PUBLISHED. Deliberately not the
+    /// same fact as the one above — a call that started later and then failed
+    /// put nothing on screen, so it must not silence an earlier call whose
+    /// fetch succeeded. Only a publish moves this.
+    private var prBindingsPublishedSeq = 0
     /// What every PR surface — toolbar split button, sidebar row indicator,
     /// status-bar chips — must read, so they cannot disagree about a worktree.
     /// Bindings when there are any; otherwise the legacy single `prStatuses`
@@ -3033,7 +3039,7 @@ final class AppState: ObservableObject {
     /// the published maps, for two reasons. On failure the maps still hold the
     /// pre-call values, which look identical to "the write did nothing". And
     /// these maps are whole-fleet: another refresh already in flight can resolve
-    /// after this one and publish its older snapshot over the top, so the maps
+    /// after this one and publish its own snapshot over the top, so the maps
     /// are not reliably what this call saw even on success.
     @discardableResult
     func refreshPRBindings() async -> PRBindingRefresh.State? {
@@ -3049,11 +3055,20 @@ final class AppState: ObservableObject {
             return nil
         }
         let next = PRBindingRefresh.state(from: result)
-        // A refresh that started later has already published, so this response
-        // is stale — return it to our own caller, who asked for it, but do not
-        // put an older snapshot back on screen. Without this a poll issued a
-        // moment before an untrack can land after it and bring the chip back.
-        guard seq == prBindingsRefreshSeq else { return next }
+        // What is already on screen came from a refresh that started LATER than
+        // this one, so this response is stale — return it to our own caller, who
+        // asked for it, but do not put an older snapshot back on screen. Without
+        // this a poll issued a moment before an untrack can land after it and
+        // bring the chip back.
+        //
+        // The comparison is against what has been PUBLISHED, not against what
+        // has merely started: a later refresh that failed returned above without
+        // touching these maps, and withholding this call's good data on account
+        // of it would leave the fleet on a snapshot older than either. Both
+        // counters are read and written on the main actor with no await in
+        // between, so no second racy read is involved.
+        guard seq > prBindingsPublishedSeq else { return next }
+        prBindingsPublishedSeq = seq
         if next.bindings != prBindings { prBindings = next.bindings }
         if next.detachedCounts != prDetachedCounts { prDetachedCounts = next.detachedCounts }
         return next
@@ -3098,7 +3113,7 @@ final class AppState: ObservableObject {
         // Judged on WHAT THIS CALL FETCHED, never on the published maps. A
         // failed refresh leaves them holding their pre-call values, which read
         // exactly like a detach that did nothing; and a whole-fleet refresh
-        // already in flight can land afterwards and publish its older snapshot
+        // already in flight can land afterwards and publish its own snapshot
         // over the top. Either would report a detach that succeeded as a
         // failure, which is its own kind of lie.
         guard let refreshed = await refreshPRBindings() else { return }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3032,6 +3032,34 @@ final class AppState: ObservableObject {
         if next.detachedCounts != prDetachedCounts { prDetachedCounts = next.detachedCounts }
     }
 
+    /// Untrack one PR from one worktree — the status bar chip's xmark.
+    ///
+    /// Tombstoning, not deleting, which is what `pr.detach` already does; the
+    /// app adds no durability story of its own. The bindings are refreshed on
+    /// the way out rather than waiting for the next poll, so the chip leaves
+    /// the bar as part of the gesture.
+    ///
+    /// A `detached: false` result is success, not failure — it says the PR was
+    /// already tombstoned, which from the chips is reachable only by
+    /// double-clicking the same xmark. The user asked for the PR to be gone and
+    /// it is. Only a thrown error is a failure, and that one is worth a toast:
+    /// the chip would otherwise stay put with nothing said.
+    func detachPR(worktreeID: UUID, url: String) async {
+        do {
+            _ = try await daemonClient.detachPR(worktreeID: worktreeID, url: url)
+        } catch {
+            logger.error("""
+                Failed to detach PR \(url, privacy: .public) from worktree \
+                \(worktreeID, privacy: .public): \
+                \(String(describing: error), privacy: .public)
+                """)
+            showTransientToast("Could not stop tracking that PR", style: .error)
+            handleConnectionError(error)
+            return
+        }
+        await refreshPRBindings()
+    }
+
     /// Trigger an immediate PR refresh for one worktree (on-select).
     func refreshPRStatus(worktreeID: UUID) async {
         do {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3017,7 +3017,12 @@ final class AppState: ObservableObject {
     /// - a worktree ABSENT from a SUCCESSFUL response loses its entry, so a
     ///   `tbd pr detach` is observed. `PRBindingRefresh.state(from:)` owns that,
     ///   which is how it can be asserted without a daemon.
-    func refreshPRBindings() async {
+    /// Returns whether the fetch actually landed. Callers that judge an
+    /// outcome by re-reading these maps must check it: on failure the maps
+    /// still hold the pre-call values, which look identical to "the write did
+    /// nothing".
+    @discardableResult
+    func refreshPRBindings() async -> Bool {
         let result: PRBindingsAllResult
         do {
             result = try await prBindingsFetcher()
@@ -3025,11 +3030,12 @@ final class AppState: ObservableObject {
             // Leave the previous values in place — a failed fetch is not
             // evidence that any worktree lost its PRs.
             logger.error("Failed to list PR bindings: \(String(describing: error), privacy: .public)")
-            return
+            return false
         }
         let next = PRBindingRefresh.state(from: result)
         if next.bindings != prBindings { prBindings = next.bindings }
         if next.detachedCounts != prDetachedCounts { prDetachedCounts = next.detachedCounts }
+        return true
     }
 
     /// Untrack one PR from one worktree — the status bar chip's xmark.
@@ -3068,8 +3074,12 @@ final class AppState: ObservableObject {
             handleConnectionError(error)
             return
         }
-        await refreshPRBindings()
-        guard effectivePRBindings(worktreeID: worktreeID).contains(where: { $0.number == number })
+        // Only a refresh that LANDED is evidence. A failed one leaves the maps
+        // holding their pre-call values, which read exactly like a detach that
+        // did nothing — and reporting a landed detach as a failure is its own
+        // kind of lie.
+        guard await refreshPRBindings(),
+              effectivePRBindings(worktreeID: worktreeID).contains(where: { $0.number == number })
         else { return }
         logger.error("""
             Detach of PR #\(number, privacy: .public) from worktree \

--- a/Sources/TBDApp/CLAUDE.md
+++ b/Sources/TBDApp/CLAUDE.md
@@ -2,33 +2,9 @@
 
 SwiftUI app target. See the repo-root `CLAUDE.md` and the `tbd-project` skill for architecture.
 
-## Tuning a visual constant: don't run the full suite per nudge
+## Tuning a visual constant
 
-A gap, an inset, a corner radius, an opacity, an animation duration — anything
-whose correct value is settled by looking at it — is tuned in a loop with a
-human at the other end. For each iteration run **`scripts/swift-safe build`, the
-one filtered suite that pins the constant, then `scripts/restart.sh`**. Skip the
-full `scripts/test.sh`, skip `swiftlint` when the diff is a numeric literal and
-its doc comment, and skip re-running a mutation check whose discriminating power
-you already established at an earlier value.
-
-The full run costs ~110s and cannot answer the only open question, which is
-whether the number looks right. Spending it per nudge turns a ten-second
-decision into a multi-minute round trip while the person who has to judge it
-sits waiting. **Run the full suite once, on the final tree, before pushing** —
-that is what catches anything the loop disturbed.
-
-This is scoped to magnitudes and styling. A change to *behavior* — what a
-control does, when it appears, which branch runs — is not a nudge, however small
-the diff, and takes the ordinary discipline.
-
-**Pick a decisive value rather than creeping toward one.** If a bump moves the
-thing visibly and the reviewer still says "more", the next step should be large
-enough to overshoot, because landing past the mark and coming back costs one
-look while three timid steps cost three. `8 → 24 → 48 → 32` is a real example
-from `HoverCardPlacement.flippedBarClearance`: four rebuilds and four rounds of
-someone's attention to reach a value a single decisive jump would have bracketed
-in two.
+While a purely visual value — a gap, inset, opacity, duration — is being eyeballed, iterate with `scripts/swift-safe build`, the one filtered suite that pins it, and `scripts/restart.sh`; the full `scripts/test.sh` costs ~110s, cannot tell you whether the number looks right, and belongs once on the final tree before pushing.
 
 ## macOS 26 (Tahoe) Liquid Glass toolbars — grouping rules
 

--- a/Sources/TBDApp/CLAUDE.md
+++ b/Sources/TBDApp/CLAUDE.md
@@ -2,6 +2,34 @@
 
 SwiftUI app target. See the repo-root `CLAUDE.md` and the `tbd-project` skill for architecture.
 
+## Tuning a visual constant: don't run the full suite per nudge
+
+A gap, an inset, a corner radius, an opacity, an animation duration — anything
+whose correct value is settled by looking at it — is tuned in a loop with a
+human at the other end. For each iteration run **`scripts/swift-safe build`, the
+one filtered suite that pins the constant, then `scripts/restart.sh`**. Skip the
+full `scripts/test.sh`, skip `swiftlint` when the diff is a numeric literal and
+its doc comment, and skip re-running a mutation check whose discriminating power
+you already established at an earlier value.
+
+The full run costs ~110s and cannot answer the only open question, which is
+whether the number looks right. Spending it per nudge turns a ten-second
+decision into a multi-minute round trip while the person who has to judge it
+sits waiting. **Run the full suite once, on the final tree, before pushing** —
+that is what catches anything the loop disturbed.
+
+This is scoped to magnitudes and styling. A change to *behavior* — what a
+control does, when it appears, which branch runs — is not a nudge, however small
+the diff, and takes the ordinary discipline.
+
+**Pick a decisive value rather than creeping toward one.** If a bump moves the
+thing visibly and the reviewer still says "more", the next step should be large
+enough to overshoot, because landing past the mark and coming back costs one
+look while three timid steps cost three. `8 → 24 → 48 → 32` is a real example
+from `HoverCardPlacement.flippedBarClearance`: four rebuilds and four rounds of
+someone's attention to reach a value a single decisive jump would have bracketed
+in two.
+
 ## macOS 26 (Tahoe) Liquid Glass toolbars — grouping rules
 
 macOS 26 redesigned toolbars: items render on **Liquid Glass capsules**, and **adjacent toolbar items are automatically fused onto one shared capsule**. Getting items onto *separate* capsules is non-obvious and cost a long trial-and-error loop — here is what actually works (verified against WWDC25 session 323 "Build a SwiftUI app with the new design" and confirmed live in this app). The working example is the PR split button in `ContentView.swift`.

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -229,16 +229,121 @@ struct HoverDwellReducer: Equatable {
     }
 }
 
+// MARK: - Placement
+
+/// Where a card's panel goes for a given anchor.
+///
+/// Pure geometry in AppKit screen coordinates (y grows upward), so the whole
+/// rule is unit-testable without a window, a panel or a screen.
+///
+/// The rule is *below the anchor, leading-aligned, unless the card would leave
+/// the anchor's own window* — then above. Screen room alone is the wrong test:
+/// a card anchored to the status bar at the bottom of the window has plenty of
+/// desktop beneath it, and placing it there drops it out of the window
+/// altogether, right onto the strip it describes. Bounding it by the window
+/// keeps every card over the surface that summoned it, and leaves anchors with
+/// room beneath them — tab-bar items, sidebar rows — exactly where they were.
+///
+/// The window is a *preference*, not a hard constraint: when neither side fits
+/// inside it (a small floating panel, a short window), the screen decides, so
+/// this can never place a card worse than the screen rule alone would.
+enum HoverCardPlacement {
+    /// Gap between the anchor's edge and the card's visible edge.
+    ///
+    /// Sized to clear the padding a bar puts around its content, not just the
+    /// anchored control: the status-bar chip sits 4pt inside a `.bar` strip, so
+    /// a card flipped above it must clear the chip *and* that padding for the
+    /// strip to stay readable underneath.
+    static let anchorGap: CGFloat = 8
+    /// Keep-out from the edge of the screen's visible frame.
+    static let screenMargin: CGFloat = 4
+
+    /// The panel frame for one card.
+    ///
+    /// `panelSize` is the whole hosted size — the card plus the transparent
+    /// `shadowInset` margin its shadow draws into on every side — while the
+    /// gap, the alignment and the clamping all apply to the *visible* card
+    /// inside it. Anything else would leave the card floating a shadow's width
+    /// away from what it describes.
+    static func panelFrame(anchor: CGRect,
+                           panelSize: CGSize,
+                           shadowInset: CGFloat,
+                           window: CGRect?,
+                           screenVisibleFrame: CGRect?) -> CGRect {
+        let card = CGSize(width: panelSize.width - shadowInset * 2,
+                          height: panelSize.height - shadowInset * 2)
+
+        let below = anchor.minY - anchorGap - card.height
+        let above = anchor.maxY + anchorGap
+
+        let screenLower = screenVisibleFrame.map { $0.minY + screenMargin }
+        let screenUpper = screenVisibleFrame.map { $0.maxY - screenMargin }
+        let fitsScreenBelow = screenLower.map { below >= $0 } ?? true
+        let fitsScreenAbove = screenUpper.map { above + card.height <= $0 } ?? true
+        let fitsWindowBelow = (window.map { below >= $0.minY } ?? true) && fitsScreenBelow
+        let fitsWindowAbove = (window.map { above + card.height <= $0.maxY } ?? true) && fitsScreenAbove
+
+        var y: CGFloat
+        if fitsWindowBelow {
+            y = below
+        } else if fitsWindowAbove {
+            y = above
+        } else if fitsScreenBelow {
+            y = below
+        } else if fitsScreenAbove {
+            y = above
+        } else {
+            y = below
+        }
+        if let screenLower, let screenUpper {
+            y = min(max(y, screenLower), max(screenLower, screenUpper - card.height))
+        }
+
+        var x = anchor.minX
+        if let screenVisibleFrame {
+            let leftmost = screenVisibleFrame.minX + screenMargin
+            let rightmost = screenVisibleFrame.maxX - screenMargin - card.width
+            x = min(max(x, leftmost), max(leftmost, rightmost))
+        }
+
+        return CGRect(x: x - shadowInset,
+                      y: y - shadowInset,
+                      width: panelSize.width,
+                      height: panelSize.height)
+    }
+}
+
 // MARK: - Card view
 
 /// Renders a `HoverCardModel`: calm neutrals, type hierarchy, color only for
-/// state. Material background + hairline border; the hosting panel's window
-/// shadow provides the elevation.
+/// state.
+///
+/// Elevation is a material fill plus a **small shadow this view draws itself**,
+/// the way a menu or a popover separates from what is behind it — no border.
+/// The hosting panel's own window shadow is deliberately off: it is sized for a
+/// window rather than for a tooltip, so on a card a few dozen points tall it
+/// reads as a thick gray edge, and it spills far enough past the card to wash
+/// out whatever the card is anchored to. Drawing the shadow here bounds it to a
+/// radius chosen for this box, and makes it recomputed with the content rather
+/// than by the window server from a shape that may still be the previous card's.
+///
+/// The price is a transparent margin: a shadow drawn inside the hosting view
+/// needs somewhere to fall, and the panel is sized to fit its content exactly.
+/// So the card carries `shadowInset` points of clear padding on every side, and
+/// `HoverCardPlacement` positions the *card* inside that margin rather than the
+/// panel.
 struct HoverCardView: View {
     let model: HoverCardModel
 
     private static let maxWidth: CGFloat = 320
     private static let cornerRadius: CGFloat = 9
+    /// Transparent margin around the card, so its own shadow has room to draw
+    /// inside a panel that is otherwise sized exactly to the card.
+    ///
+    /// `nonisolated` because `View` conformance infers whole-type `@MainActor`
+    /// isolation onto even a constant, and the placement geometry that reads it
+    /// is a pure function with no actor of its own.
+    nonisolated static let shadowInset: CGFloat = 10
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -278,11 +383,18 @@ struct HoverCardView: View {
         .padding(.vertical, 10)
         .frame(maxWidth: Self.maxWidth, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
-        .overlay(
+        .background {
+            // The shadow rides on the background shape rather than on the
+            // composed card, so it traces the rounded rect instead of haloing
+            // every glyph. Dark and soft in both appearances: over a
+            // user-themed terminal the material alone can land too close to
+            // whatever is behind it, and this is the only thing separating
+            // them now that there is no border.
             RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
-        )
+                .fill(.thinMaterial)
+                .shadow(color: .black.opacity(0.28), radius: 5, x: 0, y: 2)
+        }
+        .padding(Self.shadowInset)
     }
 
     @ViewBuilder
@@ -371,7 +483,12 @@ private final class HoverCardPanel: NSPanel {
         isOpaque = false
         backgroundColor = .clear
         level = .popUpMenu
-        hasShadow = true
+        // The card draws its own shadow (see `HoverCardView`). AppKit's window
+        // shadow is sized for a window, so on a tooltip-sized panel it reads as
+        // a thick gray edge — and it is computed by the window server from the
+        // window's alpha mask, which on this shared, resized, SwiftUI-hosted
+        // panel is whatever the *previous* card left behind.
+        hasShadow = false
         ignoresMouseEvents = true
         isMovableByWindowBackground = false
         isReleasedWhenClosed = false
@@ -420,9 +537,6 @@ final class HoverCardController {
     /// Comfortably longer than the warm-grace window so a click can't be
     /// immediately undone by a lingering warm hover.
     private static let interactionSuppression: TimeInterval = 0.4
-
-    /// Gap between the anchor's edge and the card.
-    private static let anchorGap: CGFloat = 5
 
     init(timing: HoverCardTiming = .standard) {
         self.timing = timing
@@ -529,26 +643,19 @@ final class HoverCardController {
         position(panel: panel, relativeTo: anchor)
     }
 
-    /// Below the anchor, leading-aligned; flips above when there is no room
-    /// underneath, and clamps horizontally into the screen's visible frame.
+    /// Hands the anchor's geometry to `HoverCardPlacement`, which owns the rule.
     private func position(panel: HoverCardPanel, relativeTo anchor: NSView) {
         guard let window = anchor.window else { return }
         let anchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
         let anchorFrame = window.convertToScreen(anchorFrameInWindow)
-        let size = panel.hostingView.fittingSize
-
-        var origin = NSPoint(
-            x: anchorFrame.minX,
-            y: anchorFrame.minY - size.height - Self.anchorGap
+        let frame = HoverCardPlacement.panelFrame(
+            anchor: anchorFrame,
+            panelSize: panel.hostingView.fittingSize,
+            shadowInset: HoverCardView.shadowInset,
+            window: window.frame,
+            screenVisibleFrame: (window.screen ?? NSScreen.main)?.visibleFrame
         )
-        if let screen = window.screen ?? NSScreen.main {
-            let visible = screen.visibleFrame
-            if origin.y < visible.minY {
-                origin.y = anchorFrame.maxY + Self.anchorGap
-            }
-            origin.x = min(max(origin.x, visible.minX + 4), visible.maxX - size.width - 4)
-        }
-        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+        panel.setFrame(frame, display: true)
     }
 
     private func hide() {

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -247,14 +247,38 @@ struct HoverDwellReducer: Equatable {
 /// The window is a *preference*, not a hard constraint: when neither side fits
 /// inside it (a small floating panel, a short window), the screen decides, so
 /// this can never place a card worse than the screen rule alone would.
+/// The two clearances are deliberately asymmetric — see `anchorGap` and
+/// `flippedBarClearance`.
 enum HoverCardPlacement {
-    /// Gap between the anchor's edge and the card's visible edge.
+    /// Gap under the anchor for a card in its preferred, below position.
     ///
-    /// Sized to clear the padding a bar puts around its content, not just the
-    /// anchored control: the status-bar chip sits 4pt inside a `.bar` strip, so
-    /// a card flipped above it must clear the chip *and* that padding for the
-    /// strip to stay readable underneath.
+    /// Small on purpose: a card hanging under the control that summoned it
+    /// should read as *attached* to it, the way a menu hangs off its button.
     static let anchorGap: CGFloat = 8
+
+    /// Clearance above the anchor for a card that had to **flip**, sized to
+    /// clear the whole bar the anchor sits in plus visible breathing room.
+    ///
+    /// A flip only happens because the card ran out of room on the side it
+    /// wanted — it is escaping the edge of a window, and in practice that edge
+    /// is a bar: the anchor is a chip or a label a few points tall sitting
+    /// inside a strip with its own padding, its own background and its own top
+    /// edge. Clearing the *anchor* by a hair leaves the card sitting on that
+    /// strip, covering the very row the reader is looking at, which is why this
+    /// cannot be the same constant as `anchorGap` — the below case wants to
+    /// hug, and this one must not.
+    ///
+    /// It is a constant rather than the container's measured frame because the
+    /// anchor has no container to measure. The anchor is an AppKit view
+    /// SwiftUI hosts as a `background`, and the bar around it is SwiftUI
+    /// padding and a material — no enclosing `NSView` whose frame could be
+    /// read, so recovering one would mean either sniffing the private hosting
+    /// hierarchy for a visual-effect view or making every adopter of
+    /// `.hoverCard` pass its container's frame, which fails silently for
+    /// whoever forgets. So the constant carries the container's height itself:
+    /// the tallest bar in this app plus a gap wide enough to read as a gap.
+    static let flippedBarClearance: CGFloat = 24
+
     /// Keep-out from the edge of the screen's visible frame.
     static let screenMargin: CGFloat = 4
 
@@ -274,7 +298,7 @@ enum HoverCardPlacement {
                           height: panelSize.height - shadowInset * 2)
 
         let below = anchor.minY - anchorGap - card.height
-        let above = anchor.maxY + anchorGap
+        let above = anchor.maxY + flippedBarClearance
 
         let screenLower = screenVisibleFrame.map { $0.minY + screenMargin }
         let screenUpper = screenVisibleFrame.map { $0.maxY - screenMargin }

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -278,12 +278,13 @@ enum HoverCardPlacement {
     /// whoever forgets. So the constant carries the container's height itself:
     /// the tallest bar in this app plus a gap wide enough to read as a gap.
     ///
-    /// Above a status-bar chip that leaves roughly 40pt of untouched window
+    /// Above a status-bar chip that leaves roughly 24pt of untouched window
     /// content between the top of the strip and the bottom of the card — a band
-    /// wide enough to be unmistakable rather than merely measurable. It costs
+    /// wide enough to be unmistakable rather than merely measurable, while the
+    /// card stays near enough to the chip to read as belonging to it. It costs
     /// nothing in fit: a flip is only chosen when the card had a whole window's
     /// height above the anchor to sit in.
-    static let flippedBarClearance: CGFloat = 48
+    static let flippedBarClearance: CGFloat = 32
 
     /// Keep-out from the edge of the screen's visible frame.
     static let screenMargin: CGFloat = 4

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -277,7 +277,13 @@ enum HoverCardPlacement {
     /// `.hoverCard` pass its container's frame, which fails silently for
     /// whoever forgets. So the constant carries the container's height itself:
     /// the tallest bar in this app plus a gap wide enough to read as a gap.
-    static let flippedBarClearance: CGFloat = 24
+    ///
+    /// Above a status-bar chip that leaves roughly 40pt of untouched window
+    /// content between the top of the strip and the bottom of the card — a band
+    /// wide enough to be unmistakable rather than merely measurable. It costs
+    /// nothing in fit: a flip is only chosen when the card had a whole window's
+    /// height above the anchor to sit in.
+    static let flippedBarClearance: CGFloat = 48
 
     /// Keep-out from the edge of the screen's visible frame.
     static let screenMargin: CGFloat = 4

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -34,6 +34,14 @@ struct HoverCardRow: Equatable {
     var tint: HoverCardTint
     /// Muted caption line under the value (drift warnings, staleness notes).
     var caption: String?
+    /// Another string this row's `value` may swap to while the card is up.
+    ///
+    /// Drawn **hidden but laid out**, so the row reserves the larger of the two
+    /// in both axes and the card is exactly the same size whichever is showing.
+    /// A card that resized on a swap would jump under the pointer that summoned
+    /// it — the jitter a live-updating row exists to avoid, not to cause. Set it
+    /// on both states of a swapping row, each naming the other.
+    var alternateValue: String?
 
     init(label: String? = nil,
          value: String,
@@ -41,7 +49,8 @@ struct HoverCardRow: Equatable {
          valueStyle: HoverCardTextStyle = .plain,
          monospacedDigits: Bool = false,
          tint: HoverCardTint = .normal,
-         caption: String? = nil) {
+         caption: String? = nil,
+         alternateValue: String? = nil) {
         self.label = label
         self.value = value
         self.chip = chip
@@ -49,6 +58,7 @@ struct HoverCardRow: Equatable {
         self.monospacedDigits = monospacedDigits
         self.tint = tint
         self.caption = caption
+        self.alternateValue = alternateValue
     }
 }
 
@@ -279,9 +289,7 @@ struct HoverCardView: View {
     private func valueCell(_ row: HoverCardRow) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
-                styledText(row.value, style: row.valueStyle, monospacedDigits: row.monospacedDigits)
-                    .font(.system(size: 12))
-                    .foregroundStyle(valueColor(row))
+                valueText(row)
                 if let chip = row.chip {
                     Text(chip)
                         .font(.system(size: 10, weight: .medium))
@@ -295,6 +303,30 @@ struct HoverCardView: View {
                 captionText(caption)
             }
         }
+    }
+
+    /// The value, over an invisible copy of whatever it may swap to. `.hidden()`
+    /// removes the peer from the drawing but not from the layout, so the row is
+    /// sized for both strings at once and a swap moves no pixel but the text.
+    @ViewBuilder
+    private func valueText(_ row: HoverCardRow) -> some View {
+        if let alternate = row.alternateValue {
+            ZStack(alignment: .topLeading) {
+                styledText(alternate, style: row.valueStyle, monospacedDigits: row.monospacedDigits)
+                    .font(.system(size: 12))
+                    .hidden()
+                    .accessibilityHidden(true)
+                visibleValue(row)
+            }
+        } else {
+            visibleValue(row)
+        }
+    }
+
+    private func visibleValue(_ row: HoverCardRow) -> some View {
+        styledText(row.value, style: row.valueStyle, monospacedDigits: row.monospacedDigits)
+            .font(.system(size: 12))
+            .foregroundStyle(valueColor(row))
     }
 
     private func styledText(_ string: String, style: HoverCardTextStyle, monospacedDigits: Bool) -> Text {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -820,6 +820,32 @@ actor DaemonClient {
         )
     }
 
+    /// Untrack one PR from one worktree — the same tombstoning `tbd pr detach`
+    /// performs, so the app inherits its durability rather than inventing one:
+    /// a delete would be undone by the next poll or hook fire.
+    ///
+    /// The PR is named by **URL**. A status-bar chip can be synthetic — lifted
+    /// from a cached `Worktree.prStatus` with no row behind it — so there is no
+    /// binding id to name, and the daemon tombstones by identity whether or not
+    /// a row matched.
+    ///
+    /// `source` is `manual` because the gesture records nothing but a user's
+    /// decision, and that is what makes `pr.attach` able to reverse it.
+    ///
+    /// `detached: false` in the result is NOT a failure: it means the PR was
+    /// already tombstoned. Only a thrown error is.
+    func detachPR(worktreeID: UUID, url: String) async throws -> PRDetachResult {
+        try await callAsync(
+            method: RPCMethod.prDetach,
+            params: PRBindingRefParams(
+                worktreeID: worktreeID,
+                url: url,
+                source: PRBindingSource.manual.rawValue
+            ),
+            resultType: PRDetachResult.self
+        )
+    }
+
     /// Push the user's Claude spawn-env setting overrides to the daemon.
     func setClaudeSpawnPreferences(_ preferences: ClaudeSpawnPreferences) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -824,22 +824,30 @@ actor DaemonClient {
     /// performs, so the app inherits its durability rather than inventing one:
     /// a delete would be undone by the next poll or hook fire.
     ///
-    /// The PR is named by **URL**. A status-bar chip can be synthetic — lifted
-    /// from a cached `Worktree.prStatus` with no row behind it — so there is no
-    /// binding id to name, and the daemon tombstones by identity whether or not
-    /// a row matched.
+    /// The PR is named by **URL, with its number as the fallback**. A status-bar
+    /// chip can be synthetic — lifted from a cached `Worktree.prStatus` with no
+    /// row behind it — so there is no binding id to name, and the daemon
+    /// tombstones by identity whether or not a row matched.
+    ///
+    /// Both are sent because a legacy cached status can carry a url that does
+    /// not parse (or none at all), and a control that quietly declines is the
+    /// thing this gesture exists to replace. `resolvePRRef` prefers a non-empty
+    /// url and resolves a bare number against the worktree's own repo, so the
+    /// pair costs nothing when the url is good and saves the click when it is
+    /// not.
     ///
     /// `source` is `manual` because the gesture records nothing but a user's
     /// decision, and that is what makes `pr.attach` able to reverse it.
     ///
     /// `detached: false` in the result is NOT a failure: it means the PR was
     /// already tombstoned. Only a thrown error is.
-    func detachPR(worktreeID: UUID, url: String) async throws -> PRDetachResult {
+    func detachPR(worktreeID: UUID, url: String?, number: Int) async throws -> PRDetachResult {
         try await callAsync(
             method: RPCMethod.prDetach,
             params: PRBindingRefParams(
                 worktreeID: worktreeID,
                 url: url,
+                number: number,
                 source: PRBindingSource.manual.rawValue
             ),
             resultType: PRDetachResult.self

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -104,6 +104,11 @@ struct StatusBarView: View {
         /// PR to the daemon — a synthetic chip has no row to name by id.
         let url: URL?
         let state: PRMergeableState?
+        /// The status's own words for that state, when it has any — the same
+        /// `reason ?? state.displayReason` the overflow menu and the toolbar
+        /// dropdown render. Carried rather than derived so the three surfaces
+        /// cannot describe one observation differently.
+        let reason: String?
         /// The PR's title, or nil when it was never observed (a chip lifted
         /// from a cached `Worktree.prStatus` has none). The hover overlay
         /// omits the line rather than fabricating a placeholder.
@@ -120,12 +125,14 @@ struct StatusBarView: View {
     /// calculation — nothing here consults the available width, and the
     /// overflow count is a pure function of how many bindings there are.
     ///
-    /// What the cluster yields under pressure is width, not chips: it carries
-    /// `layoutPriority(-1)` just as the path label beside it does, so a narrow
-    /// window compresses the strip rather than squeezing the path, and
-    /// compressing it truncates labels rather than folding chips into the
-    /// overflow menu. Width-aware collapsing would be the real answer and is
-    /// deliberately not built here.
+    /// It buys no width safety either, and the `layoutPriority(-1)` it carries
+    /// does not provide any: the path/branch cluster beside it is at the same
+    /// priority, so the two are peers in one bucket and share the deficit
+    /// rather than one yielding to the other. A narrow window therefore
+    /// squeezes both, truncating chip labels and path segments alike rather
+    /// than folding chips into the overflow menu — and seven chips reach that
+    /// point at a wider window than four did. Width-aware collapsing would be
+    /// the real answer and is deliberately not built here.
     nonisolated static let prChipLimit = 7
 
     /// The chip row for `bindings`, plus how many did not fit. Pure: delegates
@@ -163,6 +170,7 @@ struct StatusBarView: View {
                 refLabel: binding.refLabel,
                 url: URL(string: binding.url),
                 state: binding.status?.state,
+                reason: binding.status.map { $0.reason ?? $0.state.displayReason },
                 title: binding.title,
                 observedAt: binding.status?.observedAt
             )
@@ -192,7 +200,9 @@ struct StatusBarView: View {
             HoverCardRow(label: "PR", value: chip.label),
             HoverCardRow(
                 label: "State",
-                value: chip.state?.displayReason ?? unobservedStateValue,
+                // The status's own words when it has any, exactly as the
+                // overflow menu and the toolbar dropdown render them.
+                value: chip.reason ?? unobservedStateValue,
                 caption: PRFreshness.checkedLabel(observedAt: chip.observedAt, now: now)
             )
         ]
@@ -495,13 +505,18 @@ private struct PRChipView: View {
                 .onTapGesture {
                     if isHovering { detach() } else { open() }
                 }
-                // Accessibility does not hover, so this element keeps the
-                // untrack identity unconditionally and carries its own action —
-                // otherwise the gesture would exist for pointer users only.
+                // Accessibility never hovers, so `isHovering` is false for it
+                // and the slot's default action is "open" — which is what the
+                // label therefore says. Untracking is offered as a NAMED
+                // action instead of the default: a named action cannot be
+                // confused with the tap gesture's synthesized one, so the
+                // element can never announce one thing and do the other, and a
+                // destructive action is better reached deliberately than by
+                // activating whatever has focus.
                 .accessibilityElement()
-                .accessibilityLabel(StatusBarView.untrackLabel(chip))
+                .accessibilityLabel(StatusBarView.iconSlotLabel(chip, isHovering: isHovering))
                 .accessibilityAddTraits(.isButton)
-                .accessibilityAction { detach() }
+                .accessibilityAction(named: Text(StatusBarView.untrackLabel(chip))) { detach() }
         }
     }
 

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -115,12 +115,17 @@ struct StatusBarView: View {
 
     /// How many chips the bar shows before the rest collapse into `+N`.
     ///
-    /// Seven, because the cluster yields width rather than taking it: it
-    /// carries `layoutPriority(-1)` just as the path label beside it does, so a
-    /// narrow window degrades by collapsing chips into the overflow menu rather
-    /// than by squeezing the path. That is what makes the cap a question of how
-    /// many PRs are worth scanning at a glance rather than a bet on window
-    /// width. Past seven the dropdown is the better surface.
+    /// Seven is a judgement about how many numbers are worth scanning at a
+    /// glance; past that the dropdown is the better surface. It is not a width
+    /// calculation — nothing here consults the available width, and the
+    /// overflow count is a pure function of how many bindings there are.
+    ///
+    /// What the cluster yields under pressure is width, not chips: it carries
+    /// `layoutPriority(-1)` just as the path label beside it does, so a narrow
+    /// window compresses the strip rather than squeezing the path, and
+    /// compressing it truncates labels rather than folding chips into the
+    /// overflow menu. Width-aware collapsing would be the real answer and is
+    /// deliberately not built here.
     nonisolated static let prChipLimit = 7
 
     /// The chip row for `bindings`, plus how many did not fit. Pure: delegates
@@ -432,7 +437,13 @@ private struct PRChipView: View {
                 .padding(.leading, Self.iconTextGap)
                 // The gap beside the number is part of the open target.
                 .contentShape(Rectangle())
-                .help(StatusBarView.openLabel(chip))
+                // No `.help` here, deliberately: the hover overlay already
+                // names this PR, its state and the age of that reading, and a
+                // tooltip would surface a second, smaller box saying less on
+                // top of it. The icon slot keeps its tooltip because the
+                // overlay says nothing about what clicking the slot does.
+                // Accessibility is unaffected — the hint below carries the same
+                // sentence.
                 // Opens the DEFAULT BROWSER, not an in-app tab. Intentional,
                 // and the one place the status bar and the toolbar deliberately
                 // differ: the toolbar control and its dropdown open a webview

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -116,11 +116,11 @@ struct StatusBarView: View {
         /// When `state` was read. nil = never, which the overlay says out loud
         /// rather than passing the cached state off as current.
         let observedAt: Date?
-        /// The clause naming a last poll attempt that did not resolve, or nil
-        /// when the last attempt settled the question either way. The toolbar
-        /// and sidebar both append it; a chip that omitted it would render the
-        /// more confident of two readings of one fact.
-        let undetermined: String?
+        /// The worktree's last poll attempt, carried whole rather than as a
+        /// rendered clause so the overlay composes its caption through the same
+        /// `PRFreshness` the toolbar and sidebar use. A chip that omitted it
+        /// would render the more confident of two readings of one fact.
+        let observation: PRObservation?
     }
 
     /// How many chips the bar shows before the rest collapse into `+N`.
@@ -171,7 +171,6 @@ struct StatusBarView: View {
         observation: PRObservation? = nil
     ) -> (chips: [PRChip], overflow: Int) {
         let selected = PRBindingPresentation.statusBarChips(bindings, limit: limit)
-        let undetermined = PRFreshness.undeterminedClause(observation)
         let chips = selected.chips.map { binding in
             PRChip(
                 id: binding.id,
@@ -184,7 +183,7 @@ struct StatusBarView: View {
                 reason: binding.status.map { $0.reason ?? $0.state.displayReason },
                 title: binding.title,
                 observedAt: binding.status?.observedAt,
-                undetermined: undetermined
+                observation: observation
             )
         }
         return (chips, selected.overflow)
@@ -216,11 +215,11 @@ struct StatusBarView: View {
                 // overflow menu and the toolbar dropdown render them.
                 value: chip.reason ?? unobservedStateValue,
                 // Age first, then whether the last attempt to reconfirm it
-                // failed — the same two clauses in the same order the toolbar
-                // and sidebar compose from `PRFreshness`.
-                caption: ([PRFreshness.checkedLabel(observedAt: chip.observedAt, now: now)]
-                    + [chip.undetermined].compactMap { $0})
-                    .joined(separator: " · ")
+                // failed — composed by `PRFreshness` itself, not restated here,
+                // so this cannot drift from the toolbar and sidebar.
+                caption: PRFreshness.clauses(
+                    observedAt: chip.observedAt, observation: chip.observation, now: now
+                ).joined(separator: " · ")
             )
         ]
         return model

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -201,7 +201,14 @@ struct StatusBarView: View {
     /// A chip with no observed title renders no title line, and one with no
     /// observed status still gets its number and an honest "unknown time".
     /// Pure, so the whole overlay can be asserted without a panel.
-    nonisolated static func chipHoverCard(_ chip: PRChip, now: Date = Date()) -> HoverCardModel {
+    ///
+    /// `untrackTarget` says the pointer is over the icon slot *while that slot
+    /// is drawing the xmark*, and only changes the wording of the action row —
+    /// the row is always present, so the card cannot grow or shrink under a
+    /// pointer travelling between the chip's two click targets.
+    nonisolated static func chipHoverCard(
+        _ chip: PRChip, untrackTarget: Bool = false, now: Date = Date()
+    ) -> HoverCardModel {
         var model = HoverCardModel()
         if let title = chip.title?.trimmingCharacters(in: .whitespacesAndNewlines),
            !title.isEmpty {
@@ -220,10 +227,34 @@ struct StatusBarView: View {
                 caption: PRFreshness.clauses(
                     observedAt: chip.observedAt, observation: chip.observation, now: now
                 ).joined(separator: " · ")
+            ),
+            // Last, and always present: the chip has two click targets in about
+            // twenty points of width, and nothing else on screen says which one
+            // the pointer is on. The alternate wording rides along so the row is
+            // laid out for both sentences at once — see `HoverCardRow`.
+            HoverCardRow(
+                value: chipActionValue(untrackTarget: untrackTarget),
+                valueStyle: .mutedItalic,
+                alternateValue: chipActionValue(untrackTarget: !untrackTarget)
             )
         ]
         return model
     }
+
+    /// What the overlay's action row says the click under the pointer will do.
+    ///
+    /// Two sentences rather than a reuse of `untrackLabel` / `openLabel`: those
+    /// name the PR by number and the open one appends its state, both of which
+    /// the card has already said on its own rows. Here the subject is the click,
+    /// so the sentences start with the gesture and say nothing twice. The
+    /// untrack half still names the worktree scope, for the same reason
+    /// `untrackLabel` does — the gesture removes an association, not the PR.
+    nonisolated static func chipActionValue(untrackTarget: Bool) -> String {
+        untrackTarget ? chipUntrackActionValue : chipOpenActionValue
+    }
+
+    nonisolated static let chipOpenActionValue = "Click to open this PR on GitHub"
+    nonisolated static let chipUntrackActionValue = "Click to stop tracking this PR in this worktree"
 
     /// What the overlay's state row says for a binding nothing has polled yet.
     /// Named so a test can pin it without restating the copy.
@@ -423,6 +454,11 @@ private struct PRChipView: View {
     let chip: StatusBarView.PRChip
 
     @State private var isHovering = false
+    /// The pointer is over the icon slot specifically, rather than anywhere on
+    /// the chip. Read ONLY for emphasis and for what the overlay says the click
+    /// will do — never for the glyph, which stays on `isHovering` so travelling
+    /// from the number onto the slot cannot flicker the xmark back to a dot.
+    @State private var isSlotHovered = false
 
     /// The fixed square the status dot and the untrack xmark share.
     ///
@@ -495,10 +531,23 @@ private struct PRChipView: View {
         // Hover is read on the WHOLE chip, so travelling from the number onto
         // the xmark cannot flip the icon back under the cursor.
         .modifier(StatusBarHoverAffordance(isHovering: $isHovering))
+        // Leaving the chip clears the slot too. `onHover(false)` normally does
+        // it, but a chip torn down or reflowed under a stationary cursor need
+        // not receive one, and a stranded `true` would emphasise the xmark of
+        // the next chip to appear under the pointer.
+        .onChange(of: isHovering) { _, hovering in
+            if !hovering { isSlotHovered = false }
+        }
         // Anchored to the whole chip, so the overlay survives the pointer
         // moving from the number onto the xmark.
-        .hoverCard(StatusBarView.chipHoverCard(chip))
+        .hoverCard(StatusBarView.chipHoverCard(chip, untrackTarget: isUntrackTarget))
     }
+
+    /// The pointer is over the untrack target *and* the slot is drawing the
+    /// xmark — the same conjunction `iconSlotLabel` gates the slot's action on.
+    /// Anything the user is told about the click is derived from it, so the card
+    /// can never advertise untracking while the slot is showing a status dot.
+    private var isUntrackTarget: Bool { isHovering && isSlotHovered }
 
     /// The fixed-size leading slot: the status dot at rest, the untrack xmark
     /// while the chip is hovered. Both centred in the same square.
@@ -507,7 +556,21 @@ private struct PRChipView: View {
             if isHovering {
                 Image(systemName: "xmark")
                     .font(.system(size: Self.xmarkPointSize, weight: .bold))
-                    .foregroundStyle(.secondary)
+                    // Full strength over a faint disc once the pointer is on
+                    // the target itself, so the glyph about to be clicked reads
+                    // as a button rather than as decoration beside the number.
+                    .foregroundStyle(isSlotHovered ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+                    .background {
+                        // Drawn at exactly `untrackHitSide`: the disc is the
+                        // clickable region, so no pixel that looks like the
+                        // button fails to act as one. A `background` with its
+                        // own fixed frame is sized by itself and never proposed
+                        // to the layout, so the chip's width is identical in
+                        // all three states — at rest, chip-hovered, and here.
+                        Circle()
+                            .fill(Color.primary.opacity(isSlotHovered ? 0.11 : 0))
+                            .frame(width: Self.untrackHitSide, height: Self.untrackHitSide)
+                    }
             } else {
                 Circle()
                     .fill(dotColor)
@@ -526,6 +589,11 @@ private struct PRChipView: View {
                 // the glyph, so the click can never mean something other than
                 // what the slot is drawing — see `iconSlotLabel`.
                 .help(StatusBarView.iconSlotLabel(chip, isHovering: isHovering))
+                // Drives the emphasis and the overlay's action row, and nothing
+                // else: the glyph and the click both stay on the whole-chip
+                // `isHovering`, so this can only change what the user is TOLD,
+                // never what the slot does.
+                .onHover { isSlotHovered = $0 }
                 .onTapGesture {
                     if isHovering { detach() } else { open() }
                 }

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -116,6 +116,11 @@ struct StatusBarView: View {
         /// When `state` was read. nil = never, which the overlay says out loud
         /// rather than passing the cached state off as current.
         let observedAt: Date?
+        /// The clause naming a last poll attempt that did not resolve, or nil
+        /// when the last attempt settled the question either way. The toolbar
+        /// and sidebar both append it; a chip that omitted it would render the
+        /// more confident of two readings of one fact.
+        let undetermined: String?
     }
 
     /// How many chips the bar shows before the rest collapse into `+N`.
@@ -156,11 +161,17 @@ struct StatusBarView: View {
         readback?.phase.undeliverableReason != nil
     }
 
+    /// `observation` is the worktree's last poll attempt, carried so the
+    /// overlay can say when that attempt did not resolve — the same clause the
+    /// toolbar and sidebar append. Without it a chip would render the more
+    /// confident of two readings of one fact.
     nonisolated static func prChips(
         _ bindings: [PRBinding],
-        limit: Int = prChipLimit
+        limit: Int = prChipLimit,
+        observation: PRObservation? = nil
     ) -> (chips: [PRChip], overflow: Int) {
         let selected = PRBindingPresentation.statusBarChips(bindings, limit: limit)
+        let undetermined = PRFreshness.undeterminedClause(observation)
         let chips = selected.chips.map { binding in
             PRChip(
                 id: binding.id,
@@ -172,7 +183,8 @@ struct StatusBarView: View {
                 state: binding.status?.state,
                 reason: binding.status.map { $0.reason ?? $0.state.displayReason },
                 title: binding.title,
-                observedAt: binding.status?.observedAt
+                observedAt: binding.status?.observedAt,
+                undetermined: undetermined
             )
         }
         return (chips, selected.overflow)
@@ -203,7 +215,12 @@ struct StatusBarView: View {
                 // The status's own words when it has any, exactly as the
                 // overflow menu and the toolbar dropdown render them.
                 value: chip.reason ?? unobservedStateValue,
-                caption: PRFreshness.checkedLabel(observedAt: chip.observedAt, now: now)
+                // Age first, then whether the last attempt to reconfirm it
+                // failed — the same two clauses in the same order the toolbar
+                // and sidebar compose from `PRFreshness`.
+                caption: ([PRFreshness.checkedLabel(observedAt: chip.observedAt, now: now)]
+                    + [chip.undetermined].compactMap { $0})
+                    .joined(separator: " · ")
             )
         ]
         return model
@@ -304,7 +321,8 @@ struct StatusBarView: View {
                 // three surfaces cannot show different PRs for one worktree.
                 let bindings = appState.effectivePRBindings(worktreeID: selected.id)
                 if !bindings.isEmpty {
-                    PRChipCluster(bindings: bindings)
+                    PRChipCluster(bindings: bindings,
+                                  observation: appState.prObservations[selected.id])
                         // Same reason as the path cluster: yield width to the
                         // version/display-name label rather than squeezing it.
                         .layoutPriority(-1)
@@ -367,9 +385,12 @@ private struct StatusBarHoverAffordance: ViewModifier {
 /// `StatusBarView.prChipLimit`, then a `+N` chip listing the rest.
 private struct PRChipCluster: View {
     let bindings: [PRBinding]
+    /// The worktree's last poll attempt, so a chip's overlay can say when that
+    /// attempt did not resolve — the clause the toolbar and sidebar append.
+    let observation: PRObservation?
 
     var body: some View {
-        let model = StatusBarView.prChips(bindings)
+        let model = StatusBarView.prChips(bindings, observation: observation)
         HStack(spacing: 6) {
             ForEach(model.chips) { chip in
                 PRChipView(chip: chip)

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -95,11 +95,15 @@ struct StatusBarView: View {
         /// the PR names its tab `PR #N` and must not have to re-parse "#412".
         let number: Int
         let label: String
+        /// Which forge this binding lives on, read once from the binding's own
+        /// URL at build time. Carried on the chip rather than recomposed in the
+        /// view because the binding — the only thing that knows the URL — does
+        /// not reach the view, and every sentence the chip renders about the
+        /// request has to speak that forge's vocabulary.
+        let forge: Forge
         /// The binding named in its own forge's vocabulary (`PR #412` /
-        /// `MR !412`), for the tooltip. Carried on the chip rather than
-        /// recomposed in the view because the binding — the only thing that
-        /// knows the host — does not reach the view.
-        let refLabel: String
+        /// `MR !412`), for the tooltip.
+        var refLabel: String { forge.refLabel(number: number) }
         /// The PR's own URL, both the open target and how the detach names the
         /// PR to the daemon — a synthetic chip has no row to name by id.
         let url: URL?
@@ -177,7 +181,7 @@ struct StatusBarView: View {
                 worktreeID: binding.worktreeID,
                 number: binding.number,
                 label: "#\(binding.number)",
-                refLabel: binding.refLabel,
+                forge: Forge.forURL(binding.url),
                 url: URL(string: binding.url),
                 state: binding.status?.state,
                 reason: binding.status.map { $0.reason ?? $0.state.displayReason },
@@ -223,9 +227,9 @@ struct StatusBarView: View {
             // pointer is on. The alternate wording rides along so the row is
             // laid out for both sentences at once — see `HoverCardRow`.
             HoverCardRow(
-                value: chipActionValue(untrackTarget: untrackTarget),
+                value: chipActionValue(untrackTarget: untrackTarget, forge: chip.forge),
                 valueStyle: .mutedItalic,
-                alternateValue: chipActionValue(untrackTarget: !untrackTarget)
+                alternateValue: chipActionValue(untrackTarget: !untrackTarget, forge: chip.forge)
             )
         ]
         return model
@@ -267,12 +271,24 @@ struct StatusBarView: View {
     /// so the sentences start with the gesture and say nothing twice. The
     /// untrack half still names the worktree scope, for the same reason
     /// `untrackLabel` does — the gesture removes an association, not the PR.
-    nonisolated static func chipActionValue(untrackTarget: Bool) -> String {
-        untrackTarget ? chipUntrackActionValue : chipOpenActionValue
+    ///
+    /// Both sentences take the chip's own `forge`, so a GitLab-bound chip says
+    /// "MR" and "GitLab" where a GitHub-bound one says "PR" and "GitHub" — the
+    /// same vocabulary `refLabel` names the binding with, minus the number the
+    /// headline already carries. The card lays the pair out together, and a
+    /// chip has exactly one forge, so the width reservation still spans both
+    /// sentences it can swap between.
+    nonisolated static func chipActionValue(untrackTarget: Bool, forge: Forge) -> String {
+        untrackTarget ? chipUntrackActionValue(forge) : chipOpenActionValue(forge)
     }
 
-    nonisolated static let chipOpenActionValue = "Click to open this PR on GitHub"
-    nonisolated static let chipUntrackActionValue = "Click to stop tracking this PR in this worktree"
+    nonisolated static func chipOpenActionValue(_ forge: Forge) -> String {
+        "Click to open this \(forge.refNoun) on \(forge.displayName)"
+    }
+
+    nonisolated static func chipUntrackActionValue(_ forge: Forge) -> String {
+        "Click to stop tracking this \(forge.refNoun) in this worktree"
+    }
 
     /// Tooltip and accessibility label for a chip's untrack target — the xmark
     /// the status dot becomes on hover. It names the worktree scope explicitly

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -87,6 +87,10 @@ struct StatusBarView: View {
     /// `WorktreeRowView.rowHeight` is `nonisolated`).
     nonisolated struct PRChip: Identifiable, Equatable {
         let id: UUID
+        /// Which worktree this chip is bound to — what the untrack gesture
+        /// detaches it from. Carried on the chip rather than threaded through
+        /// the view so the whole gesture can be reasoned about as a value.
+        let worktreeID: UUID
         /// The PR number, kept alongside the rendered `label` because opening
         /// the PR names its tab `PR #N` and must not have to re-parse "#412".
         let number: Int
@@ -96,14 +100,28 @@ struct StatusBarView: View {
         /// recomposed in the view because the binding — the only thing that
         /// knows the host — does not reach the view.
         let refLabel: String
+        /// The PR's own URL, both the open target and how the detach names the
+        /// PR to the daemon — a synthetic chip has no row to name by id.
         let url: URL?
         let state: PRMergeableState?
+        /// The PR's title, or nil when it was never observed (a chip lifted
+        /// from a cached `Worktree.prStatus` has none). The hover overlay
+        /// omits the line rather than fabricating a placeholder.
+        let title: String?
+        /// When `state` was read. nil = never, which the overlay says out loud
+        /// rather than passing the cached state off as current.
+        let observedAt: Date?
     }
 
-    /// How many chips the bar shows before the rest collapse into `+N`. Four
-    /// keeps the cluster narrower than the path it sits beside on a typical
-    /// window; past that the dropdown is the better surface.
-    nonisolated static let prChipLimit = 4
+    /// How many chips the bar shows before the rest collapse into `+N`.
+    ///
+    /// Seven, because the cluster yields width rather than taking it: it
+    /// carries `layoutPriority(-1)` just as the path label beside it does, so a
+    /// narrow window degrades by collapsing chips into the overflow menu rather
+    /// than by squeezing the path. That is what makes the cap a question of how
+    /// many PRs are worth scanning at a glance rather than a bet on window
+    /// width. Past seven the dropdown is the better surface.
+    nonisolated static let prChipLimit = 7
 
     /// The chip row for `bindings`, plus how many did not fit. Pure: delegates
     /// the cap and the bind-order guarantee to `PRBindingPresentation` so the
@@ -134,14 +152,64 @@ struct StatusBarView: View {
         let chips = selected.chips.map { binding in
             PRChip(
                 id: binding.id,
+                worktreeID: binding.worktreeID,
                 number: binding.number,
                 label: "#\(binding.number)",
                 refLabel: binding.refLabel,
                 url: URL(string: binding.url),
-                state: binding.status?.state
+                state: binding.status?.state,
+                title: binding.title,
+                observedAt: binding.status?.observedAt
             )
         }
         return (chips, selected.overflow)
+    }
+
+    /// What a chip's hover overlay says: the PR's title, its number, the state
+    /// and **when that state was read**.
+    ///
+    /// The age is not decoration. `PRStatus` is a display-tier cache and was
+    /// measured reading "Ready to merge" for pull requests merged days earlier,
+    /// so no surface may render it as current truth — the wording comes from
+    /// `PRFreshness`, shared with the toolbar and sidebar so the three cannot
+    /// describe one observation differently.
+    ///
+    /// A chip with no observed title renders no title line, and one with no
+    /// observed status still gets its number and an honest "unknown time".
+    /// Pure, so the whole overlay can be asserted without a panel.
+    nonisolated static func chipHoverCard(_ chip: PRChip, now: Date = Date()) -> HoverCardModel {
+        var model = HoverCardModel()
+        if let title = chip.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty {
+            model.title = title
+        }
+        model.rows = [
+            HoverCardRow(label: "PR", value: chip.label),
+            HoverCardRow(
+                label: "State",
+                value: chip.state?.displayReason ?? unobservedStateValue,
+                caption: PRFreshness.checkedLabel(observedAt: chip.observedAt, now: now)
+            )
+        ]
+        return model
+    }
+
+    /// What the overlay's state row says for a binding nothing has polled yet.
+    /// Named so a test can pin it without restating the copy.
+    nonisolated static let unobservedStateValue = "No status observed yet"
+
+    /// Tooltip and accessibility label for a chip's untrack target — the xmark
+    /// the status dot becomes on hover. It names the worktree scope explicitly
+    /// because the gesture removes an association, not the pull request.
+    nonisolated static func untrackLabel(_ chip: PRChip) -> String {
+        "Stop tracking \(chip.refLabel) in this worktree"
+    }
+
+    /// Tooltip and accessibility hint for the chip's own click target, e.g.
+    /// `Open PR #412 — Checks failing`.
+    nonisolated static func openLabel(_ chip: PRChip) -> String {
+        guard let state = chip.state else { return "Open \(chip.refLabel)" }
+        return "Open \(chip.refLabel) — \(state.displayReason)"
     }
 
     private var footerLabel: (text: String, tooltip: String?) {
@@ -287,17 +355,40 @@ private struct PRChipCluster: View {
 
 /// One `● #412` chip. Chrome-less like `CopyableStatusText` — the hover
 /// underline plus pointing-hand cursor are the whole affordance.
+///
+/// Two click targets, deliberately laid out as **siblings** rather than as a
+/// control nested inside a tappable row: the leading icon slot untracks the PR,
+/// and everything else opens it. An `.onTapGesture` on a common ancestor is
+/// exactly the shape that swallows a child's gesture in this codebase, so there
+/// is no ancestor gesture to swallow anything — each target owns its own tap,
+/// its own tooltip and its own accessibility element.
 private struct PRChipView: View {
+    @EnvironmentObject var appState: AppState
     let chip: StatusBarView.PRChip
 
     @State private var isHovering = false
 
-    /// Tooltip and accessibility hint, e.g. `Open PR #412 — Checks failing`,
-    /// or `Open MR !412 — Checks failing` for a GitLab binding.
-    private var tooltip: String {
-        guard let state = chip.state else { return "Open \(chip.refLabel)" }
-        return "Open \(chip.refLabel) — \(state.displayReason)"
-    }
+    /// The fixed square the status dot and the untrack xmark share.
+    ///
+    /// Sized for the LARGER of the two glyphs, with both centred in it, so the
+    /// chip is exactly as wide hovered as at rest. A slot that grew on hover
+    /// would shove every chip to its right and slide the xmark out from under
+    /// the cursor that summoned it.
+    private static let iconSlotSide: CGFloat = 9
+    /// The drawn xmark's point size — under `iconSlotSide` in both axes.
+    private static let xmarkPointSize: CGFloat = 8
+    /// The untrack click region, contributed as a transparent **overlay** on
+    /// the slot rather than as padding: an overlay is proposed its parent's
+    /// size but may choose its own and never pushes a sibling, so a hit area
+    /// wider than the glyph costs no layout width. 12pt centred on the 6pt dot
+    /// reaches 3pt past the dot on each side, well inside the 6pt gap
+    /// `PRChipCluster` puts between chips, so no chip can take a neighbour's
+    /// click.
+    private static let untrackHitSide: CGFloat = 12
+    /// Gap between the icon slot and the number. Applied as leading padding on
+    /// the text rather than as `HStack` spacing so the gap belongs to the
+    /// open-the-PR target instead of being dead space.
+    private static let iconTextGap: CGFloat = 3
 
     /// The dot color, taken from the shared PR palette so a chip cannot drift
     /// from the sidebar glyph or the toolbar icon for the same state. The
@@ -312,40 +403,94 @@ private struct PRChipView: View {
     }
 
     var body: some View {
-        HStack(spacing: 3) {
-            Circle()
-                .fill(dotColor)
-                .frame(width: 6, height: 6)
+        HStack(spacing: 0) {
+            // Above the number in z-order, so the 1.5pt by which the untrack
+            // region overhangs the slot on the trailing side wins the hit test
+            // against the text's own leading padding. Later `HStack` children
+            // are otherwise drawn — and hit-tested — on top.
+            iconSlot.zIndex(1)
             Text(chip.label)
                 .lineLimit(1)
                 .underline(isHovering)
+                .padding(.leading, Self.iconTextGap)
+                // The gap beside the number is part of the open target.
+                .contentShape(Rectangle())
+                .help(StatusBarView.openLabel(chip))
+                // Opens the DEFAULT BROWSER, not an in-app tab. Intentional,
+                // and the one place the status bar and the toolbar deliberately
+                // differ: the toolbar control and its dropdown open a webview
+                // tab, while the status bar agrees with the sidebar row
+                // indicator and shells out. Not drift — the status bar is an
+                // at-a-glance strip, and a click there is a "take me to GitHub"
+                // gesture rather than a request to park a tab in the worktree.
+                .onTapGesture {
+                    guard let url = chip.url else { return }
+                    NSWorkspace.shared.open(url)
+                }
+                .accessibilityElement()
+                .accessibilityLabel("PR \(chip.label)")
+                .accessibilityHint(StatusBarView.openLabel(chip))
+                .accessibilityAddTraits(.isButton)
         }
         .foregroundStyle(.secondary)
-        // The dot and the gap beside it are part of the click target.
-        .contentShape(Rectangle())
-        .help(tooltip)
+        // Hover is read on the WHOLE chip, so travelling from the number onto
+        // the xmark cannot flip the icon back under the cursor.
         .modifier(StatusBarHoverAffordance(isHovering: $isHovering))
-        // Opens the DEFAULT BROWSER, not an in-app tab. Intentional, and the
-        // one place the status bar and the toolbar deliberately differ: the
-        // toolbar control and its dropdown open a webview tab, while the status
-        // bar agrees with the sidebar row indicator and shells out. Not drift —
-        // the status bar is an at-a-glance strip, and a click there is a "take
-        // me to GitHub" gesture rather than a request to park a tab in the
-        // worktree.
-        .onTapGesture {
-            guard let url = chip.url else { return }
-            NSWorkspace.shared.open(url)
+        // Anchored to the whole chip, so the overlay survives the pointer
+        // moving from the number onto the xmark.
+        .hoverCard(StatusBarView.chipHoverCard(chip))
+    }
+
+    /// The fixed-size leading slot: the status dot at rest, the untrack xmark
+    /// while the chip is hovered. Both centred in the same square.
+    private var iconSlot: some View {
+        ZStack {
+            if isHovering {
+                Image(systemName: "xmark")
+                    .font(.system(size: Self.xmarkPointSize, weight: .bold))
+                    .foregroundStyle(.secondary)
+            } else {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 6, height: 6)
+            }
         }
-        .accessibilityElement()
-        .accessibilityLabel("PR \(chip.label)")
-        .accessibilityHint(tooltip)
-        .accessibilityAddTraits(.isButton)
+        .frame(width: Self.iconSlotSide, height: Self.iconSlotSide)
+        .overlay {
+            // Transparent, larger than the slot, and laid over it — sized by
+            // this overlay and not by the layout, so it widens the hit area
+            // without widening the chip.
+            Color.clear
+                .frame(width: Self.untrackHitSide, height: Self.untrackHitSide)
+                .contentShape(Rectangle())
+                .help(StatusBarView.untrackLabel(chip))
+                .onTapGesture { detach() }
+                .accessibilityElement()
+                .accessibilityLabel(StatusBarView.untrackLabel(chip))
+                .accessibilityAddTraits(.isButton)
+        }
+    }
+
+    private func detach() {
+        guard let url = chip.url else { return }
+        Task { await appState.detachPR(worktreeID: chip.worktreeID, url: url.absoluteString) }
     }
 }
 
 /// The `+N` chip. Clicking it drops down the same list the toolbar's multi-PR
 /// dropdown shows — `PRBindingPresentation.menuRows`, in bind order — so the
 /// two surfaces cannot describe the same worktree differently.
+///
+/// It renders **no PR title**, and that is a decision rather than an omission.
+/// Titles reach the chips through the hover overlay, which is an ordinary
+/// SwiftUI view re-evaluated on every change. A title in these rows would have
+/// to survive AppKit's once-only `NSMenu` materialization — the constraint
+/// `PRButtonLabel.prSplitButtonID` exists for and `PRSplitButtonIDTests`
+/// tripwires — and this `Menu` has no `.id` key to fold it into, so a retitled
+/// PR would read stale here for as long as the menu lived. Sharing `menuRows`
+/// with the toolbar is also what keeps the two surfaces from disagreeing;
+/// forking it for one field would give that up to duplicate what the overlay
+/// already says better.
 private struct PRChipOverflowMenu: View {
     let bindings: [PRBinding]
     let overflow: Int

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -235,12 +235,20 @@ struct StatusBarView: View {
         return model
     }
 
-    /// The overlay's headline: `PR#412 (Checks failing) - Fix the login timeout`.
+    /// The overlay's headline: `PR#412 (Checks failing) - Fix the login timeout`,
+    /// or `MR#412 (…)` under a chip bound to a merge request.
     ///
     /// One line rather than a labelled grid. The three facts are read together —
     /// which PR, what state, what it is about — and a two-column table of them
     /// spent most of a card's width on the words "PR" and "State" saying what
     /// `#412` and "Checks failing" already say.
+    ///
+    /// The noun is the chip's own `forge.refNoun`, and `refNoun` rather than
+    /// `refLabel` because the headline is glued to the number the chip is
+    /// *already drawing*: the chip renders the bare `#412` on both forges, so a
+    /// headline built from `refLabel` would answer `MR !412` over a chip
+    /// reading `#412`. The card must never call a merge request a PR while its
+    /// own action row one line below offers to open it on GitLab.
     ///
     /// Everything but the number is optional and degrades by *omission*: a
     /// synthetic chip has no title, a never-polled binding has no state, and
@@ -249,7 +257,7 @@ struct StatusBarView: View {
     /// pointer is on already carries that color, and this card colors words
     /// only for a caution the reader must not miss.
     nonisolated static func chipHeadline(_ chip: PRChip) -> String {
-        var headline = "PR\(chip.label)"
+        var headline = "\(chip.forge.refNoun)\(chip.label)"
         // The status's own words when it has any, exactly as the overflow menu
         // and the toolbar dropdown render them.
         if let state = chip.reason?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -549,11 +557,17 @@ private struct PRChipView: View {
                 // differ: the toolbar control and its dropdown open a webview
                 // tab, while the status bar agrees with the sidebar row
                 // indicator and shells out. Not drift — the status bar is an
-                // at-a-glance strip, and a click there is a "take me to GitHub"
-                // gesture rather than a request to park a tab in the worktree.
+                // at-a-glance strip, and a click there is a "take me to the
+                // forge" gesture rather than a request to park a tab in the
+                // worktree.
                 .onTapGesture { open() }
                 .accessibilityElement()
-                .accessibilityLabel("PR \(chip.label)")
+                // The binding named in its own forge's vocabulary. The chip
+                // draws the bare number on both forges, so the announcement is
+                // where a screen reader learns which forge it belongs to —
+                // `PR #412` or `MR !412`, never a hardcoded noun. It agrees
+                // with the hint below it, which composes the same `refLabel`.
+                .accessibilityLabel(chip.refLabel)
                 .accessibilityHint(StatusBarView.openLabel(chip))
                 .accessibilityAddTraits(.isButton)
         }

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -212,6 +212,19 @@ struct StatusBarView: View {
         return "Open \(chip.refLabel) — \(state.displayReason)"
     }
 
+    /// What the leading icon slot's tooltip says, and therefore what clicking it
+    /// does — the two are one function of `isHovering` on purpose.
+    ///
+    /// The slot draws a status dot at rest and an xmark while hovered, and
+    /// `onHover` is not guaranteed to have arrived: chips are inserted and
+    /// reflowed under a stationary cursor whenever the selection changes or a
+    /// poll adds one. Deriving the meaning from the same flag as the glyph is
+    /// what stops a click on a drawn dot from untracking a PR the user meant to
+    /// open.
+    nonisolated static func iconSlotLabel(_ chip: PRChip, isHovering: Bool) -> String {
+        isHovering ? untrackLabel(chip) : openLabel(chip)
+    }
+
     private var footerLabel: (text: String, tooltip: String?) {
         let version = "v\(TBDConstants.version)"
         guard let sourcePath = Self.sourceWorktreePath,
@@ -357,11 +370,15 @@ private struct PRChipCluster: View {
 /// underline plus pointing-hand cursor are the whole affordance.
 ///
 /// Two click targets, deliberately laid out as **siblings** rather than as a
-/// control nested inside a tappable row: the leading icon slot untracks the PR,
-/// and everything else opens it. An `.onTapGesture` on a common ancestor is
-/// exactly the shape that swallows a child's gesture in this codebase, so there
-/// is no ancestor gesture to swallow anything — each target owns its own tap,
-/// its own tooltip and its own accessibility element.
+/// control nested inside a tappable row: the leading icon slot untracks the PR
+/// while the chip is hovered, and everything else opens it. An `.onTapGesture`
+/// on a common ancestor is exactly the shape that swallows a child's gesture in
+/// this codebase, so there is no ancestor gesture to swallow anything — each
+/// target owns its own tap, its own tooltip and its own accessibility element.
+///
+/// The slot's *action* is gated on the same `isHovering` that chooses its
+/// *glyph*, so a click always does what the slot is drawing: an xmark untracks,
+/// a status dot opens the PR exactly as it did before this control existed.
 private struct PRChipView: View {
     @EnvironmentObject var appState: AppState
     let chip: StatusBarView.PRChip
@@ -423,10 +440,7 @@ private struct PRChipView: View {
                 // indicator and shells out. Not drift — the status bar is an
                 // at-a-glance strip, and a click there is a "take me to GitHub"
                 // gesture rather than a request to park a tab in the worktree.
-                .onTapGesture {
-                    guard let url = chip.url else { return }
-                    NSWorkspace.shared.open(url)
-                }
+                .onTapGesture { open() }
                 .accessibilityElement()
                 .accessibilityLabel("PR \(chip.label)")
                 .accessibilityHint(StatusBarView.openLabel(chip))
@@ -463,17 +477,38 @@ private struct PRChipView: View {
             Color.clear
                 .frame(width: Self.untrackHitSide, height: Self.untrackHitSide)
                 .contentShape(Rectangle())
-                .help(StatusBarView.untrackLabel(chip))
-                .onTapGesture { detach() }
+                // Pointer behaviour follows the SAME `isHovering` that chooses
+                // the glyph, so the click can never mean something other than
+                // what the slot is drawing — see `iconSlotLabel`.
+                .help(StatusBarView.iconSlotLabel(chip, isHovering: isHovering))
+                .onTapGesture {
+                    if isHovering { detach() } else { open() }
+                }
+                // Accessibility does not hover, so this element keeps the
+                // untrack identity unconditionally and carries its own action —
+                // otherwise the gesture would exist for pointer users only.
                 .accessibilityElement()
                 .accessibilityLabel(StatusBarView.untrackLabel(chip))
                 .accessibilityAddTraits(.isButton)
+                .accessibilityAction { detach() }
         }
     }
 
-    private func detach() {
+    private func open() {
         guard let url = chip.url else { return }
-        Task { await appState.detachPR(worktreeID: chip.worktreeID, url: url.absoluteString) }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Untrack by url when the chip has one and by number when it does not — a
+    /// legacy cached status can carry a url that will not parse, and the daemon
+    /// resolves a bare number against the worktree's own repo. Silently
+    /// declining there is the failure this control was added to remove.
+    private func detach() {
+        Task {
+            await appState.detachPR(worktreeID: chip.worktreeID,
+                                    url: chip.url?.absoluteString,
+                                    number: chip.number)
+        }
     }
 }
 

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -239,9 +239,13 @@ struct StatusBarView: View {
 
     /// Tooltip and accessibility hint for the chip's own click target, e.g.
     /// `Open PR #412 — Checks failing`.
+    ///
+    /// Reads the same carried `reason` the hover overlay does. Deriving it from
+    /// `state` here instead would put the generic label in the tooltip and in
+    /// VoiceOver while the card beside them showed the status's own words.
     nonisolated static func openLabel(_ chip: PRChip) -> String {
-        guard let state = chip.state else { return "Open \(chip.refLabel)" }
-        return "Open \(chip.refLabel) — \(state.displayReason)"
+        guard let reason = chip.reason else { return "Open \(chip.refLabel)" }
+        return "Open \(chip.refLabel) — \(reason)"
     }
 
     /// What the leading icon slot's tooltip says, and therefore what clicking it

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -189,8 +189,9 @@ struct StatusBarView: View {
         return (chips, selected.overflow)
     }
 
-    /// What a chip's hover overlay says: the PR's title, its number, the state
-    /// and **when that state was read**.
+    /// What a chip's hover overlay says: one headline naming the PR, its state
+    /// and its title, the age of that reading beneath it, and what the click
+    /// under the pointer will do.
     ///
     /// The age is not decoration. `PRStatus` is a display-tier cache and was
     /// measured reading "Ready to merge" for pull requests merged days earlier,
@@ -198,8 +199,6 @@ struct StatusBarView: View {
     /// `PRFreshness`, shared with the toolbar and sidebar so the three cannot
     /// describe one observation differently.
     ///
-    /// A chip with no observed title renders no title line, and one with no
-    /// observed status still gets its number and an honest "unknown time".
     /// Pure, so the whole overlay can be asserted without a panel.
     ///
     /// `untrackTarget` says the pointer is over the icon slot *while that slot
@@ -210,27 +209,18 @@ struct StatusBarView: View {
         _ chip: PRChip, untrackTarget: Bool = false, now: Date = Date()
     ) -> HoverCardModel {
         var model = HoverCardModel()
-        if let title = chip.title?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !title.isEmpty {
-            model.title = title
-        }
+        model.title = chipHeadline(chip)
+        // Age first, then whether the last attempt to reconfirm it failed —
+        // composed by `PRFreshness` itself, not restated here, so this cannot
+        // drift from the toolbar and sidebar. It sits under the headline rather
+        // than beside the state, because it dates the whole reading.
+        model.titleCaption = PRFreshness.clauses(
+            observedAt: chip.observedAt, observation: chip.observation, now: now
+        ).joined(separator: " · ")
         model.rows = [
-            HoverCardRow(label: "PR", value: chip.label),
-            HoverCardRow(
-                label: "State",
-                // The status's own words when it has any, exactly as the
-                // overflow menu and the toolbar dropdown render them.
-                value: chip.reason ?? unobservedStateValue,
-                // Age first, then whether the last attempt to reconfirm it
-                // failed — composed by `PRFreshness` itself, not restated here,
-                // so this cannot drift from the toolbar and sidebar.
-                caption: PRFreshness.clauses(
-                    observedAt: chip.observedAt, observation: chip.observation, now: now
-                ).joined(separator: " · ")
-            ),
-            // Last, and always present: the chip has two click targets in about
-            // twenty points of width, and nothing else on screen says which one
-            // the pointer is on. The alternate wording rides along so the row is
+            // Always present: the chip has two click targets in about twenty
+            // points of width, and nothing else on screen says which one the
+            // pointer is on. The alternate wording rides along so the row is
             // laid out for both sentences at once — see `HoverCardRow`.
             HoverCardRow(
                 value: chipActionValue(untrackTarget: untrackTarget),
@@ -239,6 +229,34 @@ struct StatusBarView: View {
             )
         ]
         return model
+    }
+
+    /// The overlay's headline: `PR#412 (Checks failing) - Fix the login timeout`.
+    ///
+    /// One line rather than a labelled grid. The three facts are read together —
+    /// which PR, what state, what it is about — and a two-column table of them
+    /// spent most of a card's width on the words "PR" and "State" saying what
+    /// `#412` and "Checks failing" already say.
+    ///
+    /// Everything but the number is optional and degrades by *omission*: a
+    /// synthetic chip has no title, a never-polled binding has no state, and
+    /// neither an empty `()` nor a dangling separator may appear for either.
+    /// The state is deliberately not tinted with the PR palette — the dot the
+    /// pointer is on already carries that color, and this card colors words
+    /// only for a caution the reader must not miss.
+    nonisolated static func chipHeadline(_ chip: PRChip) -> String {
+        var headline = "PR\(chip.label)"
+        // The status's own words when it has any, exactly as the overflow menu
+        // and the toolbar dropdown render them.
+        if let state = chip.reason?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !state.isEmpty {
+            headline += " (\(state))"
+        }
+        if let title = chip.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty {
+            headline += " - \(title)"
+        }
+        return headline
     }
 
     /// What the overlay's action row says the click under the pointer will do.
@@ -255,10 +273,6 @@ struct StatusBarView: View {
 
     nonisolated static let chipOpenActionValue = "Click to open this PR on GitHub"
     nonisolated static let chipUntrackActionValue = "Click to stop tracking this PR in this worktree"
-
-    /// What the overlay's state row says for a binding nothing has polled yet.
-    /// Named so a test can pin it without restating the copy.
-    nonisolated static let unobservedStateValue = "No status observed yet"
 
     /// Tooltip and accessibility label for a chip's untrack target — the xmark
     /// the status dot becomes on hover. It names the worktree scope explicitly

--- a/Sources/TBDApp/PRBindingPresentation.swift
+++ b/Sources/TBDApp/PRBindingPresentation.swift
@@ -117,13 +117,21 @@ enum PRBindingPresentation {
     }
 
     /// Dropdown menu rows, in bind order — the same "don't move under the
-    /// cursor" reasoning as `statusBarChips`. Each row's title carries the PR
-    /// number, its human-readable reason (falling back to the state's default
-    /// when `PRStatus.reason` is nil), and the head branch, e.g.
-    /// `"#412  Checks failing  fix-login-timeout"`.
+    /// cursor" reasoning as `statusBarChips`. Each row's title carries the
+    /// request named in its own forge's vocabulary, its human-readable reason
+    /// (falling back to the state's default when `PRStatus.reason` is nil), and
+    /// the head branch, e.g. `"PR #412  Checks failing  fix-login-timeout"` or
+    /// `"MR !412  Checks failing  fix-login-timeout"`.
+    ///
+    /// A row describes ONE binding, so it takes the per-binding wording rule
+    /// rather than the neutral aggregate one: `refLabel` reads the forge from
+    /// that binding's own URL, exactly as the split button's help text does for
+    /// a lone binding. A bare `#412` would name a merge request in GitHub's
+    /// syntax — `#412` is an issue reference on GitLab, whose own syntax for
+    /// this row's subject is `!412`.
     static func menuRows(_ bindings: [PRBinding]) -> [MenuRow] {
         bindings.map { binding in
-            var parts = ["#\(binding.number)"]
+            var parts = [binding.refLabel]
             if let status = binding.status {
                 parts.append(status.reason ?? status.state.displayReason)
             }
@@ -148,6 +156,12 @@ enum PRBindingPresentation {
     /// therefore has to lead with the whole list and mention the overflow count
     /// second; "\(overflow) more pull requests" described a menu this one has
     /// never shown.
+    ///
+    /// "pull request" here is the **aggregate** wording and stays put: this
+    /// sentence counts a set, one worktree can hold bindings on both forges at
+    /// once, and no forge's own noun would be true of that set. Only text
+    /// naming ONE binding takes `refLabel` / `refNoun` — the rows this chip
+    /// opens do, and each of them speaks its own forge.
     static func overflowChipTooltip(total: Int, overflow: Int) -> String {
         "Show all \(total) pull request\(total == 1 ? "" : "s") (\(overflow) not shown here)"
     }

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -53,7 +53,14 @@ enum PRFreshness {
     /// a missing stamp, which reads as an unknown check time rather than as
     /// silence.
     static func clauses(status: PRStatus?, observation: PRObservation?, now: Date) -> [String] {
-        var out = [checkedLabel(observedAt: status?.observedAt, now: now)]
+        clauses(observedAt: status?.observedAt, observation: observation, now: now)
+    }
+
+    /// The same two clauses for a surface that carries the stamp rather than a
+    /// whole `PRStatus` — the status-bar chip. Composing them there by hand
+    /// would be a fourth place that could drift from the other three.
+    static func clauses(observedAt: Date?, observation: PRObservation?, now: Date) -> [String] {
+        var out = [checkedLabel(observedAt: observedAt, now: now)]
         if let clause = undeterminedClause(observation) { out.append(clause) }
         return out
     }

--- a/Sources/TBDCLI/Commands/PRCommands.swift
+++ b/Sources/TBDCLI/Commands/PRCommands.swift
@@ -171,7 +171,10 @@ struct PRDetachCommand: AsyncParsableCommand {
         if result.detached {
             print("Detached.")
         } else {
-            print("Not bound; nothing to detach.")
+            // A detach now records a tombstone even for a PR nothing had bound,
+            // so the only way to change nothing is for the PR to be detached
+            // already.
+            print("Already detached; nothing to do.")
         }
     }
 }

--- a/Sources/TBDCLI/Commands/PRCommands.swift
+++ b/Sources/TBDCLI/Commands/PRCommands.swift
@@ -171,10 +171,11 @@ struct PRDetachCommand: AsyncParsableCommand {
         if result.detached {
             print("Detached.")
         } else {
-            // A detach now records a tombstone even for a PR nothing had bound,
-            // so the only way to change nothing is for the PR to be detached
-            // already.
-            print("Already detached; nothing to do.")
+            // Two ways to change nothing, and this wording is true of both: the
+            // PR was already tombstoned, or it belongs to another repo and the
+            // daemon declined to record a tombstone that `pr attach` could
+            // never clear. Either way this worktree is not tracking it.
+            print("Not tracked here; nothing to do.")
         }
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1560,6 +1560,19 @@ public final class TBDDatabase: Sendable {
                 defaults: DatabaseValue.null)
         }
 
+        // A bound PR's title, so the status-bar chips can say what `#21156`
+        // actually is (docs/specs/2026-08-16-pr-chip-untrack-design.md).
+        //
+        // Nullable with NO default, for the same reason `headBranch` and
+        // `baseRef` next to it are: the refresh folds a nil in as "not observed
+        // this pass" and keeps whatever the row holds, so a backfilled "" would
+        // be a title nobody read, and a row written before the column existed
+        // must read as "never observed" rather than as an empty title.
+        migrator.registerMigration("v87_worktree_pull_request_title") { db in
+            try db.addColumnIfMissing(
+                table: "worktree_pull_request", column: "title", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/PRBindingStore.swift
+++ b/Sources/TBDDaemon/Database/PRBindingStore.swift
@@ -84,6 +84,26 @@ public struct AllWorktreeBindings: Sendable {
     }
 }
 
+/// Why a binding write could not be honoured at all — distinct from the
+/// ordinary "nothing changed" a `Bool` reports, which every caller renders as
+/// "this worktree is not tracking that PR".
+public enum PRBindingStoreError: Error, LocalizedError, CustomStringConvertible {
+    /// A worktree has accumulated `cap` tombstones, so `tombstone`'s insert arm
+    /// refused to mint another. Reaching this legitimately is not possible; it
+    /// means something is detaching PRs in a loop.
+    case tombstoneCapReached(worktreeID: String, cap: Int)
+
+    public var description: String {
+        switch self {
+        case .tombstoneCapReached(let worktreeID, let cap):
+            return "worktree \(worktreeID) already records \(cap) detached pull "
+                + "requests; nothing was written"
+        }
+    }
+
+    public var errorDescription: String? { description }
+}
+
 /// Persistence for PR bindings. Enforces first-source-wins deduplication,
 /// tombstone semantics, and the per-worktree cap.
 public struct PRBindingStore: Sendable {
@@ -274,8 +294,13 @@ public struct PRBindingStore: Sendable {
                 .filter(Column("detached") == true)
                 .fetchCount(db)
             guard tombstones < Self.maxTombstonesPerWorktree else {
-                logger.warning("dropping tombstone for PR #\(record.number, privacy: .public) on worktree \(record.worktreeID, privacy: .public): \(Self.maxTombstonesPerWorktree, privacy: .public) tombstones already recorded")
-                return false
+                // THROWN, not reported as "changed nothing". False means the PR
+                // is not tracked here, and every caller says so in those words;
+                // hitting the ceiling means the opposite — the request was not
+                // honoured and the PR may well still be tracked.
+                logger.warning("refusing tombstone for PR #\(record.number, privacy: .public) on worktree \(record.worktreeID, privacy: .public): \(Self.maxTombstonesPerWorktree, privacy: .public) tombstones already recorded")
+                throw PRBindingStoreError.tombstoneCapReached(
+                    worktreeID: record.worktreeID, cap: Self.maxTombstonesPerWorktree)
             }
             try record.insert(db)
             return true

--- a/Sources/TBDDaemon/Database/PRBindingStore.swift
+++ b/Sources/TBDDaemon/Database/PRBindingStore.swift
@@ -18,6 +18,7 @@ struct PRBindingRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var url: String
     var headBranch: String?
     var baseRef: String?
+    var title: String?
     var prStatus: String?
     var source: String
     var detached: Bool
@@ -33,6 +34,7 @@ struct PRBindingRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.url = binding.url
         self.headBranch = binding.headBranch
         self.baseRef = binding.baseRef
+        self.title = binding.title
         self.prStatus = binding.status.flatMap { status in
             (try? JSONEncoder().encode(status)).flatMap { String(data: $0, encoding: .utf8) }
         }
@@ -61,7 +63,8 @@ struct PRBindingRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             .flatMap { try? JSONDecoder().decode(PRStatus.self, from: $0) }
         return PRBinding(id: uuid, worktreeID: wtID, host: host, owner: owner,
                          repo: repo, number: number, url: url,
-                         headBranch: headBranch, baseRef: baseRef, status: status,
+                         headBranch: headBranch, baseRef: baseRef, title: title,
+                         status: status,
                          source: bindingSource, detached: detached, boundAt: boundAt)
     }
 }
@@ -202,6 +205,33 @@ public struct PRBindingStore: Sendable {
         }
     }
 
+    /// Record a tombstone for a PR this worktree has no row for at all, so a
+    /// detach can assert "this does not belong here" about a PR nothing ever
+    /// bound — a chip synthesized from the cached `Worktree.prStatus`, or a
+    /// `tbd pr detach` issued before discovery got there.
+    ///
+    /// Insert-if-missing inside ONE write transaction, so it is idempotent
+    /// against the table's unique `(worktreeID, host, owner, repo, number)`
+    /// index rather than racing it. Returns true when a row was inserted, and
+    /// false when the identity was already on record — in which case that row
+    /// is left exactly as it stands, tombstone or not.
+    ///
+    /// Deliberately NOT routed through `upsert`. The cap counts only
+    /// non-detached rows, so a tombstone can never breach it, but `upsert`
+    /// checks that count before writing anything and would evict a live
+    /// terminal binding — or drop the write entirely — to make room for a row
+    /// that occupies none of the budget.
+    @discardableResult
+    public func insertTombstone(_ binding: PRBinding) async throws -> Bool {
+        try await writer.write { db in
+            var record = PRBindingRecord(from: binding)
+            record.detached = true
+            guard try Self.fetchIdentity(db, record: record) == nil else { return false }
+            try record.insert(db)
+            return true
+        }
+    }
+
     /// Hard-delete a `branch`-sourced binding — the poll's heal path.
     ///
     /// A **delete, not a tombstone**, and only for `branch`. A tombstone records
@@ -228,12 +258,14 @@ public struct PRBindingStore: Sendable {
     }
 
     /// Persist what a refresh observed for one binding: its status, and the
-    /// descriptive `headBranch` / `baseRef` the same response carried. A nil ref
-    /// means "not observed this pass" and leaves that column alone — a `gh`
-    /// outage must not blank a branch name the CLI renders.
+    /// descriptive `headBranch` / `baseRef` / `title` the same response carried.
+    /// A nil one of those means "not observed this pass" and leaves that column
+    /// alone — a `gh` outage must not blank a branch name the CLI renders or a
+    /// title the status bar has on screen.
     public func updateObservation(bindingID: UUID, status: PRStatus?,
                                   headBranch: String? = nil,
-                                  baseRef: String? = nil) async throws {
+                                  baseRef: String? = nil,
+                                  title: String? = nil) async throws {
         let encoded = status.flatMap { value in
             (try? JSONEncoder().encode(value)).flatMap { String(data: $0, encoding: .utf8) }
         }
@@ -243,6 +275,7 @@ public struct PRBindingStore: Sendable {
             var assignments: [ColumnAssignment] = [Column("prStatus").set(to: encoded)]
             if let headBranch { assignments.append(Column("headBranch").set(to: headBranch)) }
             if let baseRef { assignments.append(Column("baseRef").set(to: baseRef)) }
+            if let title { assignments.append(Column("title").set(to: title)) }
             return try PRBindingRecord
                 .filter(key: bindingID.uuidString)
                 .updateAll(db, assignments)

--- a/Sources/TBDDaemon/Database/PRBindingStore.swift
+++ b/Sources/TBDDaemon/Database/PRBindingStore.swift
@@ -92,6 +92,23 @@ public struct PRBindingStore: Sendable {
     /// cap keeps one runaway session from unbounded polling.
     static let maxBindingsPerWorktree = 20
 
+    /// Bounds rows created by `tombstone`'s INSERT arm — a detach of a PR the
+    /// worktree never bound.
+    ///
+    /// Every other row in this table corresponds to a PR something actually
+    /// discovered, so the live cap bounds them all indirectly. Insert-on-miss is
+    /// the one path that mints a row for a PR nothing found, one per gesture and
+    /// one per distinct number, and nothing ever deletes a tombstone — so a
+    /// scripted or fat-fingered loop could otherwise grow a worktree's slice of
+    /// a table that `listAllByWorktree` decodes whole on every app refresh.
+    ///
+    /// Deliberately far above the live cap rather than equal to it: tombstones
+    /// legitimately outnumber live bindings on a long-lived worktree, which
+    /// accumulates one per PR it ever opened and detached, and evicting any of
+    /// them would resurrect a PR the user removed. This is a runaway stop, not a
+    /// budget. Past it the detach still tombstones any row that exists.
+    static let maxTombstonesPerWorktree = 200
+
     let writer: any DatabaseWriter
 
     public init(writer: any DatabaseWriter) {
@@ -252,6 +269,14 @@ public struct PRBindingStore: Sendable {
                 return true
             }
             guard insertIfMissing else { return false }
+            let tombstones = try PRBindingRecord
+                .filter(Column("worktreeID") == record.worktreeID)
+                .filter(Column("detached") == true)
+                .fetchCount(db)
+            guard tombstones < Self.maxTombstonesPerWorktree else {
+                logger.warning("dropping tombstone for PR #\(record.number, privacy: .public) on worktree \(record.worktreeID, privacy: .public): \(Self.maxTombstonesPerWorktree, privacy: .public) tombstones already recorded")
+                return false
+            }
             try record.insert(db)
             return true
         }

--- a/Sources/TBDDaemon/Database/PRBindingStore.swift
+++ b/Sources/TBDDaemon/Database/PRBindingStore.swift
@@ -223,8 +223,16 @@ public struct PRBindingStore: Sendable {
     ///
     /// Returns whether the record **changed**: true when a live row was
     /// tombstoned or a tombstone was inserted, false when the PR was already
-    /// tombstoned. An existing row keeps its own `source` and `boundAt` — only
-    /// a tombstone with no prior row records nothing but the caller's decision.
+    /// tombstoned — and false when there is no row and `insertIfMissing` is
+    /// false, which is the truthful answer there: nothing was tracking it. An
+    /// existing row keeps its own `source` and `boundAt` — only a tombstone
+    /// with no prior row records nothing but the caller's decision.
+    ///
+    /// `insertIfMissing` is the caller's policy hook rather than a convenience:
+    /// tombstoning a PR the worktree has no row for is only safe when the
+    /// caller has established that the PR could belong to it. Marking an
+    /// existing row detached always is — the row is this worktree's own record
+    /// of the PR whatever any policy says about it now.
     ///
     /// Deliberately NOT routed through `upsert`. The cap counts only
     /// non-detached rows, so a tombstone can never breach it, but `upsert`
@@ -232,7 +240,7 @@ public struct PRBindingStore: Sendable {
     /// terminal binding — or drop the write entirely — to make room for a row
     /// that occupies none of the budget.
     @discardableResult
-    public func tombstone(_ binding: PRBinding) async throws -> Bool {
+    public func tombstone(_ binding: PRBinding, insertIfMissing: Bool) async throws -> Bool {
         try await writer.write { db in
             var record = PRBindingRecord(from: binding)
             record.detached = true
@@ -243,6 +251,7 @@ public struct PRBindingStore: Sendable {
                     .updateAll(db, Column("detached").set(to: true))
                 return true
             }
+            guard insertIfMissing else { return false }
             try record.insert(db)
             return true
         }

--- a/Sources/TBDDaemon/Database/PRBindingStore.swift
+++ b/Sources/TBDDaemon/Database/PRBindingStore.swift
@@ -205,16 +205,26 @@ public struct PRBindingStore: Sendable {
         }
     }
 
-    /// Record a tombstone for a PR this worktree has no row for at all, so a
-    /// detach can assert "this does not belong here" about a PR nothing ever
-    /// bound — a chip synthesized from the cached `Worktree.prStatus`, or a
-    /// `tbd pr detach` issued before discovery got there.
+    /// Tombstone a PR whether or not this worktree has a row for it: mark the
+    /// existing row detached, or insert the tombstone when there is none.
     ///
-    /// Insert-if-missing inside ONE write transaction, so it is idempotent
-    /// against the table's unique `(worktreeID, host, owner, repo, number)`
-    /// index rather than racing it. Returns true when a row was inserted, and
-    /// false when the identity was already on record — in which case that row
-    /// is left exactly as it stands, tombstone or not.
+    /// The insert arm is what lets a detach assert "this does not belong here"
+    /// about a PR nothing ever bound — a chip synthesized from the cached
+    /// `Worktree.prStatus`, or a `tbd pr detach` issued before discovery got
+    /// there.
+    ///
+    /// **One write transaction covers both arms**, and that is the point of
+    /// having a single method rather than a `setDetached` call followed by an
+    /// insert-on-miss. Split across two transactions, a concurrent bind — the
+    /// poll's branch matcher or a hook's `pr attach`, both of which run while
+    /// the user is clicking — can insert a live row in the gap; the insert then
+    /// finds an identity already on record, declines, and the untrack silently
+    /// does nothing, which is the exact failure this gesture exists to remove.
+    ///
+    /// Returns whether the record **changed**: true when a live row was
+    /// tombstoned or a tombstone was inserted, false when the PR was already
+    /// tombstoned. An existing row keeps its own `source` and `boundAt` — only
+    /// a tombstone with no prior row records nothing but the caller's decision.
     ///
     /// Deliberately NOT routed through `upsert`. The cap counts only
     /// non-detached rows, so a tombstone can never breach it, but `upsert`
@@ -222,11 +232,17 @@ public struct PRBindingStore: Sendable {
     /// terminal binding — or drop the write entirely — to make room for a row
     /// that occupies none of the budget.
     @discardableResult
-    public func insertTombstone(_ binding: PRBinding) async throws -> Bool {
+    public func tombstone(_ binding: PRBinding) async throws -> Bool {
         try await writer.write { db in
             var record = PRBindingRecord(from: binding)
             record.detached = true
-            guard try Self.fetchIdentity(db, record: record) == nil else { return false }
+            if let existing = try Self.fetchIdentity(db, record: record) {
+                guard !existing.detached else { return false }
+                try PRBindingRecord
+                    .filter(key: existing.id)
+                    .updateAll(db, Column("detached").set(to: true))
+                return true
+            }
             try record.insert(db)
             return true
         }

--- a/Sources/TBDDaemon/PR/GitLabQueries.swift
+++ b/Sources/TBDDaemon/PR/GitLabQueries.swift
@@ -22,8 +22,14 @@ enum GitLabQueries {
     /// query's schema risk. `conflicts` was requested and never read —
     /// `detailedMergeStatus` already reports CONFLICT, and that is the only
     /// conflict signal the mapper consults.
+    ///
+    /// `title` earns its place for the same reason it does in GitHub's
+    /// selection: it is what turns a bare `!412` into something a person can
+    /// decide about in the chip's hover card. It is a core Free-tier scalar on
+    /// `MergeRequest`, so it does not weaken the availability guarantee the
+    /// rest of this set is chosen for.
     static let nodeSelection = """
-    iid state draft detailedMergeStatus
+    iid state draft title detailedMergeStatus
     sourceBranch targetBranch createdAt webUrl
     headPipeline { status }
     """
@@ -156,6 +162,9 @@ enum GitLabQueries {
             statusCheckRollupState: pipeline,
             mergeQueuePosition: nil,
             baseRefName: obj["targetBranch"] as? String ?? "",
+            // Optional on purpose, like the `gh` parser's: an omitted title
+            // must read as "not observed" and leave the stored one alone.
+            title: obj["title"] as? String,
             forge: .gitlab)
     }
 

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -173,14 +173,51 @@ public actor PRBindingCoordinator {
         }
     }
 
-    /// Tombstone a binding. Returns false when this worktree has no such PR, or
-    /// when it was already detached.
+    /// Tombstone a PR, whether or not this worktree has a row for it.
+    ///
+    /// A detach is an assertion about the PR's future — "this does not belong
+    /// to this worktree" — not an edit to a row that happens to exist. So when
+    /// nothing matches, this **inserts** the tombstone rather than reporting
+    /// failure. Without that, the status bar's untrack gesture would silently
+    /// do nothing on a chip synthesized from the cached `Worktree.prStatus`
+    /// (the state every worktree is in while `gh` is unauthenticated or offline,
+    /// and before its first successful poll after upgrade): the detach would
+    /// match no row, `detachedCount` would stay zero, the legacy-status
+    /// fallback would keep rendering the chip, and it would return on the next
+    /// pass. It also makes `tbd pr detach` order-independent — detaching a PR
+    /// before anything discovers it pre-empts the binding rather than losing to
+    /// it, because an automatic source may not revive a tombstone.
+    ///
+    /// The inserted row is `.manual`: a tombstone with no prior row records
+    /// nothing but a user's decision. `pr.attach` clears it exactly as it
+    /// clears any other, so the gesture stays reversible.
+    ///
+    /// **Returns whether this call changed the record**, which is the contract
+    /// `tbd pr detach` prints from: true when a live row was tombstoned or a
+    /// tombstone was inserted, false when the PR was already tombstoned. The
+    /// PR ends up detached either way — that half is idempotent — but reporting
+    /// "Detached." for a call that did nothing is the regression
+    /// `PRBindingStore.setDetached` was rewritten to prevent, and inserting on
+    /// miss does not revive it.
     @discardableResult
     public func detach(worktreeID: UUID, parsed: ParsedPRURL) async throws -> Bool {
-        try await store.setDetached(worktreeID: worktreeID,
-                                    identityKey: identityKey(worktreeID: worktreeID,
-                                                             parsed: parsed),
-                                    detached: true)
+        let key = identityKey(worktreeID: worktreeID, parsed: parsed)
+        if try await store.setDetached(worktreeID: worktreeID, identityKey: key,
+                                       detached: true) {
+            return true
+        }
+        // Nothing changed, so either the PR was never bound here or it is
+        // already tombstoned. `insertTombstone` tells those apart inside one
+        // transaction, so a concurrent bind cannot slip between the two.
+        let tombstone = PRBinding(
+            worktreeID: worktreeID, host: parsed.host, owner: parsed.owner,
+            repo: parsed.repo, number: parsed.number, url: parsed.url,
+            source: .manual, detached: true)
+        let inserted = try await store.insertTombstone(tombstone)
+        if inserted {
+            logger.debug("tombstoned unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): detach of a PR nothing had bound")
+        }
+        return inserted
     }
 
     /// The host `PRBindingExtractor`'s GitHub pattern hard-codes. Because that

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -206,32 +206,45 @@ public actor PRBindingCoordinator {
     /// two store calls would let the poll's branch matcher insert a live row in
     /// the gap and turn the user's click into a silent no-op.
     ///
-    /// **Insert-on-miss carries `bind`'s wrong-repo guard; tombstoning an
-    /// existing row does not.** A tombstone for a PR outside the worktree's own
-    /// repo would be permanent: `pr.attach` rejects a wrong-repo reference
-    /// before it ever reaches the row, so nothing could clear it, and the
-    /// non-zero `detachedCount` it leaves suppresses the legacy-status fallback
-    /// for that worktree forever — one mistyped `tbd pr detach <other-repo-url>`
-    /// would silently retire the worktree's real PR indicator with no way back.
-    /// A row that already exists is a different matter: it is this worktree's
-    /// own record, and detaching it must work whatever the repo says now.
-    /// Declining to insert reports `false`, which is the honest answer — this
-    /// worktree was not tracking that PR.
+    /// **Insert-on-miss declines only on a repo mismatch it can prove;
+    /// tombstoning an existing row is never gated.** A tombstone for a PR
+    /// outside the worktree's own repo would be permanent: `pr.attach` rejects
+    /// a wrong-repo reference before it ever reaches the row, so nothing could
+    /// clear it, and the non-zero `detachedCount` it leaves suppresses the
+    /// legacy-status fallback for that worktree forever — one mistyped
+    /// `tbd pr detach <other-repo-url>` would silently retire the worktree's
+    /// real PR indicator with no way back. A row that already exists is a
+    /// different matter: it is this worktree's own record, and detaching it
+    /// must work whatever the repo says now, or a repo rename would strand
+    /// every binding made before it.
+    ///
+    /// **An unresolved repo is not a mismatch, and must not be treated as one.**
+    /// `resolveRepo` is `gh repo view` behind a TTL cache, so it answers nil
+    /// exactly when `gh` is unauthenticated, offline or missing — which is the
+    /// same condition that leaves the bindings table empty and makes the
+    /// synthetic legacy-status chip the only PR on screen. Declining there
+    /// would disable insert-on-miss precisely in the scenario it was written
+    /// for and hand the xmark back its silent no-op. `bind` distinguishes the
+    /// two the same way (`.deferredUnknownRepo` versus `.rejectedWrongRepo`);
+    /// this reads the nil as "no reason to refuse".
+    ///
+    /// Declining reports `false`, which is the honest answer — this worktree
+    /// was not tracking that PR.
     @discardableResult
     public func detach(worktreeID: UUID, parsed: ParsedPRURL) async throws -> Bool {
         let own = await resolveRepo(worktreeID)
-        let isOwnRepo = own.map {
-            $0.owner.lowercased() == parsed.owner.lowercased()
-                && $0.name.lowercased() == parsed.repo.lowercased()
+        let wrongRepo = own.map {
+            $0.owner.lowercased() != parsed.owner.lowercased()
+                || $0.name.lowercased() != parsed.repo.lowercased()
         } ?? false
         let tombstone = PRBinding(
             worktreeID: worktreeID, host: parsed.host, owner: parsed.owner,
             repo: parsed.repo, number: parsed.number, url: parsed.url,
             source: .manual, detached: true)
-        let changed = try await store.tombstone(tombstone, insertIfMissing: isOwnRepo)
+        let changed = try await store.tombstone(tombstone, insertIfMissing: !wrongRepo)
         if changed {
             logger.debug("tombstoned PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public)")
-        } else if !isOwnRepo {
+        } else if wrongRepo {
             logger.debug("not tombstoning unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): PR is in \(parsed.owner, privacy: .public)/\(parsed.repo, privacy: .public), which is not this worktree's repo")
         }
         return changed

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -228,6 +228,15 @@ public actor PRBindingCoordinator {
     /// must work whatever the repo says now, or a repo rename would strand
     /// every binding made before it.
     ///
+    /// "Belongs to this repo" is the SAME question `bind` asks, and it is asked
+    /// with the same code — `mayMintTombstone` runs the `owner`/`name`
+    /// comparison and then `hostAgreement`, so a GitLab `acme/proj` and a GitHub
+    /// `acme/proj` stay two projects here exactly as they do there. Two host
+    /// checks that could disagree is precisely how a cross-host detach came to
+    /// mint the unclearable tombstone this paragraph describes: `pr.attach`
+    /// enforced the host and insert-on-miss did not, so the one write that could
+    /// clear the row was the one write that refused to.
+    ///
     /// **An unresolved repo is neither a match nor a mismatch, so it is decided
     /// on other evidence.** `resolveRepo` is `gh repo view` behind a TTL cache,
     /// so it answers nil exactly when `gh` is unauthenticated, offline or
@@ -247,24 +256,17 @@ public actor PRBindingCoordinator {
     /// `other-org/other-repo/pull/412` whenever the worktree's own cached PR
     /// happened to be #412 — minting the permanent foreign tombstone on a
     /// coincidence. A synthetic chip's URL always names the worktree's own
-    /// repo, so checking all three costs the offline path nothing.
+    /// repo, so checking all three costs the offline path nothing. The host is
+    /// then agreed on the same terms as the resolved path, against the cached
+    /// PR's own host — offline is not a reason to stop distinguishing two
+    /// forges, and a cached status is where a non-GitHub worktree's host is
+    /// still on record.
     ///
     /// Declining reports `false`, which is the honest answer — this worktree
     /// was not tracking that PR.
     @discardableResult
     public func detach(worktreeID: UUID, parsed: ParsedPRURL) async throws -> Bool {
-        let insertIfMissing: Bool
-        if let own = await resolveRepo(worktreeID) {
-            insertIfMissing = own.owner.lowercased() == parsed.owner.lowercased()
-                && own.name.lowercased() == parsed.repo.lowercased()
-        } else {
-            let cached = await cachedPRIdentity(worktreeID)
-            insertIfMissing = cached.map {
-                $0.owner.lowercased() == parsed.owner.lowercased()
-                    && $0.repo.lowercased() == parsed.repo.lowercased()
-                    && $0.number == parsed.number
-            } ?? false
-        }
+        let insertIfMissing = await mayMintTombstone(worktreeID: worktreeID, parsed: parsed)
         let tombstone = PRBinding(
             worktreeID: worktreeID, host: parsed.host, owner: parsed.owner,
             repo: parsed.repo, number: parsed.number, url: parsed.url,
@@ -273,9 +275,39 @@ public actor PRBindingCoordinator {
         if changed {
             logger.debug("tombstoned PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public)")
         } else if !insertIfMissing {
-            logger.debug("not tombstoning unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): nothing ties \(parsed.owner, privacy: .public)/\(parsed.repo, privacy: .public) to this worktree")
+            logger.debug("not tombstoning unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): nothing ties \(parsed.host, privacy: .public)/\(parsed.owner, privacy: .public)/\(parsed.repo, privacy: .public) to this worktree")
         }
         return changed
+    }
+
+    /// Whether a detach for a PR this worktree has **no row for** may mint a
+    /// brand-new tombstone.
+    ///
+    /// This gates CREATION ONLY. `detach` hands the answer to the store as
+    /// `insertIfMissing`, and the store's other arm — tombstoning a row that is
+    /// already there — ignores it entirely, which is what keeps a repo rename
+    /// from stranding bindings made before it.
+    ///
+    /// The test is `bind`'s test, reached through `bind`'s own helper: the
+    /// `owner`/`name` comparison, then `hostAgreement`. Anything `bind` would
+    /// refuse to write, this refuses to tombstone — including an
+    /// `.undetermined` forge, because a tombstone that `pr.attach` cannot clear
+    /// is worse than a detach the user repeats once the forge is known.
+    private func mayMintTombstone(worktreeID: UUID, parsed: ParsedPRURL) async -> Bool {
+        let ownHost: String
+        if let own = await resolveRepo(worktreeID) {
+            guard own.owner.lowercased() == parsed.owner.lowercased(),
+                  own.name.lowercased() == parsed.repo.lowercased() else { return false }
+            ownHost = own.host
+        } else {
+            guard let cached = await cachedPRIdentity(worktreeID),
+                  cached.owner.lowercased() == parsed.owner.lowercased(),
+                  cached.repo.lowercased() == parsed.repo.lowercased(),
+                  cached.number == parsed.number else { return false }
+            ownHost = cached.host
+        }
+        return await hostAgreement(worktreeID: worktreeID, own: ownHost,
+                                   parsed: parsed.host) == .agree
     }
 
     /// The host `PRBindingExtractor`'s GitHub pattern hard-codes. Because that

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -205,15 +205,34 @@ public actor PRBindingCoordinator {
     /// `bind` can run at — so a "tombstone the row, else insert one" written as
     /// two store calls would let the poll's branch matcher insert a live row in
     /// the gap and turn the user's click into a silent no-op.
+    ///
+    /// **Insert-on-miss carries `bind`'s wrong-repo guard; tombstoning an
+    /// existing row does not.** A tombstone for a PR outside the worktree's own
+    /// repo would be permanent: `pr.attach` rejects a wrong-repo reference
+    /// before it ever reaches the row, so nothing could clear it, and the
+    /// non-zero `detachedCount` it leaves suppresses the legacy-status fallback
+    /// for that worktree forever — one mistyped `tbd pr detach <other-repo-url>`
+    /// would silently retire the worktree's real PR indicator with no way back.
+    /// A row that already exists is a different matter: it is this worktree's
+    /// own record, and detaching it must work whatever the repo says now.
+    /// Declining to insert reports `false`, which is the honest answer — this
+    /// worktree was not tracking that PR.
     @discardableResult
     public func detach(worktreeID: UUID, parsed: ParsedPRURL) async throws -> Bool {
+        let own = await resolveRepo(worktreeID)
+        let isOwnRepo = own.map {
+            $0.owner.lowercased() == parsed.owner.lowercased()
+                && $0.name.lowercased() == parsed.repo.lowercased()
+        } ?? false
         let tombstone = PRBinding(
             worktreeID: worktreeID, host: parsed.host, owner: parsed.owner,
             repo: parsed.repo, number: parsed.number, url: parsed.url,
             source: .manual, detached: true)
-        let changed = try await store.tombstone(tombstone)
+        let changed = try await store.tombstone(tombstone, insertIfMissing: isOwnRepo)
         if changed {
             logger.debug("tombstoned PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public)")
+        } else if !isOwnRepo {
+            logger.debug("not tombstoning unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): PR is in \(parsed.owner, privacy: .public)/\(parsed.repo, privacy: .public), which is not this worktree's repo")
         }
         return changed
     }

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -199,25 +199,23 @@ public actor PRBindingCoordinator {
     /// "Detached." for a call that did nothing is the regression
     /// `PRBindingStore.setDetached` was rewritten to prevent, and inserting on
     /// miss does not revive it.
+    ///
+    /// Both arms are ONE call into the store, and so one write transaction.
+    /// This actor is reentrant — every `await` here is a point a concurrent
+    /// `bind` can run at — so a "tombstone the row, else insert one" written as
+    /// two store calls would let the poll's branch matcher insert a live row in
+    /// the gap and turn the user's click into a silent no-op.
     @discardableResult
     public func detach(worktreeID: UUID, parsed: ParsedPRURL) async throws -> Bool {
-        let key = identityKey(worktreeID: worktreeID, parsed: parsed)
-        if try await store.setDetached(worktreeID: worktreeID, identityKey: key,
-                                       detached: true) {
-            return true
-        }
-        // Nothing changed, so either the PR was never bound here or it is
-        // already tombstoned. `insertTombstone` tells those apart inside one
-        // transaction, so a concurrent bind cannot slip between the two.
         let tombstone = PRBinding(
             worktreeID: worktreeID, host: parsed.host, owner: parsed.owner,
             repo: parsed.repo, number: parsed.number, url: parsed.url,
             source: .manual, detached: true)
-        let inserted = try await store.insertTombstone(tombstone)
-        if inserted {
-            logger.debug("tombstoned unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): detach of a PR nothing had bound")
+        let changed = try await store.tombstone(tombstone)
+        if changed {
+            logger.debug("tombstoned PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public)")
         }
-        return inserted
+        return changed
     }
 
     /// The host `PRBindingExtractor`'s GitHub pattern hard-codes. Because that

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -35,6 +35,7 @@ public actor PRBindingCoordinator {
     private let store: PRBindingStore
     private let resolveRepo: @Sendable (UUID) async -> (owner: String, name: String, host: String)?
     private let isGitLabHost: @Sendable (UUID, String) async -> Bool?
+    private let cachedPRNumber: @Sendable (UUID) async -> Int?
 
     /// - Parameter resolveRepo: the worktree's own `owner`/`name` and host, or
     ///   nil when they cannot be determined (no remote, git failure, unknown
@@ -46,12 +47,20 @@ public actor PRBindingCoordinator {
     ///   put at all (no directory on this machine to ask in). Only the
     ///   `github.com` exemption in `hostAgreement` consults it, so a worktree
     ///   whose host already matches the URL's never pays for the answer.
+    /// - Parameter cachedPRNumber: the PR number the worktree's cached
+    ///   `Worktree.prStatus` names, or nil when it holds none. This is the only
+    ///   evidence about a worktree's PRs that survives `gh` being unavailable,
+    ///   and `detach` uses it to corroborate a reference it cannot check
+    ///   against a repo. Defaults to "no evidence", which is the conservative
+    ///   reading.
     public init(store: PRBindingStore,
                 resolveRepo: @escaping @Sendable (UUID) async -> (owner: String, name: String, host: String)?,
-                isGitLabHost: @escaping @Sendable (UUID, String) async -> Bool?) {
+                isGitLabHost: @escaping @Sendable (UUID, String) async -> Bool?,
+                cachedPRNumber: @escaping @Sendable (UUID) async -> Int? = { _ in nil }) {
         self.store = store
         self.resolveRepo = resolveRepo
         self.isGitLabHost = isGitLabHost
+        self.cachedPRNumber = cachedPRNumber
     }
 
     public func bind(worktreeID: UUID, parsed: ParsedPRURL,
@@ -218,34 +227,40 @@ public actor PRBindingCoordinator {
     /// must work whatever the repo says now, or a repo rename would strand
     /// every binding made before it.
     ///
-    /// **An unresolved repo is not a mismatch, and must not be treated as one.**
-    /// `resolveRepo` is `gh repo view` behind a TTL cache, so it answers nil
-    /// exactly when `gh` is unauthenticated, offline or missing — which is the
-    /// same condition that leaves the bindings table empty and makes the
-    /// synthetic legacy-status chip the only PR on screen. Declining there
-    /// would disable insert-on-miss precisely in the scenario it was written
-    /// for and hand the xmark back its silent no-op. `bind` distinguishes the
-    /// two the same way (`.deferredUnknownRepo` versus `.rejectedWrongRepo`);
-    /// this reads the nil as "no reason to refuse".
+    /// **An unresolved repo is neither a match nor a mismatch, so it is decided
+    /// on other evidence.** `resolveRepo` is `gh repo view` behind a TTL cache,
+    /// so it answers nil exactly when `gh` is unauthenticated, offline or
+    /// missing — which is also the condition that leaves the bindings table
+    /// empty and makes the synthetic legacy-status chip the only PR on screen.
+    /// Refusing on nil would disable insert-on-miss in the very scenario it was
+    /// written for; accepting on nil would let a mistyped foreign URL mint the
+    /// permanent tombstone the guard exists to prevent. So a nil falls back to
+    /// the one fact about this worktree's PRs that survives `gh` being gone:
+    /// the number its cached `Worktree.prStatus` names. That is exactly what a
+    /// synthetic chip is built from, so the xmark keeps working offline, while
+    /// `tbd pr detach <some other PR>` on an unresolvable worktree writes
+    /// nothing.
     ///
     /// Declining reports `false`, which is the honest answer — this worktree
     /// was not tracking that PR.
     @discardableResult
     public func detach(worktreeID: UUID, parsed: ParsedPRURL) async throws -> Bool {
-        let own = await resolveRepo(worktreeID)
-        let wrongRepo = own.map {
-            $0.owner.lowercased() != parsed.owner.lowercased()
-                || $0.name.lowercased() != parsed.repo.lowercased()
-        } ?? false
+        let insertIfMissing: Bool
+        if let own = await resolveRepo(worktreeID) {
+            insertIfMissing = own.owner.lowercased() == parsed.owner.lowercased()
+                && own.name.lowercased() == parsed.repo.lowercased()
+        } else {
+            insertIfMissing = await cachedPRNumber(worktreeID) == parsed.number
+        }
         let tombstone = PRBinding(
             worktreeID: worktreeID, host: parsed.host, owner: parsed.owner,
             repo: parsed.repo, number: parsed.number, url: parsed.url,
             source: .manual, detached: true)
-        let changed = try await store.tombstone(tombstone, insertIfMissing: !wrongRepo)
+        let changed = try await store.tombstone(tombstone, insertIfMissing: insertIfMissing)
         if changed {
             logger.debug("tombstoned PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public)")
-        } else if wrongRepo {
-            logger.debug("not tombstoning unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): PR is in \(parsed.owner, privacy: .public)/\(parsed.repo, privacy: .public), which is not this worktree's repo")
+        } else if !insertIfMissing {
+            logger.debug("not tombstoning unbound PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): nothing ties \(parsed.owner, privacy: .public)/\(parsed.repo, privacy: .public) to this worktree")
         }
         return changed
     }

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -35,7 +35,7 @@ public actor PRBindingCoordinator {
     private let store: PRBindingStore
     private let resolveRepo: @Sendable (UUID) async -> (owner: String, name: String, host: String)?
     private let isGitLabHost: @Sendable (UUID, String) async -> Bool?
-    private let cachedPRNumber: @Sendable (UUID) async -> Int?
+    private let cachedPRIdentity: @Sendable (UUID) async -> ParsedPRURL?
 
     /// - Parameter resolveRepo: the worktree's own `owner`/`name` and host, or
     ///   nil when they cannot be determined (no remote, git failure, unknown
@@ -47,20 +47,21 @@ public actor PRBindingCoordinator {
     ///   put at all (no directory on this machine to ask in). Only the
     ///   `github.com` exemption in `hostAgreement` consults it, so a worktree
     ///   whose host already matches the URL's never pays for the answer.
-    /// - Parameter cachedPRNumber: the PR number the worktree's cached
-    ///   `Worktree.prStatus` names, or nil when it holds none. This is the only
-    ///   evidence about a worktree's PRs that survives `gh` being unavailable,
-    ///   and `detach` uses it to corroborate a reference it cannot check
-    ///   against a repo. Defaults to "no evidence", which is the conservative
-    ///   reading.
+    /// - Parameter cachedPRIdentity: the PR the worktree's cached
+    ///   `Worktree.prStatus` names — owner, repo and number, not just the
+    ///   number — or nil when it holds none or names one that cannot be parsed.
+    ///   This is the only evidence about a worktree's PRs that survives `gh`
+    ///   being unavailable, and `detach` uses it to corroborate a reference it
+    ///   cannot check against a repo. Defaults to "no evidence", which is the
+    ///   conservative reading.
     public init(store: PRBindingStore,
                 resolveRepo: @escaping @Sendable (UUID) async -> (owner: String, name: String, host: String)?,
                 isGitLabHost: @escaping @Sendable (UUID, String) async -> Bool?,
-                cachedPRNumber: @escaping @Sendable (UUID) async -> Int? = { _ in nil }) {
+                cachedPRIdentity: @escaping @Sendable (UUID) async -> ParsedPRURL? = { _ in nil }) {
         self.store = store
         self.resolveRepo = resolveRepo
         self.isGitLabHost = isGitLabHost
-        self.cachedPRNumber = cachedPRNumber
+        self.cachedPRIdentity = cachedPRIdentity
     }
 
     public func bind(worktreeID: UUID, parsed: ParsedPRURL,
@@ -236,10 +237,17 @@ public actor PRBindingCoordinator {
     /// written for; accepting on nil would let a mistyped foreign URL mint the
     /// permanent tombstone the guard exists to prevent. So a nil falls back to
     /// the one fact about this worktree's PRs that survives `gh` being gone:
-    /// the number its cached `Worktree.prStatus` names. That is exactly what a
+    /// the PR its cached `Worktree.prStatus` names. That is exactly what a
     /// synthetic chip is built from, so the xmark keeps working offline, while
     /// `tbd pr detach <some other PR>` on an unresolvable worktree writes
     /// nothing.
+    ///
+    /// That corroboration compares **owner, repo and number**, never the number
+    /// alone. A number-only match would admit a pasted
+    /// `other-org/other-repo/pull/412` whenever the worktree's own cached PR
+    /// happened to be #412 — minting the permanent foreign tombstone on a
+    /// coincidence. A synthetic chip's URL always names the worktree's own
+    /// repo, so checking all three costs the offline path nothing.
     ///
     /// Declining reports `false`, which is the honest answer — this worktree
     /// was not tracking that PR.
@@ -250,7 +258,12 @@ public actor PRBindingCoordinator {
             insertIfMissing = own.owner.lowercased() == parsed.owner.lowercased()
                 && own.name.lowercased() == parsed.repo.lowercased()
         } else {
-            insertIfMissing = await cachedPRNumber(worktreeID) == parsed.number
+            let cached = await cachedPRIdentity(worktreeID)
+            insertIfMissing = cached.map {
+                $0.owner.lowercased() == parsed.owner.lowercased()
+                    && $0.repo.lowercased() == parsed.repo.lowercased()
+                    && $0.number == parsed.number
+            } ?? false
         }
         let tombstone = PRBinding(
             worktreeID: worktreeID, host: parsed.host, owner: parsed.owner,

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1289,7 +1289,11 @@ public actor PRStatusManager {
                                  reason: reason, mergeQueuePosition: node.mergeQueuePosition,
                                  observedAt: now()),
                 headBranch: Self.refOrNil(node.headRefName),
-                baseRef: Self.refOrNil(node.baseRefName))
+                baseRef: Self.refOrNil(node.baseRefName),
+                // Through `refOrNil` for the same reason the refs are: an empty
+                // string must reach the caller as "not observed", or it would
+                // survive `title ?? self.title` and blank a stored title.
+                title: Self.refOrNil(node.title ?? ""))
         }
         return observations
     }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1165,7 +1165,8 @@ public actor PRStatusManager {
                 // fields — they are independent of the check query that failed.
                 observations[binding.id] = PRBindingObservation(
                     status: previous, headBranch: Self.refOrNil(node.headRefName),
-                    baseRef: Self.refOrNil(node.baseRefName), title: node.title)
+                    baseRef: Self.refOrNil(node.baseRefName),
+                    title: Self.refOrNil(node.title ?? ""))
                 continue
             } else {
                 signals = Self.aggregateFallbackSignals(node.statusCheckRollupState)
@@ -1190,7 +1191,10 @@ public actor PRStatusManager {
                                  observedAt: now()),
                 headBranch: Self.refOrNil(node.headRefName),
                 baseRef: Self.refOrNil(node.baseRefName),
-                title: node.title)
+                // Through `refOrNil` for the same reason the refs are: an empty
+                // string must reach the caller as "not observed", or it would
+                // survive `title ?? self.title` and blank a stored title.
+                title: Self.refOrNil(node.title ?? ""))
         }
         return observations
     }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -2456,10 +2456,15 @@ public actor PRStatusManager {
 
     /// The per-PR field selection shared by the viewer batch and the by-number
     /// aliased query, so the two can't drift and both parse into `PRNode`.
-    /// `title` rides along because it is one short string on a query that
-    /// already runs per PR, and it is what turns a bare `#21156` into something
-    /// a person can decide about. `openPRsQuery` has always selected it; this
-    /// closes the gap rather than opening a new cost.
+    /// `title` rides along because it is what turns a bare `#21156` into
+    /// something a person can decide about. It is a real addition to the poll's
+    /// payload, not a free one: this selection is shared with the viewer batch,
+    /// which pulls up to 100 PRs, so it costs one short string per PR per pass
+    /// there — and those titles are discarded, since only the by-number path
+    /// has a binding row to persist them onto. One title is a rounding error
+    /// beside the check rollup the same node already carries, and splitting the
+    /// selection in two to avoid it would give up the guarantee that the two
+    /// queries cannot drift and both parse into `PRNode`.
     static let prNodeFieldSelection =
         "number url title state mergeStateStatus reviewDecision headRefName baseRefName createdAt isDraft "
         + "statusCheckRollup { state } mergeQueueEntry { position }"

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1001,20 +1001,23 @@ public actor PRStatusManager {
 
     /// One binding's freshly observed facts.
     ///
-    /// `headBranch` / `baseRef` are nil exactly when this pass did NOT resolve
-    /// the PR — the transient-failure paths that carry the binding's previous
-    /// status forward. A nil there means "not observed", never "the PR has no
-    /// base branch", so the caller keeps whatever it already had rather than
-    /// clearing a column a `gh` outage hid.
+    /// `headBranch` / `baseRef` / `title` are nil exactly when this pass did NOT
+    /// resolve the PR — the transient-failure paths that carry the binding's
+    /// previous status forward. A nil there means "not observed", never "the PR
+    /// has no base branch", so the caller keeps whatever it already had rather
+    /// than clearing a column a `gh` outage hid.
     public struct PRBindingObservation: Sendable, Equatable {
         public let status: PRStatus
         public let headBranch: String?
         public let baseRef: String?
+        public let title: String?
 
-        public init(status: PRStatus, headBranch: String? = nil, baseRef: String? = nil) {
+        public init(status: PRStatus, headBranch: String? = nil, baseRef: String? = nil,
+                    title: String? = nil) {
             self.status = status
             self.headBranch = headBranch
             self.baseRef = baseRef
+            self.title = title
         }
     }
 
@@ -1158,11 +1161,11 @@ public actor PRStatusManager {
                 signals = fetched
             } else if let previous = binding.status {
                 // Transient failure: keep the previous status rather than
-                // guessing. The refs still resolved, so report them — they are
-                // descriptive and independent of the check query that failed.
+                // guessing. The node still resolved, so report its descriptive
+                // fields — they are independent of the check query that failed.
                 observations[binding.id] = PRBindingObservation(
                     status: previous, headBranch: Self.refOrNil(node.headRefName),
-                    baseRef: Self.refOrNil(node.baseRefName))
+                    baseRef: Self.refOrNil(node.baseRefName), title: node.title)
                 continue
             } else {
                 signals = Self.aggregateFallbackSignals(node.statusCheckRollupState)
@@ -1186,7 +1189,8 @@ public actor PRStatusManager {
                                  reason: reason, mergeQueuePosition: node.mergeQueuePosition,
                                  observedAt: now()),
                 headBranch: Self.refOrNil(node.headRefName),
-                baseRef: Self.refOrNil(node.baseRefName))
+                baseRef: Self.refOrNil(node.baseRefName),
+                title: node.title)
         }
         return observations
     }
@@ -2173,6 +2177,11 @@ public actor PRStatusManager {
         /// whole node. Declared late so the memberwise init stays
         /// source-compatible.
         public let baseRefName: String
+        /// The PR's title. Descriptive only, and **optional on purpose**: a
+        /// response that omits it must leave the stored title alone rather than
+        /// clear it, so "absent" has to survive the parse as nil rather than
+        /// collapsing to `""`.
+        public let title: String?
         /// The forge that produced this node. Declared last with a default so
         /// the memberwise init stays source-compatible, the same reason
         /// `baseRefName` is declared where it is.
@@ -2181,7 +2190,7 @@ public actor PRStatusManager {
         init(number: Int, url: String, state: String, mergeVerdictRaw: String,
              reviewVerdictRaw: String, headRefName: String, createdAt: String, isDraft: Bool,
              statusCheckRollupState: String?, mergeQueuePosition: Int?,
-             baseRefName: String = "", forge: Forge = .github) {
+             baseRefName: String = "", title: String? = nil, forge: Forge = .github) {
             self.number = number
             self.url = url
             self.state = state
@@ -2193,6 +2202,7 @@ public actor PRStatusManager {
             self.statusCheckRollupState = statusCheckRollupState
             self.mergeQueuePosition = mergeQueuePosition
             self.baseRefName = baseRefName
+            self.title = title
             self.forge = forge
         }
     }
@@ -2446,8 +2456,12 @@ public actor PRStatusManager {
 
     /// The per-PR field selection shared by the viewer batch and the by-number
     /// aliased query, so the two can't drift and both parse into `PRNode`.
+    /// `title` rides along because it is one short string on a query that
+    /// already runs per PR, and it is what turns a bare `#21156` into something
+    /// a person can decide about. `openPRsQuery` has always selected it; this
+    /// closes the gap rather than opening a new cost.
     static let prNodeFieldSelection =
-        "number url state mergeStateStatus reviewDecision headRefName baseRefName createdAt isDraft "
+        "number url title state mergeStateStatus reviewDecision headRefName baseRefName createdAt isDraft "
         + "statusCheckRollup { state } mergeQueueEntry { position }"
 
     /// One aliased query resolving several worktrees' stored PR numbers in a
@@ -2521,7 +2535,10 @@ public actor PRStatusManager {
                       isDraft: isDraft,
                       statusCheckRollupState: statusCheckRollupState,
                       mergeQueuePosition: mergeQueuePosition,
-                      baseRefName: node["baseRefName"] as? String ?? "")
+                      baseRefName: node["baseRefName"] as? String ?? "",
+                      // Absent stays nil rather than becoming "": the caller
+                      // reads nil as "not observed" and keeps the stored title.
+                      title: node["title"] as? String)
     }
 
     /// Pure parse of the `repo.listOpenPRs` GraphQL response

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -1306,12 +1306,14 @@ public final class RPCRouter: Sendable {
     /// number** rather than failing outright, which is what makes sending both
     /// worth doing. The status bar's untrack gesture names a PR by whatever its
     /// chip holds, and a chip lifted from a cached `Worktree.prStatus` can hold
-    /// a URL `PRBindingExtractor` will not accept — its pattern is host-locked
-    /// to `https://github.com/`, so on a worktree hosted anywhere else *every*
-    /// synthetic chip is in that state, and a url-only reference would make the
-    /// xmark fail every time on exactly the worktrees that only ever have
-    /// synthetic chips. A reference with a bad URL and no number is still
-    /// unresolvable; nothing is guessed.
+    /// a URL `PRBindingExtractor` will not accept. It parses two shapes and
+    /// only two: `https://github.com/<owner>/<repo>/pull/<n>`, host-locked to
+    /// github.com, and `/-/merge_requests/<iid>` on any host. So a pull request
+    /// served by GitHub Enterprise, Bitbucket, Gitea or Codeberg parses under
+    /// neither, every synthetic chip on such a worktree is in that state, and a
+    /// url-only reference would make the xmark fail every time on exactly the
+    /// worktrees that only ever have synthetic chips. A reference with a bad
+    /// URL and no number is still unresolvable; nothing is guessed.
     ///
     /// **Off by default, and detach-only on purpose.** The fallthrough re-reads
     /// the number against *this* worktree's repo, so for an attach a URL naming

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -1289,11 +1289,20 @@ public final class RPCRouter: Sendable {
     /// The bare-number form is resolved against the worktree's own repo through
     /// the same seam the coordinator validates with, so `pr.attach 412` cannot
     /// synthesise a URL the policy would then reject as wrong-repo.
+    ///
+    /// A URL that does not parse **falls through to the number** rather than
+    /// failing outright, which is what makes sending both worth doing. The
+    /// status bar's untrack gesture names a PR by whatever its chip holds, and
+    /// a chip lifted from a cached `Worktree.prStatus` can hold a URL
+    /// `PRBindingExtractor` will not accept — its pattern is host-locked to
+    /// `https://github.com/`, so on a worktree hosted anywhere else *every*
+    /// synthetic chip is in that state, and a url-only reference would make the
+    /// xmark fail every time on exactly the worktrees that only ever have
+    /// synthetic chips. A reference with a bad URL and no number is still
+    /// unresolvable; nothing is guessed.
     private func resolvePRRef(_ params: PRBindingRefParams) async -> PRRefResolution {
-        if let url = params.url, !url.isEmpty {
-            guard let parsed = PRBindingExtractor.parsePRURLs(in: url).first else {
-                return .unresolvable
-            }
+        if let url = params.url, !url.isEmpty,
+           let parsed = PRBindingExtractor.parsePRURLs(in: url).first {
             return .resolved(parsed)
         }
         guard let number = params.number, number > 0 else { return .unresolvable }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -289,7 +289,13 @@ public final class RPCRouter: Sendable {
         }
         self.prBindingForgeResolver = forgeResolver
         self.prBindingCoordinator = PRBindingCoordinator(
-            store: db.prBindings, resolveRepo: repoResolver, isGitLabHost: forgeResolver)
+            store: db.prBindings, resolveRepo: repoResolver, isGitLabHost: forgeResolver,
+            // The cached status is the only evidence about a worktree's PRs
+            // that survives `gh` being unavailable, which is when `detach`
+            // needs it — see `PRBindingCoordinator.detach`.
+            cachedPRNumber: { [db] worktreeID in
+                try? await db.worktrees.get(id: worktreeID)?.prStatus?.number
+            })
         self.pendingQuestions = pendingQuestions
         self.repoSerializer = repoSerializer
         self.configDirManager = configDirManager

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -1238,7 +1238,9 @@ public final class RPCRouter: Sendable {
     private func handlePRDetach(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(PRBindingRefParams.self, from: paramsData)
         let parsed: ParsedPRURL
-        switch await resolvePRRef(params) {
+        // Detach-only fallthrough: see `resolvePRRef`. Untracking the wrong PR
+        // is reversible; binding one silently is not.
+        switch await resolvePRRef(params, numberFallback: true) {
         case .resolved(let value):
             parsed = value
         case .unresolvable:
@@ -1290,20 +1292,30 @@ public final class RPCRouter: Sendable {
     /// the same seam the coordinator validates with, so `pr.attach 412` cannot
     /// synthesise a URL the policy would then reject as wrong-repo.
     ///
-    /// A URL that does not parse **falls through to the number** rather than
-    /// failing outright, which is what makes sending both worth doing. The
-    /// status bar's untrack gesture names a PR by whatever its chip holds, and
-    /// a chip lifted from a cached `Worktree.prStatus` can hold a URL
-    /// `PRBindingExtractor` will not accept — its pattern is host-locked to
-    /// `https://github.com/`, so on a worktree hosted anywhere else *every*
+    /// With `numberFallback`, a URL that does not parse **falls through to the
+    /// number** rather than failing outright, which is what makes sending both
+    /// worth doing. The status bar's untrack gesture names a PR by whatever its
+    /// chip holds, and a chip lifted from a cached `Worktree.prStatus` can hold
+    /// a URL `PRBindingExtractor` will not accept — its pattern is host-locked
+    /// to `https://github.com/`, so on a worktree hosted anywhere else *every*
     /// synthetic chip is in that state, and a url-only reference would make the
     /// xmark fail every time on exactly the worktrees that only ever have
     /// synthetic chips. A reference with a bad URL and no number is still
     /// unresolvable; nothing is guessed.
-    private func resolvePRRef(_ params: PRBindingRefParams) async -> PRRefResolution {
-        if let url = params.url, !url.isEmpty,
-           let parsed = PRBindingExtractor.parsePRURLs(in: url).first {
-            return .resolved(parsed)
+    ///
+    /// **Off by default, and detach-only on purpose.** The fallthrough re-reads
+    /// the number against *this* worktree's repo, so for an attach a URL naming
+    /// #412 on some other host would silently bind this repo's #412 — a
+    /// different pull request, bound with no error. Removing a wrong
+    /// association is recoverable; creating one quietly is the failure the
+    /// wrong-repo guard exists to prevent, so attach keeps the strict form.
+    private func resolvePRRef(_ params: PRBindingRefParams,
+                              numberFallback: Bool = false) async -> PRRefResolution {
+        if let url = params.url, !url.isEmpty {
+            if let parsed = PRBindingExtractor.parsePRURLs(in: url).first {
+                return .resolved(parsed)
+            }
+            guard numberFallback else { return .unresolvable }
         }
         guard let number = params.number, number > 0 else { return .unresolvable }
         guard let parsed = await prRef(worktreeID: params.worktreeID, number: number) else {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -292,9 +292,13 @@ public final class RPCRouter: Sendable {
             store: db.prBindings, resolveRepo: repoResolver, isGitLabHost: forgeResolver,
             // The cached status is the only evidence about a worktree's PRs
             // that survives `gh` being unavailable, which is when `detach`
-            // needs it — see `PRBindingCoordinator.detach`.
-            cachedPRNumber: { [db] worktreeID in
-                try? await db.worktrees.get(id: worktreeID)?.prStatus?.number
+            // needs it — see `PRBindingCoordinator.detach`. Parsed to a full
+            // identity rather than passed as a bare number, so corroboration
+            // cannot be satisfied by a coincidence of numbering.
+            cachedPRIdentity: { [db] worktreeID in
+                guard let url = try? await db.worktrees.get(id: worktreeID)?.prStatus?.url
+                else { return nil }
+                return PRBindingExtractor.parsePRURLs(in: url).first
             })
         self.pendingQuestions = pendingQuestions
         self.repoSerializer = repoSerializer

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -875,7 +875,8 @@ public final class RPCRouter: Sendable {
             if !updated.sameValue(as: binding) {
                 try? await db.prBindings.updateObservation(
                     bindingID: binding.id, status: updated.status,
-                    headBranch: updated.headBranch, baseRef: updated.baseRef)
+                    headBranch: updated.headBranch, baseRef: updated.baseRef,
+                    title: updated.title)
             }
             refreshed.append(updated)
         }
@@ -933,7 +934,8 @@ public final class RPCRouter: Sendable {
         guard let observed else { return binding }
         return binding.withObservation(status: observed.status,
                                        headBranch: observed.headBranch,
-                                       baseRef: observed.baseRef)
+                                       baseRef: observed.baseRef,
+                                       title: observed.title)
     }
 
     /// The `Worktree.prStatus` write implied by a worktree's bindings: the worst

--- a/Sources/TBDShared/Forge.swift
+++ b/Sources/TBDShared/Forge.swift
@@ -45,8 +45,29 @@ public extension Forge {
     /// on both forges at once and no single vocabulary would be true of them.
     func refLabel(number: Int) -> String {
         switch self {
-        case .github: return "PR #\(number)"
-        case .gitlab: return "MR !\(number)"
+        case .github: return "\(refNoun) #\(number)"
+        case .gitlab: return "\(refNoun) !\(number)"
+        }
+    }
+
+    /// The same vocabulary `refLabel` composes its label from, for the
+    /// sentences that name a request the surface has ALREADY numbered — a
+    /// hover card whose headline says `PR#412` may not say the number twice,
+    /// but it still must not call a merge request a PR. Composed into
+    /// `refLabel` rather than kept beside it, so there is one noun per forge
+    /// and no second table to drift.
+    var refNoun: String {
+        switch self {
+        case .github: return "PR"
+        case .gitlab: return "MR"
+        }
+    }
+
+    /// What the forge calls itself, for text naming where a click lands.
+    var displayName: String {
+        switch self {
+        case .github: return "GitHub"
+        case .gitlab: return "GitLab"
         }
     }
 }

--- a/Sources/TBDShared/PRBinding.swift
+++ b/Sources/TBDShared/PRBinding.swift
@@ -23,6 +23,13 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
     public let url: String
     public let headBranch: String?
     public let baseRef: String?
+    /// The PR's title, as the last refresh that resolved it reported.
+    ///
+    /// Descriptive, like `headBranch` and `baseRef`: nothing matches on it, and
+    /// nil means "never observed" rather than "this PR has no title". A binding
+    /// hydrated from a cached `Worktree.prStatus` has none, and every row
+    /// written before the column existed decodes as nil.
+    public let title: String?
     /// Last observed status. nil = never polled since binding.
     public let status: PRStatus?
     public let source: PRBindingSource
@@ -32,6 +39,7 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
     public init(id: UUID = UUID(), worktreeID: UUID, host: String = "github.com",
                 owner: String, repo: String, number: Int, url: String,
                 headBranch: String? = nil, baseRef: String? = nil,
+                title: String? = nil,
                 status: PRStatus? = nil, source: PRBindingSource,
                 detached: Bool = false, boundAt: Date = Date()) {
         self.id = id
@@ -43,6 +51,7 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
         self.url = url
         self.headBranch = headBranch
         self.baseRef = baseRef
+        self.title = title
         self.status = status
         self.source = source
         self.detached = detached
@@ -50,23 +59,25 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
     }
 
     /// A copy carrying everything a refresh observed: the status plus the head
-    /// and base refs the PR reported. The poll folds its observations back onto
-    /// the bindings through this before `worst(of:)`, `allResolved(_:)` or
-    /// `mergedBindingIsOwnWork` can judge them.
+    /// ref, base ref and title the PR reported. The poll folds its observations
+    /// back onto the bindings through this before `worst(of:)`,
+    /// `allResolved(_:)` or `mergedBindingIsOwnWork` can judge them.
     ///
-    /// A **nil** ref means "not observed", never "cleared" — the stored value
-    /// survives, the same rule the persisted row follows, so a transient failure
-    /// cannot blank the branch the CLI renders.
+    /// A **nil** ref or title means "not observed", never "cleared" — the
+    /// stored value survives, the same rule the persisted row follows, so a
+    /// transient failure cannot blank the branch the CLI renders or the title
+    /// the status bar has on screen.
     ///
-    /// Status and refs move together deliberately, rather than through a
-    /// status-only sibling: the merge rule judges ownership on `headBranch`, so
-    /// a binding folded with this pass's status but the previous pass's head ref
-    /// would hold the gate shut for one poll on evidence it already had.
+    /// Status and descriptive fields move together deliberately, rather than
+    /// through a status-only sibling: the merge rule judges ownership on
+    /// `headBranch`, so a binding folded with this pass's status but the
+    /// previous pass's head ref would hold the gate shut for one poll on
+    /// evidence it already had.
     public func withObservation(status: PRStatus?, headBranch: String?,
-                                baseRef: String?) -> PRBinding {
+                                baseRef: String?, title: String?) -> PRBinding {
         PRBinding(id: id, worktreeID: worktreeID, host: host, owner: owner, repo: repo,
                   number: number, url: url, headBranch: headBranch ?? self.headBranch,
-                  baseRef: baseRef ?? self.baseRef,
+                  baseRef: baseRef ?? self.baseRef, title: title ?? self.title,
                   status: status, source: source, detached: detached, boundAt: boundAt)
     }
 
@@ -86,10 +97,12 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
     }
 
     /// This binding with its status's freshness stamp cleared, so the compiler
-    /// writes the field-by-field comparison `sameValue(as:)` needs.
+    /// writes the field-by-field comparison `sameValue(as:)` needs. Every
+    /// descriptive field is passed through unchanged — the stamp is the only
+    /// thing excluded, so a retitled PR still reads as changed and persists.
     private var unstamped: PRBinding {
         withObservation(status: status?.withObservedAt(nil),
-                        headBranch: headBranch, baseRef: baseRef)
+                        headBranch: headBranch, baseRef: baseRef, title: title)
     }
 
     /// How this one binding is named in the UI: `PR #412` on GitHub, `MR !412`

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1071,9 +1071,12 @@ public struct PRDetachResult: Codable, Sendable {
     /// recorded for a PR this worktree had no row for at all (a detach asserts
     /// that a PR does not belong here; it does not merely edit a row that
     /// happens to exist). False when the PR was already tombstoned, and when
-    /// there was nothing to tombstone and the reference named a PR outside the
-    /// worktree's own repo — in both of those the PR is not tracked here, which
-    /// is what the caller asked for.
+    /// there was nothing to tombstone and nothing tied the reference to this
+    /// worktree — in both of those the PR is not tracked here, which is what
+    /// the caller asked for, and callers may say exactly that.
+    ///
+    /// A request that could not be honoured at all is an RPC **error**, never a
+    /// false, precisely so that sentence stays true.
     public let detached: Bool
     public init(detached: Bool) { self.detached = detached }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1064,7 +1064,16 @@ public struct PRAttachResult: Codable, Sendable {
 }
 
 public struct PRDetachResult: Codable, Sendable {
-    /// False when this worktree had no such binding — not an error.
+    /// Whether the call **changed the record**, never whether it succeeded —
+    /// false is not an error.
+    ///
+    /// True when a live binding was tombstoned, and when a tombstone was
+    /// recorded for a PR this worktree had no row for at all (a detach asserts
+    /// that a PR does not belong here; it does not merely edit a row that
+    /// happens to exist). False when the PR was already tombstoned, and when
+    /// there was nothing to tombstone and the reference named a PR outside the
+    /// worktree's own repo — in both of those the PR is not tracked here, which
+    /// is what the caller asked for.
     public let detached: Bool
     public init(detached: Bool) { self.detached = detached }
 }

--- a/Tests/TBDAppTests/HoverCardPlacementTests.swift
+++ b/Tests/TBDAppTests/HoverCardPlacementTests.swift
@@ -88,7 +88,9 @@ struct HoverCardPlacementTests {
         // Modelled generously: the strip's own 4pt padding plus the difference
         // between the chip and the tallest control sharing the row with it.
         let barTopAboveChip: CGFloat = 8
-        let breathingRoom: CGFloat = 12
+        // A band that is unmistakable rather than merely measurable — the whole
+        // strip stays legible with window content visible above it.
+        let breathingRoom: CGFloat = 32
         let anchor = CGRect(x: 300, y: 414, width: 22, height: 14)
         let barTop = anchor.maxY + barTopAboveChip
         let visible = card(place(anchor: anchor, window: window, screen: screen))

--- a/Tests/TBDAppTests/HoverCardPlacementTests.swift
+++ b/Tests/TBDAppTests/HoverCardPlacementTests.swift
@@ -1,0 +1,160 @@
+import CoreGraphics
+import Testing
+@testable import TBDApp
+
+// Tier 1: the pure geometry behind where a hover card's panel lands. No panel,
+// no window, no screen — AppKit screen coordinates (y grows upward) in, a frame
+// out.
+@Suite("HoverCard placement")
+struct HoverCardPlacementTests {
+
+    /// A window floating in the middle of a tall screen: there is desktop both
+    /// above and below it, so the *window* is what decides which side a card
+    /// goes on. `visibleFrame` excludes the menu bar and the Dock, as AppKit's
+    /// does.
+    private let screen = CGRect(x: 0, y: 70, width: 1440, height: 830)
+    private let window = CGRect(x: 100, y: 400, width: 1200, height: 400)
+    private let inset = HoverCardView.shadowInset
+
+    /// The visible card inside the panel — what the gap and the alignment are
+    /// measured against, since the panel carries a transparent shadow margin.
+    private func card(_ frame: CGRect) -> CGRect {
+        frame.insetBy(dx: inset, dy: inset)
+    }
+
+    private func place(anchor: CGRect,
+                       cardSize: CGSize = CGSize(width: 260, height: 120),
+                       window: CGRect?,
+                       screen: CGRect?) -> CGRect {
+        HoverCardPlacement.panelFrame(
+            anchor: anchor,
+            panelSize: CGSize(width: cardSize.width + inset * 2,
+                              height: cardSize.height + inset * 2),
+            shadowInset: inset,
+            window: window,
+            screenVisibleFrame: screen
+        )
+    }
+
+    // MARK: - Which side of the anchor
+
+    @Test("an anchor with room beneath it inside the window keeps its card below")
+    func belowIsThePreferredSide() {
+        // A tab-bar item: near the top of the window, plenty of window below it.
+        let anchor = CGRect(x: 260, y: 770, width: 90, height: 28)
+        let visible = card(place(anchor: anchor, window: window, screen: screen))
+        #expect(visible.maxY == anchor.minY - HoverCardPlacement.anchorGap)
+        #expect(visible.minX == anchor.minX)
+    }
+
+    /// The status-bar chip: the card would fit on screen below it — there is a
+    /// whole desktop down there — but it would leave the window and land on the
+    /// strip it describes.
+    @Test("an anchor at the bottom of its window flips above, even with screen room below")
+    func windowBottomFlipsAboveDespiteScreenRoom() {
+        let anchor = CGRect(x: 300, y: 414, width: 22, height: 14)
+        let frame = place(anchor: anchor, window: window, screen: screen)
+        let visible = card(frame)
+        #expect(visible.minY == anchor.maxY + HoverCardPlacement.anchorGap)
+        // The whole card is above the anchor, so the bar it is anchored to —
+        // the chip included — stays readable underneath it.
+        #expect(visible.minY > anchor.maxY)
+        // Below would have fitted the screen, which is exactly why the screen
+        // cannot be the only test.
+        let below = anchor.minY - HoverCardPlacement.anchorGap - visible.height
+        #expect(below > screen.minY)
+        #expect(below < window.minY)
+        // The chip sits a dozen points off the bottom of the window, so no card
+        // small enough to matter fits beneath it: the flip is a property of the
+        // anchor, not of how tall this particular card happens to be.
+        let short = card(place(anchor: anchor,
+                               cardSize: CGSize(width: 200, height: 40),
+                               window: window,
+                               screen: screen))
+        #expect(short.minY == anchor.maxY + HoverCardPlacement.anchorGap)
+    }
+
+    /// The flip must clear the padding a bar puts around its content, not just
+    /// the anchored control: the chip sits 4pt inside the status strip.
+    @Test("the flipped card clears the bar its anchor sits in, not just the anchor")
+    func flippedCardClearsTheBarPadding() {
+        let barPadding: CGFloat = 4
+        let anchor = CGRect(x: 300, y: 414, width: 22, height: 14)
+        let barTop = anchor.maxY + barPadding
+        let visible = card(place(anchor: anchor, window: window, screen: screen))
+        #expect(visible.minY > barTop)
+    }
+
+    @Test("a card with no room below on screen flips above")
+    func screenBottomStillFlips() {
+        // A window whose bottom edge sits on the screen's visible bottom.
+        let bottomed = CGRect(x: 100, y: screen.minY, width: 1200, height: 700)
+        let anchor = CGRect(x: 300, y: screen.minY + 14, width: 22, height: 14)
+        let visible = card(place(anchor: anchor, window: bottomed, screen: screen))
+        #expect(visible.minY == anchor.maxY + HoverCardPlacement.anchorGap)
+    }
+
+    /// The window is a preference, not a hard constraint. A card anchored in a
+    /// short floating panel fits inside it on neither side, and the screen — the
+    /// rule that always applied — decides instead of the card being clamped over
+    /// its own anchor.
+    @Test("a window too short for either side falls back to the screen rule")
+    func shortWindowFallsBackToTheScreen() {
+        let panel = CGRect(x: 300, y: 500, width: 260, height: 60)
+        let anchor = CGRect(x: 310, y: 515, width: 200, height: 20)
+        let visible = card(place(anchor: anchor, window: panel, screen: screen))
+        #expect(visible.maxY == anchor.minY - HoverCardPlacement.anchorGap)
+        #expect(visible.minY > screen.minY)
+    }
+
+    @Test("with no window at all the screen rule stands on its own")
+    func noWindowUsesTheScreenRule() {
+        let anchor = CGRect(x: 300, y: 414, width: 22, height: 14)
+        let visible = card(place(anchor: anchor, window: nil, screen: screen))
+        #expect(visible.maxY == anchor.minY - HoverCardPlacement.anchorGap)
+    }
+
+    // MARK: - Staying on screen
+
+    @Test("a card is clamped into the screen rather than running off its right edge")
+    func clampsToTheRightEdge() {
+        let anchor = CGRect(x: 1400, y: 600, width: 22, height: 14)
+        let visible = card(place(anchor: anchor, window: window, screen: screen))
+        #expect(visible.maxX == screen.maxX - HoverCardPlacement.screenMargin)
+        #expect(visible.minX < anchor.minX)
+    }
+
+    @Test("a card is clamped into the screen rather than running off its left edge")
+    func clampsToTheLeftEdge() {
+        let anchor = CGRect(x: -20, y: 600, width: 22, height: 14)
+        let visible = card(place(anchor: anchor, window: window, screen: screen))
+        #expect(visible.minX == screen.minX + HoverCardPlacement.screenMargin)
+    }
+
+    @Test("a card taller than the screen is pinned to the top of it, not pushed under it")
+    func clampsATooTallCard() {
+        let anchor = CGRect(x: 300, y: 600, width: 22, height: 14)
+        let visible = card(place(anchor: anchor,
+                                 cardSize: CGSize(width: 260, height: 2000),
+                                 window: window,
+                                 screen: screen))
+        #expect(visible.minY == screen.minY + HoverCardPlacement.screenMargin)
+    }
+
+    // MARK: - The shadow margin
+
+    /// The panel is bigger than the card by the transparent margin the card's
+    /// own shadow draws into. Every measurement above is against the card; the
+    /// panel is offset out from it by exactly one inset on each side, so the
+    /// shadow costs the card no position.
+    @Test("the panel wraps the card by one shadow inset on every side")
+    func panelWrapsTheCard() {
+        let anchor = CGRect(x: 260, y: 770, width: 90, height: 28)
+        let frame = place(anchor: anchor, window: window, screen: screen)
+        #expect(frame.width == 260 + inset * 2)
+        #expect(frame.height == 120 + inset * 2)
+        #expect(frame.minX == anchor.minX - inset)
+        #expect(frame.maxY == anchor.minY - HoverCardPlacement.anchorGap + inset)
+        #expect(inset > 0)
+    }
+}

--- a/Tests/TBDAppTests/HoverCardPlacementTests.swift
+++ b/Tests/TBDAppTests/HoverCardPlacementTests.swift
@@ -38,13 +38,17 @@ struct HoverCardPlacementTests {
 
     // MARK: - Which side of the anchor
 
-    @Test("an anchor with room beneath it inside the window keeps its card below")
+    @Test("an anchor with room beneath it inside the window keeps its card below, hugging it")
     func belowIsThePreferredSide() {
         // A tab-bar item: near the top of the window, plenty of window below it.
         let anchor = CGRect(x: 260, y: 770, width: 90, height: 28)
         let visible = card(place(anchor: anchor, window: window, screen: screen))
         #expect(visible.maxY == anchor.minY - HoverCardPlacement.anchorGap)
         #expect(visible.minX == anchor.minX)
+        // A card hanging under its anchor should read as attached to it, so
+        // this gap stays small — and much smaller than the one a flipped card
+        // needs to escape the bar it was pushed off.
+        #expect(HoverCardPlacement.anchorGap <= 8)
     }
 
     /// The status-bar chip: the card would fit on screen below it — there is a
@@ -55,7 +59,7 @@ struct HoverCardPlacementTests {
         let anchor = CGRect(x: 300, y: 414, width: 22, height: 14)
         let frame = place(anchor: anchor, window: window, screen: screen)
         let visible = card(frame)
-        #expect(visible.minY == anchor.maxY + HoverCardPlacement.anchorGap)
+        #expect(visible.minY == anchor.maxY + HoverCardPlacement.flippedBarClearance)
         // The whole card is above the anchor, so the bar it is anchored to —
         // the chip included — stays readable underneath it.
         #expect(visible.minY > anchor.maxY)
@@ -71,18 +75,27 @@ struct HoverCardPlacementTests {
                                cardSize: CGSize(width: 200, height: 40),
                                window: window,
                                screen: screen))
-        #expect(short.minY == anchor.maxY + HoverCardPlacement.anchorGap)
+        #expect(short.minY == anchor.maxY + HoverCardPlacement.flippedBarClearance)
     }
 
-    /// The flip must clear the padding a bar puts around its content, not just
-    /// the anchored control: the chip sits 4pt inside the status strip.
-    @Test("the flipped card clears the bar its anchor sits in, not just the anchor")
-    func flippedCardClearsTheBarPadding() {
-        let barPadding: CGFloat = 4
+    /// The reader is looking at the *bar*, not at the chip. A chip is a 14pt
+    /// row inside a strip that pads it, sits it beside taller controls and
+    /// draws its own background, so the flip has to clear the strip's top edge
+    /// with a gap wide enough to see — clearing the anchor by a hair leaves the
+    /// card glued to the row it is describing.
+    @Test("a flipped card clears the whole bar its anchor sits in, with room to spare")
+    func flippedCardClearsTheWholeBar() {
+        // Modelled generously: the strip's own 4pt padding plus the difference
+        // between the chip and the tallest control sharing the row with it.
+        let barTopAboveChip: CGFloat = 8
+        let breathingRoom: CGFloat = 12
         let anchor = CGRect(x: 300, y: 414, width: 22, height: 14)
-        let barTop = anchor.maxY + barPadding
+        let barTop = anchor.maxY + barTopAboveChip
         let visible = card(place(anchor: anchor, window: window, screen: screen))
-        #expect(visible.minY > barTop)
+        #expect(visible.minY >= barTop + breathingRoom)
+        // And the asymmetry is structural rather than a nudge: a flipped card
+        // is escaping something, a card below its anchor is attached to it.
+        #expect(HoverCardPlacement.flippedBarClearance >= HoverCardPlacement.anchorGap * 2)
     }
 
     @Test("a card with no room below on screen flips above")
@@ -91,7 +104,7 @@ struct HoverCardPlacementTests {
         let bottomed = CGRect(x: 100, y: screen.minY, width: 1200, height: 700)
         let anchor = CGRect(x: 300, y: screen.minY + 14, width: 22, height: 14)
         let visible = card(place(anchor: anchor, window: bottomed, screen: screen))
-        #expect(visible.minY == anchor.maxY + HoverCardPlacement.anchorGap)
+        #expect(visible.minY == anchor.maxY + HoverCardPlacement.flippedBarClearance)
     }
 
     /// The window is a preference, not a hard constraint. A card anchored in a

--- a/Tests/TBDAppTests/HoverCardPlacementTests.swift
+++ b/Tests/TBDAppTests/HoverCardPlacementTests.swift
@@ -90,7 +90,7 @@ struct HoverCardPlacementTests {
         let barTopAboveChip: CGFloat = 8
         // A band that is unmistakable rather than merely measurable — the whole
         // strip stays legible with window content visible above it.
-        let breathingRoom: CGFloat = 32
+        let breathingRoom: CGFloat = 16
         let anchor = CGRect(x: 300, y: 414, width: 22, height: 14)
         let barTop = anchor.maxY + barTopAboveChip
         let visible = card(place(anchor: anchor, window: window, screen: screen))

--- a/Tests/TBDAppTests/PRBindingPresentationTests.swift
+++ b/Tests/TBDAppTests/PRBindingPresentationTests.swift
@@ -113,6 +113,36 @@ struct PRBindingPresentationTests {
         // And the count label, which the same set feeds.
         #expect(PRBindingPresentation.buttonLabel(
             [binding(412, .mergeable), gitLabBinding(7)]) == "2 PRs")
+
+        // The `+N` chip counts a set too, so its wording keeps the neutral noun
+        // for the same reason — it has no single binding to take a forge from,
+        // and its signature carries none.
+        let tooltip = PRBindingPresentation.overflowChipTooltip(total: 2, overflow: 1)
+        let announced = PRBindingPresentation.overflowChipAccessibilityLabel(
+            total: 2, overflow: 1)
+        for aggregate in [tooltip, announced] {
+            #expect(aggregate.contains("2 pull requests"))
+            #expect(!aggregate.contains(Forge.gitlab.refNoun))
+        }
+    }
+
+    /// A menu row describes ONE binding, so it takes the per-binding rule the
+    /// aggregates above are exempt from — and each row in one menu can take a
+    /// different forge. A bare `#7` named a merge request in GitHub's syntax;
+    /// `#7` is an issue reference on GitLab, whose syntax for this row's
+    /// subject is `!7`.
+    @Test("each menu row names its own binding's forge")
+    func menuRowsSpeakPerBindingForge() {
+        let rows = PRBindingPresentation.menuRows(
+            [binding(412, .mergeable), gitLabBinding(7)])
+        #expect(rows.map(\.title) == ["PR #412  Ready to merge",
+                                      "MR !7  Ready to merge"])
+        // The GitLab row borrows nothing from the forge beside it.
+        #expect(!rows[1].title.contains("#7"))
+        #expect(!rows[1].title.contains(Forge.github.refNoun))
+        // …and it is the same wording the split button's help gives a lone
+        // binding, rather than a second vocabulary beside it.
+        #expect(rows[1].title.hasPrefix(gitLabBinding(7).refLabel))
     }
 
     @Test("a status-bar chip carries its binding's own forge vocabulary")
@@ -190,6 +220,7 @@ struct PRBindingPresentationTests {
                       status: b.status, source: b.source, detached: false, boundAt: b.boundAt)
         let row = PRBindingPresentation.menuRows([b])[0]
         #expect(row.number == 412)
+        #expect(row.title == "PR #412  Checks failing  fix-login-timeout")
         #expect(row.title.contains("#412"))
         #expect(row.title.contains("Checks failing"))
         #expect(row.title.contains("fix-login-timeout"))

--- a/Tests/TBDAppTests/PRBindingRefreshTests.swift
+++ b/Tests/TBDAppTests/PRBindingRefreshTests.swift
@@ -177,6 +177,28 @@ struct PRBindingRefreshTests {
         }
     }
 
+    /// The seam `detachPR` judges its outcome through. The published maps are
+    /// whole-fleet, so a refresh already in flight can land afterwards and
+    /// publish its older snapshot over the top — returning what THIS call
+    /// fetched is what makes an outcome check immune to that.
+    @MainActor
+    @Test("refreshPRBindings returns the state it fetched, and nil when it failed")
+    func refreshReportsWhatItFetched() async {
+        await withStateAsync { state in
+            let wt = UUID()
+            state.prBindingsFetcher = {
+                PRBindingsAllResult(worktrees: [entry(wt, [binding(412, worktreeID: wt)])])
+            }
+            let fetched = await state.refreshPRBindings()
+            #expect(fetched?.bindings[wt]?.map(\.number) == [412])
+
+            state.prBindingsFetcher = { throw PRBindingRefreshTestError.boom }
+            #expect(await state.refreshPRBindings() == nil)
+            // …and the published map is untouched by the failure.
+            #expect(state.prBindings[wt]?.map(\.number) == [412])
+        }
+    }
+
     // MARK: - The untrack gesture
 
     /// `detachPR` judges its outcome by re-reading the bindings rather than by

--- a/Tests/TBDAppTests/PRBindingRefreshTests.swift
+++ b/Tests/TBDAppTests/PRBindingRefreshTests.swift
@@ -176,6 +176,94 @@ struct PRBindingRefreshTests {
             #expect(state.prDetachedCounts.isEmpty)
         }
     }
+
+    // MARK: - The untrack gesture
+
+    /// `detachPR` judges its outcome by re-reading the bindings rather than by
+    /// trusting `detached`, because false covers both "already tombstoned" and
+    /// "the daemon declined". Each of the three ways out gets a case.
+
+    @MainActor
+    @Test("a detach whose chip is gone afterwards says nothing")
+    func detachThatLandedIsSilent() async {
+        await withStateAsync { state in
+            let wt = UUID()
+            state.prBindings = [wt: [binding(412, worktreeID: wt)]]
+            state.prDetacher = { _, _, _ in PRDetachResult(detached: true) }
+            state.prBindingsFetcher = {
+                PRBindingsAllResult(worktrees: [entry(wt, [], detachedCount: 1)])
+            }
+
+            await state.detachPR(worktreeID: wt, url: nil, number: 412)
+
+            #expect(state.prBindings[wt] == nil)
+            #expect(state.activeToast == nil)
+        }
+    }
+
+    /// `detached: false` is not itself a failure — a second click on the same
+    /// xmark reports it — so what matters is whether the chip survived.
+    @MainActor
+    @Test("a detach whose chip survives is reported, even when the RPC did not throw")
+    func detachThatDeclinedIsReported() async {
+        await withStateAsync { state in
+            let wt = UUID()
+            state.prBindings = [wt: [binding(412, worktreeID: wt)]]
+            // The daemon declined: nothing was written, so the refresh returns
+            // the binding unchanged.
+            state.prDetacher = { _, _, _ in PRDetachResult(detached: false) }
+            state.prBindingsFetcher = {
+                PRBindingsAllResult(worktrees: [entry(wt, [binding(412, worktreeID: wt)])])
+            }
+
+            await state.detachPR(worktreeID: wt, url: nil, number: 412)
+
+            #expect(state.prBindings[wt]?.map(\.number) == [412])
+            #expect(state.activeToast?.style == .error)
+            #expect(state.activeToast?.message == "PR #412 is still tracked here")
+        }
+    }
+
+    /// The trap the outcome check has to avoid: a refresh that never landed
+    /// leaves the maps holding their pre-call values, which read exactly like a
+    /// detach that did nothing. Reporting a landed detach as a failure is its
+    /// own kind of lie.
+    @MainActor
+    @Test("a detach followed by a failed refresh is not reported as a failure")
+    func detachWithAFailedRefreshIsSilent() async {
+        await withStateAsync { state in
+            let wt = UUID()
+            state.prBindings = [wt: [binding(412, worktreeID: wt)]]
+            state.prDetacher = { _, _, _ in PRDetachResult(detached: true) }
+            state.prBindingsFetcher = { throw PRBindingRefreshTestError.boom }
+
+            await state.detachPR(worktreeID: wt, url: nil, number: 412)
+
+            // The stale map still shows the chip, and that is precisely why it
+            // is not evidence.
+            #expect(state.prBindings[wt]?.map(\.number) == [412])
+            #expect(state.activeToast == nil)
+        }
+    }
+
+    @MainActor
+    @Test("a thrown detach toasts and never reaches the outcome check")
+    func detachThatThrewIsReported() async {
+        await withStateAsync { state in
+            let wt = UUID()
+            state.prBindings = [wt: [binding(412, worktreeID: wt)]]
+            state.prDetacher = { _, _, _ in throw PRBindingRefreshTestError.boom }
+            state.prBindingsFetcher = {
+                Issue.record("a failed detach must not refresh")
+                return PRBindingsAllResult(worktrees: [])
+            }
+
+            await state.detachPR(worktreeID: wt, url: nil, number: 412)
+
+            #expect(state.activeToast?.style == .error)
+            #expect(state.activeToast?.message == "Could not stop tracking PR #412")
+        }
+    }
 }
 
 private enum PRBindingRefreshTestError: Error { case boom }

--- a/Tests/TBDAppTests/PRBindingRefreshTests.swift
+++ b/Tests/TBDAppTests/PRBindingRefreshTests.swift
@@ -199,6 +199,64 @@ struct PRBindingRefreshTests {
         }
     }
 
+    /// The stale-poll race the sequence guard exists for, driven for real:
+    /// two overlapping refreshes that resolve OUT OF ORDER.
+    ///
+    /// A background poll (A) is already in flight, holding a snapshot that
+    /// still shows #412, when the user untracks it. The untrack's own refresh
+    /// (B) starts later, resolves first, and correctly publishes the chip as
+    /// gone. Then A finally lands. Without the guard A republishes its older
+    /// whole-fleet snapshot over the top and the chip the user just dismissed
+    /// comes back on screen.
+    ///
+    /// Every other poll test here awaits one refresh before starting the next,
+    /// so this is the only case that reaches the `seq == prBindingsRefreshSeq`
+    /// branch at all.
+    @MainActor
+    @Test("a stale refresh landing last does not resurrect an untracked chip")
+    func staleRefreshDoesNotResurrectAnUntrackedChip() async {
+        await withStateAsync { state in
+            let wt = UUID()
+            // The chip is on screen when the poll goes out.
+            state.prBindings = [wt: [binding(412, worktreeID: wt)]]
+
+            let gate = RefreshGate()
+            state.prBindingsFetcher = {
+                gate.calls += 1
+                if gate.calls == 1 {
+                    // A: issued before the untrack, so it still sees #412 —
+                    // and it is held open until B has published.
+                    while !gate.open { try? await Task.sleep(for: .milliseconds(1)) }
+                    return PRBindingsAllResult(
+                        worktrees: [entry(wt, [binding(412, worktreeID: wt)])])
+                }
+                // B: issued after the untrack landed, so #412 is tombstoned.
+                return PRBindingsAllResult(worktrees: [entry(wt, [], detachedCount: 1)])
+            }
+
+            // A starts first and must stamp its sequence number and enter its
+            // fetch before B starts — otherwise B's own await hands the actor
+            // back to A and the stamps invert.
+            let taskA = Task { await state.refreshPRBindings() }
+            let entered = await waitUntil { gate.calls == 1 }
+            #expect(entered)
+
+            // B supersedes A: it resolves immediately and publishes the detach.
+            await state.refreshPRBindings()
+            #expect(state.prBindings[wt] == nil)
+            #expect(state.prDetachedCounts[wt] == 1)
+
+            // Now let A's stale snapshot resolve. It still REPORTS what it
+            // fetched to its own caller — that is the return contract — but it
+            // must not put #412 back on screen.
+            gate.open = true
+            let late = await taskA.value
+            #expect(late?.bindings[wt]?.map(\.number) == [412])
+            #expect(state.prBindings[wt] == nil)
+            #expect(state.prDetachedCounts[wt] == 1)
+        }
+    }
+
     // MARK: - The untrack gesture
 
     /// `detachPR` judges its outcome by re-reading the bindings rather than by
@@ -289,6 +347,28 @@ struct PRBindingRefreshTests {
 }
 
 private enum PRBindingRefreshTestError: Error { case boom }
+
+/// Call counter + release latch for the overlapping-refresh test, so the two
+/// fetches resolve out of order by construction rather than by racing sleeps.
+@MainActor
+private final class RefreshGate {
+    var calls = 0
+    var open = false
+}
+
+/// Poll `cond` on the main actor until true or the deadline. Returns success.
+@MainActor
+private func waitUntil(
+    deadline: Duration = .seconds(15), _ cond: @MainActor () -> Bool
+) async -> Bool {
+    let clock = ContinuousClock()
+    let start = clock.now
+    while !cond() {
+        if clock.now - start > deadline { return false }
+        try? await Task.sleep(for: .milliseconds(2))
+    }
+    return true
+}
 
 private func binding(_ number: Int, worktreeID: UUID) -> PRBinding {
     let url = "https://github.com/acme/acme-prod/pull/\(number)"

--- a/Tests/TBDAppTests/PRBindingRefreshTests.swift
+++ b/Tests/TBDAppTests/PRBindingRefreshTests.swift
@@ -257,6 +257,52 @@ struct PRBindingRefreshTests {
         }
     }
 
+    /// The other interleaving of the same two calls, and the reason the guard
+    /// counts PUBLISHES rather than starts.
+    ///
+    /// A poll (A) is in flight when a second refresh (B) starts and fails
+    /// outright — an RPC hiccup, which publishes nothing and leaves the maps
+    /// holding their pre-call values. A then resolves with perfectly good data.
+    /// Nothing newer has reached the screen, so A must publish: a guard that
+    /// asked only whether a later call had STARTED would withhold A's fleet on
+    /// account of a call that never put anything anywhere, and every toolbar
+    /// would sit on stale bindings until the next poll.
+    @MainActor
+    @Test("a later refresh that failed cannot suppress an earlier one that succeeded")
+    func failedLaterRefreshDoesNotSuppressAnEarlierSuccess() async {
+        await withStateAsync { state in
+            let wt = UUID()
+            let gate = RefreshGate()
+            state.prBindingsFetcher = {
+                gate.calls += 1
+                if gate.calls == 1 {
+                    // A: held open until B has failed.
+                    while !gate.open { try? await Task.sleep(for: .milliseconds(1)) }
+                    return PRBindingsAllResult(
+                        worktrees: [entry(wt, [binding(412, worktreeID: wt)], detachedCount: 1)])
+                }
+                // B: starts later, publishes nothing at all.
+                throw PRBindingRefreshTestError.boom
+            }
+
+            let taskA = Task { await state.refreshPRBindings() }
+            let entered = await waitUntil { gate.calls == 1 }
+            #expect(entered)
+
+            // B takes the later ticket and then fails.
+            #expect(await state.refreshPRBindings() == nil)
+            #expect(state.prBindings.isEmpty)
+
+            // A resolves last, and its data is still the newest anyone has —
+            // so it reaches the screen, not just its own caller.
+            gate.open = true
+            let late = await taskA.value
+            #expect(late?.bindings[wt]?.map(\.number) == [412])
+            #expect(state.prBindings[wt]?.map(\.number) == [412])
+            #expect(state.prDetachedCounts[wt] == 1)
+        }
+    }
+
     // MARK: - The untrack gesture
 
     /// `detachPR` judges its outcome by re-reading the bindings rather than by

--- a/Tests/TBDAppTests/PRSplitButtonIDTests.swift
+++ b/Tests/TBDAppTests/PRSplitButtonIDTests.swift
@@ -206,9 +206,15 @@ struct PRSplitButtonIDTests {
         // headBranch), so a new field is otherwise silently unkeyed: decide
         // whether the split button renders it and update prSplitButtonID (and
         // this count) accordingly.
-        // 13 = id, worktreeID, host, owner, repo, number, url, headBranch,
-        // baseRef, status, source, detached, boundAt.
+        // 14 = id, worktreeID, host, owner, repo, number, url, headBranch,
+        // baseRef, title, status, source, detached, boundAt.
+        //
+        // `title` is deliberately NOT in the key: the split button's menu rows
+        // render number, state, reason and head branch, and nothing else — the
+        // title is carried for the status-bar chips, which are a different view
+        // with its own identity. Fold it in here the moment a menu row starts
+        // rendering it, or the materialized menu will freeze on a stale title.
         let value = Self.binding(1, .mergeable, worktreeID: UUID())
-        #expect(Mirror(reflecting: value).children.count == 13)
+        #expect(Mirror(reflecting: value).children.count == 14)
     }
 }

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -3,8 +3,9 @@ import Testing
 import TBDShared
 @testable import TBDApp
 
-// Tier 1: the pure chip model behind the status bar's PR cluster. Rendering is
-// not exercised here — only the value transform the row is built from.
+// Tier 1: the pure chip model behind the status bar's PR cluster, and the pure
+// content of the hover overlay a chip carries. Rendering is not exercised here —
+// only the value transforms the row and the card are built from.
 //
 // Deliberately a `@Suite` struct rather than the free `@Test` functions the two
 // sibling StatusBarView files use: `swift test --filter` matches the test ID,
@@ -13,23 +14,49 @@ import TBDShared
 @Suite("StatusBarView PR chips")
 struct StatusBarViewChipsTests {
 
-    private func binding(_ number: Int, _ state: PRMergeableState) -> PRBinding {
+    private func binding(
+        _ number: Int,
+        _ state: PRMergeableState?,
+        worktreeID: UUID = UUID(),
+        title: String? = nil,
+        observedAt: Date? = nil
+    ) -> PRBinding {
         let url = "https://github.com/acme/acme-prod/pull/\(number)"
         return PRBinding(
-            worktreeID: UUID(), owner: "acme", repo: "acme-prod",
+            worktreeID: worktreeID, owner: "acme", repo: "acme-prod",
             number: number, url: url,
-            status: PRStatus(number: number, url: url, state: state),
+            title: title,
+            status: state.map {
+                PRStatus(number: number, url: url, state: $0, observedAt: observedAt)
+            },
             source: .hook
         )
     }
 
-    @Test("the status bar exposes a chip per bound PR, capped at four")
-    func chipsForSelection() {
-        let bindings = (1...6).map { binding($0, .mergeable) }
+    // MARK: - The cap
+
+    @Test("seven bound PRs all get a chip, with nothing pushed into the overflow")
+    func sevenChipsFitWithoutOverflow() {
+        let bindings = (1...7).map { binding($0, .mergeable) }
         let model = StatusBarView.prChips(bindings)
-        #expect(model.chips.count == 4)
-        #expect(model.overflow == 2)
-        #expect(model.chips[0].label == "#1")
+        #expect(model.chips.count == 7)
+        #expect(model.overflow == 0)
+        #expect(model.chips.map(\.label) == ["#1", "#2", "#3", "#4", "#5", "#6", "#7"])
+    }
+
+    @Test("an eighth PR is the first to collapse into +1")
+    func eighthOverflows() {
+        let bindings = (1...8).map { binding($0, .mergeable) }
+        let model = StatusBarView.prChips(bindings)
+        #expect(model.chips.count == 7)
+        #expect(model.overflow == 1)
+        // The chip counts what didn't fit; its menu still lists all eight.
+        #expect(PRBindingPresentation.overflowChipTooltip(
+            total: bindings.count, overflow: model.overflow)
+            == "Show all 8 pull requests (1 not shown here)")
+        #expect(PRBindingPresentation.overflowChipAccessibilityLabel(
+            total: bindings.count, overflow: model.overflow)
+            == "Show all 8 pull requests, 1 not shown here")
     }
 
     @Test("no bindings means no chips at all")
@@ -37,13 +64,6 @@ struct StatusBarViewChipsTests {
         let model = StatusBarView.prChips([])
         #expect(model.chips.isEmpty)
         #expect(model.overflow == 0)
-    }
-
-    @Test("a chip carries the PR's url and state for the dot colour")
-    func chipContent() {
-        let model = StatusBarView.prChips([binding(412, .checksFailed)])
-        #expect(model.chips[0].url?.absoluteString.hasSuffix("/pull/412") == true)
-        #expect(model.chips[0].state == .checksFailed)
     }
 
     @Test("chips keep bind order, not severity order")
@@ -56,15 +76,123 @@ struct StatusBarViewChipsTests {
 
     @Test("an explicit limit overrides the default cap")
     func explicitLimit() {
-        let bindings = (1...6).map { binding($0, .mergeable) }
+        let bindings = (1...9).map { binding($0, .mergeable) }
         let model = StatusBarView.prChips(bindings, limit: 2)
         #expect(model.chips.map(\.label) == ["#1", "#2"])
-        #expect(model.overflow == 4)
+        #expect(model.overflow == 7)
     }
 
     @Test("a chip id is its binding's id, so the row is stable across refreshes")
     func chipIDMatchesBinding() {
         let one = binding(412, .mergeable)
         #expect(StatusBarView.prChips([one]).chips[0].id == one.id)
+    }
+
+    // MARK: - What a chip carries
+
+    @Test("a chip carries everything its click targets and overlay need")
+    func chipContent() {
+        let worktree = UUID()
+        let observed = Date(timeIntervalSince1970: 1_700_000_000)
+        let model = StatusBarView.prChips([
+            binding(412, .checksFailed, worktreeID: worktree,
+                    title: "Fix the login timeout", observedAt: observed)
+        ])
+        let chip = model.chips[0]
+        #expect(chip.url?.absoluteString.hasSuffix("/pull/412") == true)
+        #expect(chip.state == .checksFailed)
+        #expect(chip.number == 412)
+        // The untrack gesture detaches from THIS worktree, so the chip has to
+        // name it without the view threading it through.
+        #expect(chip.worktreeID == worktree)
+        #expect(chip.title == "Fix the login timeout")
+        #expect(chip.observedAt == observed)
+    }
+
+    @Test("a chip tolerates an absent title, state and observation stamp")
+    func chipToleratesAbsentFields() {
+        // A synthetic chip lifted from a cached status has no title; a binding
+        // nothing has polled yet has neither status nor stamp.
+        let model = StatusBarView.prChips([binding(412, nil)])
+        let chip = model.chips[0]
+        #expect(chip.title == nil)
+        #expect(chip.state == nil)
+        #expect(chip.observedAt == nil)
+        #expect(chip.label == "#412")
+    }
+
+    // MARK: - The hover overlay
+
+    private func chip(
+        number: Int = 412,
+        state: PRMergeableState? = .mergeable,
+        title: String? = nil,
+        observedAt: Date? = nil
+    ) -> StatusBarView.PRChip {
+        StatusBarView.prChips([
+            binding(number, state, title: title, observedAt: observedAt)
+        ]).chips[0]
+    }
+
+    @Test("the overlay names the PR, its title, its state and the age of that reading")
+    func overlayWithTitle() {
+        let now = Date(timeIntervalSince1970: 1_700_007_200)
+        let card = StatusBarView.chipHoverCard(
+            chip(state: .checksFailed,
+                 title: "Fix the login timeout",
+                 observedAt: now.addingTimeInterval(-7200)),
+            now: now)
+        #expect(card.title == "Fix the login timeout")
+        #expect(card.rows.contains { $0.label == "PR" && $0.value == "#412" })
+        let state = card.rows.first { $0.label == "State" }
+        #expect(state?.value == PRMergeableState.checksFailed.displayReason)
+        // The age rides with the state — a display-tier cache is never rendered
+        // as current truth. Shared wording with the toolbar and sidebar.
+        #expect(state?.caption == "checked 2h ago")
+        #expect(state?.caption == PRFreshness.checkedLabel(
+            observedAt: now.addingTimeInterval(-7200), now: now))
+    }
+
+    @Test("a chip with no observed title renders no title line, not a placeholder")
+    func overlayWithoutTitle() {
+        let card = StatusBarView.chipHoverCard(chip(title: nil))
+        #expect(card.title == nil)
+        // The number and state are still worth showing.
+        #expect(card.rows.contains { $0.label == "PR" && $0.value == "#412" })
+        #expect(card.rows.contains { $0.label == "State" })
+    }
+
+    @Test("a whitespace-only title counts as absent")
+    func overlayBlankTitle() {
+        #expect(StatusBarView.chipHoverCard(chip(title: "   \n")).title == nil)
+    }
+
+    @Test("a chip with no observed status still gets a number, and says the age is unknown")
+    func overlayWithoutStatus() {
+        let card = StatusBarView.chipHoverCard(chip(state: nil, observedAt: nil))
+        #expect(card.rows.contains { $0.label == "PR" && $0.value == "#412" })
+        let state = card.rows.first { $0.label == "State" }
+        #expect(state?.value == StatusBarView.unobservedStateValue)
+        #expect(state?.caption == PRFreshness.checkedLabel(observedAt: nil, now: Date()))
+    }
+
+    // MARK: - The two click targets
+
+    @Test("the untrack target says it removes the PR from THIS worktree")
+    func untrackLabelNamesTheWorktreeScope() {
+        // Wording matters: the gesture removes an association TBD inferred, not
+        // the pull request, so the label must not read as "close PR #412".
+        let label = StatusBarView.untrackLabel(chip())
+        #expect(label == "Stop tracking PR #412 in this worktree")
+        // …and it is a different sentence from the chip's own target, so the
+        // two accessibility elements cannot be confused for each other.
+        #expect(label != StatusBarView.openLabel(chip()))
+    }
+
+    @Test("the open target names the state when there is one, and doesn't invent one when there isn't")
+    func openLabelCarriesState() {
+        #expect(StatusBarView.openLabel(chip(state: .checksFailed))
+                == "Open PR #412 — \(PRMergeableState.checksFailed.displayReason)")
+        #expect(StatusBarView.openLabel(chip(state: nil)) == "Open PR #412")
     }
 }

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -197,6 +197,30 @@ struct StatusBarViewChipsTests {
         #expect(state?.caption == PRFreshness.checkedLabel(observedAt: nil, now: Date()))
     }
 
+    /// The toolbar and sidebar both append "last check did not resolve" after
+    /// the age. A chip that dropped it would render the more confident of two
+    /// readings of one fact — the exact drift `PRFreshness` exists to prevent.
+    @Test("the overlay says when the last poll attempt did not resolve")
+    func overlayCarriesTheUndeterminedClause() {
+        let now = Date(timeIntervalSince1970: 1_700_007_200)
+        let observed = now.addingTimeInterval(-7200)
+        let observation = PRObservation(
+            outcome: .undetermined(cause: "gh unauthenticated"), observedAt: observed)
+        let model = StatusBarView.prChips(
+            [binding(412, .mergeable, observedAt: observed)], observation: observation)
+
+        let caption = StatusBarView.chipHoverCard(model.chips[0], now: now)
+            .rows.first { $0.label == "State" }?.caption
+        #expect(caption == "checked 2h ago · last check did not resolve (gh unauthenticated)")
+
+        // A settled attempt adds nothing — the clause is a caveat, not a field.
+        let settled = StatusBarView.prChips(
+            [binding(412, .mergeable, observedAt: observed)],
+            observation: PRObservation(outcome: .none, observedAt: observed))
+        #expect(StatusBarView.chipHoverCard(settled.chips[0], now: now)
+            .rows.first { $0.label == "State" }?.caption == "checked 2h ago")
+    }
+
     // MARK: - The two click targets
 
     @Test("the untrack target says it removes the PR from THIS worktree")

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -134,7 +134,7 @@ struct StatusBarViewChipsTests {
         ]).chips[0]
     }
 
-    @Test("the overlay names the PR, its title, its state and the age of that reading")
+    @Test("the overlay's headline names the PR, its state and its title on one line")
     func overlayWithTitle() {
         let now = Date(timeIntervalSince1970: 1_700_007_200)
         let card = StatusBarView.chipHoverCard(
@@ -142,29 +142,46 @@ struct StatusBarViewChipsTests {
                  title: "Fix the login timeout",
                  observedAt: now.addingTimeInterval(-7200)),
             now: now)
-        #expect(card.title == "Fix the login timeout")
-        #expect(card.rows.contains { $0.label == "PR" && $0.value == "#412" })
-        let state = card.rows.first { $0.label == "State" }
-        #expect(state?.value == PRMergeableState.checksFailed.displayReason)
-        // The age rides with the state — a display-tier cache is never rendered
-        // as current truth. Shared wording with the toolbar and sidebar.
-        #expect(state?.caption == "checked 2h ago")
-        #expect(state?.caption == PRFreshness.checkedLabel(
+        #expect(card.title == "PR#412 (\(PRMergeableState.checksFailed.displayReason))"
+                + " - Fix the login timeout")
+        // No labelled grid: the three facts are the headline, and the only row
+        // left is the one naming the click.
+        #expect(card.rows.count == 1)
+        #expect(card.rows.allSatisfy { $0.label == nil })
+        // The age rides under the headline — a display-tier cache is never
+        // rendered as current truth. Shared wording with the toolbar and sidebar.
+        #expect(card.titleCaption == "checked 2h ago")
+        #expect(card.titleCaption == PRFreshness.checkedLabel(
             observedAt: now.addingTimeInterval(-7200), now: now))
     }
 
-    @Test("a chip with no observed title renders no title line, not a placeholder")
-    func overlayWithoutTitle() {
-        let card = StatusBarView.chipHoverCard(chip(title: nil))
-        #expect(card.title == nil)
-        // The number and state are still worth showing.
-        #expect(card.rows.contains { $0.label == "PR" && $0.value == "#412" })
-        #expect(card.rows.contains { $0.label == "State" })
+    /// Every part of the headline but the number is optional, and an absent one
+    /// is *omitted* rather than filled: no empty `()`, and no dangling ` - `.
+    @Test("the headline degrades to whichever of state and title were observed")
+    func headlineDegradesByOmission() {
+        let state = PRMergeableState.merged.displayReason
+        #expect(StatusBarView.chipHeadline(
+            chip(state: .merged, title: "Relay the GitHub event"))
+            == "PR#412 (\(state)) - Relay the GitHub event")
+        #expect(StatusBarView.chipHeadline(chip(state: .merged, title: nil))
+                == "PR#412 (\(state))")
+        #expect(StatusBarView.chipHeadline(chip(state: nil, title: "Relay the GitHub event"))
+                == "PR#412 - Relay the GitHub event")
+        #expect(StatusBarView.chipHeadline(chip(state: nil, title: nil)) == "PR#412")
+        // …and no combination leaves a separator with nothing after it.
+        for headline in [StatusBarView.chipHeadline(chip(state: .merged, title: nil)),
+                         StatusBarView.chipHeadline(chip(state: nil, title: nil)),
+                         StatusBarView.chipHeadline(chip(state: nil, title: "x"))] {
+            #expect(headline.hasSuffix(" - ") == false)
+            #expect(headline.contains("()") == false)
+        }
     }
 
     @Test("a whitespace-only title counts as absent")
     func overlayBlankTitle() {
-        #expect(StatusBarView.chipHoverCard(chip(title: "   \n")).title == nil)
+        let card = StatusBarView.chipHoverCard(chip(state: nil, title: "   \n"))
+        #expect(card.title == "PR#412")
+        #expect(card.title?.contains("-") == false)
     }
 
     /// The overflow menu and the toolbar dropdown render `reason ?? state`, so
@@ -180,9 +197,9 @@ struct StatusBarViewChipsTests {
             source: .hook)
         let chip = StatusBarView.prChips([binding]).chips[0]
 
-        let value = StatusBarView.chipHoverCard(chip).rows.first { $0.label == "State" }?.value
-        #expect(value == "Changes requested by reviewer")
-        #expect(value != PRMergeableState.blocked.displayReason)
+        let headline = StatusBarView.chipHeadline(chip)
+        #expect(headline == "PR#412 (Changes requested by reviewer)")
+        #expect(headline.contains(PRMergeableState.blocked.displayReason) == false)
         // …and it is the same string the overflow menu row is built from.
         #expect(PRBindingPresentation.menuRows([binding])[0].title
             .contains("Changes requested by reviewer"))
@@ -195,10 +212,11 @@ struct StatusBarViewChipsTests {
     @Test("a chip with no observed status still gets a number, and says the age is unknown")
     func overlayWithoutStatus() {
         let card = StatusBarView.chipHoverCard(chip(state: nil, observedAt: nil))
-        #expect(card.rows.contains { $0.label == "PR" && $0.value == "#412" })
-        let state = card.rows.first { $0.label == "State" }
-        #expect(state?.value == StatusBarView.unobservedStateValue)
-        #expect(state?.caption == PRFreshness.checkedLabel(observedAt: nil, now: Date()))
+        #expect(card.title == "PR#412")
+        // A missing stamp is an unknown check time rather than silence — the
+        // card never renders a state, or the absence of one, without its age.
+        #expect(card.titleCaption == PRFreshness.checkedLabel(observedAt: nil, now: Date()))
+        #expect(card.titleCaption == "last checked at an unknown time")
     }
 
     /// The toolbar and sidebar both append "last check did not resolve" after
@@ -213,8 +231,7 @@ struct StatusBarViewChipsTests {
         let model = StatusBarView.prChips(
             [binding(412, .mergeable, observedAt: observed)], observation: observation)
 
-        let caption = StatusBarView.chipHoverCard(model.chips[0], now: now)
-            .rows.first { $0.label == "State" }?.caption
+        let caption = StatusBarView.chipHoverCard(model.chips[0], now: now).titleCaption
         #expect(caption == "checked 2h ago · last check did not resolve (gh unauthenticated)")
 
         // A settled attempt adds nothing — the clause is a caveat, not a field.
@@ -222,7 +239,7 @@ struct StatusBarViewChipsTests {
             [binding(412, .mergeable, observedAt: observed)],
             observation: PRObservation(outcome: .none, observedAt: observed))
         #expect(StatusBarView.chipHoverCard(settled.chips[0], now: now)
-            .rows.first { $0.label == "State" }?.caption == "checked 2h ago")
+            .titleCaption == "checked 2h ago")
     }
 
     // MARK: - The two click targets
@@ -302,15 +319,14 @@ struct StatusBarViewChipsTests {
         let open = StatusBarView.chipHoverCard(one, untrackTarget: false, now: now)
         let untrack = StatusBarView.chipHoverCard(one, untrackTarget: true, now: now)
 
+        // The headline and its age are untouched…
         #expect(open.title == untrack.title)
+        #expect(open.titleCaption == untrack.titleCaption)
+        #expect(open.titleCaption == "checked 2h ago")
         #expect(open.rows.count == untrack.rows.count)
-        #expect(open.rows.count == 3)
-        // The PR row, the state row and its age are untouched…
-        #expect(open.rows[0] == untrack.rows[0])
-        #expect(open.rows[1] == untrack.rows[1])
-        #expect(open.rows[1].caption == "checked 2h ago")
-        // …and the action row is the last one in both, never inserted midway.
-        #expect(open.rows[2].value != untrack.rows[2].value)
+        #expect(open.rows.count == 1)
+        // …and only the action row's sentence differs.
+        #expect(open.rows[0].value != untrack.rows[0].value)
         // The card is re-rendered on model INEQUALITY, so the swap only reaches
         // the screen because the two models genuinely differ.
         #expect(open != untrack)
@@ -329,10 +345,9 @@ struct StatusBarViewChipsTests {
         // The reservation is worth having only because the two differ enough to
         // reflow — a peer equal to the value would be decoration.
         #expect(open?.value != untrack?.value)
-        // Nothing else on the card reserves an alternate, so no other row can
-        // resize either.
-        #expect(StatusBarView.chipHoverCard(chip()).rows.dropLast()
-            .allSatisfy { $0.alternateValue == nil })
+        // It is the card's only row, so the reservation covers every row that
+        // could resize it — the headline and its age do not swap.
+        #expect(StatusBarView.chipHoverCard(chip()).rows.count == 1)
     }
 
     @Test("the action line is a function of which target the pointer is on")
@@ -356,12 +371,11 @@ struct StatusBarViewChipsTests {
     @Test("a chip with no title and one with no status still say what a click does")
     func actionRowSurvivesAbsentFields() {
         let untitled = StatusBarView.chipHoverCard(chip(title: nil), untrackTarget: true)
-        #expect(untitled.title == nil)
+        #expect(untitled.title?.contains(" - ") == false)
         #expect(untitled.rows.last?.value == StatusBarView.chipUntrackActionValue)
 
         let unobserved = StatusBarView.chipHoverCard(chip(state: nil, observedAt: nil))
-        #expect(unobserved.rows.first { $0.label == "State" }?.value
-                == StatusBarView.unobservedStateValue)
+        #expect(unobserved.title == "PR#412")
         #expect(unobserved.rows.last?.value == StatusBarView.chipOpenActionValue)
         #expect(unobserved.rows.last?.alternateValue == StatusBarView.chipUntrackActionValue)
     }

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -167,6 +167,27 @@ struct StatusBarViewChipsTests {
         #expect(StatusBarView.chipHoverCard(chip(title: "   \n")).title == nil)
     }
 
+    /// The overflow menu and the toolbar dropdown render `reason ?? state`, so
+    /// the overlay has to as well — three surfaces describing one observation
+    /// differently is exactly what sharing the presentation exists to prevent.
+    @Test("the overlay prefers the status's own words to the generic state label")
+    func overlayPrefersTheStatusReason() {
+        let url = "https://github.com/acme/acme-prod/pull/412"
+        let binding = PRBinding(
+            worktreeID: UUID(), owner: "acme", repo: "acme-prod", number: 412, url: url,
+            status: PRStatus(number: 412, url: url, state: .blocked,
+                             reason: "Changes requested by reviewer"),
+            source: .hook)
+        let chip = StatusBarView.prChips([binding]).chips[0]
+
+        let value = StatusBarView.chipHoverCard(chip).rows.first { $0.label == "State" }?.value
+        #expect(value == "Changes requested by reviewer")
+        #expect(value != PRMergeableState.blocked.displayReason)
+        // …and it is the same string the overflow menu row is built from.
+        #expect(PRBindingPresentation.menuRows([binding])[0].title
+            .contains("Changes requested by reviewer"))
+    }
+
     @Test("a chip with no observed status still gets a number, and says the age is unknown")
     func overlayWithoutStatus() {
         let card = StatusBarView.chipHoverCard(chip(state: nil, observedAt: nil))

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -195,4 +195,22 @@ struct StatusBarViewChipsTests {
                 == "Open PR #412 — \(PRMergeableState.checksFailed.displayReason)")
         #expect(StatusBarView.openLabel(chip(state: nil)) == "Open PR #412")
     }
+
+    /// The icon slot draws a status dot at rest and an xmark while hovered, and
+    /// `onHover` is not guaranteed to have arrived — a chip can be inserted or
+    /// reflowed under a stationary cursor. So the slot's meaning is derived from
+    /// the same flag as its glyph: a click can never destroy an association the
+    /// slot is not currently offering to remove.
+    @Test("the icon slot means untrack only while hovered, and open otherwise")
+    func iconSlotMeaningFollowsTheGlyph() {
+        let one = chip(state: .checksFailed)
+        #expect(StatusBarView.iconSlotLabel(one, isHovering: true)
+                == StatusBarView.untrackLabel(one))
+        // Not hovering: the slot is a status dot, and clicking a status dot
+        // opens the PR exactly as it did before the untrack gesture existed.
+        #expect(StatusBarView.iconSlotLabel(one, isHovering: false)
+                == StatusBarView.openLabel(one))
+        #expect(StatusBarView.iconSlotLabel(one, isHovering: true)
+                != StatusBarView.iconSlotLabel(one, isHovering: false))
+    }
 }

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -262,4 +262,107 @@ struct StatusBarViewChipsTests {
         #expect(StatusBarView.iconSlotLabel(one, isHovering: true)
                 != StatusBarView.iconSlotLabel(one, isHovering: false))
     }
+
+    // MARK: - Naming the click under the pointer
+
+    /// The chip packs two click targets into about twenty points, and the
+    /// tooltip that would have distinguished them loses a race it cannot win:
+    /// the macOS help-tag delay is longer than the card's 0.55s floor, so the
+    /// card is already up by the time a tag would appear. The card therefore
+    /// has to say it itself.
+    @Test("the overlay names the untrack gesture while the pointer is on the xmark")
+    func overlayNamesTheUntrackAction() {
+        let card = StatusBarView.chipHoverCard(chip(title: "Fix the login timeout"),
+                                               untrackTarget: true)
+        #expect(card.rows.last?.value == "Click to stop tracking this PR in this worktree")
+        // It names the worktree scope for the same reason `untrackLabel` does:
+        // the gesture removes an association, not the pull request.
+        #expect(card.rows.last?.value.contains("this worktree") == true)
+    }
+
+    @Test("the overlay names the open gesture anywhere else on the chip")
+    func overlayNamesTheOpenAction() {
+        let card = StatusBarView.chipHoverCard(chip(title: "Fix the login timeout"))
+        #expect(card.rows.last?.value == "Click to open this PR on GitHub")
+        // Default: a chip is an open target until the pointer reaches the slot.
+        #expect(card.rows.last?.value
+                == StatusBarView.chipHoverCard(chip(title: "Fix the login timeout"),
+                                               untrackTarget: false).rows.last?.value)
+    }
+
+    /// A row that appeared and disappeared would resize the card under the
+    /// pointer — the jitter this line exists to cure. So the row is always
+    /// there, in the same place, and only its sentence swaps.
+    @Test("only the action row's text differs between the two states")
+    func onlyTheActionRowDiffers() {
+        let now = Date(timeIntervalSince1970: 1_700_007_200)
+        let one = chip(state: .checksFailed,
+                       title: "Fix the login timeout",
+                       observedAt: now.addingTimeInterval(-7200))
+        let open = StatusBarView.chipHoverCard(one, untrackTarget: false, now: now)
+        let untrack = StatusBarView.chipHoverCard(one, untrackTarget: true, now: now)
+
+        #expect(open.title == untrack.title)
+        #expect(open.rows.count == untrack.rows.count)
+        #expect(open.rows.count == 3)
+        // The PR row, the state row and its age are untouched…
+        #expect(open.rows[0] == untrack.rows[0])
+        #expect(open.rows[1] == untrack.rows[1])
+        #expect(open.rows[1].caption == "checked 2h ago")
+        // …and the action row is the last one in both, never inserted midway.
+        #expect(open.rows[2].value != untrack.rows[2].value)
+        // The card is re-rendered on model INEQUALITY, so the swap only reaches
+        // the screen because the two models genuinely differ.
+        #expect(open != untrack)
+    }
+
+    /// The card is sized to fit its content, so two sentences of different
+    /// length would resize it as the pointer crossed onto the slot. Each state
+    /// carries the other sentence as a laid-out-but-hidden peer, which pins the
+    /// row — and therefore the card — to the larger of the two in both axes.
+    @Test("each action row reserves room for the sentence it can swap to")
+    func actionRowReservesBothSentences() {
+        let open = StatusBarView.chipHoverCard(chip()).rows.last
+        let untrack = StatusBarView.chipHoverCard(chip(), untrackTarget: true).rows.last
+        #expect(open?.alternateValue == untrack?.value)
+        #expect(untrack?.alternateValue == open?.value)
+        // The reservation is worth having only because the two differ enough to
+        // reflow — a peer equal to the value would be decoration.
+        #expect(open?.value != untrack?.value)
+        // Nothing else on the card reserves an alternate, so no other row can
+        // resize either.
+        #expect(StatusBarView.chipHoverCard(chip()).rows.dropLast()
+            .allSatisfy { $0.alternateValue == nil })
+    }
+
+    @Test("the action line is a function of which target the pointer is on")
+    func chipActionValueFollowsTheTarget() {
+        #expect(StatusBarView.chipActionValue(untrackTarget: true)
+                == StatusBarView.chipUntrackActionValue)
+        #expect(StatusBarView.chipActionValue(untrackTarget: false)
+                == StatusBarView.chipOpenActionValue)
+        #expect(StatusBarView.chipActionValue(untrackTarget: true)
+                != StatusBarView.chipActionValue(untrackTarget: false))
+        // Both describe the click rather than restating the PR's number or
+        // state, which the rows above them already carry.
+        #expect(StatusBarView.chipOpenActionValue.hasPrefix("Click to"))
+        #expect(StatusBarView.chipUntrackActionValue.hasPrefix("Click to"))
+        #expect(StatusBarView.chipOpenActionValue.contains("#412") == false)
+    }
+
+    /// A synthetic chip has no title and a never-polled one has no status, and
+    /// both are still clickable — the line that says what the click does cannot
+    /// be a passenger of the rows that happen to be missing.
+    @Test("a chip with no title and one with no status still say what a click does")
+    func actionRowSurvivesAbsentFields() {
+        let untitled = StatusBarView.chipHoverCard(chip(title: nil), untrackTarget: true)
+        #expect(untitled.title == nil)
+        #expect(untitled.rows.last?.value == StatusBarView.chipUntrackActionValue)
+
+        let unobserved = StatusBarView.chipHoverCard(chip(state: nil, observedAt: nil))
+        #expect(unobserved.rows.first { $0.label == "State" }?.value
+                == StatusBarView.unobservedStateValue)
+        #expect(unobserved.rows.last?.value == StatusBarView.chipOpenActionValue)
+        #expect(unobserved.rows.last?.alternateValue == StatusBarView.chipUntrackActionValue)
+    }
 }

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -416,6 +416,71 @@ struct StatusBarViewChipsTests {
                 == "Click to stop tracking this PR in this worktree")
     }
 
+    /// The headline is the card's own name for the request, so it speaks the
+    /// chip's forge like every other sentence on the card. It read `PR#412`
+    /// under a GitLab chip whose action row, one line below, offered to open
+    /// that same request on GitLab — the card contradicting itself twice in
+    /// three lines, on the surface built so a user need not open a browser to
+    /// tell which change a chip is.
+    ///
+    /// The noun is glued to the number the chip is already drawing, which is
+    /// the bare `#412` on both forges — hence `refNoun` and not `refLabel`,
+    /// whose `!412` would disagree with the chip under the pointer.
+    @Test("the headline names the request in its own forge's vocabulary")
+    func headlineSpeaksTheChipsForge() {
+        let state = PRMergeableState.mergeable.displayReason
+        #expect(StatusBarView.chipHeadline(chip()) == "PR#412 (\(state))")
+        #expect(StatusBarView.chipHeadline(gitlabChip()) == "MR#412 (\(state))")
+
+        // Every degradation arm carries the noun too: a chip with neither state
+        // nor title is the shortest headline there is, and still not a "PR".
+        #expect(StatusBarView.chipHeadline(gitlabChip(state: nil)) == "MR#412")
+        #expect(StatusBarView.chipHeadline(gitlabChip(state: nil, title: "Trim the relay"))
+                == "MR#412 - Trim the relay")
+        #expect(StatusBarView.chipHeadline(gitlabChip(state: .merged, title: "Trim the relay"))
+                == "MR#412 (\(PRMergeableState.merged.displayReason)) - Trim the relay")
+
+        // The card renders that headline rather than composing its own, and the
+        // whole card speaks ONE forge — no headline may say "PR" over an action
+        // row that says "GitLab", which is the defect this pins.
+        let mr = gitlabChip(title: "Trim the relay")
+        let card = StatusBarView.chipHoverCard(mr)
+        #expect(card.title == StatusBarView.chipHeadline(mr))
+        #expect(card.title?.contains("PR") == false)
+        #expect(card.rows.last?.value.contains("GitLab") == true)
+    }
+
+    /// The chip itself draws the bare number on both forges, so the number
+    /// element's accessibility label — what `PRChipView` passes as
+    /// `chip.refLabel` — is where a screen reader learns which forge this is.
+    /// It was a hardcoded `PR #412` for every chip.
+    @Test("the number element announces the binding in its forge's vocabulary")
+    func numberElementAnnouncesItsForge() {
+        #expect(chip().refLabel == "PR #412")
+        #expect(gitlabChip().refLabel == "MR !412")
+        // The hint on the same element composes that value, so the element
+        // cannot announce one forge and hint another.
+        #expect(StatusBarView.openLabel(gitlabChip()).contains(gitlabChip().refLabel))
+    }
+
+    /// Both click targets already composed `refLabel`; this pins that they do,
+    /// because every earlier round of this defect fixed one surface and left
+    /// the next one asserting only GitHub.
+    @Test("both click targets name a merge request the way GitLab does")
+    func clickTargetLabelsSpeakGitLab() {
+        let mr = gitlabChip(state: .checksFailed)
+        let untrack = StatusBarView.untrackLabel(mr)
+        let open = StatusBarView.openLabel(mr)
+        #expect(untrack == "Stop tracking MR !412 in this worktree")
+        #expect(open == "Open MR !412 — \(PRMergeableState.checksFailed.displayReason)")
+        #expect(StatusBarView.iconSlotLabel(mr, isHovering: true) == untrack)
+        #expect(StatusBarView.iconSlotLabel(mr, isHovering: false) == open)
+        for label in [untrack, open] {
+            #expect(label.contains(Forge.github.refNoun) == false)
+            #expect(label.contains("#412") == false)
+        }
+    }
+
     @Test("a GitLab chip's action row says MR and GitLab")
     func actionRowSpeaksGitLab() {
         let mr = gitlabChip()

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -186,6 +186,10 @@ struct StatusBarViewChipsTests {
         // …and it is the same string the overflow menu row is built from.
         #expect(PRBindingPresentation.menuRows([binding])[0].title
             .contains("Changes requested by reviewer"))
+        // …and the tooltip and VoiceOver hint beside the card agree with it,
+        // rather than falling back to the generic state label.
+        #expect(StatusBarView.openLabel(chip)
+            == "Open PR #412 — Changes requested by reviewer")
     }
 
     @Test("a chip with no observed status still gets a number, and says the age is unknown")

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -134,6 +134,27 @@ struct StatusBarViewChipsTests {
         ]).chips[0]
     }
 
+    /// The same chip bound to a GitLab merge request instead — built through
+    /// `prChips` like every other fixture here, so the forge is read from the
+    /// binding's own URL exactly as production reads it.
+    private func gitlabChip(
+        number: Int = 412,
+        state: PRMergeableState? = .mergeable,
+        title: String? = nil
+    ) -> StatusBarView.PRChip {
+        let url = "https://gitlab.acme.example/acme/group/acme-prod/-/merge_requests/\(number)"
+        return StatusBarView.prChips([
+            PRBinding(
+                worktreeID: UUID(), host: "gitlab.acme.example",
+                owner: "acme/group", repo: "acme-prod",
+                number: number, url: url,
+                title: title,
+                status: state.map { PRStatus(number: number, url: url, state: $0) },
+                source: .hook
+            )
+        ]).chips[0]
+    }
+
     @Test("the overlay's headline names the PR, its state and its title on one line")
     func overlayWithTitle() {
         let now = Date(timeIntervalSince1970: 1_700_007_200)
@@ -352,17 +373,17 @@ struct StatusBarViewChipsTests {
 
     @Test("the action line is a function of which target the pointer is on")
     func chipActionValueFollowsTheTarget() {
-        #expect(StatusBarView.chipActionValue(untrackTarget: true)
-                == StatusBarView.chipUntrackActionValue)
-        #expect(StatusBarView.chipActionValue(untrackTarget: false)
-                == StatusBarView.chipOpenActionValue)
-        #expect(StatusBarView.chipActionValue(untrackTarget: true)
-                != StatusBarView.chipActionValue(untrackTarget: false))
+        #expect(StatusBarView.chipActionValue(untrackTarget: true, forge: .github)
+                == StatusBarView.chipUntrackActionValue(.github))
+        #expect(StatusBarView.chipActionValue(untrackTarget: false, forge: .github)
+                == StatusBarView.chipOpenActionValue(.github))
+        #expect(StatusBarView.chipActionValue(untrackTarget: true, forge: .github)
+                != StatusBarView.chipActionValue(untrackTarget: false, forge: .github))
         // Both describe the click rather than restating the PR's number or
         // state, which the rows above them already carry.
-        #expect(StatusBarView.chipOpenActionValue.hasPrefix("Click to"))
-        #expect(StatusBarView.chipUntrackActionValue.hasPrefix("Click to"))
-        #expect(StatusBarView.chipOpenActionValue.contains("#412") == false)
+        #expect(StatusBarView.chipOpenActionValue(.github).hasPrefix("Click to"))
+        #expect(StatusBarView.chipUntrackActionValue(.github).hasPrefix("Click to"))
+        #expect(StatusBarView.chipOpenActionValue(.github).contains("#412") == false)
     }
 
     /// A synthetic chip has no title and a never-polled one has no status, and
@@ -372,11 +393,61 @@ struct StatusBarViewChipsTests {
     func actionRowSurvivesAbsentFields() {
         let untitled = StatusBarView.chipHoverCard(chip(title: nil), untrackTarget: true)
         #expect(untitled.title?.contains(" - ") == false)
-        #expect(untitled.rows.last?.value == StatusBarView.chipUntrackActionValue)
+        #expect(untitled.rows.last?.value == StatusBarView.chipUntrackActionValue(.github))
 
         let unobserved = StatusBarView.chipHoverCard(chip(state: nil, observedAt: nil))
         #expect(unobserved.title == "PR#412")
-        #expect(unobserved.rows.last?.value == StatusBarView.chipOpenActionValue)
-        #expect(unobserved.rows.last?.alternateValue == StatusBarView.chipUntrackActionValue)
+        #expect(unobserved.rows.last?.value == StatusBarView.chipOpenActionValue(.github))
+        #expect(unobserved.rows.last?.alternateValue
+                == StatusBarView.chipUntrackActionValue(.github))
+    }
+
+    // MARK: - Forge vocabulary
+
+    /// The card's action row names the request the way its own forge does. It
+    /// is the last chip surface that did not: the tooltip and the accessibility
+    /// label already read `MR !412` for a merge request, and a card beside them
+    /// promising to "open this PR on GitHub" would be plainly false.
+    @Test("a GitHub chip's action row says PR and GitHub")
+    func actionRowSpeaksGitHub() {
+        let card = StatusBarView.chipHoverCard(chip())
+        #expect(card.rows.last?.value == "Click to open this PR on GitHub")
+        #expect(StatusBarView.chipHoverCard(chip(), untrackTarget: true).rows.last?.value
+                == "Click to stop tracking this PR in this worktree")
+    }
+
+    @Test("a GitLab chip's action row says MR and GitLab")
+    func actionRowSpeaksGitLab() {
+        let mr = gitlabChip()
+        #expect(mr.forge == .gitlab)
+        #expect(mr.refLabel == "MR !412")
+        let card = StatusBarView.chipHoverCard(mr)
+        #expect(card.rows.last?.value == "Click to open this MR on GitLab")
+        #expect(StatusBarView.chipHoverCard(mr, untrackTarget: true).rows.last?.value
+                == "Click to stop tracking this MR in this worktree")
+        // The vocabulary is the forge's own, not a second table beside it.
+        #expect(card.rows.last?.value.contains(Forge.gitlab.refNoun) == true)
+        #expect(card.rows.last?.value.contains("GitHub") == false)
+    }
+
+    /// The reservation is per chip, and a chip has exactly one forge, so the
+    /// hidden peer is the other sentence *for that same forge* — the pair a
+    /// pointer can actually swap between. Asserted on both forges because a
+    /// mechanism that reserved GitHub's wording under a GitLab chip would still
+    /// pin a width, just the wrong one.
+    @Test("the width reservation still pairs the two sentences of one forge")
+    func reservationHoldsPerForge() {
+        for target in [chip(), gitlabChip()] {
+            let open = StatusBarView.chipHoverCard(target).rows.last
+            let untrack = StatusBarView.chipHoverCard(target, untrackTarget: true).rows.last
+            #expect(open?.alternateValue == untrack?.value)
+            #expect(untrack?.alternateValue == open?.value)
+            #expect(open?.value != untrack?.value)
+            // Both halves speak the chip's own forge — neither the visible
+            // sentence nor its hidden peer borrows the other forge's noun.
+            #expect(open?.value.contains(target.forge.refNoun) == true)
+            #expect(open?.alternateValue?.contains(target.forge.refNoun) == true)
+            #expect(StatusBarView.chipHoverCard(target).rows.count == 1)
+        }
     }
 }

--- a/Tests/TBDDaemonTests/GitLabQueriesTests.swift
+++ b/Tests/TBDDaemonTests/GitLabQueriesTests.swift
@@ -8,7 +8,7 @@ struct GitLabQueriesTests {
 
     /// The exact GraphQL field set every merge-request query may ask for.
     static let expectedNodeFields =
-        "iid state draft detailedMergeStatus sourceBranch targetBranch createdAt webUrl "
+        "iid state draft title detailedMergeStatus sourceBranch targetBranch createdAt webUrl "
         + "headPipeline { status }"
 
     /// Runs of whitespace collapsed to one space, so a query pin survives
@@ -65,6 +65,7 @@ struct GitLabQueriesTests {
 
     static let oneNode = """
     {"iid":"412","state":"opened","draft":false,
+     "title":"Rate-limit the ingest queue",
      "detailedMergeStatus":"NOT_APPROVED",
      "sourceBranch":"feat/x","targetBranch":"main",
      "createdAt":"2026-08-01T10:00:00Z",
@@ -111,7 +112,20 @@ struct GitLabQueriesTests {
         #expect(n.headRefName == "feat/x")
         #expect(n.baseRefName == "main")
         #expect(n.statusCheckRollupState == "SUCCESS")
+        #expect(n.title == "Rate-limit the ingest queue")
         #expect(n.url.hasSuffix("/-/merge_requests/412"))
+    }
+
+    /// An instance that answers without a title must leave the stored one
+    /// alone rather than blank it — the same nil-means-unobserved contract the
+    /// `gh` parser keeps.
+    @Test("a node with no title parses, reporting the title as unobserved")
+    func missingTitleIsUnobserved() throws {
+        let node = Self.oneNode.replacingOccurrences(
+            of: #""title":"Rate-limit the ingest queue","#, with: "")
+        let (nodes, _) = try #require(Self.answered(Self.response(node)))
+        #expect(nodes.count == 1)
+        #expect(nodes[0].title == nil)
     }
 
     @Test("a null headPipeline yields a nil rollup state rather than dropping the node")

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -355,6 +355,24 @@ struct PRBindingCoordinatorTests {
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
     }
 
+    /// The scenario insert-on-miss exists for, and the one the guard must not
+    /// swallow: `resolveRepo` is `gh repo view` behind a cache, so it answers
+    /// nil exactly when `gh` is unauthenticated or offline — the same condition
+    /// that leaves the bindings table empty and makes the synthetic chip the
+    /// only PR on screen. An unresolved repo is not a mismatch.
+    @Test("detaching an unbound PR still tombstones when the repo cannot be resolved")
+    func detachTombstonesWhenRepoIsUnresolved() async throws {
+        let fixture = try await Fixture(repo: nil)
+        let wt = try await fixture.newWorktree()
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed))
+
+        let recorded = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+        #expect(recorded.count == 1)
+        #expect(recorded.first?.detached == true)
+        #expect(recorded.first?.source == .manual)
+    }
+
     /// The guard covers creation, not modification. A row that already exists
     /// is this worktree's own record of the PR, and detaching it must work
     /// whatever the repo resolves to now — otherwise a repo rename would strand

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -23,7 +23,8 @@ struct PRBindingCoordinatorTests {
         ///   worktree's forge at all.
         init(repo: (owner: String, name: String, host: String)? =
             ("acme", "acme-prod", "github.com"),
-             gitLabHosts: Set<String>? = []) async throws {
+             gitLabHosts: Set<String>? = [],
+             cachedPRNumber: Int? = nil) async throws {
             db = try TBDDatabase(inMemory: true)
             let created = try await db.repos.create(
                 path: "/tmp/prbinding-coord-repo-\(UUID().uuidString)",
@@ -32,7 +33,8 @@ struct PRBindingCoordinatorTests {
             store = db.prBindings
             coordinator = PRBindingCoordinator(
                 store: store, resolveRepo: { _ in repo },
-                isGitLabHost: { _, host in gitLabHosts.map { $0.contains(host.lowercased()) } })
+                isGitLabHost: { _, host in gitLabHosts.map { $0.contains(host.lowercased()) } },
+                cachedPRNumber: { _ in cachedPRNumber })
         }
 
         func newWorktree() async throws -> UUID {
@@ -359,10 +361,12 @@ struct PRBindingCoordinatorTests {
     /// swallow: `resolveRepo` is `gh repo view` behind a cache, so it answers
     /// nil exactly when `gh` is unauthenticated or offline — the same condition
     /// that leaves the bindings table empty and makes the synthetic chip the
-    /// only PR on screen. An unresolved repo is not a mismatch.
-    @Test("detaching an unbound PR still tombstones when the repo cannot be resolved")
-    func detachTombstonesWhenRepoIsUnresolved() async throws {
-        let fixture = try await Fixture(repo: nil)
+    /// only PR on screen. With no repo to check against, the worktree's cached
+    /// status is the evidence that decides it, and a synthetic chip is built
+    /// from exactly that status.
+    @Test("detaching the cached PR still tombstones when the repo cannot be resolved")
+    func detachTombstonesTheCachedPRWhenRepoIsUnresolved() async throws {
+        let fixture = try await Fixture(repo: nil, cachedPRNumber: 412)
         let wt = try await fixture.newWorktree()
 
         #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed))
@@ -371,6 +375,30 @@ struct PRBindingCoordinatorTests {
         #expect(recorded.count == 1)
         #expect(recorded.first?.detached == true)
         #expect(recorded.first?.source == .manual)
+    }
+
+    /// …but an unresolved repo must not become a licence to tombstone anything.
+    /// A tombstone for a PR in another repo is permanent — `pr.attach` rejects
+    /// the reference before it reaches the row — so with no repo to check
+    /// against and nothing tying the PR to this worktree, nothing is written.
+    @Test("an unresolved repo does not license tombstoning an unrelated PR")
+    func detachDeclinesAnUncorroboratedPRWhenRepoIsUnresolved() async throws {
+        let fixture = try await Fixture(repo: nil, cachedPRNumber: 999)
+        let wt = try await fixture.newWorktree()
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed) == false)
+
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+    }
+
+    @Test("an unresolved repo with no cached status writes nothing")
+    func detachDeclinesWhenNoEvidenceAtAll() async throws {
+        let fixture = try await Fixture(repo: nil)
+        let wt = try await fixture.newWorktree()
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed) == false)
+
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
     }
 
     /// The guard covers creation, not modification. A row that already exists

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -336,6 +336,43 @@ struct PRBindingCoordinatorTests {
         #expect(recorded.first?.source == .hook)
     }
 
+    /// A tombstone for a PR outside the worktree's own repo would be permanent:
+    /// `bind` rejects a wrong-repo reference before it ever reaches the row, so
+    /// `pr.attach` could not clear it, and the `detachedCount` it leaves
+    /// suppresses the legacy-status fallback for that worktree forever. So the
+    /// insert arm carries the same repo guard `bind` does — one mistyped
+    /// `tbd pr detach <other-repo-url>` must not retire a worktree's real PR
+    /// indicator with no way back.
+    @Test("detaching an unbound PR from another repo records nothing")
+    func detachDoesNotTombstoneAForeignUnboundPR() async throws {
+        let fixture = try await Fixture(repo: ("acme", "other-repo"))
+        let wt = try await fixture.newWorktree()
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed) == false)
+
+        // Nothing written at all — in particular no tombstone, so detachedCount
+        // stays zero and the legacy-status fallback keeps working.
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+    }
+
+    /// The guard covers creation, not modification. A row that already exists
+    /// is this worktree's own record of the PR, and detaching it must work
+    /// whatever the repo resolves to now — otherwise a repo rename would strand
+    /// every binding made before it.
+    @Test("detaching an existing row works even when the repo no longer matches")
+    func detachTombstonesAnExistingRowRegardlessOfRepo() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        _ = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
+
+        let renamed = PRBindingCoordinator(store: fixture.store,
+                                           resolveRepo: { _ in ("acme", "renamed-repo") })
+        #expect(try await renamed.detach(worktreeID: wt, parsed: parsed))
+
+        #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
+    }
+
     /// The gesture stays reversible whichever way the tombstone got there.
     @Test("a manual attach clears a tombstone that insert-on-miss created")
     func attachClearsAnInsertedTombstone() async throws {

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -442,6 +442,136 @@ struct PRBindingCoordinatorTests {
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
     }
 
+    /// The insert arm carries `bind`'s HOST check too, not just its
+    /// `owner`/`name` one, and this is the asymmetry that makes it mandatory:
+    /// `pr.attach` refuses a reference whose host disagrees, so a tombstone
+    /// minted for one could never be cleared by anything, and the
+    /// `detachedCount` it raises suppresses the worktree's legacy-status
+    /// fallback for good.
+    ///
+    /// Both rows are same-owner/same-name across two hosts — the collision the
+    /// forge work exists to keep apart — and neither worktree has a row for the
+    /// PR being detached.
+    ///
+    /// Against the gate as it stood, both wrote a permanent tombstone.
+    @Test("detaching an unbound PR from another host records nothing")
+    func detachDoesNotTombstoneAPRFromAnotherHost() async throws {
+        let cases: [(own: (owner: String, name: String, host: String),
+                     gitLabHosts: Set<String>, url: String)] = [
+            // A GitLab worktree handed a github.com pull request: the exemption
+            // for the extractor's hard-coded host stops here, exactly as it does
+            // in `bind`.
+            (("acme", "acme-prod", "gitlab.acme.example"), ["gitlab.acme.example"],
+             "https://github.com/acme/acme-prod/pull/412"),
+            // …and the mirror image, where the URL carries its own captured host
+            // and no forge question is asked at all.
+            (("acme", "acme-prod", "github.com"), [],
+             "https://git.acme.example/acme/acme-prod/-/merge_requests/412"),
+        ]
+        for testCase in cases {
+            let fixture = try await Fixture(repo: testCase.own,
+                                            gitLabHosts: testCase.gitLabHosts)
+            let wt = try await fixture.newWorktree()
+            let parsed = try parseOne(testCase.url)
+
+            #expect(try await fixture.coordinator.detach(worktreeID: wt,
+                                                         parsed: parsed) == false,
+                    "expected no change for \(testCase.url)")
+
+            #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty,
+                    "expected nothing recorded for \(testCase.url)")
+        }
+    }
+
+    /// An undetermined forge declines too. A deferral costs the user one
+    /// repeated `tbd pr detach`; a tombstone `pr.attach` cannot clear costs them
+    /// the worktree's PR indicator permanently.
+    @Test("detaching an unbound PR declines when the checkout's forge is unknown")
+    func detachDeclinesWhenForgeUndetermined() async throws {
+        let fixture = try await Fixture(repo: ("acme", "acme-prod", "git.acme.example"),
+                                        gitLabHosts: nil)
+        let wt = try await fixture.newWorktree()
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed) == false)
+
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+    }
+
+    /// The other half of sharing `bind`'s check: it must not tighten what `bind`
+    /// allows. A GitHub Enterprise or mirror checkout takes a `github.com` URL
+    /// there — the extractor stamps that host as a constant rather than reading
+    /// it — so the xmark on such a worktree still has to work.
+    @Test("still tombstones a github.com URL on an enterprise or mirror checkout")
+    func detachTombstonesGitHubURLOnAnotherHostCheckout() async throws {
+        for host in ["ghe.acme.example", "git.acme.example"] {
+            let fixture = try await Fixture(repo: ("acme", "acme-prod", host))
+            let wt = try await fixture.newWorktree()
+
+            #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed),
+                    "expected a tombstone on \(host)")
+
+            let recorded = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+            #expect(recorded.count == 1, "expected one row on \(host)")
+            #expect(recorded.first?.detached == true)
+        }
+    }
+
+    /// The offline path is the same rule against the same helper. `resolveRepo`
+    /// answers nil when `gh` is gone, and the cached `Worktree.prStatus` is then
+    /// the only record of this worktree's PRs — including of the host it is on.
+    /// Owner, repo and number all agree in both rows below; only the host does
+    /// not, and that is enough.
+    @Test("an unresolved repo does not license tombstoning a PR from another host")
+    func detachDeclinesAForeignHostPRWhenRepoIsUnresolved() async throws {
+        let cases: [(cached: String, detachURL: String, gitLabHosts: Set<String>)] = [
+            // Cached MR on GitLab, detach aimed at github.com: the exemption is
+            // consulted and refused, because this worktree's forge speaks GitLab.
+            ("https://git.acme.example/acme/acme-prod/-/merge_requests/412",
+             "https://github.com/acme/acme-prod/pull/412", ["git.acme.example"]),
+            // Cached PR on github.com, detach aimed at a GitLab MR: two hosts,
+            // neither of them the extractor's constant, so no question is asked.
+            ("https://github.com/acme/acme-prod/pull/412",
+             "https://git.acme.example/acme/acme-prod/-/merge_requests/412", []),
+        ]
+        for testCase in cases {
+            let fixture = try await Fixture(repo: nil, gitLabHosts: testCase.gitLabHosts,
+                                            cachedPRURL: testCase.cached)
+            let wt = try await fixture.newWorktree()
+            let parsed = try parseOne(testCase.detachURL)
+
+            #expect(try await fixture.coordinator.detach(worktreeID: wt,
+                                                         parsed: parsed) == false,
+                    "expected no change for \(testCase.detachURL)")
+
+            #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty,
+                    "expected nothing recorded for \(testCase.detachURL)")
+        }
+    }
+
+    /// …and the gate is on CREATION only, on the host axis exactly as on the
+    /// repo axis. A row that already exists is this worktree's own record; a
+    /// remote moved to another forge — or a resolver that starts reporting a
+    /// different host — must not strand it.
+    @Test("detaching an existing row works even when the host no longer agrees")
+    func detachTombstonesAnExistingRowRegardlessOfHost() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        _ = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
+
+        let moved = PRBindingCoordinator(
+            store: fixture.store,
+            resolveRepo: { _ in ("acme", "acme-prod", "gitlab.acme.example") },
+            isGitLabHost: { _, _ in true })
+        #expect(try await moved.detach(worktreeID: wt, parsed: parsed))
+
+        #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
+        let recorded = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+        #expect(recorded.count == 1)
+        // The row it already had, not a fresh manual one — insert-on-miss did
+        // not fire, and did not need to.
+        #expect(recorded.first?.source == .hook)
+    }
+
     /// The gesture stays reversible whichever way the tombstone got there.
     @Test("a manual attach clears a tombstone that insert-on-miss created")
     func attachClearsAnInsertedTombstone() async throws {
@@ -462,6 +592,41 @@ struct PRBindingCoordinatorTests {
         }
         #expect(!revived.detached)
         #expect(try await fixture.store.list(worktreeID: wt).map(\.number) == [412])
+    }
+
+    /// The reentrancy the single write transaction is for, at the layer that
+    /// claims it. This actor suspends at every `await` in `detach` — the repo
+    /// resolution, the cached-identity fallback, the store write — and the
+    /// poll's branch matcher binds through the same actor while the user is
+    /// clicking.
+    ///
+    /// Neither ordering is asserted; the invariant that holds under both is.
+    /// The PR the user removed is never left live, and one identity never grows
+    /// a second row.
+    @Test("a bind racing a detach of one identity leaves one row, and it is detached")
+    func detachRacingABindLeavesOneDetachedRow() async throws {
+        for round in 1...20 {
+            let fixture = try await Fixture()
+            let wt = try await fixture.newWorktree()
+
+            if round.isMultiple(of: 2) {
+                async let detached = fixture.coordinator.detach(worktreeID: wt, parsed: parsed)
+                async let bound = fixture.coordinator.bind(worktreeID: wt, parsed: parsed,
+                                                           source: .branch)
+                _ = try await (detached, bound)
+            } else {
+                async let bound = fixture.coordinator.bind(worktreeID: wt, parsed: parsed,
+                                                           source: .branch)
+                async let detached = fixture.coordinator.detach(worktreeID: wt, parsed: parsed)
+                _ = try await (bound, detached)
+            }
+
+            #expect(try await fixture.store.list(worktreeID: wt).isEmpty,
+                    "round \(round): a live row survived the detach")
+            let all = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+            #expect(all.count == 1, "round \(round): expected one row, got \(all.count)")
+            #expect(all.first?.detached == true, "round \(round): the row is not detached")
+        }
     }
 
     // MARK: - Heal

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -24,17 +24,18 @@ struct PRBindingCoordinatorTests {
         init(repo: (owner: String, name: String, host: String)? =
             ("acme", "acme-prod", "github.com"),
              gitLabHosts: Set<String>? = [],
-             cachedPRNumber: Int? = nil) async throws {
+             cachedPRURL: String? = nil) async throws {
             db = try TBDDatabase(inMemory: true)
             let created = try await db.repos.create(
                 path: "/tmp/prbinding-coord-repo-\(UUID().uuidString)",
                 displayName: "acme-prod", defaultBranch: "main")
             repoID = created.id
             store = db.prBindings
+            let cached = cachedPRURL.flatMap { PRBindingExtractor.parsePRURLs(in: $0).first }
             coordinator = PRBindingCoordinator(
                 store: store, resolveRepo: { _ in repo },
                 isGitLabHost: { _, host in gitLabHosts.map { $0.contains(host.lowercased()) } },
-                cachedPRNumber: { _ in cachedPRNumber })
+                cachedPRIdentity: { _ in cached })
         }
 
         func newWorktree() async throws -> UUID {
@@ -366,7 +367,8 @@ struct PRBindingCoordinatorTests {
     /// from exactly that status.
     @Test("detaching the cached PR still tombstones when the repo cannot be resolved")
     func detachTombstonesTheCachedPRWhenRepoIsUnresolved() async throws {
-        let fixture = try await Fixture(repo: nil, cachedPRNumber: 412)
+        let fixture = try await Fixture(
+            repo: nil, cachedPRURL: "https://github.com/acme/acme-prod/pull/412")
         let wt = try await fixture.newWorktree()
 
         #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed))
@@ -383,10 +385,29 @@ struct PRBindingCoordinatorTests {
     /// against and nothing tying the PR to this worktree, nothing is written.
     @Test("an unresolved repo does not license tombstoning an unrelated PR")
     func detachDeclinesAnUncorroboratedPRWhenRepoIsUnresolved() async throws {
-        let fixture = try await Fixture(repo: nil, cachedPRNumber: 999)
+        let fixture = try await Fixture(
+            repo: nil, cachedPRURL: "https://github.com/acme/acme-prod/pull/999")
         let wt = try await fixture.newWorktree()
 
         #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed) == false)
+
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+    }
+
+    /// The corroboration compares owner, repo AND number. Matching on the
+    /// number alone would admit a pasted foreign URL whenever the worktree's
+    /// own cached PR happened to share its number — minting the permanent
+    /// tombstone the guard exists to prevent, on a coincidence.
+    @Test("a foreign PR sharing the cached number is not corroborated by it")
+    func detachDeclinesAForeignPRWithACoincidentalNumber() async throws {
+        let fixture = try await Fixture(
+            repo: nil, cachedPRURL: "https://github.com/acme/acme-prod/pull/412")
+        let wt = try await fixture.newWorktree()
+        let foreign = ParsedPRURL(
+            host: "github.com", owner: "other-org", repo: "other-repo", number: 412,
+            url: "https://github.com/other-org/other-repo/pull/412")
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: foreign) == false)
 
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
     }

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -348,7 +348,7 @@ struct PRBindingCoordinatorTests {
     /// indicator with no way back.
     @Test("detaching an unbound PR from another repo records nothing")
     func detachDoesNotTombstoneAForeignUnboundPR() async throws {
-        let fixture = try await Fixture(repo: ("acme", "other-repo"))
+        let fixture = try await Fixture(repo: ("acme", "other-repo", "github.com"))
         let wt = try await fixture.newWorktree()
 
         #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed) == false)
@@ -432,8 +432,10 @@ struct PRBindingCoordinatorTests {
         let wt = try await fixture.newWorktree()
         _ = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
 
-        let renamed = PRBindingCoordinator(store: fixture.store,
-                                           resolveRepo: { _ in ("acme", "renamed-repo") })
+        let renamed = PRBindingCoordinator(
+            store: fixture.store,
+            resolveRepo: { _ in ("acme", "renamed-repo", "github.com") },
+            isGitLabHost: { _, _ in false })
         #expect(try await renamed.detach(worktreeID: wt, parsed: parsed))
 
         #expect(try await fixture.store.list(worktreeID: wt).isEmpty)

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -282,6 +282,82 @@ struct PRBindingCoordinatorTests {
         #expect(try await fixture.store.list(worktreeID: wt).count == 1)
     }
 
+    // MARK: - Detach
+
+    /// The status bar renders a chip for a worktree whose only PR evidence is
+    /// the cached `Worktree.prStatus` — a synthetic binding that by design never
+    /// reaches the database. A detach that only ever UPDATEd would match no row
+    /// there, leave `detachedCount` at zero, and the chip would come straight
+    /// back. So detach asserts rather than edits: with nothing on record it
+    /// writes the tombstone itself.
+    @Test("detaching a PR nothing ever bound inserts a manual tombstone")
+    func detachInsertsTombstoneOnMiss() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed))
+
+        #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
+        let recorded = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+        #expect(recorded.count == 1)
+        #expect(recorded.first?.number == 412)
+        #expect(recorded.first?.detached == true)
+        // A tombstone with no prior row records nothing but a user's decision.
+        #expect(recorded.first?.source == .manual)
+        #expect(recorded.first?.url == parsed.url)
+    }
+
+    @Test("detaching an already-tombstoned PR adds no row and does not error")
+    func detachTwiceIsIdempotent() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed))
+
+        // Reports "changed nothing" — the PR is already detached — rather than
+        // duplicating the row or tripping the unique index.
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed) == false)
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
+    }
+
+    @Test("detaching a live binding still tombstones the row it already has")
+    func detachTombstonesALiveRow() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        _ = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
+
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed))
+
+        let recorded = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+        #expect(recorded.count == 1)
+        #expect(recorded.first?.detached == true)
+        // Insert-on-miss must not have fired: the original row is still the
+        // hook's, not a fresh manual one.
+        #expect(recorded.first?.source == .hook)
+    }
+
+    /// The gesture stays reversible whichever way the tombstone got there.
+    @Test("a manual attach clears a tombstone that insert-on-miss created")
+    func attachClearsAnInsertedTombstone() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        #expect(try await fixture.coordinator.detach(worktreeID: wt, parsed: parsed))
+
+        // An automatic source still may not revive it — insert-on-miss creates
+        // a real tombstone, not a weaker one.
+        let auto = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .branch)
+        guard case .tombstoned = auto else {
+            Issue.record("expected .tombstoned, got \(auto)"); return
+        }
+
+        let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .manual)
+        guard case .bound(let revived) = outcome else {
+            Issue.record("expected .bound, got \(outcome)"); return
+        }
+        #expect(!revived.detached)
+        #expect(try await fixture.store.list(worktreeID: wt).map(\.number) == [412])
+    }
+
     // MARK: - Heal
 
     @Test("a heal removes a branch binding and leaves hook and manual ones alone")

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -261,6 +261,37 @@ struct PRBindingRPCTests {
                 == "https://github.com/acme/acme-prod/pull/412")
     }
 
+    /// The status bar names a PR by whatever its chip holds, and a chip lifted
+    /// from a cached `Worktree.prStatus` can hold a url `PRBindingExtractor`
+    /// will not accept — its pattern is host-locked to `https://github.com/`,
+    /// so on a worktree hosted anywhere else EVERY synthetic chip is in that
+    /// state. Sending url and number together is only worth anything if a url
+    /// that does not parse falls through to the number instead of failing.
+    @Test("a reference whose url does not parse falls through to its number")
+    func unparseableURLFallsThroughToNumber() async throws {
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
+
+        #expect(try await harness.detach(
+            url: "https://git.acme-corp.example/acme/acme-prod/pull/412", number: 412))
+
+        // Resolved against the worktree's own repo, exactly as a bare number is.
+        let recorded = try await harness.db.prBindings.list(
+            worktreeID: harness.worktreeID, includeDetached: true)
+        #expect(recorded.count == 1)
+        #expect(recorded.first?.number == 412)
+        #expect(recorded.first?.url == "https://github.com/acme/acme-prod/pull/412")
+    }
+
+    @Test("a reference with an unparseable url and no number is still an error")
+    func unparseableURLWithoutNumberIsAnError() async throws {
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
+        // Nothing is guessed — the fallthrough adds a second chance, not a
+        // default.
+        await #expect(throws: (any Error).self) {
+            try await harness.detach(url: "not a pr url at all")
+        }
+    }
+
     @Test("pr.attach reports a wrong-repo rejection instead of binding")
     func attachWrongRepo() async throws {
         let harness = try await PRBindingRPCHarness(repo: ("acme", "other-repo", "github.com"))

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -412,10 +412,47 @@ struct PRBindingRPCTests {
         #expect(all.worktrees.map(\.worktreeID) == [harness.worktreeID])
     }
 
-    @Test("pr.detach of an unbound PR reports false rather than erroring")
-    func detachUnknown() async throws {
+    /// The last leg of the title's round trip: the column reaches the app as a
+    /// field on the binding `pr.bindings` returns, so the status bar can say
+    /// what `#412` actually is.
+    @Test("pr.bindings carries a stored title")
+    func bindingsCarryTitle() async throws {
         let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
-        #expect(try await harness.detach(number: 999) == false)
+        let attached = try await harness.attach(number: 412)
+        let bindingID = try #require(attached.binding?.id)
+        #expect(attached.binding?.title == nil)
+
+        try await harness.db.prBindings.updateObservation(
+            bindingID: bindingID,
+            status: PRStatus(number: 412, url: "https://github.com/acme/acme-prod/pull/412",
+                             state: .mergeable),
+            title: "Fix the login timeout")
+
+        #expect(try await harness.bindings().bindings.first?.title == "Fix the login timeout")
+    }
+
+    /// A worktree with no bindings but a cached `Worktree.prStatus` renders a
+    /// synthetic chip, and the app's untrack gesture detaches it by number. If
+    /// that matched no row and reported failure, `detachedCount` would stay
+    /// zero, the legacy-status fallback would keep the chip on screen, and the
+    /// control would silently decline. So the detach records the tombstone —
+    /// and the non-zero count is the signal the app reads.
+    @Test("pr.detach of an unbound PR tombstones it and raises detachedCount")
+    func detachUnbound() async throws {
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
+        #expect(try await harness.detach(number: 999))
+
+        let listed = try await harness.bindings()
+        #expect(listed.bindings.isEmpty)
+        #expect(listed.detachedCount == 1)
+
+        // Durable, exactly like any other tombstone: an automatic source may
+        // not bring the PR back on the next poll or hook fire.
+        let rebind = try await harness.attach(number: 999, source: PRBindingSource.branch.rawValue)
+        #expect(rebind.outcome == "tombstoned")
+        // And a manual attach still reverses it.
+        #expect(try await harness.attach(number: 999).outcome == "bound")
+        #expect(try await harness.bindings().detachedCount == 0)
     }
 
     @Test("pr.attach with neither url nor number is an RPC error")

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -299,7 +299,7 @@ struct PRBindingRPCTests {
     /// silently and with no error.
     @Test("pr.attach does not fall through from an unparseable url to the number")
     func attachDoesNotFallThroughToNumber() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
 
         await #expect(throws: (any Error).self) {
             try await harness.attach(

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -292,6 +292,22 @@ struct PRBindingRPCTests {
         }
     }
 
+    /// The fallthrough is detach-only. Re-reading a number against *this*
+    /// worktree's repo is a recoverable mistake when it removes an association
+    /// and an unrecoverable one when it creates one: an attach would bind this
+    /// repo's #412 in place of the #412 the caller named on some other host,
+    /// silently and with no error.
+    @Test("pr.attach does not fall through from an unparseable url to the number")
+    func attachDoesNotFallThroughToNumber() async throws {
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+
+        await #expect(throws: (any Error).self) {
+            try await harness.attach(
+                url: "https://git.acme-corp.example/acme/acme-prod/pull/412", number: 412)
+        }
+        #expect(try await harness.bindings().bindings.isEmpty)
+    }
+
     @Test("pr.attach reports a wrong-repo rejection instead of binding")
     func attachWrongRepo() async throws {
         let harness = try await PRBindingRPCHarness(repo: ("acme", "other-repo", "github.com"))

--- a/Tests/TBDDaemonTests/PRBindingStoreTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingStoreTests.swift
@@ -256,7 +256,7 @@ struct PRBindingStoreTests {
         let wt = try await fixture.newWorktree()
         let candidate = binding(9, worktreeID: wt, source: .manual)
 
-        #expect(try await fixture.store.tombstone(candidate))
+        #expect(try await fixture.store.tombstone(candidate, insertIfMissing: true))
 
         #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
         let all = try await fixture.store.list(worktreeID: wt, includeDetached: true)
@@ -270,10 +270,10 @@ struct PRBindingStoreTests {
         let fixture = try await Fixture()
         let wt = try await fixture.newWorktree()
         let candidate = binding(9, worktreeID: wt, source: .manual)
-        #expect(try await fixture.store.tombstone(candidate))
+        #expect(try await fixture.store.tombstone(candidate, insertIfMissing: true))
         // Second call: no duplicate row, no unique-constraint error, and it says
         // it changed nothing.
-        #expect(try await fixture.store.tombstone(candidate) == false)
+        #expect(try await fixture.store.tombstone(candidate, insertIfMissing: true) == false)
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
     }
 
@@ -289,7 +289,7 @@ struct PRBindingStoreTests {
         let live = try #require(
             try await fixture.store.upsert(binding(9, worktreeID: wt, source: .hook)))
 
-        #expect(try await fixture.store.tombstone(binding(9, worktreeID: wt, source: .manual)))
+        #expect(try await fixture.store.tombstone(binding(9, worktreeID: wt, source: .manual), insertIfMissing: true))
 
         #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
         let all = try await fixture.store.list(worktreeID: wt, includeDetached: true)
@@ -317,12 +317,41 @@ struct PRBindingStoreTests {
         #expect(try await fixture.store.list(worktreeID: wt).count == 20)
 
         #expect(try await fixture.store.tombstone(
-            binding(21, worktreeID: wt, source: .manual)))
+            binding(21, worktreeID: wt, source: .manual), insertIfMissing: true))
 
         let live = try await fixture.store.list(worktreeID: wt)
         #expect(live.count == 20)
         #expect(live.contains { $0.number == 20 })   // the evictable one survived
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 21)
+    }
+
+    /// `insertIfMissing: false` is the caller saying "only touch a row that is
+    /// already here". It must write nothing and say so, rather than recording a
+    /// tombstone the caller declined to authorise.
+    @Test("tombstone declines to insert when the caller withholds permission")
+    func tombstoneWithoutPermissionWritesNothing() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+
+        #expect(try await fixture.store.tombstone(
+            binding(9, worktreeID: wt, source: .manual), insertIfMissing: false) == false)
+
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+    }
+
+    /// …but an existing row is always fair game: it is this worktree's own
+    /// record, and the permission gate covers creation, not modification.
+    @Test("tombstone still detaches an existing row when insertion is withheld")
+    func tombstoneWithoutPermissionStillDetachesAnExistingRow() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        _ = try await fixture.store.upsert(binding(9, worktreeID: wt, source: .hook))
+
+        #expect(try await fixture.store.tombstone(
+            binding(9, worktreeID: wt, source: .manual), insertIfMissing: false))
+
+        #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
     }
 
     @Test("setDetached reports false when the state did not actually change")

--- a/Tests/TBDDaemonTests/PRBindingStoreTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingStoreTests.swift
@@ -367,9 +367,13 @@ struct PRBindingStoreTests {
                 binding(n, worktreeID: wt, source: .manual), insertIfMissing: true))
         }
 
-        // One past the cap writes nothing and says so.
-        #expect(try await fixture.store.tombstone(
-            binding(9_001, worktreeID: wt, source: .manual), insertIfMissing: true) == false)
+        // One past the cap THROWS rather than reporting "changed nothing":
+        // false means the PR is not tracked here, which callers say in those
+        // words, and hitting the ceiling means the opposite.
+        await #expect(throws: PRBindingStoreError.self) {
+            try await fixture.store.tombstone(
+                binding(9_001, worktreeID: wt, source: .manual), insertIfMissing: true)
+        }
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count
             == PRBindingStore.maxTombstonesPerWorktree)
 

--- a/Tests/TBDDaemonTests/PRBindingStoreTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingStoreTests.swift
@@ -199,6 +199,120 @@ struct PRBindingStoreTests {
         #expect(kept?.baseRef == "main")
     }
 
+    @Test("updateObservation round-trips a title and never blanks a stored one")
+    func updateObservationStoresTitle() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        let stored = try #require(try await fixture.store.upsert(binding(1, worktreeID: wt)))
+        #expect(stored.title == nil)
+
+        let status = PRStatus(number: 1, url: stored.url, state: .mergeable)
+        try await fixture.store.updateObservation(
+            bindingID: stored.id, status: status, title: "Fix the login timeout")
+        #expect(try await fixture.store.list(worktreeID: wt).first?.title == "Fix the login timeout")
+
+        // A pass that resolved no title (transient failure) must not blank the
+        // one the status bar has on screen.
+        try await fixture.store.updateObservation(bindingID: stored.id, status: status)
+        #expect(try await fixture.store.list(worktreeID: wt).first?.title == "Fix the login timeout")
+
+        // A retitled PR does move it.
+        try await fixture.store.updateObservation(
+            bindingID: stored.id, status: status, title: "Fix the login timeout, again")
+        #expect(try await fixture.store.list(worktreeID: wt).first?.title
+            == "Fix the login timeout, again")
+    }
+
+    /// The migration rule's real test: a row written before the `title` column
+    /// existed holds SQL NULL there, and must still decode — as nil, meaning
+    /// "never observed", rather than failing the whole row.
+    @Test("a row written without a title decodes as nil rather than failing")
+    func preTitleRowDecodes() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        let id = UUID().uuidString
+        try await fixture.store.writer.write { db in
+            try db.execute(
+                sql: """
+                INSERT INTO worktree_pull_request
+                  (id, worktreeID, host, owner, repo, number, url, source, detached, boundAt)
+                VALUES (?, ?, 'github.com', 'acme', 'acme-prod', 7,
+                        'https://github.com/acme/acme-prod/pull/7', 'hook', 0,
+                        '2026-08-01 00:00:00.000')
+                """,
+                arguments: [id, wt.uuidString])
+        }
+        let listed = try await fixture.store.list(worktreeID: wt)
+        #expect(listed.count == 1)
+        #expect(listed.first?.number == 7)
+        #expect(listed.first?.title == nil)
+    }
+
+    // MARK: - Tombstoning a PR that was never bound
+
+    @Test("insertTombstone records a PR this worktree never bound")
+    func insertTombstoneRecordsUnboundPR() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        let candidate = binding(9, worktreeID: wt, source: .manual)
+
+        #expect(try await fixture.store.insertTombstone(candidate))
+
+        #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
+        let all = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+        #expect(all.count == 1)
+        #expect(all.first?.detached == true)
+        #expect(all.first?.source == .manual)
+    }
+
+    @Test("insertTombstone is idempotent against the unique index")
+    func insertTombstoneIsIdempotent() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        let candidate = binding(9, worktreeID: wt, source: .manual)
+        #expect(try await fixture.store.insertTombstone(candidate))
+        // Second call: no duplicate row, no unique-constraint error, and it says
+        // it changed nothing.
+        #expect(try await fixture.store.insertTombstone(candidate) == false)
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
+    }
+
+    @Test("insertTombstone leaves an existing live binding alone")
+    func insertTombstoneDoesNotDetachALiveRow() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        _ = try await fixture.store.upsert(binding(9, worktreeID: wt, source: .hook))
+        #expect(try await fixture.store.insertTombstone(
+            binding(9, worktreeID: wt, source: .manual)) == false)
+        let listed = try await fixture.store.list(worktreeID: wt)
+        #expect(listed.count == 1)
+        #expect(listed.first?.source == .hook)
+    }
+
+    /// The cap counts non-detached rows, so a tombstone occupies none of the
+    /// budget — and must not be able to spend any of it either. `upsert` checks
+    /// the cap before writing anything, so a tombstone routed through it would
+    /// evict a live terminal binding to make room for a row that takes up no
+    /// room.
+    @Test("a tombstone insert at a full worktree evicts nothing and still records")
+    func insertTombstoneIgnoresTheCap() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        for n in 1...19 {
+            _ = try await fixture.store.upsert(binding(n, worktreeID: wt, state: .mergeable))
+        }
+        _ = try await fixture.store.upsert(binding(20, worktreeID: wt, state: .merged))
+        #expect(try await fixture.store.list(worktreeID: wt).count == 20)
+
+        #expect(try await fixture.store.insertTombstone(
+            binding(21, worktreeID: wt, source: .manual)))
+
+        let live = try await fixture.store.list(worktreeID: wt)
+        #expect(live.count == 20)
+        #expect(live.contains { $0.number == 20 })   // the evictable one survived
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 21)
+    }
+
     @Test("setDetached reports false when the state did not actually change")
     func setDetachedReportsRealChange() async throws {
         // `updateAll` counts MATCHED rows, so the naive `> 0` made `tbd pr

--- a/Tests/TBDDaemonTests/PRBindingStoreTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingStoreTests.swift
@@ -354,6 +354,33 @@ struct PRBindingStoreTests {
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
     }
 
+    /// Insert-on-miss is the one path that mints a row for a PR nothing ever
+    /// discovered, and nothing ever deletes a tombstone — so a scripted or
+    /// fat-fingered loop would otherwise grow a worktree's slice of a table
+    /// that `listAllByWorktree` decodes whole on every app refresh.
+    @Test("the insert arm stops at the tombstone cap, and still detaches live rows past it")
+    func tombstoneInsertsAreBounded() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        for n in 1...PRBindingStore.maxTombstonesPerWorktree {
+            #expect(try await fixture.store.tombstone(
+                binding(n, worktreeID: wt, source: .manual), insertIfMissing: true))
+        }
+
+        // One past the cap writes nothing and says so.
+        #expect(try await fixture.store.tombstone(
+            binding(9_001, worktreeID: wt, source: .manual), insertIfMissing: true) == false)
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count
+            == PRBindingStore.maxTombstonesPerWorktree)
+
+        // …but the cap is a runaway stop on CREATION only: a live row past it
+        // is still detachable, or a full worktree could never untrack anything.
+        _ = try await fixture.store.upsert(binding(9_002, worktreeID: wt, source: .hook))
+        #expect(try await fixture.store.tombstone(
+            binding(9_002, worktreeID: wt, source: .manual), insertIfMissing: true))
+        #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
+    }
+
     @Test("setDetached reports false when the state did not actually change")
     func setDetachedReportsRealChange() async throws {
         // `updateAll` counts MATCHED rows, so the naive `> 0` made `tbd pr

--- a/Tests/TBDDaemonTests/PRBindingStoreTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingStoreTests.swift
@@ -301,6 +301,51 @@ struct PRBindingStoreTests {
         #expect(all.first?.source == .hook)
     }
 
+    /// The transactional claim, run rather than reasoned about.
+    ///
+    /// `tombstone` is one method — and so one write transaction — precisely
+    /// because a bind can land a live row between a caller's look and its write.
+    /// The tests above set that state up sequentially, which pins the logic of
+    /// each arm but never actually races anything. This one starts both writes
+    /// as concurrent child tasks and lets the writer order them.
+    ///
+    /// Both orderings are legal and neither is asserted: what is asserted is the
+    /// invariant that survives either. After a bind and a detach of ONE identity,
+    /// the worktree holds exactly one row for it and that row is detached —
+    /// never a live row the user asked to remove, and never a second row for one
+    /// identity. Split into `setDetached` plus an insert-on-miss, the ordering
+    /// where the bind wins leaves the live row behind and the untrack becomes
+    /// the silent no-op the gesture exists to remove.
+    ///
+    /// Rounds alternate which child task is spawned first, so neither ordering
+    /// depends on the scheduler happening to favour one.
+    @Test("a bind racing a detach of one identity leaves one row, and it is detached")
+    func tombstoneRacingABindLeavesOneDetachedRow() async throws {
+        for round in 1...20 {
+            let fixture = try await Fixture()
+            let wt = try await fixture.newWorktree()
+            // The poll's branch matcher and the user's click, on the same PR.
+            let discovered = binding(9, worktreeID: wt, source: .branch)
+            let removal = binding(9, worktreeID: wt, source: .manual)
+
+            if round.isMultiple(of: 2) {
+                async let tombstoned = fixture.store.tombstone(removal, insertIfMissing: true)
+                async let bound = fixture.store.upsert(discovered)
+                _ = try await (tombstoned, bound)
+            } else {
+                async let bound = fixture.store.upsert(discovered)
+                async let tombstoned = fixture.store.tombstone(removal, insertIfMissing: true)
+                _ = try await (bound, tombstoned)
+            }
+
+            #expect(try await fixture.store.list(worktreeID: wt).isEmpty,
+                    "round \(round): a live row survived the detach")
+            let all = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+            #expect(all.count == 1, "round \(round): expected one row, got \(all.count)")
+            #expect(all.first?.detached == true, "round \(round): the row is not detached")
+        }
+    }
+
     /// The cap counts non-detached rows, so a tombstone occupies none of the
     /// budget — and must not be able to spend any of it either. `upsert` checks
     /// the cap before writing anything, so a tombstone routed through it would

--- a/Tests/TBDDaemonTests/PRBindingStoreTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingStoreTests.swift
@@ -248,15 +248,15 @@ struct PRBindingStoreTests {
         #expect(listed.first?.title == nil)
     }
 
-    // MARK: - Tombstoning a PR that was never bound
+    // MARK: - Tombstoning, bound or not
 
-    @Test("insertTombstone records a PR this worktree never bound")
-    func insertTombstoneRecordsUnboundPR() async throws {
+    @Test("tombstone records a PR this worktree never bound")
+    func tombstoneRecordsUnboundPR() async throws {
         let fixture = try await Fixture()
         let wt = try await fixture.newWorktree()
         let candidate = binding(9, worktreeID: wt, source: .manual)
 
-        #expect(try await fixture.store.insertTombstone(candidate))
+        #expect(try await fixture.store.tombstone(candidate))
 
         #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
         let all = try await fixture.store.list(worktreeID: wt, includeDetached: true)
@@ -265,28 +265,40 @@ struct PRBindingStoreTests {
         #expect(all.first?.source == .manual)
     }
 
-    @Test("insertTombstone is idempotent against the unique index")
-    func insertTombstoneIsIdempotent() async throws {
+    @Test("tombstone is idempotent against the unique index")
+    func tombstoneIsIdempotent() async throws {
         let fixture = try await Fixture()
         let wt = try await fixture.newWorktree()
         let candidate = binding(9, worktreeID: wt, source: .manual)
-        #expect(try await fixture.store.insertTombstone(candidate))
+        #expect(try await fixture.store.tombstone(candidate))
         // Second call: no duplicate row, no unique-constraint error, and it says
         // it changed nothing.
-        #expect(try await fixture.store.insertTombstone(candidate) == false)
+        #expect(try await fixture.store.tombstone(candidate) == false)
         #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).count == 1)
     }
 
-    @Test("insertTombstone leaves an existing live binding alone")
-    func insertTombstoneDoesNotDetachALiveRow() async throws {
+    /// The arm that makes the two-transaction version of this unsafe: a row
+    /// that exists when the write runs must be tombstoned by the SAME call that
+    /// would otherwise have inserted one. A concurrent bind is exactly how a
+    /// live row appears between a caller's look and its write, and leaving it
+    /// live would turn the user's untrack into a silent no-op.
+    @Test("tombstone detaches an existing live binding in place, keeping its source")
+    func tombstoneDetachesALiveRowInPlace() async throws {
         let fixture = try await Fixture()
         let wt = try await fixture.newWorktree()
-        _ = try await fixture.store.upsert(binding(9, worktreeID: wt, source: .hook))
-        #expect(try await fixture.store.insertTombstone(
-            binding(9, worktreeID: wt, source: .manual)) == false)
-        let listed = try await fixture.store.list(worktreeID: wt)
-        #expect(listed.count == 1)
-        #expect(listed.first?.source == .hook)
+        let live = try #require(
+            try await fixture.store.upsert(binding(9, worktreeID: wt, source: .hook)))
+
+        #expect(try await fixture.store.tombstone(binding(9, worktreeID: wt, source: .manual)))
+
+        #expect(try await fixture.store.list(worktreeID: wt).isEmpty)
+        let all = try await fixture.store.list(worktreeID: wt, includeDetached: true)
+        #expect(all.count == 1)
+        #expect(all.first?.detached == true)
+        // The row that was already there is the row that got tombstoned — its
+        // identity and provenance survive; only `detached` moved.
+        #expect(all.first?.id == live.id)
+        #expect(all.first?.source == .hook)
     }
 
     /// The cap counts non-detached rows, so a tombstone occupies none of the
@@ -295,7 +307,7 @@ struct PRBindingStoreTests {
     /// evict a live terminal binding to make room for a row that takes up no
     /// room.
     @Test("a tombstone insert at a full worktree evicts nothing and still records")
-    func insertTombstoneIgnoresTheCap() async throws {
+    func tombstoneIgnoresTheCap() async throws {
         let fixture = try await Fixture()
         let wt = try await fixture.newWorktree()
         for n in 1...19 {
@@ -304,7 +316,7 @@ struct PRBindingStoreTests {
         _ = try await fixture.store.upsert(binding(20, worktreeID: wt, state: .merged))
         #expect(try await fixture.store.list(worktreeID: wt).count == 20)
 
-        #expect(try await fixture.store.insertTombstone(
+        #expect(try await fixture.store.tombstone(
             binding(21, worktreeID: wt, source: .manual)))
 
         let live = try await fixture.store.list(worktreeID: wt)

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -1527,14 +1527,15 @@ struct WorktreePRStatusFromBindingsTests {
         #expect(updates.first { $0.worktreeID == b }?.status.state == .blocked)
     }
 
-    @Test("withObservation carries the observed refs and never clears a stored one")
+    @Test("withObservation carries the observed refs and title, and never clears a stored one")
     func withObservationCarriesRefs() {
         let wt = UUID()
         let original = binding(7, worktreeID: wt, state: nil)
         let fresh = PRStatus(number: 7, url: original.url, state: .merged)
 
         let observed = original.withObservation(
-            status: fresh, headBranch: "tbd/feature", baseRef: "main")
+            status: fresh, headBranch: "tbd/feature", baseRef: "main",
+            title: "Fix the login timeout")
         #expect(observed.id == original.id)
         #expect(observed.identityKey == original.identityKey)
         #expect(observed.source == original.source)
@@ -1542,11 +1543,20 @@ struct WorktreePRStatusFromBindingsTests {
         #expect(observed.status == fresh)
         #expect(observed.headBranch == "tbd/feature")
         #expect(observed.baseRef == "main")
+        #expect(observed.title == "Fix the login timeout")
 
-        // A nil ref means "not observed this pass", never "cleared".
-        let unobserved = observed.withObservation(status: fresh, headBranch: nil, baseRef: nil)
+        // A nil ref or title means "not observed this pass", never "cleared" —
+        // a `gh` outage must not blank the title the status bar has on screen.
+        let unobserved = observed.withObservation(status: fresh, headBranch: nil,
+                                                  baseRef: nil, title: nil)
         #expect(unobserved.headBranch == "tbd/feature")
         #expect(unobserved.baseRef == "main")
+        #expect(unobserved.title == "Fix the login timeout")
+
+        // A retitled PR does replace it — "not observed" is nil, not a lock.
+        let retitled = observed.withObservation(status: fresh, headBranch: nil,
+                                                baseRef: nil, title: "Fix the login timeout, again")
+        #expect(retitled.title == "Fix the login timeout, again")
     }
 
     /// The fold the poll applies before judging the merge rule: an absent
@@ -1560,9 +1570,61 @@ struct WorktreePRStatusFromBindingsTests {
 
         let fresh = PRStatus(number: 7, url: original.url, state: .merged)
         let folded = RPCRouter.folding(original, onto: PRStatusManager.PRBindingObservation(
-            status: fresh, headBranch: "tbd/feature", baseRef: "main"))
+            status: fresh, headBranch: "tbd/feature", baseRef: "main",
+            title: "Fix the login timeout"))
         #expect(folded.status == fresh)
         #expect(folded.headBranch == "tbd/feature")
         #expect(folded.baseRef == "main")
+        #expect(folded.title == "Fix the login timeout")
+    }
+
+    /// The fold is the only place the poll can lose a title, and the pass that
+    /// keeps a previous status (a failed check query) is the one that would do
+    /// it: it reports refs and title from the node it DID resolve, and folding
+    /// must carry them rather than dropping back to what the row held.
+    @Test("folding an observation with no title keeps the stored one")
+    func foldingKeepsAStoredTitle() {
+        let wt = UUID()
+        let stored = PRBinding(
+            worktreeID: wt, owner: "acme", repo: "acme-prod", number: 7,
+            url: "https://github.com/acme/acme-prod/pull/7",
+            title: "Fix the login timeout", source: .hook)
+        let fresh = PRStatus(number: 7, url: stored.url, state: .mergeable)
+
+        let folded = RPCRouter.folding(stored, onto: PRStatusManager.PRBindingObservation(
+            status: fresh, headBranch: nil, baseRef: nil, title: nil))
+        #expect(folded.title == "Fix the login timeout")
+
+        // And an absent observation leaves the binding wholly alone.
+        #expect(RPCRouter.folding(stored, onto: nil).title == "Fix the login timeout")
+    }
+
+    /// Persist-on-change reads `sameValue`, so a title has to be inside it or a
+    /// renamed PR would never reach the row — and `observedAt` has to stay
+    /// outside it or every idle poll would write every binding.
+    @Test("a changed title is a change, a fresh stamp on an identical title is not")
+    func titleParticipatesInChangeDetection() {
+        let wt = UUID()
+        // One id and one boundAt across every variant: `sameValue` compares
+        // whole bindings, so two independently minted rows differ on identity
+        // alone and would prove nothing about the title.
+        let id = UUID()
+        let boundAt = Date(timeIntervalSince1970: 0)
+        let url = "https://github.com/acme/acme-prod/pull/7"
+        func stamped(_ title: String?, at date: Date) -> PRBinding {
+            PRBinding(id: id, worktreeID: wt, owner: "acme", repo: "acme-prod",
+                      number: 7, url: url, title: title,
+                      status: PRStatus(number: 7, url: url, state: .mergeable,
+                                       observedAt: date),
+                      source: .hook, boundAt: boundAt)
+        }
+        let early = Date(timeIntervalSince1970: 1_000)
+        let later = Date(timeIntervalSince1970: 2_000)
+
+        #expect(stamped("Fix the login timeout", at: early)
+            .sameValue(as: stamped("Fix the login timeout", at: later)))
+        #expect(!stamped("Fix the login timeout", at: early)
+            .sameValue(as: stamped("Fix the login timeout, again", at: early)))
+        #expect(!stamped(nil, at: early).sameValue(as: stamped("Fix the login timeout", at: early)))
     }
 }

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -202,6 +202,7 @@ private actor GitLabFake {
     private func node(iid: Int, state: String) -> String {
         """
         {"iid":"\(iid)","state":"\(state)","draft":false,
+        "title":"Rate-limit the ingest queue",
         "detailedMergeStatus":"\(detailedMergeStatus)",
         "sourceBranch":"\(sourceBranch)","targetBranch":"main",
         "createdAt":"2026-08-01T10:00:00Z",
@@ -779,6 +780,10 @@ struct PRStatusManagerBindingTests {
         #expect(observed[binding.id]?.status.url == Self.gitLabMRURL)
         #expect(observed[binding.id]?.headBranch == "tbd/my-branch")
         #expect(observed[binding.id]?.baseRef == "main")
+        // The hover card renders `binding.title` whatever the forge, so a
+        // GitLab arm that never observed one renders a permanently degraded
+        // card: a number and a state, and nothing saying what the MR is.
+        #expect(observed[binding.id]?.title == "Rate-limit the ingest queue")
         #expect(await gl.sawGraphQL)
         #expect(await gl.waitForRecheck())
         // Outside a GitLab checkout `glab api` defaults to gitlab.com, so a

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -1494,6 +1494,47 @@ struct PRStatusManagerTests {
         #expect(matches.first?.node.mergeQueuePosition == 3)
     }
 
+    /// The title is what turns a bare `#454` on a status-bar chip into
+    /// something a person can decide about, so the by-number parse has to carry
+    /// it — and has to report a response that omitted it as nil, not "", since
+    /// the caller reads nil as "not observed" and keeps the stored title.
+    @Test("parseNumberedPRNodes carries the PR title, and reports an absent one as nil")
+    func parseNumberedPRNodesCarriesTitle() {
+        func response(titleLine: String) -> Data {
+            """
+            {
+              "data": {
+                "repository": {
+                  "pr0": {
+                    "number": 454,
+                    "url": "https://github.com/acme/acme/pull/454",
+            \(titleLine)
+                    "state": "OPEN",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewDecision": "APPROVED",
+                    "headRefName": "show-weekly-reset",
+                    "createdAt": "2026-07-10T00:00:00Z",
+                    "isDraft": false,
+                    "statusCheckRollup": { "state": "SUCCESS" }
+                  }
+                }
+              }
+            }
+            """.data(using: .utf8)!
+        }
+        let wt = UUID()
+        let titled = PRStatusManager.parseNumberedPRNodes(
+            from: response(titleLine: #"        "title": "Fix the login timeout","#),
+            aliases: [(alias: "pr0", worktreeID: wt)])
+        #expect(titled.first?.node.title == "Fix the login timeout")
+
+        let untitled = PRStatusManager.parseNumberedPRNodes(
+            from: response(titleLine: ""), aliases: [(alias: "pr0", worktreeID: wt)])
+        // The node still parses — a title is descriptive, never a parse gate.
+        #expect(untitled.count == 1)
+        #expect(untitled.first?.node.title == nil)
+    }
+
     @Test("parseNumberedPRNodes skips a null pullRequest (deleted/inaccessible PR) without crashing")
     func parseNumberedPRNodesSkipsNullPullRequest() {
         let wt = UUID()
@@ -2255,6 +2296,9 @@ struct PRStatusManagerTests {
         #expect(query.contains("pr0: pullRequest(number: 454)"))
         #expect(query.contains("pr1: pullRequest(number: 12)"))
         #expect(query.contains("repository(owner: $owner, name: $name)"))
+        // A title nothing asks for is a title no response can carry, and the
+        // parse would then look correct while the column stayed empty forever.
+        #expect(query.contains("title"))
     }
 }
 

--- a/Tests/TBDSharedTests/PRBindingTests.swift
+++ b/Tests/TBDSharedTests/PRBindingTests.swift
@@ -221,6 +221,42 @@ struct PRBindingTests {
             branchCandidates: ["feature-1"], provenancePRNumber: 1))
     }
 
+    /// The shared-model half of the migration rule: a row or payload written
+    /// before `title` existed carries no such key, and it must still decode —
+    /// as "never observed", which is what an absent title means everywhere.
+    @Test("a binding encoded before the title column existed still decodes, with no title")
+    func decodesWithoutATitle() throws {
+        let legacy = """
+        {
+          "id": "\(UUID().uuidString)",
+          "worktreeID": "\(UUID().uuidString)",
+          "host": "github.com",
+          "owner": "acme",
+          "repo": "acme-prod",
+          "number": 412,
+          "url": "https://github.com/acme/acme-prod/pull/412",
+          "source": "hook",
+          "detached": false,
+          "boundAt": 745200000
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(PRBinding.self, from: legacy)
+        #expect(decoded.number == 412)
+        #expect(decoded.title == nil)
+    }
+
+    @Test("a title survives an encode/decode round trip")
+    func titleRoundTripsThroughJSON() throws {
+        let original = PRBinding(
+            worktreeID: UUID(), owner: "acme", repo: "acme-prod", number: 412,
+            url: "https://github.com/acme/acme-prod/pull/412",
+            title: "Fix the login timeout", source: .manual)
+        let decoded = try JSONDecoder().decode(
+            PRBinding.self, from: try JSONEncoder().encode(original))
+        #expect(decoded.title == "Fix the login timeout")
+        #expect(decoded == original)
+    }
+
     @Test("a binding with no observed status is not resolved")
     func unknownStatusBlocksResolution() {
         var unknown = binding(2, .mergeable)

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -1,0 +1,168 @@
+# Untracking and identifying a PR from the status-bar chips
+
+## Problem
+
+The status bar renders one chip per PR bound to the selected worktree — a
+status dot plus `#21156` — capped at four, with the rest collapsed into `+N`.
+Three things are missing from that strip.
+
+**A chip cannot be removed.** A worktree that has been alive for a week
+accumulates PRs that merged, got closed, or belonged to work nobody is thinking
+about any more. `tbd pr detach` removes one, but the gesture lives in a terminal
+while the thing being removed is on screen; nobody runs it. So the cluster only
+ever grows, and the chips that matter get pushed behind `+N` by chips that do
+not.
+
+**A chip says only its number.** `#21156` identifies a PR to GitHub and to
+nobody else. Deciding whether a chip is worth keeping — or worth clicking —
+means opening it in a browser, which is the action the strip exists to make
+unnecessary.
+
+**Four is too few** for a worktree whose agent has opened a handful of PRs, so
+the overflow menu carries PRs that would have fit on screen.
+
+## Design
+
+### Cap
+
+Seven chips before `+N`, up from four. The cluster already yields width to the
+path label (`layoutPriority(-1)`), so a narrow window degrades by collapsing
+into the overflow menu rather than by squeezing its neighbours — which is what
+makes raising the cap safe rather than a gamble on window width.
+
+### Untracking from the chip
+
+Hovering a chip turns its **status dot into an `xmark`**, in place. Clicking the
+xmark detaches that PR from the worktree; clicking anywhere else on the chip
+keeps its present meaning and opens the PR in the default browser.
+
+The dot is the right host for this, and not merely the convenient one. It is the
+only part of the chip with no click behaviour of its own, so nothing is
+displaced; it is already the chip's leading affordance, so the cursor is
+travelling past it anyway; and swapping in place means the chip does not grow a
+control that has to be laid out somewhere.
+
+Two constraints govern the implementation:
+
+- **The layout must not move between the two states.** The icon slot is a fixed
+  size that fits the larger of the two glyphs, and both are centred in it. A
+  chip that changed width on hover would shove every chip to its right, and the
+  xmark would slide out from under the cursor that summoned it.
+- **The hit area is at least 12×12pt**, larger than the 6pt dot and larger than
+  the drawn xmark. It is contributed by a transparent overlay rather than by
+  padding, so it costs no layout width: an overlay is sized by its parent and
+  cannot push its siblings. At 12pt centred on a 6pt dot the region extends 3pt
+  past the dot on each side, which stays inside the 6pt gap between chips, so no
+  chip can steal a click from its neighbour.
+
+Detaching is **tombstoning**, which is what `pr.detach` already does — a delete
+would be undone by the next poll or hook fire. The status bar therefore inherits
+the whole of the existing durability story rather than inventing one.
+
+#### Detach must be able to tombstone a PR that was never bound
+
+A worktree with no bindings but a cached `Worktree.prStatus` renders a
+**synthetic** binding — a display-only value lifted from that status, which by
+design never reaches the database. It is not an edge case worth ignoring: it is
+what keeps the PR surfaces alive when `gh` is unauthenticated or offline, and
+what every worktree shows before its first successful poll after upgrade.
+
+Against today's `pr.detach` the xmark on such a chip would do nothing at all.
+The detach matches no row, updates nothing, and reports `detached: false`; the
+cached status is untouched, so the chip returns on the next render. A control
+that silently declines is worse than an absent one.
+
+So `pr.detach` gains one rule: **when no row matches, insert a tombstone
+instead of reporting failure.** The detach becomes an assertion about the PR's
+future — "this does not belong to this worktree" — rather than an edit to a row
+that happens to exist. Three consequences follow, all wanted:
+
+- the xmark works uniformly, on every chip, whatever backs it;
+- `detachedCount` becomes non-zero, which is precisely the signal that
+  suppresses the legacy-status fallback, so the chip clears and stays cleared;
+- `tbd pr detach` becomes idempotent and order-independent — detaching a PR
+  before anything discovers it pre-empts the binding rather than losing to it.
+
+The inserted row is `source = manual`, because a tombstone with no prior row
+records nothing but a user's decision. `pr.attach` clears it exactly as it
+clears any other tombstone, so the gesture stays reversible.
+
+### Identifying a chip: the hover overlay
+
+Resting on a chip shows an overlay carrying the PR **number, title, state, and
+the age of that observation**. The title is the whole point: it is what turns
+`#21156` into something a person can decide about.
+
+**No description.** GitHub's GraphQL cannot return a truncated body — `body` and
+`bodyText` come whole — so any excerpt would be trimmed only after the bytes had
+crossed the wire, on every PR, on every poll, on a fleet that polls
+continuously. PR bodies routinely run to kilobytes and are template-heavy. A
+title is one short string riding a query that already runs, and it answers the
+question the strip actually poses. The description belongs to the PR page, which
+is one click away.
+
+Titles are fetched by adding `title` to `prNodeFieldSelection`, the by-number
+selection the binding refresh already issues. The viewer-authored batch query
+alongside it fetches `title` already, so this closes a gap rather than opening a
+cost.
+
+The title is persisted on the binding row, in a new nullable `title` column
+(the migration follows the shared-model rule: column, GRDB record, and Codable
+model in one commit). It is folded in through `withObservation`, on the same
+terms as `headBranch` and `baseRef`: **nil means "not observed", never
+"cleared"**, so a transient fetch failure cannot blank a title that is already
+on screen.
+
+A synthetic binding has no title, and the overlay renders without one rather
+than fabricating a placeholder — number, state and age are still worth showing,
+and the missing line is honest about a status that was hydrated rather than
+polled.
+
+The overlay states the observation's age because the cached `PRStatus` is
+display-tier and has been measured reading "Ready to merge" for PRs merged days
+earlier. Every surface that renders it must render its age with it.
+
+## Testing
+
+- Chip cap — seven bindings produce seven chips and no overflow; eight produce
+  seven and `+1`; the overflow chip's tooltip still names the total.
+- Detach on a live binding tombstones it, and the chip does not return after a
+  poll.
+- Detach with no matching row inserts a `manual` tombstone; a second detach of
+  the same PR is a no-op rather than a duplicate row; `pr.attach` afterwards
+  clears it.
+- Detaching the last chip of a worktree whose bindings were synthetic leaves the
+  cluster empty, because `detachedCount` suppresses the legacy fallback.
+- Title parse — a by-number GraphQL response carrying `title` populates it; one
+  omitting `title` leaves the stored value untouched rather than clearing it.
+- Title round-trips through the row, the RPC, and back.
+- Overlay content for a binding with a title, without one, and with no observed
+  status.
+
+## Rejected alternatives
+
+**A separate xmark button beside the number.** Every chip grows a permanent
+control, the cluster gets wider at exactly the moment the cap went up, and the
+dot — which carries the state — competes with it for the eye.
+
+**A right-click context menu.** Discoverable by nobody, and a second interaction
+grammar for a strip whose entire vocabulary is "click the thing".
+
+**Fetching bodies in the poll and truncating server-side.** The bandwidth is
+spent before the truncation happens, which is the cost being avoided.
+
+**Fetching the body lazily on hover.** Bounded by what the user looks at, so the
+bandwidth objection mostly dissolves — but it buys a new RPC, a cache, and a
+loading state in the overlay for content that the PR page presents better. Left
+available if titles prove insufficient.
+
+**Hiding the xmark on synthetic chips** rather than making detach tombstone
+unconditionally. Zero daemon change, but one chip in a row would silently lack
+the affordance its neighbours have, with no way to explain why.
+
+## Why no feature flag
+
+The convention gates behavior that acts without a user gesture or that destroys
+state. This is the opposite of both: every removal here is a deliberate click,
+and it removes an association TBD inferred, not any repository or session state.
+The PR itself is untouched, and `pr.attach` reverses the gesture.

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -45,11 +45,20 @@ Hovering a chip turns its **status dot into an `xmark`**, in place. Clicking the
 xmark detaches that PR from the worktree; clicking anywhere else on the chip
 keeps its present meaning and opens the PR in the default browser.
 
-The dot is the right host for this, and not merely the convenient one. It is the
-only part of the chip with no click behaviour of its own, so nothing is
-displaced; it is already the chip's leading affordance, so the cursor is
-travelling past it anyway; and swapping in place means the chip does not grow a
-control that has to be laid out somewhere.
+The dot is the right host for this, though not a free one. It is already the
+chip's leading affordance, so the cursor is travelling past it anyway, and
+swapping in place means the chip does not grow a control that has to be laid out
+somewhere.
+
+What it costs is worth stating plainly: those pixels were not inert. The whole
+chip carried one tap gesture that opened the PR, so the dot opened it too, and
+roughly a third of a chip's width changes meaning. That is why the slot's action
+follows its glyph — a dot still opens, only a drawn xmark untracks — and it is
+the reason a user who clicks without registering the swap gets the destructive
+action. The gesture is reversible with `tbd pr attach`, and nothing in the
+repository or the session is touched, which is what makes the trade acceptable
+rather than costless. An in-app undo on the success path is the obvious
+improvement and is deliberately left for its own change.
 
 Two constraints govern the implementation:
 

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -60,6 +60,33 @@ repository or the session is touched, which is what makes the trade acceptable
 rather than costless. An in-app undo on the success path is the obvious
 improvement and is deliberately left for its own change.
 
+Two things narrow that cost rather than merely accepting it, and both work on
+the same problem: two click targets share about twenty points of width, and
+nothing about the pointer's position tells you which one it is on.
+
+- **The hover overlay names the click under the cursor** — see below. It is the
+  surface already showing when a hand is on the chip, and it has room for a
+  sentence.
+- **The xmark takes on a button's appearance while the pointer is actually over
+  it**: full-strength foreground over a faint circular disc, drawn at exactly
+  the size of the click region, so no pixel that looks like the control fails to
+  act as one. Emphasis is reached through a `background` with its own fixed
+  frame, which is sized by itself and never proposed to the layout, so the chip
+  is the same width at rest, hovered, and emphasised.
+
+A tooltip on the untrack target is not the mitigation, though the slot carries
+one for the accessibility phrasing it shares. The macOS help-tag delay is longer
+than the overlay's 0.55s floor, so the card is already up by the time a tag
+would appear, and a second, smaller box saying less would arrive on top of it —
+if it arrived at all.
+
+Emphasis and wording read a **separate** hover flag, true only for the icon
+slot, while the glyph stays on the whole-chip flag. That split is what keeps a
+pointer travelling from the number onto the slot from flickering the xmark back
+to a dot. It also inherits the rule above unchanged: the untrack wording is
+shown only where the slot is *drawing* the xmark, so nothing on screen can offer
+to untrack while the slot is a status dot that would open.
+
 Two constraints govern the implementation:
 
 - **The layout must not move between the two states.** The icon slot is a fixed
@@ -282,6 +309,25 @@ The overlay states the observation's age because the cached `PRStatus` is
 display-tier and has been measured reading "Ready to merge" for PRs merged days
 earlier. Every surface that renders it must render its age with it.
 
+#### The overlay also says what the click will do
+
+A last row names the action under the pointer: *Click to open this PR on GitHub*
+anywhere on the chip, *Click to stop tracking this PR in this worktree* while
+the pointer is on the xmark. The sentences describe the gesture and nothing
+else — the number and the state are on the rows above them — and the untrack
+half names the worktree scope for the same reason the slot's label does: what is
+removed is an association TBD inferred, not the pull request.
+
+The row is **always present and its text swaps**, never a row that appears when
+the pointer reaches the slot. A card that gained a line would grow under the
+hand that summoned it, which is the jitter this is meant to cure rather than
+cause. The card is sized to its content, so the two sentences would resize it on
+their own: each state therefore carries the other as a laid-out-but-hidden peer,
+pinning the row — and with it the card — to the larger of the two in both axes.
+The peer is a general property of an overlay row rather than something the chip
+does for itself, because any row whose text swaps while a card is up has this
+problem.
+
 ## Testing
 
 - Chip cap — seven bindings produce seven chips and no overflow; eight produce
@@ -316,6 +362,12 @@ earlier. Every surface that renders it must render its age with it.
 - Title round-trips through the row, the RPC, and back.
 - Overlay content for a binding with a title, without one, and with no observed
   status.
+- The overlay's action row: the untrack sentence while the icon slot is the
+  target and the open sentence otherwise; the rest of the card — title, PR row,
+  state row and age — byte-identical between the two, with the two models still
+  unequal so the swap actually reaches the panel; each state reserving the
+  other's sentence; and both sentences surviving a chip with no title and one
+  with no observed status.
 
 ## Rejected alternatives
 

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -362,8 +362,26 @@ card over the surface that summoned it, and leaves anchors with room beneath
 them — tab-bar items, sidebar rows — exactly where they were. The window is a
 preference rather than a hard constraint: where neither side fits inside it, the
 screen decides, so the rule can never place a card worse than screen room alone
-would. The gap clears the padding a bar puts around its content, not merely the
-anchored control, so the strip stays readable under a flipped card.
+would.
+
+The two clearances are **asymmetric**, and deliberately so. A card hanging below
+its anchor hugs it, the way a menu hangs off the button that opened it: it reads
+as attached, which is what it is. A card that *flipped* is escaping something —
+in practice the edge of a window, which in practice is a bar — so it clears the
+whole strip the anchor sits in, with a gap wide enough to see, rather than
+clearing the anchor by a hair. The reader is looking at the bar, not at the
+chip: a chip is a 14pt row inside a strip that pads it, seats it beside taller
+controls and draws its own background, and a card that clears only the chip
+still sits on the row it is describing.
+
+The flipped clearance is a constant carrying the container's height rather than
+the container's measured frame, because the anchor has no container to measure:
+it is an AppKit view SwiftUI hosts as a `background`, and the bar around it is
+padding and a material with no enclosing view whose frame could be read.
+Recovering one would mean sniffing the private hosting hierarchy for a
+visual-effect view, or making every `.hoverCard` adopter pass its container's
+frame — which fails silently for whoever forgets, on the surface where the
+failure is least visible.
 
 Separation from what is behind the card is a material fill plus a **small shadow
 the card draws itself**, the way a menu or a popover separates — no border. The

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -30,13 +30,14 @@ numbers are worth scanning at a glance, not a width calculation: nothing
 consults the available width, and the overflow count is a pure function of how
 many bindings there are.
 
-What the cluster does give up under pressure is width, not chips. It carries
-`layoutPriority(-1)` just as the path label beside it does, so a narrow window
-compresses the strip rather than squeezing the path — and compressing it
-truncates chip labels (`#41…`) rather than folding chips into the overflow
-menu. Seven chips reach that point at a wider window than four did. Width-aware
-collapsing would be the real answer and is deliberately not built here; it is a
-layout change to make on its own, with the window in front of you.
+It buys no width safety either. The `layoutPriority(-1)` the cluster carries is
+the same priority the path/branch cluster beside it carries, so the two are
+peers in one bucket and share the deficit rather than one yielding to the other.
+A narrow window squeezes both, truncating chip labels (`#41…`) and path segments
+alike rather than folding chips into the overflow menu — and seven chips reach
+that point at a wider window than four did. Width-aware collapsing would be the
+real answer and is deliberately not built here; it is a layout change to make on
+its own, with the window in front of you.
 
 ### Untracking from the chip
 

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -176,6 +176,13 @@ suppress that worktree's legacy-status fallback permanently. One mistyped
 `tbd pr detach <other-repo-url>` would retire a worktree's real PR indicator
 with no way back.
 
+"Belongs to this repo" means what `pr.attach` means by it, and is decided by the
+same code: owner and name, then the host. A GitLab `acme/proj` and a GitHub
+`acme/proj` are two projects, and a detach aimed at the wrong one of them must
+not mint a tombstone the attach that could clear it would reject. Two separate
+host checks would be free to drift apart, and the arm that skipped one is
+exactly the arm that can write a row nothing can ever remove.
+
 An **unresolved** repo is neither a match nor a mismatch, and both readings of
 it are wrong. The resolver is `gh repo view` behind a TTL cache, so it answers
 nil under exactly the conditions that produce the synthetic chip in the first
@@ -195,7 +202,10 @@ Matching on the number would admit a pasted `other-org/other-repo/pull/412`
 whenever the worktree's own cached PR happened to be #412 — minting the
 permanent foreign tombstone on a coincidence. A synthetic chip's URL always
 names the worktree's own repo, so checking all three costs the offline path
-nothing.
+nothing. The host is then agreed against the cached PR's own host, on the same
+terms as the resolved path: being offline is not a reason to stop telling two
+forges apart, and the cached status is where a non-GitHub worktree's host is
+still on record.
 
 ### Who reclaims a tombstone
 
@@ -413,10 +423,15 @@ panel, is what sits a gap away from the anchor.
   row in place instead, keeping that row's id and `source` — the arm that makes
   a concurrent bind harmless.
 - Detaching an unbound PR from another repo writes nothing and reports no
-  change. With the repo unresolvable, the worktree's cached PR is still
-  tombstoned while any other PR is not, and a worktree with no cached status
-  gets neither. Detaching a row that already exists works after the worktree's
-  repo has changed under it.
+  change, and so does one that differs only in host — the insert arm agrees
+  hosts exactly as an attach does, on the resolved path and on the cached one.
+  With the repo unresolvable, the worktree's cached PR is still tombstoned while
+  any other PR is not, and a worktree with no cached status gets neither.
+  Detaching a row that already exists works after the worktree's repo has
+  changed under it, and after its host has.
+- A bind and a detach of one identity, actually run concurrently, leave exactly
+  one row and never a live one — the invariant the single write transaction
+  exists to hold, asserted over both orderings rather than over a sequence.
 - The untrack gesture's four outcomes: the detach landed, the daemon declined
   and the chip survived, the refresh failed so the stale map is not evidence,
   and the RPC threw.

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -372,7 +372,11 @@ whole strip the anchor sits in, with a gap wide enough to see, rather than
 clearing the anchor by a hair. The reader is looking at the bar, not at the
 chip: a chip is a 14pt row inside a strip that pads it, seats it beside taller
 controls and draws its own background, and a card that clears only the chip
-still sits on the row it is describing.
+still sits on the row it is describing. Above a status-bar chip the flipped
+clearance leaves roughly 40pt of untouched window content between the top of the
+strip and the bottom of the card — a band wide enough to be unmistakable rather
+than merely measurable, and free: a flip is only chosen when the card had a
+whole window's height above the anchor to sit in.
 
 The flipped clearance is a constant carrying the container's height rather than
 the container's measured frame, because the anchor has no container to measure:

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -373,10 +373,11 @@ clearing the anchor by a hair. The reader is looking at the bar, not at the
 chip: a chip is a 14pt row inside a strip that pads it, seats it beside taller
 controls and draws its own background, and a card that clears only the chip
 still sits on the row it is describing. Above a status-bar chip the flipped
-clearance leaves roughly 40pt of untouched window content between the top of the
+clearance leaves roughly 24pt of untouched window content between the top of the
 strip and the bottom of the card — a band wide enough to be unmistakable rather
-than merely measurable, and free: a flip is only chosen when the card had a
-whole window's height above the anchor to sit in.
+than merely measurable, while the card stays near enough to the chip to read as
+belonging to it. It is free: a flip is only chosen when the card had a whole
+window's height above the anchor to sit in.
 
 The flipped clearance is a constant carrying the container's height rather than
 the container's measured frame, because the anchor has no container to measure:

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -147,12 +147,36 @@ place — `gh` unauthenticated, offline, or missing. Reading that nil as a refus
 disables insert-on-miss in the one scenario it was written for. Reading it as
 consent lets a mistyped foreign URL mint the permanent tombstone above.
 
-So a nil is decided on other evidence: **the PR number the worktree's cached
+So a nil is decided on other evidence: **the PR the worktree's cached
 `Worktree.prStatus` names**, which is the only fact about its PRs that survives
 `gh` being gone, and is exactly what a synthetic chip is built from. The offline
 xmark therefore works, while `tbd pr detach <some other PR>` on an unresolvable
 worktree writes nothing. A worktree with no cached status offers no evidence and
 gets no tombstone.
+
+That corroboration compares **owner, repo and number**, never the number alone.
+Matching on the number would admit a pasted `other-org/other-repo/pull/412`
+whenever the worktree's own cached PR happened to be #412 — minting the
+permanent foreign tombstone on a coincidence. A synthetic chip's URL always
+names the worktree's own repo, so checking all three costs the offline path
+nothing.
+
+### Who reclaims a tombstone
+
+Every row here dies with its worktree: `worktree_pull_request.worktreeID` is a
+foreign key `ON DELETE CASCADE`, so no tombstone outlives the thing it describes
+and none can be orphaned. Within a live worktree they are permanent by design —
+a tombstone that aged out would resurrect a PR the user removed — and that is
+fine for rows that correspond to PRs something actually discovered, which the
+live cap bounds indirectly.
+
+Insert-on-miss is the exception worth bounding: it is the one path that writes a
+row for a PR nothing found, one per gesture and one per distinct number, into a
+table `pr.bindingsAll` decodes whole on every app refresh. So the insert arm
+stops at a per-worktree tombstone ceiling far above any legitimate count. It is
+a runaway stop rather than a budget, and it gates creation only — a live row is
+still detachable past it, or a worktree that hit the ceiling could never untrack
+anything again.
 
 One case is beyond that corroboration and is reported rather than papered over:
 a reference whose URL does not parse **and** whose worktree's repo cannot be

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -140,11 +140,19 @@ suppress that worktree's legacy-status fallback permanently. One mistyped
 `tbd pr detach <other-repo-url>` would retire a worktree's real PR indicator
 with no way back.
 
-An **unresolved** repo is not a mismatch. The resolver is `gh repo view` behind
-a TTL cache, so it answers nil under exactly the conditions that produce the
-synthetic chip in the first place — `gh` unauthenticated, offline, or missing.
-Reading that nil as a refusal would disable insert-on-miss in the one scenario
-it was written for. It reads as "no reason to refuse".
+An **unresolved** repo is neither a match nor a mismatch, and both readings of
+it are wrong. The resolver is `gh repo view` behind a TTL cache, so it answers
+nil under exactly the conditions that produce the synthetic chip in the first
+place — `gh` unauthenticated, offline, or missing. Reading that nil as a refusal
+disables insert-on-miss in the one scenario it was written for. Reading it as
+consent lets a mistyped foreign URL mint the permanent tombstone above.
+
+So a nil is decided on other evidence: **the PR number the worktree's cached
+`Worktree.prStatus` names**, which is the only fact about its PRs that survives
+`gh` being gone, and is exactly what a synthetic chip is built from. The offline
+xmark therefore works, while `tbd pr detach <some other PR>` on an unresolvable
+worktree writes nothing. A worktree with no cached status offers no evidence and
+gets no tombstone.
 
 Declining reports "changed nothing", which is the honest answer: this worktree
 is not tracking that PR. The CLI says exactly that, because the same false also
@@ -244,9 +252,15 @@ earlier. Every surface that renders it must render its age with it.
   row in place instead, keeping that row's id and `source` — the arm that makes
   a concurrent bind harmless.
 - Detaching an unbound PR from another repo writes nothing and reports no
-  change; detaching one whose repo cannot be resolved at all still tombstones
-  it; and detaching a row that already exists works after the worktree's repo
-  has changed under it.
+  change. With the repo unresolvable, the worktree's cached PR is still
+  tombstoned while any other PR is not, and a worktree with no cached status
+  gets neither. Detaching a row that already exists works after the worktree's
+  repo has changed under it.
+- The untrack gesture's four outcomes: the detach landed, the daemon declined
+  and the chip survived, the refresh failed so the stale map is not evidence,
+  and the RPC threw.
+- The overlay carries the "last check did not resolve" clause after the age,
+  exactly as the toolbar and sidebar do.
 - A `pr.detach` whose URL does not parse resolves through its number, against
   the worktree's own repo; one with neither is still an error; and `pr.attach`
   does not fall through at all.

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -54,6 +54,16 @@ Two constraints govern the implementation:
   cannot push its siblings. At 12pt centred on a 6pt dot the region extends 3pt
   past the dot on each side, which stays inside the 6pt gap between chips, so no
   chip can steal a click from its neighbour.
+- **The slot's action is derived from the same flag as its glyph.** Hover state
+  is not a fact the view can rely on having received: chips are inserted and
+  reflowed under a stationary cursor every time the selection changes or a poll
+  adds one, and `onHover` need not have fired. An untrack target that stayed
+  live under a *drawn status dot* would turn "open this PR" into "stop tracking
+  it" on a click the user read correctly. So while the slot draws a dot it
+  behaves as a dot did before this gesture existed — it opens the PR — and it
+  untracks only while it is drawing the xmark. Accessibility does not hover, so
+  that element keeps the untrack identity unconditionally and carries its own
+  action; the gesture must not be reachable by pointer only.
 
 Detaching is **tombstoning**, which is what `pr.detach` already does — a delete
 would be undone by the next poll or hook fire. The status bar therefore inherits
@@ -86,6 +96,40 @@ that happens to exist. Three consequences follow, all wanted:
 The inserted row is `source = manual`, because a tombstone with no prior row
 records nothing but a user's decision. `pr.attach` clears it exactly as it
 clears any other tombstone, so the gesture stays reversible.
+
+**Both arms are one write transaction**, not a tombstone-the-row call followed
+by an insert-on-miss call. `PRBindingCoordinator` is a reentrant actor, so every
+`await` in a detach is a point at which a concurrent bind — the poll's branch
+matcher, or a hook's `pr attach` — can run. Split in two, that bind lands a live
+row in the gap; the insert then finds an identity already on record, declines,
+and the click becomes the silent no-op this whole section exists to remove. The
+store therefore exposes a single `tombstone` that detaches an existing row or
+inserts one, and reports whether the record changed.
+
+The app names the PR by **URL with its number as a fallback**, sending both. A
+chip lifted from a legacy cached status can carry a URL that does not parse, and
+a control that quietly declines on such a chip is the same failure in a
+different disguise; `pr.detach` already resolves a bare number against the
+worktree's own repo.
+
+#### What insert-on-miss costs, and why the cost is accepted here
+
+`detachedCount` is a per-worktree scalar, and the legacy fallback reads any
+non-zero count as "this worktree's PR evidence was deliberately removed". Before
+insert-on-miss that implication held, because a tombstone could only come from a
+row the worktree really had. It no longer does: on a worktree whose only PR
+evidence is a cached `Worktree.prStatus` for one PR, `tbd pr detach <some other
+number>` now records a tombstone for a PR nobody was tracking, and the count it
+raises suppresses the *cached* PR's chip along with it.
+
+That is worth stating rather than hiding, and it is still the right trade. The
+gesture the chips need cannot work without insert-on-miss; the mismatch is
+unreachable from the chips themselves, since a chip always names its own PR; it
+requires a hand-typed number on a worktree that has never successfully polled;
+and it suppresses a display-tier cache rather than unbinding anything, so the
+first successful poll restores the chip. Making it impossible means reporting
+which PRs are tombstoned instead of how many — a change to the `pr.bindings`
+payload, and a decision for its own spec rather than a detail of this one.
 
 ### Identifying a chip: the hover overlay
 
@@ -131,6 +175,11 @@ earlier. Every surface that renders it must render its age with it.
 - Detach with no matching row inserts a `manual` tombstone; a second detach of
   the same PR is a no-op rather than a duplicate row; `pr.attach` afterwards
   clears it.
+- The same store call that would insert a tombstone detaches an existing live
+  row in place instead, keeping that row's id and `source` — the arm that makes
+  a concurrent bind harmless.
+- The icon slot means untrack while hovered and open while not, so a click can
+  never destroy an association the slot is not offering to remove.
 - Detaching the last chip of a worktree whose bindings were synthetic leaves the
   cluster empty, because `detachedCount` suppresses the legacy fallback.
 - Title parse — a by-number GraphQL response carrying `title` populates it; one

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -154,6 +154,16 @@ xmark therefore works, while `tbd pr detach <some other PR>` on an unresolvable
 worktree writes nothing. A worktree with no cached status offers no evidence and
 gets no tombstone.
 
+One case is beyond that corroboration and is reported rather than papered over:
+a reference whose URL does not parse **and** whose worktree's repo cannot be
+resolved. There is nothing left to name the PR's host, owner and repo with — the
+number alone cannot be turned into a row — so `pr.detach` answers `unknownRepo`
+and the chip's toast says the gesture did not go through. That is an error, not
+a silent decline, which is the property this design cares about. Reaching it
+needs a non-github.com worktree *and* `gh` unavailable at the same moment; the
+first alone still detaches by number, and the second alone still detaches by
+URL.
+
 Declining reports "changed nothing", which is the honest answer: this worktree
 is not tracking that PR. The CLI says exactly that, because the same false also
 means "already tombstoned" and one sentence has to be true of both.

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -3,7 +3,7 @@
 ## Problem
 
 The status bar renders one chip per PR bound to the selected worktree — a
-status dot plus `#21156` — capped at four, with the rest collapsed into `+N`.
+status dot plus `#412` — capped at four, with the rest collapsed into `+N`.
 Three things are missing from that strip.
 
 **A chip cannot be removed.** A worktree that has been alive for a week
@@ -13,7 +13,7 @@ while the thing being removed is on screen; nobody runs it. So the cluster only
 ever grows, and the chips that matter get pushed behind `+N` by chips that do
 not.
 
-**A chip says only its number.** `#21156` identifies a PR to GitHub and to
+**A chip says only its number.** `#412` identifies a PR to GitHub and to
 nobody else. Deciding whether a chip is worth keeping — or worth clicking —
 means opening it in a browser, which is the action the strip exists to make
 unnecessary.
@@ -274,20 +274,20 @@ payload, and a decision for its own spec rather than a detail of this one.
 
 Resting on a chip shows an overlay carrying the PR **number, title, state, and
 the age of that observation**. The title is the whole point: it is what turns
-`#21156` into something a person can decide about.
+`#412` into something a person can decide about.
 
 Those first three are **one headline**, not a labelled grid:
 
 ```
-PR#21485 (Merged) - longdesk relay: adding a GitHub event no longer means
-redeploying the team-shared relay
+PR#412 (Merged) - acme-relay: stop redeploying the shared relay just to add
+an event
 ```
 
 They are read together — which PR, what state, what it is about — and a
 two-column table of them spent most of the card's width on the words "PR" and
-"State" saying what `#21485` and "Merged" already say. Everything but the number
-is optional and degrades by **omission**: no state gives `PR#21485 - <title>`,
-no title gives `PR#21485 (Merged)`, neither gives `PR#21485`, and no combination
+"State" saying what `#412` and "Merged" already say. Everything but the number
+is optional and degrades by **omission**: no state gives `PR#412 - <title>`,
+no title gives `PR#412 (Merged)`, neither gives `PR#412`, and no combination
 leaves an empty `()` or a separator with nothing after it. The headline wraps
 inside the card's width rather than widening it.
 

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -207,9 +207,13 @@ question the strip actually poses. The description belongs to the PR page, which
 is one click away.
 
 Titles are fetched by adding `title` to `prNodeFieldSelection`, the by-number
-selection the binding refresh already issues. The viewer-authored batch query
-alongside it fetches `title` already, so this closes a gap rather than opening a
-cost.
+selection the binding refresh already issues. That selection is shared with the
+viewer-authored batch, which pulls up to a hundred PRs, so this is a real
+addition to the poll's payload rather than a free one — one short string per PR
+per pass, and the batch's copies are discarded, because only the by-number path
+has a binding row to persist them onto. It is a rounding error beside the check
+rollup the same node already carries, and forking the selection in two to avoid
+it would give up the guarantee that the two queries cannot drift.
 
 The title is persisted on the binding row, in a new nullable `title` column
 (the migration follows the shared-model rule: column, GRDB record, and Codable

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -124,15 +124,35 @@ precisely the worktrees that have nothing but synthetic chips. A reference with
 a bad URL and no number is still an error; the fallthrough is a second chance,
 not a default.
 
-**The insert arm carries `bind`'s wrong-repo guard.** Tombstoning an existing
-row is always allowed — it is this worktree's own record of the PR, and a repo
-rename must not strand it. Creating one is not: `pr.attach` rejects a wrong-repo
-reference before it ever reaches a row, so a tombstone for a foreign PR could
-never be cleared, and the non-zero `detachedCount` it leaves would suppress that
-worktree's legacy-status fallback permanently. One mistyped
+That fallthrough is **detach-only**. It re-reads the number against *this*
+worktree's repo, which for an attach would mean a URL naming #412 on some other
+host silently binding this repo's #412 — a different pull request, with no
+error. Removing a wrong association is recoverable; creating one quietly is
+what the wrong-repo guard exists to prevent.
+
+**The insert arm declines only on a repo mismatch it can prove.** Tombstoning an
+existing row is never gated — it is this worktree's own record of the PR, and a
+repo rename must not strand it. Creating one is: `pr.attach` rejects a
+wrong-repo reference before it ever reaches a row, so a tombstone for a foreign
+PR could never be cleared, and the non-zero `detachedCount` it leaves would
+suppress that worktree's legacy-status fallback permanently. One mistyped
 `tbd pr detach <other-repo-url>` would retire a worktree's real PR indicator
-with no way back. Declining reports "changed nothing", which is the honest
-answer: this worktree was not tracking that PR.
+with no way back.
+
+An **unresolved** repo is not a mismatch. The resolver is `gh repo view` behind
+a TTL cache, so it answers nil under exactly the conditions that produce the
+synthetic chip in the first place — `gh` unauthenticated, offline, or missing.
+Reading that nil as a refusal would disable insert-on-miss in the one scenario
+it was written for. It reads as "no reason to refuse".
+
+Declining reports "changed nothing", which is the honest answer: this worktree
+is not tracking that PR. The CLI says exactly that, because the same false also
+means "already tombstoned" and one sentence has to be true of both.
+
+**The app judges the outcome, not the flag.** Rather than teach the status bar
+which false is which, it re-reads the bindings it just refreshed and speaks up
+only if the chip the user clicked is still on screen — which also catches the
+case no flag could describe, a concurrent bind putting the PR straight back.
 
 #### Removal reflows the strip, and no suppression window is added
 
@@ -219,10 +239,12 @@ earlier. Every surface that renders it must render its age with it.
   row in place instead, keeping that row's id and `source` — the arm that makes
   a concurrent bind harmless.
 - Detaching an unbound PR from another repo writes nothing and reports no
-  change, while detaching a row that already exists still works after the
-  worktree's repo has changed under it.
-- A reference whose URL does not parse resolves through its number, against the
-  worktree's own repo; one with neither is still an error.
+  change; detaching one whose repo cannot be resolved at all still tombstones
+  it; and detaching a row that already exists works after the worktree's repo
+  has changed under it.
+- A `pr.detach` whose URL does not parse resolves through its number, against
+  the worktree's own repo; one with neither is still an error; and `pr.attach`
+  does not fall through at all.
 - The icon slot means untrack while hovered and open while not, so a click can
   never destroy an association the slot is not offering to remove.
 - Detaching the last chip of a worktree whose bindings were synthetic leaves the

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -25,10 +25,18 @@ the overflow menu carries PRs that would have fit on screen.
 
 ### Cap
 
-Seven chips before `+N`, up from four. The cluster already yields width to the
-path label (`layoutPriority(-1)`), so a narrow window degrades by collapsing
-into the overflow menu rather than by squeezing its neighbours — which is what
-makes raising the cap safe rather than a gamble on window width.
+Seven chips before `+N`, up from four. The cap is a judgement about how many
+numbers are worth scanning at a glance, not a width calculation: nothing
+consults the available width, and the overflow count is a pure function of how
+many bindings there are.
+
+What the cluster does give up under pressure is width, not chips. It carries
+`layoutPriority(-1)` just as the path label beside it does, so a narrow window
+compresses the strip rather than squeezing the path — and compressing it
+truncates chip labels (`#41…`) rather than folding chips into the overflow
+menu. Seven chips reach that point at a wider window than four did. Width-aware
+collapsing would be the real answer and is deliberately not built here; it is a
+layout change to make on its own, with the window in front of you.
 
 ### Untracking from the chip
 
@@ -106,11 +114,43 @@ and the click becomes the silent no-op this whole section exists to remove. The
 store therefore exposes a single `tombstone` that detaches an existing row or
 inserts one, and reports whether the record changed.
 
-The app names the PR by **URL with its number as a fallback**, sending both. A
-chip lifted from a legacy cached status can carry a URL that does not parse, and
-a control that quietly declines on such a chip is the same failure in a
-different disguise; `pr.detach` already resolves a bare number against the
-worktree's own repo.
+The app names the PR by **URL with its number as a fallback**, sending both, and
+`pr.detach` falls through to the number when the URL does not parse. Both halves
+are needed and the second is the load-bearing one: `PRBindingExtractor`'s
+pattern is host-locked to `https://github.com/`, so on a worktree hosted
+anywhere else no binding can ever form, *every* chip is synthetic, and every one
+of them carries a URL the daemon will reject. Url-only, the xmark would fail on
+precisely the worktrees that have nothing but synthetic chips. A reference with
+a bad URL and no number is still an error; the fallthrough is a second chance,
+not a default.
+
+**The insert arm carries `bind`'s wrong-repo guard.** Tombstoning an existing
+row is always allowed — it is this worktree's own record of the PR, and a repo
+rename must not strand it. Creating one is not: `pr.attach` rejects a wrong-repo
+reference before it ever reaches a row, so a tombstone for a foreign PR could
+never be cleared, and the non-zero `detachedCount` it leaves would suppress that
+worktree's legacy-status fallback permanently. One mistyped
+`tbd pr detach <other-repo-url>` would retire a worktree's real PR indicator
+with no way back. Declining reports "changed nothing", which is the honest
+answer: this worktree was not tracking that PR.
+
+#### Removal reflows the strip, and no suppression window is added
+
+The chip leaves the bar within an RPC round trip, and its neighbour slides into
+the pixels the cursor is sitting on. A second click there — an impatient double
+click on the xmark — lands on the neighbour, and if `onHover` has reached it by
+then it untracks that PR too.
+
+The obvious cure is the wrong one. A suppression window after a detach would
+also block untracking two chips in a row, which is exactly the workflow a cap of
+seven invites: a worktree carrying a week of merged PRs is cleared by clicking
+several xmarks in sequence, and a control that ignores the second click is worse
+than one that occasionally acts on it. The gesture is reversible —
+`tbd pr attach` puts the binding back — and the neighbour's identity is on
+screen the whole time. The real fix is for the strip not to reflow under the
+cursor at all: hold a removed chip's slot until the pointer leaves the cluster.
+That is a layout change, and it belongs with the width-aware collapsing above
+rather than bolted onto this gesture.
 
 #### What insert-on-miss costs, and why the cost is accepted here
 
@@ -178,6 +218,11 @@ earlier. Every surface that renders it must render its age with it.
 - The same store call that would insert a tombstone detaches an existing live
   row in place instead, keeping that row's id and `source` — the arm that makes
   a concurrent bind harmless.
+- Detaching an unbound PR from another repo writes nothing and reports no
+  change, while detaching a row that already exists still works after the
+  worktree's repo has changed under it.
+- A reference whose URL does not parse resolves through its number, against the
+  worktree's own repo; one with neither is still an error.
 - The icon slot means untrack while hovered and open while not, so a click can
   never destroy an association the slot is not offering to remove.
 - Detaching the last chip of a worktree whose bindings were synthetic leaves the

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -276,6 +276,29 @@ Resting on a chip shows an overlay carrying the PR **number, title, state, and
 the age of that observation**. The title is the whole point: it is what turns
 `#21156` into something a person can decide about.
 
+Those first three are **one headline**, not a labelled grid:
+
+```
+PR#21485 (Merged) - longdesk relay: adding a GitHub event no longer means
+redeploying the team-shared relay
+```
+
+They are read together — which PR, what state, what it is about — and a
+two-column table of them spent most of the card's width on the words "PR" and
+"State" saying what `#21485` and "Merged" already say. Everything but the number
+is optional and degrades by **omission**: no state gives `PR#21485 - <title>`,
+no title gives `PR#21485 (Merged)`, neither gives `PR#21485`, and no combination
+leaves an empty `()` or a separator with nothing after it. The headline wraps
+inside the card's width rather than widening it.
+
+The state is **not** tinted with the PR palette. The status dot the pointer is
+resting on already carries that color, and this card colors words only for a
+caution the reader must not miss — a second colored copy of a fact three points
+away would compete with the title for the eye.
+
+The age is a muted caption directly under the headline. It dates the whole
+reading rather than the state alone, which is what it always did.
+
 **No description.** GitHub's GraphQL cannot return a truncated body — `body` and
 `bodyText` come whole — so any excerpt would be trimmed only after the bytes had
 crossed the wire, on every PR, on every poll, on a fleet that polls
@@ -300,9 +323,9 @@ terms as `headBranch` and `baseRef`: **nil means "not observed", never
 "cleared"**, so a transient fetch failure cannot blank a title that is already
 on screen.
 
-A synthetic binding has no title, and the overlay renders without one rather
+A synthetic binding has no title, and the headline ends after the state rather
 than fabricating a placeholder — number, state and age are still worth showing,
-and the missing line is honest about a status that was hydrated rather than
+and the missing half is honest about a status that was hydrated rather than
 polled.
 
 The overlay states the observation's age because the cached `PRStatus` is
@@ -311,10 +334,10 @@ earlier. Every surface that renders it must render its age with it.
 
 #### The overlay also says what the click will do
 
-A last row names the action under the pointer: *Click to open this PR on GitHub*
-anywhere on the chip, *Click to stop tracking this PR in this worktree* while
-the pointer is on the xmark. The sentences describe the gesture and nothing
-else — the number and the state are on the rows above them — and the untrack
+The card's one row names the action under the pointer: *Click to open this PR on
+GitHub* anywhere on the chip, *Click to stop tracking this PR in this worktree*
+while the pointer is on the xmark. The sentences describe the gesture and
+nothing else — the number and the state are in the headline above — and the untrack
 half names the worktree scope for the same reason the slot's label does: what is
 removed is an association TBD inferred, not the pull request.
 
@@ -327,6 +350,32 @@ pinning the row — and with it the card — to the larger of the two in both ax
 The peer is a general property of an overlay row rather than something the chip
 does for itself, because any row whose text swaps while a card is up has this
 problem.
+
+#### Where the overlay sits, and how it is separated from the terminal
+
+Hover cards go **below their anchor unless the card would leave the anchor's own
+window**, and above it when it would. Screen room is the wrong test on its own:
+the status bar is at the bottom edge of the window with a whole desktop beneath
+it, so a card placed by screen room alone drops out of the window and lands on
+the very strip it describes. Bounding the placement by the window keeps every
+card over the surface that summoned it, and leaves anchors with room beneath
+them — tab-bar items, sidebar rows — exactly where they were. The window is a
+preference rather than a hard constraint: where neither side fits inside it, the
+screen decides, so the rule can never place a card worse than screen room alone
+would. The gap clears the padding a bar puts around its content, not merely the
+anchored control, so the strip stays readable under a flipped card.
+
+Separation from what is behind the card is a material fill plus a **small shadow
+the card draws itself**, the way a menu or a popover separates — no border. The
+hosting panel's AppKit window shadow is off: it is sized for a window, so on a
+tooltip-sized panel it reads as a thick gray edge, and it spills far enough past
+the card to wash out the strip the card is anchored to. Drawing the shadow in
+the card bounds it to a radius chosen for this box, and it is recomputed with
+the content rather than by the window server from a shape that may still be the
+previous card's — the panel is shared across every anchor in the app and resized
+on each show. The cost is a transparent margin inside the panel for the shadow
+to fall into, which the placement geometry subtracts so the *card*, not the
+panel, is what sits a gap away from the anchor.
 
 ## Testing
 
@@ -361,13 +410,20 @@ problem.
   omitting `title` leaves the stored value untouched rather than clearing it.
 - Title round-trips through the row, the RPC, and back.
 - Overlay content for a binding with a title, without one, and with no observed
-  status.
+  status: the headline's four combinations of state and title, none of them
+  leaving an empty `()` or a trailing separator, and the age caption present in
+  every one — including the "unknown time" phrasing for a binding with no stamp.
 - The overlay's action row: the untrack sentence while the icon slot is the
-  target and the open sentence otherwise; the rest of the card — title, PR row,
-  state row and age — byte-identical between the two, with the two models still
-  unequal so the swap actually reaches the panel; each state reserving the
-  other's sentence; and both sentences surviving a chip with no title and one
-  with no observed status.
+  target and the open sentence otherwise; the headline and the age caption
+  byte-identical between the two, with the two models still unequal so the swap
+  actually reaches the panel; each state reserving the other's sentence; and
+  both sentences surviving a chip with no title and one with no observed status.
+- Placement: an anchor with window room below keeps its card below; one at the
+  bottom of its window flips above even though the screen has room beneath it,
+  and clears the bar's padding rather than only the anchor; a window too short
+  for either side falls back to the screen rule; cards clamp into the screen's
+  visible frame on both horizontal edges and when taller than the screen; and
+  the panel wraps the card by exactly one shadow inset on every side.
 
 ## Rejected alternatives
 


### PR DESCRIPTION
## Summary

A worktree that has been alive for a week collects pull requests — merged, closed, or belonging to work nobody is thinking about any more. The status bar showed them as a row of numbered chips that only ever grew, and the chips that mattered got pushed behind `+N` by chips that did not. Removing one meant running `tbd pr detach` in a terminal, while the thing being removed sat on screen; nobody did.

Now hovering a chip turns its status dot into an `xmark`, and clicking that untracks the PR. Resting on a chip tells you which PR it is — `PR#21485 (Merged) - longdesk relay: adding a GitHub event no longer means redeploying the relay` — so deciding whether a chip is worth keeping no longer means opening a browser, which is the trip the strip exists to save. The cap rose from four chips to seven.

## Why this shape

Spec: [`docs/specs/2026-08-16-pr-chip-untrack-design.md`](docs/specs/2026-08-16-pr-chip-untrack-design.md).

**The xmark replaces the dot rather than sitting beside it.** A permanent second control would widen every chip at exactly the moment the cap went up, and would compete with the dot for the eye. The cost is real and stated in the spec rather than argued away: those pixels already opened the PR, so about a third of a chip's width changes meaning on hover. Two things contain it — the slot's action is derived from the same flag as its glyph, so a *drawn dot* always opens and only a *drawn xmark* untracks, and the gesture is reversible with `tbd pr attach`.

**Titles, but no descriptions.** GitHub's GraphQL cannot return a truncated body — `body` and `bodyText` come whole — so an excerpt would be trimmed only after kilobytes had crossed the wire, per PR, per poll, on a fleet that polls continuously. A title is one short string on queries that already run, and it is a real if small added payload rather than a free one: `prNodeFieldSelection` is a single selection shared by the by-number query and the viewer-authored batch, so `title` lands on both. That cost is stated in the code's doc comment and in the spec, and it is the trade being made — tens of bytes per PR against a body's kilobytes.

**`pr.detach` now tombstones a PR that was never bound.** A worktree with no bindings but a cached `Worktree.prStatus` renders a *synthetic* chip, which by design never reaches the database — that is what keeps the PR surfaces alive when `gh` is unauthenticated or offline. Against the old behaviour the xmark there matched no row, left `detachedCount` at zero, and watched the chip return on the next render. Detach becomes an assertion about the PR's future rather than an edit to a row that happens to exist, which also makes `tbd pr detach` idempotent and order-independent.

Rejected, with reasons in the spec: a separate xmark button beside the number; a right-click context menu; fetching bodies and truncating server-side; hiding the xmark on synthetic chips.

## What this PR does

- `title` joins `prNodeFieldSelection`, rides through `PRNode` → `PRBindingObservation` → `PRBinding` → a new nullable `title` column (migration `v87`, no SQL default). Same rule as `headBranch`/`baseRef`: nil means *not observed*, never *cleared*, so a `gh` outage cannot blank a title that is on screen.
- `PRBindingStore.tombstone` detaches an existing row or inserts one **in a single write transaction**. Split in two, a concurrent bind lands a live row in the gap and the click becomes the silent no-op this feature exists to remove.
- The app names the PR by URL **with its number as a fallback**. `PRBindingExtractor` parses GitHub URLs on `github.com` only, and GitLab MR URLs on any host — so a worktree on GitHub Enterprise, Bitbucket or Gitea forms no binding at all, every chip there is synthetic, and each carries a URL the daemon will not parse. URL-only, the xmark would fail on exactly the worktrees that have nothing else.
- Status bar: cap 4 → 7; fixed 9pt icon slot with both glyphs centred so the chip is the same width in every state; a 12×12pt hit region contributed as a transparent overlay, which is sized by its parent and never joins the layout.
- The hover card carries the headline, the freshness caption, and an action row naming what the click will do. That row's width reserves the union of both sentences (`HoverCardRow.alternateValue`), so the panel cannot resize as the text swaps under the pointer.
- `HoverCardPlacement.panelFrame` extracted as a pure function: below the anchor unless the card would leave its window, then above, with asymmetric clearance — 8pt below (a card under its anchor should read as attached) and 32pt when flipped, which clears the whole bar rather than just the chip inside it.
- The hover card's panel no longer sets `hasShadow`. That was an AppKit *window* shadow on a tooltip-sized box, on a shared panel resized per show with no `invalidateShadow()` — so the halo in flight could be the previous card's shape. It draws its own shadow now, and the border stroke is gone.

## Assumptions

- Anything a poll does not observe keeps its stored value. A GitHub outage therefore shows a stale title and an honest age, never a blank one.
- `PRStatus` is display-tier. Every surface renders its age with it — this cache was measured reading "Ready to merge" for PRs merged days earlier.
- A tombstone means "not this worktree", not "not a PR". `pr.attach` clears it.

## Evidence & verification

- Full suite on the final tree: **6812 tests in 689 suites passed**, 70 known issues (standing quarantine fixtures), zero non-known issues.
- The cap change was mutation-checked: reverted to 4, seven assertions went red. The hover-card action row was mutation-checked: stubbing `untrackTarget` and dropping `alternateValue` reddened 4 of 6 new tests. The flipped clearance is pinned by a test that fails at both 8pt and 24pt, and a structural assertion that fails if the two gap constants are ever collapsed back together.
- Detach is covered for: a live row, a row that does not exist, an already-tombstoned row, attach-after-detach, and the tombstone ceiling.
- Live verification: run in the app across four rounds against a real fleet — chip cap, the dot→xmark swap with no layout shift, the hit area, the card's headline and placement, and an actual untrack that survived a poll.

A residual worth knowing: `tbd pr detach <wrong same-repo number>` raises `detachedCount` and suppresses that worktree's cached chip until the next successful poll. Fixing it properly means reporting *which* PRs are tombstoned rather than how many, which changes the `pr.bindings` payload and belongs in its own spec.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=195A6DE1-9629-4F16-9A84-D157A6F3A115)

