### PR TITLE
Feat: Start and steer Claude cloud sessions from TBD, behind a default-off flag

### DIFF
--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -281,4 +281,47 @@ extension AppState {
             return "Off, but a poller from before this change is still running in the daemon — restart to fully stop it."
         }
     }
+
+    /// Persist the Claude cloud gate, then re-fetch capabilities so the
+    /// Settings toggle reflects the daemon's persisted state. Cloud requires
+    /// BOTH this flag and the outer remote-backends flag, and neither takes
+    /// effect until the daemon restarts.
+    func setClaudeCloudEnabled(_ enabled: Bool) async {
+        do {
+            try await claudeCloudFlagSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            remoteLogger.error("Failed to set Claude cloud sessions: \(error, privacy: .public)")
+            showAlert(
+                "Failed to set Claude cloud sessions: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Caption for the Claude cloud toggle, telling the user which of the four
+    /// `(claudeCloudEnabled, claudeCloudLive)` states they are actually in. The
+    /// daemon registers the built-in provider only at boot, so the persisted
+    /// flag and the live provider disagree in both directions — the same shape
+    /// `remoteBackendsStatusCaption` handles for the outer flag.
+    nonisolated static func claudeCloudStatusCaption(enabled: Bool, live: Bool) -> String {
+        switch (enabled, live) {
+        case (false, false):
+            return "Off. Turning this on requires a daemon restart before cloud sessions appear."
+        case (true, false):
+            return "On, but restart the daemon before cloud sessions appear."
+        case (true, true):
+            return "On and running — cloud sessions are being polled."
+        case (false, true):
+            return "Off, but the provider registered before this change is still live in the daemon — restart to fully stop it."
+        }
+    }
+
+    /// Whether the cloud toggle can be operated at all. Cloud is reached
+    /// through the same `remote.*` verbs as every other provider, so it is a
+    /// second gate INSIDE the remote-sessions switch and never a bypass —
+    /// turning it on while the outer switch is off would promise something no
+    /// verb can deliver. A named function rather than an inline `.disabled(…)`
+    /// expression, so both branches are assertable without a view harness.
+    nonisolated static func claudeCloudToggleOperable(remoteBackendsEnabled: Bool) -> Bool {
+        remoteBackendsEnabled
+    }
 }

--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -297,21 +297,48 @@ extension AppState {
         }
     }
 
-    /// Caption for the Claude cloud toggle, telling the user which of the four
-    /// `(claudeCloudEnabled, claudeCloudLive)` states they are actually in. The
-    /// daemon registers the built-in provider only at boot, so the persisted
-    /// flag and the live provider disagree in both directions — the same shape
-    /// `remoteBackendsStatusCaption` handles for the outer flag.
-    nonisolated static func claudeCloudStatusCaption(enabled: Bool, live: Bool) -> String {
-        switch (enabled, live) {
-        case (false, false):
+    /// Caption for the Claude cloud toggle, telling the user which state they
+    /// are actually in across three inputs: the persisted cloud flag
+    /// (`enabled`), whether the built-in provider is actually live in the
+    /// daemon right now (`live`, frozen at boot), and the persisted state of
+    /// the OUTER remote-sessions flag (`remoteBackendsEnabled`, re-read on
+    /// every fetch). Cloud requires both flags simultaneously true AT BOOT to
+    /// go live (`Daemon.swift`), but `config.setClaudeCloud` persists this
+    /// flag unconditionally — it does not check the outer flag
+    /// (`RPCRouter+ConfigHandlers.swift`) — so `enabled` can be true while
+    /// `remoteBackendsEnabled` is false, and a caption built from `(enabled,
+    /// live)` alone would call that state "on" when a restart right now would
+    /// not actually start cloud sessions.
+    ///
+    /// `remoteBackendsLive` (the outer flag's own boot-frozen liveness) is
+    /// deliberately NOT a parameter here: whenever `live` is true, the outer
+    /// manager was necessarily live at that same boot (cloud's boot-time gate
+    /// checks `remoteBackendsEnabled` before constructing the manager at all),
+    /// so `live` already implies the outer manager was live — a separate
+    /// `remoteBackendsLive` input could never disagree with `live` in any
+    /// reachable state and would only add branches nothing can distinguish.
+    /// The outer flag's OWN restart/live nuance is already surfaced by the
+    /// sibling `remoteBackendsStatusCaption`, rendered directly above this
+    /// toggle — this caption only needs to say when the outer flag's CURRENT
+    /// value changes what a restart would do to cloud.
+    nonisolated static func claudeCloudStatusCaption(
+        enabled: Bool, live: Bool, remoteBackendsEnabled: Bool
+    ) -> String {
+        switch (enabled, live, remoteBackendsEnabled) {
+        case (false, false, false):
+            return "Off. Turning this on requires remote sessions above enabled and a daemon restart before cloud sessions appear."
+        case (false, false, true):
             return "Off. Turning this on requires a daemon restart before cloud sessions appear."
-        case (true, false):
-            return "On, but restart the daemon before cloud sessions appear."
-        case (true, true):
-            return "On and running — cloud sessions are being polled."
-        case (false, true):
+        case (false, true, _):
             return "Off, but the provider registered before this change is still live in the daemon — restart to fully stop it."
+        case (true, false, false):
+            return "On, but remote sessions above are off — enable both, then restart the daemon before cloud sessions appear."
+        case (true, false, true):
+            return "On, but restart the daemon before cloud sessions appear."
+        case (true, true, false):
+            return "On, but remote sessions above are now off — restarting will stop cloud sessions unless you re-enable remote sessions above first."
+        case (true, true, true):
+            return "On and running — cloud sessions are being polled."
         }
     }
 

--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -351,4 +351,21 @@ extension AppState {
     nonisolated static func claudeCloudToggleOperable(remoteBackendsEnabled: Bool) -> Bool {
         remoteBackendsEnabled
     }
+
+    /// What cloud sessions TBD can see, stated once and independently of
+    /// which flag state the user is in.
+    ///
+    /// `list` answers from the ledger of what THIS machine started, because no
+    /// supported interface enumerates an account's cloud sessions. So a
+    /// session begun on claude.ai, in the mobile app, or by `claude --cloud`
+    /// in a terminal TBD did not spawn has no row here at all — not a partial
+    /// one, not a stale one, simply none. Saying so makes the absence read as
+    /// a property of the feature rather than as a bug.
+    ///
+    /// A separate value from `claudeCloudStatusCaption` deliberately: that
+    /// function's seven arms answer "which state am I in", they are pinned
+    /// byte-for-byte by tests, and this sentence is true in all seven.
+    nonisolated static let claudeCloudScopeCaption =
+        "Only sessions started from TBD on this Mac appear here — one begun on claude.ai, in the "
+        + "mobile app, or from a terminal TBD did not spawn is not listed."
 }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1258,6 +1258,11 @@ final class AppState: ObservableObject {
     /// injectable for the same reason as `controlModeSetter`.
     lazy var queuedPromptFlagSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setQueuedPrompt(enabled: enabled) }
+    /// How `setClaudeCloudEnabled` persists the Claude cloud gate — injectable
+    /// for the same reason as `controlModeSetter`, so the Settings toggle's
+    /// success and failure branches are testable without a real daemon.
+    lazy var claudeCloudFlagSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in try await daemonClient.setClaudeCloud(enabled: enabled) }
     /// The worktree a queued prompt is being composed for, driving
     /// `ContentView`'s `.sheet(item:)`. Non-nil only while the modal is up, and
     /// only ever set when the daemon reports `queuedPromptEnabled`

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -993,6 +993,16 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the Claude cloud sessions gate (default OFF). The daemon builds
+    /// its provider manager only at boot, so this takes effect on the next
+    /// daemon restart rather than the next gesture.
+    func setClaudeCloud(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetClaudeCloud,
+            params: ConfigSetClaudeCloudParams(enabled: enabled)
+        )
+    }
+
     /// Park the prompt composed while a worktree was still being created, to be
     /// delivered to its primary agent whenever that agent turns up. `text: nil`
     /// unparks. A second call replaces the first — one prompt per worktree, not

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -214,6 +214,7 @@ struct GeneralSettingsTab: View {
 
             Section("Remote Sessions") {
                 remoteBackendsToggle
+                claudeCloudToggle
                 remoteProvidersRegistryRow
             }
 
@@ -512,6 +513,27 @@ struct GeneralSettingsTab: View {
         ))
         .help("Providers are registered in the file below. The daemon only builds its provider manager at boot, so turning this on requires a daemon restart before polling starts.")
         Text(AppState.remoteBackendsStatusCaption(enabled: enabled, live: live))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    /// Claude cloud sessions. A second gate INSIDE the remote-sessions switch
+    /// above, never a bypass — cloud is reached through the same `remote.*`
+    /// verbs, so it requires both. Reads the persisted flag from
+    /// `daemon.capabilities` and writes via `config.setClaudeCloud`.
+    @ViewBuilder
+    private var claudeCloudToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        let enabled = capabilities?.claudeCloudEnabled ?? false
+        let live = capabilities?.claudeCloudLive ?? false
+        Toggle("Enable Claude cloud sessions", isOn: Binding(
+            get: { enabled },
+            set: { newValue in Task { await appState.setClaudeCloudEnabled(newValue) } }
+        ))
+        .disabled(!AppState.claudeCloudToggleOperable(
+            remoteBackendsEnabled: capabilities?.remoteBackendsEnabled ?? false))
+        .help("Creates and watches Claude Code sessions running on Anthropic's hosted infrastructure. Requires remote agent sessions above, and a daemon restart before anything is polled. Off by default (soaking).")
+        Text(AppState.claudeCloudStatusCaption(enabled: enabled, live: live))
             .font(.caption)
             .foregroundStyle(.secondary)
     }

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -526,14 +526,14 @@ struct GeneralSettingsTab: View {
         let capabilities = appState.daemonCapabilities
         let enabled = capabilities?.claudeCloudEnabled ?? false
         let live = capabilities?.claudeCloudLive ?? false
+        let remoteEnabled = capabilities?.remoteBackendsEnabled ?? false
         Toggle("Enable Claude cloud sessions", isOn: Binding(
             get: { enabled },
             set: { newValue in Task { await appState.setClaudeCloudEnabled(newValue) } }
         ))
-        .disabled(!AppState.claudeCloudToggleOperable(
-            remoteBackendsEnabled: capabilities?.remoteBackendsEnabled ?? false))
+        .disabled(!AppState.claudeCloudToggleOperable(remoteBackendsEnabled: remoteEnabled))
         .help("Creates and watches Claude Code sessions running on Anthropic's hosted infrastructure. Requires remote agent sessions above, and a daemon restart before anything is polled. Off by default (soaking).")
-        Text(AppState.claudeCloudStatusCaption(enabled: enabled, live: live))
+        Text(AppState.claudeCloudStatusCaption(enabled: enabled, live: live, remoteBackendsEnabled: remoteEnabled))
             .font(.caption)
             .foregroundStyle(.secondary)
     }

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -536,6 +536,9 @@ struct GeneralSettingsTab: View {
         Text(AppState.claudeCloudStatusCaption(enabled: enabled, live: live, remoteBackendsEnabled: remoteEnabled))
             .font(.caption)
             .foregroundStyle(.secondary)
+        Text(AppState.claudeCloudScopeCaption)
+            .font(.caption)
+            .foregroundStyle(.secondary)
     }
 
     /// The registry file row — tilde-abbreviated path + copy-path button,

--- a/Sources/TBDApp/Sidebar/CloudCreateEntryPresentation.swift
+++ b/Sources/TBDApp/Sidebar/CloudCreateEntryPresentation.swift
@@ -1,0 +1,31 @@
+import Foundation
+import TBDShared
+
+/// Which providers a repository's create surfaces offer.
+///
+/// The daemon registers the compiled cloud provider only when it BOOTED with
+/// `claude_cloud_enabled` on, so a provider that is absent is already absent
+/// from `remoteProviders` and needs no filtering. What this gate covers is the
+/// other direction: a daemon that booted with the flag on and a user who has
+/// since turned it off, where the provider is still registered but every one
+/// of its verbs is refused by the daemon's inner gate. Offering an entry that
+/// can only fail is exactly what the repository's omit-don't-disable
+/// convention exists to prevent.
+enum CloudCreateEntryPresentation {
+    /// The providers the "New Remote Session…" enumeration should list.
+    static func createProviders(
+        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+    ) -> [RemoteProviderStatus] {
+        guard !claudeCloudEnabled else { return providers }
+        return providers.filter { $0.config.name != ClaudeCloudProvider.name }
+    }
+
+    /// The compiled cloud provider, when there is one to offer. Nil both when
+    /// the flag is off and when the daemon never registered it.
+    static func cloudProvider(
+        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+    ) -> RemoteProviderStatus? {
+        guard claudeCloudEnabled else { return nil }
+        return providers.first { $0.config.name == ClaudeCloudProvider.name }
+    }
+}

--- a/Sources/TBDApp/Sidebar/CloudCreateEntryPresentation.swift
+++ b/Sources/TBDApp/Sidebar/CloudCreateEntryPresentation.swift
@@ -20,12 +20,21 @@ enum CloudCreateEntryPresentation {
         return providers.filter { $0.config.name != ClaudeCloudProvider.name }
     }
 
-    /// The compiled cloud provider, when there is one to offer. Nil both when
-    /// the flag is off and when the daemon never registered it.
+    /// The compiled cloud provider, when there is one to offer. Nil when the
+    /// flag is off, when the daemon never registered it, or when its
+    /// inventory is stale. The `+` picker's cloud row (this function's only
+    /// caller) has no disabled state of its own — unlike the context menu
+    /// and the Remote section header, which both disable their own `+` on
+    /// `hasStaleSnapshot` — so a stale snapshot has to remove the row the
+    /// same way an absent provider does, or the sheet would open onto a
+    /// create call the daemon refuses with "inventory is stale".
     static func cloudProvider(
         _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
     ) -> RemoteProviderStatus? {
         guard claudeCloudEnabled else { return nil }
-        return providers.first { $0.config.name == ClaudeCloudProvider.name }
+        guard let provider = providers.first(where: { $0.config.name == ClaudeCloudProvider.name }) else {
+            return nil
+        }
+        return provider.hasStaleSnapshot ? nil : provider
     }
 }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -181,6 +181,37 @@ struct RemoteProviderHeaderRow: View {
         RemoteProviderStatusPresentation.issueSummary(provider)
     }
 
+    /// Whether this header's `+` and its `RemoteCreateSheet` may be offered
+    /// at all — the third create surface routed through
+    /// `CloudCreateEntryPresentation`, alongside `RepoSectionView`'s context
+    /// menu (`remoteSessionMenuProviders`) and `+` picker
+    /// (`cloudSessionProvider`). True for every non-cloud provider regardless
+    /// of the flag; false for the compiled cloud provider once
+    /// `claude_cloud_enabled` has been turned off, even though the daemon
+    /// booted with it on and still keeps the provider registered here — the
+    /// state `remote.create` refuses with "claude cloud sessions disabled".
+    /// Omitted (not merely disabled) to match the same convention the
+    /// context menu and `+` picker already follow for this gate; staleness
+    /// stays a separate, disabled-not-omitted axis on the button below.
+    private var canCreate: Bool {
+        RemoteProviderHeaderRow.canCreate(
+            provider: provider,
+            claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false)
+    }
+
+    /// Pure form of `canCreate`, over a single provider — split out so a test
+    /// can call the exact decision this row renders from without an
+    /// `AppState`/view hierarchy, and so a parity test can check it against
+    /// `RepoSectionView`'s two create surfaces directly (see
+    /// `CloudCreateEntryPresentationTests`'s cross-surface parity suite).
+    nonisolated static func canCreate(
+        provider: RemoteProviderStatus, claudeCloudEnabled: Bool
+    ) -> Bool {
+        !CloudCreateEntryPresentation.createProviders(
+            [provider], claudeCloudEnabled: claudeCloudEnabled
+        ).isEmpty
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: -1) {
             HStack(spacing: 4) {
@@ -204,20 +235,22 @@ struct RemoteProviderHeaderRow: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Open \(provider.describe?.name ?? provider.config.name) provider desk")
                 healthSuffix
-                Button {
-                    showingCreateSheet = true
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
+                if canCreate {
+                    Button {
+                        showingCreateSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 16, height: 16)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(provider.hasStaleSnapshot)
+                    .help(provider.hasStaleSnapshot
+                          ? "Inventory is stale; refresh must recover before creating sessions"
+                          : "New \(provider.describe?.name ?? provider.config.name) session")
                 }
-                .buttonStyle(.plain)
-                .disabled(provider.hasStaleSnapshot)
-                .help(provider.hasStaleSnapshot
-                      ? "Inventory is stale; refresh must recover before creating sessions"
-                      : "New \(provider.describe?.name ?? provider.config.name) session")
             }
             if let issueSummary {
                 Text(issueSummary)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -260,8 +260,8 @@ struct RepoSectionView: View {
                             repoID: repo.id,
                             highlightDefaultProfile: newWorktreeMenu.isTriggerHovered,
                             onClose: { newWorktreeMenu.closeNow() },
-                            onSelectCloudSession: CloudCreateEntryPresentation.cloudProvider(
-                                appState.remoteProviders,
+                            onSelectCloudSession: RepoSectionView.cloudSessionProvider(
+                                providers: appState.remoteProviders,
                                 claudeCloudEnabled: appState.daemonCapabilities?
                                     .claudeCloudEnabled ?? false
                             ).map { provider in
@@ -402,6 +402,33 @@ struct RepoSectionView: View {
         return ISO8601DateFormatter().date(from: raw)
     }
 
+    // MARK: - The cloud gate — pure, view-free forms of what the two owned
+    // create surfaces render, so a test can call the exact decision each
+    // surface makes rather than re-deriving it. See
+    // `CloudCreateEntryPresentationTests`'s cross-surface parity suite,
+    // which checks these two against `RemoteProviderHeaderRow.canCreate`
+    // (`RemoteSectionView.swift`) — the third owned surface — for agreement.
+
+    /// The providers `newRemoteSessionMenuItem`'s context menu lists. A thin,
+    /// named forward to `CloudCreateEntryPresentation.createProviders` so the
+    /// view has no inline gate logic of its own to drift from what this
+    /// function (and its test coverage) pins.
+    nonisolated static func remoteSessionMenuProviders(
+        providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+    ) -> [RemoteProviderStatus] {
+        CloudCreateEntryPresentation.createProviders(providers, claudeCloudEnabled: claudeCloudEnabled)
+    }
+
+    /// The provider `newWorktreePlusButton` opens the create sheet for, or
+    /// nil to omit the `+` picker's cloud row entirely. A thin, named forward
+    /// to `CloudCreateEntryPresentation.cloudProvider` for the same reason as
+    /// `remoteSessionMenuProviders` above.
+    nonisolated static func cloudSessionProvider(
+        providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+    ) -> RemoteProviderStatus? {
+        CloudCreateEntryPresentation.cloudProvider(providers, claudeCloudEnabled: claudeCloudEnabled)
+    }
+
     // MARK: - Context menu
 
     /// Extracted out of the row's `.contextMenu` — the nested conditionals
@@ -440,8 +467,8 @@ struct RepoSectionView: View {
     /// two-entry submenu with a dead row in it.
     @ViewBuilder
     private var newRemoteSessionMenuItem: some View {
-        let providers = CloudCreateEntryPresentation.createProviders(
-            appState.remoteProviders,
+        let providers = RepoSectionView.remoteSessionMenuProviders(
+            providers: appState.remoteProviders,
             claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false)
         if !providers.isEmpty {
             if providers.count == 1, let only = providers.first {

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -259,7 +259,14 @@ struct RepoSectionView: View {
                         content: WorktreeProfilePickerView(
                             repoID: repo.id,
                             highlightDefaultProfile: newWorktreeMenu.isTriggerHovered,
-                            onClose: { newWorktreeMenu.closeNow() }
+                            onClose: { newWorktreeMenu.closeNow() },
+                            onSelectCloudSession: CloudCreateEntryPresentation.cloudProvider(
+                                appState.remoteProviders,
+                                claudeCloudEnabled: appState.daemonCapabilities?
+                                    .claudeCloudEnabled ?? false
+                            ).map { provider in
+                                { openRemoteCreateSheet(for: provider) }
+                            }
                         )
                         .environmentObject(appState)
                         .background(.ultraThickMaterial)
@@ -420,21 +427,29 @@ struct RepoSectionView: View {
         }
     }
 
-    /// Task 10: a repo-scoped entry point into the create sheet, prefilled
-    /// with this repo — omitted (not disabled) when no remote provider is
-    /// registered at all, mirroring how `RemoteSessionActionMenu` omits
-    /// capability-gated items rather than graying them out. A single
-    /// provider skips straight to the sheet; more than one asks which
-    /// provider first.
+    /// A repo-scoped entry point into the create sheet, prefilled with this
+    /// repo — omitted (not disabled) when no remote provider is offerable at
+    /// all, mirroring how `RemoteSessionActionMenu` omits capability-gated
+    /// items rather than graying them out. A single provider skips straight
+    /// to the sheet; more than one asks which provider first.
+    ///
+    /// The compiled cloud provider joins this list for free once the daemon
+    /// registers it; `CloudCreateEntryPresentation` is what takes it back out
+    /// when the flag has been turned off since boot, and the fast-path count
+    /// is decided AFTER that filter so a hidden entry cannot leave a
+    /// two-entry submenu with a dead row in it.
     @ViewBuilder
     private var newRemoteSessionMenuItem: some View {
-        if !appState.remoteProviders.isEmpty {
-            if appState.remoteProviders.count == 1, let only = appState.remoteProviders.first {
+        let providers = CloudCreateEntryPresentation.createProviders(
+            appState.remoteProviders,
+            claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false)
+        if !providers.isEmpty {
+            if providers.count == 1, let only = providers.first {
                 Button("New Remote Session…") { openRemoteCreateSheet(for: only) }
                     .disabled(only.hasStaleSnapshot)
             } else {
                 Menu("New Remote Session…") {
-                    ForEach(appState.remoteProviders, id: \.config.name) { provider in
+                    ForEach(providers, id: \.config.name) { provider in
                         Button(provider.describe?.name ?? provider.config.name) {
                             openRemoteCreateSheet(for: provider)
                         }

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -34,6 +34,11 @@ struct WorktreeProfilePickerView: View {
     /// `@Environment(\.dismiss)` of its own (that's a SwiftUI popover/sheet
     /// concept). Wired to the owning `HoverMenuModel.closeNow()`.
     var onClose: () -> Void = {}
+    /// Opens the cloud-session create sheet. **Nil omits the row entirely** —
+    /// the repo header's `+` supplies it only when there is a cloud provider
+    /// to create against, and the nested `+` on a worktree row never does: a
+    /// cloud session is created against a repository, not beneath a lane.
+    var onSelectCloudSession: (() -> Void)? = nil
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
@@ -100,6 +105,18 @@ struct WorktreeProfilePickerView: View {
                 page = .branches
             }
             .padding(.top, 2)
+
+            if let onSelectCloudSession {
+                ProfilePickerRow(
+                    title: "New cloud session…",
+                    subtitle: "Runs on Anthropic's infrastructure",
+                    systemImage: "cloud"
+                ) {
+                    dismiss()
+                    onClose()
+                    onSelectCloudSession()
+                }
+            }
 
             Divider()
                 .padding(.vertical, 2)

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -294,6 +294,85 @@ public final class Daemon: Sendable {
         return verifier
     }
 
+    /// The construction behind `remote_backends_enabled` / `claude_cloud_enabled`
+    /// at boot (Task 7) — the sole place `RemoteProviderManager` is
+    /// constructed in production. Extracted from `start()` for the same
+    /// reason `wireDeliveryVerification` was: a flag's states are distinct
+    /// behaviors, and none of them was reachable from a test while this was
+    /// inline — every cloud test built the manager by hand instead, which is
+    /// how an earlier draft of this delivery nearly shipped without
+    /// `actuationLog:` (dropping it silently disables `syncFilingDecisions`
+    /// for every provider, `RemoteProviderManager.swift`, behind one `.debug`
+    /// log line — no crash, no error, suite still green). `actuationLog` has
+    /// no default here, unlike on `RemoteProviderManager`'s own initializer,
+    /// so the omission that mattered cannot happen silently at this, the one
+    /// production call site.
+    ///
+    /// Three outcomes:
+    /// - `remote_backends_enabled` off (or mock mode never calls this at
+    ///   all): `(nil, false)`.
+    /// - on, `claude_cloud_enabled` off: a manager with no `claude-cloud`
+    ///   entry, `claudeCloudLive == false`.
+    /// - on, `claude_cloud_enabled` on: a manager whose `claude-cloud` entry
+    ///   depends on `resolveClaudeExecutable` — present with
+    ///   `claudeCloudLive == true` when it succeeds, absent with
+    ///   `claudeCloudLive == false` when it throws (no `claude` on this box;
+    ///   registering a provider whose every verb would fail is worse than
+    ///   registering none). Both keep the manager itself non-nil, so every
+    ///   other registered backend stays live regardless of cloud's own state.
+    ///
+    /// Both gates are read once, here: the built-in provider is registered
+    /// into the dispatcher at this same moment, so a manager built while the
+    /// cloud flag was off has no `claude-cloud` entry at all, and flipping
+    /// the flag without a restart cannot conjure one into a running actor.
+    /// `claudeCloudLive` is what lets the app say "on, but needs a restart"
+    /// without calling a `remote.*` verb and parsing its error string.
+    ///
+    /// `registryURL` and `subprocess` are injection seams for tests only —
+    /// both default to production's real values (`TBDConstants.agentProvidersPath`,
+    /// a genuine `ProviderRunner`), so the one production call site
+    /// (`start()`) never passes either and behavior there is unchanged.
+    static func makeRemoteProviderManager(
+        database: TBDDatabase, subs: StateSubscriptionManager, actuationLog: ActuationLog,
+        registryURL: URL = URL(fileURLWithPath: TBDConstants.agentProvidersPath),
+        subprocess: any RemoteProviderInvoking = ProviderRunner(),
+        resolveClaudeExecutable: () throws -> String = { try ClaudeExecutableResolver.resolve() }
+    ) async -> (manager: RemoteProviderManager?, claudeCloudLive: Bool) {
+        let bootConfig = try? await database.config.get()
+        guard bootConfig?.remoteBackendsEnabled == true else { return (nil, false) }
+        var builtIns: [String: any RemoteProviderInvoking] = [:]
+        var builtInConfigs: [RemoteProviderConfig] = []
+        if bootConfig?.claudeCloudEnabled == true {
+            do {
+                let claudePath = try resolveClaudeExecutable()
+                builtIns[ClaudeCloudProvider.name] = ClaudeCloudInvoker(
+                    db: database,
+                    spawner: BoundedProcessClaudeSpawner(executable: claudePath))
+                // `RemoteProviderConfig` requires an `exec` the built-in
+                // provider has no honest use for: the dispatcher routes the
+                // reserved name in-process before `exec` is ever read. It
+                // carries the resolved `claude` path because the app-side
+                // attach path needs a real path to spawn.
+                builtInConfigs = [
+                    RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: claudePath)
+                ]
+            } catch {
+                // No `claude` on this box. Registering a provider whose
+                // every verb would fail is worse than registering none, and
+                // `claudeCloudLive` staying false is what says so on screen.
+                daemonLogger.error(
+                    "claude cloud is enabled but no claude executable resolved: \(String(describing: error), privacy: .public)")
+            }
+        }
+        let manager = RemoteProviderManager(
+            db: database, subscriptions: subs,
+            runner: ProviderDispatcher(subprocess: subprocess, builtIns: builtIns),
+            registryURL: registryURL,
+            actuationLog: actuationLog,
+            builtInProviders: builtInConfigs)
+        return (manager, !builtIns.isEmpty)
+    }
+
     /// Recreate the base scratch directory if it's missing. Safe to call every startup.
     static func ensureScratchDir() {
         let fm = FileManager.default
@@ -502,48 +581,12 @@ public final class Daemon: Sendable {
 
         var remoteManager: RemoteProviderManager?
         var claudeCloudLive = false
-        let bootConfig = try? await database.config.get()
-        if mockMode == nil, bootConfig?.remoteBackendsEnabled == true {
-            // Cloud requires BOTH gates, and both are read once here: the
-            // built-in provider is registered into the dispatcher at this same
-            // moment, so a manager built while the cloud flag was off has no
-            // `claude-cloud` entry at all and flipping the flag cannot conjure
-            // one into a running actor. `claudeCloudLive` is what lets the app
-            // say "on, but needs a restart" without calling a `remote.*` verb
-            // and parsing its error string.
-            var builtIns: [String: any RemoteProviderInvoking] = [:]
-            var builtInConfigs: [RemoteProviderConfig] = []
-            if bootConfig?.claudeCloudEnabled == true {
-                do {
-                    let claudePath = try ClaudeExecutableResolver.resolve()
-                    builtIns[ClaudeCloudProvider.name] = ClaudeCloudInvoker(
-                        db: database,
-                        spawner: BoundedProcessClaudeSpawner(executable: claudePath))
-                    // `RemoteProviderConfig` requires an `exec` the built-in
-                    // provider has no honest use for: the dispatcher routes the
-                    // reserved name in-process before `exec` is ever read. It
-                    // carries the resolved `claude` path because the app-side
-                    // attach path needs a real path to spawn.
-                    builtInConfigs = [
-                        RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: claudePath)
-                    ]
-                } catch {
-                    // No `claude` on this box. Registering a provider whose
-                    // every verb would fail is worse than registering none, and
-                    // `claudeCloudLive` staying false is what says so on screen.
-                    daemonLogger.error(
-                        "claude cloud is enabled but no claude executable resolved: \(String(describing: error), privacy: .public)")
-                }
-            }
-            let manager = RemoteProviderManager(
-                db: database, subscriptions: subs,
-                runner: ProviderDispatcher(subprocess: ProviderRunner(), builtIns: builtIns),
-                registryURL: URL(fileURLWithPath: TBDConstants.agentProvidersPath),
-                actuationLog: actuationLog,
-                builtInProviders: builtInConfigs)
-            self.remoteManager = manager
-            remoteManager = manager
-            claudeCloudLive = !builtIns.isEmpty
+        if mockMode == nil {
+            let outcome = await Self.makeRemoteProviderManager(
+                database: database, subs: subs, actuationLog: actuationLog)
+            remoteManager = outcome.manager
+            claudeCloudLive = outcome.claudeCloudLive
+            self.remoteManager = outcome.manager
         }
 
         let prManager = PRStatusManager()

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -504,17 +504,46 @@ public final class Daemon: Sendable {
         var claudeCloudLive = false
         let bootConfig = try? await database.config.get()
         if mockMode == nil, bootConfig?.remoteBackendsEnabled == true {
-            let manager = RemoteProviderManager(
-                db: database, subscriptions: subs, runner: ProviderRunner(),
-                registryURL: URL(fileURLWithPath: TBDConstants.agentProvidersPath),
-                actuationLog: actuationLog)
-            self.remoteManager = manager
-            remoteManager = manager
             // Cloud requires BOTH gates, and both are read once here: the
             // built-in provider is registered into the dispatcher at this same
             // moment, so a manager built while the cloud flag was off has no
-            // `claude-cloud` entry at all.
-            claudeCloudLive = bootConfig?.claudeCloudEnabled == true
+            // `claude-cloud` entry at all and flipping the flag cannot conjure
+            // one into a running actor. `claudeCloudLive` is what lets the app
+            // say "on, but needs a restart" without calling a `remote.*` verb
+            // and parsing its error string.
+            var builtIns: [String: any RemoteProviderInvoking] = [:]
+            var builtInConfigs: [RemoteProviderConfig] = []
+            if bootConfig?.claudeCloudEnabled == true {
+                do {
+                    let claudePath = try ClaudeExecutableResolver.resolve()
+                    builtIns[ClaudeCloudProvider.name] = ClaudeCloudInvoker(
+                        db: database,
+                        spawner: BoundedProcessClaudeSpawner(executable: claudePath))
+                    // `RemoteProviderConfig` requires an `exec` the built-in
+                    // provider has no honest use for: the dispatcher routes the
+                    // reserved name in-process before `exec` is ever read. It
+                    // carries the resolved `claude` path because the app-side
+                    // attach path needs a real path to spawn.
+                    builtInConfigs = [
+                        RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: claudePath)
+                    ]
+                } catch {
+                    // No `claude` on this box. Registering a provider whose
+                    // every verb would fail is worse than registering none, and
+                    // `claudeCloudLive` staying false is what says so on screen.
+                    daemonLogger.error(
+                        "claude cloud is enabled but no claude executable resolved: \(String(describing: error), privacy: .public)")
+                }
+            }
+            let manager = RemoteProviderManager(
+                db: database, subscriptions: subs,
+                runner: ProviderDispatcher(subprocess: ProviderRunner(), builtIns: builtIns),
+                registryURL: URL(fileURLWithPath: TBDConstants.agentProvidersPath),
+                actuationLog: actuationLog,
+                builtInProviders: builtInConfigs)
+            self.remoteManager = manager
+            remoteManager = manager
+            claudeCloudLive = !builtIns.isEmpty
         }
 
         let prManager = PRStatusManager()

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -501,13 +501,20 @@ public final class Daemon: Sendable {
         let actuationLog = ActuationLog(path: TBDConstants.actuationLogPath)
 
         var remoteManager: RemoteProviderManager?
-        if mockMode == nil, (try? await database.config.get())?.remoteBackendsEnabled == true {
+        var claudeCloudLive = false
+        let bootConfig = try? await database.config.get()
+        if mockMode == nil, bootConfig?.remoteBackendsEnabled == true {
             let manager = RemoteProviderManager(
                 db: database, subscriptions: subs, runner: ProviderRunner(),
                 registryURL: URL(fileURLWithPath: TBDConstants.agentProvidersPath),
                 actuationLog: actuationLog)
             self.remoteManager = manager
             remoteManager = manager
+            // Cloud requires BOTH gates, and both are read once here: the
+            // built-in provider is registered into the dispatcher at this same
+            // moment, so a manager built while the cloud flag was off has no
+            // `claude-cloud` entry at all.
+            claudeCloudLive = bootConfig?.claudeCloudEnabled == true
         }
 
         let prManager = PRStatusManager()
@@ -542,6 +549,7 @@ public final class Daemon: Sendable {
             modelProfileResolver: modelProfileResolver,
             pendingQuestions: pendingQuestions,
             remoteManager: remoteManager,
+            claudeCloudLive: claudeCloudLive,
             actuationLog: actuationLog
         )
         // Wire the shared input activity tracker to the coordinator

--- a/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
+++ b/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
@@ -200,17 +200,59 @@ public struct ClaudeCloudSessionStore: Sendable {
     /// fail a create that otherwise succeeded. A retry that resolves the same
     /// `id` twice, or names an `id` this store has never seen, is a harmless
     /// no-op: there is nothing to double-apply and nothing to update.
+    ///
+    /// Compare-and-set on `sessionID`, deliberately **not** on `state`. The
+    /// two invariants that matter here are narrower than "the row is still
+    /// pending": a session id must never be lost, and it must never be
+    /// overwritten by a *different* one. `WHERE id = ? AND (sessionID IS NULL
+    /// OR sessionID = ?)` enforces exactly those two and nothing more:
+    ///
+    /// - a `pending` row (`sessionID` NULL) resolves normally;
+    /// - a row that reached `failed` while its spawn was still in flight —
+    ///   `markFailed`'s own doc comment describes the gap that produces this
+    ///   — still had no session id recorded, so it still resolves rather than
+    ///   orphaning the session that was actually created;
+    /// - a same-id retry is the harmless idempotent no-op already promised
+    ///   above;
+    /// - a row already naming a **different** session refuses. That case
+    ///   means two sessions exist under one ledger row, which this store has
+    ///   no way to reconcile on its own, so it is logged loudly rather than
+    ///   silently dropped or silently overwritten.
+    ///
+    /// A `state = 'pending'` predicate — the shape `claimForSpawn` and
+    /// `markFailed` use — was considered and rejected: it would make this
+    /// call silently DROP the write whenever the row is not `pending`,
+    /// including the `failed`-with-no-id case above, and losing a real
+    /// session's id is the exact harm this ledger exists to prevent. A guard
+    /// that causes that harm is worse than no guard at all.
     public func resolve(id: String, sessionID: String, title: String?, now: Date) async throws {
         try await writer.write { db in
             try db.execute(
                 sql: """
                 UPDATE claude_cloud_session
                 SET state = ?, sessionID = ?, title = ?, resolvedAt = ?
-                WHERE id = ?
+                WHERE id = ? AND (sessionID IS NULL OR sessionID = ?)
                 """,
                 arguments: [
-                    ClaudeCloudLedgerState.resolved.rawValue, sessionID, title, now, id,
+                    ClaudeCloudLedgerState.resolved.rawValue, sessionID, title, now, id, sessionID,
                 ])
+            guard db.changesCount == 1 else {
+                // Either the id does not exist (the documented no-op above) or
+                // it exists but already names a DIFFERENT session — the only
+                // other way this UPDATE can affect zero rows. Only the latter
+                // is worth a human's attention, so check which one this was.
+                if let existing = try ClaudeCloudSessionRow
+                    .filter(Column("id") == id).fetchOne(db),
+                    let existingSessionID = existing.sessionID, existingSessionID != sessionID {
+                    claudeCloudLogger.error(
+                        """
+                        claude-cloud resolve refused: row \(id, privacy: .public) already names \
+                        session \(existingSessionID, privacy: .public); refusing to overwrite with \
+                        \(sessionID, privacy: .public) — two sessions now exist under one ledger row
+                        """)
+                }
+                return
+            }
         }
     }
 

--- a/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
+++ b/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
@@ -89,4 +89,41 @@ public struct ClaudeCloudSessionStore: Sendable {
             return row
         }
     }
+
+    /// A create whose output named a session. The provenance link is written
+    /// here and nowhere else. `title` is the vendor's parsed summary, or nil
+    /// when the title parse found nothing — a cosmetic loss that must never
+    /// fail a create that otherwise succeeded. A retry that resolves the same
+    /// `id` twice, or names an `id` this store has never seen, is a harmless
+    /// no-op: there is nothing to double-apply and nothing to update.
+    public func resolve(id: String, sessionID: String, title: String?, now: Date) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                UPDATE claude_cloud_session
+                SET state = ?, sessionID = ?, title = ?, resolvedAt = ?
+                WHERE id = ?
+                """,
+                arguments: [
+                    ClaudeCloudLedgerState.resolved.rawValue, sessionID, title, now, id,
+                ])
+        }
+    }
+
+    /// A pending create that produced no readable session id inside the
+    /// failure window. The row stops asking to be treated as in-flight and is
+    /// RETAINED rather than deleted, so a create that may well have started a
+    /// real session TBD cannot name stays visible as an unresolved create.
+    /// `ids` is a batch: an empty batch is a no-op rather than an `IN ()`
+    /// clause GRDB would otherwise turn into a query matching nothing (safe)
+    /// or, via a hand-rolled `IN ()`, a query matching everything (not safe) —
+    /// so the empty case is refused explicitly rather than trusted to SQL.
+    public func markFailed(ids: [String]) async throws {
+        guard !ids.isEmpty else { return }
+        try await writer.write { db in
+            try ClaudeCloudSessionRow
+                .filter(ids.contains(Column("id")))
+                .updateAll(db, Column("state").set(to: ClaudeCloudLedgerState.failed.rawValue))
+        }
+    }
 }

--- a/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
+++ b/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
@@ -151,6 +151,15 @@ public struct ClaudeCloudSessionStore: Sendable {
                     guard existing.sessionID == nil else { return .resolved(existing) }
                     reclaimable = ClaudeCloudLedgerState.resolved.rawValue
                 case .failed:
+                    // A failed row can still carry a session id: `resolve`
+                    // can land in the gap between `list()`'s read of a
+                    // pending row and its separate `markFailed` write, and a
+                    // row caught in exactly that gap must not be reclaimed
+                    // and re-spawned — it already names a real session, and
+                    // reclaiming it would overwrite that session's id on the
+                    // next `resolve`. Answer from the recorded session
+                    // instead, exactly like a resolved row with a session id.
+                    guard existing.sessionID == nil else { return .resolved(existing) }
                     reclaimable = ClaudeCloudLedgerState.failed.rawValue
                 case .pending:
                     reclaimable = nil
@@ -213,11 +222,25 @@ public struct ClaudeCloudSessionStore: Sendable {
     /// clause GRDB would otherwise turn into a query matching nothing (safe)
     /// or, via a hand-rolled `IN ()`, a query matching everything (not safe) —
     /// so the empty case is refused explicitly rather than trusted to SQL.
+    ///
+    /// Compare-and-set on `state = pending`: `ids` was computed from a read
+    /// taken in a SEPARATE transaction (`list()`'s snapshot), so by the time
+    /// this write runs, a row in that batch may already have resolved — a
+    /// `create` that finally read its session id in the gap between the read
+    /// and this write. Without the predicate this UPDATE would stamp that
+    /// row back to `failed`, destroying its `sessionID` even though `list()`
+    /// only projects `resolved` rows: the session would vanish from every
+    /// future `list` with no discovery to recover it, and `claimForSpawn`
+    /// would go on to reclaim the row and spawn a second real cloud session
+    /// under the same key. The predicate makes a row that resolved in the
+    /// gap skipped rather than clobbered — this is a no-op for it, not an
+    /// error, because the batch was already known to be a stale snapshot.
     public func markFailed(ids: [String]) async throws {
         guard !ids.isEmpty else { return }
         try await writer.write { db in
             try ClaudeCloudSessionRow
                 .filter(ids.contains(Column("id")))
+                .filter(Column("state") == ClaudeCloudLedgerState.pending.rawValue)
                 .updateAll(db, Column("state").set(to: ClaudeCloudLedgerState.failed.rawValue))
         }
     }

--- a/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
+++ b/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
@@ -117,7 +117,22 @@ public struct ClaudeCloudSessionStore: Sendable {
     /// moves it back to `pending` with a compare-and-set and claims only when
     /// that UPDATE actually changed a row. The transition is both the claim
     /// and the truth: an attempt is in flight again, so the pending window
-    /// governs it again.
+    /// governs it again — which is why the reclaim UPDATE also rewrites
+    /// `createdAt` to this call's `now`, not just `state`. `createdAt` carries
+    /// two meanings that stay consistent under that rewrite: it is the clock
+    /// `list`'s pending-failure window measures, and it is the session's
+    /// creation time in the `list` payload. A reclaimed row that goes on to
+    /// resolve did have its session created by THIS attempt, so both readings
+    /// stay true. Leaving the old `createdAt` in place — writing only `state`
+    /// — would make a row reclaimed the instant before a `list` poll read as
+    /// already past the window under the ORIGINAL attempt's age, so the very
+    /// next sweep marks it `failed` again while the reclaiming caller's spawn
+    /// is still in flight, and a third replay reclaims and spawns a second
+    /// time: the double-spawn hazard this method exists to close. The cost is
+    /// that a reclaimed row no longer records when the original attempt ran —
+    /// acceptable because nothing reads that: `list()` projects only
+    /// `resolved` rows, and the row is retained under the new timestamp
+    /// either way.
     public func claimForSpawn(
         idempotencyKey: String, repoKey: String, repoPath: String,
         branch: String?, environment: String?, paramsJSON: String, now: Date
@@ -146,13 +161,17 @@ public struct ClaudeCloudSessionStore: Sendable {
                 }
                 guard let expected = reclaimable else { return .inFlight }
                 try db.execute(
-                    sql: "UPDATE claude_cloud_session SET state = ? WHERE id = ? AND state = ?",
+                    sql: """
+                    UPDATE claude_cloud_session SET state = ?, createdAt = ?
+                    WHERE id = ? AND state = ?
+                    """,
                     arguments: [
-                        ClaudeCloudLedgerState.pending.rawValue, existing.id, expected,
+                        ClaudeCloudLedgerState.pending.rawValue, now, existing.id, expected,
                     ])
                 guard db.changesCount == 1 else { return .inFlight }
                 var claimed = existing
                 claimed.state = ClaudeCloudLedgerState.pending.rawValue
+                claimed.createdAt = now
                 return .claimed(claimed)
             }
             let row = ClaudeCloudSessionRow(

--- a/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
+++ b/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
@@ -1,0 +1,92 @@
+import Foundation
+import GRDB
+
+/// What a create in the cloud ledger currently knows about itself.
+///
+/// `pending` — the idempotency key was written and the invocation may or may
+/// not have produced a session. `resolved` — a session id was read out of
+/// `create`'s output and is on file. `failed` — the create did not produce a
+/// readable id within the failure window, so the row stops claiming a session
+/// while being RETAINED: the record of a create that may have started a real
+/// session must outlive the judgement that it did not.
+public enum ClaudeCloudLedgerState: String, Codable, Sendable {
+    case pending, resolved, failed
+}
+
+/// GRDB row for `claude_cloud_session`: **what this machine started.**
+///
+/// Distinct from the `remote_session` mirror, which is what the manager last
+/// observed. Daemon-internal — it never crosses the RPC wire, so it has no
+/// `TBDShared` Codable model, exactly like `watch_desk_judge_lease`.
+///
+/// This ledger is the whole of the `claude-cloud` provider's inventory: no
+/// supported interface enumerates an account's cloud sessions, so `list`
+/// answers from these rows alone and is permanently `complete: false`.
+public struct ClaudeCloudSessionRow: Codable, FetchableRecord, PersistableRecord, Sendable {
+    public static let databaseTableName = "claude_cloud_session"
+    public var id: String
+    public var idempotencyKey: String
+    public var state: String
+    /// Null until a create's output was read. A row with no session id is
+    /// never listed — there is no session to name.
+    public var sessionID: String?
+    /// The vendor's own server-derived summary of the opening instruction,
+    /// parsed off `create`'s first line. Null when that parse found nothing,
+    /// in which case the lane is named from its id instead. NEVER the
+    /// submitted prompt: a cloud session's name comes from the vendor.
+    public var title: String?
+    public var createdAt: Date
+    public var resolvedAt: Date?
+    /// The value the row contributes as `meta["repo"]`, so a ledger-only
+    /// session still resolves to its registered repository and gets adopted.
+    public var repoKey: String
+    /// The local checkout `create` runs from.
+    public var repoPath: String
+    public var branch: String?
+    public var environment: String?
+    public var paramsJSON: String
+    /// The filing axis, orthogonal to liveness. Written by the provider's
+    /// `archive`/`unarchive` verbs and reported on every later `list`, because
+    /// the contract requires archived sessions to stay enumerated — a session
+    /// filtered out of successive snapshots is indistinguishable from a
+    /// deleted one.
+    public var archived: Bool
+}
+
+public struct ClaudeCloudSessionStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) { self.writer = writer }
+
+    public func rows() async throws -> [ClaudeCloudSessionRow] {
+        try await writer.read { db in
+            try ClaudeCloudSessionRow.order(Column("createdAt")).fetchAll(db)
+        }
+    }
+
+    /// Writes the idempotency key and its state BEFORE the invocation, so a
+    /// create whose output could not be read leaves a `pending` row rather
+    /// than nothing — carrying the repository, the branch and the prompt that
+    /// were submitted. Idempotent on the key: the daemon's single same-key
+    /// retry finds the row it already wrote and keeps its original timestamp.
+    @discardableResult
+    public func upsertPending(
+        idempotencyKey: String, repoKey: String, repoPath: String,
+        branch: String?, environment: String?, paramsJSON: String, now: Date
+    ) async throws -> ClaudeCloudSessionRow {
+        try await writer.write { db in
+            if let existing = try ClaudeCloudSessionRow
+                .filter(Column("idempotencyKey") == idempotencyKey).fetchOne(db) {
+                return existing
+            }
+            let row = ClaudeCloudSessionRow(
+                id: UUID().uuidString, idempotencyKey: idempotencyKey,
+                state: ClaudeCloudLedgerState.pending.rawValue, sessionID: nil, title: nil,
+                createdAt: now, resolvedAt: nil, repoKey: repoKey, repoPath: repoPath,
+                branch: branch, environment: environment, paramsJSON: paramsJSON,
+                archived: false)
+            try row.insert(db)
+            return row
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
+++ b/Sources/TBDDaemon/Database/ClaudeCloudSessionStore.swift
@@ -90,6 +90,82 @@ public struct ClaudeCloudSessionStore: Sendable {
         }
     }
 
+    /// Whether a caller may spawn `claude --cloud` under an idempotency key.
+    public enum SpawnClaim: Sendable {
+        /// This caller owns the spawn; the row is `pending`.
+        case claimed(ClaudeCloudSessionRow)
+        /// Another attempt under this key holds the claim.
+        case inFlight
+        /// A session is already on file — answer from it rather than spawning.
+        case resolved(ClaudeCloudSessionRow)
+    }
+
+    /// Claims an idempotency key for a spawn, deciding and recording in ONE
+    /// write.
+    ///
+    /// A read followed by `upsertPending` could not be made safe however
+    /// carefully it was written, because `upsertPending` returns an existing
+    /// row UNCHANGED: a `failed` row stayed `failed` across the spawn, so two
+    /// replays arriving after the pending window gave up both read `failed`,
+    /// both fell through, and both spawned. With no discovery to reconcile
+    /// two live cloud sessions against one ledger row, that orphans one of
+    /// them permanently — and whichever `resolve` lands second overwrites the
+    /// first session id, erasing the only record of it.
+    ///
+    /// GRDB admits a single writer, so a concurrent caller waits and then
+    /// observes whatever state this one left. Reclaiming a row additionally
+    /// moves it back to `pending` with a compare-and-set and claims only when
+    /// that UPDATE actually changed a row. The transition is both the claim
+    /// and the truth: an attempt is in flight again, so the pending window
+    /// governs it again.
+    public func claimForSpawn(
+        idempotencyKey: String, repoKey: String, repoPath: String,
+        branch: String?, environment: String?, paramsJSON: String, now: Date
+    ) async throws -> SpawnClaim {
+        try await writer.write { db in
+            if let existing = try ClaudeCloudSessionRow
+                .filter(Column("idempotencyKey") == idempotencyKey).fetchOne(db) {
+                // The state this row must still be in for the claim to be
+                // this caller's. Nil means no claim is available at all.
+                let reclaimable: String?
+                switch ClaudeCloudLedgerState(rawValue: existing.state) {
+                case .resolved:
+                    // A resolved row with no session id names nothing, so it
+                    // is reclaimable rather than an answer. `resolve` always
+                    // writes one, so this is a can't-happen guarded anyway.
+                    guard existing.sessionID == nil else { return .resolved(existing) }
+                    reclaimable = ClaudeCloudLedgerState.resolved.rawValue
+                case .failed:
+                    reclaimable = ClaudeCloudLedgerState.failed.rawValue
+                case .pending:
+                    reclaimable = nil
+                case nil:
+                    // An unrecognized state is not a licence to start a second
+                    // cloud session; refuse rather than guess.
+                    reclaimable = nil
+                }
+                guard let expected = reclaimable else { return .inFlight }
+                try db.execute(
+                    sql: "UPDATE claude_cloud_session SET state = ? WHERE id = ? AND state = ?",
+                    arguments: [
+                        ClaudeCloudLedgerState.pending.rawValue, existing.id, expected,
+                    ])
+                guard db.changesCount == 1 else { return .inFlight }
+                var claimed = existing
+                claimed.state = ClaudeCloudLedgerState.pending.rawValue
+                return .claimed(claimed)
+            }
+            let row = ClaudeCloudSessionRow(
+                id: UUID().uuidString, idempotencyKey: idempotencyKey,
+                state: ClaudeCloudLedgerState.pending.rawValue, sessionID: nil, title: nil,
+                createdAt: now, resolvedAt: nil, repoKey: repoKey, repoPath: repoPath,
+                branch: branch, environment: environment, paramsJSON: paramsJSON,
+                archived: false)
+            try row.insert(db)
+            return .claimed(row)
+        }
+    }
+
     /// A create whose output named a session. The provenance link is written
     /// here and nowhere else. `title` is the vendor's parsed summary, or nil
     /// when the title parse found nothing — a cosmetic loss that must never

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -64,7 +64,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var gc_profile_dirs_enabled: Bool?
     /// The Claude cloud sessions gate (design 2026-08-15 §7). **Genuinely
     /// tri-state**, same shape as `queued_prompt_enabled`: the
-    /// `v80_config_claude_cloud` column carries no SQL default, so `nil` here
+    /// `v81_config_claude_cloud` column carries no SQL default, so `nil` here
     /// means "never chose" rather than "off". Resolve it through
     /// `Config.claudeCloudEnabledDefault`, never through `?? false`.
     var claude_cloud_enabled: Bool?

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -62,6 +62,12 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// Resolve it through `Config.gcProfileDirsEnabledDefault`, never through
     /// `?? false`.
     var gc_profile_dirs_enabled: Bool?
+    /// The Claude cloud sessions gate (design 2026-08-15 §7). **Genuinely
+    /// tri-state**, same shape as `queued_prompt_enabled`: the
+    /// `v80_config_claude_cloud` column carries no SQL default, so `nil` here
+    /// means "never chose" rather than "off". Resolve it through
+    /// `Config.claudeCloudEnabledDefault`, never through `?? false`.
+    var claude_cloud_enabled: Bool?
 
     /// - Parameter queuedPromptDefault: the shipped default a NULL
     ///   `queued_prompt_enabled` resolves to. Defaulted to the real constant;
@@ -74,10 +80,14 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   constant to change.
     /// - Parameter gcProfileDirsDefault: same shape again, for
     ///   `gc_profile_dirs_enabled` — the profile-dir collector's own soak gate.
+    /// - Parameter claudeCloudEnabledDefault: same shape again, for the Claude
+    ///   cloud gate — the parameter exists so tests can prove NULL follows a
+    ///   changed default while an explicit `false` does not.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
         supervisionEnabledDefault: Bool = Config.supervisionEnabledDefault,
-        gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault
+        gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault,
+        claudeCloudEnabledDefault: Bool = Config.claudeCloudEnabledDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -125,7 +135,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             supervisionEnabled: supervision_enabled ?? supervisionEnabledDefault,
             // Same reasoning again, for the profile-dir collector's gate —
             // NOT `?? false`.
-            gcProfileDirsEnabled: gc_profile_dirs_enabled ?? gcProfileDirsDefault
+            gcProfileDirsEnabled: gc_profile_dirs_enabled ?? gcProfileDirsDefault,
+            // Same reasoning again, for the Claude cloud gate — NOT `?? false`.
+            claudeCloudEnabled: claude_cloud_enabled ?? claudeCloudEnabledDefault
         )
     }
 }
@@ -405,6 +417,24 @@ public struct ConfigStore: Sendable {
                 arguments: [enabled, Self.singletonID]
             )
             return previous ?? Config.supervisionEnabledDefault
+        }
+    }
+
+    /// Persist the Claude cloud sessions gate (design 2026-08-15 §7). Off is the
+    /// shipped default. Writing either value is an explicit gesture that leaves
+    /// the column non-NULL forever after — including `false`, which is the
+    /// point: somebody who turned a scheduled network call off stays off when
+    /// the shipped default eventually graduates.
+    ///
+    /// The daemon builds its provider manager and registers the built-in
+    /// provider only at boot, so flipping this on does not start anything until
+    /// a restart — `DaemonCapabilitiesResult.claudeCloudLive` is what tells the
+    /// user which of the two states they are in.
+    public func setClaudeCloud(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET claude_cloud_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID])
         }
     }
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1462,6 +1462,8 @@ public final class TBDDatabase: Sendable {
         migrator.registerMigration("v80_clear_scratch_pr_observation") { db in
             try db.execute(
                 sql: "UPDATE worktree SET prObservation = NULL WHERE repoID IS NULL")
+        }
+
         // Claude cloud sessions (design 2026-08-15 §7): the second, inner gate
         // for the compiled `claude-cloud` provider. Shipped OFF per the house
         // default-off-flag rule — the behavior is autonomous background polling
@@ -1488,7 +1490,7 @@ public final class TBDDatabase: Sendable {
         // feature toggles, where "unset" must stay a third state so a shipped
         // default can be flipped later. This is data with an explicit writer
         // at every site, and there is no default to graduate.
-        migrator.registerMigration("v81_claude_cloud_session") { db in
+        migrator.registerMigration("v82_claude_cloud_session") { db in
             try db.createTableIfNotExists("claude_cloud_session") { t in
                 t.primaryKey("id", .text).notNull()
                 t.column("idempotencyKey", .text).notNull()

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -29,6 +29,7 @@ public final class TBDDatabase: Sendable {
     public let remoteSessions: RemoteSessionStore
     public let watchDeskLeases: WatchDeskLeaseStore
     public let prBindings: PRBindingStore
+    public let claudeCloudSessions: ClaudeCloudSessionStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -70,6 +71,7 @@ public final class TBDDatabase: Sendable {
         self.remoteSessions = RemoteSessionStore(writer: pool)
         self.watchDeskLeases = WatchDeskLeaseStore(writer: pool)
         self.prBindings = PRBindingStore(writer: pool)
+        self.claudeCloudSessions = ClaudeCloudSessionStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -111,6 +113,7 @@ public final class TBDDatabase: Sendable {
         self.remoteSessions = RemoteSessionStore(writer: queue)
         self.watchDeskLeases = WatchDeskLeaseStore(writer: queue)
         self.prBindings = PRBindingStore(writer: queue)
+        self.claudeCloudSessions = ClaudeCloudSessionStore(writer: queue)
         try Self.buildMigrator().migrate(queue)
     }
 
@@ -1474,6 +1477,39 @@ public final class TBDDatabase: Sendable {
         migrator.registerMigration("v81_config_claude_cloud") { db in
             try db.addColumnIfMissing(
                 table: "config", column: "claude_cloud_enabled", type: .boolean)
+        }
+
+        // The cloud create ledger: what THIS machine started, as distinct
+        // from `remote_session`, which is what the manager last observed.
+        // Daemon-internal, so it has no wire model.
+        //
+        // `archived` carries a SQL default deliberately, and the house
+        // no-SQL-default rule does not apply: that rule is about `config`
+        // feature toggles, where "unset" must stay a third state so a shipped
+        // default can be flipped later. This is data with an explicit writer
+        // at every site, and there is no default to graduate.
+        migrator.registerMigration("v81_claude_cloud_session") { db in
+            try db.createTableIfNotExists("claude_cloud_session") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("idempotencyKey", .text).notNull()
+                t.column("state", .text).notNull()
+                t.column("sessionID", .text)
+                t.column("title", .text)
+                t.column("createdAt", .datetime).notNull()
+                t.column("resolvedAt", .datetime)
+                t.column("repoKey", .text).notNull()
+                t.column("repoPath", .text).notNull()
+                t.column("branch", .text)
+                t.column("environment", .text)
+                t.column("paramsJSON", .text).notNull()
+                t.column("archived", .boolean).notNull().defaults(to: false)
+            }
+            try db.addIndexIfMissing(
+                "idx_claude_cloud_session_key", on: "claude_cloud_session",
+                columns: ["idempotencyKey"], unique: true)
+            try db.addIndexIfMissing(
+                "idx_claude_cloud_session_session", on: "claude_cloud_session",
+                columns: ["sessionID"], where: "sessionID IS NOT NULL")
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1459,6 +1459,21 @@ public final class TBDDatabase: Sendable {
         migrator.registerMigration("v80_clear_scratch_pr_observation") { db in
             try db.execute(
                 sql: "UPDATE worktree SET prObservation = NULL WHERE repoID IS NULL")
+        // Claude cloud sessions (design 2026-08-15 §7): the second, inner gate
+        // for the compiled `claude-cloud` provider. Shipped OFF per the house
+        // default-off-flag rule — the behavior is autonomous background polling
+        // against a network service.
+        //
+        // Tri-state like `v73_config_queued_prompt` and
+        // `v77_config_supervision_enabled`: **no SQL default**, so a
+        // pre-migration row reads NULL ("never chose") rather than 0. NULL
+        // resolves through `Config.claudeCloudEnabledDefault` in
+        // `ConfigRecord.toModel()` — the single place graduation changes, which
+        // matters more here than for most flags because somebody who turned a
+        // scheduled network call off did so deliberately.
+        migrator.registerMigration("v81_config_claude_cloud") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "claude_cloud_enabled", type: .boolean)
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/RemoteSessionStore.swift
+++ b/Sources/TBDDaemon/Database/RemoteSessionStore.swift
@@ -169,12 +169,29 @@ public struct RemoteSessionStore: Sendable {
         return resolved
     }
 
-    /// Reconcile one provider's full session list against the mirror table.
+    /// Reconcile one provider's session list against the mirror table.
     /// Rows for OTHER providers are never touched — snapshots are
     /// provider-scoped, so an empty snapshot from provider B must not affect
     /// provider A's rows.
+    ///
+    /// `complete` is the contract's snapshot-completeness claim
+    /// (`docs/remote-provider-contract.md` § Snapshot completeness). It splits
+    /// the three things a snapshot does. An INCOMPLETE snapshot still
+    /// **adopts** and **updates** the sessions it sighted — a session observed
+    /// in a partial view has been positively observed, and that observation is
+    /// as good as any other — while advancing **neither** the absence
+    /// bookkeeping **nor** freshness. Absence from a snapshot that never
+    /// claimed to see everything is evidence of nothing.
+    ///
+    /// Both halves of freshness are suppressed, and the persisted one is why
+    /// this is not cosmetic: the in-memory stamp lives in
+    /// `RemoteProviderManager.lastSuccessfulSnapshotAt`, but the `tbd_meta`
+    /// row below is what a daemon restart recovers from, so writing it on a
+    /// partial view would make that view survive a restart looking current.
+    /// Defaulted to `true` so every caller that predates the field keeps its
+    /// exact behavior.
     public func applySnapshot(
-        provider: String, sessions: [RemoteSessionPayload], now: Date
+        provider: String, sessions: [RemoteSessionPayload], complete: Bool = true, now: Date
     ) async throws -> SnapshotOutcome {
         try await writer.write { db in
             var changed = false
@@ -201,23 +218,36 @@ public struct RemoteSessionStore: Sendable {
 
             // Everything left in byID was absent from this snapshot. Two
             // consecutive absences mark a row gone (transports flake); a row
-            // already gone is left alone.
-            for var row in byID.values where !row.gone {
-                row.missingCount += 1
-                if row.missingCount >= 2 { row.gone = true }
-                changed = true
-                try row.update(db)
+            // already gone is left alone. Skipped entirely for an incomplete
+            // snapshot — it is authoritative about presence only, and per the
+            // contract an unbroken run of incomplete snapshots leaves the
+            // mirror exactly where it stands.
+            if complete {
+                for var row in byID.values where !row.gone {
+                    row.missingCount += 1
+                    if row.missingCount >= 2 { row.gone = true }
+                    changed = true
+                    try row.update(db)
+                }
             }
 
             // Persist the authoritative full-inventory observation in this
             // same transaction. Event-stream upserts deliberately do not
             // touch this key: a healthy single-session stream must never make
-            // a broken full-list path look fresh after daemon restart.
-            try db.execute(
-                sql: "INSERT INTO tbd_meta (key, value) VALUES (?, ?) "
-                    + "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                arguments: [Self.snapshotTimestampKey(provider: provider), String(now.timeIntervalSince1970)]
-            )
+            // a broken full-list path look fresh after daemon restart. An
+            // incomplete snapshot is excluded for the same reason — it is not
+            // a full-inventory observation, and one written here would outlive
+            // the daemon looking like one.
+            if complete {
+                try db.execute(
+                    sql: "INSERT INTO tbd_meta (key, value) VALUES (?, ?) "
+                        + "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    arguments: [
+                        Self.snapshotTimestampKey(provider: provider),
+                        String(now.timeIntervalSince1970),
+                    ]
+                )
+            }
             return SnapshotOutcome(changed: changed, attention: attention)
         }
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -38,8 +38,13 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var pinnedAt: Date?  // sidebar dock pin; nil = unpinned
     var pinSortOrder: Int?  // sidebar dock ordering; nil = falls back to pinnedAt
     var location: String?  // "local" | "remote"; nil reads as local
-    var providerName: String?  // set only alongside location == "remote"
-    var providerSessionID: String?  // set only alongside location == "remote"
+    // The provider session behind this row, PAST OR PRESENT. Set whenever the
+    // row has one — a landed lane keeps both while its `location` says
+    // "local". `idx_worktree_provider_session` (v72) indexes the pair, which is
+    // what lets `findRemote` keep matching a landed row and stops adoption from
+    // minting a second lane for a session that already has one.
+    var providerName: String?
+    var providerSessionID: String?
     // Prompt parked at creation time, delivered when the primary agent turns up
     // (v71). nil = nothing parked.
     var pending_prompt: String?
@@ -83,16 +88,13 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.panel_surface_imported_at = nil  // new worktrees start unimported; stamped via stampPanelSurfaceImported
         self.pinnedAt = wt.pinnedAt
         self.pinSortOrder = wt.pinSortOrder
-        switch wt.location {
-        case .local:
-            self.location = "local"
-            self.providerName = nil
-            self.providerSessionID = nil
-        case let .remote(provider, sessionID):
-            self.location = "remote"
-            self.providerName = provider
-            self.providerSessionID = sessionID
-        }
+        // Symmetric with `toModel()`: the location string says where the files
+        // are, the two provider columns say where the lane came from. Writing
+        // them from `wt.origin` rather than from `wt.location` is what stops a
+        // landed row's provenance being erased on save.
+        self.location = wt.location.isLocal ? "local" : "remote"
+        self.providerName = wt.origin?.provider
+        self.providerSessionID = wt.origin?.sessionID
         self.pending_prompt = wt.pendingPrompt
         self.pending_prompt_submit = wt.pendingPromptSubmit
         self.prObservation = FactColumnJSON.encode(wt.prObservation)
@@ -132,10 +134,17 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             decodeLogger.warning("worktree row \(id, privacy: .public): unknown status \(status, privacy: .public); defaulting to .active")
             worktreeStatus = .active
         }
-        // Mirrors `Worktree.init(from:)`: only a complete "remote" triple is a
-        // remote row. A null column (pre-v70), an unknown kind, or a "remote"
-        // missing either provider field reads as local rather than dropping
-        // the row.
+        // Mirrors `Worktree.init(from:)`. The two provider columns are the
+        // ORIGIN and are read whenever both are present; the location string
+        // decides only whether the files are also over there. A "remote" string
+        // missing either column, an unknown kind, or a null column (pre-v70)
+        // all read as local rather than dropping the row.
+        let worktreeOrigin: WorktreeOrigin?
+        if let providerName, let providerSessionID {
+            worktreeOrigin = WorktreeOrigin(provider: providerName, sessionID: providerSessionID)
+        } else {
+            worktreeOrigin = nil
+        }
         let worktreeLocation: WorktreeLocation
         if location == "remote", let providerName, let providerSessionID {
             worktreeLocation = .remote(provider: providerName, sessionID: providerSessionID)
@@ -167,6 +176,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             pinnedAt: pinnedAt,
             pinSortOrder: pinSortOrder,
             location: worktreeLocation,
+            origin: worktreeOrigin,
             pendingPrompt: pending_prompt,
             pendingPromptSubmit: pending_prompt_submit,
             prObservation: Self.decodePRObservation(prObservation)

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -1019,6 +1019,28 @@ final class PipeDataAccumulator: @unchecked Sendable {
         return true
     }
 
+    /// `readAvailable`'s raw-`read(2)` twin, for a descriptor that is not a
+    /// pipe. A pseudo-terminal primary returns -1/EIO — not 0 — once the last
+    /// holder of the replica exits, and `FileHandle.availableData` turns that
+    /// errno into an Objective-C `NSFileHandleOperationException`, which Swift
+    /// cannot catch and which would abort the daemon. Reading the descriptor
+    /// directly keeps EOF a return value.
+    func readAvailableRaw(from handle: FileHandle) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !finished else { return false }
+        var chunk = [UInt8](repeating: 0, count: 65_536)
+        let count = read(handle.fileDescriptor, &chunk, chunk.count)
+        if count > 0 {
+            data.append(contentsOf: chunk.prefix(count))
+            return true
+        }
+        if count < 0 && (errno == EINTR || errno == EAGAIN) { return true }
+        // 0 = EOF; -1/EIO = the replica's last holder exited. Either way there
+        // is nothing more to wait for.
+        return false
+    }
+
     /// Drains whatever is already buffered in the pipe WITHOUT blocking,
     /// closes the parent's read end, and returns the full accumulated buffer.
     /// On the termination path the direct child is dead, so everything it

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
@@ -2,6 +2,37 @@ import Foundation
 import TBDShared
 
 extension ClaudeCloudInvoker {
+    /// The answer to a replay whose key already has a session on file.
+    ///
+    /// Built from the ORIGINAL call's repo, branch and environment rather
+    /// than whatever this replay's body says: the session being described is
+    /// the recorded one. Nil when the row names no session, which `resolve`
+    /// never leaves behind.
+    static func recordedSessionResult(_ existing: ClaudeCloudSessionRow) -> ProviderResult? {
+        guard let sessionID = existing.sessionID else { return nil }
+        var meta = ["repo": existing.repoKey]
+        if let branch = existing.branch, !branch.isEmpty { meta["branch"] = branch }
+        if let environment = existing.environment, !environment.isEmpty {
+            meta["environment"] = environment
+        }
+        let payload = ClaudeCloudSessionProjection.payload(
+            sessionID: sessionID, title: existing.title, createdAt: existing.createdAt,
+            archived: existing.archived, meta: meta)
+        return ProviderResult(
+            exitCode: 0,
+            stdout: (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(),
+            stderr: "")
+    }
+
+    /// The refusal for a key some other attempt holds. Transient on purpose:
+    /// the pending window is what turns it back into a key that can spawn.
+    static func inFlightResult(_ idempotencyKey: String) -> ProviderResult {
+        Self.errorResult(
+            exitCode: 3, code: "in_progress",
+            message: "create with idempotency key '\(idempotencyKey)' is already "
+                + "in flight; retry once it resolves or the pending window elapses")
+    }
+
     /// `create` runs `claude --cloud "<prompt>"` from the repository
     /// checkout, on a pseudo-terminal, and reads the session id and its title
     /// out of what it prints.
@@ -25,37 +56,21 @@ extension ClaudeCloudInvoker {
 
         // A same-key replay must never spawn `claude --cloud` a second time —
         // there is no discovery to reconcile a second live session with the
-        // first, so a duplicate spawn orphans one of them permanently. This
-        // has to run BEFORE `upsertPending` below: that call is itself
-        // idempotent on the key and returns the existing row unchanged, so
-        // reading its result could never distinguish "this row already
-        // existed" from "this row was just inserted, and of course it reads
-        // pending" — the two look identical the instant after either happens.
+        // first, so a duplicate spawn orphans one of them permanently.
+        //
+        // This classification is a FAST PATH, not the guard. It answers a key
+        // that is already settled before the parameter validation below can
+        // reject a replay whose body differs from the original's — a resolved
+        // key is answered from the ledger, and a key another attempt holds is
+        // refused, without either needing this call's `prompt` or repository
+        // to be valid. `claimForSpawn` is what actually licenses a spawn, and
+        // it decides atomically; see its doc comment for why nothing weaker
+        // can be correct here.
         if let existing = try await db.claudeCloudSessions.rows()
             .first(where: { $0.idempotencyKey == idempotencyKey }) {
             switch existing.state {
             case ClaudeCloudLedgerState.resolved.rawValue:
-                if let sessionID = existing.sessionID {
-                    // Return the recorded session rather than spawning again.
-                    // Re-spawning here would race `Store.resolve` and could
-                    // overwrite the first session's id on this very row,
-                    // erasing the only record of it (finding 4's "latent"
-                    // case) — so the replay is answered from what is already
-                    // on file, using the ORIGINAL call's repo/branch/environment
-                    // rather than whatever this replay's body happens to say.
-                    var meta = ["repo": existing.repoKey]
-                    if let branch = existing.branch, !branch.isEmpty { meta["branch"] = branch }
-                    if let environment = existing.environment, !environment.isEmpty {
-                        meta["environment"] = environment
-                    }
-                    let payload = ClaudeCloudSessionProjection.payload(
-                        sessionID: sessionID, title: existing.title, createdAt: existing.createdAt,
-                        archived: existing.archived, meta: meta)
-                    return ProviderResult(
-                        exitCode: 0,
-                        stdout: (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(),
-                        stderr: "")
-                }
+                if let answer = Self.recordedSessionResult(existing) { return answer }
             case ClaudeCloudLedgerState.pending.rawValue:
                 // The FIRST attempt under this key may still be running, or
                 // may have crashed before recording anything — there is no
@@ -67,10 +82,7 @@ extension ClaudeCloudInvoker {
                 // this from being a dead end: once the window judges the
                 // first attempt failed, the SAME key falls through below and
                 // spawns fresh.
-                return Self.errorResult(
-                    exitCode: 3, code: "in_progress",
-                    message: "create with idempotency key '\(idempotencyKey)' is already "
-                        + "in flight; retry once it resolves or the pending window elapses")
+                return Self.inFlightResult(idempotencyKey)
             default:
                 // `.failed`: the pending window already gave up on this key
                 // with no session ever recorded, so a replay is the closest
@@ -110,9 +122,26 @@ extension ClaudeCloudInvoker {
         let paramsJSON = String(
             data: (try? JSONSerialization.data(withJSONObject: params)) ?? Data("{}".utf8),
             encoding: .utf8) ?? "{}"
-        let row = try await db.claudeCloudSessions.upsertPending(
+        // The authoritative decision, and the only one that may license a
+        // spawn. The classification above is a fast path that answers a
+        // settled key before this call's parameter validation can reject a
+        // replay it would have answered from the ledger; it cannot be the
+        // guard, because between reading a `failed` row and spawning, a
+        // concurrent replay reads the same row and spawns too.
+        let row: ClaudeCloudSessionRow
+        switch try await db.claudeCloudSessions.claimForSpawn(
             idempotencyKey: idempotencyKey, repoKey: repoKey, repoPath: repo.path,
-            branch: branch, environment: environment, paramsJSON: paramsJSON, now: now())
+            branch: branch, environment: environment, paramsJSON: paramsJSON, now: now()) {
+        case .claimed(let claimed):
+            row = claimed
+        case .inFlight:
+            return Self.inFlightResult(idempotencyKey)
+        case .resolved(let existing):
+            guard let answer = Self.recordedSessionResult(existing) else {
+                return Self.inFlightResult(idempotencyKey)
+            }
+            return answer
+        }
 
         // The measured CLI surface (design §11) takes the description and
         // nothing else — no branch flag, no environment flag. Both are

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
@@ -12,7 +12,7 @@ extension ClaudeCloudInvoker {
     /// submitted. That row is what keeps an unreadable answer from being
     /// silent: it names what was asked for, and with no discovery to match it
     /// against, it is what the user is shown.
-    func create(stdin: Data?) async throws -> ProviderResult {
+    func create(stdin: Data?, timeout: TimeInterval) async throws -> ProviderResult {
         guard let stdin,
               let body = try? JSONSerialization.jsonObject(with: stdin) as? [String: Any]
         else {
@@ -62,7 +62,7 @@ extension ClaudeCloudInvoker {
             arguments: ["--cloud", prompt],
             workingDirectory: repo.path,
             usesPseudoTerminal: true,
-            timeout: 60)
+            timeout: timeout)
         let outcome = try await spawner.spawn(request)
         switch outcome {
         case .timedOut:
@@ -97,6 +97,7 @@ extension ClaudeCloudInvoker {
                     id: row.id, sessionID: sessionID, title: title, now: resolvedAt)
                 var meta = ["repo": repoKey]
                 if let branch { meta["branch"] = branch }
+                if let environment { meta["environment"] = environment }
                 let payload = ClaudeCloudSessionProjection.payload(
                     sessionID: sessionID, title: title, createdAt: row.createdAt,
                     archived: false, meta: meta)

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
@@ -1,0 +1,140 @@
+import Foundation
+import TBDShared
+
+extension ClaudeCloudInvoker {
+    /// `create` runs `claude --cloud "<prompt>"` from the repository
+    /// checkout, on a pseudo-terminal, and reads the session id and its title
+    /// out of what it prints.
+    ///
+    /// **The ledger row is written BEFORE the invocation**, so a create whose
+    /// output could not be read leaves a `pending` row rather than nothing,
+    /// carrying the repository, the branch and the prompt that were
+    /// submitted. That row is what keeps an unreadable answer from being
+    /// silent: it names what was asked for, and with no discovery to match it
+    /// against, it is what the user is shown.
+    func create(stdin: Data?) async throws -> ProviderResult {
+        guard let stdin,
+              let body = try? JSONSerialization.jsonObject(with: stdin) as? [String: Any]
+        else {
+            return Self.errorResult(
+                exitCode: 2, code: "invalid_params",
+                message: "create requires a JSON object on stdin")
+        }
+        let params = body["params"] as? [String: Any] ?? [:]
+        let idempotencyKey = (body["idempotency_key"] as? String) ?? UUID().uuidString
+        let prompt = ((params["prompt"] as? String) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            return Self.errorResult(
+                exitCode: 2, code: "invalid_params",
+                message: "create requires a non-empty `prompt`")
+        }
+        let repoKey = ((params["repo"] as? String) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = (params["branch"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let environment = (params["environment"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+
+        // The checkout `claude --cloud` runs from. Resolved through the same
+        // normalization the mirror uses for `meta["repo"]`, so a session
+        // created here round-trips into the repository its `+` was clicked
+        // from instead of landing unmatched.
+        let repos = try await db.repos.list()
+        guard let repoID = RemoteRepoMatching.resolveRepoID(metaRepo: repoKey, repos: repos),
+              let repo = try await db.repos.get(id: repoID)
+        else {
+            return Self.errorResult(
+                exitCode: 1, code: "not_found",
+                message: "no repository registered in TBD matches '\(repoKey)'")
+        }
+
+        let paramsJSON = String(
+            data: (try? JSONSerialization.data(withJSONObject: params)) ?? Data("{}".utf8),
+            encoding: .utf8) ?? "{}"
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: idempotencyKey, repoKey: repoKey, repoPath: repo.path,
+            branch: branch, environment: environment, paramsJSON: paramsJSON, now: now())
+
+        // The measured CLI surface (design §11) takes the description and
+        // nothing else — no branch flag, no environment flag. Both are
+        // recorded on the ledger row and reported as `meta`; inventing a flag
+        // would be a guess about a surface this design is written to.
+        let request = ClaudeCloudSpawnRequest(
+            arguments: ["--cloud", prompt],
+            workingDirectory: repo.path,
+            usesPseudoTerminal: true,
+            timeout: 60)
+        let outcome = try await spawner.spawn(request)
+        switch outcome {
+        case .timedOut:
+            // Thrown, not synthesized: the handler's single same-key retry is
+            // armed by `ProviderRunError`, and the pending row above is what
+            // makes that retry safe.
+            throw ProviderRunError.timeout(verb: "create")
+        case let .completed(status, output):
+            guard status == 0 else {
+                return Self.errorResult(
+                    exitCode: 1, code: "unreachable",
+                    message: "claude --cloud exited \(status): "
+                        + ClaudeCloudCreateOutputParser.failureMessage(
+                            .noSessionID, received: output))
+            }
+            switch ClaudeCloudCreateOutputParser.sessionID(fromOutput: output) {
+            case .failure(let failure):
+                // `contractBug` is the honest class: the built-in provider
+                // could not satisfy the contract, and the remedy is a fix to
+                // TBD rather than a retry or a re-authentication.
+                let message = ClaudeCloudCreateOutputParser.failureMessage(
+                    failure, received: output)
+                claudeCloudLogger.error(
+                    "claude-cloud create could not read a session id: \(message, privacy: .public)")
+                return Self.errorResult(exitCode: 2, code: "contract_bug", message: message)
+            case .success(let sessionID):
+                // Lenient by design: a missing title costs friendliness, not
+                // the lane, so it never fails a create that succeeded.
+                let title = ClaudeCloudCreateOutputParser.title(fromOutput: output)
+                let resolvedAt = now()
+                try await db.claudeCloudSessions.resolve(
+                    id: row.id, sessionID: sessionID, title: title, now: resolvedAt)
+                var meta = ["repo": repoKey]
+                if let branch { meta["branch"] = branch }
+                let payload = ClaudeCloudSessionProjection.payload(
+                    sessionID: sessionID, title: title, createdAt: row.createdAt,
+                    archived: false, meta: meta)
+                return ProviderResult(
+                    exitCode: 0,
+                    stdout: (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(),
+                    stderr: "")
+            }
+        }
+    }
+}
+
+/// The one place a ledger row becomes a contract Session object, shared by
+/// `create` and `list` so the two can never describe the same session
+/// differently.
+enum ClaudeCloudSessionProjection {
+    static func payload(
+        sessionID: String, title: String?, createdAt: Date, archived: Bool,
+        meta: [String: String]
+    ) -> [String: Any] {
+        var object: [String: Any] = [
+            "id": sessionID,
+            "created_at": ISO8601DateFormatter().string(from: createdAt),
+            // The ledger knows a session was created; it does not know
+            // whether it lives. The contract is explicit that `unknown` means
+            // only that no machine-readable state is available — never
+            // healthy, idle, or finished.
+            "state": "unknown",
+            "agent_state": "unknown",
+            // ALWAYS explicit, including `false`. The wire field is
+            // three-valued — absent means "no claim made" and moves no row —
+            // so omitting it when a session is unarchived would mean TBD never
+            // observes the `false` transition, and unarchiving through this
+            // ledger would not return the row to the active list.
+            "archived": archived,
+            "meta": meta,
+        ]
+        if let title { object["title"] = title }
+        return object
+    }
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
@@ -22,6 +22,66 @@ extension ClaudeCloudInvoker {
         }
         let params = body["params"] as? [String: Any] ?? [:]
         let idempotencyKey = (body["idempotency_key"] as? String) ?? UUID().uuidString
+
+        // A same-key replay must never spawn `claude --cloud` a second time —
+        // there is no discovery to reconcile a second live session with the
+        // first, so a duplicate spawn orphans one of them permanently. This
+        // has to run BEFORE `upsertPending` below: that call is itself
+        // idempotent on the key and returns the existing row unchanged, so
+        // reading its result could never distinguish "this row already
+        // existed" from "this row was just inserted, and of course it reads
+        // pending" — the two look identical the instant after either happens.
+        if let existing = try await db.claudeCloudSessions.rows()
+            .first(where: { $0.idempotencyKey == idempotencyKey }) {
+            switch existing.state {
+            case ClaudeCloudLedgerState.resolved.rawValue:
+                if let sessionID = existing.sessionID {
+                    // Return the recorded session rather than spawning again.
+                    // Re-spawning here would race `Store.resolve` and could
+                    // overwrite the first session's id on this very row,
+                    // erasing the only record of it (finding 4's "latent"
+                    // case) — so the replay is answered from what is already
+                    // on file, using the ORIGINAL call's repo/branch/environment
+                    // rather than whatever this replay's body happens to say.
+                    var meta = ["repo": existing.repoKey]
+                    if let branch = existing.branch, !branch.isEmpty { meta["branch"] = branch }
+                    if let environment = existing.environment, !environment.isEmpty {
+                        meta["environment"] = environment
+                    }
+                    let payload = ClaudeCloudSessionProjection.payload(
+                        sessionID: sessionID, title: existing.title, createdAt: existing.createdAt,
+                        archived: existing.archived, meta: meta)
+                    return ProviderResult(
+                        exitCode: 0,
+                        stdout: (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(),
+                        stderr: "")
+                }
+            case ClaudeCloudLedgerState.pending.rawValue:
+                // The FIRST attempt under this key may still be running, or
+                // may have crashed before recording anything — there is no
+                // discovery to check whether a cloud session already exists,
+                // so this refuses to spawn a second one rather than guess
+                // (finding 4's "live" case: a retried timeout starting a
+                // second real session TBD can never list). The row itself,
+                // and `list`'s `pendingFailureWindow` sweep, are what keep
+                // this from being a dead end: once the window judges the
+                // first attempt failed, the SAME key falls through below and
+                // spawns fresh.
+                return Self.errorResult(
+                    exitCode: 3, code: "in_progress",
+                    message: "create with idempotency key '\(idempotencyKey)' is already "
+                        + "in flight; retry once it resolves or the pending window elapses")
+            default:
+                // `.failed`: the pending window already gave up on this key
+                // with no session ever recorded, so a replay is the closest
+                // thing to a fresh attempt available and is allowed to spawn
+                // — it reuses the same ledger row id, and `resolve` below
+                // turns it back to `resolved` on success exactly as it would
+                // for a brand-new row.
+                break
+            }
+        }
+
         let prompt = ((params["prompt"] as? String) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !prompt.isEmpty else {
@@ -75,11 +135,32 @@ extension ClaudeCloudInvoker {
         // here and unused.
         case let .completed(status, output, _):
             guard status == 0 else {
-                return Self.errorResult(
-                    exitCode: 1, code: "unreachable",
-                    message: "claude --cloud exited \(status): "
-                        + ClaudeCloudCreateOutputParser.failureMessage(
-                            .noSessionID, received: output))
+                // The status guard used to always report `.noSessionID`,
+                // which claims "printed no session id" even when the id is
+                // sitting right there in the quoted evidence, and discarded
+                // it instead of recording it — orphaning a session that was
+                // genuinely created before some later step made the verb
+                // exit non-zero. Parse first, so a readable id is recorded
+                // even though the verb still reports failure.
+                switch ClaudeCloudCreateOutputParser.sessionID(fromOutput: output) {
+                case .success(let sessionID):
+                    let title = ClaudeCloudCreateOutputParser.title(fromOutput: output)
+                    try await db.claudeCloudSessions.resolve(
+                        id: row.id, sessionID: sessionID, title: title, now: now())
+                    claudeCloudLogger.error(
+                        "claude-cloud create exited \(status, privacy: .public) after printing a session id; recording it before reporting failure")
+                    return Self.errorResult(
+                        exitCode: 1, code: "unreachable",
+                        message: "claude --cloud exited \(status): created \(sessionID) "
+                            + "but reported failure; received: "
+                            + ClaudeCloudCreateOutputParser.boundedQuote(output))
+                case .failure:
+                    return Self.errorResult(
+                        exitCode: 1, code: "unreachable",
+                        message: "claude --cloud exited \(status): "
+                            + ClaudeCloudCreateOutputParser.failureMessage(
+                                .noSessionID, received: output))
+                }
             }
             switch ClaudeCloudCreateOutputParser.sessionID(fromOutput: output) {
             case .failure(let failure):

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
@@ -70,7 +70,10 @@ extension ClaudeCloudInvoker {
             // armed by `ProviderRunError`, and the pending row above is what
             // makes that retry safe.
             throw ProviderRunError.timeout(verb: "create")
-        case let .completed(status, output):
+        // `create` runs on a pty, so the two streams already merged into
+        // `output`; the separate pipe-mode `stderr` field is always empty
+        // here and unused.
+        case let .completed(status, output, _):
             guard status == 0 else {
                 return Self.errorResult(
                     exitCode: 1, code: "unreachable",

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
@@ -15,11 +15,10 @@ import TBDShared
 enum ClaudeCloudCreateOutputParser {
     static let titlePrefix = "Created cloud session: "
     /// The vendor's id shape. Fixed, and printed on all three lines, which is
-    /// what makes disagreement detectable.
-    /// `nonisolated(unsafe)`: a `Regex` literal is immutable after
-    /// construction and only ever read, so sharing it across threads is safe
-    /// — the same rationale as `TranscriptParser.iso8601`.
-    nonisolated(unsafe) private static let idPattern = /session_[A-Za-z0-9]+/
+    /// what makes disagreement detectable. A computed property rather than a
+    /// stored `static let`, so building it sidesteps `Regex`'s missing
+    /// `Sendable` conformance instead of reaching for `nonisolated(unsafe)`.
+    private static var idPattern: Regex<Substring> { /session_[A-Za-z0-9]+/ }
 
     enum ParseFailure: Error, Equatable {
         case noSessionID
@@ -58,7 +57,13 @@ enum ClaudeCloudCreateOutputParser {
     /// the pty reports inserts a real newline mid-title.
     static func title(fromOutput raw: String) -> String? {
         let text = ANSIEscape.strip(raw)
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        // `split(separator: "\n")` treats `\n` as one specific Character and
+        // does not split `"\r\n"` at all — CRLF is a single grapheme cluster
+        // in Swift, distinct from `"\n"`. A pty's canonical line discipline
+        // emits CRLF by default, and `create` runs on a pty, so that is the
+        // realistic case here, not an edge case. `.isNewline` recognizes
+        // `\r\n`, lone `\r`, and lone `\n` alike as one separator each.
+        let lines = text.split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })
             .map { String($0).trimmingCharacters(in: .whitespaces) }
         guard let start = lines.firstIndex(where: { $0.hasPrefix(titlePrefix) }) else {
             return nil

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
@@ -1,0 +1,91 @@
+import Foundation
+import TBDShared
+
+/// Reads the created session's id and its title out of the three prose lines
+/// `claude --cloud "<description>"` prints. There is no structured form —
+/// `--print` is refused alongside `--cloud` — so those lines are the only
+/// channel either value travels on.
+///
+/// **This is not screen-scraping.** The repository's rule forbids inferring an
+/// agent's STATE from a rendered terminal screen; this reads the result line
+/// of a non-interactive command TBD itself invoked, the same category as
+/// parsing `git`'s output. Nothing here reads a TUI and nothing here infers
+/// state — liveness is whatever `list` reports, which for a ledger row is
+/// `unknown`.
+enum ClaudeCloudCreateOutputParser {
+    static let titlePrefix = "Created cloud session: "
+    /// The vendor's id shape. Fixed, and printed on all three lines, which is
+    /// what makes disagreement detectable.
+    /// `nonisolated(unsafe)`: a `Regex` literal is immutable after
+    /// construction and only ever read, so sharing it across threads is safe
+    /// — the same rationale as `TranscriptParser.iso8601`.
+    nonisolated(unsafe) private static let idPattern = /session_[A-Za-z0-9]+/
+
+    enum ParseFailure: Error, Equatable {
+        case noSessionID
+        case conflictingSessionIDs([String])
+    }
+
+    /// Strict, and cross-checked against every match in the output. An
+    /// unreadable id costs the lane its identity — there is no session to
+    /// record — so zero matches or more than one distinct id is a `create`
+    /// FAILURE rather than a silent empty string.
+    static func sessionID(fromOutput raw: String) -> Result<String, ParseFailure> {
+        let text = ANSIEscape.strip(raw)
+        var seen: [String] = []
+        for match in text.matches(of: idPattern) {
+            let value = String(match.output)
+            if !seen.contains(value) { seen.append(value) }
+        }
+        switch seen.count {
+        case 0: return .failure(.noSessionID)
+        case 1: return .success(seen[0])
+        default: return .failure(.conflictingSessionIDs(seen))
+        }
+    }
+
+    /// Lenient, and deliberately so. The title line is prose, not a value with
+    /// a shape to check, so this parse can only tell whether THIS prefix
+    /// matched — a reworded sentence is indistinguishable from a missing one.
+    /// A missing or empty title costs nothing but friendliness, because the
+    /// row is still named from its id, so it is never a reason to fail a
+    /// create that otherwise succeeded. The prefix not matching, the line
+    /// being absent, and the remainder being blank after trimming are ONE
+    /// outcome: return nil and take the fallback.
+    ///
+    /// Everything after the prefix up to the next KNOWN line is joined with
+    /// single spaces, because a child that formatted to a narrower width than
+    /// the pty reports inserts a real newline mid-title.
+    static func title(fromOutput raw: String) -> String? {
+        let text = ANSIEscape.strip(raw)
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+        guard let start = lines.firstIndex(where: { $0.hasPrefix(titlePrefix) }) else {
+            return nil
+        }
+        var parts = [String(lines[start].dropFirst(titlePrefix.count))]
+        for line in lines[(start + 1)...] {
+            // The two other measured lines end the title; so does a blank one.
+            if line.isEmpty || line.hasPrefix("View:") || line.hasPrefix("Resume with:") { break }
+            parts.append(line)
+        }
+        let joined = parts.joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return joined.isEmpty ? nil : joined
+    }
+
+    /// The message a `create` failure carries, quoting what was received so
+    /// the `contractBug` on screen names its evidence. Bounded, because the
+    /// CLI's output is not a size TBD controls.
+    static func failureMessage(_ failure: ParseFailure, received raw: String) -> String {
+        let stripped = ANSIEscape.strip(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+        let quoted = stripped.count > 400 ? String(stripped.prefix(399)) + "…" : stripped
+        switch failure {
+        case .noSessionID:
+            return "claude --cloud printed no session id; received: \(quoted)"
+        case .conflictingSessionIDs(let ids):
+            return "claude --cloud printed conflicting session ids "
+                + "(\(ids.joined(separator: ", "))); received: \(quoted)"
+        }
+    }
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
@@ -40,16 +40,35 @@ enum ClaudeCloudCreateOutputParser {
         }
     }
 
-    /// Strict, and cross-checked against every match in the output. An
-    /// unreadable id costs the lane its identity — there is no session to
-    /// record — so zero matches or more than one distinct id is a `create`
-    /// FAILURE rather than a silent empty string.
+    /// Strict, and cross-checked against every match — but ONLY on the two
+    /// lines whose id is structural: `View:` and `Resume with:`. The third
+    /// printed line, `Created cloud session: <title>`, is the vendor's own
+    /// server-derived summary of the user's submitted prompt, not a value
+    /// with a fixed shape — and a prompt that itself names a
+    /// `session_`-prefixed identifier (a filename, a variable, a session the
+    /// user asked to resume) makes that line match the id pattern too. Scanning
+    /// the whole blob would then see a second, spurious id and fail a create
+    /// that actually succeeded, orphaning a real cloud session with no
+    /// discovery to ever recover it. Restricting the scan to the two
+    /// structural lines keeps the cross-check — two independent witnesses
+    /// that must agree — without ever reading the user's own words as if they
+    /// were the vendor's identifier.
+    ///
+    /// An unreadable id costs the lane its identity — there is no session to
+    /// record — so zero matches or more than one distinct id is still a
+    /// `create` FAILURE rather than a silent empty string.
     static func sessionID(fromOutput raw: String) -> Result<String, ParseFailure> {
         let text = ANSIEscape.strip(raw)
+        let lines = text.split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })
+            .map { String($0) }
         var seen: [String] = []
-        for match in text.matches(of: idPattern) {
-            let value = String(match.output)
-            if !seen.contains(value) { seen.append(value) }
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("View:") || trimmed.hasPrefix("Resume with:") else { continue }
+            for match in trimmed.matches(of: idPattern) {
+                let value = String(match.output)
+                if !seen.contains(value) { seen.append(value) }
+            }
         }
         switch seen.count {
         case 0: return .failure(.noSessionID)
@@ -94,12 +113,20 @@ enum ClaudeCloudCreateOutputParser {
         return joined.isEmpty ? nil : joined
     }
 
-    /// The message a `create` failure carries, quoting what was received so
-    /// the `contractBug` on screen names its evidence. Bounded, because the
-    /// CLI's output is not a size TBD controls.
-    static func failureMessage(_ failure: ParseFailure, received raw: String) -> String {
+    /// ANSI-stripped, trimmed, and bounded quoting of raw CLI output for
+    /// embedding in a message — shared by `failureMessage` below and by a
+    /// non-zero `create` exit that still managed to print a readable id
+    /// (`ClaudeCloudCreate.swift`). Bounded because the CLI's output is not a
+    /// size TBD controls.
+    static func boundedQuote(_ raw: String) -> String {
         let stripped = ANSIEscape.strip(raw).trimmingCharacters(in: .whitespacesAndNewlines)
-        let quoted = ClaudeCloudTextBounding.truncated(stripped, limit: 400)
+        return ClaudeCloudTextBounding.truncated(stripped, limit: 400)
+    }
+
+    /// The message a `create` failure carries, quoting what was received so
+    /// the `contractBug` on screen names its evidence.
+    static func failureMessage(_ failure: ParseFailure, received raw: String) -> String {
+        let quoted = boundedQuote(raw)
         switch failure {
         case .noSessionID:
             return "claude --cloud printed no session id; received: \(quoted)"

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
@@ -99,7 +99,7 @@ enum ClaudeCloudCreateOutputParser {
     /// CLI's output is not a size TBD controls.
     static func failureMessage(_ failure: ParseFailure, received raw: String) -> String {
         let stripped = ANSIEscape.strip(raw).trimmingCharacters(in: .whitespacesAndNewlines)
-        let quoted = stripped.count > 400 ? String(stripped.prefix(399)) + "…" : stripped
+        let quoted = ClaudeCloudTextBounding.truncated(stripped, limit: 400)
         switch failure {
         case .noSessionID:
             return "claude --cloud printed no session id; received: \(quoted)"

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
@@ -20,9 +20,24 @@ enum ClaudeCloudCreateOutputParser {
     /// `Sendable` conformance instead of reaching for `nonisolated(unsafe)`.
     private static var idPattern: Regex<Substring> { /session_[A-Za-z0-9]+/ }
 
-    enum ParseFailure: Error, Equatable {
+    // `LocalizedError` on the declaration, not a later extension: without an
+    // `errorDescription`, `localizedDescription` returns the NSError bridge
+    // string and the ids that made a create ambiguous — the whole reason this
+    // failure is worth reporting — never reach the log line.
+    enum ParseFailure: LocalizedError, Equatable {
         case noSessionID
         case conflictingSessionIDs([String])
+
+        var errorDescription: String? {
+            switch self {
+            case .noSessionID:
+                return
+                    "No session id in the create output: `claude --cloud` printed no `session_…` token, so the lane has no identity to record."
+            case .conflictingSessionIDs(let ids):
+                return
+                    "Conflicting session ids in the create output: \(ids.joined(separator: ", ")). The three printed lines must agree on one id."
+            }
+        }
     }
 
     /// Strict, and cross-checked against every match in the output. An

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudDescribe.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudDescribe.swift
@@ -13,8 +13,13 @@ import TBDShared
 /// requires to answer without one, and would make the Attach segment appear
 /// and vanish rather than explain itself.
 ///
-/// Three capability names are deliberately ABSENT, and each absence is a fact
-/// about the vendor surface rather than an unimplemented verb:
+/// Capabilities are a promise a caller acts on — the app offers a
+/// corresponding action, and `retire()`'s capability check lets a declared
+/// verb reach this provider — so nothing is declared here that
+/// `ClaudeCloudInvoker.run` cannot actually carry out.
+///
+/// Several capability names are deliberately ABSENT, and each absence is a
+/// fact about the vendor surface rather than an unimplemented verb:
 ///
 /// - `stop` — nothing exposed terminates a running cloud session. That is
 ///   also why `contract_versions` is `[2]` alone: major 1 requires `stop`.
@@ -22,18 +27,21 @@ import TBDShared
 /// - `transcript` — no supported interface reads a cloud session's
 ///   conversation.
 ///
-/// `archive` and `unarchive` ARE declared, implemented against this
-/// provider's own ledger: the ledger is the only inventory this provider has,
-/// so retiring a row within it is a real retirement of the only inventory
-/// that exists here. Nothing is sent to Anthropic, and the row says so.
+/// `land`, `archive` and `unarchive` are ALSO absent, but for a different
+/// reason than the three above: this is a real gap in the current build, not
+/// a fact about the vendor. `ClaudeCloudInvoker.run` answers all three with
+/// `not_implemented` — they are a later slice of this feature, which will
+/// re-add each capability string together with its implementation in the
+/// same change. Declaring them ahead of that would offer the app an action
+/// (Land, Archive, Unarchive on a cloud lane) that always fails.
 enum ClaudeCloudDescribe {
-    static let capabilities = ["send", "attach", "land", "archive", "unarchive"]
+    static let capabilities = ["send", "attach"]
 
     static let json = Data(#"""
     {
       "contract_versions": [2],
       "name": "\#(ClaudeCloudProvider.name)",
-      "capabilities": ["send", "attach", "land", "archive", "unarchive"],
+      "capabilities": ["send", "attach"],
       "create_params": [
         {"name": "repo", "type": "string", "label": "Repository", "required": true},
         {"name": "branch", "type": "string", "label": "Branch"},

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudDescribe.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudDescribe.swift
@@ -1,0 +1,45 @@
+import Foundation
+import TBDShared
+
+/// The compiled provider's static, offline `describe` answer.
+///
+/// It touches no network and no credential store, and it does NOT vary with
+/// the signed-in account. `attach` is declared because the provider
+/// implements it — it knows the command, composes the argv, and spawns on the
+/// pane's PTY. Whether a given account is PERMITTED to attach is an
+/// entitlement: a runtime condition of the account, the same kind of fact as
+/// an expired credential, and not a capability. Making `describe` dynamic to
+/// express it would put a network round trip inside the one verb the contract
+/// requires to answer without one, and would make the Attach segment appear
+/// and vanish rather than explain itself.
+///
+/// Three capability names are deliberately ABSENT, and each absence is a fact
+/// about the vendor surface rather than an unimplemented verb:
+///
+/// - `stop` — nothing exposed terminates a running cloud session. That is
+///   also why `contract_versions` is `[2]` alone: major 1 requires `stop`.
+/// - `log` — a cloud session has no terminal to scroll.
+/// - `transcript` — no supported interface reads a cloud session's
+///   conversation.
+///
+/// `archive` and `unarchive` ARE declared, implemented against this
+/// provider's own ledger: the ledger is the only inventory this provider has,
+/// so retiring a row within it is a real retirement of the only inventory
+/// that exists here. Nothing is sent to Anthropic, and the row says so.
+enum ClaudeCloudDescribe {
+    static let capabilities = ["send", "attach", "land", "archive", "unarchive"]
+
+    static let json = Data(#"""
+    {
+      "contract_versions": [2],
+      "name": "\#(ClaudeCloudProvider.name)",
+      "capabilities": ["send", "attach", "land", "archive", "unarchive"],
+      "create_params": [
+        {"name": "repo", "type": "string", "label": "Repository", "required": true},
+        {"name": "branch", "type": "string", "label": "Branch"},
+        {"name": "prompt", "type": "text", "label": "Initial prompt", "required": true},
+        {"name": "environment", "type": "string", "label": "Environment"}
+      ]
+    }
+    """#.utf8)
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
@@ -44,12 +44,15 @@ struct ClaudeCloudInvoker: RemoteProviderInvoking {
                 return Self.errorResult(
                     exitCode: 2, code: "invalid_params", message: "send requires a session id")
             }
-            return try await send(sessionID: verb[1], stdin: stdin)
+            return try await send(sessionID: verb[1], stdin: stdin, timeout: timeout)
         case "archive", "unarchive", "land":
-            // Declared by `describe` and implemented by the archive and land
-            // steps of this same delivery. Until then this fails loudly as a
-            // contract bug rather than exiting 0 with nothing, which is the
-            // failure a caller could not distinguish from success.
+            // Not (yet) declared by `describe` — a later slice adds each
+            // capability string together with its implementation here, in
+            // the same change. This case exists so that a caller reaching
+            // this verb anyway (a stale capability cache, a call that skips
+            // the capability check) fails loudly as a contract bug rather
+            // than exiting 0 with nothing, which is the failure a caller
+            // could not distinguish from success.
             return Self.notImplementedResult(verb: verb[0])
         default:
             let verbName = verb.first ?? ""

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
@@ -36,7 +36,7 @@ struct ClaudeCloudInvoker: RemoteProviderInvoking {
         case "describe":
             return ProviderResult(exitCode: 0, stdout: ClaudeCloudDescribe.json, stderr: "")
         case "create":
-            return try await create(stdin: stdin)
+            return try await create(stdin: stdin, timeout: timeout)
         case "archive", "unarchive", "land":
             // Declared by `describe` and implemented by the archive and land
             // steps of this same delivery. Until then this fails loudly as a

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
@@ -37,6 +37,8 @@ struct ClaudeCloudInvoker: RemoteProviderInvoking {
             return ProviderResult(exitCode: 0, stdout: ClaudeCloudDescribe.json, stderr: "")
         case "create":
             return try await create(stdin: stdin, timeout: timeout)
+        case "list":
+            return try await list()
         case "archive", "unarchive", "land":
             // Declared by `describe` and implemented by the archive and land
             // steps of this same delivery. Until then this fails loudly as a

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
@@ -39,6 +39,12 @@ struct ClaudeCloudInvoker: RemoteProviderInvoking {
             return try await create(stdin: stdin, timeout: timeout)
         case "list":
             return try await list()
+        case "send":
+            guard verb.count >= 2 else {
+                return Self.errorResult(
+                    exitCode: 2, code: "invalid_params", message: "send requires a session id")
+            }
+            return try await send(sessionID: verb[1], stdin: stdin)
         case "archive", "unarchive", "land":
             // Declared by `describe` and implemented by the archive and land
             // steps of this same delivery. Until then this fails loudly as a

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
@@ -1,0 +1,77 @@
+import Foundation
+import TBDShared
+import os
+
+let claudeCloudLogger = Logger(subsystem: "com.tbd.daemon", category: "claudeCloud")
+
+/// The compiled `claude-cloud` provider: a second production conformance of
+/// `RemoteProviderInvoking`, selected by `ProviderDispatcher` at the
+/// manager's single `runner` injection site.
+///
+/// **Why it is compiled.** How to talk to one vendor's session API is a
+/// mechanism, not a theory: there is one API, and no project's convention
+/// changes its shape. Mechanisms compile.
+///
+/// It synthesizes the same `ProviderResult` envelope a subprocess produces,
+/// fabricated exit code included, so it passes through
+/// `ProviderFailureClass.classify` and the same health, auth-banner and
+/// staleness handling an external provider gets.
+struct ClaudeCloudInvoker: RemoteProviderInvoking {
+    let db: TBDDatabase
+    let spawner: any ClaudeCloudSpawning
+    /// The date seam: every timestamp here is persisted to or compared
+    /// against the ledger, so it is data, never behavior.
+    let now: @Sendable () -> Date
+
+    init(db: TBDDatabase, spawner: any ClaudeCloudSpawning,
+         now: @escaping @Sendable () -> Date = Date.init) {
+        self.db = db
+        self.spawner = spawner
+        self.now = now
+    }
+
+    func run(_ config: RemoteProviderConfig, verb: [String], stdin: Data?,
+             timeout: TimeInterval, contractVersion: Int) async throws -> ProviderResult {
+        switch verb.first {
+        case "describe":
+            return ProviderResult(exitCode: 0, stdout: ClaudeCloudDescribe.json, stderr: "")
+        case "archive", "unarchive", "land":
+            // Declared by `describe` and implemented by the archive and land
+            // steps of this same delivery. Until then this fails loudly as a
+            // contract bug rather than exiting 0 with nothing, which is the
+            // failure a caller could not distinguish from success.
+            return Self.notImplementedResult(verb: verb[0])
+        default:
+            let verbName = verb.first ?? ""
+            claudeCloudLogger.debug(
+                "claude-cloud received an undeclared verb: \(verbName, privacy: .public)")
+            return Self.errorResult(
+                exitCode: 2, code: "invalid_params",
+                message: "claude-cloud does not implement the verb '\(verbName)'")
+        }
+    }
+
+    /// One contract-shaped error envelope, so every verb's failure reaches
+    /// `ProviderFailureClass.classify` exactly as a subprocess's would.
+    static func errorResult(
+        exitCode: Int32, code: String, message: String,
+        remediation: (label: String, command: String?)? = nil
+    ) -> ProviderResult {
+        var object: [String: Any] = ["code": code, "message": message, "retryable": exitCode == 3]
+        if let remediation {
+            var r: [String: Any] = ["label": remediation.label]
+            if let command = remediation.command { r["command"] = command }
+            object["remediation"] = r
+        }
+        let payload: [String: Any] = ["error": object]
+        let data = (try? JSONSerialization.data(withJSONObject: payload))
+            ?? Data(#"{"error":{"code":"internal","message":"error envelope could not be encoded"}}"#.utf8)
+        return ProviderResult(exitCode: exitCode, stdout: data, stderr: "")
+    }
+
+    static func notImplementedResult(verb: String) -> ProviderResult {
+        errorResult(
+            exitCode: 2, code: "not_implemented",
+            message: "claude-cloud declares '\(verb)' but this build does not implement it yet")
+    }
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudInvoker.swift
@@ -35,6 +35,8 @@ struct ClaudeCloudInvoker: RemoteProviderInvoking {
         switch verb.first {
         case "describe":
             return ProviderResult(exitCode: 0, stdout: ClaudeCloudDescribe.json, stderr: "")
+        case "create":
+            return try await create(stdin: stdin)
         case "archive", "unarchive", "land":
             // Declared by `describe` and implemented by the archive and land
             // steps of this same delivery. Until then this fails loudly as a

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
@@ -49,6 +49,14 @@ extension ClaudeCloudInvoker {
             else { return nil }
             var meta = ["repo": row.repoKey]
             if let branch = row.branch, !branch.isEmpty { meta["branch"] = branch }
+            // `create` includes `environment` in the `meta` it returns; this
+            // was the one field `list` dropped on the very next poll, so a
+            // value that had round-tripped safely through the database
+            // vanished from every caller permanently — there is no
+            // discovery to re-supply it later.
+            if let environment = row.environment, !environment.isEmpty {
+                meta["environment"] = environment
+            }
             return ClaudeCloudSessionProjection.payload(
                 sessionID: sessionID, title: row.title, createdAt: row.createdAt,
                 archived: row.archived, meta: meta)

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
@@ -6,6 +6,14 @@ extension ClaudeCloudInvoker {
     /// invocation is a create that failed. There is no discovery to confirm
     /// it AGAINST here, so the window alone decides — and the row is retained
     /// either way, so the judgement costs nothing but a state label.
+    ///
+    /// 600s is a soak-tuned starting value, not a measured one — no field data
+    /// exists yet for how long a `create` actually takes. It was chosen to sit
+    /// comfortably longer than a `create` should ever take, while staying short
+    /// enough that an idempotency key stuck behind one that hung frees up
+    /// within a single working session rather than the next day. What would
+    /// revise it: real creates observed resolving later than this window
+    /// during the soak.
     static let pendingFailureWindow: TimeInterval = 600
 
     /// `list` returns the `claude_cloud_session` ledger — what this machine

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
@@ -1,0 +1,63 @@
+import Foundation
+import TBDShared
+
+extension ClaudeCloudInvoker {
+    /// A pending create a complete view could not confirm this long after the
+    /// invocation is a create that failed. There is no discovery to confirm
+    /// it AGAINST here, so the window alone decides — and the row is retained
+    /// either way, so the judgement costs nothing but a state label.
+    static let pendingFailureWindow: TimeInterval = 600
+
+    /// `list` returns the `claude_cloud_session` ledger — what this machine
+    /// started — and nothing else. It is always `complete: false`.
+    ///
+    /// **There is no discovery, and adding one is not the fix.** No supported
+    /// interface enumerates an account's cloud sessions: the Compliance API's
+    /// remote-session endpoints exclude Claude Code on the web by name, the
+    /// documented `/v1/claude_code/` namespace grants no read access, and the
+    /// undocumented claude.ai endpoints are barred by Anthropic's Consumer
+    /// Terms outside the API-key carve-out — which a subscription-login cloud
+    /// session can never be inside. Driving them would put TBD's users outside
+    /// the terms of the account they are signed into, for a feature they can
+    /// already reach in a browser. That is a design constraint, not a gap
+    /// awaiting an implementation. What would reopen it is a supported
+    /// interface, not a smaller or more careful scraper.
+    ///
+    /// The permanent incompleteness is what makes that safe rather than
+    /// merely honest: a caller may adopt and update on an incomplete
+    /// snapshot but must never retire on one, so a provider that never claims
+    /// completeness cannot cause a false retirement however partial its view.
+    /// A cloud lane leaves the working set by the user archiving it.
+    func list() async throws -> ProviderResult {
+        let rows = try await db.claudeCloudSessions.rows()
+        let at = now()
+
+        // Bookkeeping first, so this snapshot reflects it.
+        let expired = rows.filter {
+            $0.state == ClaudeCloudLedgerState.pending.rawValue
+                && at.timeIntervalSince($0.createdAt) > Self.pendingFailureWindow
+        }.map(\.id)
+        try await db.claudeCloudSessions.markFailed(ids: expired)
+
+        // Only a row that names a session can be listed; `pending` and
+        // `failed` rows name none. Archived rows STAY enumerated, with their
+        // flag set — that is what the contract requires, and filtering them
+        // would drive the session toward `gone`.
+        let sessions = rows.compactMap { row -> [String: Any]? in
+            guard let sessionID = row.sessionID,
+                  row.state == ClaudeCloudLedgerState.resolved.rawValue
+            else { return nil }
+            var meta = ["repo": row.repoKey]
+            if let branch = row.branch, !branch.isEmpty { meta["branch"] = branch }
+            return ClaudeCloudSessionProjection.payload(
+                sessionID: sessionID, title: row.title, createdAt: row.createdAt,
+                archived: row.archived, meta: meta)
+        }
+        let envelope: [String: Any] = ["complete": false, "sessions": sessions]
+        return ProviderResult(
+            exitCode: 0,
+            stdout: (try? JSONSerialization.data(withJSONObject: envelope))
+                ?? Data(#"{"complete":false,"sessions":[]}"#.utf8),
+            stderr: "")
+    }
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudList.swift
@@ -14,6 +14,17 @@ extension ClaudeCloudInvoker {
     /// within a single working session rather than the next day. What would
     /// revise it: real creates observed resolving later than this window
     /// during the soak.
+    ///
+    /// Must stay strictly greater than `RPCRouter.remoteCreateTimeout`
+    /// (`RPCRouter+RemoteHandlers.swift`) — pinned by
+    /// `ClaudeCloudTimeoutRelationshipTests`. That RPC-level timeout bounds how
+    /// long a single `create` invocation (including its one same-key retry)
+    /// may run; this window bounds how long `claimForSpawn` waits before
+    /// reclaiming a `pending` row and licensing a second spawn under the same
+    /// idempotency key. If the create timeout ever reached or exceeded this
+    /// window, a still-running first invocation could have its row reclaimed
+    /// and re-spawned while it was still in flight — the double-spawn this
+    /// ledger exists to prevent.
     static let pendingFailureWindow: TimeInterval = 600
 
     /// `list` returns the `claude_cloud_session` ledger — what this machine

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSend.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSend.swift
@@ -18,7 +18,14 @@ enum ClaudeCloudSendPayload {
     static func message(fromStdin stdin: Data) -> String? {
         // swiftlint:disable:next optional_data_string_conversion
         var text = String(decoding: stdin, as: UTF8.self)
-        if text.hasSuffix("\r") || text.hasSuffix("\n") { text.removeLast() }
+        // `"\r\n"` is ONE `Character` (grapheme cluster) in Swift, distinct
+        // from both `"\r"` and `"\n"` — the same trap the title parser was
+        // bitten by. Checking `"\r\n"` explicitly, not just its two halves,
+        // is what makes a genuine CRLF terminator strip cleanly instead of
+        // surviving into the message body.
+        if text.hasSuffix("\r\n") || text.hasSuffix("\r") || text.hasSuffix("\n") {
+            text.removeLast()
+        }
         return text.isEmpty ? nil : text
     }
 }
@@ -41,7 +48,7 @@ extension ClaudeCloudInvoker {
     /// No pseudo-terminal: `--print` is explicitly a non-interactive
     /// invocation and returns JSON on an ordinary pipe, and a pty would merge
     /// stderr into that JSON.
-    func send(sessionID: String, stdin: Data?) async throws -> ProviderResult {
+    func send(sessionID: String, stdin: Data?, timeout: TimeInterval) async throws -> ProviderResult {
         guard let stdin, let message = ClaudeCloudSendPayload.message(fromStdin: stdin) else {
             return Self.errorResult(
                 exitCode: 2, code: "invalid_params",
@@ -51,7 +58,7 @@ extension ClaudeCloudInvoker {
             arguments: ["-p", message, "--cloud", sessionID, "--output-format", "json"],
             workingDirectory: FileManager.default.temporaryDirectory.path,
             usesPseudoTerminal: false,
-            timeout: 30)
+            timeout: timeout)
         switch try await spawner.spawn(request) {
         case .timedOut:
             return Self.errorResult(

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSend.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSend.swift
@@ -1,0 +1,91 @@
+import Foundation
+import TBDShared
+
+/// Turning the contract's keystroke bytes into one message.
+enum ClaudeCloudSendPayload {
+    /// The contract's `send` delivers stdin bytes verbatim to a session as
+    /// keystrokes, and requires the caller to append `\r` when it means the
+    /// terminal Enter key. TBD sends a cloud session exactly the bytes it
+    /// sends any provider; what the contract fixes is the CALLER's side of
+    /// the wire, and how a provider delivers those bytes to a session with no
+    /// terminal is the provider's business.
+    ///
+    /// So: decode as UTF-8, strip a SINGLE trailing `\r` or `\n` as the
+    /// submit gesture it is, and pass the remainder as one message. A byte
+    /// stream carrying interior newlines therefore becomes one multi-line
+    /// message rather than several, and a deliberate blank last line survives.
+    /// Nil means there is nothing to send.
+    static func message(fromStdin stdin: Data) -> String? {
+        // swiftlint:disable:next optional_data_string_conversion
+        var text = String(decoding: stdin, as: UTF8.self)
+        if text.hasSuffix("\r") || text.hasSuffix("\n") { text.removeLast() }
+        return text.isEmpty ? nil : text
+    }
+}
+
+private struct ClaudeCloudSendReply: Decodable {
+    let ok: Bool?
+    let sessionID: String?
+    let url: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok, url
+        case sessionID = "session_id"
+    }
+}
+
+extension ClaudeCloudInvoker {
+    /// `send` posts one message through
+    /// `claude -p "<msg>" --cloud <id> --output-format json`. `ok` plus a
+    /// `session_id` matching the id sent is the success condition.
+    ///
+    /// No pseudo-terminal: `--print` is explicitly a non-interactive
+    /// invocation and returns JSON on an ordinary pipe, and a pty would merge
+    /// stderr into that JSON.
+    func send(sessionID: String, stdin: Data?) async throws -> ProviderResult {
+        guard let stdin, let message = ClaudeCloudSendPayload.message(fromStdin: stdin) else {
+            return Self.errorResult(
+                exitCode: 2, code: "invalid_params",
+                message: "send received no message bytes")
+        }
+        let request = ClaudeCloudSpawnRequest(
+            arguments: ["-p", message, "--cloud", sessionID, "--output-format", "json"],
+            workingDirectory: FileManager.default.temporaryDirectory.path,
+            usesPseudoTerminal: false,
+            timeout: 30)
+        switch try await spawner.spawn(request) {
+        case .timedOut:
+            return Self.errorResult(
+                exitCode: 3, code: "unreachable",
+                message: "claude -p --cloud did not answer before its deadline")
+        case let .completed(status, output):
+            guard status == 0 else {
+                return Self.errorResult(
+                    exitCode: 1, code: "unreachable",
+                    message: "claude -p --cloud exited \(status): \(Self.bounded(output))")
+            }
+            guard let reply = try? JSONDecoder().decode(
+                ClaudeCloudSendReply.self, from: Data(output.utf8))
+            else {
+                return Self.errorResult(
+                    exitCode: 1, code: "unreachable",
+                    message: "claude -p --cloud returned unparseable output: \(Self.bounded(output))")
+            }
+            guard reply.ok == true, reply.sessionID == sessionID else {
+                return Self.errorResult(
+                    exitCode: 1, code: "unreachable",
+                    message: "claude -p --cloud did not accept the message for \(sessionID) "
+                        + "(ok=\(String(describing: reply.ok)), "
+                        + "session_id=\(reply.sessionID ?? "nil"))")
+            }
+            // The contract's `send` answers `{}`. Exit 0 keeps its contract
+            // meaning: handed to the transport, not acted upon.
+            return ProviderResult(exitCode: 0, stdout: Data("{}".utf8), stderr: "")
+        }
+    }
+
+    static func bounded(_ text: String, limit: Int = 400) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count > limit ? String(trimmed.prefix(limit - 1)) + "…" : trimmed
+    }
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSend.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSend.swift
@@ -26,10 +26,9 @@ enum ClaudeCloudSendPayload {
 private struct ClaudeCloudSendReply: Decodable {
     let ok: Bool?
     let sessionID: String?
-    let url: String?
 
     enum CodingKeys: String, CodingKey {
-        case ok, url
+        case ok
         case sessionID = "session_id"
     }
 }
@@ -58,18 +57,24 @@ extension ClaudeCloudInvoker {
             return Self.errorResult(
                 exitCode: 3, code: "unreachable",
                 message: "claude -p --cloud did not answer before its deadline")
-        case let .completed(status, output):
+        case let .completed(status, output, stderr):
+            // `output` is stdout alone on this pipe (see `ClaudeCloudSpawning`'s
+            // doc comment) — the only thing decoded as strict JSON below, so
+            // incidental stderr chatter on an otherwise-successful call can
+            // never break that parse. Diagnostic MESSAGES still quote both
+            // streams, matching what a failing invocation actually printed.
+            let diagnostic = output + stderr
             guard status == 0 else {
                 return Self.errorResult(
                     exitCode: 1, code: "unreachable",
-                    message: "claude -p --cloud exited \(status): \(Self.bounded(output))")
+                    message: "claude -p --cloud exited \(status): \(Self.bounded(diagnostic))")
             }
             guard let reply = try? JSONDecoder().decode(
                 ClaudeCloudSendReply.self, from: Data(output.utf8))
             else {
                 return Self.errorResult(
                     exitCode: 1, code: "unreachable",
-                    message: "claude -p --cloud returned unparseable output: \(Self.bounded(output))")
+                    message: "claude -p --cloud returned unparseable output: \(Self.bounded(diagnostic))")
             }
             guard reply.ok == true, reply.sessionID == sessionID else {
                 return Self.errorResult(
@@ -86,6 +91,6 @@ extension ClaudeCloudInvoker {
 
     static func bounded(_ text: String, limit: Int = 400) -> String {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.count > limit ? String(trimmed.prefix(limit - 1)) + "…" : trimmed
+        return ClaudeCloudTextBounding.truncated(trimmed, limit: limit)
     }
 }

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSpawning.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSpawning.swift
@@ -42,7 +42,16 @@ protocol ClaudeCloudSpawning: Sendable {
 struct BoundedProcessClaudeSpawner: ClaudeCloudSpawning {
     let executable: String
 
-    init(executable: String) { self.executable = executable }
+    /// Behavior seam for the subprocess deadline (`Tests/CLAUDE.md`, "Clock and
+    /// date seams"), matching `GitManager`/`TmuxManager.runExternalCommand`.
+    /// Tests pass a `TestClock` to drive `runBoundedProcess`'s deadline in
+    /// virtual time instead of racing a real one on a loaded runner.
+    let clock: any Clock<Duration>
+
+    init(executable: String, clock: any Clock<Duration> = ContinuousClock()) {
+        self.executable = executable
+        self.clock = clock
+    }
 
     /// The environment one invocation runs under. Pure and static so the
     /// pinned geometry is assertable without a spawn.
@@ -77,7 +86,8 @@ struct BoundedProcessClaudeSpawner: ClaudeCloudSpawning {
             // outright, and neither verb here has anything to write.
             stdin: nil,
             timeout: .seconds(request.timeout),
-            stdio: request.usesPseudoTerminal ? .pseudoTerminal : .pipes)
+            stdio: request.usesPseudoTerminal ? .pseudoTerminal : .pipes,
+            clock: clock)
         switch outcome {
         case .timedOut:
             return .timedOut

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSpawning.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSpawning.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// One invocation of the vendor `claude` CLI, as a value.
+struct ClaudeCloudSpawnRequest: Sendable, Equatable {
+    /// Arguments after the executable. Never a shell string — the CLI is
+    /// executed directly, so nothing here is shell-escaped or re-parsed.
+    let arguments: [String]
+    let workingDirectory: String
+    /// `create` alone. The CLI refuses `--cloud` creation when stdout is not
+    /// a terminal, by design and loudly, so the obvious pipe implementation
+    /// does not degrade — it never works. Everything else must stay on pipes:
+    /// a pty is ONE descriptor, so stdout and stderr merge on it.
+    let usesPseudoTerminal: Bool
+    let timeout: TimeInterval
+}
+
+enum ClaudeCloudSpawnOutcome: Sendable, Equatable {
+    /// `output` is the captured stdout, plus stderr when the two merged on a
+    /// pseudo-terminal. Decoded lossily so ANSI bytes survive to the parser's
+    /// strip step rather than failing the decode.
+    case completed(status: Int32, output: String)
+    case timedOut
+}
+
+/// The seam every vendor invocation goes through, so no test reaches a real
+/// `claude` binary, a network, or a credential store.
+protocol ClaudeCloudSpawning: Sendable {
+    func spawn(_ request: ClaudeCloudSpawnRequest) async throws -> ClaudeCloudSpawnOutcome
+}
+
+/// Production conformance over the same bounded runner every other daemon
+/// spawn uses — watchdog-backed deadline, incremental draining, single-resume
+/// guard — rather than a second engine whose deadline discipline could rot.
+struct BoundedProcessClaudeSpawner: ClaudeCloudSpawning {
+    let executable: String
+
+    init(executable: String) { self.executable = executable }
+
+    /// The environment one invocation runs under. Pure and static so the
+    /// pinned geometry is assertable without a spawn.
+    ///
+    /// `runBoundedProcess` REPLACES the child's environment wholesale, so this
+    /// starts from the caller's full login environment and overrides. Under a
+    /// pseudo-terminal the geometry is pinned to the runner's own 400x200:
+    /// `winsize` is advisory and the kernel wraps nothing, but a child that
+    /// ASKS formats to it and inserts REAL newlines at the wrap, which would
+    /// land in the captured bytes and split the line the create parse reads.
+    static func invocationEnvironment(
+        base: [String: String], usesPseudoTerminal: Bool
+    ) -> [String: String] {
+        guard usesPseudoTerminal else { return base }
+        var env = base
+        env["TERM"] = "xterm-256color"
+        env["COLUMNS"] = "400"
+        env["LINES"] = "200"
+        return env
+    }
+
+    func spawn(_ request: ClaudeCloudSpawnRequest) async throws -> ClaudeCloudSpawnOutcome {
+        let outcome = try await runBoundedProcess(
+            executable: executable,
+            arguments: request.arguments,
+            currentDirectory: request.workingDirectory,
+            environment: Self.invocationEnvironment(
+                base: ProcessInfo.processInfo.environment,
+                usesPseudoTerminal: request.usesPseudoTerminal),
+            // None, ever: under `.pseudoTerminal` the replica is the child's
+            // stdin AND stdout on one descriptor, so a payload is refused
+            // outright, and neither verb here has anything to write.
+            stdin: nil,
+            timeout: .seconds(request.timeout),
+            stdio: request.usesPseudoTerminal ? .pseudoTerminal : .pipes)
+        switch outcome {
+        case .timedOut:
+            return .timedOut
+        case let .completed(status, stdoutData, stderrData):
+            // Under a pty `stderrData` is always empty (the streams merged);
+            // under pipes it carries the CLI's diagnostics, which belong in
+            // the message a failing verb reports.
+            // swiftlint:disable:next optional_data_string_conversion
+            let stdout = String(decoding: stdoutData, as: UTF8.self)
+            // swiftlint:disable:next optional_data_string_conversion
+            let stderr = String(decoding: stderrData, as: UTF8.self)
+            return .completed(status: status, output: stdout + stderr)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSpawning.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudSpawning.swift
@@ -16,9 +16,17 @@ struct ClaudeCloudSpawnRequest: Sendable, Equatable {
 
 enum ClaudeCloudSpawnOutcome: Sendable, Equatable {
     /// `output` is the captured stdout, plus stderr when the two merged on a
-    /// pseudo-terminal. Decoded lossily so ANSI bytes survive to the parser's
-    /// strip step rather than failing the decode.
-    case completed(status: Int32, output: String)
+    /// pseudo-terminal — genuinely one descriptor there. On a plain pipe the
+    /// two streams are separate, so `output` carries stdout ALONE: `send`
+    /// parses `output` as strict JSON on a pipe, and incidental stderr
+    /// chatter from an otherwise-successful invocation must never land where
+    /// that parse can see it. `stderr` carries the pipe-mode diagnostic
+    /// stream on its own, for a caller that still wants it in a failure
+    /// message; it reads empty under a pseudo-terminal, where the streams
+    /// already merged into `output` and the runner reports it empty anyway.
+    /// Both decoded lossily so ANSI bytes survive to the parser's strip step
+    /// rather than failing the decode.
+    case completed(status: Int32, output: String, stderr: String)
     case timedOut
 }
 
@@ -74,14 +82,19 @@ struct BoundedProcessClaudeSpawner: ClaudeCloudSpawning {
         case .timedOut:
             return .timedOut
         case let .completed(status, stdoutData, stderrData):
-            // Under a pty `stderrData` is always empty (the streams merged);
-            // under pipes it carries the CLI's diagnostics, which belong in
-            // the message a failing verb reports.
+            // Under a pty `stderrData` is always empty (the streams merged
+            // onto stdout already); under pipes it carries the CLI's own
+            // diagnostics on a genuinely separate descriptor, kept apart from
+            // `output` so a strict-JSON consumer on a pipe never has to parse
+            // through it.
             // swiftlint:disable:next optional_data_string_conversion
             let stdout = String(decoding: stdoutData, as: UTF8.self)
             // swiftlint:disable:next optional_data_string_conversion
             let stderr = String(decoding: stderrData, as: UTF8.self)
-            return .completed(status: status, output: stdout + stderr)
+            return .completed(
+                status: status,
+                output: request.usesPseudoTerminal ? stdout + stderr : stdout,
+                stderr: request.usesPseudoTerminal ? "" : stderr)
         }
     }
 }

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudTextBounding.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudTextBounding.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// The truncate-with-ellipsis rule shared by every place in this directory
+/// that quotes raw vendor output into a bounded diagnostic message. Callers
+/// own their own pre-processing — trimming, ANSI stripping, or neither — this
+/// is only the cut: reserve the last character of `limit` for the ellipsis,
+/// so the quoted text plus its ellipsis never exceeds `limit` characters.
+enum ClaudeCloudTextBounding {
+    static func truncated(_ text: String, limit: Int) -> String {
+        text.count > limit ? String(text.prefix(limit - 1)) + "…" : text
+    }
+}

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeExecutableResolver.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeExecutableResolver.swift
@@ -6,17 +6,26 @@ import Foundation
 /// A configured `TBD_CLAUDE_EXECUTABLE` absolute path wins, followed by every
 /// ABSOLUTE `PATH` entry in order. Relative and empty entries are ignored on
 /// both inputs: resolving them against the daemon's current directory could
-/// execute an untrusted worktree-local `claude`. The returned path is always
-/// absolute, so nothing downstream repeats the lookup under a different
-/// environment.
+/// execute an untrusted worktree-local `claude`. An absolute override that is
+/// not executable is a hard failure rather than a silent fallback to PATH
+/// search — someone who set an explicit override did so because the wrong
+/// binary was being picked up, and handing them a different `claude` on a
+/// typo with no diagnostic would be a worse footgun than not-found. The
+/// returned path is always absolute, so nothing downstream repeats the
+/// lookup under a different environment.
 enum ClaudeExecutableResolver {
     static let executableOverrideEnvironmentKey = "TBD_CLAUDE_EXECUTABLE"
 
     enum ResolveError: LocalizedError, Equatable {
+        case invalidOverride(environmentKey: String, value: String)
         case notFound(searchPath: String)
 
         var errorDescription: String? {
             switch self {
+            case .invalidOverride(let environmentKey, let value):
+                return "\(environmentKey) is set to \"\(value)\", but that path is not "
+                    + "executable; set it to an absolute path to an executable `claude`, "
+                    + "or unset it"
             case .notFound(let searchPath):
                 return "no executable `claude` found on PATH (\(searchPath)); "
                     + "set \(executableOverrideEnvironmentKey) to an absolute path"
@@ -30,8 +39,12 @@ enum ClaudeExecutableResolver {
         searchPath: String = ProcessInfo.processInfo.environment["PATH"] ?? "",
         isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
     ) throws -> String {
-        if let configuredOverride, configuredOverride.hasPrefix("/"),
-           isExecutable(configuredOverride) {
+        if let configuredOverride, configuredOverride.hasPrefix("/") {
+            guard isExecutable(configuredOverride) else {
+                throw ResolveError.invalidOverride(
+                    environmentKey: executableOverrideEnvironmentKey,
+                    value: configuredOverride)
+            }
             return URL(fileURLWithPath: configuredOverride).standardizedFileURL.path
         }
         for entry in searchPath.split(separator: ":", omittingEmptySubsequences: false) {

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeExecutableResolver.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeExecutableResolver.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Resolves the vendor `claude` executable daemon-side, in the shape
+/// `CodexExecutableResolver` establishes for the other vendor CLI.
+///
+/// A configured `TBD_CLAUDE_EXECUTABLE` absolute path wins, followed by every
+/// ABSOLUTE `PATH` entry in order. Relative and empty entries are ignored on
+/// both inputs: resolving them against the daemon's current directory could
+/// execute an untrusted worktree-local `claude`. The returned path is always
+/// absolute, so nothing downstream repeats the lookup under a different
+/// environment.
+enum ClaudeExecutableResolver {
+    static let executableOverrideEnvironmentKey = "TBD_CLAUDE_EXECUTABLE"
+
+    enum ResolveError: LocalizedError, Equatable {
+        case notFound(searchPath: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notFound(let searchPath):
+                return "no executable `claude` found on PATH (\(searchPath)); "
+                    + "set \(executableOverrideEnvironmentKey) to an absolute path"
+            }
+        }
+    }
+
+    static func resolve(
+        configuredOverride: String? = ProcessInfo.processInfo
+            .environment[executableOverrideEnvironmentKey],
+        searchPath: String = ProcessInfo.processInfo.environment["PATH"] ?? "",
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) throws -> String {
+        if let configuredOverride, configuredOverride.hasPrefix("/"),
+           isExecutable(configuredOverride) {
+            return URL(fileURLWithPath: configuredOverride).standardizedFileURL.path
+        }
+        for entry in searchPath.split(separator: ":", omittingEmptySubsequences: false) {
+            let dir = String(entry)
+            guard dir.hasPrefix("/") else { continue }
+            let candidate = URL(fileURLWithPath: dir)
+                .appendingPathComponent("claude").standardizedFileURL.path
+            if isExecutable(candidate) { return candidate }
+        }
+        throw ResolveError.notFound(searchPath: searchPath)
+    }
+}

--- a/Sources/TBDDaemon/Remote/ProviderDispatcher.swift
+++ b/Sources/TBDDaemon/Remote/ProviderDispatcher.swift
@@ -1,0 +1,37 @@
+import Foundation
+import TBDShared
+
+/// Routes one provider invocation to whichever conformance serves that
+/// provider: a reserved name to an in-process built-in, everything else to
+/// the subprocess runner.
+///
+/// The selection lands at `RemoteProviderManager`'s single `runner` injection
+/// site rather than at each call, and three properties make that the right
+/// seam:
+///
+/// - **One place decides.** The manager holds a dispatcher instead of a
+///   runner and is otherwise unchanged, so no verb path grows an "is this the
+///   built-in one" branch that a later verb could forget.
+/// - **The built-in provider is put through the same machinery.** It
+///   synthesizes the same `ProviderResult` envelope a subprocess produces,
+///   fabricated exit code included, so it passes through
+///   `ProviderFailureClass.classify` and the same health, auth-banner and
+///   staleness handling an external provider gets.
+/// - **The test seam is unchanged.** `FakeProviderInvoker` conforms to the
+///   same protocol and stands in for either arm, so cloud behavior is
+///   testable with no network and no credential store.
+struct ProviderDispatcher: RemoteProviderInvoking {
+    /// `ProviderRunner` in production.
+    let subprocess: any RemoteProviderInvoking
+    /// Keyed by provider name. Empty when no built-in is enabled at boot, in
+    /// which case every name falls through to `subprocess`.
+    let builtIns: [String: any RemoteProviderInvoking]
+
+    func run(_ config: RemoteProviderConfig, verb: [String], stdin: Data?,
+             timeout: TimeInterval, contractVersion: Int) async throws -> ProviderResult {
+        let target = builtIns[config.name] ?? subprocess
+        return try await target.run(
+            config, verb: verb, stdin: stdin, timeout: timeout,
+            contractVersion: contractVersion)
+    }
+}

--- a/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
+++ b/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
@@ -162,6 +162,10 @@ actor ProviderEventsSupervisor {
     /// available — a supervisor that keeps spawning provider children forever
     /// while every event it parses applies to nobody, silently.
     private let manager: RemoteProviderManager
+    /// The contract major `RemoteProviderManager` negotiated for this provider,
+    /// captured at construction. The supervisor's whole lifetime belongs to one
+    /// `describe`, so re-reading it per spawn would buy nothing.
+    private let contractVersion: Int
     private var supervision: Task<Void, Never>?
     private var currentProcess: Process?
     /// Incremented per `runOnce`, so a previous run's teardown can never nil
@@ -199,13 +203,26 @@ actor ProviderEventsSupervisor {
     private static let killGrace: Duration = .milliseconds(500)
     private static let drainGrace: Duration = .milliseconds(50)
 
+    /// The environment the `events` child runs under. Pure and static for the
+    /// same reason `ProviderRunner.invocationEnvironment` is: the two daemon
+    /// emitters agreeing is a property worth asserting without a spawn.
+    static func streamEnvironment(
+        base: [String: String], contractVersion: Int
+    ) -> [String: String] {
+        var env = base
+        env["TBD_CONTRACT_VERSION"] = String(contractVersion)
+        return env
+    }
+
     init(config: RemoteProviderConfig, manager: RemoteProviderManager,
+         contractVersion: Int,
          silenceLimit: TimeInterval = 90, backoffCap: TimeInterval = 60,
          healthyResetUptime: TimeInterval = 300,
          clock: any Clock<Duration> = ContinuousClock(),
          now: @Sendable @escaping () -> Date = { Date() }) {
         self.config = config
         self.manager = manager
+        self.contractVersion = contractVersion
         self.silenceLimit = silenceLimit
         self.backoffCap = backoffCap
         self.healthyResetUptime = healthyResetUptime
@@ -270,8 +287,8 @@ actor ProviderEventsSupervisor {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: config.exec)
         process.arguments = (config.args ?? []) + ["events"]
-        var env = ProcessInfo.processInfo.environment
-        env["TBD_CONTRACT_VERSION"] = "1"
+        let env = Self.streamEnvironment(
+            base: ProcessInfo.processInfo.environment, contractVersion: contractVersion)
         process.environment = env
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
+++ b/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
@@ -417,9 +417,9 @@ actor ProviderEventsSupervisor {
         switch event {
         case .hello, .ping:
             break   // activity timestamp already updated by the caller
-        case .snapshot(let sessions):
+        case .snapshot(let sessions, let complete):
             try? await manager.apply(
-                snapshot: sessions, provider: config.name,
+                snapshot: sessions, provider: config.name, complete: complete,
                 requestStartedAt: connectionOpenedAt)
         case .session(let session):
             await manager.applyUpsert(session, provider: config.name)

--- a/Sources/TBDDaemon/Remote/ProviderRunner.swift
+++ b/Sources/TBDDaemon/Remote/ProviderRunner.swift
@@ -40,8 +40,12 @@ public enum ProviderRunError: LocalizedError, Sendable {
 }
 
 public protocol RemoteProviderInvoking: Sendable {
+    /// - Parameter contractVersion: the major `RemoteProviderManager` negotiated
+    ///   for this provider. Passed rather than read from a constant so both
+    ///   conformances — the subprocess runner and any in-process built-in —
+    ///   announce the same value the daemon agreed to.
     func run(_ config: RemoteProviderConfig, verb: [String], stdin: Data?,
-             timeout: TimeInterval) async throws -> ProviderResult
+             timeout: TimeInterval, contractVersion: Int) async throws -> ProviderResult
 }
 
 /// Spawns the provider executable, feeds it `stdin`, and captures stdout /
@@ -58,10 +62,22 @@ public protocol RemoteProviderInvoking: Sendable {
 public struct ProviderRunner: RemoteProviderInvoking {
     public init() {}
 
+    /// The environment one provider invocation runs under. Pure and static so
+    /// the emitted contract major is assertable without a spawn — this is one
+    /// of the daemon's two emitters, and the two disagreeing is exactly the
+    /// defect the negotiation work exists to close.
+    public static func invocationEnvironment(
+        base: [String: String], contractVersion: Int
+    ) -> [String: String] {
+        var env = base
+        env["TBD_CONTRACT_VERSION"] = String(contractVersion)
+        return env
+    }
+
     public func run(_ config: RemoteProviderConfig, verb: [String], stdin: Data?,
-                    timeout: TimeInterval) async throws -> ProviderResult {
-        var env = ProcessInfo.processInfo.environment
-        env["TBD_CONTRACT_VERSION"] = "1"
+                    timeout: TimeInterval, contractVersion: Int) async throws -> ProviderResult {
+        let env = Self.invocationEnvironment(
+            base: ProcessInfo.processInfo.environment, contractVersion: contractVersion)
         let verbName = verb.first ?? "?"
 
         switch try await runBoundedProcess(

--- a/Sources/TBDDaemon/Remote/RemoteEventParser.swift
+++ b/Sources/TBDDaemon/Remote/RemoteEventParser.swift
@@ -8,7 +8,10 @@ import TBDShared
 /// absence from `list`/`snapshot` polls.
 enum RemoteEvent: Equatable, Sendable {
     case hello(contractVersion: Int)
-    case snapshot([RemoteSessionPayload])
+    /// `complete` carries the contract's snapshot-completeness claim, with
+    /// exactly the meaning it has on `list`: an incomplete snapshot retires
+    /// nothing and refreshes no freshness. Absent reads as `true`.
+    case snapshot([RemoteSessionPayload], complete: Bool)
     case session(RemoteSessionPayload)
     case removed(id: String)
     case ping
@@ -26,8 +29,9 @@ enum RemoteEventParser {
         let sessions: [RemoteSessionPayload]?
         let session: RemoteSessionPayload?
         let id: String?
+        let complete: Bool?
         enum CodingKeys: String, CodingKey {
-            case event, sessions, session, id
+            case event, sessions, session, id, complete
             case contractVersion = "contract_version"
         }
     }
@@ -39,7 +43,7 @@ enum RemoteEventParser {
               let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else { return nil }
         switch envelope.event {
         case "hello": return .hello(contractVersion: envelope.contractVersion ?? 1)
-        case "snapshot": return .snapshot(envelope.sessions ?? [])
+        case "snapshot": return .snapshot(envelope.sessions ?? [], complete: envelope.complete ?? true)
         case "session": return envelope.session.map { .session($0) }
         case "removed": return envelope.id.map { .removed(id: $0) }
         case "ping": return .ping

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -29,6 +29,10 @@ public actor RemoteProviderManager {
 
     private var providers: [String: RemoteProviderConfig] = [:]
     private var describes: [String: ProviderDescribe] = [:]
+    /// The contract major negotiated per provider — the highest version both
+    /// TBD and the provider declare. Absent until `describe` has succeeded,
+    /// which is why `contractMajor(for:)` falls back rather than trapping.
+    private var negotiatedMajors: [String: Int] = [:]
     private var health:
         [String: (state: ProviderHealth, message: String?, remediation: ProviderRemediation?)] = [:]
     /// Most recent complete inventory accepted for each provider. Kept
@@ -160,11 +164,25 @@ public actor RemoteProviderManager {
                 provider: config.name, to: (.error, "describe returned an unparseable response", nil))
             return
         }
-        guard describe.contractVersions.contains(1) else {
+        // An INTERSECTION with TBD's own supported set, not a hard requirement
+        // on major 1. A provider is free to declare only the versions it can
+        // actually serve — `claude-cloud` declares `[2]` alone because nothing
+        // exposed terminates a running cloud session, so it cannot implement
+        // `stop`, which major 1 requires.
+        guard let negotiated = Self.negotiate(declared: describe.contractVersions) else {
             setHealth(provider: config.name, to: (.error, "no common contract version", nil))
             return
         }
+        negotiatedMajors[config.name] = negotiated
         describes[config.name] = describe
+    }
+
+    /// Contract majors this build of TBD can speak.
+    static let supportedContractMajors: Set<Int> = [1, 2]
+
+    /// The highest major both sides declare, or nil when they share none.
+    static func negotiate(declared: [Int]) -> Int? {
+        declared.filter { supportedContractMajors.contains($0) }.max()
     }
 
     /// Spawns/re-spawns the 60s poll loop for every provider with a valid
@@ -826,6 +844,16 @@ public actor RemoteProviderManager {
         supervisors[name] != nil
     }
 
+    /// Runs `describe` for every registered provider without arming poll loops
+    /// or event supervisors. Exists so the negotiation rule is testable without
+    /// a running actor's background tasks — the same reason `hasSupervisor`
+    /// exists.
+    func describeAllForTests() async {
+        for config in providers.values.sorted(by: { $0.name < $1.name }) {
+            await describeProvider(config)
+        }
+    }
+
     func invoke(
         providerName: String, verb: [String], stdin: Data?,
         timeout: TimeInterval
@@ -875,10 +903,20 @@ public actor RemoteProviderManager {
         Set(describes[provider]?.capabilities ?? [])
     }
 
-    /// The contract major to announce for one provider. Task 4 backs this with
-    /// the negotiated value; until then every provider gets the fallback, which
-    /// is the constant the runner used to hardcode.
-    func contractMajor(for provider: String) -> Int { Self.fallbackContractMajor }
+    /// The contract major to announce for one provider: the negotiated value
+    /// once `describe` has landed, and the conservative fallback before that —
+    /// `describe` itself is the one invocation that necessarily precedes
+    /// negotiation.
+    func contractMajor(for provider: String) -> Int {
+        negotiatedMajors[provider] ?? Self.fallbackContractMajor
+    }
+
+    /// The negotiated major, or nil when this provider has no valid `describe`
+    /// on file. Exposed so `providerStatuses()` and tests read one value rather
+    /// than re-deriving the rule.
+    func negotiatedContractMajor(for provider: String) -> Int? {
+        negotiatedMajors[provider]
+    }
 
     /// What TBD announces before it has negotiated anything — the conservative
     /// reading, and the value the runner emitted unconditionally before.

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -141,7 +141,9 @@ public actor RemoteProviderManager {
     private func describeProvider(_ config: RemoteProviderConfig) async {
         let result: ProviderResult
         do {
-            result = try await runner.run(config, verb: ["describe"], stdin: nil, timeout: 10)
+            result = try await runner.run(
+                config, verb: ["describe"], stdin: nil, timeout: 10,
+                contractVersion: contractMajor(for: config.name))
         } catch {
             remoteLogger.error(
                 "describe \(config.name, privacy: .public) couldn't run: \(String(describing: error), privacy: .public)"
@@ -284,7 +286,9 @@ public actor RemoteProviderManager {
         // accounted for a local filing decision. See `syncFilingDecisions`.
         let requestStartedAt = Date()
         do {
-            let result = try await runner.run(provider, verb: ["list"], stdin: nil, timeout: 30)
+            let result = try await runner.run(
+                provider, verb: ["list"], stdin: nil, timeout: 30,
+                contractVersion: contractMajor(for: provider.name))
             if let failure = result.failureClass {
                 await recordPollFailure(provider: provider.name, class: failure, result: result)
                 return
@@ -829,7 +833,9 @@ public actor RemoteProviderManager {
         guard let config = providers[providerName] ?? loadAdHoc(named: providerName) else {
             throw RemoteProviderError.unknownProvider(providerName)
         }
-        let result = try await runner.run(config, verb: verb, stdin: stdin, timeout: timeout)
+        let result = try await runner.run(
+            config, verb: verb, stdin: stdin, timeout: timeout,
+            contractVersion: contractMajor(for: providerName))
         if let failure = result.failureClass {
             recordFailure(provider: providerName, class: failure, result: result)
         }
@@ -868,6 +874,15 @@ public actor RemoteProviderManager {
     func declaredCapabilities(provider: String) -> Set<String> {
         Set(describes[provider]?.capabilities ?? [])
     }
+
+    /// The contract major to announce for one provider. Task 4 backs this with
+    /// the negotiated value; until then every provider gets the fallback, which
+    /// is the constant the runner used to hardcode.
+    func contractMajor(for provider: String) -> Int { Self.fallbackContractMajor }
+
+    /// What TBD announces before it has negotiated anything — the conservative
+    /// reading, and the value the runner emitted unconditionally before.
+    static let fallbackContractMajor = 1
 
     func providerStatuses() async -> [RemoteProviderStatus] {
         for name in providers.keys {

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -17,6 +17,12 @@ public actor RemoteProviderManager {
     private let adopter: RemoteSessionAdopter
     private let runner: any RemoteProviderInvoking
     private let registryURL: URL
+    /// Providers TBD compiles in rather than reading from the registry file.
+    /// Empty unless the daemon wired one at boot. They are registered and
+    /// described exactly like registry entries, so their health, negotiated
+    /// major and poll loop all work the same way — a built-in provider is a
+    /// provider.
+    private let builtInProviders: [RemoteProviderConfig]
     private let clock: any Clock<Duration>
     /// Where the filing sync records the archives and revives it performs.
     /// Optional only so the many fixtures that construct this actor for
@@ -76,6 +82,7 @@ public actor RemoteProviderManager {
         db: TBDDatabase, subscriptions: StateSubscriptionManager,
         runner: any RemoteProviderInvoking, registryURL: URL,
         actuationLog: ActuationLog? = nil,
+        builtInProviders: [RemoteProviderConfig] = [],
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.db = db
@@ -84,11 +91,16 @@ public actor RemoteProviderManager {
         self.runner = runner
         self.registryURL = registryURL
         self.actuationLog = actuationLog
+        self.builtInProviders = builtInProviders
         self.clock = clock
         // RPC becomes available before `start()` runs, so seed the registry
         // synchronously. The first status or mutation-gate read can then recover
         // persisted freshness instead of briefly treating an existing mirror as
         // current while the initial provider poll is pending.
+        for config in builtInProviders {
+            providers[config.name] = config
+            health[config.name] = (.ok, nil, nil)
+        }
         if let configs = try? RemoteProviderRegistry.load(from: registryURL) {
             for config in configs {
                 providers[config.name] = config
@@ -117,13 +129,22 @@ public actor RemoteProviderManager {
     /// bounds this to at most one `describe` child process in flight rather
     /// than one per remaining provider.
     func loadRegistryAndDescribe() async {
-        let configs: [RemoteProviderConfig]
+        var configs: [RemoteProviderConfig] = builtInProviders
         do {
-            configs = try RemoteProviderRegistry.load(from: registryURL)
+            let loaded = try RemoteProviderRegistry.loadEntries(from: registryURL)
+            for name in loaded.skippedReservedNames {
+                remoteLogger.error(
+                    """
+                    provider registry entry named \(name, privacy: .public) was skipped: \
+                    that name is reserved for a provider compiled into TBD
+                    """)
+            }
+            configs += loaded.configs
         } catch {
             remoteLogger.error(
                 "provider registry unreadable: \(String(describing: error), privacy: .public)")
-            return
+            // The built-ins are still described: a malformed registry FILE
+            // says nothing about a provider that does not come from it.
         }
         for config in configs {
             guard !Task.isCancelled else { return }
@@ -1041,6 +1062,19 @@ public actor RemoteProviderManager {
         let inheritable = previous?.state == .needsAuth ? previous : nil
         setHealth(provider: name, to: (.needsAuth, inheritable?.message, inheritable?.remediation))
         guard previous?.state != .needsAuth else { return }
+        await pollOnce(provider: config)
+    }
+
+    /// Exactly ONE out-of-band `list` after a locally-observed create.
+    ///
+    /// The row for a created session arrives by adoption on a snapshot rather
+    /// than being minted by the create call, and the poll loop's interval is
+    /// 60 seconds, so without this a lane created from the `+` menu can sit
+    /// invisible for up to a minute after a create that already succeeded.
+    /// Bounded exactly as `recordAttachExit`'s probe is: one extra `list` per
+    /// create, never a loop, and only on a create that succeeded.
+    func refreshAfterCreate(provider name: String) async {
+        guard let config = providers[name] else { return }
         await pollOnce(provider: config)
     }
 

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -940,7 +940,8 @@ public actor RemoteProviderManager {
                 remediationLabel: h.remediation?.label,
                 remediationCommand: h.remediation?.command,
                 lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name],
-                freshnessUnreadable: snapshotFreshnessUnreadable.contains(config.name))
+                freshnessUnreadable: snapshotFreshnessUnreadable.contains(config.name),
+                contractVersion: negotiatedMajors[config.name])
         }
     }
 

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -869,6 +869,23 @@ public actor RemoteProviderManager {
         supervisors[name] != nil
     }
 
+    /// Test seam: `snapshotFreshnessUnreadable`'s raw value for `name`, with
+    /// no recovery attempt in between. Every *production* reader
+    /// (`providerStatuses()`, `hasStaleSnapshot(provider:)`) calls
+    /// `recoverLastSuccessfulSnapshotAtIfNeeded` first, which — whenever
+    /// `lastSuccessfulSnapshotAt[name]` is still nil — unconditionally
+    /// re-derives this flag from a fresh `tbd_meta` read and overwrites
+    /// whatever `apply(snapshot:provider:complete:now:)` just left there. That
+    /// is correct production behavior (the freshest read should win) but it
+    /// means those accessors cannot discriminate a regression in `apply`'s own
+    /// gate: whether or not the incomplete branch clears the flag, the very
+    /// next status read silently recomputes the same answer from the
+    /// database. This seam reads the field directly so a test can observe
+    /// `apply`'s effect before any recovery call has a chance to launder it.
+    func freshnessUnreadableForTests(provider name: String) -> Bool {
+        snapshotFreshnessUnreadable.contains(name)
+    }
+
     /// Runs `describe` for every registered provider without arming poll loops
     /// or event supervisors. Exists so the negotiation rule is testable without
     /// a running actor's background tasks — the same reason `hasSupervisor`

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -316,7 +316,8 @@ public actor RemoteProviderManager {
             let envelope = try result.decoded(RemoteSessionListEnvelope.self)
             let snapshotAt = Date()
             try await apply(
-                snapshot: envelope.sessions, provider: provider.name, now: snapshotAt,
+                snapshot: envelope.sessions, provider: provider.name,
+                complete: envelope.complete, now: snapshotAt,
                 requestStartedAt: requestStartedAt)
         } catch {
             remoteLogger.debug(
@@ -327,7 +328,16 @@ public actor RemoteProviderManager {
         }
     }
 
-    /// Shared by the poll path and the events snapshot path (Task 6).
+    /// Shared by the poll path and the events snapshot path.
+    ///
+    /// `complete` carries the contract's snapshot-completeness claim through
+    /// to the mirror and to freshness. An INCOMPLETE snapshot still adopts
+    /// what it sighted, still files the decisions those sightings imply, and
+    /// still clears degraded health — the provider answered — while claiming
+    /// no complete inventory in either store: not the in-memory stamp below,
+    /// and not the persisted `tbd_meta` row `applySnapshot` writes. Defaulted
+    /// to `true` so every caller that predates the field keeps its exact
+    /// behavior.
     ///
     /// `now` is arrival — when this response landed. `requestStartedAt` is
     /// when the question behind it was posed: the poll stamps it before
@@ -338,28 +348,41 @@ public actor RemoteProviderManager {
     /// `applyUpsert`'s pushed `session` line — reads correctly without
     /// inventing a start time.
     func apply(
-        snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date(),
+        snapshot sessions: [RemoteSessionPayload], provider: String,
+        complete: Bool = true, now: Date = Date(),
         requestStartedAt: Date? = nil
     ) async throws {
         let outcome = try await db.remoteSessions.applySnapshot(
-            provider: provider, sessions: sessions, now: now)
+            provider: provider, sessions: sessions, complete: complete, now: now)
         // After the mirror, never before: adoption reads the repo association
         // `applySnapshot` just pinned rather than resolving `meta["repo"]` a
         // second time. Unconditional on `outcome.changed` — a session can
         // become adoptable without its payload changing at all, because the
         // mirror re-attempts resolution on every poll while its pin is null,
         // and the poll after the user registers the repo is exactly that case.
+        // Also unconditional on `complete`: an incomplete snapshot is
+        // authoritative about presence, so a session it sighted is adopted.
         broadcastAdoptions(await adopter.adopt(sessions: sessions, provider: provider))
         // After adoption, never before: a session first sighted in this very
         // snapshot already reporting `archived: true` must be filed on the
         // row adoption just minted, not skipped for lack of one.
+        //
+        // Unconditional on `complete`, for the same reason adoption is: this
+        // reads each sighted session's own `archived` claim and never infers
+        // anything from absence, so an incomplete snapshot is as authoritative
+        // here as a complete one. Completeness gates only the absence-derived
+        // and inventory-freshness conclusions below.
         await syncFilingDecisions(
             sessions: sessions, provider: provider,
             requestStartedAt: requestStartedAt ?? now, now: now)
-        lastSuccessfulSnapshotAt[provider] = now
-        // A live snapshot supersedes whatever the persisted row would have
-        // said, so an earlier unreadable read no longer gates anything.
-        snapshotFreshnessUnreadable.remove(provider)
+        if complete {
+            lastSuccessfulSnapshotAt[provider] = now
+            // A live COMPLETE snapshot supersedes whatever the persisted row
+            // would have said, so an earlier unreadable read no longer gates
+            // anything. An incomplete one supersedes nothing — it wrote no
+            // persisted row — so the unreadable flag is left where it stands.
+            snapshotFreshnessUnreadable.remove(provider)
+        }
         markHealthy(provider: provider)
         if outcome.changed {
             subscriptions.broadcast(delta: .remoteSessionsChanged)

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -274,7 +274,9 @@ public actor RemoteProviderManager {
     /// supervised low-latency NDJSON stream.
     private func startLoop(for config: RemoteProviderConfig) async {
         if describes[config.name]?.capabilities.contains("events") == true {
-            let supervisor = ProviderEventsSupervisor(config: config, manager: self, clock: clock)
+            let supervisor = ProviderEventsSupervisor(
+                config: config, manager: self,
+                contractVersion: contractMajor(for: config.name), clock: clock)
             supervisors[config.name] = supervisor
             // Awaiting `supervisor.start()` (a different actor) suspends this
             // actor's executor, which by itself does NOT close the race

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -138,6 +138,21 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the Claude cloud sessions gate (design 2026-08-15 §7).
+    ///
+    /// The daemon builds its provider manager, and registers the built-in
+    /// provider into it, only at boot — so unlike the queued-prompt flag this
+    /// one does NOT take effect on the next gesture.
+    /// `DaemonCapabilitiesResult.claudeCloudLive` is what tells the user
+    /// whether a restart is still owed.
+    func handleConfigSetClaudeCloud(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetClaudeCloudParams.self, from: paramsData)
+        try await db.config.setClaudeCloud(params.enabled)
+        // Broadcast so the app reloads daemon capabilities.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the auto-close-setup-tab soak flag. Read fresh at spawn time,
     /// so it applies to the next worktree creation immediately — already-open
     /// setup tabs are unaffected.

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -57,6 +57,17 @@ extension RPCRouter {
     /// off entirely, this says the compiled cloud provider is.
     private static let claudeCloudDisabledResponse = RPCResponse(error: "claude cloud sessions disabled")
 
+    /// The per-invocation timeout for the `create` verb, applied to both the
+    /// initial call and its one same-key retry below. Provider-agnostic at
+    /// this layer — every `remote.*` backend's `create` gets this budget —
+    /// but for the compiled `claude-cloud` provider it is in a load-bearing
+    /// numeric relationship with `ClaudeCloudInvoker.pendingFailureWindow`
+    /// (`ClaudeCloudList.swift`): that window must stay strictly greater than
+    /// this timeout, or a `create` still running past its own timeout budget
+    /// could have its ledger row reclaimed and re-spawned out from under it.
+    /// Pinned by `ClaudeCloudTimeoutRelationshipTests`.
+    static let remoteCreateTimeout: TimeInterval = 60
+
     /// The second, inner gate. `claude_cloud_enabled` is checked INSIDE
     /// `remoteGate()` — cloud is reached through the same `remote.*` verbs, so
     /// it requires BOTH flags and the inner one is never a bypass.
@@ -183,13 +194,13 @@ extension RPCRouter {
         let result: ProviderResult
         do {
             result = try await manager.invoke(
-                providerName: params.provider, verb: ["create"], stdin: stdin, timeout: 60)
+                providerName: params.provider, verb: ["create"], stdin: stdin, timeout: Self.remoteCreateTimeout)
         } catch is ProviderRunError {
             // One retry with the SAME key — the provider dedupes, so a
             // timed-out-but-actually-succeeded create doesn't double-spawn.
             do {
                 result = try await manager.invoke(
-                    providerName: params.provider, verb: ["create"], stdin: stdin, timeout: 60)
+                    providerName: params.provider, verb: ["create"], stdin: stdin, timeout: Self.remoteCreateTimeout)
             } catch let error as ProviderRunError {
                 remoteHandlerLogger.error(
                     "remote.create provider=\(params.provider, privacy: .public) timed out on both the initial call and the retry")

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -70,7 +70,14 @@ extension RPCRouter {
     /// becomes the sole gate for cloud.
     ///
     /// Returns the refusal to send, or nil when the invocation is permitted.
-    private func cloudGate(provider: String) async throws -> RPCResponse? {
+    ///
+    /// Internal rather than private for the same reason as `remoteGate()`
+    /// above: `worktree.archive` / `worktree.revive`'s remote branches
+    /// (`RPCRouter+WorktreeHandlers.swift`) reach a provider verb too — via
+    /// `RemoteLaneLifecycle+Actuate`'s `archiveDecision`/`reviveDecision` —
+    /// and must refuse with the same inner-gate message when cloud is off,
+    /// not just when the outer flag is.
+    func cloudGate(provider: String) async throws -> RPCResponse? {
         guard provider == ClaudeCloudProvider.name else { return nil }
         guard try await db.config.get().claudeCloudEnabled else {
             return Self.claudeCloudDisabledResponse
@@ -304,6 +311,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteArchiveParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         return try await retire(
             verb: "archive", surface: .remoteArchive, manager: manager,
             provider: params.provider, sessionID: params.sessionID, actor: actor, now: now)
@@ -320,6 +328,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteUnarchiveParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         return try await retire(
             verb: "unarchive", surface: .remoteUnarchive, manager: manager,
             provider: params.provider, sessionID: params.sessionID, actor: actor, now: now)

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -52,6 +52,32 @@ extension RPCRouter {
     /// the same words when the subsystem is off.
     static let remoteBackendsDisabledResponse = RPCResponse(error: "remote backends disabled")
 
+    /// The inner gate's refusal. A separate string from the outer one because
+    /// they are separate conditions: the outer flag says remote backends are
+    /// off entirely, this says the compiled cloud provider is.
+    private static let claudeCloudDisabledResponse = RPCResponse(error: "claude cloud sessions disabled")
+
+    /// The second, inner gate. `claude_cloud_enabled` is checked INSIDE
+    /// `remoteGate()` — cloud is reached through the same `remote.*` verbs, so
+    /// it requires BOTH flags and the inner one is never a bypass.
+    ///
+    /// The two stay separate rather than merging because
+    /// `remote_backends_enabled` was written to be DELETABLE after soak, on
+    /// the reasoning that the feature is inert without a registered provider
+    /// file. A provider compiled into the daemon is never inert, so folding
+    /// this into it would silently convert a disposable flag into a permanent
+    /// one. When the outer flag is eventually deleted, its gate goes and this
+    /// becomes the sole gate for cloud.
+    ///
+    /// Returns the refusal to send, or nil when the invocation is permitted.
+    private func cloudGate(provider: String) async throws -> RPCResponse? {
+        guard provider == ClaudeCloudProvider.name else { return nil }
+        guard try await db.config.get().claudeCloudEnabled else {
+            return Self.claudeCloudDisabledResponse
+        }
+        return nil
+    }
+
     private static func staleSnapshotMutationResponse(provider: String) -> RPCResponse {
         RPCResponse(error: "provider '\(provider)' inventory is stale; refresh must recover before changing remote sessions")
     }
@@ -126,6 +152,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteCreateParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         if await manager.hasStaleSnapshot(provider: params.provider) {
             return Self.staleSnapshotMutationResponse(provider: params.provider)
         }
@@ -181,6 +208,9 @@ extension RPCRouter {
         }
         // Adopt immediately so the sidebar shows `starting` before the next poll.
         await manager.applyUpsert(session, provider: params.provider)
+        // …and ask for one immediate snapshot, because a provider whose rows
+        // arrive by adoption has nothing on screen until one lands.
+        await manager.refreshAfterCreate(provider: params.provider)
         await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: session)
     }
@@ -192,6 +222,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteStopParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         if await manager.hasStaleSnapshot(provider: params.provider) {
             return Self.staleSnapshotMutationResponse(provider: params.provider)
         }
@@ -407,6 +438,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteSendParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         if await manager.hasStaleSnapshot(provider: params.provider) {
             return Self.staleSnapshotMutationResponse(provider: params.provider)
         }
@@ -441,6 +473,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteLogParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         var verb = ["log", params.sessionID]
         if let lines = params.lines { verb += ["--lines", String(lines)] }
         let result: ProviderResult
@@ -479,6 +512,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteRenameParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         if await manager.hasStaleSnapshot(provider: params.provider) {
             return Self.staleSnapshotMutationResponse(provider: params.provider)
         }
@@ -509,6 +543,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteDismissParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         let changed = try await db.remoteSessions.dismiss(provider: params.provider, sessionID: params.sessionID)
         if changed {
             subscriptions.broadcast(delta: .remoteSessionsChanged)
@@ -531,6 +566,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteSetPinParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         let changed = try await db.remoteSessions.setPinned(
             provider: params.provider, sessionID: params.sessionID,
             pinnedAt: params.pinned ? Date() : nil)
@@ -557,6 +593,7 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteReportAttachExitParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
         try await manager.recordAttachExit(provider: params.provider, exitCode: params.exitCode)
         return .ok()
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -280,6 +280,15 @@ extension RPCRouter {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
+        // Same inner gate `remote.archive` goes through — this route reaches
+        // the identical provider verb, addressed by worktree row instead of
+        // by params, and must refuse the same way when cloud is off. Above
+        // `beginActuation` for the same reason every other refusal here is:
+        // nothing was attempted.
+        if case .remote(let provider, _) = worktree.location,
+           let refusal = try await cloudGate(provider: provider) {
+            return refusal
+        }
         let lanes = RemoteLaneLifecycle(db: db, subscriptions: subscriptions, manager: manager)
         let step: RemoteLaneLifecycle.ArchiveStep
         switch try await lanes.archiveDecision(for: worktree, force: force) {
@@ -318,6 +327,13 @@ extension RPCRouter {
     ) async throws -> RPCResponse {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
+        }
+        // See `archiveRemoteLane`'s matching comment: same inner gate as
+        // `remote.unarchive`, same worktree-addressed route to the same
+        // provider verb, same pre-`beginActuation` placement.
+        if case .remote(let provider, _) = worktree.location,
+           let refusal = try await cloudGate(provider: provider) {
+            return refusal
         }
         let lanes = RemoteLaneLifecycle(db: db, subscriptions: subscriptions, manager: manager)
         let step: RemoteLaneLifecycle.ReviveStep

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -599,6 +599,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetDeliveryVerification(request.paramsData)
             case RPCMethod.configSetQueuedPrompt:
                 return try await handleConfigSetQueuedPrompt(request.paramsData)
+            case RPCMethod.configSetClaudeCloud:
+                return try await handleConfigSetClaudeCloud(request.paramsData)
             case RPCMethod.configSetAutoCloseSetup:
                 return try await handleConfigSetAutoCloseSetup(request.paramsData)
             case RPCMethod.configSetAutoTrustWorktrees:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -68,6 +68,10 @@ public final class RPCRouter: Sendable {
     /// restarting. `remote.*` handlers return an error response rather than
     /// crashing when this is nil — see `RPCRouter+RemoteHandlers.swift`.
     let remoteManager: RemoteProviderManager?
+    /// Whether the daemon wired the built-in `claude-cloud` provider at boot.
+    /// Captured rather than recomputed, because the answer is about what
+    /// happened at construction time and cannot change without a restart.
+    let claudeCloudLive: Bool
     /// In-memory per-profile OAuth usage poller. Wired post-construction by
     /// Daemon.swift (mirrors `claudeUsagePoller`); nil in unit tests / mock
     /// mode, where usage snapshots are simply absent.
@@ -228,6 +232,7 @@ public final class RPCRouter: Sendable {
         claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
         loginSessions: LoginSessionCoordinator = LoginSessionCoordinator(),
         remoteManager: RemoteProviderManager? = nil,
+        claudeCloudLive: Bool = false,
         codexExecutableResolver: (@Sendable () throws -> String)? = nil,
         codexHomeEnsurer: (@Sendable () throws -> URL)? = nil,
         prBindingRepoResolver: (@Sendable (UUID) async -> (owner: String, name: String, host: String)?)? = nil,
@@ -291,6 +296,7 @@ public final class RPCRouter: Sendable {
         self.panelCoordinator = PanelCoordinator(
             db: db, broadcast: { [subscriptions] delta in subscriptions.broadcast(delta: delta) })
         self.remoteManager = remoteManager
+        self.claudeCloudLive = claudeCloudLive
         self.codexExecutableResolver = codexExecutableResolver ?? {
             if tmux.dryRun { return "/opt/tbd-test/bin/codex" }
             return try CodexExecutableResolver.resolve()
@@ -712,7 +718,9 @@ public final class RPCRouter: Sendable {
             panelSurfaceEnabled: config.panelSurfaceEnabled,
             remoteBackendsEnabled: config.remoteBackendsEnabled,
             remoteBackendsLive: remoteManager != nil,
-            queuedPromptEnabled: config.queuedPromptEnabled))
+            queuedPromptEnabled: config.queuedPromptEnabled,
+            claudeCloudEnabled: config.claudeCloudEnabled,
+            claudeCloudLive: claudeCloudLive))
     }
 
     // MARK: - PR Status

--- a/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
+++ b/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
@@ -233,6 +233,29 @@ enum BoundedProcessStdio: Sendable {
     case pseudoTerminal
 }
 
+/// The `winsize` reported to a `.pseudoTerminal` child via `TIOCGWINSZ`.
+///
+/// **This is a capture surface, not a display surface — do NOT "restore" it to
+/// the 24x80 that `TmuxControlConnection` uses.** That site is not a precedent:
+/// what crosses its pty is tmux's `-CC` control protocol, which is not
+/// width-formatted at all, so the reported width cannot affect its bytes.
+///
+/// Here it can, and does. The pty itself never wraps — `winsize` is advisory
+/// metadata and the kernel line discipline inserts nothing — but a child that
+/// ASKS will format to it, and the CLIs this mode exists for do exactly that:
+/// an ANSI-rendering layer formats to `process.stdout.columns` and inserts REAL
+/// newlines at the wrap, which then land in the captured bytes and corrupt any
+/// downstream parse. The measured headroom at 80 was six columns: a reference
+/// output's longest line is 74 characters, and a `Created cloud session: `
+/// prefix (23 characters) leaves 57 for a title that a parser reads with no
+/// cross-check. Reporting a width no realistic output reaches removes the whole
+/// class of failure; the cost of an over-wide report is nil, because nothing
+/// pads to the full width.
+private enum PseudoTerminalGeometry {
+    static let columns: UInt16 = 400
+    static let rows: UInt16 = 200
+}
+
 /// Refusals that belong to the runner itself rather than to the child.
 enum BoundedProcessRunnerError: Error, Equatable, LocalizedError {
     /// A `stdin` payload was supplied under `.pseudoTerminal`. The replica is
@@ -380,10 +403,28 @@ func runBoundedProcess(
             // Raw: no echo, no canonical editing, no CR translation, so the
             // bytes the parent reads are the bytes the child wrote.
             cfmakeraw(&term)
-            var size = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)
+            // See `PseudoTerminalGeometry`: wide on purpose, because the child
+            // formats its output to whatever width it is told.
+            var size = winsize(
+                ws_row: PseudoTerminalGeometry.rows,
+                ws_col: PseudoTerminalGeometry.columns,
+                ws_xpixel: 0,
+                ws_ypixel: 0)
             guard openpty(&primary, &replica, nil, &term, &size) == 0 else {
                 continuation.resume(throwing: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO))
                 return
+            }
+            // Non-blocking primary. `readAvailableRaw` runs on a GCD worker and
+            // holds the accumulator lock across its `read(2)`, so a spurious
+            // readability wakeup on a BLOCKING descriptor would park that worker
+            // holding the lock — and `finish()`, which the watchdog thread calls
+            // on the deadline path, would then block behind it. That thread is
+            // the one this file promises never blocks. `EAGAIN` is already a
+            // "keep draining" return, and `finish()` sets this flag itself, so
+            // the pattern is unchanged, only earlier.
+            let flags = fcntl(primary, F_GETFL)
+            if flags >= 0 {
+                _ = fcntl(primary, F_SETFL, flags | O_NONBLOCK)
             }
             let replicaHandle = FileHandle(fileDescriptor: replica, closeOnDealloc: false)
             stdoutHandle = FileHandle(fileDescriptor: primary, closeOnDealloc: false)

--- a/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
+++ b/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import os
 
@@ -213,6 +214,43 @@ enum BoundedProcessOutcome {
     case timedOut
 }
 
+/// How the child's standard streams are wired.
+///
+/// `.pipes` is the default and what every pre-existing call site gets.
+/// `.pseudoTerminal` substitutes one `openpty(3)` pair for both pipes and hands
+/// the replica to the child as stdin, stdout and stderr — the same allocation
+/// `TmuxControlConnection.start()` performs, including the detail that matters:
+/// the parent closes its copy of the replica after spawn so the primary sees
+/// EOF when the child exits.
+///
+/// **PTY mode is opt-in per invocation, not a property of a caller, and the
+/// reason is a real loss.** A pseudo-terminal is one file descriptor, so the
+/// child's stdout and stderr merge on it. Any verb that returns a control
+/// record in a stderr envelope cannot survive that separation collapsing, so
+/// only a caller that returns no envelope may set it.
+enum BoundedProcessStdio: Sendable {
+    case pipes
+    case pseudoTerminal
+}
+
+/// Refusals that belong to the runner itself rather than to the child.
+enum BoundedProcessRunnerError: Error, Equatable, LocalizedError {
+    /// A `stdin` payload was supplied under `.pseudoTerminal`. The replica is
+    /// the child's stdin AND its stdout on one descriptor, so there is no write
+    /// end to close and a child that waits for EOF would hang until the
+    /// deadline. Refusing is louder than hanging.
+    case stdinUnsupportedOnPseudoTerminal
+
+    var errorDescription: String? {
+        switch self {
+        case .stdinUnsupportedOnPseudoTerminal:
+            return "a stdin payload cannot be delivered under the pseudo-terminal stdio mode: "
+                + "the pty replica is the child's stdin and stdout on one descriptor, so there "
+                + "is no write end to close and a child waiting for EOF would hang"
+        }
+    }
+}
+
 /// Runs an external command with a hard timeout, draining stdout/stderr, and
 /// resolves to `.completed(status, stdout, stderr)` or `.timedOut` — or throws
 /// the spawn error if `Process.run()` fails. Shared by
@@ -238,6 +276,14 @@ enum BoundedProcessOutcome {
 /// that doesn't drain concurrently) would block the CALLING thread until the
 /// child reads enough to make room, the same way an undrained large stdout
 /// would block the child.
+///
+/// `stdio` defaults to `.pipes`, which is exactly what every call site got
+/// before the parameter existed. `.pseudoTerminal` swaps the two pipes for one
+/// `openpty(3)` pair — for a child that refuses to run unless its stdout is a
+/// terminal — and is deliberately opt-in per invocation: the two output streams
+/// merge onto that single descriptor, so the reported `stderr` is always empty
+/// and a `stdin` payload is REFUSED rather than silently hanging (there is no
+/// separate write end to close). See `BoundedProcessStdio`.
 ///
 /// The deadline is immune to GCD-pool starvation via two independent guarantees:
 ///
@@ -287,8 +333,12 @@ func runBoundedProcess(
     environment: [String: String]? = nil,
     stdin: Data? = nil,
     timeout: Duration,
+    stdio: BoundedProcessStdio = .pipes,
     clock: any Clock<Duration> = ContinuousClock()
 ) async throws -> BoundedProcessOutcome {
+    if stdio == .pseudoTerminal, stdin != nil {
+        throw BoundedProcessRunnerError.stdinUnsupportedOnPseudoTerminal
+    }
     // Single-resume guard shared by the watchdog fire path, the termination
     // handler, and the spawn-failure path. Whichever fires first wins; the
     // losers are no-ops.
@@ -304,10 +354,45 @@ func runBoundedProcess(
     return try await withTaskCancellationHandler(operation: {
     try await withCheckedThrowingContinuation { continuation in
         let process = Process()
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
         let stdoutAccumulator = PipeDataAccumulator()
         let stderrAccumulator = PipeDataAccumulator()
+
+        // Under `.pseudoTerminal` there is ONE descriptor: the parent reads the
+        // primary and the child holds the replica as all three standard
+        // streams, so `stderrHandle` stays nil and the reported stderr is
+        // always empty.
+        let stdoutHandle: FileHandle
+        let stderrHandle: FileHandle?
+        var replicaToClose: Int32 = -1
+
+        switch stdio {
+        case .pipes:
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            stdoutHandle = stdoutPipe.fileHandleForReading
+            stderrHandle = stderrPipe.fileHandleForReading
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+        case .pseudoTerminal:
+            var primary: Int32 = -1
+            var replica: Int32 = -1
+            var term = termios()
+            // Raw: no echo, no canonical editing, no CR translation, so the
+            // bytes the parent reads are the bytes the child wrote.
+            cfmakeraw(&term)
+            var size = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)
+            guard openpty(&primary, &replica, nil, &term, &size) == 0 else {
+                continuation.resume(throwing: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO))
+                return
+            }
+            let replicaHandle = FileHandle(fileDescriptor: replica, closeOnDealloc: false)
+            stdoutHandle = FileHandle(fileDescriptor: primary, closeOnDealloc: false)
+            stderrHandle = nil
+            replicaToClose = replica
+            process.standardInput = replicaHandle
+            process.standardOutput = replicaHandle
+            process.standardError = replicaHandle
+        }
 
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
@@ -317,35 +402,41 @@ func runBoundedProcess(
         if let environment {
             process.environment = environment
         }
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
         // Only wire up a stdin pipe when the caller actually has bytes to
         // send — otherwise leave `standardInput` unset so the child inherits
         // the parent's stdin, exactly as it did before this parameter existed.
+        // Refused outright under `.pseudoTerminal` (guarded above).
         let stdinPipe = stdin.map { _ in Pipe() }
         if let stdinPipe {
             process.standardInput = stdinPipe
         }
 
-        // Drain both pipes incrementally as chunks arrive: no thread parks for
-        // the subprocess's lifetime, and a child emitting more than the 64KB
-        // pipe buffer never deadlocks against an undrained pipe.
-        stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-            if !stdoutAccumulator.readAvailable(from: handle) { handle.readabilityHandler = nil }
-        }
-        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-            if !stderrAccumulator.readAvailable(from: handle) { handle.readabilityHandler = nil }
+        // Drain incrementally as chunks arrive: no thread parks for the
+        // subprocess's lifetime, and a child emitting more than the buffer
+        // never deadlocks against an undrained reader.
+        switch stdio {
+        case .pipes:
+            stdoutHandle.readabilityHandler = { handle in
+                if !stdoutAccumulator.readAvailable(from: handle) { handle.readabilityHandler = nil }
+            }
+            stderrHandle?.readabilityHandler = { handle in
+                if !stderrAccumulator.readAvailable(from: handle) { handle.readabilityHandler = nil }
+            }
+        case .pseudoTerminal:
+            stdoutHandle.readabilityHandler = { handle in
+                if !stdoutAccumulator.readAvailableRaw(from: handle) { handle.readabilityHandler = nil }
+            }
         }
 
-        // Detach the drain handlers and snapshot both pipes WITHOUT waiting for
-        // EOF — EOF is NOT guaranteed (grandchildren may still hold the write
-        // ends) — then close the parent read ends. Idempotent and thread-safe;
-        // shared by every resume path.
+        // Detach the drain handlers and snapshot WITHOUT waiting for EOF — EOF
+        // is NOT guaranteed (grandchildren may still hold the write ends, and a
+        // pty primary reports EIO rather than EOF) — then close the parent read
+        // ends. Idempotent and thread-safe; shared by every resume path.
         @Sendable func snapshot() -> (Data, Data) {
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
-            let out = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
-            let err = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
+            stdoutHandle.readabilityHandler = nil
+            stderrHandle?.readabilityHandler = nil
+            let out = stdoutAccumulator.finish(handle: stdoutHandle)
+            let err = stderrHandle.map { stderrAccumulator.finish(handle: $0) } ?? Data()
             return (out, err)
         }
 
@@ -447,6 +538,13 @@ func runBoundedProcess(
 
         do {
             try process.run()
+            // The child now holds the replica; close the parent's copy so the
+            // primary sees EOF when the child exits. Same discipline as
+            // `TmuxControlConnection.start()`.
+            if replicaToClose >= 0 {
+                Darwin.close(replicaToClose)
+                replicaToClose = -1
+            }
             // KILL ON ARRIVAL. The deadline may have fired *during* the spawn,
             // when `processIdentifier` was still 0 and its own kill was skipped.
             // Whoever claimed the continuation, a child that is still running at
@@ -463,6 +561,10 @@ func runBoundedProcess(
                 }
             }
         } catch {
+            if replicaToClose >= 0 {
+                Darwin.close(replicaToClose)
+                replicaToClose = -1
+            }
             // Spawn failed: no child will ever write — detach the drain handlers
             // and close the read ends so nothing lingers. `run()` fails
             // synchronously and immediately, long before the (>=100ms) watchdog

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -166,6 +166,31 @@ public enum WorktreeLocation: Equatable, Sendable, Hashable {
     }
 }
 
+/// Which provider session a lane came from, independent of where its files are
+/// now. `WorktreeLocation` answers the second question; this answers the first,
+/// and a landed lane needs both — `.local` files with the cloud session it was
+/// reconstructed from. Kept a separate field rather than a payload on
+/// `.local` so every existing `switch` over `WorktreeLocation` across the
+/// daemon and the app compiles untouched.
+public struct WorktreeOrigin: Codable, Equatable, Hashable, Sendable {
+    public let provider: String
+    public let sessionID: String
+    public init(provider: String, sessionID: String) {
+        self.provider = provider
+        self.sessionID = sessionID
+    }
+}
+
+public extension WorktreeLocation {
+    /// The origin a `.remote` location implies, or nil for `.local`. Used to
+    /// default `Worktree.origin` so a `.remote` row satisfies the
+    /// "remote implies an origin" invariant by construction.
+    var originPair: WorktreeOrigin? {
+        guard case let .remote(provider, sessionID) = self else { return nil }
+        return WorktreeOrigin(provider: provider, sessionID: sessionID)
+    }
+}
+
 public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     /// nil for scratch spaces (repo-less worktrees).
@@ -259,11 +284,18 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// `.local`, which is what they are.
     public var location: WorktreeLocation = .local
 
+    /// Which provider session this lane came from, past or present. Nil for a
+    /// lane that never had one. Rows written before this field decode their
+    /// origin from the same two wire keys `location` uses.
+    public var origin: WorktreeOrigin?
+
     /// The `(provider, sessionID)` pair identifying this row's provider
-    /// session, or nil when the worktree is local.
+    /// session, or nil when the row never had one. Reads `origin` rather than
+    /// `location`, so it keeps meaning "the provider session behind this row"
+    /// across a landing.
     public var providerBinding: (provider: String, sessionID: String)? {
-        guard case let .remote(provider, sessionID) = location else { return nil }
-        return (provider, sessionID)
+        guard let origin else { return nil }
+        return (origin.provider, origin.sessionID)
     }
     /// Text the operator composed at creation time and parked for the primary
     /// agent, `nil` when nothing is parked
@@ -333,6 +365,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 pinnedAt: Date? = nil,
                 pinSortOrder: Int? = nil,
                 location: WorktreeLocation = .local,
+                origin: WorktreeOrigin? = nil,
                 pendingPrompt: String? = nil,
                 pendingPromptSubmit: Bool? = nil,
                 prObservation: PRObservation? = nil) {
@@ -361,6 +394,10 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.pinnedAt = pinnedAt
         self.pinSortOrder = pinSortOrder
         self.location = location
+        // Defaulted from the location's own pair so all existing construction
+        // sites keep satisfying "a `.remote` row has an origin" without being
+        // revisited.
+        self.origin = origin ?? location.originPair
         self.pendingPrompt = pendingPrompt
         self.pendingPromptSubmit = pendingPromptSubmit
         self.prObservation = prObservation
@@ -409,11 +446,20 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         // NEWER daemon will send an older app. Both land on `.local`: a
         // pre-v70 row genuinely is local, and an unrecognized kind is safer
         // read as local than dropped, which would fail the whole decode.
+        //
+        // The two provider keys carry the ORIGIN, and the kind decides only
+        // whether the files are also over there. A landed row therefore
+        // arrives as `locationKind: "local"` with the pair set.
         let kind = try c.decodeIfPresent(String.self, forKey: .locationKind) ?? "local"
-        if kind == "remote",
-           let provider = try c.decodeIfPresent(String.self, forKey: .providerName),
-           let sessionID = try c.decodeIfPresent(String.self, forKey: .providerSessionID) {
-            location = .remote(provider: provider, sessionID: sessionID)
+        let provider = try c.decodeIfPresent(String.self, forKey: .providerName)
+        let providerSession = try c.decodeIfPresent(String.self, forKey: .providerSessionID)
+        if let provider, let providerSession {
+            origin = WorktreeOrigin(provider: provider, sessionID: providerSession)
+        } else {
+            origin = nil
+        }
+        if kind == "remote", let provider, let providerSession {
+            location = .remote(provider: provider, sessionID: providerSession)
         } else {
             location = .local
         }
@@ -461,13 +507,12 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         try c.encodeIfPresent(pinnedAt, forKey: .pinnedAt)
         try c.encodeIfPresent(pinSortOrder, forKey: .pinSortOrder)
         switch location {
-        case .local:
-            try c.encode("local", forKey: .locationKind)
-        case let .remote(provider, sessionID):
-            try c.encode("remote", forKey: .locationKind)
-            try c.encode(provider, forKey: .providerName)
-            try c.encode(sessionID, forKey: .providerSessionID)
+        case .local: try c.encode("local", forKey: .locationKind)
+        case .remote: try c.encode("remote", forKey: .locationKind)
         }
+        // The origin rides the same two keys, whatever the kind says.
+        try c.encodeIfPresent(origin?.provider, forKey: .providerName)
+        try c.encodeIfPresent(origin?.sessionID, forKey: .providerSessionID)
         try c.encodeIfPresent(pendingPrompt, forKey: .pendingPrompt)
         try c.encodeIfPresent(pendingPromptSubmit, forKey: .pendingPromptSubmit)
         try c.encodeIfPresent(prObservation, forKey: .prObservation)

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -119,6 +119,14 @@ public enum NightwatchMode: String, Codable, Sendable, CaseIterable {
     case nightwatch
 }
 
+/// The compiled provider's reserved name. Reserved **unconditionally** and not
+/// behind the cloud flag: a name that became available when a feature was off
+/// and unavailable when it was turned on would change which providers load as a
+/// side effect of a toggle.
+public enum ClaudeCloudProvider {
+    public static let name = "claude-cloud"
+}
+
 /// Where a worktree's files live. `.local` means a git worktree on this
 /// machine at the worktree's path. `.remote` means an agent session on a
 /// machine TBD does not manage, reached through a registered provider; there is
@@ -1259,6 +1267,16 @@ public struct Config: Codable, Sendable, Equatable {
     /// means "never chose" and follows the shipped default wherever it goes;
     /// `0`/`1` is an explicit gesture and is honored forever.
     public var gcProfileDirsEnabled: Bool
+    /// The Claude cloud sessions gate
+    /// (`docs/specs/2026-08-15-cloud-sessions-slice-1-design.md` §7). A second
+    /// gate INSIDE `remoteBackendsEnabled`, never a bypass: cloud is reached
+    /// through the `remote.*` verbs, so it requires both.
+    ///
+    /// **Resolved, not stored**, like `queuedPromptEnabled`: the backing column
+    /// carries no SQL default and stays NULL until somebody touches the toggle,
+    /// so this property is
+    /// `claude_cloud_enabled ?? Config.claudeCloudEnabledDefault`.
+    public var claudeCloudEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -1289,6 +1307,10 @@ public struct Config: Codable, Sendable, Equatable {
     /// this constant — no forcing `UPDATE` migration, and an explicit opt-out
     /// is left alone.
     public static let gcProfileDirsEnabledDefault = false
+    /// The shipped default for `claudeCloudEnabled`, and the single place it
+    /// lives. Cloud ships off; graduating it is a change to this constant — no
+    /// forcing `UPDATE` migration, and an explicit opt-out is left alone.
+    public static let claudeCloudEnabledDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1317,7 +1339,8 @@ public struct Config: Codable, Sendable, Equatable {
                 deliveryVerificationEnabled: Bool = false,
                 queuedPromptEnabled: Bool = Config.queuedPromptDefault,
                 supervisionEnabled: Bool = Config.supervisionEnabledDefault,
-                gcProfileDirsEnabled: Bool = Config.gcProfileDirsEnabledDefault) {
+                gcProfileDirsEnabled: Bool = Config.gcProfileDirsEnabledDefault,
+                claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -1346,6 +1369,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.queuedPromptEnabled = queuedPromptEnabled
         self.supervisionEnabled = supervisionEnabled
         self.gcProfileDirsEnabled = gcProfileDirsEnabled
+        self.claudeCloudEnabled = claudeCloudEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1414,6 +1438,8 @@ public struct Config: Codable, Sendable, Equatable {
         // default rather than hardcoding `false`.
         gcProfileDirsEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .gcProfileDirsEnabled) ?? Config.gcProfileDirsEnabledDefault
+        claudeCloudEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .claudeCloudEnabled) ?? Config.claudeCloudEnabledDefault
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -294,6 +294,29 @@ public enum RPCMethod {
     public static let remoteDismiss = "remote.dismiss"
     public static let remoteSetPin = "remote.setPin"
     public static let remoteReportAttachExit = "remote.reportAttachExit"
+
+    /// Every `remote.*` verb addressed by a `provider` field in its params (or,
+    /// for the two worktree-addressed retirement routes, by the worktree's
+    /// bound `location`) — as opposed to `remoteProviders`/`remoteSessions`,
+    /// which enumerate across every provider and take none.
+    ///
+    /// This is the single list the daemon's cloud gate (`RPCRouter.cloudGate`)
+    /// must cover and `ClaudeCloudGateTests` asserts against, so the two
+    /// cannot independently go stale against each other the way they did
+    /// before `remote.archive`/`remote.unarchive` were found ungated — the
+    /// test's list had quietly come to describe the bug instead of the
+    /// contract. It is still a hand-maintained array, not something the
+    /// compiler enforces: `RPCMethod` is a namespace of static string
+    /// constants, not a `CaseIterable` enum, so nothing stops a new
+    /// `remote.*` case from being added to `RPCRouter.handle`'s switch
+    /// without a matching entry here. Add any new provider-named `remote.*`
+    /// method to this array in the same commit that adds its RPC case.
+    public static let providerNamedRemoteMethods: [String] = [
+        remoteCreate, remoteStop, remoteArchive, remoteUnarchive,
+        remoteSend, remoteLog, remoteRename, remoteDismiss,
+        remoteSetPin, remoteReportAttachExit,
+    ]
+
     public static let configSetRemoteBackends = "config.setRemoteBackends"
     public static let panelGet = "panel.get"
     public static let panelApply = "panel.apply"

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -260,6 +260,7 @@ public enum RPCMethod {
     public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
     public static let configSetDeliveryVerification = "config.setDeliveryVerification"
     public static let configSetQueuedPrompt = "config.setQueuedPrompt"
+    public static let configSetClaudeCloud = "config.setClaudeCloud"
     public static let configSetSupervisionEnabled = "config.setSupervisionEnabled"
     public static let superviseStatus = "supervise.status"
     public static let superviseSetProjectMark = "supervise.setProjectMark"
@@ -2081,6 +2082,18 @@ public struct ConfigSetDeliveryVerificationParams: Codable, Sendable {
 /// until this verb writes to it, and a written `false` stays off even after the
 /// shipped default graduates.
 public struct ConfigSetQueuedPromptParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setClaudeCloud` — the Claude cloud sessions gate
+/// (design 2026-08-15 §7, default OFF). A second gate inside
+/// `remote_backends_enabled`, never a bypass.
+///
+/// Sending either value is an explicit gesture: the backing column is NULL
+/// until this verb writes to it, and a written `false` stays off even after the
+/// shipped default graduates.
+public struct ConfigSetClaudeCloudParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -2722,6 +2722,19 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// `Config.queuedPromptDefault`, so an install that never touched the
     /// toggle reports whatever the shipped default currently is.
     public let queuedPromptEnabled: Bool
+    /// Whether the Claude cloud sessions gate is currently set (design
+    /// 2026-08-15 §7). Default OFF while it soaks. Resolved through
+    /// `Config.claudeCloudEnabledDefault`, so an install that never touched the
+    /// toggle reports whatever the shipped default currently is.
+    public let claudeCloudEnabled: Bool
+    /// Whether the daemon actually wired the built-in cloud provider at boot.
+    /// `false` when either gate was off at that moment — AND when the flag was
+    /// flipped on afterwards, since the provider manager is constructed only at
+    /// boot and flipping a flag cannot conjure a provider into a running actor.
+    /// Lets the app say "on, but needs a restart" without calling a `remote.*`
+    /// verb and parsing its error string, exactly as `remoteBackendsLive` does
+    /// for the outer flag.
+    public let claudeCloudLive: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
@@ -2733,7 +2746,9 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 panelSurfaceEnabled: Bool = false,
                 remoteBackendsEnabled: Bool = false,
                 remoteBackendsLive: Bool = false,
-                queuedPromptEnabled: Bool = Config.queuedPromptDefault) {
+                queuedPromptEnabled: Bool = Config.queuedPromptDefault,
+                claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault,
+                claudeCloudLive: Bool = false) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
@@ -2745,6 +2760,8 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         self.remoteBackendsEnabled = remoteBackendsEnabled
         self.remoteBackendsLive = remoteBackendsLive
         self.queuedPromptEnabled = queuedPromptEnabled
+        self.claudeCloudEnabled = claudeCloudEnabled
+        self.claudeCloudLive = claudeCloudLive
     }
 
     public init(from decoder: Decoder) throws {
@@ -2774,6 +2791,13 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         // default rather than assuming the feature is live.
         queuedPromptEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .queuedPromptEnabled) ?? Config.queuedPromptDefault
+        // New fields for the Claude cloud gate. A daemon that does not send
+        // `claudeCloudEnabled` cannot serve the feature either, so fall through
+        // to the shipped default rather than assuming it is live. `live` is a
+        // fact about THIS daemon's boot, so an absent value is honestly false.
+        claudeCloudEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .claudeCloudEnabled) ?? Config.claudeCloudEnabledDefault
+        claudeCloudLive = try c.decodeIfPresent(Bool.self, forKey: .claudeCloudLive) ?? false
     }
 }
 

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let registryLogger = Logger(subsystem: "com.tbd.daemon", category: "remote")
 
 // MARK: - Remote provider contract types (docs/remote-provider-contract.md, v1)
 
@@ -421,20 +424,66 @@ public struct RemoteProviderStatus: Codable, Sendable, Identifiable {
 /// Loads `agent-providers.json`. Missing file = no providers (not an error);
 /// duplicate names or empty exec = configuration error.
 public enum RemoteProviderRegistry {
-    public static func load(from url: URL) throws -> [RemoteProviderConfig] {
-        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+    /// Names TBD's own compiled providers answer to. Reserved
+    /// **unconditionally** and not behind the cloud flag: a name that became
+    /// available when a feature was off and unavailable when it was turned on
+    /// would change which providers load as a side effect of a toggle.
+    public static let reservedProviderNames: Set<String> = [ClaudeCloudProvider.name]
+
+    public static func isReserved(_ name: String) -> Bool {
+        reservedProviderNames.contains(name)
+    }
+
+    /// What one registry file yielded: the entries TBD will use, and the
+    /// reserved-name entries it stepped over.
+    public struct RegistryLoad: Sendable, Equatable {
+        public let configs: [RemoteProviderConfig]
+        public let skippedReservedNames: [String]
+
+        public init(configs: [RemoteProviderConfig], skippedReservedNames: [String]) {
+            self.configs = configs
+            self.skippedReservedNames = skippedReservedNames
+        }
+    }
+
+    /// A reserved entry is SKIPPED, never a reason to reject the file. The
+    /// skip is deliberately checked BEFORE the duplicate rule so two reserved
+    /// entries are two skips rather than a whole-file failure — this function
+    /// throws for the entire registry on a duplicate, and two of its three
+    /// call sites swallow that with `try?`, so one bad entry would otherwise
+    /// silently remove every provider the user registered. Each skip is
+    /// logged here (rather than left for callers to notice) so it is
+    /// surfaced regardless of which of the three call sites triggered it.
+    public static func loadEntries(from url: URL) throws -> RegistryLoad {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return RegistryLoad(configs: [], skippedReservedNames: [])
+        }
         let data = try Data(contentsOf: url)
-        let configs = try JSONDecoder().decode([RemoteProviderConfig].self, from: data)
+        let decoded = try JSONDecoder().decode([RemoteProviderConfig].self, from: data)
+        var configs: [RemoteProviderConfig] = []
+        var skipped: [String] = []
         var seen = Set<String>()
-        for c in configs {
+        for c in decoded {
             guard !c.name.isEmpty, !c.exec.isEmpty else {
                 throw RegistryError.invalidEntry(c.name)
+            }
+            if isReserved(c.name) {
+                registryLogger.warning(
+                    "skipping registry entry for reserved provider name \(c.name, privacy: .public): reserved for TBD's compiled provider"
+                )
+                skipped.append(c.name)
+                continue
             }
             guard seen.insert(c.name).inserted else {
                 throw RegistryError.duplicateName(c.name)
             }
+            configs.append(c)
         }
-        return configs
+        return RegistryLoad(configs: configs, skippedReservedNames: skipped)
+    }
+
+    public static func load(from url: URL) throws -> [RemoteProviderConfig] {
+        try loadEntries(from: url).configs
     }
 
     public enum RegistryError: LocalizedError, Equatable {

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -195,7 +195,33 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
 
 public struct RemoteSessionListEnvelope: Codable, Sendable {
     public let sessions: [RemoteSessionPayload]
-    public init(sessions: [RemoteSessionPayload]) { self.sessions = sessions }
+    /// Whether `sessions` is the provider's ENTIRE inventory or only part of
+    /// it (`docs/remote-provider-contract.md` § Snapshot completeness).
+    ///
+    /// An incomplete snapshot is authoritative about **presence only**: a
+    /// caller may adopt and update on it, and MUST NOT retire anything on it
+    /// or treat it as refreshing freshness. Absent reads as `true`, so every
+    /// provider written before this field keeps its exact current meaning.
+    public let complete: Bool
+
+    public init(sessions: [RemoteSessionPayload], complete: Bool = true) {
+        self.sessions = sessions
+        self.complete = complete
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessions, complete
+    }
+
+    /// Hand-written so `complete` can default when absent: Swift's
+    /// synthesized `init(from:)` ignores property default values, and the
+    /// contract's absent-means-complete rule is the whole reason a v1
+    /// provider needs no edit.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sessions = try c.decode([RemoteSessionPayload].self, forKey: .sessions)
+        complete = try c.decodeIfPresent(Bool.self, forKey: .complete) ?? true
+    }
 }
 
 /// `describe` response.

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -319,19 +319,27 @@ public struct RemoteProviderStatus: Codable, Sendable, Identifiable {
     /// disagreeing is how cached rows once kept rendering as confidently
     /// running in exactly the case the daemon knew the least.
     public let freshnessUnreadable: Bool
+    /// The contract major the daemon negotiated for this provider — the highest
+    /// version both sides declare. Nil when `describe` has not succeeded, and
+    /// nil in a payload from a daemon that predates negotiation; a reader with
+    /// no value falls back to `1`, which is what every emitter announced
+    /// unconditionally before.
+    public let contractVersion: Int?
     public init(config: RemoteProviderConfig, describe: ProviderDescribe?, health: ProviderHealth,
                 errorMessage: String?, remediationLabel: String?, remediationCommand: String?,
-                lastSuccessfulSnapshotAt: Date? = nil, freshnessUnreadable: Bool = false) {
+                lastSuccessfulSnapshotAt: Date? = nil, freshnessUnreadable: Bool = false,
+                contractVersion: Int? = nil) {
         self.config = config; self.describe = describe; self.health = health
         self.errorMessage = errorMessage
         self.remediationLabel = remediationLabel; self.remediationCommand = remediationCommand
         self.lastSuccessfulSnapshotAt = lastSuccessfulSnapshotAt
         self.freshnessUnreadable = freshnessUnreadable
+        self.contractVersion = contractVersion
     }
 
     private enum CodingKeys: String, CodingKey {
         case config, describe, health, errorMessage, remediationLabel, remediationCommand
-        case lastSuccessfulSnapshotAt, freshnessUnreadable
+        case lastSuccessfulSnapshotAt, freshnessUnreadable, contractVersion
     }
 
     /// Hand-written so `freshnessUnreadable` can default when absent: a
@@ -347,6 +355,7 @@ public struct RemoteProviderStatus: Codable, Sendable, Identifiable {
         remediationCommand = try c.decodeIfPresent(String.self, forKey: .remediationCommand)
         lastSuccessfulSnapshotAt = try c.decodeIfPresent(Date.self, forKey: .lastSuccessfulSnapshotAt)
         freshnessUnreadable = try c.decodeIfPresent(Bool.self, forKey: .freshnessUnreadable) ?? false
+        contractVersion = try c.decodeIfPresent(Int.self, forKey: .contractVersion)
     }
 
     /// True when there is cached state on screen that must stop being

--- a/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
+++ b/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
@@ -25,26 +25,65 @@ struct ClaudeCloudSettingsTests {
         defaults.removePersistentDomain(forName: name)
     }
 
-    // MARK: - The caption, one case per branch
+    // MARK: - The caption, one case per reachable (enabled, live, remoteBackendsEnabled) branch
+    //
+    // `config.setClaudeCloud` persists `enabled` unconditionally — it does not
+    // check the outer remote-sessions flag — so `enabled` can be true while
+    // `remoteBackendsEnabled` is false, and a caption that only looked at
+    // (enabled, live) could describe that state as "on" when a restart right
+    // now would not actually start cloud sessions. Every branch below is a
+    // state genuinely reachable by toggling the two flags independently and
+    // optionally restarting.
 
-    @Test func captionOffAndNeverLive() {
-        #expect(AppState.claudeCloudStatusCaption(enabled: false, live: false)
+    @Test func captionOffNeverLiveRemoteAlsoOff() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: false, live: false, remoteBackendsEnabled: false)
+                == "Off. Turning this on requires remote sessions above enabled and a daemon restart before cloud sessions appear.")
+    }
+
+    @Test func captionOffNeverLiveRemoteOn() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: false, live: false, remoteBackendsEnabled: true)
                 == "Off. Turning this on requires a daemon restart before cloud sessions appear.")
     }
 
-    @Test func captionOnButNotYetRestarted() {
-        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: false)
+    @Test func captionOnButNotYetRestartedRemoteOn() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: false, remoteBackendsEnabled: true)
                 == "On, but restart the daemon before cloud sessions appear.")
     }
 
-    @Test func captionOnAndLive() {
-        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: true)
+    /// The brief's original two-argument signature would have said "On, but
+    /// restart the daemon before cloud sessions appear" here too — implying a
+    /// restart alone is sufficient. It is not: the outer flag also has to be
+    /// turned on before a restart can make cloud live.
+    @Test func captionOnButNotYetRestartedRemoteOff() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: false, remoteBackendsEnabled: false)
+                == "On, but remote sessions above are off — enable both, then restart the daemon before cloud sessions appear.")
+    }
+
+    @Test func captionOnAndLiveRemoteOn() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: true, remoteBackendsEnabled: true)
                 == "On and running — cloud sessions are being polled.")
     }
 
-    @Test func captionOffButStillLiveFromBeforeTheChange() {
-        #expect(AppState.claudeCloudStatusCaption(enabled: false, live: true)
-                == "Off, but the provider registered before this change is still live in the daemon — restart to fully stop it.")
+    /// The brief's original two-argument signature would have said "On and
+    /// running" here too — reachable by enabling both, restarting, then
+    /// turning the outer flag off again without restarting. The toggle greys
+    /// out via `claudeCloudToggleOperable`, but the caption must not still
+    /// claim cloud sessions are being polled: a restart right now would stop
+    /// them.
+    @Test func captionOnAndLiveRemoteOff() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: true, remoteBackendsEnabled: false)
+                == "On, but remote sessions above are now off — restarting will stop cloud sessions unless you re-enable remote sessions above first.")
+    }
+
+    /// `(enabled: false, live: true)` is unaffected by the outer flag's
+    /// current value: turning the cloud flag off already guarantees the next
+    /// restart will not bring cloud back, regardless of `remoteBackendsEnabled`
+    /// — so both values of the outer flag must produce the identical message.
+    @Test func captionOffButStillLiveIsUnaffectedByRemoteFlag() {
+        let withRemoteOn = AppState.claudeCloudStatusCaption(enabled: false, live: true, remoteBackendsEnabled: true)
+        let withRemoteOff = AppState.claudeCloudStatusCaption(enabled: false, live: true, remoteBackendsEnabled: false)
+        #expect(withRemoteOn == "Off, but the provider registered before this change is still live in the daemon — restart to fully stop it.")
+        #expect(withRemoteOn == withRemoteOff)
     }
 
     // MARK: - The inner-gate predicate, both branches

--- a/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
+++ b/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
@@ -140,13 +140,21 @@ struct ClaudeCloudSettingsTests {
     /// never listed, never adopted, and have no lane. The caption is what
     /// makes that absence read as a property of the feature.
     ///
-    /// Asserted on the COMPOSED string rather than against a blacklist of
-    /// forbidden words, so a rewording that drops the claim fails here.
+    /// Pinned byte-for-byte, the same way the seven `claudeCloudStatusCaption`
+    /// arms above are — a `contains("started")` / `contains("claude.ai")` /
+    /// non-empty check (the previous shape of this test) cannot tell the real
+    /// sentence from an OVERCLAIMING rewrite that inverts its whole point,
+    /// e.g. "Cloud sessions you started appear here, including ones from
+    /// claude.ai." — that string contains "started" and "claude.ai" and is
+    /// non-empty, so it would have passed all three old assertions, even
+    /// though it claims the opposite of what the feature actually does (it
+    /// says claude.ai sessions DO show up here). It is unequal to the real
+    /// string below, so the exact-match assertion fails on it and passes on
+    /// the genuine caption — the discrimination this test exists to provide.
     @Test func theScopeCaptionSaysOnlySessionsStartedInTBDAppear() {
-        let caption = AppState.claudeCloudScopeCaption
-        #expect(caption.lowercased().contains("started"))
-        #expect(caption.lowercased().contains("claude.ai"))
-        #expect(!caption.isEmpty)
+        #expect(AppState.claudeCloudScopeCaption ==
+            "Only sessions started from TBD on this Mac appear here — one begun on claude.ai, in the "
+            + "mobile app, or from a terminal TBD did not spawn is not listed.")
     }
 
     /// It is state-independent, which is why it is its own value: the seven

--- a/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
+++ b/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The Settings surface for the Claude cloud gate.
+///
+/// The caption is the whole reason the capability carries two booleans: the
+/// daemon wires the built-in provider only at boot, so the persisted flag and
+/// the live provider can disagree in BOTH directions, and a toggle that said
+/// only "on" would be lying in the most confusing of the four states.
+///
+/// Every test that constructs `AppState` does so against a unique throwaway
+/// `UserDefaults` suite and tears it down — TBDApp ships as an unbundled SPM
+/// executable, so `UserDefaults.standard` is the running developer's real
+/// `TBDApp.plist`.
+@MainActor
+@Suite("ClaudeCloudSettings")
+struct ClaudeCloudSettingsTests {
+
+    private func withAppState(_ body: (AppState) async -> Void) async {
+        let name = "tbd-cloud-settings-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        await body(AppState(userDefaults: defaults))
+        defaults.removePersistentDomain(forName: name)
+    }
+
+    // MARK: - The caption, one case per branch
+
+    @Test func captionOffAndNeverLive() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: false, live: false)
+                == "Off. Turning this on requires a daemon restart before cloud sessions appear.")
+    }
+
+    @Test func captionOnButNotYetRestarted() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: false)
+                == "On, but restart the daemon before cloud sessions appear.")
+    }
+
+    @Test func captionOnAndLive() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: true, live: true)
+                == "On and running — cloud sessions are being polled.")
+    }
+
+    @Test func captionOffButStillLiveFromBeforeTheChange() {
+        #expect(AppState.claudeCloudStatusCaption(enabled: false, live: true)
+                == "Off, but the provider registered before this change is still live in the daemon — restart to fully stop it.")
+    }
+
+    // MARK: - The inner-gate predicate, both branches
+
+    /// Cloud is a second gate INSIDE the remote-sessions switch, never a
+    /// bypass, so the toggle is inert while the outer flag is off. A pure
+    /// predicate rather than an inline `.disabled(...)` expression, so both
+    /// branches are assertable.
+    @Test func toggleIsOperableOnlyWhileRemoteSessionsAreEnabled() {
+        #expect(AppState.claudeCloudToggleOperable(remoteBackendsEnabled: true))
+        #expect(!AppState.claudeCloudToggleOperable(remoteBackendsEnabled: false))
+    }
+
+    // MARK: - The setter, both branches
+
+    @Test func setterPersistsAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            var refreshes = 0
+            state.claudeCloudFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return DaemonCapabilitiesResult(controlModeEnabled: false, claudeCloudEnabled: true)
+            }
+
+            await state.setClaudeCloudEnabled(true)
+
+            #expect(written == [true])
+            #expect(refreshes == 1)
+            #expect(state.daemonCapabilities?.claudeCloudEnabled == true)
+        }
+    }
+
+    @Test func setterSurfacesAFailureAndLeavesCapabilitiesAlone() async {
+        struct Boom: Error {}
+        await withAppState { state in
+            var refreshes = 0
+            state.claudeCloudFlagSetter = { @MainActor _ in throw Boom() }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return nil
+            }
+
+            await state.setClaudeCloudEnabled(true)
+
+            #expect(refreshes == 0, "a failed write must not be followed by a refresh")
+            #expect(state.alertMessage != nil)
+        }
+    }
+}

--- a/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
+++ b/Tests/TBDAppTests/ClaudeCloudSettingsTests.swift
@@ -133,4 +133,30 @@ struct ClaudeCloudSettingsTests {
             #expect(state.alertMessage != nil)
         }
     }
+
+    // MARK: - The scope caption, state-independent (Design §3)
+
+    /// Design §3: sessions TBD did not start have no ledger row, so they are
+    /// never listed, never adopted, and have no lane. The caption is what
+    /// makes that absence read as a property of the feature.
+    ///
+    /// Asserted on the COMPOSED string rather than against a blacklist of
+    /// forbidden words, so a rewording that drops the claim fails here.
+    @Test func theScopeCaptionSaysOnlySessionsStartedInTBDAppear() {
+        let caption = AppState.claudeCloudScopeCaption
+        #expect(caption.lowercased().contains("started"))
+        #expect(caption.lowercased().contains("claude.ai"))
+        #expect(!caption.isEmpty)
+    }
+
+    /// It is state-independent, which is why it is its own value: the seven
+    /// arms of `claudeCloudStatusCaption` stay byte-identical.
+    @Test func theStatusCaptionArmsAreUnchangedByTheScopeCaption() {
+        #expect(AppState.claudeCloudStatusCaption(
+            enabled: true, live: true, remoteBackendsEnabled: true)
+            == "On and running — cloud sessions are being polled.")
+        #expect(!AppState.claudeCloudStatusCaption(
+            enabled: true, live: true, remoteBackendsEnabled: true)
+            .contains("claude.ai"))
+    }
 }

--- a/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
+++ b/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
@@ -57,4 +57,43 @@ struct CloudCreateEntryPresentationTests {
         #expect(CloudCreateEntryPresentation.createProviders([], claudeCloudEnabled: true).isEmpty)
         #expect(CloudCreateEntryPresentation.cloudProvider([], claudeCloudEnabled: true) == nil)
     }
+
+    // MARK: - The menu's own shape
+
+    /// The single-provider fast path must be computed from the FILTERED list,
+    /// not the raw one: with the flag off and cloud plus one registry
+    /// provider on file, the menu must be the one-provider shape, not a
+    /// two-entry submenu with a dead row.
+    @Test func theSingleProviderFastPathIsDecidedAfterFiltering() {
+        let filtered = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: false)
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.config.name == "acme")
+
+        let unfiltered = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: true)
+        #expect(unfiltered.count == 2)
+    }
+
+    /// With cloud the only provider and the flag off, the menu item is
+    /// omitted whole — an empty filtered list is what `newRemoteSessionMenuItem`
+    /// already reads as "show nothing".
+    @Test func cloudAloneWithTheFlagOffLeavesNothingToOffer() {
+        let cloudOnly = [status(ClaudeCloudProvider.name)]
+        #expect(CloudCreateEntryPresentation.createProviders(
+            cloudOnly, claudeCloudEnabled: false).isEmpty)
+        #expect(CloudCreateEntryPresentation.createProviders(
+            cloudOnly, claudeCloudEnabled: true).count == 1)
+    }
+
+    // MARK: - The `+` button's row
+
+    /// The `+` button's row is present exactly when there is a cloud provider
+    /// to open the sheet for — omitted, never disabled.
+    @Test func thePlusButtonRowFollowsTheSameGateAsTheMenu() {
+        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: true) != nil)
+        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: false) == nil)
+        // And a daemon that never registered it shows nothing even with the
+        // flag on — the flipped-on-without-restart state.
+        #expect(CloudCreateEntryPresentation.cloudProvider(
+            [status("acme")], claudeCloudEnabled: true) == nil)
+    }
 }

--- a/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
+++ b/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+
+// Tier 1: pure over values.
+@Suite("CloudCreateEntryPresentation")
+struct CloudCreateEntryPresentationTests {
+    private func status(_ name: String) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: name, exec: "/x"),
+            describe: ProviderDescribe(contractVersions: [2], name: name, capabilities: ["send"]),
+            health: .ok, errorMessage: nil, remediationLabel: nil, remediationCommand: nil)
+    }
+
+    private var both: [RemoteProviderStatus] {
+        [status("acme"), status(ClaudeCloudProvider.name)]
+    }
+
+    /// OMITTED, not disabled — matching how capability-gated remote items are
+    /// already omitted rather than grayed out.
+    @Test func theCloudProviderIsOmittedWhenTheFlagIsOff() {
+        let shown = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: false)
+        #expect(shown.map { $0.config.name } == ["acme"])
+        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: false) == nil)
+    }
+
+    /// The discriminating half: with the flag on it is shown, so the filter
+    /// did not simply delete the entry.
+    @Test func theCloudProviderIsShownWhenTheFlagIsOn() {
+        let shown = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: true)
+        #expect(shown.map { $0.config.name } == ["acme", ClaudeCloudProvider.name])
+        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: true)?
+            .config.name == ClaudeCloudProvider.name)
+    }
+
+    /// A registered provider is never touched by this gate, whichever way the
+    /// cloud flag points.
+    @Test func aRegisteredProviderIsUnaffectedByTheCloudFlag() {
+        let only = [status("acme")]
+        #expect(CloudCreateEntryPresentation.createProviders(only, claudeCloudEnabled: false)
+            .map { $0.config.name } == ["acme"])
+        #expect(CloudCreateEntryPresentation.createProviders(only, claudeCloudEnabled: true)
+            .map { $0.config.name } == ["acme"])
+        #expect(CloudCreateEntryPresentation.cloudProvider(only, claudeCloudEnabled: true) == nil)
+    }
+
+    /// The daemon registers the cloud provider only when it booted with the
+    /// flag on, so "flag on but provider absent" is the flipped-after-boot
+    /// state and must show nothing rather than a row that cannot work.
+    @Test func aFlagOnWithNoRegisteredCloudProviderShowsNoCloudEntry() {
+        let only = [status("acme")]
+        #expect(CloudCreateEntryPresentation.cloudProvider(only, claudeCloudEnabled: true) == nil)
+    }
+
+    @Test func anEmptyProviderListStaysEmpty() {
+        #expect(CloudCreateEntryPresentation.createProviders([], claudeCloudEnabled: true).isEmpty)
+        #expect(CloudCreateEntryPresentation.cloudProvider([], claudeCloudEnabled: true) == nil)
+    }
+}

--- a/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
+++ b/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
@@ -96,4 +96,133 @@ struct CloudCreateEntryPresentationTests {
         #expect(CloudCreateEntryPresentation.cloudProvider(
             [status("acme")], claudeCloudEnabled: true) == nil)
     }
+
+    // MARK: - The `+` button's row honors staleness (final review item 2)
+
+    private func staleStatus(_ name: String) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: name, exec: "/x"),
+            describe: ProviderDescribe(contractVersions: [2], name: name, capabilities: ["send"]),
+            health: .stale, errorMessage: nil, remediationLabel: nil, remediationCommand: nil,
+            freshnessUnreadable: true)
+    }
+
+    /// The picker's cloud row has no disabled state of its own — unlike the
+    /// context menu and the Remote section header, which both disable their
+    /// own `+` on `hasStaleSnapshot` — so a stale cloud provider must be
+    /// OMITTED the same way an absent or flag-off provider is, or the sheet
+    /// opens onto a create call the daemon refuses as stale.
+    @Test func cloudProviderIsOmittedWhenTheCloudProvidersInventoryIsStale() {
+        let stale = [status("acme"), staleStatus(ClaudeCloudProvider.name)]
+        #expect(CloudCreateEntryPresentation.cloudProvider(stale, claudeCloudEnabled: true) == nil)
+    }
+
+    /// The discriminating half: a non-stale cloud provider is unaffected —
+    /// confirms the staleness check doesn't simply always return nil.
+    @Test func cloudProviderIsShownWhenNotStale() {
+        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: true) != nil)
+    }
+
+    /// Staleness on a DIFFERENT, unrelated provider must never suppress the
+    /// cloud row — the check is scoped to the cloud provider's own status.
+    @Test func aStaleUnrelatedProviderDoesNotSuppressTheCloudRow() {
+        let mixed = [staleStatus("acme"), status(ClaudeCloudProvider.name)]
+        #expect(CloudCreateEntryPresentation.cloudProvider(mixed, claudeCloudEnabled: true) != nil)
+    }
+}
+
+// MARK: - Cross-surface parity (final review item 4)
+//
+// The three owned create surfaces — `RepoSectionView`'s context menu
+// (`remoteSessionMenuProviders`), its `+` picker (`cloudSessionProvider`),
+// and `RemoteSectionView`'s header `+` (`RemoteProviderHeaderRow.canCreate`)
+// — must reach the same "can this surface offer cloud?" verdict for a given
+// (providers, claudeCloudEnabled) pair, with one documented exception: the
+// picker additionally omits a STALE cloud provider, which the other two
+// instead render and disable (see the staleness tests above).
+//
+// Each test below calls the actual `nonisolated static` functions the three
+// view bodies call — not a re-implementation of their logic — so a future
+// edit that re-derives the gate inline in one surface, drops a filter, or
+// stops routing through `CloudCreateEntryPresentation` reddens this suite
+// even without a rendered view. That is the gap the pure
+// `CloudCreateEntryPresentation` tests above cannot close on their own: they
+// only ever called the shared function directly, so a surface that silently
+// stopped calling it left the whole suite green.
+@Suite("CloudCreateEntryPresentation — cross-surface parity")
+struct CloudCreateEntryPresentationParityTests {
+    private func status(
+        _ name: String, health: ProviderHealth = .ok, freshnessUnreadable: Bool = false
+    ) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: name, exec: "/x"),
+            describe: ProviderDescribe(contractVersions: [2], name: name, capabilities: ["send"]),
+            health: health, errorMessage: nil, remediationLabel: nil, remediationCommand: nil,
+            freshnessUnreadable: freshnessUnreadable)
+    }
+
+    private var both: [RemoteProviderStatus] {
+        [status("acme"), status(ClaudeCloudProvider.name)]
+    }
+
+    private func cloudEntry(in providers: [RemoteProviderStatus]) -> RemoteProviderStatus {
+        providers.first { $0.config.name == ClaudeCloudProvider.name }!
+    }
+
+    /// Flag off: all three surfaces must agree the cloud row is hidden.
+    @Test func allThreeSurfacesAgreeTheCloudRowIsHiddenWhenTheFlagIsOff() {
+        let menu = RepoSectionView.remoteSessionMenuProviders(providers: both, claudeCloudEnabled: false)
+        let picker = RepoSectionView.cloudSessionProvider(providers: both, claudeCloudEnabled: false)
+        let header = RemoteProviderHeaderRow.canCreate(provider: cloudEntry(in: both), claudeCloudEnabled: false)
+
+        #expect(!menu.contains { $0.config.name == ClaudeCloudProvider.name })
+        #expect(picker == nil)
+        #expect(!header)
+    }
+
+    /// Flag on, healthy provider: all three surfaces must agree it is shown.
+    @Test func allThreeSurfacesAgreeTheCloudRowIsShownWhenTheFlagIsOnAndHealthy() {
+        let menu = RepoSectionView.remoteSessionMenuProviders(providers: both, claudeCloudEnabled: true)
+        let picker = RepoSectionView.cloudSessionProvider(providers: both, claudeCloudEnabled: true)
+        let header = RemoteProviderHeaderRow.canCreate(provider: cloudEntry(in: both), claudeCloudEnabled: true)
+
+        #expect(menu.contains { $0.config.name == ClaudeCloudProvider.name })
+        #expect(picker != nil)
+        #expect(header)
+    }
+
+    /// Flipped-on-without-restart: the daemon never registered the provider,
+    /// so it is simply absent from `providers` — both surfaces that can be
+    /// checked against an empty registration must show nothing rather than
+    /// inventing a row.
+    @Test func menuAndPickerShowNothingWhenTheProviderWasNeverRegistered() {
+        let onlyAcme = [status("acme")]
+        let menu = RepoSectionView.remoteSessionMenuProviders(providers: onlyAcme, claudeCloudEnabled: true)
+        let picker = RepoSectionView.cloudSessionProvider(providers: onlyAcme, claudeCloudEnabled: true)
+
+        #expect(!menu.contains { $0.config.name == ClaudeCloudProvider.name })
+        #expect(picker == nil)
+        // No header assertion here: `RemoteSectionView` only ever renders a
+        // header for a provider present in `appState.remoteProviders`
+        // (`ForEach(appState.remoteProviders, ...)`), so there is no
+        // `RemoteProviderStatus` to call `canCreate` with in this state.
+    }
+
+    /// The one documented divergence: a STALE cloud provider is disabled
+    /// (not omitted) by the menu and the header's `+`, but OMITTED by the
+    /// picker, whose row has no disabled state of its own. Pinning this as a
+    /// deliberate divergence — rather than asserting the three must always
+    /// agree — catches a future change that makes them agree the wrong way,
+    /// e.g. the picker starting to show a stale row it cannot act on.
+    @Test func staleInventoryDivergesByDesignBetweenThePickerAndTheOtherTwo() {
+        let stale = [status("acme"), status(ClaudeCloudProvider.name, health: .stale, freshnessUnreadable: true)]
+        let menu = RepoSectionView.remoteSessionMenuProviders(providers: stale, claudeCloudEnabled: true)
+        let picker = RepoSectionView.cloudSessionProvider(providers: stale, claudeCloudEnabled: true)
+        let header = RemoteProviderHeaderRow.canCreate(provider: cloudEntry(in: stale), claudeCloudEnabled: true)
+
+        #expect(menu.contains { $0.config.name == ClaudeCloudProvider.name },
+                "the menu still lists a stale provider — it disables the row instead of omitting it")
+        #expect(header, "the header's + still renders for a stale provider — it disables the button instead")
+        #expect(picker == nil, "the picker has no disabled state, so a stale cloud provider must be omitted")
+    }
 }

--- a/Tests/TBDDaemonLiveTests/ClaudeCloudSpawnerTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/ClaudeCloudSpawnerTimeoutTests.swift
@@ -1,39 +1,80 @@
+import Clocks
 import Foundation
 import Testing
+import TestSupport
 @testable import TBDDaemonLib
 
-/// **Tier 3** — spawns a real child (`/bin/sh -c "sleep 5"`) racing a real
-/// deadline (`Tests/CLAUDE.md`'s test-tier taxonomy names this case verbatim:
-/// a suite belongs here if it "spawns a child racing a deadline"). Runs
-/// serially with the rest of `Tests/TBDDaemonLiveTests` on an otherwise-idle
-/// machine, so 0.2s is a real margin rather than a tolerance liable to flake
-/// under the fast pass's unbounded suite parallelism.
+/// **Tier 3** — both tests spawn a real child. `Tests/CLAUDE.md`'s test-tier
+/// taxonomy names this case verbatim: a suite belongs here if it "spawns a
+/// child racing a deadline," and that holds even when the *deadline itself*
+/// is virtual — `GitManagerTimeoutTests` is the precedent for a `TestClock`
+/// still living in this tier.
 ///
-/// `BoundedProcessClaudeSpawner` has no injected clock — its `spawn(_:)` is
-/// fixed by `ClaudeCloudSpawning`'s brief-specified shape, and unlike
-/// `GitManager`/`TmuxManager.runExternalCommand` it forwards no `clock:`
-/// parameter of its own to `runBoundedProcess`, so this suite races a real
-/// deadline rather than following `SubprocessTimeoutTests`'/
-/// `GitManagerTimeoutTests`' `TestClock` idiom. That is acceptable here
-/// because the property under test is narrow — that `spawn(_:)`'s outcome
-/// mapping passes `.timedOut` through untouched, not a structural promptness
-/// or kill-path proof — matching `ProviderRunnerTimeoutTests`' simpler
-/// real-deadline shape rather than the heavier virtual-time suites.
-@Suite("ClaudeCloudSpawner timeout (live)")
+/// `BoundedProcessClaudeSpawner` now threads an injected `clock:` through to
+/// `runBoundedProcess`, matching `GitManager`/`TmuxManager.runExternalCommand`.
+/// `spawnTimesOutOnInjectedClockDeadline` below is the discriminating proof of
+/// that wiring: it advances only a `TestClock` the spawner was constructed
+/// with, never sleeps for real, and the deadline still fires — which is only
+/// possible if `spawn(_:)` actually forwards `clock` to `runBoundedProcess`
+/// rather than dropping it on the floor. Delete the `clock:` argument from
+/// that call and this test hangs on the real (600s-unreachable) deadline
+/// instead of observing `.timedOut`, tripping the suite's one-minute limit.
+///
+/// `spawnMapsATimeoutToTimedOut` is kept alongside it as the simpler
+/// real-deadline regression guard for the outcome mapping itself (that
+/// `.timedOut` passes through the `switch` in `spawn(_:)` untouched) —
+/// matching `ProviderRunnerTimeoutTests`' shape, on the default `ContinuousClock()`
+/// a caller gets when it does not inject one, same as production.
+///
+/// WHY AN EXPLICIT `.timeLimit(.minutes(1))` AND NOT `.clockDriven`: this is
+/// tier 3, so CI runs it serially (`--filter '^TBDDaemonLiveTests\.'
+/// --no-parallel`) on an otherwise-idle machine — the raised 4-minute
+/// `.clockDriven` limit exists to absorb the fast parallel pass's arming
+/// latency, which does not apply here, and a hang in this suite should be
+/// caught promptly rather than tolerated for minutes.
+@Suite(.timeLimit(.minutes(1)))
 struct ClaudeCloudSpawnerTimeoutTests {
+    private static var tmp: String { FileManager.default.temporaryDirectory.path }
+
+    /// Far enough out that the real watchdog cannot reach it inside the
+    /// suite's one-minute hang limit, so only the injected `TestClock` can
+    /// fire this deadline.
+    private static let unreachableTimeout: TimeInterval = 600
+
     /// `.timedOut` must pass through the outcome mapping untouched — the
     /// other branch of the `switch` in `spawn(_:)`. `/bin/sh -c "sleep 5"`
     /// against a far shorter deadline exercises the real bounded-process
     /// watchdog rather than asserting the mapping in isolation.
     @Test func spawnMapsATimeoutToTimedOut() async throws {
-        let tmp = FileManager.default.temporaryDirectory.path
         let spawner = BoundedProcessClaudeSpawner(executable: "/bin/sh")
         let outcome = try await spawner.spawn(
             ClaudeCloudSpawnRequest(
                 arguments: ["-c", "sleep 5"],
-                workingDirectory: tmp,
+                workingDirectory: Self.tmp,
                 usesPseudoTerminal: false,
                 timeout: 0.2))
+        #expect(outcome == .timedOut)
+    }
+
+    /// Proves `spawn(_:)` actually forwards its injected `clock` to
+    /// `runBoundedProcess` rather than always taking the `ContinuousClock()`
+    /// default. The clock never sees a real 600s wait — `advanceWhenSuspended`
+    /// only returns once the spawner has armed a sleeper on `clock`, and the
+    /// deadline fires the instant virtual time crosses it, so a passing run
+    /// proves the wiring rather than a generous real timeout.
+    @Test func spawnTimesOutOnInjectedClockDeadline() async throws {
+        let clock = TestClock()
+        let spawner = BoundedProcessClaudeSpawner(executable: "/bin/sh", clock: clock)
+        let call = Task {
+            try await spawner.spawn(
+                ClaudeCloudSpawnRequest(
+                    arguments: ["-c", "exec sleep 120"],
+                    workingDirectory: Self.tmp,
+                    usesPseudoTerminal: false,
+                    timeout: Self.unreachableTimeout))
+        }
+        await clock.advanceWhenSuspended(by: .seconds(Self.unreachableTimeout))
+        let outcome = try await call.value
         #expect(outcome == .timedOut)
     }
 }

--- a/Tests/TBDDaemonLiveTests/ClaudeCloudSpawnerTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/ClaudeCloudSpawnerTimeoutTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// **Tier 3** — spawns a real child (`/bin/sh -c "sleep 5"`) racing a real
+/// deadline (`Tests/CLAUDE.md`'s test-tier taxonomy names this case verbatim:
+/// a suite belongs here if it "spawns a child racing a deadline"). Runs
+/// serially with the rest of `Tests/TBDDaemonLiveTests` on an otherwise-idle
+/// machine, so 0.2s is a real margin rather than a tolerance liable to flake
+/// under the fast pass's unbounded suite parallelism.
+///
+/// `BoundedProcessClaudeSpawner` has no injected clock — its `spawn(_:)` is
+/// fixed by `ClaudeCloudSpawning`'s brief-specified shape, and unlike
+/// `GitManager`/`TmuxManager.runExternalCommand` it forwards no `clock:`
+/// parameter of its own to `runBoundedProcess`, so this suite races a real
+/// deadline rather than following `SubprocessTimeoutTests`'/
+/// `GitManagerTimeoutTests`' `TestClock` idiom. That is acceptable here
+/// because the property under test is narrow — that `spawn(_:)`'s outcome
+/// mapping passes `.timedOut` through untouched, not a structural promptness
+/// or kill-path proof — matching `ProviderRunnerTimeoutTests`' simpler
+/// real-deadline shape rather than the heavier virtual-time suites.
+@Suite("ClaudeCloudSpawner timeout (live)")
+struct ClaudeCloudSpawnerTimeoutTests {
+    /// `.timedOut` must pass through the outcome mapping untouched — the
+    /// other branch of the `switch` in `spawn(_:)`. `/bin/sh -c "sleep 5"`
+    /// against a far shorter deadline exercises the real bounded-process
+    /// watchdog rather than asserting the mapping in isolation.
+    @Test func spawnMapsATimeoutToTimedOut() async throws {
+        let tmp = FileManager.default.temporaryDirectory.path
+        let spawner = BoundedProcessClaudeSpawner(executable: "/bin/sh")
+        let outcome = try await spawner.spawn(
+            ClaudeCloudSpawnRequest(
+                arguments: ["-c", "sleep 5"],
+                workingDirectory: tmp,
+                usesPseudoTerminal: false,
+                timeout: 0.2))
+        #expect(outcome == .timedOut)
+    }
+}

--- a/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
+++ b/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
@@ -96,7 +96,7 @@ struct ProviderEventsSupervisorTests {
             registryURL: dir.appendingPathComponent("unused.json"))
         let config = RemoteProviderConfig(name: "stub", exec: script.path)
         let supervisor = ProviderEventsSupervisor(
-            config: config, manager: manager,
+            config: config, manager: manager, contractVersion: 1,
             silenceLimit: 5, backoffCap: 1, healthyResetUptime: 1)
         await supervisor.start()
 
@@ -159,7 +159,7 @@ struct ProviderEventsSupervisorTests {
             registryURL: dir.appendingPathComponent("unused.json"))
         let supervisor = ProviderEventsSupervisor(
             config: RemoteProviderConfig(name: "stubborn", exec: script.path), manager: manager,
-            silenceLimit: 90, backoffCap: 1, healthyResetUptime: 1)
+            contractVersion: 1, silenceLimit: 90, backoffCap: 1, healthyResetUptime: 1)
         await supervisor.start()
 
         // Bounded wait for the child to exist before stopping it.

--- a/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
+++ b/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
@@ -131,6 +131,88 @@ struct ProviderEventsSupervisorTests {
         try outcome.get()
     }
 
+    /// Only the parser and `RemoteProviderManager.apply(...)` have unit
+    /// coverage of `complete`; the pass-through at
+    /// `ProviderEventsSupervisor.handle(_:)` — private, and not itself
+    /// exercised by any other live test — has none. `snapshotAppliedAndRestartResyncs`
+    /// above never asserts on it: its stub's snapshot line never sets
+    /// `"complete"` at all, so it only ever walks the default-true branch. A
+    /// hardcoded `complete: true` at the pass-through would leave every test
+    /// in this file green while quietly resuming exactly the tombstoning the
+    /// events half of this feature exists to prevent.
+    ///
+    /// The stub emits one COMPLETE baseline snapshot (`keep-a`, `drop-b`),
+    /// then one INCOMPLETE snapshot that omits `drop-b` and introduces
+    /// `new-c`. `new-c` exists nowhere else in the script, so its arrival in
+    /// the mirror is the positive signal that the second, incomplete event
+    /// was actually applied — not just sent — which is what makes the
+    /// absence assertion that follows trustworthy rather than a race. Once
+    /// that signal fires, `drop-b`'s absence bookkeeping (`missingCount`/
+    /// `gone`, the two-absence rule in `RemoteSessionStore.applySnapshot`)
+    /// must be untouched: an incomplete snapshot is authoritative about
+    /// presence only, never about absence.
+    @Test func incompleteEventsSnapshotDoesNotAdvanceAbsenceBookkeeping() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("events-supervisor-incomplete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let pidFile = dir.appendingPathComponent("pid")
+        let script = dir.appendingPathComponent("events-incomplete-stub.sh")
+        try """
+        #!/bin/bash
+        if [ "$1" != "events" ]; then echo '{"sessions": []}'; exit 0; fi
+        echo $$ > "\(pidFile.path)"
+        echo '{"event": "hello", "contract_version": 1}'
+        echo '{"event": "snapshot", "complete": true, "sessions": [{"id": "keep-a", "state": "running"}, {"id": "drop-b", "state": "running"}]}'
+        echo '{"event": "snapshot", "complete": false, "sessions": [{"id": "keep-a", "state": "running"}, {"id": "new-c", "state": "running"}]}'
+        sleep 600 &
+        child=$!
+        trap 'kill "$child" 2>/dev/null; exit 143' TERM INT
+        wait "$child"
+        """.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+
+        let db = try TBDDatabase(inMemory: true)
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: StateSubscriptionManager(), runner: ProviderRunner(),
+            registryURL: dir.appendingPathComponent("unused.json"))
+        let config = RemoteProviderConfig(name: "stub-incomplete", exec: script.path)
+        // Well above anything this test's bounded polling could take: unlike
+        // `snapshotAppliedAndRestartResyncs`, nothing here exercises restart,
+        // so a watchdog-triggered respawn mid-assertion would only be noise
+        // to keep out, not behavior under test.
+        let supervisor = ProviderEventsSupervisor(
+            config: config, manager: manager, contractVersion: 1,
+            silenceLimit: 90, backoffCap: 1, healthyResetUptime: 1)
+        await supervisor.start()
+
+        // Same teardown-before-cleanup shape as `snapshotAppliedAndRestartResyncs`
+        // above, for the same reason: `stop()` is async so `defer` can't await
+        // it, and it must run before the temp dir goes away regardless of
+        // outcome.
+        let outcome: Result<Void, any Error>
+        do {
+            try await runIncompleteSnapshotAssertions(db: db)
+            outcome = .success(())
+        } catch {
+            outcome = .failure(error)
+        }
+        await supervisor.stop()
+
+        let pid = Int32((try? String(contentsOf: pidFile, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "") ?? 0
+        var alive = true
+        let leakDeadline = Date().addingTimeInterval(Self.reapDeadline)
+        while Date() < leakDeadline {
+            alive = pid > 0 && kill(-pid, 0) == 0
+            if !alive { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        #expect(!alive, "stub process group \(pid) survived stop(); leaked children")
+
+        try? FileManager.default.removeItem(at: dir)
+        try outcome.get()
+    }
+
     /// A provider that IGNORES SIGTERM must still die: `stop()` escalates to
     /// SIGKILL against the process group and only returns once the child is
     /// gone and the supervision task has finished. Without the escalation this
@@ -288,6 +370,45 @@ struct ProviderEventsSupervisorTests {
                 observed rows=\(rows.map(\.sessionID))
                 """)
         }
+    }
+
+    /// Bounded wait for the positive signal (`new-c`'s arrival) that the
+    /// INCOMPLETE snapshot reached the mirror, then a direct check of
+    /// `drop-b`'s absence bookkeeping. See
+    /// `incompleteEventsSnapshotDoesNotAdvanceAbsenceBookkeeping`'s doc
+    /// comment for why the positive signal is what makes this trustworthy.
+    private func runIncompleteSnapshotAssertions(db: TBDDatabase) async throws {
+        var rows: [RemoteSessionRow] = []
+        let deadline = Date().addingTimeInterval(Self.saturatedWaitDeadline)
+        while Date() < deadline {
+            rows = (try? await db.remoteSessions.list()) ?? []
+            if rows.contains(where: { $0.sessionID == "new-c" }) { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        guard rows.contains(where: { $0.sessionID == "new-c" }) else {
+            throw Failure("""
+                the incomplete snapshot never reached the mirror within \
+                \(Self.saturatedWaitDeadline)s — "new-c" only exists in that event; \
+                observed rows=\(rows.map(\.sessionID))
+                """)
+        }
+
+        let dropB = try #require(
+            rows.first { $0.sessionID == "drop-b" },
+            "the baseline COMPLETE snapshot's \"drop-b\" row must still exist")
+        #expect(
+            dropB.missingCount == 0,
+            """
+            an incomplete snapshot omitting "drop-b" must not advance its absence \
+            count; got missingCount=\(dropB.missingCount)
+            """)
+        #expect(!dropB.gone, "\"drop-b\" must not be tombstoned by an incomplete snapshot")
+
+        let keepA = try #require(
+            rows.first { $0.sessionID == "keep-a" },
+            "\"keep-a\", present in both snapshots, must still exist")
+        #expect(keepA.missingCount == 0)
+        #expect(!keepA.gone)
     }
 
     /// Highest `n` across ids shaped `run-<n>`, or `nil` if the mirror carries

--- a/Tests/TBDDaemonLiveTests/ProviderRunnerTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/ProviderRunnerTimeoutTests.swift
@@ -15,7 +15,8 @@ struct ProviderRunnerTimeoutTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path.path)
         let config = RemoteProviderConfig(name: "hang", exec: path.path)
         await #expect(throws: ProviderRunError.self) {
-            _ = try await ProviderRunner().run(config, verb: ["list"], stdin: nil, timeout: 1)
+            _ = try await ProviderRunner().run(
+                config, verb: ["list"], stdin: nil, timeout: 1, contractVersion: 1)
         }
     }
 }

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
@@ -1,4 +1,5 @@
 import Clocks
+import Darwin
 import Foundation
 import Testing
 import TestSupport
@@ -48,6 +49,11 @@ struct SubprocessTimeoutTests {
     /// Far enough out that the real watchdog cannot reach it inside the suite's
     /// one-minute hang limit, so only the `TestClock` can fire the deadline.
     private static let unreachableTimeout: Duration = .seconds(600)
+
+    /// How long `pseudoTerminalRunTimesOutAndKillsTheChild` waits to observe
+    /// the child disappear. Kept small enough that one `advanceWhenSuspended`
+    /// guard (45 s) plus this budget still fits the suite's 60 s limit.
+    private static let killObservationBudget: Duration = .seconds(10)
 
     @Test func runExternalCommandThrowsTimedOutOnSlowBinary() async {
         // Assert the OUTCOME (throws .timedOut), never wall-clock timing. The
@@ -174,5 +180,107 @@ struct SubprocessTimeoutTests {
             clock: TestClock()
         )
         #expect(out.contains("ok"))
+    }
+
+    /// The deadline and the kill must still work when the child's streams are a
+    /// pseudo-terminal rather than pipes — the mode replaces the pipe pair with
+    /// one `openpty(3)` descriptor, and the deadline path snapshots and CLOSES
+    /// that descriptor before it signals. A pty primary is a character device,
+    /// so nothing about closing it terminates the child; only the SIGTERM does.
+    /// This drives `runBoundedProcess` directly rather than
+    /// `runExternalCommand`, which has no `stdio` parameter of its own.
+    ///
+    /// The kill is asserted, not assumed, and the observation is deliberately
+    /// argv-based rather than pid-file-based. Under a `TestClock` the deadline
+    /// is armed BEFORE `Process.run()` and fires the instant the test advances,
+    /// so the child is killed on arrival — it may never execute a single line,
+    /// and anything it was asked to write down would race. Its argv, by
+    /// contrast, is set by the kernel at spawn, so a per-run marker embedded in
+    /// the `-c` string identifies it whether or not it ever ran. The leading
+    /// `:;` matters: `/bin/sh -c "<one simple command>"` exec-optimizes into
+    /// the command itself and the marker would be lost with the shell's argv.
+    ///
+    /// The assertion is not vacuous, because `.timedOut` can only be reached
+    /// after `Process.run()` succeeded — so a marked process definitely existed,
+    /// and "no live marked process remains" is a real claim about the
+    /// SIGTERM→SIGKILL path. Mutation-checked: neutering BOTH signals turns this
+    /// red (`still live: [<pid> S /bin/sh -c :; sleep 60 # tbd-pty-timeout-…]`)
+    /// while every other test in the file stays green. Deleting only the SIGTERM
+    /// does NOT redden it — the 500 ms SIGKILL escalation covers that on its
+    /// own, which is the escalation working as designed, not a weak assertion.
+    ///
+    /// Worth recording for anyone reasoning about this mode: closing the pty
+    /// primary does **not** by itself terminate the child. `Process` does not
+    /// `setsid`, so the child never acquires the pty as its CONTROLLING
+    /// terminal and no SIGHUP is delivered when the last primary descriptor
+    /// closes — measured directly, a child survived the close indefinitely.
+    /// The signals are the only thing that ends it.
+    ///
+    /// The `sleep 60` grandchild is NOT killed and may linger for its full
+    /// minute — the same tolerated orphanage as the two grandchild tests above.
+    @Test func pseudoTerminalRunTimesOutAndKillsTheChild() async throws {
+        let marker = "tbd-pty-timeout-\(UUID().uuidString)"
+
+        let clock = TestClock()
+        let call = Task {
+            try await runBoundedProcess(
+                executable: "/bin/sh",
+                arguments: ["-c", ":; sleep 60 # \(marker)"],
+                currentDirectory: nil,
+                timeout: Self.unreachableTimeout,
+                stdio: .pseudoTerminal,
+                clock: clock
+            )
+        }
+        await clock.advanceWhenSuspended(by: Self.unreachableTimeout)
+        let outcome = try await call.value
+        guard case .timedOut = outcome else {
+            Issue.record("expected .timedOut under .pseudoTerminal, got \(outcome)")
+            return
+        }
+
+        // Bounded poll (assertion-hygiene rule 3): the runner escalates
+        // SIGTERM → SIGKILL after 500ms of REAL time and Foundation reaps the
+        // child asynchronously, so "gone" is observable but not instant. A
+        // reaped-but-unwaited zombie still appears in `ps`, hence the `Z` filter.
+        var survivors: [String] = []
+        let deadline = ContinuousClock.now + Self.killObservationBudget
+        while ContinuousClock.now < deadline {
+            survivors = try await liveProcessLines(matching: marker)
+            if survivors.isEmpty { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        if !survivors.isEmpty {
+            Issue.record(PTYChildSurvivedDeadline(
+                survivors: survivors, waited: Self.killObservationBudget))
+        }
+    }
+
+    /// `ps` lines for non-zombie processes whose argv contains `marker`.
+    private func liveProcessLines(matching marker: String) async throws -> [String] {
+        let outcome = try await runBoundedProcess(
+            executable: "/bin/ps",
+            arguments: ["-Ao", "pid=,stat=,command="],
+            currentDirectory: nil,
+            timeout: .seconds(15)
+        )
+        guard case .completed(_, let stdout, _) = outcome else { return [] }
+        return (String(data: stdout, encoding: .utf8) ?? "")
+            .split(separator: "\n")
+            .map(String.init)
+            .filter { $0.contains(marker) && !$0.contains(" Z") }
+    }
+}
+
+/// Timeout diagnostic for `pseudoTerminalRunTimesOutAndKillsTheChild`. A thrown
+/// `Error` rather than an `#expect` message so the OBSERVED state reaches the
+/// primary failure line, and therefore the CI summary (`Tests/CLAUDE.md`,
+/// assertion-hygiene rule 4).
+private struct PTYChildSurvivedDeadline: Error, CustomStringConvertible {
+    let survivors: [String]
+    let waited: Duration
+    var description: String {
+        "the pty child outlived its deadline by \(waited) — the SIGTERM→SIGKILL "
+            + "path did not reach it; still live: \(survivors)"
     }
 }

--- a/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
+++ b/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
@@ -120,6 +120,27 @@ struct BoundedProcessRunnerTests {
         #expect(status == 7)
     }
 
+    /// Every other `.pseudoTerminal` test in this file drives a child that
+    /// exits 0, so none of them can tell a correctly-read exit status from one
+    /// hardcoded to zero. `childExitingBeforeReadingLargeStdinFailsTheCallNotTheProcess`
+    /// above proves status 7 survives under `.pipes`; this is its `.pseudoTerminal`
+    /// twin, closing the one gap that shape leaves — a status-reading bug
+    /// (e.g. reading the wrong process, or a stray `status == 0` fallback)
+    /// specific to the pty branch would pass every existing pty test here and
+    /// only show up on a nonzero exit.
+    @Test func pseudoTerminalModePreservesTheChildsNonzeroExitStatus() async throws {
+        let outcome = try await runBoundedProcess(
+            executable: "/bin/sh", arguments: ["-c", "echo hello; exit 7"],
+            currentDirectory: nil, timeout: .seconds(10), stdio: .pseudoTerminal)
+        guard case .completed(let status, let stdout, let stderr) = outcome else {
+            Issue.record("expected .completed under .pseudoTerminal, got \(outcome)")
+            return
+        }
+        #expect(status == 7)
+        #expect((String(data: stdout, encoding: .utf8) ?? "").contains("hello"))
+        #expect(stderr.isEmpty)
+    }
+
     /// The whole point of the mode. The vendor CLI refuses `--cloud` creation
     /// when stdout is not a terminal, so a probe that reports what it sees is
     /// the only assertion that proves the child got one. Both arms run the SAME

--- a/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
+++ b/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
@@ -179,6 +179,56 @@ struct BoundedProcessRunnerTests {
         }
     }
 
+    /// The reported terminal geometry is wide ON PURPOSE and a comment alone
+    /// cannot stop someone "restoring" it to the 24x80 that
+    /// `TmuxControlConnection` uses. A pty never wraps by itself — `winsize` is
+    /// advisory metadata — but a child that reads `TIOCGWINSZ` formats to it and
+    /// inserts REAL newlines at the wrap, which then corrupt the captured bytes.
+    /// At 80 columns the headroom over a realistic output line was six
+    /// characters. `stty size` is what the child sees, so this pins the actual
+    /// contract rather than the constant's spelling.
+    @Test func pseudoTerminalReportsAWideGeometryToTheChild() async throws {
+        let outcome = try await runBoundedProcess(
+            executable: "/bin/sh", arguments: ["-c", "stty size"],
+            currentDirectory: nil, timeout: .seconds(10), stdio: .pseudoTerminal)
+        guard case .completed(let status, let stdout, _) = outcome else {
+            Issue.record("expected .completed under .pseudoTerminal, got \(outcome)")
+            return
+        }
+        #expect(status == 0)
+        let reported = (String(data: stdout, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(reported == "200 400", "child saw rows/cols \(reported.debugDescription), wanted \"200 400\"")
+    }
+
+    /// The merge itself, asserted directly rather than inferred from an empty
+    /// `stderr`. `pseudoTerminalModeGivesTheChildATty` checks only that the
+    /// reported stderr is empty, and emptiness is the WRONG witness: deleting
+    /// `process.standardError = replicaHandle` leaves it empty too — the
+    /// child's stderr would simply escape to the daemon's own stderr, where the
+    /// CLI's error text vanishes unlogged and a nonzero status arrives with
+    /// nothing to diagnose from. Requiring BOTH streams to appear in `stdout`
+    /// is the contract; the empty `stderr` is only its consequence.
+    ///
+    /// Its `.pipes` twin is `defaultStdioIsStillPipes` below, which runs the
+    /// same probe and requires the two streams to stay SEPARATE — so between
+    /// them the merge is pinned in both directions.
+    @Test func pseudoTerminalModeMergesStderrIntoStdout() async throws {
+        let outcome = try await runBoundedProcess(
+            executable: "/bin/sh", arguments: ["-c", "echo out; echo err 1>&2"],
+            currentDirectory: nil, timeout: .seconds(10), stdio: .pseudoTerminal)
+        guard case .completed(let status, let stdout, let stderr) = outcome else {
+            Issue.record("expected .completed under .pseudoTerminal, got \(outcome)")
+            return
+        }
+        #expect(status == 0)
+        let merged = String(data: stdout, encoding: .utf8) ?? ""
+        #expect(merged.contains("out"), "child's stdout missing from the merged capture: \(merged.debugDescription)")
+        #expect(merged.contains("err"), "child's stderr missing from the merged capture: \(merged.debugDescription)")
+        // One descriptor, so there is nothing left to report separately.
+        #expect(stderr.isEmpty)
+    }
+
     /// The default is unchanged, which is what keeps every existing call site
     /// on pipes without being revisited.
     @Test func defaultStdioIsStillPipes() async throws {

--- a/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
+++ b/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
@@ -119,4 +119,77 @@ struct BoundedProcessRunnerTests {
         }
         #expect(status == 7)
     }
+
+    /// The whole point of the mode. The vendor CLI refuses `--cloud` creation
+    /// when stdout is not a terminal, so a probe that reports what it sees is
+    /// the only assertion that proves the child got one. Both arms run the SAME
+    /// probe, so the test discriminates rather than merely passing.
+    @Test func pseudoTerminalModeGivesTheChildATty() async throws {
+        let probe = "if [ -t 1 ]; then echo tty; else echo pipe; fi"
+
+        let pty = try await runBoundedProcess(
+            executable: "/bin/sh", arguments: ["-c", probe],
+            currentDirectory: nil, timeout: .seconds(10), stdio: .pseudoTerminal)
+        guard case .completed(let ptyStatus, let ptyOut, let ptyErr) = pty else {
+            Issue.record("expected .completed under .pseudoTerminal, got \(pty)")
+            return
+        }
+        #expect(ptyStatus == 0)
+        #expect((String(data: ptyOut, encoding: .utf8) ?? "").contains("tty"))
+        // One file descriptor: everything the child wrote is on stdout.
+        #expect(ptyErr.isEmpty)
+
+        let piped = try await runBoundedProcess(
+            executable: "/bin/sh", arguments: ["-c", probe],
+            currentDirectory: nil, timeout: .seconds(10))
+        guard case .completed(let pipeStatus, let pipeOut, _) = piped else {
+            Issue.record("expected .completed under the default .pipes, got \(piped)")
+            return
+        }
+        #expect(pipeStatus == 0)
+        #expect((String(data: pipeOut, encoding: .utf8) ?? "").contains("pipe"))
+    }
+
+    /// A pty has a small kernel buffer, so the incremental drain matters here
+    /// at least as much as it does for a pipe: a child that outruns it would
+    /// otherwise block on write while the parent waits for exit.
+    @Test func pseudoTerminalModeDrainsMoreThanOneBufferful() async throws {
+        let outcome = try await runBoundedProcess(
+            executable: "/bin/sh",
+            arguments: ["-c", "head -c 200000 /dev/zero | tr '\\0' 'x'"],
+            currentDirectory: nil, timeout: .seconds(20), stdio: .pseudoTerminal)
+        guard case .completed(let status, let stdout, _) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(status == 0)
+        // Raw mode, so no CR is inserted and the byte count is exact.
+        #expect(stdout.count == 200_000)
+    }
+
+    /// The replica is the child's stdin AND its stdout on one descriptor, so
+    /// there is no write end to close and a child waiting for EOF would hang
+    /// forever. Refusing loudly beats hanging quietly; `create` passes no stdin.
+    @Test func pseudoTerminalModeRefusesAStdinPayload() async {
+        await #expect(throws: BoundedProcessRunnerError.stdinUnsupportedOnPseudoTerminal) {
+            _ = try await runBoundedProcess(
+                executable: "/bin/cat", arguments: [],
+                currentDirectory: nil, stdin: Data("hi".utf8),
+                timeout: .seconds(10), stdio: .pseudoTerminal)
+        }
+    }
+
+    /// The default is unchanged, which is what keeps every existing call site
+    /// on pipes without being revisited.
+    @Test func defaultStdioIsStillPipes() async throws {
+        let outcome = try await runBoundedProcess(
+            executable: "/bin/sh", arguments: ["-c", "echo out; echo err 1>&2"],
+            currentDirectory: nil, timeout: .seconds(10))
+        guard case .completed(_, let stdout, let stderr) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect((String(data: stdout, encoding: .utf8) ?? "").contains("out"))
+        #expect((String(data: stderr, encoding: .utf8) ?? "").contains("err"))
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudCreateOutputParserTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudCreateOutputParserTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+// Tier 1: pure string work.
+@Suite("ClaudeCloudCreateOutputParser")
+struct ClaudeCloudCreateOutputParserTests {
+    /// The measured three-line success form (design §11).
+    private let threeLines = """
+        Created cloud session: Add probe pong reply
+        View: https://claude.ai/code/session_01AAAAAAAAAAAAAAAAAAAAAA?from=cli&m=0
+        Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA
+        """
+
+    // MARK: - The id: strict, cross-checked, fails loudly
+
+    @Test func theThreeLineSuccessFormYieldsTheSessionID() throws {
+        #expect(try ClaudeCloudCreateOutputParser.sessionID(fromOutput: threeLines).get()
+            == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+    }
+
+    @Test func ansiControlSequencesAroundTheSameLinesYieldTheSameID() throws {
+        let decorated = "\u{1B}[1mCreated cloud session: Add probe pong reply\u{1B}[0m\r\n"
+            + "\u{1B}[2mView: https://claude.ai/code/session_01AAAAAAAAAAAAAAAAAAAAAA?from=cli\u{1B}[0m\r\n"
+            + "\u{1B}]0;title\u{07}Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA\r\n"
+        #expect(try ClaudeCloudCreateOutputParser.sessionID(fromOutput: decorated).get()
+            == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+    }
+
+    @Test func noMatchIsAFailureRatherThanAnEmptyID() {
+        #expect(
+            ClaudeCloudCreateOutputParser.sessionID(
+                fromOutput: "Error: --cloud requires an interactive terminal.")
+                == .failure(.noSessionID))
+    }
+
+    @Test func emptyOutputIsAFailure() {
+        #expect(ClaudeCloudCreateOutputParser.sessionID(fromOutput: "") == .failure(.noSessionID))
+    }
+
+    /// All three printed lines carry the id, so disagreement is a signal, not
+    /// noise — the strict shape checked three times over is what lets an
+    /// unreadable id fail loudly instead of costing the lane its identity.
+    @Test func twoDistinctIDsAreAFailureNamingBoth() {
+        let result = ClaudeCloudCreateOutputParser.sessionID(fromOutput: """
+            Created cloud session: two
+            View: https://claude.ai/code/session_01AAA?from=cli
+            Resume with: claude --teleport session_01BBB
+            """)
+        #expect(result == .failure(.conflictingSessionIDs(["session_01AAA", "session_01BBB"])))
+    }
+
+    /// The bounded message quotes what the provider received, so a
+    /// `contractBug` on screen names the evidence rather than a bare code.
+    @Test func theFailureMessageQuotesTheReceivedTextAndIsBounded() {
+        let message = ClaudeCloudCreateOutputParser.failureMessage(
+            .noSessionID, received: String(repeating: "x", count: 5_000))
+        #expect(message.contains("xxx"))
+        #expect(message.count <= 600)
+    }
+
+    // MARK: - The title: lenient, uncross-checked, never fails a create
+
+    @Test func theTitleIsTheFirstLineAfterItsPrefixTrimmed() {
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: threeLines)
+            == "Add probe pong reply")
+    }
+
+    /// The pty reports 400 columns, but a child that formats to a narrower
+    /// width would insert a REAL newline, so a wrapped title line must still
+    /// read as one title rather than as a truncated one.
+    @Test func aWrappedTitleLineIsRejoined() {
+        let wrapped = "Created cloud session: Add probe pong\nreply\n"
+            + "View: https://claude.ai/code/session_01AAA?from=cli\n"
+            + "Resume with: claude --teleport session_01AAA"
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: wrapped)
+            == "Add probe pong reply")
+    }
+
+    /// The three lenient cases are ONE outcome — take the fallback — not
+    /// three to distinguish on screen.
+    @Test func aMissingPrefixAMissingLineAndABlankRemainderAllYieldNil() {
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: """
+            Started a cloud session: Add probe pong reply
+            Resume with: claude --teleport session_01AAA
+            """) == nil)
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: "") == nil)
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: "Created cloud session:    \n") == nil)
+    }
+
+    /// The two parses have deliberately opposite failure postures, and this
+    /// is the pair that proves it: output whose title is unreadable still
+    /// yields an id, so the create succeeds and the lane is named from its id.
+    @Test func anUnreadableTitleStillYieldsAReadableID() throws {
+        let output = """
+            Something else entirely
+            Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA
+            """
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: output) == nil)
+        #expect(try ClaudeCloudCreateOutputParser.sessionID(fromOutput: output).get()
+            == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeCloudCreateOutputParserTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudCreateOutputParserTests.swift
@@ -100,4 +100,47 @@ struct ClaudeCloudCreateOutputParserTests {
         #expect(try ClaudeCloudCreateOutputParser.sessionID(fromOutput: output).get()
             == "session_01AAAAAAAAAAAAAAAAAAAAAA")
     }
+
+    /// A pty's canonical line discipline emits `\r\n`, and `"\r\n"` is ONE
+    /// `Character` in Swift — distinct from `"\n"` — so a naive
+    /// `split(separator: "\n")` does not split this at all. Built by
+    /// concatenation with explicit `\r\n`, not a triple-quoted literal:
+    /// Swift's compiler normalizes triple-quoted literals to bare `\n`, which
+    /// is exactly why the suite's other wrapped-title test could not have
+    /// caught this — it structurally cannot construct CRLF.
+    @Test func aWrappedTitleLineWithRealCRLFIsStillRejoinedCleanly() {
+        let wrapped = "Created cloud session: Add probe pong\r\nreply\r\n"
+            + "View: https://claude.ai/code/session_01AAA?from=cli\r\n"
+            + "Resume with: claude --teleport session_01AAA\r\n"
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: wrapped)
+            == "Add probe pong reply")
+    }
+
+    // MARK: - The title's three line-terminator branches, independently
+
+    /// A blank line ends the title even with no trailing `View:`/`Resume
+    /// with:` line to catch it.
+    @Test func aBlankLineEndsTheTitle() {
+        let output = "Created cloud session: Add probe pong reply\n\nignored trailer\n"
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: output)
+            == "Add probe pong reply")
+    }
+
+    /// A `View:` line ends the title even with no blank line before it.
+    @Test func aViewLineEndsTheTitle() {
+        let output = "Created cloud session: Add probe pong reply\n"
+            + "View: https://claude.ai/code/session_01AAA?from=cli\n"
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: output)
+            == "Add probe pong reply")
+    }
+
+    /// A `Resume with:` line ends the title even with no `View:` line before
+    /// it (the `--print`-refused form never omits `View:`, but the parser
+    /// does not assume that — each terminator is checked independently).
+    @Test func aResumeWithLineEndsTheTitle() {
+        let output = "Created cloud session: Add probe pong reply\n"
+            + "Resume with: claude --teleport session_01AAA\n"
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: output)
+            == "Add probe pong reply")
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
@@ -107,4 +107,35 @@ struct ClaudeCloudFlagSchemaTests {
     @Test func theReservedProviderNameIsClaudeCloud() {
         #expect(ClaudeCloudProvider.name == "claude-cloud")
     }
+
+    /// The RPC is what the Settings toggle writes through, and it must
+    /// broadcast so another client's capability fetch sees the change without a
+    /// reconnect — the same shape every sibling config verb uses.
+    @Test func setClaudeCloudRPCPersistsAndBroadcasts() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs,
+            actuationLog: ActuationLog(
+                path: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("cloud-rpc-\(UUID().uuidString).jsonl").path))
+
+        let params = try JSONEncoder().encode(ConfigSetClaudeCloudParams(enabled: true))
+        let response = try await router.handleConfigSetClaudeCloud(params)
+        #expect(response.success)
+        #expect(try await db.config.get().claudeCloudEnabled == true)
+
+        let off = try JSONEncoder().encode(ConfigSetClaudeCloudParams(enabled: false))
+        #expect(try await router.handleConfigSetClaudeCloud(off).success)
+        #expect(try await db.config.get().claudeCloudEnabled == false)
+    }
+
+    @Test func theRPCMethodNameIsStable() {
+        #expect(RPCMethod.configSetClaudeCloud == "config.setClaudeCloud")
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
@@ -138,4 +138,62 @@ struct ClaudeCloudFlagSchemaTests {
     @Test func theRPCMethodNameIsStable() {
         #expect(RPCMethod.configSetClaudeCloud == "config.setClaudeCloud")
     }
+
+    /// The flag reaches the app through `daemon.capabilities`, and it needs the
+    /// live/enabled distinction for the same reason `remoteBackendsEnabled`
+    /// does: the daemon wires the built-in provider only at boot, so a flag
+    /// flipped on afterwards is on-but-not-live.
+    @Test func capabilitiesReportEnabledButNotLiveAfterAPostBootFlip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setClaudeCloud(true)
+        // `claudeCloudLive` defaults to false — this router stands in for a
+        // daemon that booted with the flag off.
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: ActuationLog(
+                path: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("cloud-caps-\(UUID().uuidString).jsonl").path))
+
+        let response = try await router.handleDaemonCapabilities()
+        let payload = try #require(response.result)
+        let caps = try JSONDecoder().decode(
+            DaemonCapabilitiesResult.self, from: Data(payload.utf8))
+        #expect(caps.claudeCloudEnabled == true)
+        #expect(caps.claudeCloudLive == false)
+    }
+
+    @Test func capabilitiesReportTheFlagOffWhenNobodyTouchedIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: ActuationLog(
+                path: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("cloud-caps-\(UUID().uuidString).jsonl").path))
+
+        let response = try await router.handleDaemonCapabilities()
+        let payload = try #require(response.result)
+        let caps = try JSONDecoder().decode(
+            DaemonCapabilitiesResult.self, from: Data(payload.utf8))
+        #expect(caps.claudeCloudEnabled == Config.claudeCloudEnabledDefault)
+        #expect(caps.claudeCloudLive == false)
+    }
+
+    /// A daemon that does not send the field cannot serve the feature either,
+    /// so an absent value falls through to the shipped default rather than a
+    /// hardcoded `false` — the same reading `queuedPromptEnabled` takes.
+    @Test func capabilitiesFromAnOlderDaemonFollowTheShippedDefault() throws {
+        let json = #"{"controlModeEnabled":false}"#
+        let caps = try JSONDecoder().decode(
+            DaemonCapabilitiesResult.self, from: Data(json.utf8))
+        #expect(caps.claudeCloudEnabled == Config.claudeCloudEnabledDefault)
+        #expect(caps.claudeCloudLive == false)
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
@@ -10,7 +10,7 @@ import Testing
 ///
 /// The column is added with **no SQL default**, so "never chose" (NULL) stays
 /// distinguishable from "explicitly off" (0). If someone adds `defaults: false`
-/// to `v80_config_claude_cloud`, `claudeCloudIsNullBeforeAnyGesture` goes red —
+/// to `v81_config_claude_cloud`, `claudeCloudIsNullBeforeAnyGesture` goes red —
 /// that is its only job. The distinction matters more here than for most flags:
 /// this feature calls a network service on a schedule, so somebody who turned it
 /// off did so deliberately.
@@ -34,7 +34,7 @@ struct ClaudeCloudFlagSchemaTests {
             """
             config.claude_cloud_enabled must be NULL until the toggle is \
             touched — read back \(String(describing: record.claude_cloud_enabled)). \
-            A non-nil value here means v80_config_claude_cloud grew a \
+            A non-nil value here means v81_config_claude_cloud grew a \
             `defaults:` argument; remove it.
             """)
     }

--- a/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudFlagSchemaTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema guards for `config.claude_cloud_enabled`
+/// (`docs/specs/2026-08-15-cloud-sessions-slice-1-design.md` §7).
+///
+/// The column is added with **no SQL default**, so "never chose" (NULL) stays
+/// distinguishable from "explicitly off" (0). If someone adds `defaults: false`
+/// to `v80_config_claude_cloud`, `claudeCloudIsNullBeforeAnyGesture` goes red —
+/// that is its only job. The distinction matters more here than for most flags:
+/// this feature calls a network service on a schedule, so somebody who turned it
+/// off did so deliberately.
+@Suite("ClaudeCloudFlagSchema")
+struct ClaudeCloudFlagSchemaTests {
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by v1,
+    /// so every install has a row that predates v80. After v80 its
+    /// `claude_cloud_enabled` must read NULL, not `0`.
+    @Test func claudeCloudIsNullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.claude_cloud_enabled == nil,
+            """
+            config.claude_cloud_enabled must be NULL until the toggle is \
+            touched — read back \(String(describing: record.claude_cloud_enabled)). \
+            A non-nil value here means v80_config_claude_cloud grew a \
+            `defaults:` argument; remove it.
+            """)
+    }
+
+    /// The same guard against a row written by a real pre-v80 daemon: migrate
+    /// only through v77, write to the config row, then finish migrating.
+    @Test func rowWrittenBeforeV78StillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v77_config_supervision_enabled")
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET supervision_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["claude_cloud_enabled"]
+            #expect(raw.isNull, "a config row written before v80 must read NULL, not \(raw)")
+            // The pre-existing write survived — v80 is purely additive.
+            #expect(row["supervision_enabled"] == true)
+        }
+    }
+
+    /// NULL follows `Config.claudeCloudEnabledDefault` wherever it goes; an
+    /// explicit `false` does not. This is the property that makes graduation a
+    /// one-line constant change with no forcing `UPDATE` migration.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.claude_cloud_enabled == nil)
+        #expect(untouched.toModel(claudeCloudEnabledDefault: false).claudeCloudEnabled == false)
+        #expect(
+            untouched.toModel(claudeCloudEnabledDefault: true).claudeCloudEnabled == true,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setClaudeCloud(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.claude_cloud_enabled == false)
+        #expect(explicitlyOff.toModel(claudeCloudEnabledDefault: false).claudeCloudEnabled == false)
+        #expect(
+            explicitlyOff.toModel(claudeCloudEnabledDefault: true).claudeCloudEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes")
+    }
+
+    /// The shipped default today. Graduation edits this constant and nothing else.
+    @Test func shippedDefaultIsOff() async throws {
+        #expect(Config.claudeCloudEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().claudeCloudEnabled == false)
+    }
+
+    @Test func setClaudeCloudRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setClaudeCloud(true)
+        #expect(try await db.config.get().claudeCloudEnabled == true)
+        try await db.config.setClaudeCloud(false)
+        #expect(try await db.config.get().claudeCloudEnabled == false)
+    }
+
+    /// The reserved name is a shared constant so the dispatcher, the registry
+    /// loader and the app all spell it the same way.
+    @Test func theReservedProviderNameIsClaudeCloud() {
+        #expect(ClaudeCloudProvider.name == "claude-cloud")
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeCloudGateTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudGateTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+// Tier 2: in-memory GRDB plus fakes; no subprocess, no real `claude`.
+@Suite("ClaudeCloudGate")
+struct ClaudeCloudGateTests: ~Copyable {
+    let db: TBDDatabase
+    let dir: URL
+    let registryURL: URL
+
+    init() throws {
+        let localDB = try TBDDatabase(inMemory: true)
+        let localDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cloud-gate-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: localDir, withIntermediateDirectories: true)
+        let localRegistryURL = localDir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent"}]"#
+            .write(to: localRegistryURL, atomically: true, encoding: .utf8)
+        db = localDB
+        dir = localDir
+        registryURL = localRegistryURL
+    }
+
+    deinit { try? FileManager.default.removeItem(at: dir) }
+
+    /// The cloud provider is present in the manager — modelling a daemon that
+    /// booted with BOTH flags on — so the only thing that can refuse a cloud
+    /// verb in these tests is the gate itself.
+    private func router(cloud: FakeProviderInvoker) -> RPCRouter {
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: StateSubscriptionManager(),
+            runner: ProviderDispatcher(
+                subprocess: FakeProviderInvoker(script: []),
+                builtIns: [ClaudeCloudProvider.name: cloud]),
+            registryURL: registryURL,
+            builtInProviders: [
+                RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: "/opt/acme/claude")
+            ])
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: StateSubscriptionManager(),
+            remoteManager: manager, actuationLog: makeTestActuationLog())
+    }
+
+    private func call(_ router: RPCRouter, _ method: String, _ params: String) async -> RPCResponse {
+        await router.handle(RPCRequest(method: method, params: params))
+    }
+
+    private let cloudParams = #"{"provider": "claude-cloud", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1}"#
+    private let otherParams = #"{"provider": "fake", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1}"#
+
+    private let gatedMethods = [
+        "remote.create", "remote.stop", "remote.send", "remote.log",
+        "remote.rename", "remote.dismiss", "remote.setPin", "remote.reportAttachExit",
+    ]
+
+    /// Combination 1 of 4: outer OFF, inner OFF.
+    @Test func bothFlagsOffRefusesWithTheOuterMessage() async throws {
+        let cloud = FakeProviderInvoker(script: [])
+        let r = router(cloud: cloud)
+        for method in gatedMethods {
+            let response = await call(r, method, cloudParams)
+            #expect(response.error == "remote backends disabled", "\(method)")
+        }
+        #expect(cloud.calls.isEmpty)
+    }
+
+    /// Combination 2 of 4: outer OFF, inner ON. The outer gate still wins —
+    /// the inner flag is a second gate INSIDE the first, never a bypass.
+    @Test func theInnerFlagAloneNeverBypassesTheOuterGate() async throws {
+        try await db.config.setClaudeCloud(true)
+        let cloud = FakeProviderInvoker(script: [])
+        let r = router(cloud: cloud)
+        for method in gatedMethods {
+            let response = await call(r, method, cloudParams)
+            #expect(response.error == "remote backends disabled", "\(method)")
+        }
+        #expect(cloud.calls.isEmpty)
+    }
+
+    /// Combination 3 of 4: outer ON, inner OFF. This is the case the inner
+    /// gate exists for — a user who turned cloud off after boot.
+    @Test func theOuterFlagAloneRefusesEveryCloudVerb() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let cloud = FakeProviderInvoker(script: [])
+        let r = router(cloud: cloud)
+        for method in gatedMethods {
+            let response = await call(r, method, cloudParams)
+            #expect(response.error == "claude cloud sessions disabled", "\(method)")
+        }
+        #expect(cloud.calls.isEmpty, "no cloud verb may be invoked while the inner flag is off")
+    }
+
+    /// The discriminating half of combination 3: a NON-cloud provider is
+    /// untouched by the inner gate, so the gate did not become a second outer
+    /// flag.
+    @Test func aNonCloudProviderIsUnaffectedByTheInnerGate() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let r = router(cloud: FakeProviderInvoker(script: []))
+        let response = await call(r, "remote.dismiss", otherParams)
+        #expect(response.success)
+    }
+
+    /// Combination 4 of 4: both ON — the verb reaches the provider.
+    @Test func bothFlagsOnLetsACloudVerbThrough() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setClaudeCloud(true)
+        let cloud = FakeProviderInvoker(script: [providerOK("{}")])
+        let r = router(cloud: cloud)
+        let response = await call(r, "remote.send", cloudParams)
+        #expect(response.success)
+        #expect(cloud.calls == [["send", "s"]])
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeCloudGateTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudGateTests.swift
@@ -56,10 +56,16 @@ struct ClaudeCloudGateTests: ~Copyable {
     private let cloudParams = #"{"provider": "claude-cloud", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1}"#
     private let otherParams = #"{"provider": "fake", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1}"#
 
-    private let gatedMethods = [
-        "remote.create", "remote.stop", "remote.send", "remote.log",
-        "remote.rename", "remote.dismiss", "remote.setPin", "remote.reportAttachExit",
-    ]
+    /// Drawn from `RPCMethod.providerNamedRemoteMethods` — the production
+    /// list of every `remote.*` verb addressed by a provider — rather than
+    /// hand-duplicated here, so this suite cannot independently drift into
+    /// agreeing with a gap the way it did for `remote.archive`/
+    /// `remote.unarchive`: both being ungated and both being absent from this
+    /// list were the same mistake made twice, and a single source closes one
+    /// of the two ways to make it. See the doc comment on
+    /// `providerNamedRemoteMethods` for what still isn't mechanically
+    /// enforced.
+    private let gatedMethods = RPCMethod.providerNamedRemoteMethods
 
     /// Combination 1 of 4: outer OFF, inner OFF.
     @Test func bothFlagsOffRefusesWithTheOuterMessage() async throws {
@@ -117,5 +123,61 @@ struct ClaudeCloudGateTests: ~Copyable {
         let response = await call(r, "remote.send", cloudParams)
         #expect(response.success)
         #expect(cloud.calls == [["send", "s"]])
+    }
+
+    // MARK: - The worktree-addressed route
+
+    /// `worktree.archive` / `worktree.revive` reach the same `archive` /
+    /// `unarchive` provider verbs as `remote.archive` / `remote.unarchive`,
+    /// but address the provider by the worktree's bound `location` rather
+    /// than by a `provider` param — a second route to the identical hole
+    /// this suite's `gatedMethods` list cannot see, because that route never
+    /// calls a `remote.*` method at all. Seeds a lane bound to `claude-cloud`
+    /// and drives both verbs through it.
+    private func seedCloudLane() async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
+            provider: ClaudeCloudProvider.name, sessionID: "s")
+        _ = try await db.remoteSessions.upsertOne(
+            provider: ClaudeCloudProvider.name,
+            session: RemoteSessionPayload(id: "s", state: .running, agentState: .idle),
+            now: Date())
+        return worktree
+    }
+
+    /// Outer ON, inner OFF — the case the inner gate exists for. Neither verb
+    /// may reach the provider, and the refusal is the inner gate's message,
+    /// not a capability refusal or a not-yet-known-provider error.
+    @Test func worktreeAddressedArchiveAndReviveAreAlsoCloudGated() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let cloud = FakeProviderInvoker(script: [])
+        let r = router(cloud: cloud)
+        let lane = try await seedCloudLane()
+
+        let archiveResponse = await r.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive, params: WorktreeArchiveParams(worktreeID: lane.id)))
+        #expect(archiveResponse.error == "claude cloud sessions disabled")
+
+        let reviveResponse = await r.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive, params: WorktreeReviveParams(worktreeID: lane.id)))
+        #expect(reviveResponse.error == "claude cloud sessions disabled")
+
+        #expect(cloud.calls.isEmpty, "no cloud verb, and no describe probe, may run while the inner flag is off")
+    }
+
+    /// Both flags off: the outer gate refuses first, same as every other
+    /// route.
+    @Test func worktreeAddressedArchiveRefusesWithTheOuterMessageWhenBothFlagsAreOff() async throws {
+        let cloud = FakeProviderInvoker(script: [])
+        let r = router(cloud: cloud)
+        let lane = try await seedCloudLane()
+
+        let response = await r.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive, params: WorktreeArchiveParams(worktreeID: lane.id)))
+
+        #expect(response.error == "remote backends disabled")
+        #expect(cloud.calls.isEmpty)
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -1184,6 +1184,142 @@ struct ClaudeCloudInvokerTests {
     ) -> ClaudeCloudInvoker {
         ClaudeCloudInvoker(db: db, spawner: spawner, now: now)
     }
+
+    // MARK: - markFailed compare-and-set
+
+    /// The gap `markFailed` must not stamp over: `list()` reads rows in one
+    /// transaction, computes the expired-pending ids from that snapshot, and
+    /// writes `markFailed` in a SEPARATE transaction. If a `create` resolves
+    /// in between, the batch `markFailed` receives still names a row that is
+    /// no longer pending. This drives that exact read-then-write
+    /// interleaving directly against the store — `rows()` first, `resolve`
+    /// second, `markFailed` last with the STALE ids from the first read — so
+    /// the test is deterministic instead of racing a real gap.
+    ///
+    /// Against the pre-fix unguarded UPDATE, this row is stamped back to
+    /// `failed` and loses nothing on its face (the row count never moves,
+    /// see the finding), but its `sessionID` is orphaned: `list()` only
+    /// projects `resolved` rows, so the session would vanish from every
+    /// future `list` with no discovery to recover it.
+    @Test func markFailedSkipsARowThatResolvedInTheGapSinceItWasRead() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let created = Date(timeIntervalSince1970: 1_000_000)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: "{}", now: created)
+
+        // The read `list()` takes before deciding which ids are expired.
+        let snapshot = try await db.claudeCloudSessions.rows()
+        #expect(snapshot.map(\.id) == [row.id])
+
+        // A `create` resolves in the gap between that read and the write
+        // below — this is the interleaving `list()`'s two separate
+        // transactions cannot prevent.
+        let resolvedAt = created.addingTimeInterval(650)
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAAAAAAAAAAAAAAAAAAAAA",
+            title: "Add probe", now: resolvedAt)
+
+        // The stale batch computed from the earlier snapshot — exactly what
+        // `list()` would pass, since `row` was still `pending` and past the
+        // window when the snapshot was taken.
+        try await db.claudeCloudSessions.markFailed(ids: snapshot.map(\.id))
+
+        let after = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(after.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(after.sessionID == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+    }
+
+    /// The other half: a row that is genuinely still `pending` when
+    /// `markFailed` runs must still be marked `failed` — the
+    /// compare-and-set narrows WHICH rows the sweep touches, it must not
+    /// disable the sweep entirely. A CAS that never matches anything would
+    /// make the test above pass while silently breaking the whole
+    /// pending-failure mechanism, so this is the discriminating positive.
+    @Test func markFailedStillFailsARowThatIsGenuinelyStillPending() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let created = Date(timeIntervalSince1970: 1_000_000)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: "{}", now: created)
+
+        try await db.claudeCloudSessions.markFailed(ids: [row.id])
+
+        let after = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(after.state == ClaudeCloudLedgerState.failed.rawValue)
+    }
+
+    /// The downstream consequence, chained onto the exact interleaving from
+    /// `markFailedSkipsARowThatResolvedInTheGapSinceItWasRead`: read, then
+    /// resolve, then a stale `markFailed`. With that CAS in place the row
+    /// stays `resolved`, and `create`'s own fast path (a `resolved` row with
+    /// a session id is answered before `claimForSpawn` is even consulted) is
+    /// what protects a replay in the common case.
+    ///
+    /// That leaves the SECOND guard — `claimForSpawn`'s `.failed` branch —
+    /// untested by that path alone, because it is never reached once the row
+    /// stays `resolved`. So this test goes one step further and forces the
+    /// row to `failed` while it still names a session, exactly the shape
+    /// `claimForSpawn`'s doc comment names as possible ("a resolve landing
+    /// in the gap … or any future writer that stamps failed without
+    /// clearing sessionID") — a shape `markFailed`'s own CAS can no longer
+    /// produce through `list()`'s sweep, which is why it has to be written
+    /// directly here to exercise `claimForSpawn`'s guard in isolation from
+    /// `markFailed`'s.
+    ///
+    /// Asserted on the SPAWN COUNT and the returned session id, not the
+    /// ledger row count — the unique index on `idempotencyKey` pins the row
+    /// count at 1 either way, which is exactly why this class of bug hides
+    /// behind a row-count assertion. Without the guard, this row is
+    /// reclaimed unconditionally and a second real `claude --cloud` spawns,
+    /// silently overwriting the first session's id on the next `resolve`.
+    @Test func aFailedRowThatStillNamesASessionIsNeverReclaimedAndRespawned() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let created = Date(timeIntervalSince1970: 1_000_000)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: "{}", now: created)
+
+        let snapshot = try await db.claudeCloudSessions.rows()
+        let resolvedAt = created.addingTimeInterval(650)
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAAAAAAAAAAAAAAAAAAAAA",
+            title: "Add probe", now: resolvedAt)
+        try await db.claudeCloudSessions.markFailed(ids: snapshot.map(\.id))
+        #expect(
+            try await db.claudeCloudSessions.rows().first?.state
+                == ClaudeCloudLedgerState.resolved.rawValue,
+            "the CAS above must have left this row alone")
+
+        // The hypothetical `claimForSpawn`'s own doc comment names: some
+        // other writer stamps the row `failed` without clearing `sessionID`.
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "UPDATE claude_cloud_session SET state = ? WHERE id = ?",
+                arguments: [ClaudeCloudLedgerState.failed.rawValue, row.id])
+        }
+
+        // Scripted rather than empty, so a regression that DOES reclaim and
+        // respawn fails on a clean assertion mismatch instead of crashing
+        // the run on `FakeClaudeSpawner`'s exhausted-script precondition.
+        let respawnOutput = """
+            Created cloud session: Second spawn
+            View: https://claude.ai/code/session_01BBBBBBBBBBBBBBBBBBBBBB?from=cli&m=0
+            Resume with: claude --teleport session_01BBBBBBBBBBBBBBBBBBBBBB
+            """
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: respawnOutput, stderr: "")
+        ])
+        let result = try await invoker(db: db, spawner: spawner, now: { resolvedAt }).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 0)
+        #expect(
+            spawner.requestsSnapshot().isEmpty,
+            "a failed row that still names a session must answer from it, not spawn")
+        let session = try result.decoded(RemoteSessionPayload.self)
+        #expect(session.id == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+    }
 }
 
 /// Lets a test hold one spawn open and observe that it started.

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -202,4 +202,212 @@ struct ClaudeCloudInvokerTests {
         #expect(result.exitCode == 2)
         #expect(result.failureClass == .contractBug)
     }
+
+    // MARK: - create
+
+    private func createBody(
+        repo: String = "acme/api", branch: String? = "fix-ci",
+        prompt: String = "add a probe", key: String = "tbd-1"
+    ) -> Data {
+        var params: [String: String] = ["repo": repo, "prompt": prompt]
+        if let branch { params["branch"] = branch }
+        let body: [String: Any] = ["params": params, "idempotency_key": key]
+        return try! JSONSerialization.data(withJSONObject: body)
+    }
+
+    private func seedRepo(_ db: TBDDatabase) async throws {
+        _ = try await db.repos.create(
+            path: "/tmp/api", displayName: "api", defaultBranch: "main",
+            remoteURL: "https://github.com/acme/api")
+    }
+
+    private let successOutput = """
+        Created cloud session: Add probe pong reply
+        View: https://claude.ai/code/session_01AAAAAAAAAAAAAAAAAAAAAA?from=cli&m=0
+        Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA
+        """
+
+    @Test func createSpawnsOnAPseudoTerminalInTheRepoCheckoutAndReturnsTheSession() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+
+        #expect(result.exitCode == 0)
+        let request = try #require(spawner.requestsSnapshot().first)
+        #expect(request.arguments == ["--cloud", "add a probe"])
+        #expect(request.workingDirectory == "/tmp/api")
+        // Non-negotiable: the CLI refuses `--cloud` creation on a pipe, so a
+        // piped spawn does not degrade — it never works.
+        #expect(request.usesPseudoTerminal)
+
+        let session = try result.decoded(RemoteSessionPayload.self)
+        #expect(session.id == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+        // The name comes from the VENDOR's server-derived summary…
+        #expect(session.title == "Add probe pong reply")
+        // …never from what was submitted.
+        #expect(session.title != "add a probe")
+        // The ledger knows a session was created; it does not know whether it
+        // lives, and the contract forbids guessing.
+        #expect(session.state == .unknown)
+        #expect(session.agentState == .unknown)
+        #expect(session.meta?["repo"] == "acme/api")
+        #expect(session.meta?["branch"] == "fix-ci")
+    }
+
+    @Test func createWritesTheLedgerRowBeforeResolvingIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        _ = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        let row = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(row.idempotencyKey == "tbd-1")
+        #expect(row.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(row.sessionID == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+        #expect(row.title == "Add probe pong reply")
+        #expect(row.repoKey == "acme/api")
+        #expect(row.repoPath == "/tmp/api")
+        #expect(row.branch == "fix-ci")
+        #expect(row.archived == false)
+    }
+
+    /// An unreadable id costs the lane its identity, so it fails LOUDLY as a
+    /// contract bug — and the pending row it left behind is what keeps that
+    /// failure from being silent.
+    @Test func anUnreadableSessionIDFailsTheCreateAndLeavesThePendingRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: "Something went sideways")
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 2)
+        #expect(result.failureClass == .contractBug)
+        #expect(result.decodedError?.message.contains("Something went sideways") == true)
+        let row = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(row.state == ClaudeCloudLedgerState.pending.rawValue)
+        #expect(row.sessionID == nil)
+    }
+
+    @Test func conflictingSessionIDsAlsoFailAsAContractBug() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: """
+                Created cloud session: two
+                View: https://claude.ai/code/session_01AAA?from=cli
+                Resume with: claude --teleport session_01BBB
+                """)
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.failureClass == .contractBug)
+        #expect(try await db.claudeCloudSessions.rows().first?.state
+            == ClaudeCloudLedgerState.pending.rawValue)
+    }
+
+    /// The opposite posture, and the pair that discriminates: an unreadable
+    /// TITLE must never fail a create that produced a readable id.
+    @Test func anUnreadableTitleStillSucceedsAndNamesTheRowFromItsID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output:
+                "Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA")
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 0)
+        let session = try result.decoded(RemoteSessionPayload.self)
+        #expect(session.id == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+        #expect(session.title == nil)
+        #expect(try await db.claudeCloudSessions.rows().first?.title == nil)
+    }
+
+    /// The single same-key retry must find the row it already wrote, keeping
+    /// the original timestamp — the failure window is measured from the
+    /// create, not from the retry.
+    @Test func replayingTheSameIdempotencyKeyReusesTheSameLedgerRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: successOutput),
+            .completed(status: 0, output: successOutput),
+        ])
+        let inv = invoker(db: db, spawner: spawner)
+        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+                              timeout: 60, contractVersion: 2)
+        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+                              timeout: 60, contractVersion: 2)
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    @Test func aNonZeroVendorExitIsAPermanentFailureCarryingItsOutput() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 1, output: "Error: not logged in")
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 1)
+        #expect(result.failureClass == .permanent)
+        #expect(result.decodedError?.message.contains("not logged in") == true)
+    }
+
+    /// A timeout is thrown, not synthesized, because the handler's single
+    /// same-key retry is armed by `ProviderRunError` — and that retry is
+    /// exactly what the pending ledger row exists to make safe.
+    @Test func aSpawnTimeoutThrowsSoTheHandlerCanRetryTheSameKey() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.timedOut])
+        await #expect(throws: ProviderRunError.self) {
+            _ = try await invoker(db: db, spawner: spawner).run(
+                config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        }
+        #expect(try await db.claudeCloudSessions.rows().first?.state
+            == ClaudeCloudLedgerState.pending.rawValue)
+    }
+
+    @Test func anUnregisteredRepositoryIsRefusedBeforeAnythingIsSpawned() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(repo: "acme/unknown"),
+            timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 1)
+        #expect(result.decodedError?.code == "not_found")
+        #expect(spawner.requestsSnapshot().isEmpty)
+        #expect(try await db.claudeCloudSessions.rows().isEmpty)
+    }
+
+    @Test func aBlankPromptIsRefusedBeforeAnythingIsSpawned() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(prompt: "   "),
+            timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 2)
+        #expect(result.decodedError?.code == "invalid_params")
+        #expect(spawner.requestsSnapshot().isEmpty)
+    }
+
+    /// The measured CLI surface exposes no flag for either, so they are
+    /// RECORDED and reported rather than submitted. Do not invent flags.
+    @Test func branchAndEnvironmentAreRecordedNotPassedToTheCLI() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        _ = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        let request = try #require(spawner.requestsSnapshot().first)
+        #expect(!request.arguments.contains("fix-ci"))
+        #expect(!request.arguments.contains(where: { $0.hasPrefix("--branch") }))
+        #expect(try await db.claudeCloudSessions.rows().first?.branch == "fix-ci")
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -40,7 +40,13 @@ final class FakeClaudeSpawner: ClaudeCloudSpawning, @unchecked Sendable {
     }
 }
 
-// Tier 1: pure over injected values.
+// Tier 1 + Tier 2: the two `invocationEnvironment` tests are pure over
+// injected values (no subprocess, no filesystem); the two `spawn(_:)` tests
+// spawn short-lived local processes (`/usr/bin/env`) this suite fully
+// controls, with generous (5s) timeouts against near-instant children — no
+// deadline-racing test belongs in this file. `.timedOut`-outcome coverage
+// lives in `Tests/TBDDaemonLiveTests/ClaudeCloudSpawnerTimeoutTests.swift`
+// (Tier 3), per `Tests/CLAUDE.md`'s "spawns a child racing a deadline" rule.
 @Suite("ClaudeCloudInvoker")
 struct ClaudeCloudInvokerTests {
     /// The pty is a capture surface at 400x200, but the child still formats
@@ -123,21 +129,5 @@ struct ClaudeCloudInvokerTests {
         #expect(status == 0)
         #expect(!output.contains("COLUMNS=400"))
         #expect(!output.contains("LINES=200"))
-    }
-
-    /// `.timedOut` must pass through the outcome mapping untouched — the
-    /// other branch of the `switch` in `spawn(_:)`. `/bin/sh -c "sleep 5"`
-    /// against a far shorter deadline exercises the real watchdog rather
-    /// than asserting the mapping in isolation.
-    @Test func spawnMapsATimeoutToTimedOut() async throws {
-        let tmp = FileManager.default.temporaryDirectory.path
-        let spawner = BoundedProcessClaudeSpawner(executable: "/bin/sh")
-        let outcome = try await spawner.spawn(
-            ClaudeCloudSpawnRequest(
-                arguments: ["-c", "sleep 5"],
-                workingDirectory: tmp,
-                usesPseudoTerminal: false,
-                timeout: 0.2))
-        #expect(outcome == .timedOut)
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -482,4 +482,148 @@ struct ClaudeCloudInvokerTests {
         let request = try #require(spawner.requestsSnapshot().first)
         #expect(request.timeout == 137)
     }
+
+    // MARK: - list
+
+    private func listSessions(_ result: ProviderResult) throws -> [[String: Any]] {
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: result.stdout) as? [String: Any])
+        return try #require(object["sessions"] as? [[String: Any]])
+    }
+
+    private func listEnvelope(_ result: ProviderResult) throws -> [String: Any] {
+        try #require(try JSONSerialization.jsonObject(with: result.stdout) as? [String: Any])
+    }
+
+    /// Permanently `complete: false`, by construction and not by care. The
+    /// ledger is a record of what THIS machine started and never a claim
+    /// about the account's inventory — no supported interface enumerates one.
+    /// A provider that never claims completeness cannot cause a false
+    /// retirement however wrong its view is.
+    @Test func listIsAlwaysIncompleteEvenWhenEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let result = try await invoker(db: db, spawner: FakeClaudeSpawner(outcomes: [])).run(
+            config(), verb: ["list"], stdin: nil, timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 0)
+        #expect(try listEnvelope(result)["complete"] as? Bool == false)
+        #expect(try listSessions(result).isEmpty)
+    }
+
+    @Test func listNeverSpawnsTheVendorCLI() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let inv = invoker(db: db, spawner: spawner)
+        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+                              timeout: 60, contractVersion: 2)
+        _ = try await inv.run(config(), verb: ["list"], stdin: nil,
+                              timeout: 30, contractVersion: 2)
+        // Exactly the one create spawn; `list` reads the ledger and nothing
+        // else, so there is no discovery call to make.
+        #expect(spawner.requestsSnapshot().count == 1)
+    }
+
+    @Test func aResolvedRowIsListedUnknownOnBothAxesCarryingItsRepoAndTitle() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let inv = invoker(db: db, spawner: spawner)
+        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+                              timeout: 60, contractVersion: 2)
+        let sessions = try listSessions(
+            try await inv.run(config(), verb: ["list"], stdin: nil,
+                              timeout: 30, contractVersion: 2))
+        #expect(sessions.count == 1)
+        let session = try #require(sessions.first)
+        #expect(session["id"] as? String == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+        #expect(session["title"] as? String == "Add probe pong reply")
+        #expect(session["state"] as? String == "unknown")
+        #expect(session["agent_state"] as? String == "unknown")
+        let meta = try #require(session["meta"] as? [String: String])
+        #expect(meta["repo"] == "acme/api")
+        #expect(meta["branch"] == "fix-ci")
+    }
+
+    /// **`archived` is emitted EXPLICITLY on every session, `false` included.**
+    /// The wire field is three-valued: absent means "no claim made" and moves
+    /// no row, which is what stops a provider with no archiving concept from
+    /// dragging archived rows back into the active list every minute. Omitting
+    /// it when unarchived would mean TBD never observes the `false`
+    /// transition, and unarchiving through this ledger would not return the
+    /// row to the active list at all. Asserting on the RAW JSON is what
+    /// discriminates — a decoded `Bool?` would read `nil` and `false` alike
+    /// through `isArchived`.
+    @Test func listEmitsArchivedExplicitlyEvenWhenFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let inv = invoker(db: db, spawner: spawner)
+        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+                              timeout: 60, contractVersion: 2)
+        let session = try #require(try listSessions(
+            try await inv.run(config(), verb: ["list"], stdin: nil,
+                              timeout: 30, contractVersion: 2)).first)
+        #expect(session.keys.contains("archived"), "the field must be PRESENT, not omitted")
+        #expect(session["archived"] as? Bool == false)
+    }
+
+    /// The contract requires archived sessions to stay enumerated: one
+    /// filtered out of successive snapshots is indistinguishable from a
+    /// deleted one, and would be silently marked gone.
+    @Test func anArchivedLedgerRowStaysEnumeratedWithItsFlagSet() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let inv = invoker(db: db, spawner: spawner)
+        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+                              timeout: 60, contractVersion: 2)
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: "UPDATE claude_cloud_session SET archived = 1")
+        }
+        let sessions = try listSessions(
+            try await inv.run(config(), verb: ["list"], stdin: nil,
+                              timeout: 30, contractVersion: 2))
+        #expect(sessions.count == 1)
+        #expect(sessions.first?["archived"] as? Bool == true)
+    }
+
+    /// A row with no session id names no session, so there is nothing to
+    /// list. It is still retained, and still visible as an unresolved create.
+    @Test func pendingAndFailedRowsAreNotListed() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "k", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1_000_000))
+        let result = try await invoker(db: db, spawner: FakeClaudeSpawner(outcomes: [])).run(
+            config(), verb: ["list"], stdin: nil, timeout: 30, contractVersion: 2)
+        #expect(try listSessions(result).isEmpty)
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    /// A create whose output could not be read stays `pending` through the
+    /// window and only then becomes `failed` — retained either way.
+    @Test func aPendingRowFlipsToFailedOnlyOnceThePendingWindowHasElapsed() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let created = Date(timeIntervalSince1970: 1_000_000)
+        _ = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "k", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: created)
+
+        _ = try await invoker(
+            db: db, spawner: FakeClaudeSpawner(outcomes: []),
+            now: { created.addingTimeInterval(599) }
+        ).run(config(), verb: ["list"], stdin: nil, timeout: 30, contractVersion: 2)
+        #expect(try await db.claudeCloudSessions.rows().first?.state
+            == ClaudeCloudLedgerState.pending.rawValue)
+
+        _ = try await invoker(
+            db: db, spawner: FakeClaudeSpawner(outcomes: []),
+            now: { created.addingTimeInterval(601) }
+        ).run(config(), verb: ["list"], stdin: nil, timeout: 30, contractVersion: 2)
+        let row = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(row.state == ClaudeCloudLedgerState.failed.rawValue)
+        // Retained: the record of a create that may have started a real
+        // session outlives the judgement that it did not.
+        #expect(row.idempotencyKey == "k")
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -1054,4 +1054,123 @@ struct ClaudeCloudInvokerTests {
         #expect(ClaudeCloudSendPayload.message(fromStdin: Data(interiorAndTrailing.utf8))
             == "one" + "\r\n" + "two")
     }
+
+    /// Two replays of a key the pending window already gave up on must
+    /// produce exactly ONE spawn.
+    ///
+    /// The gate is what makes this discriminating rather than lucky: it holds
+    /// the first spawn open, so the second `create` provably does its own
+    /// claim while the first is still in flight. Two bare concurrent calls
+    /// need not interleave at all, and would pass against the very race this
+    /// exists to catch.
+    ///
+    /// Asserted on the SPAWN count, not the row count: the unique index on
+    /// `idempotencyKey` keeps the ledger at one row either way, so a row-count
+    /// assertion is exactly the one that cannot see this bug. A second spawn
+    /// starts a second real cloud session, and with no discovery to reconcile
+    /// the two, whichever `resolve` lands second overwrites the first id.
+    @Test func twoConcurrentReplaysOfAFailedKeySpawnOnlyOnce() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: "{}",
+            now: Date(timeIntervalSince1970: 1_000_000))
+        try await db.claudeCloudSessions.markFailed(ids: [row.id])
+
+        let gate = SpawnGate()
+        let spawner = GatedClaudeSpawner(
+            gate: gate, outcome: .completed(status: 0, output: successOutput, stderr: ""))
+        let inv = gatedInvoker(db: db, spawner: spawner)
+
+        async let firstResult = inv.run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        // Resumes only once the first spawn is genuinely under way.
+        await gate.waitUntilEntered()
+        let second = try await inv.run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        await gate.release()
+        let first = try await firstResult
+
+        #expect(spawner.requestsSnapshot().count == 1)
+        #expect(first.exitCode == 0)
+        #expect(second.exitCode == 3)
+        #expect(second.failureClass == .transient)
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    private func gatedInvoker(
+        db: TBDDatabase, spawner: GatedClaudeSpawner,
+        now: @escaping @Sendable () -> Date = { Date(timeIntervalSince1970: 1_000_000) }
+    ) -> ClaudeCloudInvoker {
+        ClaudeCloudInvoker(db: db, spawner: spawner, now: now)
+    }
+}
+
+/// Lets a test hold one spawn open and observe that it started.
+actor SpawnGate {
+    private var entered = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releasedFlag = false
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func markEntered() {
+        entered = true
+        for waiter in enteredWaiters { waiter.resume() }
+        enteredWaiters = []
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func release() {
+        releasedFlag = true
+        for waiter in releaseWaiters { waiter.resume() }
+        releaseWaiters = []
+    }
+
+    func waitUntilReleased() async {
+        if releasedFlag { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+}
+
+/// Records every spawn and parks the FIRST one until the test releases it, so
+/// a concurrency test can put a second caller through its claim while the
+/// first is provably still spawning.
+final class GatedClaudeSpawner: ClaudeCloudSpawning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [ClaudeCloudSpawnRequest] = []
+    private let gate: SpawnGate
+    private let outcome: ClaudeCloudSpawnOutcome
+
+    init(gate: SpawnGate, outcome: ClaudeCloudSpawnOutcome) {
+        self.gate = gate
+        self.outcome = outcome
+    }
+
+    func spawn(_ request: ClaudeCloudSpawnRequest) async throws -> ClaudeCloudSpawnOutcome {
+        if record(request) {
+            await gate.markEntered()
+            await gate.waitUntilReleased()
+        }
+        return outcome
+    }
+
+    /// Synchronous so the NSLock critical section is not taken from an async
+    /// context. Returns whether this was the first spawn.
+    private func record(_ request: ClaudeCloudSpawnRequest) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        requests.append(request)
+        return requests.count == 1
+    }
+
+    func requestsSnapshot() -> [ClaudeCloudSpawnRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -626,4 +626,100 @@ struct ClaudeCloudInvokerTests {
         // session outlives the judgement that it did not.
         #expect(row.idempotencyKey == "k")
     }
+
+    // MARK: - send
+
+    private let sendOK = #"{"ok":true,"session_id":"session_01AAA","url":"https://claude.ai/code/session_01AAA"}"#
+
+    /// The contract's `send` takes stdin bytes destined for a terminal and
+    /// requires the caller to append `\r` when it means Enter. A session with
+    /// no terminal takes that trailing submit gesture off and treats the rest
+    /// as ONE message — so interior newlines stay one multi-line message
+    /// rather than becoming several.
+    @Test func theSubmitGestureIsStrippedAndInteriorNewlinesSurvive() {
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data("hello\r".utf8)) == "hello")
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data("hello\n".utf8)) == "hello")
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data("hello".utf8)) == "hello")
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data("one\ntwo\r".utf8)) == "one\ntwo")
+        // Exactly ONE trailing terminator, so a deliberate blank last line
+        // survives the strip.
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data("one\n\n".utf8)) == "one\n")
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data("\r".utf8)) == nil)
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data()) == nil)
+    }
+
+    @Test func sendPostsOneMessageOnAPipeAndReportsSuccess() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: sendOK)])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("try again\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 0)
+        let request = try #require(spawner.requestsSnapshot().first)
+        #expect(request.arguments
+            == ["-p", "try again", "--cloud", "session_01AAA", "--output-format", "json"])
+        // `--print` is explicitly a NON-interactive invocation and returns
+        // JSON on an ordinary pipe. A pty here would merge stderr into that
+        // JSON.
+        #expect(request.usesPseudoTerminal == false)
+        // The contract's `send` answers `{}`; exit 0 means the bytes were
+        // handed to the transport, not that the agent acted on them.
+        #expect(try JSONSerialization.jsonObject(with: result.stdout) is [String: Any])
+    }
+
+    /// `ok` plus a `session_id` matching the id sent is the success
+    /// condition — a reply about a DIFFERENT session is not a success.
+    @Test func aMismatchedSessionIDInTheReplyIsAFailure() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: #"{"ok":true,"session_id":"session_01ZZZ"}"#)
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 1)
+        #expect(result.decodedError?.message.contains("session_01ZZZ") == true)
+    }
+
+    @Test func anOkFalseReplyIsAFailure() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: #"{"ok":false,"session_id":"session_01AAA"}"#)
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 1)
+    }
+
+    @Test func unparseableSendOutputIsAFailureCarryingWhatArrived() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: "not json")])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 1)
+        #expect(result.decodedError?.message.contains("not json") == true)
+    }
+
+    @Test func anEmptyMessageIsRefusedBeforeAnythingIsSpawned() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 2)
+        #expect(result.decodedError?.code == "invalid_params")
+        #expect(spawner.requestsSnapshot().isEmpty)
+    }
+
+    @Test func aSendTimeoutIsTransientRatherThanPermanent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [.timedOut])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 3)
+        #expect(result.failureClass == .transient)
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -207,10 +207,12 @@ struct ClaudeCloudInvokerTests {
 
     private func createBody(
         repo: String = "acme/api", branch: String? = "fix-ci",
+        environment: String? = nil,
         prompt: String = "add a probe", key: String = "tbd-1"
     ) -> Data {
         var params: [String: String] = ["repo": repo, "prompt": prompt]
         if let branch { params["branch"] = branch }
+        if let environment { params["environment"] = environment }
         let body: [String: Any] = ["params": params, "idempotency_key": key]
         return try! JSONSerialization.data(withJSONObject: body)
     }
@@ -356,6 +358,11 @@ struct ClaudeCloudInvokerTests {
         #expect(result.exitCode == 1)
         #expect(result.failureClass == .permanent)
         #expect(result.decodedError?.message.contains("not logged in") == true)
+        // The ledger row written before the spawn is the record of what was
+        // asked for; a permanent vendor failure must leave it exactly where
+        // it was, not resolved and not deleted.
+        #expect(try await db.claudeCloudSessions.rows().first?.state
+            == ClaudeCloudLedgerState.pending.rawValue)
     }
 
     /// A timeout is thrown, not synthesized, because the handler's single
@@ -395,6 +402,9 @@ struct ClaudeCloudInvokerTests {
         #expect(result.exitCode == 2)
         #expect(result.decodedError?.code == "invalid_params")
         #expect(spawner.requestsSnapshot().isEmpty)
+        // A refusal this early must not even write the pending row — nothing
+        // was validated enough yet to be worth recording.
+        #expect(try await db.claudeCloudSessions.rows().isEmpty)
     }
 
     /// The measured CLI surface exposes no flag for either, so they are
@@ -409,5 +419,67 @@ struct ClaudeCloudInvokerTests {
         #expect(!request.arguments.contains("fix-ci"))
         #expect(!request.arguments.contains(where: { $0.hasPrefix("--branch") }))
         #expect(try await db.claudeCloudSessions.rows().first?.branch == "fix-ci")
+    }
+
+    /// `environment` is persisted on the ledger row exactly like `branch`
+    /// (per `ClaudeCloudCreate`'s own doc comment); it must also reach the
+    /// wire payload's `meta`, or a value that safely round-trips through the
+    /// database is invisible to every caller for the rest of this slice —
+    /// `list` answers from the ledger alone and has no discovery to re-supply
+    /// it with later.
+    @Test func createIncludesEnvironmentInMetaWhenSupplied() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"],
+            stdin: createBody(environment: "prod"), timeout: 60, contractVersion: 2)
+        let session = try result.decoded(RemoteSessionPayload.self)
+        #expect(session.meta?["environment"] == "prod")
+        #expect(try await db.claudeCloudSessions.rows().first?.environment == "prod")
+    }
+
+    /// The pairing negative: no environment supplied must mean no
+    /// `"environment"` key at all, not an empty-string placeholder — `meta`
+    /// is inspected by presence, mirroring how `branch`'s absence is already
+    /// covered.
+    @Test func createOmitsEnvironmentFromMetaWhenNotSupplied() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        let session = try result.decoded(RemoteSessionPayload.self)
+        #expect(session.meta?["environment"] == nil)
+    }
+
+    /// The pairing negative for `branch`: an absent branch must produce a
+    /// `meta` with no `"branch"` key, not a stored empty string — the
+    /// omission path in the `meta` construction (`if let branch { … }`) had
+    /// no test exercising `branch == nil` at all.
+    @Test func createOmitsBranchFromMetaWhenNotSupplied() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"],
+            stdin: createBody(branch: nil), timeout: 60, contractVersion: 2)
+        let session = try result.decoded(RemoteSessionPayload.self)
+        #expect(session.meta?["branch"] == nil)
+        #expect(try await db.claudeCloudSessions.rows().first?.branch == nil)
+    }
+
+    /// `run`'s `timeout` parameter must actually reach the spawn request —
+    /// today it happens to work only because the sole production caller also
+    /// hardcodes 60, so a caller-supplied value that DIFFERS from 60 is the
+    /// only assertion that discriminates real wiring from that coincidence.
+    @Test func createThreadsTheCallersTimeoutIntoTheSpawnRequest() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        _ = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 137, contractVersion: 2)
+        let request = try #require(spawner.requestsSnapshot().first)
+        #expect(request.timeout == 137)
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Scriptable stand-in for the vendor CLI. **No test in this file, or any
+/// other, may invoke a real `claude` binary** — every vendor call goes
+/// through `ClaudeCloudSpawning`.
+final class FakeClaudeSpawner: ClaudeCloudSpawning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var script: [Result<ClaudeCloudSpawnOutcome, any Error>]
+    private(set) var requests: [ClaudeCloudSpawnRequest] = []
+
+    init(outcomes: [ClaudeCloudSpawnOutcome]) {
+        self.script = outcomes.map { .success($0) }
+    }
+
+    init(results: [Result<ClaudeCloudSpawnOutcome, any Error>]) {
+        self.script = results
+    }
+
+    func spawn(_ request: ClaudeCloudSpawnRequest) async throws -> ClaudeCloudSpawnOutcome {
+        try pop(request)
+    }
+
+    /// Synchronous so the NSLock critical section is not taken from an async
+    /// context (recent Foundation marks `NSLock.lock` unavailable there).
+    private func pop(_ request: ClaudeCloudSpawnRequest) throws -> ClaudeCloudSpawnOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        requests.append(request)
+        precondition(!script.isEmpty, "FakeClaudeSpawner script exhausted for \(request.arguments)")
+        return try script.removeFirst().get()
+    }
+
+    func requestsSnapshot() -> [ClaudeCloudSpawnRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+}
+
+// Tier 1: pure over injected values.
+@Suite("ClaudeCloudInvoker")
+struct ClaudeCloudInvokerTests {
+    /// The pty is a capture surface at 400x200, but the child still formats
+    /// to whatever width it is TOLD, so the width must be pinned rather than
+    /// inherited from whatever the daemon happened to be launched with.
+    @Test func aPseudoTerminalSpawnPinsTermAndGeometry() {
+        let env = BoundedProcessClaudeSpawner.invocationEnvironment(
+            base: ["PATH": "/usr/bin", "COLUMNS": "80", "TERM": "dumb"],
+            usesPseudoTerminal: true)
+        #expect(env["TERM"] == "xterm-256color")
+        #expect(env["COLUMNS"] == "400")
+        #expect(env["LINES"] == "200")
+        // The rest of the login environment survives: `runBoundedProcess`
+        // REPLACES the environment wholesale, so a partial dict would hand the
+        // child no PATH at all.
+        #expect(env["PATH"] == "/usr/bin")
+    }
+
+    /// The discriminating half: a piped spawn must NOT be handed a terminal's
+    /// vocabulary, or `send`'s JSON could arrive decorated.
+    @Test func aPipedSpawnLeavesTheGeometryAlone() {
+        let env = BoundedProcessClaudeSpawner.invocationEnvironment(
+            base: ["PATH": "/usr/bin", "COLUMNS": "80"], usesPseudoTerminal: false)
+        #expect(env["COLUMNS"] == "80")
+        #expect(env["LINES"] == nil)
+        #expect(env["PATH"] == "/usr/bin")
+    }
+
+    /// End-to-end over the real `spawn(_:)` implementation, not just the pure
+    /// helper: proves the production conformance actually wires
+    /// `usesPseudoTerminal` through to `runBoundedProcess`'s `stdio`
+    /// parameter and that the pinned values reach a REAL child's environment
+    /// — using `/usr/bin/env` so no vendor binary is touched. No `setenv`:
+    /// this repo's test suites keep the ambient process environment alone
+    /// (see `BoundedProcessRunnerTests.swift`'s file comment and the
+    /// injection-seam precedent throughout `Tests/TBDDaemonTests`) because
+    /// `setenv` is a process-wide mutation that races every suite running
+    /// concurrently in the same test binary. The pure-function tests above
+    /// already cover override-vs-inherit with an explicit conflicting `base`
+    /// dict; this test covers the wiring the pure tests cannot reach.
+    @Test func spawnPinsGeometryOnARealPseudoTerminalRun() async throws {
+        let tmp = FileManager.default.temporaryDirectory.path
+        let spawner = BoundedProcessClaudeSpawner(executable: "/usr/bin/env")
+        let outcome = try await spawner.spawn(
+            ClaudeCloudSpawnRequest(
+                arguments: [],
+                workingDirectory: tmp,
+                usesPseudoTerminal: true,
+                timeout: 5))
+        guard case let .completed(status, output) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(status == 0)
+        #expect(output.contains("TERM=xterm-256color"))
+        #expect(output.contains("COLUMNS=400"))
+        #expect(output.contains("LINES=200"))
+    }
+
+    /// A piped spawn must not gain a pty's vocabulary — proves the request
+    /// flag actually reaches `runBoundedProcess`'s `stdio` parameter, not
+    /// just the pure environment helper. No realistic ambient test
+    /// environment carries `COLUMNS=400`/`LINES=200` on its own (unlike
+    /// `TERM`, which a real dev/CI shell may legitimately already set to
+    /// `xterm-256color` — passthrough, not pinning — so that key is not
+    /// asserted here), so their absence is a meaningful negative.
+    @Test func spawnLeavesGeometryAloneOnAPipedRun() async throws {
+        let tmp = FileManager.default.temporaryDirectory.path
+        let spawner = BoundedProcessClaudeSpawner(executable: "/usr/bin/env")
+        let outcome = try await spawner.spawn(
+            ClaudeCloudSpawnRequest(
+                arguments: [],
+                workingDirectory: tmp,
+                usesPseudoTerminal: false,
+                timeout: 5))
+        guard case let .completed(status, output) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(status == 0)
+        #expect(!output.contains("COLUMNS=400"))
+        #expect(!output.contains("LINES=200"))
+    }
+
+    /// `.timedOut` must pass through the outcome mapping untouched — the
+    /// other branch of the `switch` in `spawn(_:)`. `/bin/sh -c "sleep 5"`
+    /// against a far shorter deadline exercises the real watchdog rather
+    /// than asserting the mapping in isolation.
+    @Test func spawnMapsATimeoutToTimedOut() async throws {
+        let tmp = FileManager.default.temporaryDirectory.path
+        let spawner = BoundedProcessClaudeSpawner(executable: "/bin/sh")
+        let outcome = try await spawner.spawn(
+            ClaudeCloudSpawnRequest(
+                arguments: ["-c", "sleep 5"],
+                workingDirectory: tmp,
+                usesPseudoTerminal: false,
+                timeout: 0.2))
+        #expect(outcome == .timedOut)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -96,7 +96,7 @@ struct ClaudeCloudInvokerTests {
                 workingDirectory: tmp,
                 usesPseudoTerminal: true,
                 timeout: 5))
-        guard case let .completed(status, output) = outcome else {
+        guard case let .completed(status, output, _) = outcome else {
             Issue.record("expected .completed, got \(outcome)")
             return
         }
@@ -122,13 +122,59 @@ struct ClaudeCloudInvokerTests {
                 workingDirectory: tmp,
                 usesPseudoTerminal: false,
                 timeout: 5))
-        guard case let .completed(status, output) = outcome else {
+        guard case let .completed(status, output, _) = outcome else {
             Issue.record("expected .completed, got \(outcome)")
             return
         }
         #expect(status == 0)
         #expect(!output.contains("COLUMNS=400"))
         #expect(!output.contains("LINES=200"))
+    }
+
+    /// The discriminating case named in `ClaudeCloudSpawnOutcome`'s own doc
+    /// comment: on a plain pipe stdout and stderr are genuinely separate
+    /// descriptors, so `output` must carry stdout ALONE — stderr chatter on
+    /// an otherwise-successful call must never land where `send` parses
+    /// strict JSON.
+    @Test func spawnExcludesStderrFromOutputOnAPipedRun() async throws {
+        let tmp = FileManager.default.temporaryDirectory.path
+        let spawner = BoundedProcessClaudeSpawner(executable: "/bin/sh")
+        let outcome = try await spawner.spawn(
+            ClaudeCloudSpawnRequest(
+                arguments: ["-c", "printf 'out'; printf 'err' 1>&2"],
+                workingDirectory: tmp,
+                usesPseudoTerminal: false,
+                timeout: 5))
+        guard case let .completed(status, output, stderr) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(status == 0)
+        #expect(output == "out")
+        #expect(stderr == "err")
+    }
+
+    /// The pty side of the same pair: the two streams genuinely merge onto
+    /// one descriptor there, so `output` keeps carrying both — matching
+    /// `create`, which depends on that merge and is otherwise unaffected by
+    /// this task's fix.
+    @Test func spawnMergesStderrIntoOutputOnAPseudoTerminalRun() async throws {
+        let tmp = FileManager.default.temporaryDirectory.path
+        let spawner = BoundedProcessClaudeSpawner(executable: "/bin/sh")
+        let outcome = try await spawner.spawn(
+            ClaudeCloudSpawnRequest(
+                arguments: ["-c", "printf 'out'; printf 'err' 1>&2"],
+                workingDirectory: tmp,
+                usesPseudoTerminal: true,
+                timeout: 5))
+        guard case let .completed(status, output, stderr) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(status == 0)
+        #expect(output.contains("out"))
+        #expect(output.contains("err"))
+        #expect(stderr.isEmpty)
     }
 
     // MARK: - describe
@@ -232,7 +278,7 @@ struct ClaudeCloudInvokerTests {
     @Test func createSpawnsOnAPseudoTerminalInTheRepoCheckoutAndReturnsTheSession() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
 
@@ -261,7 +307,7 @@ struct ClaudeCloudInvokerTests {
     @Test func createWritesTheLedgerRowBeforeResolvingIt() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         _ = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
         let row = try #require(try await db.claudeCloudSessions.rows().first)
@@ -282,7 +328,7 @@ struct ClaudeCloudInvokerTests {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
         let spawner = FakeClaudeSpawner(outcomes: [
-            .completed(status: 0, output: "Something went sideways")
+            .completed(status: 0, output: "Something went sideways", stderr: "")
         ])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
@@ -302,7 +348,7 @@ struct ClaudeCloudInvokerTests {
                 Created cloud session: two
                 View: https://claude.ai/code/session_01AAA?from=cli
                 Resume with: claude --teleport session_01BBB
-                """)
+                """, stderr: "")
         ])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
@@ -318,7 +364,7 @@ struct ClaudeCloudInvokerTests {
         try await seedRepo(db)
         let spawner = FakeClaudeSpawner(outcomes: [
             .completed(status: 0, output:
-                "Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA")
+                "Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA", stderr: "")
         ])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
@@ -336,8 +382,8 @@ struct ClaudeCloudInvokerTests {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
         let spawner = FakeClaudeSpawner(outcomes: [
-            .completed(status: 0, output: successOutput),
-            .completed(status: 0, output: successOutput),
+            .completed(status: 0, output: successOutput, stderr: ""),
+            .completed(status: 0, output: successOutput, stderr: ""),
         ])
         let inv = invoker(db: db, spawner: spawner)
         _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
@@ -351,7 +397,7 @@ struct ClaudeCloudInvokerTests {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
         let spawner = FakeClaudeSpawner(outcomes: [
-            .completed(status: 1, output: "Error: not logged in")
+            .completed(status: 1, output: "Error: not logged in", stderr: "")
         ])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
@@ -412,7 +458,7 @@ struct ClaudeCloudInvokerTests {
     @Test func branchAndEnvironmentAreRecordedNotPassedToTheCLI() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         _ = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
         let request = try #require(spawner.requestsSnapshot().first)
@@ -430,7 +476,7 @@ struct ClaudeCloudInvokerTests {
     @Test func createIncludesEnvironmentInMetaWhenSupplied() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"],
             stdin: createBody(environment: "prod"), timeout: 60, contractVersion: 2)
@@ -446,7 +492,7 @@ struct ClaudeCloudInvokerTests {
     @Test func createOmitsEnvironmentFromMetaWhenNotSupplied() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
         let session = try result.decoded(RemoteSessionPayload.self)
@@ -460,7 +506,7 @@ struct ClaudeCloudInvokerTests {
     @Test func createOmitsBranchFromMetaWhenNotSupplied() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"],
             stdin: createBody(branch: nil), timeout: 60, contractVersion: 2)
@@ -476,7 +522,7 @@ struct ClaudeCloudInvokerTests {
     @Test func createThreadsTheCallersTimeoutIntoTheSpawnRequest() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         _ = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["create"], stdin: createBody(), timeout: 137, contractVersion: 2)
         let request = try #require(spawner.requestsSnapshot().first)
@@ -512,7 +558,7 @@ struct ClaudeCloudInvokerTests {
     @Test func listNeverSpawnsTheVendorCLI() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let inv = invoker(db: db, spawner: spawner)
         _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
                               timeout: 60, contractVersion: 2)
@@ -526,7 +572,7 @@ struct ClaudeCloudInvokerTests {
     @Test func aResolvedRowIsListedUnknownOnBothAxesCarryingItsRepoAndTitle() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let inv = invoker(db: db, spawner: spawner)
         _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
                               timeout: 60, contractVersion: 2)
@@ -556,7 +602,7 @@ struct ClaudeCloudInvokerTests {
     @Test func listEmitsArchivedExplicitlyEvenWhenFalse() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let inv = invoker(db: db, spawner: spawner)
         _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
                               timeout: 60, contractVersion: 2)
@@ -573,7 +619,7 @@ struct ClaudeCloudInvokerTests {
     @Test func anArchivedLedgerRowStaysEnumeratedWithItsFlagSet() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
         let inv = invoker(db: db, spawner: spawner)
         _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
                               timeout: 60, contractVersion: 2)
@@ -650,7 +696,7 @@ struct ClaudeCloudInvokerTests {
 
     @Test func sendPostsOneMessageOnAPipeAndReportsSuccess() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: sendOK)])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: sendOK, stderr: "")])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["send", "session_01AAA"], stdin: Data("try again\r".utf8),
             timeout: 30, contractVersion: 2)
@@ -667,12 +713,43 @@ struct ClaudeCloudInvokerTests {
         #expect(try JSONSerialization.jsonObject(with: result.stdout) is [String: Any])
     }
 
+    /// The fix this round of findings exists for: incidental stderr chatter
+    /// on an otherwise-successful pipe invocation must never break the
+    /// strict JSON parse `send` runs against `output` alone.
+    @Test func stderrChatterOnASuccessfulSendDoesNotBreakTheParse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: sendOK, stderr: "warning: something incidental\n")
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 0)
+    }
+
+    /// The non-zero-exit branch — named in the review brief's own
+    /// "check with particular care" list as one of the four cases a `send`
+    /// implementation must distinguish from success, and the one the brief's
+    /// own Step 1 test list omitted.
+    @Test func aNonZeroSendExitIsAPermanentFailureCarryingWhatArrived() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 1, output: "Error: not logged in", stderr: "")
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 1)
+        #expect(result.failureClass == .permanent)
+        #expect(result.decodedError?.message.contains("not logged in") == true)
+    }
+
     /// `ok` plus a `session_id` matching the id sent is the success
     /// condition — a reply about a DIFFERENT session is not a success.
     @Test func aMismatchedSessionIDInTheReplyIsAFailure() async throws {
         let db = try TBDDatabase(inMemory: true)
         let spawner = FakeClaudeSpawner(outcomes: [
-            .completed(status: 0, output: #"{"ok":true,"session_id":"session_01ZZZ"}"#)
+            .completed(status: 0, output: #"{"ok":true,"session_id":"session_01ZZZ"}"#, stderr: "")
         ])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
@@ -684,7 +761,23 @@ struct ClaudeCloudInvokerTests {
     @Test func anOkFalseReplyIsAFailure() async throws {
         let db = try TBDDatabase(inMemory: true)
         let spawner = FakeClaudeSpawner(outcomes: [
-            .completed(status: 0, output: #"{"ok":false,"session_id":"session_01AAA"}"#)
+            .completed(status: 0, output: #"{"ok":false,"session_id":"session_01AAA"}"#, stderr: "")
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 1)
+    }
+
+    /// Distinct from `ok:false`: the key is entirely ABSENT from the reply.
+    /// `ClaudeCloudSendReply.ok` is `Bool?`, so a missing key must fail the
+    /// `reply.ok == true` guard exactly like an explicit `false` — this pins
+    /// that the decode's optionality, not a value comparison, is what makes
+    /// that so.
+    @Test func aReplyWithNoOkKeyAtAllIsAFailure() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: #"{"session_id":"session_01AAA"}"#, stderr: "")
         ])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
@@ -694,7 +787,7 @@ struct ClaudeCloudInvokerTests {
 
     @Test func unparseableSendOutputIsAFailureCarryingWhatArrived() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: "not json")])
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: "not json", stderr: "")])
         let result = try await invoker(db: db, spawner: spawner).run(
             config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
             timeout: 30, contractVersion: 2)

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -206,13 +206,21 @@ struct ClaudeCloudInvokerTests {
         // `[2]` ALONE: nothing exposed terminates a running cloud session, so
         // the provider cannot implement `stop`, which major 1 requires.
         #expect(describe.contractVersions == [2])
-        #expect(describe.capabilities.sorted()
-            == ["archive", "attach", "land", "send", "unarchive"])
+        #expect(describe.capabilities.sorted() == ["attach", "send"])
         // Each absence is a fact about the surface, not an unimplemented verb.
         #expect(!describe.capabilities.contains("stop"))
         #expect(!describe.capabilities.contains("log"))
         #expect(!describe.capabilities.contains("transcript"))
         #expect(!describe.capabilities.contains("events"))
+        // `land`/`archive`/`unarchive` are a DIFFERENT kind of absence than
+        // the four above: `run` does implement a case for each (see
+        // `anUnwiredDeclaredVerbFailsAsAContractBug`), but a later slice of
+        // this feature owns re-adding the capability string together with a
+        // real implementation. Declaring them now would offer the app an
+        // action that always fails.
+        #expect(!describe.capabilities.contains("land"))
+        #expect(!describe.capabilities.contains("archive"))
+        #expect(!describe.capabilities.contains("unarchive"))
         #expect(describe.createParams.map(\.name) == ["repo", "branch", "prompt", "environment"])
         #expect(describe.createParams.first(where: { $0.name == "repo" })?.required == true)
         #expect(describe.createParams.first(where: { $0.name == "prompt" })?.required == true)
@@ -223,10 +231,12 @@ struct ClaudeCloudInvokerTests {
         #expect(describe.createParams.first(where: { $0.name == "prompt" })?.type == "text")
     }
 
-    /// A declared capability whose verb is not wired yet must say so as a
-    /// contract error rather than exiting 0 with nothing — these arms are
-    /// filled in by the archive and land steps of the same delivery.
-    @Test func anUnwiredDeclaredVerbFailsAsAContractBug() async throws {
+    /// Not (yet) a declared capability — see the note in
+    /// `describeIsStaticOfflineAndSpawnsNothing` — but `run` still refuses to
+    /// exit 0 with nothing if one of these verbs is reached anyway (a stale
+    /// capability cache, a call that skips the capability check). A later
+    /// slice fills these arms in together with re-declaring each capability.
+    @Test func anUnwiredUndeclaredVerbFailsAsAContractBug() async throws {
         let db = try TBDDatabase(inMemory: true)
         let spawner = FakeClaudeSpawner(outcomes: [])
         for verb in [["archive", "s"], ["unarchive", "s"], ["land", "s"]] {
@@ -237,6 +247,37 @@ struct ClaudeCloudInvokerTests {
             #expect(result.decodedError?.code == "not_implemented")
         }
         #expect(spawner.requestsSnapshot().isEmpty)
+    }
+
+    /// The regression this pins: a capability `describe` declares must be a
+    /// verb `run` actually answers, never `not_implemented`. Before this
+    /// finding was fixed, `ClaudeCloudDescribe` declared `land`/`archive`/
+    /// `unarchive` while `run` answered all three with `not_implemented` —
+    /// this iterates the REAL declared list, `ClaudeCloudDescribe.capabilities`,
+    /// rather than a hand-picked one, so a future capability declared ahead of
+    /// its implementation fails this test instead of only failing silently
+    /// for a user.
+    ///
+    /// `attach` is exercised too, even though it is never dispatched through
+    /// `run` in production (the contract's TTY passthrough is exec'd directly
+    /// on the pane, not through this JSON stdin/stdout path) — `run`'s
+    /// `default` arm answers an undeclared-verb `invalid_params`, which is
+    /// still correctly NOT `not_implemented`, so the assertion holds without
+    /// having to special-case it.
+    @Test func everyDeclaredCapabilityIsNotAnsweredAsNotImplemented() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        for capability in ClaudeCloudDescribe.capabilities {
+            let needsSend = capability == "send"
+            let spawner = FakeClaudeSpawner(
+                outcomes: needsSend ? [.completed(status: 0, output: sendOK, stderr: "")] : [])
+            let result = try await invoker(db: db, spawner: spawner).run(
+                config(), verb: [capability, "s"],
+                stdin: needsSend ? Data("hi\r".utf8) : nil,
+                timeout: 30, contractVersion: 2)
+            #expect(
+                result.decodedError?.code != "not_implemented",
+                "declared capability '\(capability)' is not implemented by run()")
+        }
     }
 
     /// An undeclared verb is a caller bug — the contract forbids invoking one
@@ -377,20 +418,78 @@ struct ClaudeCloudInvokerTests {
 
     /// The single same-key retry must find the row it already wrote, keeping
     /// the original timestamp — the failure window is measured from the
-    /// create, not from the retry.
+    /// create, not from the retry. And it must NOT spawn `claude --cloud` a
+    /// second time: finding 4. Only ONE outcome is scripted, so if the fix
+    /// regresses and `create` spawns again on the replay, `FakeClaudeSpawner`
+    /// crashes on its exhausted script — the spawn-count assertion below is
+    /// what would have caught it even if the script had a second outcome to
+    /// consume, which is exactly what the old two-outcome version of this
+    /// test hid.
     @Test func replayingTheSameIdempotencyKeyReusesTheSameLedgerRow() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)
         let spawner = FakeClaudeSpawner(outcomes: [
             .completed(status: 0, output: successOutput, stderr: ""),
-            .completed(status: 0, output: successOutput, stderr: ""),
         ])
         let inv = invoker(db: db, spawner: spawner)
-        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+        let first = try await inv.run(config(), verb: ["create"], stdin: createBody(),
                               timeout: 60, contractVersion: 2)
-        _ = try await inv.run(config(), verb: ["create"], stdin: createBody(),
+        let second = try await inv.run(config(), verb: ["create"], stdin: createBody(),
                               timeout: 60, contractVersion: 2)
         #expect(try await db.claudeCloudSessions.rows().count == 1)
+        #expect(spawner.requestsSnapshot().count == 1)
+        #expect(second.exitCode == 0)
+        let firstSession = try first.decoded(RemoteSessionPayload.self)
+        let secondSession = try second.decoded(RemoteSessionPayload.self)
+        #expect(secondSession.id == firstSession.id)
+    }
+
+    /// The decision this design makes for a replay of a STILL-PENDING key
+    /// (finding 4's "live" case): there is no discovery to check whether the
+    /// first attempt's spawn already started a real cloud session, so a
+    /// replay refuses to spawn a second one rather than guess — a retried
+    /// timeout that actually succeeded must never become two live sessions
+    /// this ledger can never reconcile. The failure is transient (exit 3):
+    /// once `list`'s `pendingFailureWindow` gives up on the row, the SAME key
+    /// is free to spawn fresh (see `aPendingRowFlipsToFailedOnlyOnceThePendingWindowHasElapsed`
+    /// for that half).
+    @Test func replayingAStillPendingKeyRefusesToSpawnAgain() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: "{}",
+            now: Date(timeIntervalSince1970: 1_000_000))
+        let spawner = FakeClaudeSpawner(outcomes: [])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 3)
+        #expect(result.failureClass == .transient)
+        #expect(spawner.requestsSnapshot().isEmpty)
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    /// The other half of that decision: a key that already reached `failed`
+    /// (the pending window gave up with no session ever recorded) is treated
+    /// as a fresh attempt and IS allowed to spawn, reusing the same row.
+    @Test func replayingAFailedKeySpawnsFreshAndReusesTheRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: "{}",
+            now: Date(timeIntervalSince1970: 1_000_000))
+        try await db.claudeCloudSessions.markFailed(ids: [row.id])
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 0, output: successOutput, stderr: ""),
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 0)
+        #expect(spawner.requestsSnapshot().count == 1)
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+        #expect(try await db.claudeCloudSessions.rows().first?.id == row.id)
+        #expect(try await db.claudeCloudSessions.rows().first?.state
+            == ClaudeCloudLedgerState.resolved.rawValue)
     }
 
     @Test func aNonZeroVendorExitIsAPermanentFailureCarryingItsOutput() async throws {
@@ -814,5 +913,145 @@ struct ClaudeCloudInvokerTests {
             timeout: 30, contractVersion: 2)
         #expect(result.exitCode == 3)
         #expect(result.failureClass == .transient)
+    }
+
+    /// Finding 8 (Minor): `send` used to hardcode `timeout: 30` instead of
+    /// threading `run`'s caller-supplied timeout the way `create` already
+    /// does. It worked today only because the sole production caller ALSO
+    /// hardcodes 30 — so, matching `createThreadsTheCallersTimeoutIntoTheSpawnRequest`,
+    /// a value that differs from both 30 and 60 is the only assertion that
+    /// discriminates real wiring from that coincidence.
+    @Test func sendThreadsTheCallersTimeoutIntoTheSpawnRequest() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: sendOK, stderr: "")])
+        _ = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 91, contractVersion: 2)
+        let request = try #require(spawner.requestsSnapshot().first)
+        #expect(request.timeout == 91)
+    }
+
+    // MARK: - findings fixed in this pass
+
+    /// Finding 1 (CRITICAL): the session-id cross-check used to scan the
+    /// ENTIRE output, including the vendor's title line — and that line is
+    /// the vendor's own server-derived summary of the user's PROMPT. A
+    /// prompt that happens to mention a `session_`-shaped token (a filename,
+    /// here) produced a second, spurious match and failed a create that had
+    /// actually succeeded, permanently orphaning the real cloud session —
+    /// there is no discovery to recover it by any other means.
+    ///
+    /// Confirmed failing against the pre-fix implementation: with the id scan
+    /// running over the whole blob, this exact title yields
+    /// `.conflictingSessionIDs(["session_01AAAAAAAAAAAAAAAAAAAAAA", "session_store"])`
+    /// (the regex has no `_` in its character class, so it matches
+    /// `session_store` out of `session_store_test.py` and stops there) — the
+    /// create fails as a `contract_bug` even though `claude --cloud`
+    /// succeeded. Restricting the scan to the `View:` and `Resume with:`
+    /// lines — the two structurally-typed witnesses — is the fix: only the
+    /// real id appears on either, so there is exactly one distinct match.
+    @Test func aTitleThatEchoesAPromptMentioningASessionIDDoesNotFailTheCreate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let output = """
+            Created cloud session: Fix the flake in session_store_test.py
+            View: https://claude.ai/code/session_01AAAAAAAAAAAAAAAAAAAAAA?from=cli&m=0
+            Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA
+            """
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: output, stderr: "")])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"],
+            stdin: createBody(prompt: "fix the flake in session_store_test.py"),
+            timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 0)
+        #expect(result.failureClass == nil)
+        let session = try result.decoded(RemoteSessionPayload.self)
+        #expect(session.id == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+        #expect(session.title == "Fix the flake in session_store_test.py")
+        let row = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(row.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(row.sessionID == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+    }
+
+    /// Finding 2: `list` used to omit `environment` from `meta` while
+    /// `create` included it, so a value that safely round-tripped through the
+    /// database vanished from every caller after the very next poll, with no
+    /// discovery to ever re-supply it. `createIncludesEnvironmentInMetaWhenSupplied`
+    /// pins the `create` half; this is the `list` counterpart the review
+    /// found missing.
+    @Test func listIncludesEnvironmentInMetaWhenPresentOnTheRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [.completed(status: 0, output: successOutput, stderr: "")])
+        let inv = invoker(db: db, spawner: spawner)
+        _ = try await inv.run(config(), verb: ["create"],
+                              stdin: createBody(environment: "prod"), timeout: 60, contractVersion: 2)
+        let session = try #require(try listSessions(
+            try await inv.run(config(), verb: ["list"], stdin: nil,
+                              timeout: 30, contractVersion: 2)).first)
+        let meta = try #require(session["meta"] as? [String: String])
+        #expect(meta["environment"] == "prod")
+    }
+
+    /// Finding 5: nothing pinned that `send`'s failure message carries the
+    /// vendor's STDERR. `send` runs on a pipe, where a CLI writes its errors
+    /// to stderr — but both existing failure tests
+    /// (`aNonZeroSendExitIsAPermanentFailureCarryingWhatArrived`,
+    /// `unparseableSendOutputIsAFailureCarryingWhatArrived`) put the error
+    /// text in `output` and leave `stderr` empty, so deleting `+ stderr` from
+    /// the diagnostic — the tempting "simplification" right after the
+    /// stdout/stderr-split fix landed, since `output` is what gets parsed —
+    /// would stay green and leave a logged-out user with
+    /// `claude -p --cloud exited 1: ` and nothing after the colon.
+    @Test func aNonZeroSendExitCarriesVendorStderrEvenWhenOutputIsEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 1, output: "", stderr: "Error: not logged in"),
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["send", "session_01AAA"], stdin: Data("hi\r".utf8),
+            timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 1)
+        #expect(result.failureClass == .permanent)
+        #expect(result.decodedError?.message.contains("not logged in") == true)
+    }
+
+    /// Finding 6 (Minor): a non-zero `create` exit used to always report
+    /// `.noSessionID` — claiming "printed no session id" even when the id was
+    /// sitting right there in the quoted evidence — and discarded it instead
+    /// of recording it, orphaning a session that was genuinely created before
+    /// some later step made the verb exit non-zero. The fix parses first and
+    /// records a readable id even though the verb still reports failure.
+    @Test func aNonZeroCreateExitThatStillPrintedASessionIDRecordsItRatherThanOrphaningIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+        let spawner = FakeClaudeSpawner(outcomes: [
+            .completed(status: 1, output: successOutput, stderr: ""),
+        ])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(result.exitCode == 1)
+        #expect(result.failureClass == .permanent)
+        #expect(result.decodedError?.message.contains("session_01AAAAAAAAAAAAAAAAAAAAAA") == true)
+        #expect(result.decodedError?.message.contains("printed no session id") == false)
+        let row = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(row.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(row.sessionID == "session_01AAAAAAAAAAAAAAAAAAAAAA")
+    }
+
+    /// Finding 7 (Minor): `"\r\n"` is ONE `Character` (grapheme cluster) in
+    /// Swift, distinct from both `"\r"` and `"\n"` — the same trap the title
+    /// parser (`ClaudeCloudCreateOutputParser.title(fromOutput:)`) was
+    /// already bitten by and fixed for. Built by explicit concatenation, not
+    /// a triple-quoted literal: Swift's multiline string literals normalize
+    /// to bare `\n`, so a literal could never construct a real CRLF to catch
+    /// this regression.
+    @Test func theSubmitGestureStripsATrailingCRLFAsOneGrapheme() {
+        let crlf = "hello" + "\r\n"
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data(crlf.utf8)) == "hello")
+        // Interior CRLF must still survive, exactly like interior `\n` does.
+        let interiorAndTrailing = "one" + "\r\n" + "two" + "\r\n"
+        #expect(ClaudeCloudSendPayload.message(fromStdin: Data(interiorAndTrailing.utf8))
+            == "one" + "\r\n" + "two")
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -130,4 +130,76 @@ struct ClaudeCloudInvokerTests {
         #expect(!output.contains("COLUMNS=400"))
         #expect(!output.contains("LINES=200"))
     }
+
+    // MARK: - describe
+
+    private func invoker(
+        db: TBDDatabase, spawner: FakeClaudeSpawner,
+        now: @escaping @Sendable () -> Date = { Date(timeIntervalSince1970: 1_000_000) }
+    ) -> ClaudeCloudInvoker {
+        ClaudeCloudInvoker(db: db, spawner: spawner, now: now)
+    }
+
+    private func config() -> RemoteProviderConfig {
+        RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: "/opt/acme/claude")
+    }
+
+    /// `describe` is static and OFFLINE, and its answer does not vary with
+    /// the account — including for `attach`, which is declared because the
+    /// provider implements it. Whether a given account may USE it is a
+    /// separate runtime question.
+    @Test func describeIsStaticOfflineAndSpawnsNothing() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [])
+        let result = try await invoker(db: db, spawner: spawner).run(
+            config(), verb: ["describe"], stdin: nil, timeout: 10, contractVersion: 2)
+        #expect(result.exitCode == 0)
+        #expect(spawner.requestsSnapshot().isEmpty, "describe must touch no process at all")
+        let describe = try result.decoded(ProviderDescribe.self)
+        #expect(describe.name == ClaudeCloudProvider.name)
+        // `[2]` ALONE: nothing exposed terminates a running cloud session, so
+        // the provider cannot implement `stop`, which major 1 requires.
+        #expect(describe.contractVersions == [2])
+        #expect(describe.capabilities.sorted()
+            == ["archive", "attach", "land", "send", "unarchive"])
+        // Each absence is a fact about the surface, not an unimplemented verb.
+        #expect(!describe.capabilities.contains("stop"))
+        #expect(!describe.capabilities.contains("log"))
+        #expect(!describe.capabilities.contains("transcript"))
+        #expect(!describe.capabilities.contains("events"))
+        #expect(describe.createParams.map(\.name) == ["repo", "branch", "prompt", "environment"])
+        #expect(describe.createParams.first(where: { $0.name == "repo" })?.required == true)
+        #expect(describe.createParams.first(where: { $0.name == "prompt" })?.required == true)
+        // `environment` is typed `string`, not `enum`: `describe` answers
+        // offline and the set of configured cloud environments is knowable
+        // only from the account.
+        #expect(describe.createParams.first(where: { $0.name == "environment" })?.type == "string")
+        #expect(describe.createParams.first(where: { $0.name == "prompt" })?.type == "text")
+    }
+
+    /// A declared capability whose verb is not wired yet must say so as a
+    /// contract error rather than exiting 0 with nothing — these arms are
+    /// filled in by the archive and land steps of the same delivery.
+    @Test func anUnwiredDeclaredVerbFailsAsAContractBug() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let spawner = FakeClaudeSpawner(outcomes: [])
+        for verb in [["archive", "s"], ["unarchive", "s"], ["land", "s"]] {
+            let result = try await invoker(db: db, spawner: spawner).run(
+                config(), verb: verb, stdin: nil, timeout: 30, contractVersion: 2)
+            #expect(result.exitCode == 2)
+            #expect(result.failureClass == .contractBug)
+            #expect(result.decodedError?.code == "not_implemented")
+        }
+        #expect(spawner.requestsSnapshot().isEmpty)
+    }
+
+    /// An undeclared verb is a caller bug — the contract forbids invoking one
+    /// — and must be reported as such rather than silently succeeding.
+    @Test func anUndeclaredVerbIsAContractError() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let result = try await invoker(db: db, spawner: FakeClaudeSpawner(outcomes: [])).run(
+            config(), verb: ["stop", "s"], stdin: nil, timeout: 30, contractVersion: 2)
+        #expect(result.exitCode == 2)
+        #expect(result.failureClass == .contractBug)
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -1099,6 +1099,85 @@ struct ClaudeCloudInvokerTests {
         #expect(try await db.claudeCloudSessions.rows().count == 1)
     }
 
+    /// The bug `claimForSpawn`'s own doc comment claims not to have: a
+    /// reclaim UPDATE that rewrote `state` back to `pending` but left
+    /// `createdAt` alone left the pending-failure window still measuring
+    /// from the ORIGINAL attempt's timestamp, so a `list()` poll landing
+    /// after that original window — but well inside a fresh one — re-failed
+    /// a row whose reclaiming spawn was still genuinely in flight. A further
+    /// replay then read `failed` again and reclaimed AND SPAWNED a second
+    /// time: the exact double-spawn hazard `claimForSpawn` exists to close.
+    ///
+    /// The gate is what makes this discriminating rather than lucky: it
+    /// holds the reclaiming spawn open, so the `list()` poll and the third
+    /// replay both provably land while that spawn is still running, not
+    /// after it quietly finished.
+    @Test func aReclaimSurvivesAListPollBeforeItResolves() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await seedRepo(db)
+
+        let originalCreatedAt = Date(timeIntervalSince1970: 1_000_000)
+        _ = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: "{}", now: originalCreatedAt)
+
+        // Age the row past the pending window so a `list()` marks it
+        // `failed` — the precondition a reclaim needs to observe.
+        let markFailedAt = originalCreatedAt.addingTimeInterval(601)
+        _ = try await invoker(
+            db: db, spawner: FakeClaudeSpawner(outcomes: []), now: { markFailedAt }
+        ).run(config(), verb: ["list"], stdin: nil, timeout: 30, contractVersion: 2)
+        #expect(try await db.claudeCloudSessions.rows().first?.state
+            == ClaudeCloudLedgerState.failed.rawValue)
+
+        // Reclaim: a same-key `create` replay standing in for a spawn
+        // genuinely in flight. `reclaimAt` is what a correct reclaim stamps
+        // as the row's NEW `createdAt`.
+        let reclaimAt = markFailedAt
+        let gate = SpawnGate()
+        let spawner = GatedClaudeSpawner(
+            gate: gate, outcome: .completed(status: 0, output: successOutput, stderr: ""))
+        let reclaimInvoker = ClaudeCloudInvoker(db: db, spawner: spawner, now: { reclaimAt })
+
+        async let reclaimResult = reclaimInvoker.run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        // Resumes only once the reclaim's spawn is genuinely under way, so
+        // the poll below races a real in-flight spawn rather than a
+        // completed one.
+        await gate.waitUntilEntered()
+
+        // The discriminating poll. `pollAt` is chosen so the two readings of
+        // "how old is this row" disagree: 300s elapsed measured from
+        // `reclaimAt` (INSIDE the 600s window — a correct reclaim keeps the
+        // row `pending`), but 901s elapsed measured from the untouched
+        // `originalCreatedAt` (OUTSIDE the window — the bug re-fails the row
+        // here, while the reclaiming spawn is still running).
+        let pollAt = reclaimAt.addingTimeInterval(300)
+        _ = try await invoker(
+            db: db, spawner: FakeClaudeSpawner(outcomes: []), now: { pollAt }
+        ).run(config(), verb: ["list"], stdin: nil, timeout: 30, contractVersion: 2)
+        let polled = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(polled.state == ClaudeCloudLedgerState.pending.rawValue)
+
+        // The consequence: with the row correctly still `pending`, a THIRD
+        // replay of the same key must be refused rather than spawning a
+        // second real cloud session. Reuses the SAME gated spawner so its
+        // request count is the discriminator — the unique index on
+        // `idempotencyKey` pins the ROW count at one either way, which is
+        // exactly why a row-count assertion cannot see this class of bug.
+        let thirdInvoker = ClaudeCloudInvoker(db: db, spawner: spawner, now: { pollAt })
+        let thirdResult = try await thirdInvoker.run(
+            config(), verb: ["create"], stdin: createBody(), timeout: 60, contractVersion: 2)
+        #expect(thirdResult.exitCode == 3)
+        #expect(thirdResult.decodedError?.code == "in_progress")
+        #expect(spawner.requestsSnapshot().count == 1)
+
+        await gate.release()
+        let reclaimed = try await reclaimResult
+        #expect(reclaimed.exitCode == 0)
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
     private func gatedInvoker(
         db: TBDDatabase, spawner: GatedClaudeSpawner,
         now: @escaping @Sendable () -> Date = { Date(timeIntervalSince1970: 1_000_000) }

--- a/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+// Tier 2: in-memory GRDB only.
+@Suite("ClaudeCloudLedgerStore")
+struct ClaudeCloudLedgerStoreTests {
+    @Test func aPendingRowIsWrittenBeforeTheInvocationAndReadBack() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: "fix-ci", environment: nil, paramsJSON: #"{"prompt":"hi"}"#, now: now)
+        #expect(row.state == ClaudeCloudLedgerState.pending.rawValue)
+        #expect(row.sessionID == nil)
+        #expect(row.title == nil)
+        #expect(row.archived == false)
+        let all = try await db.claudeCloudSessions.rows()
+        #expect(all.map(\.idempotencyKey) == ["tbd-1"])
+        #expect(all.first?.repoKey == "acme/api")
+        #expect(all.first?.repoPath == "/tmp/api")
+        #expect(all.first?.branch == "fix-ci")
+        #expect(all.first?.createdAt == now)
+    }
+
+    /// The daemon retries a timed-out create ONCE with the same key. A pending
+    /// row is expected during that retry, not a reason to refuse it — and the
+    /// original creation time must survive, because the failure window is
+    /// measured from the create, not from the retry.
+    @Test func theSameKeyTwiceYieldsOneRowWithItsOriginalTimestamp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let first = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: nil, environment: nil, paramsJSON: "{}",
+            now: Date(timeIntervalSince1970: 10))
+        let second = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
+            branch: nil, environment: nil, paramsJSON: "{}",
+            now: Date(timeIntervalSince1970: 20))
+        #expect(first.id == second.id)
+        #expect(second.createdAt == Date(timeIntervalSince1970: 10))
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    @Test func distinctKeysYieldDistinctRowsOrderedByCreation() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-2", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 200))
+        _ = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 100))
+        #expect(try await db.claudeCloudSessions.rows().map(\.idempotencyKey) == ["tbd-1", "tbd-2"])
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
@@ -134,6 +134,86 @@ struct ClaudeCloudLedgerStoreTests {
         #expect(try await db.claudeCloudSessions.rows().count == 1)
     }
 
+    /// The ungated path: a `pending` row (no session id yet) must still
+    /// resolve normally. Proves the id-based guard did not disable ordinary
+    /// resolution — only a NAMED different id is refused.
+    @Test func resolveOnAPendingRowRecordsTheSession() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        #expect(row.sessionID == nil)
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "first",
+            now: Date(timeIntervalSince1970: 2))
+        let stored = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(stored.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(stored.sessionID == "session_01AAA")
+    }
+
+    /// Resolving the SAME session id twice must remain the harmless idempotent
+    /// no-op already promised by the doc comment — the guard is on the id,
+    /// not on the state, so a same-id retry must not be refused.
+    @Test func resolveWithTheSameSessionIDTwiceIsANoOpThatKeepsTheRowIntact() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "first",
+            now: Date(timeIntervalSince1970: 2))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "second",
+            now: Date(timeIntervalSince1970: 3))
+        let stored = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(stored.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(stored.sessionID == "session_01AAA")
+        #expect(stored.title == "second")
+        #expect(stored.resolvedAt == Date(timeIntervalSince1970: 3))
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    /// A row that already names a DIFFERENT session must refuse — the harm a
+    /// state-based predicate would not catch, and the harm a bare
+    /// `WHERE id = ?` never guarded against. The original id and its
+    /// resolvedAt survive untouched.
+    @Test func resolveRefusesToOverwriteADifferentSessionID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "original",
+            now: Date(timeIntervalSince1970: 2))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_02BBB", title: "different",
+            now: Date(timeIntervalSince1970: 3))
+        let stored = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(stored.state == ClaudeCloudLedgerState.resolved.rawValue)
+        // The original id, title and resolvedAt all survive — not silently
+        // overwritten by the second call naming a different session.
+        #expect(stored.sessionID == "session_01AAA")
+        #expect(stored.title == "original")
+        #expect(stored.resolvedAt == Date(timeIntervalSince1970: 2))
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    /// `resolve` must not throw when the guard refuses the write — the
+    /// refusal is loud in the log, not in the caller's control flow.
+    @Test func resolveRefusingADifferentSessionIDDoesNotThrow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "original",
+            now: Date(timeIntervalSince1970: 2))
+        // Must not throw.
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_02BBB", title: "different",
+            now: Date(timeIntervalSince1970: 3))
+    }
+
     @Test func markFailedFlipsOnlyTheNamedRowsAndRetainsThem() async throws {
         let db = try TBDDatabase(inMemory: true)
         let keep = try await db.claudeCloudSessions.upsertPending(

--- a/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
@@ -10,17 +10,33 @@ struct ClaudeCloudLedgerStoreTests {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let row = try await db.claudeCloudSessions.upsertPending(
             idempotencyKey: "tbd-1", repoKey: "acme/api", repoPath: "/tmp/api",
-            branch: "fix-ci", environment: nil, paramsJSON: #"{"prompt":"hi"}"#, now: now)
+            branch: "fix-ci", environment: "staging", paramsJSON: #"{"prompt":"hi"}"#, now: now)
         #expect(row.state == ClaudeCloudLedgerState.pending.rawValue)
         #expect(row.sessionID == nil)
         #expect(row.title == nil)
         #expect(row.archived == false)
         let all = try await db.claudeCloudSessions.rows()
         #expect(all.map(\.idempotencyKey) == ["tbd-1"])
-        #expect(all.first?.repoKey == "acme/api")
-        #expect(all.first?.repoPath == "/tmp/api")
-        #expect(all.first?.branch == "fix-ci")
-        #expect(all.first?.createdAt == now)
+        let stored = try #require(all.first)
+        // `id` is a generated UUID, not asserted against a literal — only that
+        // the write and read paths agree on it.
+        #expect(stored.id == row.id)
+        #expect(stored.idempotencyKey == "tbd-1")
+        #expect(stored.state == ClaudeCloudLedgerState.pending.rawValue)
+        // Not yet resolved: a create's output has not been read at this point
+        // in the lifecycle, so both are expected nil rather than skipped.
+        #expect(stored.sessionID == nil)
+        #expect(stored.title == nil)
+        #expect(stored.createdAt == now)
+        #expect(stored.resolvedAt == nil)
+        #expect(stored.repoKey == "acme/api")
+        #expect(stored.repoPath == "/tmp/api")
+        #expect(stored.branch == "fix-ci")
+        #expect(stored.environment == "staging")
+        // The column this table exists to carry — a dropped or truncated
+        // paramsJSON is the failure this row would otherwise never catch.
+        #expect(stored.paramsJSON == #"{"prompt":"hi"}"#)
+        #expect(stored.archived == false)
     }
 
     /// The daemon retries a timed-out create ONCE with the same key. A pending

--- a/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudLedgerStoreTests.swift
@@ -68,4 +68,118 @@ struct ClaudeCloudLedgerStoreTests {
             environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 100))
         #expect(try await db.claudeCloudSessions.rows().map(\.idempotencyKey) == ["tbd-1", "tbd-2"])
     }
+
+    @Test func resolveStampsTheSessionIDAndTitleAndFlipsTheState() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: "fix",
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "Add probe pong reply",
+            now: Date(timeIntervalSince1970: 2))
+        let stored = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(stored.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(stored.sessionID == "session_01AAA")
+        #expect(stored.title == "Add probe pong reply")
+        #expect(stored.resolvedAt == Date(timeIntervalSince1970: 2))
+        // Neighbouring columns a naive UPDATE could clobber must survive.
+        #expect(stored.repoKey == "a/b")
+        #expect(stored.repoPath == "/a")
+        #expect(stored.branch == "fix")
+        #expect(stored.createdAt == Date(timeIntervalSince1970: 1))
+    }
+
+    /// A title parse that found nothing is not a failure — the row resolves
+    /// with a null title and the lane is named from its id instead.
+    @Test func resolveAcceptsANilTitleWithoutFailingTheCreate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: nil,
+            now: Date(timeIntervalSince1970: 2))
+        let stored = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(stored.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(stored.title == nil)
+    }
+
+    /// Resolving a row that does not exist is reachable on a retry path and
+    /// must not throw — there is nothing to update, so it is a silent no-op.
+    @Test func resolvingAnUnknownIDIsANoOp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.claudeCloudSessions.resolve(
+            id: "does-not-exist", sessionID: "session_01AAA", title: "x",
+            now: Date(timeIntervalSince1970: 2))
+        #expect(try await db.claudeCloudSessions.rows().isEmpty)
+    }
+
+    /// A retry may resolve the same row twice; the second call must remain a
+    /// harmless overwrite rather than erroring or double-applying anything.
+    @Test func resolvingTheSameRowTwiceIsIdempotent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "tbd-1", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "first",
+            now: Date(timeIntervalSince1970: 2))
+        try await db.claudeCloudSessions.resolve(
+            id: row.id, sessionID: "session_01AAA", title: "second",
+            now: Date(timeIntervalSince1970: 3))
+        let stored = try #require(try await db.claudeCloudSessions.rows().first)
+        #expect(stored.state == ClaudeCloudLedgerState.resolved.rawValue)
+        #expect(stored.title == "second")
+        #expect(stored.resolvedAt == Date(timeIntervalSince1970: 3))
+        #expect(try await db.claudeCloudSessions.rows().count == 1)
+    }
+
+    @Test func markFailedFlipsOnlyTheNamedRowsAndRetainsThem() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let keep = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "k", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        let doomed = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "d", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 2))
+        try await db.claudeCloudSessions.markFailed(ids: [doomed.id])
+        let rows = try await db.claudeCloudSessions.rows()
+        // Retained, not deleted: the record of a create that may have started
+        // a real session outlives the judgement that it did not.
+        #expect(rows.count == 2)
+        #expect(rows.first(where: { $0.id == keep.id })?.state
+            == ClaudeCloudLedgerState.pending.rawValue)
+        #expect(rows.first(where: { $0.id == doomed.id })?.state
+            == ClaudeCloudLedgerState.failed.rawValue)
+        // The row markFailed leaves alone must be untouched, not just
+        // "still pending" — check a neighbouring column too.
+        #expect(rows.first(where: { $0.id == keep.id })?.idempotencyKey == "k")
+    }
+
+    /// The batch takes ids, so an empty batch must be a no-op rather than an
+    /// `IN ()` that matches everything.
+    @Test func anEmptyFailureBatchTouchesNothing() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "k", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.markFailed(ids: [])
+        let rows = try await db.claudeCloudSessions.rows()
+        #expect(rows.count == 1)
+        #expect(rows.first?.state == ClaudeCloudLedgerState.pending.rawValue)
+    }
+
+    /// A failure batch may name a row already marked failed on a retry path;
+    /// re-applying must not error or disturb its neighbours.
+    @Test func markFailedTwiceOnTheSameIDIsIdempotent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let row = try await db.claudeCloudSessions.upsertPending(
+            idempotencyKey: "k", repoKey: "a/b", repoPath: "/a", branch: nil,
+            environment: nil, paramsJSON: "{}", now: Date(timeIntervalSince1970: 1))
+        try await db.claudeCloudSessions.markFailed(ids: [row.id])
+        try await db.claudeCloudSessions.markFailed(ids: [row.id])
+        let rows = try await db.claudeCloudSessions.rows()
+        #expect(rows.count == 1)
+        #expect(rows.first?.state == ClaudeCloudLedgerState.failed.rawValue)
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudTimeoutRelationshipTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudTimeoutRelationshipTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+// Tier 1: pure constant comparison, no I/O.
+//
+// Pins the numeric relationship between `RPCRouter.remoteCreateTimeout`
+// (`RPCRouter+RemoteHandlers.swift`) and `ClaudeCloudInvoker.pendingFailureWindow`
+// (`ClaudeCloudList.swift`). The two live in different files and nothing else
+// ties them together mechanically — this test is that mechanism. If a create
+// timeout can reach or exceed the pending-failure window, a `create` still
+// running past its own timeout budget can have its ledger row reclaimed by
+// `claimForSpawn` and re-spawned while the first invocation is still in
+// flight: the double-spawn `claude_cloud_session` exists to prevent.
+@Suite("ClaudeCloudTimeoutRelationship")
+struct ClaudeCloudTimeoutRelationshipTests {
+    @Test func createTimeoutStaysStrictlyBelowThePendingFailureWindow() {
+        let createTimeout = RPCRouter.remoteCreateTimeout
+        let pendingFailureWindow = ClaudeCloudInvoker.pendingFailureWindow
+        #expect(
+            createTimeout < pendingFailureWindow,
+            """
+            RPCRouter.remoteCreateTimeout (\(createTimeout)s) must stay strictly \
+            below ClaudeCloudInvoker.pendingFailureWindow (\(pendingFailureWindow)s): \
+            a single create invocation must give up and throw well before the ledger \
+            gives up on its row — otherwise `claimForSpawn` can reclaim and re-spawn \
+            a `pending` row whose original create is still running past its own \
+            timeout budget, spawning a second real cloud session under the same \
+            idempotency key.
+            """)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeExecutableResolverTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeExecutableResolverTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+// Tier 1: pure over injected values — never stats the real filesystem.
+@Suite("ClaudeExecutableResolver")
+struct ClaudeExecutableResolverTests {
+    @Test func aConfiguredAbsoluteOverrideWins() throws {
+        let path = try ClaudeExecutableResolver.resolve(
+            configuredOverride: "/opt/acme/claude",
+            searchPath: "/usr/bin:/bin",
+            isExecutable: { $0 == "/opt/acme/claude" || $0 == "/usr/bin/claude" })
+        #expect(path == "/opt/acme/claude")
+    }
+
+    @Test func absolutePathEntriesAreSearchedInOrder() throws {
+        let path = try ClaudeExecutableResolver.resolve(
+            configuredOverride: nil,
+            searchPath: "/first:/second",
+            isExecutable: { $0 == "/first/claude" || $0 == "/second/claude" })
+        #expect(path == "/first/claude")
+    }
+
+    /// Relative and empty entries are ignored outright: resolving them
+    /// against the daemon's current directory could execute an untrusted
+    /// worktree-local `claude`.
+    @Test func relativeAndEmptyPathEntriesAreIgnored() throws {
+        let path = try ClaudeExecutableResolver.resolve(
+            configuredOverride: nil,
+            searchPath: "::.:node_modules/.bin:/real",
+            isExecutable: { $0.hasSuffix("/claude") })
+        #expect(path == "/real/claude")
+    }
+
+    /// Distinct from `relativeAndEmptyPathEntriesAreIgnored`: here both PATH
+    /// entries are valid absolute directories, but only the second one
+    /// actually has an executable `claude` in it.
+    @Test func aLaterAbsoluteEntryWinsWhenAnEarlierOneLacksTheExecutable() throws {
+        let path = try ClaudeExecutableResolver.resolve(
+            configuredOverride: nil,
+            searchPath: "/first:/second",
+            isExecutable: { $0 == "/second/claude" })
+        #expect(path == "/second/claude")
+    }
+
+    @Test func aRelativeOverrideIsIgnoredRatherThanResolved() throws {
+        let path = try ClaudeExecutableResolver.resolve(
+            configuredOverride: "bin/claude",
+            searchPath: "/real",
+            isExecutable: { $0 == "/real/claude" })
+        #expect(path == "/real/claude")
+    }
+
+    @Test func nothingExecutableAnywhereThrowsNotFound() {
+        #expect(throws: ClaudeExecutableResolver.ResolveError.notFound(searchPath: "/a:/b")) {
+            try ClaudeExecutableResolver.resolve(
+                configuredOverride: nil, searchPath: "/a:/b", isExecutable: { _ in false })
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeExecutableResolverTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeExecutableResolverTests.swift
@@ -43,12 +43,37 @@ struct ClaudeExecutableResolverTests {
         #expect(path == "/second/claude")
     }
 
+    /// `isExecutable` also matches the relative spelling, so this
+    /// discriminates the `hasPrefix("/")` guard itself: an implementation
+    /// that dropped the guard and called `isExecutable("bin/claude")` would
+    /// get `true` here (not a coincidental `false`) and resolve to the wrong
+    /// path, so the test would fail rather than passing for the wrong
+    /// reason.
     @Test func aRelativeOverrideIsIgnoredRatherThanResolved() throws {
         let path = try ClaudeExecutableResolver.resolve(
             configuredOverride: "bin/claude",
             searchPath: "/real",
-            isExecutable: { $0 == "/real/claude" })
+            isExecutable: { $0 == "/real/claude" || $0 == "bin/claude" })
         #expect(path == "/real/claude")
+    }
+
+    /// An absolute override that fails the executable check is a hard
+    /// failure, not a silent fallback to PATH search: someone who set an
+    /// explicit override did so because the wrong binary was being picked
+    /// up, so resolving to a different `claude` on a typo would defeat the
+    /// override's purpose with no diagnostic. `/real/claude` is a valid PATH
+    /// candidate in this same fixture, so a resolver that incorrectly fell
+    /// through would succeed silently instead of throwing — that's the
+    /// discriminating half of this test, not just "it throws something".
+    @Test func anAbsoluteOverrideThatIsNotExecutableThrowsRatherThanFallingThroughToPATH() {
+        #expect(throws: ClaudeExecutableResolver.ResolveError.invalidOverride(
+            environmentKey: ClaudeExecutableResolver.executableOverrideEnvironmentKey,
+            value: "/opt/acme/claude")) {
+            try ClaudeExecutableResolver.resolve(
+                configuredOverride: "/opt/acme/claude",
+                searchPath: "/real",
+                isExecutable: { $0 == "/real/claude" })
+        }
     }
 
     @Test func nothingExecutableAnywhereThrowsNotFound() {

--- a/Tests/TBDDaemonTests/ContractVersionNegotiationTests.swift
+++ b/Tests/TBDDaemonTests/ContractVersionNegotiationTests.swift
@@ -92,4 +92,45 @@ struct ContractVersionNegotiationTests {
         #expect(status.errorMessage?.contains("no common contract version") == true)
         #expect(status.describe == nil)
     }
+
+    // MARK: - The negotiated value reaches the wire DTO
+
+    /// The path that crosses a process boundary. The app spawns `attach`
+    /// itself, directly on the pane's PTY, and never passes through
+    /// `RemoteProviderInvoking` — so unless the negotiated major rides
+    /// `remote.providers`, the app has no way to learn it and goes on
+    /// announcing `1` forever.
+    @Test func theNegotiatedMajorReachesTheProviderStatus() async throws {
+        let invoker = FakeProviderInvoker(script: [providerOK(describeJSON([1, 2]))])
+        let (manager, registry) = try makeManager(invoker)
+        defer { try? FileManager.default.removeItem(at: registry) }
+
+        await manager.describeAllForTests()
+        let status = try #require(await manager.providerStatuses().first { $0.config.name == "p" })
+        #expect(status.contractVersion == 2)
+    }
+
+    /// Before `describe` lands there is nothing negotiated, and saying so is
+    /// what lets the app apply its own conservative fallback rather than
+    /// trusting a fabricated number.
+    @Test func statusCarriesNoMajorBeforeDescribeSucceeds() async throws {
+        let invoker = FakeProviderInvoker(script: [providerOK(describeJSON([3]))])
+        let (manager, registry) = try makeManager(invoker)
+        defer { try? FileManager.default.removeItem(at: registry) }
+
+        await manager.describeAllForTests()
+        let status = try #require(await manager.providerStatuses().first { $0.config.name == "p" })
+        #expect(status.contractVersion == nil)
+    }
+
+    /// A status encoded by a daemon that predates the field decodes with nil
+    /// rather than failing the whole payload.
+    @Test func statusFromAnOlderDaemonDecodesWithNoMajor() throws {
+        let json = """
+        {"config":{"name":"p","exec":"/bin/true"},"health":"ok","freshnessUnreadable":false}
+        """
+        let decoded = try JSONDecoder().decode(RemoteProviderStatus.self, from: Data(json.utf8))
+        #expect(decoded.contractVersion == nil)
+        #expect(decoded.config.name == "p")
+    }
 }

--- a/Tests/TBDDaemonTests/ContractVersionNegotiationTests.swift
+++ b/Tests/TBDDaemonTests/ContractVersionNegotiationTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `describeProvider` used to hard-require that `contract_versions` contained
+/// `1`, so a `[2]`-only provider was refused outright with "no common contract
+/// version". The compiled `claude-cloud` provider declares `[2]` alone — it
+/// cannot implement `stop`, which major 1 requires — so the guard has to become
+/// an intersection with TBD's own supported set.
+///
+/// Tier 1: `FakeProviderInvoker` is the only provider, nothing is spawned and
+/// nothing touches `~/tbd`.
+@Suite("ContractVersionNegotiation")
+struct ContractVersionNegotiationTests {
+
+    private func describeJSON(_ versions: [Int]) -> String {
+        let list = versions.map(String.init).joined(separator: ",")
+        return """
+        {"contract_versions":[\(list)],"name":"p","capabilities":["send"],"create_params":[]}
+        """
+    }
+
+    // MARK: - The pure rule, one case per branch
+
+    @Test func negotiatesTheHighestCommonMajor() {
+        #expect(RemoteProviderManager.negotiate(declared: [1, 2]) == 2)
+        #expect(RemoteProviderManager.negotiate(declared: [1]) == 1)
+        #expect(RemoteProviderManager.negotiate(declared: [2]) == 2)
+        #expect(RemoteProviderManager.negotiate(declared: [2, 1]) == 2)
+    }
+
+    @Test func refusesOnAnEmptyIntersection() {
+        #expect(RemoteProviderManager.negotiate(declared: [3]) == nil)
+        #expect(RemoteProviderManager.negotiate(declared: []) == nil)
+    }
+
+    // MARK: - The negotiated value reaches the runner
+
+    private func makeManager(
+        _ invoker: FakeProviderInvoker
+    ) throws -> (RemoteProviderManager, URL) {
+        let registry = FileManager.default.temporaryDirectory
+            .appendingPathComponent("providers-\(UUID().uuidString).json")
+        try Data(#"[{"name":"p","exec":"/bin/true"}]"#.utf8).write(to: registry)
+        let db = try TBDDatabase(inMemory: true)
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: StateSubscriptionManager(),
+            runner: invoker, registryURL: registry)
+        return (manager, registry)
+    }
+
+    @Test func aV2OnlyProviderIsDescribedAndItsVerbsAnnounceTwo() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(describeJSON([2])),
+            providerOK(#"{"sessions":[]}"#)
+        ])
+        let (manager, registry) = try makeManager(invoker)
+        defer { try? FileManager.default.removeItem(at: registry) }
+
+        await manager.describeAllForTests()
+        #expect(await manager.negotiatedContractMajor(for: "p") == 2)
+
+        await manager.pollOnce(provider: RemoteProviderConfig(name: "p", exec: "/bin/true"))
+        let versions = invoker.contractVersionsSnapshot()
+        #expect(versions.count == 2)
+        // The first call is `describe` itself, before anything is negotiated —
+        // conservative fallback. The second is `list`, which must carry 2.
+        #expect(versions[0] == 1)
+        #expect(versions[1] == 2)
+    }
+
+    @Test func aV1OnlyProviderStillNegotiatesOne() async throws {
+        let invoker = FakeProviderInvoker(script: [providerOK(describeJSON([1]))])
+        let (manager, registry) = try makeManager(invoker)
+        defer { try? FileManager.default.removeItem(at: registry) }
+
+        await manager.describeAllForTests()
+        #expect(await manager.negotiatedContractMajor(for: "p") == 1)
+    }
+
+    @Test func aProviderWithNoCommonMajorIsRefusedWithAClearError() async throws {
+        let invoker = FakeProviderInvoker(script: [providerOK(describeJSON([3]))])
+        let (manager, registry) = try makeManager(invoker)
+        defer { try? FileManager.default.removeItem(at: registry) }
+
+        await manager.describeAllForTests()
+        #expect(await manager.negotiatedContractMajor(for: "p") == nil)
+        let status = try #require(await manager.providerStatuses().first { $0.config.name == "p" })
+        #expect(status.health == .error)
+        #expect(status.errorMessage?.contains("no common contract version") == true)
+        #expect(status.describe == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/DaemonRemoteManagerBootTests.swift
+++ b/Tests/TBDDaemonTests/DaemonRemoteManagerBootTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// `Daemon.makeRemoteProviderManager` is the only production construction of
+/// `RemoteProviderManager` (`Daemon.swift`'s boot block, Task 7). Before this
+/// suite it was inline in `Daemon.start()` and reachable from no test — every
+/// cloud test built the manager by hand instead, which is exactly how an
+/// earlier draft of the delivery nearly shipped without `actuationLog:`
+/// (dropping it silently disables `syncFilingDecisions` for every provider
+/// behind one `.debug` log line, with the suite still green).
+///
+/// Tier 2: in-memory GRDB, a scripted `FakeProviderInvoker` standing in for
+/// `subprocess`, no real `claude` binary, no `~/tbd` — every call below
+/// passes an explicit `registryURL` in a temp directory rather than the
+/// default `TBDConstants.agentProvidersPath`, which would otherwise read the
+/// developer's real registry.
+@Suite("Daemon.makeRemoteProviderManager")
+struct DaemonRemoteManagerBootTests {
+    private func tempRegistryURL(tag: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("boot-registry-\(tag)-\(UUID().uuidString).json")
+    }
+
+    private func names(_ statuses: [RemoteProviderStatus]) -> Set<String> {
+        Set(statuses.map { $0.config.name })
+    }
+
+    // MARK: - The three branches
+
+    @Test func remoteBackendsDisabledReturnsNoManager() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        // Nobody called setRemoteBackendsEnabled: NULL resolves through
+        // Config.remoteBackendsEnabledDefault, which ships false.
+        let outcome = await Daemon.makeRemoteProviderManager(
+            database: db, subs: StateSubscriptionManager(), actuationLog: makeTestActuationLog(),
+            registryURL: tempRegistryURL(tag: "off"))
+        #expect(outcome.manager == nil)
+        #expect(outcome.claudeCloudLive == false)
+    }
+
+    @Test func outerFlagOnCloudFlagOffReturnsAManagerWithNoCloudProvider() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteBackendsEnabled(true)
+        let outcome = await Daemon.makeRemoteProviderManager(
+            database: db, subs: StateSubscriptionManager(), actuationLog: makeTestActuationLog(),
+            registryURL: tempRegistryURL(tag: "cloud-off"))
+        let manager = try #require(outcome.manager, "the outer flag alone must still build a manager")
+        #expect(outcome.claudeCloudLive == false)
+        #expect(!names(await manager.providerStatuses()).contains(ClaudeCloudProvider.name))
+    }
+
+    @Test func bothFlagsOnAndTheResolverSucceedingRegistersCloud() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setClaudeCloud(true)
+        let outcome = await Daemon.makeRemoteProviderManager(
+            database: db, subs: StateSubscriptionManager(), actuationLog: makeTestActuationLog(),
+            registryURL: tempRegistryURL(tag: "cloud-live"),
+            resolveClaudeExecutable: { "/opt/acme/claude" })
+        let manager = try #require(outcome.manager)
+        #expect(outcome.claudeCloudLive == true)
+        let statuses = await manager.providerStatuses()
+        #expect(names(statuses).contains(ClaudeCloudProvider.name))
+        #expect(statuses.first { $0.config.name == ClaudeCloudProvider.name }?.config.exec == "/opt/acme/claude")
+    }
+
+    @Test func bothFlagsOnAndTheResolverThrowingRegistersNoCloudButKeepsTheManager() async throws {
+        struct NoClaudeOnThisBox: Error {}
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setClaudeCloud(true)
+        let outcome = await Daemon.makeRemoteProviderManager(
+            database: db, subs: StateSubscriptionManager(), actuationLog: makeTestActuationLog(),
+            registryURL: tempRegistryURL(tag: "cloud-unresolved"),
+            resolveClaudeExecutable: { throw NoClaudeOnThisBox() })
+        let manager = try #require(
+            outcome.manager, "a resolver failure must not take down remote backends entirely")
+        #expect(outcome.claudeCloudLive == false)
+        #expect(!names(await manager.providerStatuses()).contains(ClaudeCloudProvider.name))
+    }
+
+    // MARK: - The `actuationLog:` regression this factory exists to prevent
+
+    /// Proves `actuationLog` reaches the constructed manager by observing
+    /// its one visible effect — `syncFilingDecisions` filing a row — rather
+    /// than by introspecting a private property. Uses a registry-loaded
+    /// provider declaring `archive`, not `claude-cloud`: `claude-cloud`'s own
+    /// `describe` no longer declares `archive` (finding 3 of this round),
+    /// so it can no longer drive this path.
+    @Test func theConstructedManagerHasAWorkingFilingSync() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteBackendsEnabled(true)
+        let registryURL = tempRegistryURL(tag: "filing-sync")
+        try #"[{"name": "fake", "exec": "/nonexistent"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        let describe = providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": ["archive"]}"#)
+        let subprocess = FakeProviderInvoker(script: [describe])
+        let actuationLog = makeTestActuationLog(tag: "boot-filing-sync")
+
+        let outcome = await Daemon.makeRemoteProviderManager(
+            database: db, subs: StateSubscriptionManager(), actuationLog: actuationLog,
+            registryURL: registryURL, subprocess: subprocess)
+        let manager = try #require(outcome.manager)
+        await manager.loadRegistryAndDescribe()
+
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
+            provider: "fake", sessionID: "sess-1")
+
+        try await manager.apply(
+            snapshot: [RemoteSessionPayload(id: "sess-1", state: .running, agentState: .idle, archived: true)],
+            provider: "fake")
+
+        let after = try await db.worktrees.get(id: worktree.id)
+        #expect(
+            after?.status == .archived,
+            "the filing sync did not run — actuationLog was not threaded through the production factory")
+    }
+
+    /// Discriminates the pin above: the identical scenario, but on a manager
+    /// built with `actuationLog: nil` — what dropping the argument at the
+    /// production call site would produce — leaves the row untouched. Without
+    /// this, the test above could pass for a reason unrelated to
+    /// `actuationLog` and nobody would notice.
+    @Test func withoutAnActuationLogTheSameSnapshotLeavesTheRowUnarchived() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let registryURL = tempRegistryURL(tag: "filing-sync-regressed")
+        try #"[{"name": "fake", "exec": "/nonexistent"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        let describe = providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": ["archive"]}"#)
+        let subprocess = FakeProviderInvoker(script: [describe])
+        // Hand-built, bypassing the factory, with actuationLog OMITTED —
+        // exactly the regression the factory's non-defaulted parameter now
+        // makes impossible at the real call site.
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: StateSubscriptionManager(),
+            runner: ProviderDispatcher(subprocess: subprocess, builtIns: [:]),
+            registryURL: registryURL)
+        await manager.loadRegistryAndDescribe()
+
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
+            provider: "fake", sessionID: "sess-1")
+
+        try await manager.apply(
+            snapshot: [RemoteSessionPayload(id: "sess-1", state: .running, agentState: .idle, archived: true)],
+            provider: "fake")
+
+        let after = try await db.worktrees.get(id: worktree.id)
+        #expect(after?.status == .active, "sanity: an absent actuationLog must skip the filing sync")
+    }
+}

--- a/Tests/TBDDaemonTests/ProviderContractEnvironmentTests.swift
+++ b/Tests/TBDDaemonTests/ProviderContractEnvironmentTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The contract requires `TBD_CONTRACT_VERSION` on every invocation, and the
+/// daemon has two emitters of it. Both must announce the major the daemon
+/// negotiated for that provider rather than a constant, or a provider that
+/// branches on the version sees a different answer per verb.
+///
+/// Tier 2: the one spawn here is `/bin/sh -c env`, a short-lived child this
+/// suite fully controls.
+@Suite("ProviderContractEnvironment")
+struct ProviderContractEnvironmentTests {
+
+    @Test func runnerEnvironmentCarriesTheNegotiatedMajor() {
+        let env = ProviderRunner.invocationEnvironment(
+            base: ["PATH": "/usr/bin"], contractVersion: 2)
+        #expect(env["TBD_CONTRACT_VERSION"] == "2")
+        #expect(env["PATH"] == "/usr/bin")
+    }
+
+    @Test func runnerEnvironmentStillEmitsOneForAV1Provider() {
+        let env = ProviderRunner.invocationEnvironment(base: [:], contractVersion: 1)
+        #expect(env["TBD_CONTRACT_VERSION"] == "1")
+    }
+
+    /// End to end through a real spawn: the variable the child actually sees is
+    /// the negotiated major, not the constant the runner used to hardcode.
+    @Test func spawnedProviderSeesTheNegotiatedMajor() async throws {
+        let config = RemoteProviderConfig(name: "probe", exec: "/bin/sh", args: ["-c", "env"])
+        let result = try await ProviderRunner().run(
+            config, verb: ["describe"], stdin: nil, timeout: 10, contractVersion: 2)
+        let text = String(data: result.stdout, encoding: .utf8) ?? ""
+        #expect(text.contains("TBD_CONTRACT_VERSION=2"))
+        #expect(!text.contains("TBD_CONTRACT_VERSION=1"))
+    }
+}

--- a/Tests/TBDDaemonTests/ProviderContractEnvironmentTests.swift
+++ b/Tests/TBDDaemonTests/ProviderContractEnvironmentTests.swift
@@ -36,4 +36,26 @@ struct ProviderContractEnvironmentTests {
         #expect(text.contains("TBD_CONTRACT_VERSION=2"))
         #expect(!text.contains("TBD_CONTRACT_VERSION=1"))
     }
+
+    /// The second daemon-side emitter. It hardcoded `"1"` alongside the
+    /// runner's, so the two would disagree for any provider that negotiated
+    /// anything else — and the events stream is a long-lived process, so the
+    /// disagreement would persist for the provider's whole lifetime.
+    @Test func eventsStreamEnvironmentCarriesTheNegotiatedMajor() {
+        let env = ProviderEventsSupervisor.streamEnvironment(
+            base: ["PATH": "/usr/bin"], contractVersion: 2)
+        #expect(env["TBD_CONTRACT_VERSION"] == "2")
+        #expect(env["PATH"] == "/usr/bin")
+    }
+
+    /// Both emitters agree for a given major — the property that matters, since
+    /// they are two independent code paths spawning the same provider.
+    @Test func bothDaemonEmittersAgree() {
+        for major in [1, 2] {
+            let runner = ProviderRunner.invocationEnvironment(base: [:], contractVersion: major)
+            let stream = ProviderEventsSupervisor.streamEnvironment(base: [:], contractVersion: major)
+            #expect(runner["TBD_CONTRACT_VERSION"] == stream["TBD_CONTRACT_VERSION"])
+            #expect(runner["TBD_CONTRACT_VERSION"] == String(major))
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/ProviderDispatcherTests.swift
+++ b/Tests/TBDDaemonTests/ProviderDispatcherTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Tier 1: pure routing over two fakes.
+@Suite("ProviderDispatcher")
+struct ProviderDispatcherTests {
+    /// A verb naming a reserved provider is served IN-PROCESS and never
+    /// reaches `ProviderRunner`, so no registered-provider executable is
+    /// spawned for it.
+    @Test func aReservedNameIsServedInProcess() async throws {
+        let subprocess = FakeProviderInvoker(script: [providerOK("{}")])
+        let builtIn = FakeProviderInvoker(script: [providerOK(#"{"served":"builtin"}"#)])
+        let dispatcher = ProviderDispatcher(
+            subprocess: subprocess, builtIns: [ClaudeCloudProvider.name: builtIn])
+
+        let result = try await dispatcher.run(
+            RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: "/opt/acme/claude"),
+            verb: ["list"], stdin: nil, timeout: 30, contractVersion: 2)
+
+        #expect(String(decoding: result.stdout, as: UTF8.self) == #"{"served":"builtin"}"#)
+        #expect(builtIn.calls == [["list"]])
+        #expect(subprocess.calls.isEmpty)
+    }
+
+    /// The discriminating half: a registered provider still goes through the
+    /// runner, so the built-in entry did not capture everything.
+    @Test func aRegisteredNameStillGoesThroughTheSubprocessArm() async throws {
+        let subprocess = FakeProviderInvoker(script: [providerOK(#"{"served":"subprocess"}"#)])
+        let builtIn = FakeProviderInvoker(script: [])
+        let dispatcher = ProviderDispatcher(
+            subprocess: subprocess, builtIns: [ClaudeCloudProvider.name: builtIn])
+
+        let result = try await dispatcher.run(
+            RemoteProviderConfig(name: "acme", exec: "/usr/bin/acme"),
+            verb: ["list"], stdin: nil, timeout: 30, contractVersion: 1)
+
+        #expect(String(decoding: result.stdout, as: UTF8.self) == #"{"served":"subprocess"}"#)
+        #expect(subprocess.calls == [["list"]])
+        #expect(builtIn.calls.isEmpty)
+    }
+
+    /// With no built-in registered — the cloud flag off at boot — the
+    /// reserved name has no in-process entry and falls through like any other
+    /// unknown provider, rather than being special-cased into a hole.
+    @Test func anEmptyBuiltInTableRoutesEverythingToTheSubprocessArm() async throws {
+        let subprocess = FakeProviderInvoker(script: [providerOK("{}")])
+        let dispatcher = ProviderDispatcher(subprocess: subprocess, builtIns: [:])
+        _ = try await dispatcher.run(
+            RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: "/opt/acme/claude"),
+            verb: ["describe"], stdin: nil, timeout: 10, contractVersion: 2)
+        #expect(subprocess.calls == [["describe"]])
+    }
+
+    /// Every argument reaches the selected arm unchanged — stdin and the
+    /// negotiated major most of all, since the whole point of threading the
+    /// major is that both conformances announce the value the daemon agreed
+    /// to.
+    @Test func stdinAndTheNegotiatedMajorReachTheBuiltInUnchanged() async throws {
+        let builtIn = FakeProviderInvoker(script: [providerOK("{}")])
+        let dispatcher = ProviderDispatcher(
+            subprocess: FakeProviderInvoker(script: []),
+            builtIns: [ClaudeCloudProvider.name: builtIn])
+
+        _ = try await dispatcher.run(
+            RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: "/opt/acme/claude"),
+            verb: ["send", "s"], stdin: Data("hi\r".utf8), timeout: 30, contractVersion: 2)
+
+        #expect(builtIn.stdinsSnapshot() == [Data("hi\r".utf8)])
+        #expect(builtIn.contractVersionsSnapshot() == [2])
+    }
+
+    // MARK: - Built-in registration
+
+    private func makeRegistry(_ json: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dispatcher-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("agent-providers.json")
+        try json.write(to: file, atomically: true, encoding: .utf8)
+        return file
+    }
+
+    /// A built-in provider must appear in `providerStatuses()` and negotiate
+    /// its own major, exactly as a registered one does — the manager is what
+    /// arms its poll loop and holds its health.
+    @Test func aBuiltInProviderIsRegisteredAndDescribed() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let registryURL = try makeRegistry(#"[{"name": "acme", "exec": "/usr/bin/acme"}]"#)
+        let builtIn = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 0, stdout: ClaudeCloudDescribe.json, stderr: "")
+        ])
+        let subprocess = FakeProviderInvoker(script: [
+            providerOK(#"{"contract_versions": [1], "name": "acme", "capabilities": []}"#)
+        ])
+        let m = RemoteProviderManager(
+            db: db, subscriptions: StateSubscriptionManager(),
+            runner: ProviderDispatcher(
+                subprocess: subprocess, builtIns: [ClaudeCloudProvider.name: builtIn]),
+            registryURL: registryURL,
+            builtInProviders: [
+                RemoteProviderConfig(name: ClaudeCloudProvider.name, exec: "/opt/acme/claude")
+            ])
+
+        await m.loadRegistryAndDescribe()
+
+        let names = await m.providerStatuses().map { $0.config.name }
+        #expect(Set(names) == [ClaudeCloudProvider.name, "acme"])
+        // `[2]` alone negotiates 2 rather than being refused.
+        #expect(await m.negotiatedContractMajor(for: ClaudeCloudProvider.name) == 2)
+        #expect(await m.negotiatedContractMajor(for: "acme") == 1)
+    }
+
+    /// The discriminating half: with no built-in passed, the reserved name is
+    /// simply absent — which is the shape a boot with the cloud flag off
+    /// produces.
+    @Test func noBuiltInMeansTheReservedNameIsAbsentEntirely() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let registryURL = try makeRegistry(#"[{"name": "acme", "exec": "/usr/bin/acme"}]"#)
+        let m = RemoteProviderManager(
+            db: db, subscriptions: StateSubscriptionManager(),
+            runner: ProviderDispatcher(
+                subprocess: FakeProviderInvoker(script: [
+                    providerOK(#"{"contract_versions": [1], "name": "acme", "capabilities": []}"#)
+                ]),
+                builtIns: [:]),
+            registryURL: registryURL)
+
+        await m.loadRegistryAndDescribe()
+
+        #expect(await m.providerStatuses().map { $0.config.name } == ["acme"])
+    }
+
+    /// A registry entry claiming the reserved name is skipped while every
+    /// other entry in the file still loads — one bad entry must never
+    /// silently remove every provider the user registered.
+    @Test func aRegistryEntryClaimingTheReservedNameIsSkippedAndTheRestLoad() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let registryURL = try makeRegistry(#"""
+        [{"name": "acme", "exec": "/usr/bin/acme"},
+         {"name": "claude-cloud", "exec": "/usr/bin/impostor"}]
+        """#)
+        let m = RemoteProviderManager(
+            db: db, subscriptions: StateSubscriptionManager(),
+            runner: ProviderDispatcher(
+                subprocess: FakeProviderInvoker(script: [
+                    providerOK(#"{"contract_versions": [1], "name": "acme", "capabilities": []}"#)
+                ]),
+                builtIns: [:]),
+            registryURL: registryURL)
+
+        await m.loadRegistryAndDescribe()
+
+        let statuses = await m.providerStatuses()
+        #expect(statuses.map { $0.config.name } == ["acme"])
+        // The impostor's exec never became a registered provider.
+        #expect(!statuses.contains { $0.config.exec == "/usr/bin/impostor" })
+    }
+}

--- a/Tests/TBDDaemonTests/ProviderRunnerTests.swift
+++ b/Tests/TBDDaemonTests/ProviderRunnerTests.swift
@@ -26,7 +26,8 @@ struct ProviderRunnerTests: ~Copyable {
 
     @Test func successCapturesStdoutAndContractVersionEnv() async throws {
         let config = try stub(#"echo "{\"ok\": true, \"v\": \"$TBD_CONTRACT_VERSION\"}""#)
-        let result = try await ProviderRunner().run(config, verb: ["list"], stdin: nil, timeout: 10)
+        let result = try await ProviderRunner().run(
+            config, verb: ["list"], stdin: nil, timeout: 10, contractVersion: 1)
         #expect(result.exitCode == 0)
         let text = String(data: result.stdout, encoding: .utf8) ?? ""
         #expect(text.contains(#""v": "1""#))
@@ -35,29 +36,33 @@ struct ProviderRunnerTests: ~Copyable {
     @Test func stdinIsDelivered() async throws {
         let config = try stub("cat")
         let result = try await ProviderRunner().run(
-            config, verb: ["create"], stdin: Data("hello".utf8), timeout: 10)
+            config, verb: ["create"], stdin: Data("hello".utf8), timeout: 10, contractVersion: 1)
         #expect(String(data: result.stdout, encoding: .utf8) == "hello")
     }
 
     @Test func exitCodesClassify() async throws {
         let auth = try stub(#"echo '{"error": {"code": "auth_expired", "message": "x"}}'; exit 4"#)
-        let result = try await ProviderRunner().run(auth, verb: ["list"], stdin: nil, timeout: 10)
+        let result = try await ProviderRunner().run(
+            auth, verb: ["list"], stdin: nil, timeout: 10, contractVersion: 1)
         #expect(result.failureClass == .authNeeded)
         #expect(result.decodedError?.code == "auth_expired")
 
         let transient = try stub("exit 3")
-        let t = try await ProviderRunner().run(transient, verb: ["list"], stdin: nil, timeout: 10)
+        let t = try await ProviderRunner().run(
+            transient, verb: ["list"], stdin: nil, timeout: 10, contractVersion: 1)
         #expect(t.failureClass == .transient)
         #expect(t.decodedError == nil)   // unparseable stdout → class-only fallback
 
         let weird = try stub("exit 17")
-        let w = try await ProviderRunner().run(weird, verb: ["list"], stdin: nil, timeout: 10)
+        let w = try await ProviderRunner().run(
+            weird, verb: ["list"], stdin: nil, timeout: 10, contractVersion: 1)
         #expect(w.failureClass == .permanent)
     }
 
     @Test func stderrIsCapturedSeparately() async throws {
         let config = try stub(#"echo '{"sessions": []}'; echo "diag" 1>&2"#)
-        let result = try await ProviderRunner().run(config, verb: ["list"], stdin: nil, timeout: 10)
+        let result = try await ProviderRunner().run(
+            config, verb: ["list"], stdin: nil, timeout: 10, contractVersion: 1)
         #expect(String(data: result.stdout, encoding: .utf8) == "{\"sessions\": []}\n")
         #expect(result.stderr.contains("diag"))
     }
@@ -65,7 +70,8 @@ struct ProviderRunnerTests: ~Copyable {
     @Test func missingExecutableThrows() async throws {
         let config = RemoteProviderConfig(name: "gone", exec: dir.appendingPathComponent("nope").path)
         await #expect(throws: (any Error).self) {
-            _ = try await ProviderRunner().run(config, verb: ["list"], stdin: nil, timeout: 10)
+            _ = try await ProviderRunner().run(
+                config, verb: ["list"], stdin: nil, timeout: 10, contractVersion: 1)
         }
     }
 
@@ -80,7 +86,8 @@ struct ProviderRunnerTests: ~Copyable {
     @Test func largeStdoutIsFullyCapturedWithoutDeadlock() async throws {
         let expectedByteCount = 300_000
         let config = try stub(#"yes "0123456789abcdef" | head -c \#(expectedByteCount)"#)
-        let result = try await ProviderRunner().run(config, verb: ["log"], stdin: nil, timeout: 10)
+        let result = try await ProviderRunner().run(
+            config, verb: ["log"], stdin: nil, timeout: 10, contractVersion: 1)
         #expect(result.exitCode == 0)
         #expect(result.stdout.count == expectedByteCount)
     }

--- a/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
@@ -246,13 +246,15 @@ struct RPCRouterRemoteTests: ~Copyable {
     @Test func createPassesParamsThroughAndReturnsSession() async throws {
         try await db.config.setRemoteBackendsEnabled(true)
         let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"id": "new-1", "state": "starting"}"#)
+            providerOK(#"{"id": "new-1", "state": "starting"}"#),
+            providerOK(#"{"complete": true, "sessions": [{"id": "new-1", "state": "running"}]}"#),
         ])
         let r = router(invoker: invoker)
         let response = await call(r, "remote.create",
             #"{"provider": "fake", "paramsJSON": "{\"repo\": \"acme/api\"}"}"#)
         #expect(response.success)
-        #expect(invoker.calls == [["create"]])
+        #expect(invoker.calls == [["create"], ["list"]],
+                "a successful create asks for exactly one immediate refresh")
         let session = try response.decodeResult(RemoteSessionPayload.self)
         #expect(session.id == "new-1")
     }
@@ -265,7 +267,8 @@ struct RPCRouterRemoteTests: ~Copyable {
     @Test func createBodyContainsCallerParamsAndOneIdempotencyKey() async throws {
         try await db.config.setRemoteBackendsEnabled(true)
         let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"id": "new-1", "state": "starting"}"#)
+            providerOK(#"{"id": "new-1", "state": "starting"}"#),
+            providerOK(#"{"complete": true, "sessions": [{"id": "new-1", "state": "running"}]}"#),
         ])
         let r = router(invoker: invoker)
         let response = await call(r, "remote.create",
@@ -290,17 +293,55 @@ struct RPCRouterRemoteTests: ~Copyable {
         let invoker = FakeProviderInvoker(outcomes: [
             .timeout,
             .result(providerOK(#"{"id": "new-1", "state": "starting"}"#)),
+            .result(providerOK(#"{"complete": true, "sessions": [{"id": "new-1", "state": "running"}]}"#)),
         ])
         let r = router(invoker: invoker)
         let response = await call(r, "remote.create",
             #"{"provider": "fake", "paramsJSON": "{}"}"#)
         #expect(response.success)
-        #expect(invoker.calls == [["create"], ["create"]],
-                "a timeout must produce exactly two create calls")
-        let stdins = invoker.stdinsSnapshot()
+        #expect(invoker.calls == [["create"], ["create"], ["list"]],
+                "a timeout must produce exactly two create calls, then one refresh")
+        let stdins = invoker.stdinsSnapshot().prefix(2)
         #expect(stdins.count == 2)
         #expect(stdins[0] == stdins[1],
                 "the retry must reuse the SAME idempotency key, not mint a fresh one")
+    }
+
+    /// The row a create produces arrives by ADOPTION rather than being minted
+    /// by the create call, and the poll loop's interval is 60 seconds — so a
+    /// lane created from the `+` menu would otherwise sit invisible for up to
+    /// a minute after a create that already succeeded. One immediate refresh
+    /// closes that, in the same shape `recordAttachExit` already uses after a
+    /// locally-observed event.
+    @Test func aSuccessfulCreateTriggersExactlyOneRefreshAndNeverALoop() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"id": "new-1", "state": "starting"}"#),
+            providerOK(#"{"complete": true, "sessions": [{"id": "new-1", "state": "running"}]}"#),
+        ])
+        let r = router(invoker: invoker)
+        let response = await call(r, "remote.create",
+            #"{"provider": "fake", "paramsJSON": "{}"}"#)
+        #expect(response.success)
+        #expect(invoker.calls == [["create"], ["list"]])
+    }
+
+    /// The discriminating half: a FAILED create must ask for nothing — the
+    /// refresh is bounded to one per successful create, never a poll flood on
+    /// a provider that is already failing.
+    @Test func aFailedCreateTriggersNoRefresh() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 1,
+                stdout: Data(#"{"error": {"code": "invalid_params", "message": "no"}}"#.utf8),
+                stderr: "")
+        ])
+        let r = router(invoker: invoker)
+        let response = await call(r, "remote.create",
+            #"{"provider": "fake", "paramsJSON": "{}"}"#)
+        #expect(response.success == false)
+        #expect(invoker.calls == [["create"]])
     }
 
     /// A timeout on both attempts must surface a readable message, not the
@@ -328,11 +369,14 @@ struct RPCRouterRemoteTests: ~Copyable {
     @Test func createNormalizesEmptyParamsJSONToEmptyObject() async throws {
         try await db.config.setRemoteBackendsEnabled(true)
         let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"id": "new-1", "state": "starting"}"#)
+            providerOK(#"{"id": "new-1", "state": "starting"}"#),
+            providerOK(#"{"complete": true, "sessions": [{"id": "new-1", "state": "running"}]}"#),
         ])
         let r = router(invoker: invoker)
         let response = await call(r, "remote.create", #"{"provider": "fake", "paramsJSON": ""}"#)
         #expect(response.success)
+        #expect(invoker.calls == [["create"], ["list"]],
+                "a successful create asks for exactly one immediate refresh")
         let stdin = try #require(invoker.stdinsSnapshot().first ?? nil)
         let body = try #require(try JSONSerialization.jsonObject(with: stdin) as? [String: Any])
         #expect((body["params"] as? [String: Any])?.isEmpty == true)

--- a/Tests/TBDDaemonTests/RemoteEventParserTests.swift
+++ b/Tests/TBDDaemonTests/RemoteEventParserTests.swift
@@ -13,8 +13,11 @@ struct RemoteEventParserTests {
         #expect(RemoteEventParser.parse(line: #"{"event": "removed", "id": "x"}"#) == .removed(id: "x"))
         let snap = RemoteEventParser.parse(
             line: #"{"event": "snapshot", "sessions": [{"id": "a", "state": "running"}]}"#)
-        guard case .snapshot(let sessions) = snap else { Issue.record("not a snapshot"); return }
+        guard case .snapshot(let sessions, let complete) = snap else {
+            Issue.record("not a snapshot"); return
+        }
         #expect(sessions.map(\.id) == ["a"])
+        #expect(complete, "an absent `complete` on a snapshot event reads as true")
         let sess = RemoteEventParser.parse(
             line: #"{"event": "session", "session": {"id": "b", "state": "exited"}}"#)
         guard case .session(let s) = sess else { Issue.record("not a session"); return }
@@ -38,5 +41,21 @@ struct RemoteEventParserTests {
         #expect(RemoteEventParser.parse(line: "   ") == nil)
         #expect(RemoteEventParser.parse(line: #"{"event": "future_thing"}"#) == nil)
         #expect(RemoteEventParser.parse(line: "not json") == nil)
+    }
+
+    /// The contract states `complete` on the events snapshot with exactly the
+    /// meaning and the caller rules it has on `list`, so the parser must not
+    /// silently drop it — a caller that only honored the `list` half would let
+    /// an events-capable partial provider retire its own live sessions.
+    @Test func theSnapshotEventCarriesCompleteness() {
+        #expect(
+            RemoteEventParser.parse(line: #"{"event": "snapshot", "complete": false, "sessions": []}"#)
+                == .snapshot([], complete: false))
+        #expect(
+            RemoteEventParser.parse(line: #"{"event": "snapshot", "complete": true, "sessions": []}"#)
+                == .snapshot([], complete: true))
+        #expect(
+            RemoteEventParser.parse(line: #"{"event": "snapshot", "sessions": []}"#)
+                == .snapshot([], complete: true))
     }
 }

--- a/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
+++ b/Tests/TBDDaemonTests/RemoteFilingSyncTests.swift
@@ -566,7 +566,7 @@ struct RemoteFilingSyncTests {
         let fixed = Date(timeIntervalSince1970: 7_000)
         let supervisor = ProviderEventsSupervisor(
             config: RemoteProviderConfig(name: "fake", exec: "/nonexistent"), manager: m,
-            now: { fixed })
+            contractVersion: 1, now: { fixed })
 
         #expect(await supervisor.connectionOpenedAt == fixed)
     }
@@ -645,7 +645,8 @@ private final class MidCallFilingInvoker: RemoteProviderInvoking, @unchecked Sen
     }
 
     func run(
-        _ config: RemoteProviderConfig, verb: [String], stdin: Data?, timeout: TimeInterval
+        _ config: RemoteProviderConfig, verb: [String], stdin: Data?, timeout: TimeInterval,
+        contractVersion: Int
     ) async throws -> ProviderResult {
         if verb.first == "list", let onListCall {
             await onListCall()

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -25,6 +25,10 @@ final class FakeProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
     /// stdin bytes for each call, same index as `calls`. `nil` entries are
     /// calls made with no stdin (e.g. `stop`/`log`).
     private(set) var stdins: [Data?] = []
+    /// Contract major handed to each call, same index as `calls`. The whole
+    /// point of the parameter is that it varies per provider, so a fake that
+    /// dropped it could not prove the negotiated value ever arrives.
+    private(set) var contractVersions: [Int] = []
     /// Runs after a verb is asked for and before its canned outcome is
     /// returned — the seam for observing daemon state *mid-flight*, while the
     /// provider call is still outstanding, without sleeping. Same shape as
@@ -47,20 +51,23 @@ final class FakeProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
 
     func run(
         _ config: RemoteProviderConfig, verb: [String], stdin: Data?,
-        timeout: TimeInterval
+        timeout: TimeInterval, contractVersion: Int
     ) async throws -> ProviderResult {
         if let onCall { await onCall(verb) }
-        return try popScript(verb, stdin: stdin)
+        return try popScript(verb, stdin: stdin, contractVersion: contractVersion)
     }
 
     /// Synchronous helper so the NSLock critical section isn't taken from an
     /// `async` context (recent Foundation marks `NSLock.lock`/`unlock` as
     /// unavailable from async contexts to discourage blocking there).
-    private func popScript(_ verb: [String], stdin: Data?) throws -> ProviderResult {
+    private func popScript(
+        _ verb: [String], stdin: Data?, contractVersion: Int
+    ) throws -> ProviderResult {
         lock.lock()
         defer { lock.unlock() }
         calls.append(verb)
         stdins.append(stdin)
+        contractVersions.append(contractVersion)
         precondition(!script.isEmpty, "FakeProviderInvoker script exhausted for verb \(verb)")
         switch script.removeFirst() {
         case .result(let result):
@@ -84,6 +91,13 @@ final class FakeProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return stdins
+    }
+
+    /// Locked snapshot of `contractVersions`, same rationale as `callsSnapshot()`.
+    func contractVersionsSnapshot() -> [Int] {
+        lock.lock()
+        defer { lock.unlock() }
+        return contractVersions
     }
 }
 

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -877,12 +877,13 @@ struct RemoteProviderManagerTests {
 
     @Test func versionMismatchNeverPolls() async throws {
         // describe negotiates no common contract version (provider only
-        // speaks v2) — start() must surface a health error and must never
-        // spawn a poll loop for this provider, so no `list` call is ever
-        // recorded, not even after start() returns and would otherwise have
-        // spawned loops for every successfully-described provider.
+        // speaks v3, which TBD does not support) — start() must surface a
+        // health error and must never spawn a poll loop for this provider, so
+        // no `list` call is ever recorded, not even after start() returns and
+        // would otherwise have spawned loops for every successfully-described
+        // provider.
         let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"contract_versions": [2], "name": "fake"}"#)
+            providerOK(#"{"contract_versions": [3], "name": "fake"}"#)
         ])
         let m = manager(invoker)
         await m.start()

--- a/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
+++ b/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
@@ -229,4 +229,63 @@ struct SnapshotCompletenessTests {
 
         #expect(await m.providerStatuses().first?.lastSuccessfulSnapshotAt == good)
     }
+
+    /// The other half of the same `if complete` gate: an incomplete snapshot
+    /// must not clear `snapshotFreshnessUnreadable` either, or a partial view
+    /// would silently launder a prior "freshness could not be read" state
+    /// into a clean one. Reuses the `DROP TABLE tbd_meta` technique from
+    /// `unreadableFreshnessStateGatesMutationsInsteadOfFailingOpen` in
+    /// RemoteProviderManagerTests to induce the flag.
+    ///
+    /// This reads the flag through `freshnessUnreadableForTests` rather than
+    /// `providerStatuses()`/`hasStaleSnapshot()`. Both of those call
+    /// `recoverLastSuccessfulSnapshotAtIfNeeded` first, which — while
+    /// `lastSuccessfulSnapshotAt["fake"]` stays nil, which it does throughout
+    /// this test — unconditionally re-derives the flag from a fresh
+    /// `tbd_meta` read on every single call. Checked empirically: a version
+    /// of this test built on `providerStatuses()` alone read `true` after the
+    /// incomplete apply *regardless* of whether `apply`'s own gate was
+    /// correct, because that trailing status read re-threw against the still
+    /// dropped table and stamped the flag back to `true` on its own. Going
+    /// through the plain accessor observes `apply`'s effect before any
+    /// recovery call gets a chance to launder it.
+    @Test func anIncompleteSnapshotLeavesFreshnessUnreadableSet() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake",
+            sessions: [RemoteSessionPayload(id: "a", state: .running)],
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: "DROP TABLE tbd_meta")
+        }
+        let subs = StateSubscriptionManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-complete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let registryURL = dir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        let m = RemoteProviderManager(
+            db: db, subscriptions: subs,
+            runner: FakeProviderInvoker(script: [
+                ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+            ]),
+            registryURL: registryURL)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+
+        // Establish the unreadable state: the read that recovers
+        // `lastSuccessfulSnapshotAt` from the (now-dropped) `tbd_meta` table
+        // fails, so `hasStaleSnapshot` sets `snapshotFreshnessUnreadable`.
+        await m.pollOnce(provider: provider)
+        #expect(await m.freshnessUnreadableForTests(provider: "fake") == true)
+
+        // An incomplete apply must not touch the flag one way or the other,
+        // so the table's readability is irrelevant to this call — leave it
+        // dropped.
+        try await m.apply(
+            snapshot: [], provider: "fake", complete: false,
+            now: Date(timeIntervalSince1970: 1_700_000_500))
+
+        #expect(await m.freshnessUnreadableForTests(provider: "fake") == true)
+    }
 }

--- a/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
+++ b/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
@@ -122,4 +122,111 @@ struct SnapshotCompletenessTests {
         _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [], now: Date())
         #expect(try await db.remoteSessions.list()[0].gone)
     }
+
+    // MARK: - The manager half
+
+    /// The whole point of the field for `claude-cloud`: a provider whose
+    /// snapshots are always incomplete never claims freshness, so a restart
+    /// cannot recover a timestamp it never earned.
+    @Test func anIncompleteSnapshotDoesNotStampInMemoryFreshness() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-complete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let registryURL = dir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"complete": false, "sessions": [{"id": "a", "state": "running"}]}"#)
+        ])
+        let m = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        let status = await m.providerStatuses().first
+        // The provider ANSWERED, so degraded health clears…
+        #expect(status?.health == .ok)
+        // …but nothing claims a complete inventory was ever held.
+        #expect(status?.lastSuccessfulSnapshotAt == nil)
+        // And the row it sighted was still adopted into the mirror.
+        #expect(try await db.remoteSessions.list().map(\.sessionID) == ["a"])
+        // Mutations stay available: `isStaleSnapshot` deliberately excludes a
+        // provider confirmed never to have snapshotted, so Send renders.
+        #expect(await m.hasStaleSnapshot(provider: "fake") == false)
+        #expect(status?.hasStaleSnapshot == false)
+    }
+
+    @Test func aCompleteSnapshotStillStampsInMemoryFreshness() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-complete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let registryURL = dir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"complete": true, "sessions": [{"id": "a", "state": "running"}]}"#)
+        ])
+        let m = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        #expect(await m.providerStatuses().first?.lastSuccessfulSnapshotAt != nil)
+    }
+
+    /// A provider that only ever answers incompletely must still recover from
+    /// a transport failure — "the provider answered" is what clears degraded
+    /// health, and conflating it with freshness would wedge Send forever.
+    @Test func anIncompleteSnapshotClearsDegradedHealth() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-complete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let registryURL = dir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline"),
+            providerOK(#"{"complete": false, "sessions": []}"#),
+        ])
+        let m = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+
+        await m.pollOnce(provider: provider)
+        #expect(await m.providerStatuses().first?.health == .stale)
+
+        await m.pollOnce(provider: provider)
+        #expect(await m.providerStatuses().first?.health == .ok)
+    }
+
+    /// A recovered-from-disk stamp is knowledge the manager legitimately has;
+    /// an incomplete snapshot must not overwrite it with `now`.
+    @Test func anIncompleteSnapshotLeavesARecoveredStampAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let good = Date(timeIntervalSince1970: 1_700_000_000)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake", sessions: [RemoteSessionPayload(id: "a", state: .running)],
+            complete: true, now: good)
+        let subs = StateSubscriptionManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-complete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let registryURL = dir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+        let m = RemoteProviderManager(
+            db: db, subscriptions: subs,
+            runner: FakeProviderInvoker(script: [providerOK(#"{"complete": false, "sessions": []}"#)]),
+            registryURL: registryURL)
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        #expect(await m.providerStatuses().first?.lastSuccessfulSnapshotAt == good)
+    }
 }

--- a/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
+++ b/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
@@ -33,4 +33,93 @@ struct SnapshotCompletenessTests {
         #expect(RemoteSessionListEnvelope(sessions: []).complete)
         #expect(RemoteSessionListEnvelope(sessions: [], complete: false).complete == false)
     }
+
+    // MARK: - The store half
+
+    private func payload(_ id: String) -> RemoteSessionPayload {
+        RemoteSessionPayload(id: id, state: .running, agentState: .working)
+    }
+
+    /// The defect being fixed: a provider that can only ever enumerate part
+    /// of its inventory would tombstone its own live lanes two polls after
+    /// creating them.
+    @Test func anIncompleteSnapshotNeverAdvancesMissingCount() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], complete: false, now: Date())
+        for _ in 0..<5 {
+            _ = try await db.remoteSessions.applySnapshot(
+                provider: "p", sessions: [], complete: false, now: Date())
+        }
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.count == 1)
+        #expect(rows[0].missingCount == 0)
+        #expect(rows[0].gone == false)
+    }
+
+    /// The discriminating pair: the SAME absence under a complete snapshot
+    /// must still retire, or the fix would have disabled the rule outright.
+    @Test func aCompleteSnapshotStillRetiresOnTwoAbsences() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], complete: true, now: Date())
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [], complete: true, now: Date())
+        #expect(try await db.remoteSessions.list()[0].missingCount == 1)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [], complete: true, now: Date())
+        #expect(try await db.remoteSessions.list()[0].gone)
+    }
+
+    /// An incomplete snapshot is authoritative about PRESENCE, so a session
+    /// it sighted is still adopted into the mirror.
+    @Test func anIncompleteSnapshotStillInsertsASessionItSighted() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let outcome = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], complete: false, now: Date())
+        #expect(outcome.changed)
+        #expect(try await db.remoteSessions.list().map(\.sessionID) == ["a"])
+    }
+
+    /// The persisted half of freshness. Without this the partial view
+    /// survives a daemon restart looking fresh.
+    @Test func anIncompleteSnapshotWritesNoPersistedFreshnessKey() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], complete: false,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(try await db.remoteSessions.lastSuccessfulSnapshotAt(provider: "p") == nil)
+    }
+
+    @Test func aCompleteSnapshotStillWritesThePersistedFreshnessKey() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let at = Date(timeIntervalSince1970: 1_700_000_000)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], complete: true, now: at)
+        #expect(try await db.remoteSessions.lastSuccessfulSnapshotAt(provider: "p") == at)
+    }
+
+    /// A later incomplete snapshot must not CLOBBER a good persisted stamp
+    /// either — suppression means "leave it where it was", not "write now".
+    @Test func anIncompleteSnapshotLeavesAnEarlierFreshnessStampIntact() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let good = Date(timeIntervalSince1970: 1_700_000_000)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], complete: true, now: good)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], complete: false,
+            now: Date(timeIntervalSince1970: 1_700_009_999))
+        #expect(try await db.remoteSessions.lastSuccessfulSnapshotAt(provider: "p") == good)
+    }
+
+    /// Omitting the argument keeps today's behavior, which is what lets every
+    /// pre-existing call site stand.
+    @Test func theDefaultedArgumentBehavesAsComplete() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a")], now: Date())
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [], now: Date())
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [], now: Date())
+        #expect(try await db.remoteSessions.list()[0].gone)
+    }
 }

--- a/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
+++ b/Tests/TBDDaemonTests/SnapshotCompletenessTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Tier 1: pure decode, no I/O.
+@Suite("SnapshotCompleteness")
+struct SnapshotCompletenessTests {
+    private func envelope(_ json: String) throws -> RemoteSessionListEnvelope {
+        try JSONDecoder().decode(RemoteSessionListEnvelope.self, from: Data(json.utf8))
+    }
+
+    /// The contract's default: "Absent — MUST be read as `true`. A provider
+    /// that always enumerates everything need never emit the field."
+    @Test func anAbsentCompleteFieldReadsAsTrue() throws {
+        let decoded = try envelope(#"{"sessions": [{"id": "a", "state": "running"}]}"#)
+        #expect(decoded.complete)
+        #expect(decoded.sessions.map(\.id) == ["a"])
+    }
+
+    @Test func anExplicitFalseSurvivesDecoding() throws {
+        let decoded = try envelope(#"{"complete": false, "sessions": []}"#)
+        #expect(decoded.complete == false)
+    }
+
+    @Test func anExplicitTrueSurvivesDecoding() throws {
+        let decoded = try envelope(#"{"complete": true, "sessions": []}"#)
+        #expect(decoded.complete)
+    }
+
+    /// The memberwise init keeps its old call shape for every existing fixture.
+    @Test func theMemberwiseInitDefaultsToComplete() {
+        #expect(RemoteSessionListEnvelope(sessions: []).complete)
+        #expect(RemoteSessionListEnvelope(sessions: [], complete: false).complete == false)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeLocationStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLocationStoreTests.swift
@@ -28,4 +28,61 @@ import Foundation
         let fetched = try #require(try await db.worktrees.get(id: wt.id))
         #expect(fetched.location == .remote(provider: "agentbox", sessionID: "s-1"))
     }
+
+    /// A landed row: `location` says the files are here, the two provider
+    /// columns say which session it came from. Today the record erases that in
+    /// both directions — `init(from:)` nils both columns for the `.local` case
+    /// and `toModel()` discards them unless the kind is `"remote"`.
+    @Test func landedRowRoundTripsThroughTheRecord() throws {
+        let landed = Worktree(
+            repoID: UUID(), name: "w", displayName: "w", branch: "b",
+            path: "/tmp/landed", tmuxServer: "srv",
+            location: .local,
+            origin: WorktreeOrigin(provider: "claude-cloud", sessionID: "session_01AAAA"))
+        let round = try #require(WorktreeRecord(from: landed).toModel())
+        #expect(round.location == .local)
+        #expect(round.origin == WorktreeOrigin(provider: "claude-cloud", sessionID: "session_01AAAA"))
+        #expect(round.localPath == "/tmp/landed")
+    }
+
+    /// Adoption's idempotence check must keep matching after a landing, or the
+    /// next complete snapshot mints a second row for a session that already has
+    /// a lane on this machine.
+    @Test func findRemoteStillMatchesALandedRow() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let remote = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "w", branch: "b",
+            provider: "claude-cloud", sessionID: "session_01BBBB")
+
+        // Land it: the files arrive on this machine, the provenance stays.
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "UPDATE worktree SET location = 'local', path = ? WHERE id = ?",
+                arguments: ["/tmp/landed-\(remote.id.uuidString)", remote.id.uuidString])
+        }
+
+        let fetched = try #require(try await db.worktrees.get(id: remote.id))
+        #expect(fetched.location == .local)
+        #expect(fetched.origin == WorktreeOrigin(provider: "claude-cloud", sessionID: "session_01BBBB"))
+
+        let found = try #require(
+            try await db.worktrees.findRemote(provider: "claude-cloud", sessionID: "session_01BBBB"))
+        #expect(found.id == remote.id)
+    }
+
+    /// A row that never had a provider session reads back with no origin at
+    /// all — nil is a real third answer, not an empty pair.
+    @Test func plainLocalRowHasNoOrigin() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/r/w-\(UUID().uuidString)", tmuxServer: "s")
+        let fetched = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(fetched.origin == nil)
+        #expect(fetched.location == .local)
+    }
 }

--- a/Tests/TBDSharedTests/RemoteProviderReservedNameTests.swift
+++ b/Tests/TBDSharedTests/RemoteProviderReservedNameTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+// Tier 2: reads a temp file, no daemon and no network.
+@Suite("RemoteProviderReservedName")
+struct RemoteProviderReservedNameTests {
+    private func write(_ json: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("reserved-name-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("agent-providers.json")
+        try json.write(to: file, atomically: true, encoding: .utf8)
+        return file
+    }
+
+    /// One bad entry must cost that entry, never the file: `load` throws for
+    /// the WHOLE registry on a duplicate, and two of its three call sites
+    /// swallow that, so a reserved-name collision would otherwise silently
+    /// remove every provider the user registered.
+    @Test func aReservedEntryIsSkippedAndFlaggedWhileEveryOtherEntryLoads() throws {
+        let file = try write(#"""
+        [{"name": "acme", "exec": "/usr/bin/acme"},
+         {"name": "claude-cloud", "exec": "/usr/bin/impostor"},
+         {"name": "other", "exec": "/usr/bin/other"}]
+        """#)
+        let loaded = try RemoteProviderRegistry.loadEntries(from: file)
+        #expect(loaded.configs.map(\.name) == ["acme", "other"])
+        #expect(loaded.skippedReservedNames == ["claude-cloud"])
+    }
+
+    /// The skip is checked BEFORE the duplicate rule, so two reserved entries
+    /// are two skips rather than a duplicate-name failure of the whole file.
+    @Test func twoReservedEntriesAreTwoSkipsNotADuplicate() throws {
+        let file = try write(#"""
+        [{"name": "claude-cloud", "exec": "/a"}, {"name": "claude-cloud", "exec": "/b"}]
+        """#)
+        let loaded = try RemoteProviderRegistry.loadEntries(from: file)
+        #expect(loaded.configs.isEmpty)
+        #expect(loaded.skippedReservedNames == ["claude-cloud", "claude-cloud"])
+    }
+
+    /// The discriminating half: a duplicate of a NON-reserved name still
+    /// rejects the file, so the skip did not weaken the duplicate rule.
+    @Test func aDuplicateNonReservedNameStillRejectsTheWholeFile() throws {
+        let file = try write(#"[{"name": "acme", "exec": "/a"}, {"name": "acme", "exec": "/b"}]"#)
+        #expect(throws: RemoteProviderRegistry.RegistryError.duplicateName("acme")) {
+            try RemoteProviderRegistry.loadEntries(from: file)
+        }
+    }
+
+    @Test func loadKeepsItsSignatureAndDropsTheReservedEntry() throws {
+        let file = try write(#"""
+        [{"name": "acme", "exec": "/usr/bin/acme"}, {"name": "claude-cloud", "exec": "/x"}]
+        """#)
+        #expect(try RemoteProviderRegistry.load(from: file).map(\.name) == ["acme"])
+    }
+
+    @Test func aMissingFileIsStillNoProvidersRatherThanAnError() throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("absent-\(UUID().uuidString).json")
+        let loaded = try RemoteProviderRegistry.loadEntries(from: missing)
+        #expect(loaded.configs.isEmpty)
+        #expect(loaded.skippedReservedNames.isEmpty)
+    }
+
+    @Test func isReservedAnswersForBothCases() {
+        #expect(RemoteProviderRegistry.isReserved(ClaudeCloudProvider.name))
+        #expect(!RemoteProviderRegistry.isReserved("acme"))
+    }
+}

--- a/Tests/TBDSharedTests/WorktreeLocationTests.swift
+++ b/Tests/TBDSharedTests/WorktreeLocationTests.swift
@@ -99,4 +99,64 @@ import Foundation
         #expect(object?["path"] as? String == "/tmp/n")
         #expect(object?["localPath"] == nil)
     }
+
+    /// A landed lane: the files are here (`.local`) and the provenance is the
+    /// cloud session it was reconstructed from. Until `origin` exists there is
+    /// nowhere to put the second fact, and the sidebar forgets which session it
+    /// rebuilt the moment the daemon reloads the row.
+    @Test func landedRowKeepsItsOriginAcrossCodable() throws {
+        let wt = Worktree(
+            repoID: UUID(), name: "n", displayName: "n", branch: "b",
+            path: "/tmp/n", tmuxServer: "s",
+            location: .local,
+            origin: WorktreeOrigin(provider: "claude-cloud", sessionID: "session_01AAAA"))
+        let decoded = try JSONDecoder().decode(Worktree.self, from: JSONEncoder().encode(wt))
+        #expect(decoded.location == .local)
+        #expect(decoded.origin == WorktreeOrigin(provider: "claude-cloud", sessionID: "session_01AAAA"))
+    }
+
+    /// A landed row rides the wire as `locationKind: "local"` with the pair
+    /// set, which an older peer reads exactly as it reads a local row today.
+    @Test func landedRowEncodesAsLocalKindWithThePairSet() throws {
+        let wt = Worktree(
+            repoID: UUID(), name: "n", displayName: "n", branch: "b",
+            path: "/tmp/n", tmuxServer: "s",
+            location: .local,
+            origin: WorktreeOrigin(provider: "claude-cloud", sessionID: "session_01BBBB"))
+        let object = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(wt)) as? [String: Any]
+        #expect(object?["locationKind"] as? String == "local")
+        #expect(object?["providerName"] as? String == "claude-cloud")
+        #expect(object?["providerSessionID"] as? String == "session_01BBBB")
+    }
+
+    /// Every existing construction site passes no `origin`, so a `.remote` row
+    /// must satisfy the invariant by construction rather than by call-site
+    /// discipline.
+    @Test func remoteLocationDefaultsOriginToItsOwnPair() {
+        let wt = Worktree(
+            repoID: UUID(), name: "n", displayName: "n", branch: "b",
+            path: "", tmuxServer: "",
+            location: .remote(provider: "agentbox", sessionID: "s-1"))
+        #expect(wt.origin == WorktreeOrigin(provider: "agentbox", sessionID: "s-1"))
+    }
+
+    /// `providerBinding` means "the provider session behind this row", which is
+    /// exactly what survives a landing — so it reads `origin`, not `location`.
+    @Test func providerBindingSurvivesTheLanding() throws {
+        let landed = Worktree(
+            repoID: UUID(), name: "n", displayName: "n", branch: "b",
+            path: "/tmp/n", tmuxServer: "s",
+            location: .local,
+            origin: WorktreeOrigin(provider: "claude-cloud", sessionID: "session_01CCCC"))
+        let binding = try #require(landed.providerBinding)
+        #expect(binding.provider == "claude-cloud")
+        #expect(binding.sessionID == "session_01CCCC")
+
+        let plainLocal = Worktree(
+            repoID: UUID(), name: "n", displayName: "n", branch: "b",
+            path: "/tmp/n", tmuxServer: "s")
+        #expect(plainLocal.origin == nil)
+        #expect(plainLocal.providerBinding == nil)
+    }
 }

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -1527,7 +1527,7 @@ autonomous background polling against a network service, squarely inside the
 default-off rule.
 
 **The column is added with no SQL default**, so unset stays a genuine third
-state. Migration `v80_config_claude_cloud` calls
+state. Migration `v81_config_claude_cloud` calls
 `addColumnIfMissing(table:column:type:)` with `defaults:` **omitted** —
 `v73_config_queued_prompt` (`Database.swift`:1334) and `v77_config_supervision_enabled`
 (:1406) are the precedents, and the long comment above the former states the

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -432,6 +432,75 @@ and none of that separation survives a PTY. So the mode is opt-in per invocation
 rather than a property of the provider, and `create`, whose whole answer is three
 lines of prose on stdout, is the only verb that sets it.
 
+### The process `create` spawns has no reconciler, on purpose
+
+`create` is a new kind of durable resource for TBD: a process spawned outside
+tmux, on a pty the daemon opened for exactly this call. Per `CLAUDE.md`'s
+reconciler doctrine
+([`2026-08-15-named-reconciler-doctrine-design.md`](2026-08-15-named-reconciler-doctrine-design.md)),
+that requires one of three answers — name the reconciler that covers it, argue
+that an orphan cannot arise, or point to a spec that deliberately chose
+otherwise. This is the third: no sweep reclaims this process, and this
+subsection is that decision, recorded where the spawn lives rather than at the
+end of the document.
+
+**The failure mode is real, and it was reproduced rather than argued.** The
+deadline on a `create` invocation lives entirely inside the daemon that spawned
+it — `runBoundedProcess` hands it to `SubprocessWatchdog`, a thread in the
+daemon's own process, not anything independent of it. If the daemon dies while
+a `create` is in flight, the watchdog dies with it and the child is reparented
+to pid 1 with nothing left supervising it. This was measured, not inferred: a
+child holding a pty replica, with its parent process killed with `SIGKILL`,
+survived and was observed reparented to pid 1 — its `ppid` changed from the
+parent to `1` — and kept running. Nothing signals it when this happens: the
+runner never calls `setsid` or claims the pty as the child's controlling
+terminal with `TIOCSCTTY` — neither call appears in `BoundedProcessRunner.swift`
+— so the pty the child inherits is never *controlling*, and closing the primary
+side sends it no `SIGHUP`. The ordinary way a lost parent's children learn to
+die never fires here.
+
+Nor does `AgentReaper` reach it. `findStructuralOrphans`
+(`Sources/TBDDaemon/Process/AgentReaper.swift`:36) only considers children of a
+known `tbd-*` tmux server; a `create` invocation has no tmux server anywhere in
+its ancestry — the whole reason it needed its own pty in the first place
+(above) is that it runs outside tmux entirely.
+
+**Why the answer is "no sweep" rather than "extend one."** The process is a
+single short-lived CLI invocation, not an accumulating resource: it holds no
+lock, no lease, no git ref, no tmux server or socket, no database row of its
+own, and no file that outlives it — the row `create` writes to the
+`claude_cloud_session` ledger is written *before* the invocation and belongs to
+the ledger regardless of whether the process behind it is still running (above).
+It is bounded by its own work: `claude --cloud` makes its call, prints its
+three lines, and exits (§11); on the way out, its first write to a pty replica
+whose primary side has already closed returns `EIO`, so the ordinary exit path
+is self-terminating even with nothing watching it. And the window for the
+failure is narrow — the daemon has to die during the seconds one `create` is in
+flight, not at any other time.
+
+That is a different shape from the leaks the doctrine responds to. 2,804
+leaked git branches and roughly 7,100 dead tmux socket files were unbounded
+accumulations — resources that never went away on their own and kept growing
+for as long as nothing reclaimed them. A `create` process outliving its daemon
+is bounded by comparison: at most one per crash, and gone on its own once the
+call it is making returns.
+
+**What this does not claim.** The pathological case is real, and this section
+does not pretend otherwise: a child that hangs *before* it ever writes — a
+stalled network call mid-request, say — has no `EIO` to trip over and no
+controlling terminal to signal it, and can linger indefinitely once the daemon
+that was timing it is gone. This slice does not build machinery for that case.
+It is a known gap, not a hidden one.
+
+**What would reverse this decision.** Orphaned `claude` processes actually
+observed during the soak. If that happens, the remedy is to record the spawned
+pid and its process start time on the ledger's `pending` row at spawn time, so
+a future sweep can confirm the pid is still alive, compare its recorded start
+time against the running process's to rule out pid reuse, and check the running
+binary is `claude` before signalling it. That is enough for a reconciler to act
+safely without a live daemon ever having supervised the child directly — it is
+just not needed until the pathological case shows up outside a lab.
+
 ### Reading the session id and the title out of `create`'s output
 
 `create` is fire-and-forget: it exits 0 immediately without attaching, having

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -4,7 +4,8 @@
 **Status:** Design, not yet implemented.
 **Scope:** The first end-to-end path through the cloud-sessions design: create a
 cloud session from a repo's `+` menu, see it as a row in that repo's tree, watch
-it (attach and transcript), and land it into a local worktree.
+it through a structured transcript (with an attach terminal beside it where the
+account is entitled to one), and land it into a local worktree.
 **Parent design:** [`2026-08-07-claude-cloud-sessions-design.md`](2026-08-07-claude-cloud-sessions-design.md).
 Everything here is downstream of that document and contradicts none of it.
 **Also depends on:**
@@ -28,11 +29,20 @@ This slice builds the shortest path that is genuinely useful, end to end:
   a flag that ships off.
 - **Appear.** The session is adopted as a worktree row in that repository's
   tree, nested and sorted like every other lane.
-- **Watch.** Selecting that row shows an attach terminal and a structured
-  transcript of the conversation.
+- **Watch.** Selecting that row shows a structured transcript of the
+  conversation — the same renderer a local lane gets, tool cards and all —
+  with an attach terminal beside it.
 - **Land.** A row action converts the lane in place from remote to local:
   the branch is checked out on this machine, the row keeps its identity, and
   the conversation resumes in the first pane.
+
+**Done is create → transcript → land.** Attach is implemented and declared, but
+whether a given account may attach to a running cloud session is an entitlement
+the vendor grants server-side, and it is off by default (§10). On an account
+without it the Attach segment is present and shows a call to action naming the
+condition, rather than a terminal that dies on connect; on an account with it,
+attach works. The slice is complete either way, because the transcript — not
+the attach pane — is the watch surface, and it depends on nothing attach needs.
 
 Four things the parent design specifies are deliberately **out of scope here**,
 each for a reason that is about sequencing rather than doubt:
@@ -92,7 +102,7 @@ merely a missing field:
   `wt.location` and sets `providerName` and `providerSessionID` to `nil` for the
   `.local` case. Writing a landed row through the domain model clears its origin
   columns.
-- **Dropped on read.** `WorktreeRecord.toModel()` (same file, :139-144) rebuilds
+- **Dropped on read.** `WorktreeRecord.toModel()` (same file, :139-143) rebuilds
   `.remote(provider:sessionID:)` only when the stored `location` string is
   `"remote"` **and** both columns are present, and falls through to `.local`
   otherwise — so whatever survived a write is discarded on the way back.
@@ -134,7 +144,7 @@ The mapping becomes symmetric and single-sourced:
   construction sites keep compiling and keep satisfying the invariant by
   construction.
 
-`Worktree.providerBinding` (`Models.swift`:261-266) currently derives the pair
+`Worktree.providerBinding` (`Models.swift`:264-267) currently derives the pair
 from `location` and returns `nil` for a local row. It reads `origin` instead, so
 it keeps meaning "the provider session behind this row" across the landing.
 
@@ -173,25 +183,140 @@ are `repo`, `branch`, `prompt` and `environment`, the last typed `string` becaus
 `describe` answers offline and the set of configured cloud environments is
 knowable only from the account.
 
+`describe` is **static and offline**, exactly as the parent design fixes it. It
+answers from compiled constants, touches no network, and its answer does not vary
+with the signed-in account — including for `attach`, which is declared because the
+provider implements it. Whether a given account is permitted to use it is a
+separate, runtime question, and §5 is where that is answered.
+
 **Verbs.** `create` runs `claude --cloud "<prompt>"` from the repository
-checkout. `list` returns the union of a `claude_cloud_session` ledger (what this
+checkout, on a pseudo-terminal, and reads the session id out of what it prints
+(below). `list` returns the union of a `claude_cloud_session` ledger (what this
 machine started) with discovered sessions, under the parent design's three union
 rules: two consecutive complete snapshots retire a resolved ledger row, a
 ledger-only row carries `state: "unknown"` rather than a fabricated `running`,
 and a discovered row always wins over a ledger row for the same id. `send` posts
-one message, stripping a single trailing `\r` or `\n` as the submit gesture it is
-and preserving interior newlines. `attach` runs `claude --cloud <id>` on the
-pane's PTY. `transcript` reads the server-stored conversation, cursor-tailed.
-`land` reports the session's repository and branch with a `resume_command` of
-`claude --teleport <id>` and `forks: true`. Create idempotency is the parent
-design's: the key and its state are written to the ledger before the invocation,
-a pending row is expected during the daemon's single same-key retry, and a
-pending row is resolved by the next complete discovery.
+one message through `claude -p "<msg>" --cloud <id> --output-format json`,
+stripping a single trailing `\r` or `\n` as the submit gesture it is and
+preserving interior newlines; the response is
+`{"ok": true, "session_id": "…", "url": "…"}`, and `ok` plus a `session_id`
+matching the id sent is the success condition. `attach` runs
+`claude --cloud <id>` on the pane's PTY. `transcript` reads the server-stored
+conversation, cursor-tailed. `land` reports the session's repository and branch
+with a `resume_command` of `claude --teleport <id>` and `forks: true`. Create
+idempotency is the parent design's: the key and its state are written to the
+ledger before the invocation, a pending row is expected during the daemon's
+single same-key retry, and a pending row is resolved by the next complete
+discovery.
+
+### `create` needs a pseudo-terminal; nothing else does
+
+This is the one place the built-in provider cannot be a plain subprocess. The
+vendor CLI refuses `--cloud` creation when stdout is not a terminal, by design
+and loudly (§10), so the obvious implementation — spawn `claude`, capture the
+pipe, read the id — does not merely degrade, it never works.
+
+The asymmetry is worth stating because it decides where the complexity goes:
+**`send`, `land`, `transcript`, `archive` and `unarchive` need no terminal**;
+`send`'s `--print` form is explicitly a non-interactive invocation and returns
+JSON on an ordinary pipe. Only `create` needs a PTY, and only on the daemon
+side — `attach` runs on the pane's own PTY, which the app already allocates.
+
+**The provider allocates the PTY through the engine that already bounds every
+other spawn.** `runBoundedProcess`
+(`Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift`:283) is what `ProviderRunner`
+uses, and it owns the properties this call needs as much as any other: a
+watchdog-backed deadline that survives executor starvation, incremental draining
+so a chatty child cannot deadlock on a full buffer, and a single-resume guard.
+It builds its own `Pipe()`s, so it gains one opt-in stdio mode that substitutes
+an `openpty(3)` pair for them, handing the replica to the child as stdin, stdout
+and stderr and reading the primary. That is the same allocation
+`TmuxControlConnection.start()`
+(`Sources/TBDDaemon/Tmux/ControlMode/TmuxControlConnection.swift`:63-111, `openpty`
+at :70) already performs for the control-mode connection, including the detail
+that matters: the parent closes its copy of the replica after spawn so the
+primary sees EOF when the child exits.
+
+A second bounded runner is the alternative, and it is the wrong one — the
+deadline discipline in that function took a starvation bug and a regression
+suite to get right, and a PTY-shaped copy of it would be a second place for that
+to rot.
+
+**PTY mode is create-only, and the reason is a real loss.** A pseudo-terminal is
+one file descriptor, so the child's stdout and stderr merge on it. `transcript`
+returns its continuation cursor in a stderr envelope precisely so a control
+record never mixes into the JSONL data stream, and that separation cannot
+survive a PTY. So the mode is opt-in per invocation rather than a property of
+the provider, and `create` — which returns no envelope — is the only verb that
+sets it.
+
+### Reading the session id out of `create`'s output
+
+`create` is fire-and-forget: it exits 0 immediately without attaching, having
+printed three lines naming the created session, its web URL, and the command
+that would resume it (§10). There is no JSON form — `--print` is refused
+alongside `--cloud` — so those lines are the only channel the id travels on.
+
+The provider strips ANSI control sequences from the captured output and takes
+the first token matching `session_[A-Za-z0-9]+`, requiring that every match in
+the output name the **same** id. All three printed lines carry it, so a single
+distinct id is the healthy case and disagreement is a signal, not noise.
+
+**Reading a command's own stdout is not screen-scraping.** The repository's rule
+forbids inferring an agent's state from a rendered terminal screen; this reads
+the result line of a non-interactive command TBD itself invoked, which is the
+same category as parsing `git`'s output. Nothing here reads a TUI, and nothing
+here infers state — liveness and agent state come from `list`, exactly as the
+contract requires.
+
+**A parse that finds nothing fails loudly and is classified.** Zero matches, or
+more than one distinct id, is a `create` failure: the provider synthesizes exit
+code 2 with an error object whose message quotes what it received, which
+`ProviderFailureClass.classify` (`Sources/TBDShared/RemoteProvider.swift`:99-103)
+reads as `contractBug` and `RemoteProviderManager.recordFailure` turns into
+`.error` health with that message on screen. `contractBug` is the honest class:
+the built-in provider could not satisfy the contract, and the remedy is a fix to
+TBD rather than a retry or a re-authentication.
+
+The ledger is what makes that failure safe. The idempotency key and its state
+are written **before** the invocation, so a create whose output could not be
+read leaves a `pending` row rather than nothing — and the session, which very
+likely exists, is adopted by the next complete discovery through the parent
+design's pending-row matching. An unreadable answer costs the provenance link,
+never the session.
+
+### The session title comes from discovery, never from what was submitted
+
+The vendor derives a session's title server-side; it is a summary of the opening
+instruction, not that instruction's text (§10 records the measured pair). So
+nothing in TBD may treat the submitted `prompt` as the lane's name.
+
+Nothing does, and this slice must not change that. Adoption already reads the
+title off the provider's own payload:
+`RemoteSessionAdopter.displayName(session:)`
+(`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:228-232) takes
+`session.title` when the provider reports one and falls back to the session id,
+and `claude-cloud`'s `create_params` are `repo`, `branch`, `prompt` and
+`environment` — no `title` among them, so there is nothing for TBD to have
+submitted and nothing to reconcile. The create surface (§9, step 7) therefore
+writes no display name of its own; the row's name arrives with the row.
+
+**Create asks for one out-of-band `list`.** Because the row arrives by adoption
+rather than being minted by the create call, and the poll loop's interval is 60
+seconds (`RemoteProviderManager.pollInterval`), a lane created from the `+` menu
+would otherwise sit invisible for up to a minute after a create that already
+succeeded. A successful `create` triggers exactly one immediate poll for that
+provider, which is the shape `recordAttachExit`
+(`Sources/TBDDaemon/Remote/RemoteProviderManager.swift`:479-491) already uses to
+refresh state after a locally-observed event, and it is bounded the same way:
+one extra `list` per create, never a loop.
 
 **The reserved name.** `claude-cloud` is reserved. A registry entry claiming it is
 skipped with a visible flag rather than rejecting the whole file — the loader
-currently throws for the entire registry on a duplicate name, and two of its three
-call sites swallow that, so one bad entry silently removes every provider. The
+(`RemoteProviderRegistry.load`, `Sources/TBDShared/RemoteProvider.swift`:363-377)
+currently throws for the entire registry on a duplicate name (:372-374), and two of
+its three call sites swallow that, so one bad entry silently removes every
+provider. The
 reservation is unconditional and does not depend on the flag in §7: a name that
 became available when a feature was off, and unavailable when it was turned on,
 would change which providers load as a side effect of a toggle.
@@ -205,7 +330,7 @@ shape without saying where it attaches.
 is a one-method protocol with exactly one production conformance —
 `ProviderRunner` (:58), which spawns the registered executable — and exactly one
 injection site: `RemoteProviderManager`'s `runner` property (`RemoteProviderManager.swift`:18,
-assigned from the initializer at :53-59). Every verb the manager issues goes
+assigned in the initializer at :51-59). Every verb the manager issues goes
 through that one property (:122 for `describe`, :260 for `list`, :388 for the
 pass-through path).
 
@@ -286,7 +411,7 @@ Meanwhile `RemoteSessionDetailView`, which has everything to say about it, is
 reachable only through `AppState.selectedRemoteSession`: `DetailSectionHostPager.targetTab`
 (`ContentView.swift`:640-649) returns `.remote` whenever that value is non-nil,
 which routes to `RemoteSessionHostSlot` (:660-670) and thence to the detail view.
-`selectRemoteSession` (`Sources/TBDApp/AppState+Navigation.swift`:305-309) is the
+`selectRemoteSession` (`Sources/TBDApp/AppState+Navigation.swift`:305) is the
 only writer, and it is called only from the flat section's rows.
 
 **The decision: selecting an adopted cloud row also marks it the selected remote
@@ -368,18 +493,19 @@ it needs stating:
   detail pane comes back with it. The flat section's own entry point keeps
   recording `.remoteSession` entries for sessions that own no row.
 - **`selectRemoteSession` is untouched.** It still clears `selectedWorktreeIDs`
-  (via `activateRemoteSession`, :351-366) because the sessions it is called for
+  (via `activateRemoteSession`, :350-364) because the sessions it is called for
   have no worktree row to keep selected. The two entry points therefore do not
   fight: one is for lanes, one is for the sessions that never became lanes.
 - **Attach keep-alive is unaffected.** `attachedRemoteSelections`
-  (`Sources/TBDApp/AppState+RemoteAttach.swift`:134-152) and
+  (`Sources/TBDApp/AppState+RemoteAttach.swift`:150-152) and
   `remoteSessionHostSelection` (:166-168) read `selectedRemoteSession` and the
   recency log exactly as they do now, so a cloud lane joins the bounded keep-alive
   set on the same terms as any other remote session.
 
 ### The pager's invariant is preserved
 
-`DetailSectionHostPager` (`ContentView.swift`:509-560 doc comment, :561 onward) is
+`DetailSectionHostPager` (`ContentView.swift`, doc comment :509-559, declaration at
+:560) is
 an `NSTabViewController` with `tabStyle = .unspecified` (:578) — an invisible
 pager holding exactly three tab items. Two distinct properties depend on that
 shape, and this change must break neither:
@@ -410,14 +536,16 @@ gates that decide what renders live in
 `Sources/TBDApp/Remote/RemoteSessionDetailGates.swift` and are unit-tested in
 `Tests/TBDAppTests/RemoteSessionDetailGatesTests.swift`:
 
-- `available(capabilities:gone:)` (:40-45) builds the ordered tab list. It gains a
-  `transcript` arm between attach and log. **Attach is dropped when the session is
-  `gone`; transcript is not** — reading a retired session's conversation is still
-  useful, which is exactly the reasoning that already keeps `log` available for a
-  tombstoned row.
-- `initialTab(available:requested:)` (:55-60) honors a one-shot navigation hint
+- `available(capabilities:gone:)` (:40-46) builds the ordered tab list. It gains
+  a `transcript` arm, placed **first** — ahead of attach and log — so a provider
+  that offers a structured conversation lands the user there rather than in a
+  terminal. **Attach is dropped when the session is `gone`; transcript is not** —
+  reading a retired session's conversation is still useful, which is exactly the
+  reasoning that already keeps `log` available for a tombstoned row.
+- `initialTab(available:requested:)` (:55-62) honors a one-shot navigation hint
   when it names an available tab and otherwise takes the list's first entry. It
-  needs no change; the new case flows through it.
+  needs no change; the new case flows through it, and the ordering above is what
+  makes Transcript the landing tab.
 - `showsPicker(available:)` (:66-68) renders the segmented control only when there
   is a real choice — `available.count > 1`. No change.
 - `showsSendField(capabilities:gone:snapshotFresh:)` (:75-79) is independent of
@@ -428,11 +556,29 @@ The picker itself is at `RemoteSessionDetailView.swift`:173-182, the send field
 is gated just below it at :186-192, and `RemoteLogTabView` (:607-659) is the
 existing read-only scrollback pane the new tab sits beside.
 
+Ordering `transcript` first changes nothing for any provider registered today,
+because `transcript` is a v2 capability and no external provider declares it —
+the first provider to reach that arm is the built-in one.
+
+**The view's placeholder tab has to stop naming a real tab, or the ordering
+above means nothing.** `selectedTab` is `@State` defaulting to `.attach` (:112),
+reset to `.attach` on every selection change (:230), and `effectiveTab` (:159-161)
+passes it to `initialTab` as `requested` — which honors a requested tab whenever
+it is available. So a placeholder that names `.attach` beats the list's own first
+entry for any provider that declares attach. It works today only because the
+one provider shape that exercises the fallback is `log`-only, where `.attach` is
+absent from the list by luck rather than by design, and the doc comment at
+:152-158 says as much. `selectedTab` therefore becomes optional with `nil` as the
+placeholder, reset to `nil` rather than `.attach`, and the Picker binds through a
+computed binding over `effectiveTab`. "No tab has been chosen yet" then has a
+representation, and `available`'s ordering decides the landing tab for every
+provider rather than for one shape of provider.
+
 **What a cloud lane's picker shows.** Cloud declares `transcript` and `attach`
-but not `log`, so `available` returns `[.attach, .transcript]`, `showsPicker` is
+but not `log`, so `available` returns `[.transcript, .attach]`, `showsPicker` is
 true, and the segmented control offers exactly those two, in that order, with
-Attach selected by default. A **gone** cloud lane returns `[.transcript]` alone —
-one tab, so no picker renders and the transcript content fills the pane
+Transcript selected by default. A **gone** cloud lane returns `[.transcript]`
+alone — one tab, so no picker renders and the transcript content fills the pane
 unconditionally, which is the shape a single-tab provider already gets. A provider
 declaring none of the three still reaches the existing empty state.
 
@@ -442,44 +588,172 @@ declaring none of the three still reaches the existing empty state.
 handlers for providers, sessions, create, stop, send, log, rename, dismiss,
 setPin and reportAttachExit (:57, :64, :86, :152, :189, :225, :263, :293, :315,
 :341) and nothing else. A new `handleRemoteTranscript` joins them, gated by the
-same `remoteGate()` (:26-29) as every sibling.
+same `remoteGate()` (:25-28) as every sibling.
 
-**The Transcript segment renders provider JSONL through a simpler path in this
-slice, rather than reusing the structured table renderer.** The recommendation is
-the cheaper option, and the trade-off is real.
+**The Transcript segment renders through the real structured renderer — the same
+tool cards, the same row-height cache, the same overlay a local lane gets.** A
+cloud lane has no attach guarantee and no `log`, so the transcript is not a
+secondary view of the conversation; it is the *only* watch surface. A degraded
+renderer would therefore not be a lesser second opinion, it would be the whole
+experience — a wall of prose where a local lane shows an Edit card with a diff, a
+Bash card with its command and output, an Agent card that drills into a subagent
+thread. That is the argument for paying the seam's cost rather than the simpler
+view's.
 
+**The seam already exists one layer down, which is what makes this affordable.**
+The renderer proper — `TableTranscriptView`, the view-based `NSTableView` that
+hosts one `SelectableTranscriptRow` per cell behind an explicit height cache —
+takes render nodes and a `TranscriptCardContext`, and neither mentions a terminal
+or a worktree. It already has a **second, non-terminal caller**:
+`HistoryPaneView` (`Sources/TBDApp/Panes/HistoryPaneView.swift`:452-471) builds
+the same `TranscriptPresentation` and hosts the same table with
+`TranscriptCardContext(terminalID: nil, …)`, over messages it fetched by file
+path rather than from a terminal. So the cards, the presentation build, the
+height cache and the workbench index are already source-agnostic in production,
+not merely in principle.
+
+What is terminal-keyed is the pane *above* it.
 `TableTranscriptPaneView` (`Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift`:12-14)
-is terminal-and-session-keyed end to end. It takes a `terminalID` and a
-`worktreeID`, and resolves content by looking up the terminal in
-`appState.terminals[worktreeID]`, reading `terminal.claudeSessionID` off it, and
-indexing `appState.sessionTranscripts` by that session id (:68-79). It is hosted
-from exactly one place, `PanePlaceholder.swift`:352, and `PanePlaceholder` takes a
-`LocalWorktree` (:49). A cloud lane has no terminal row, no Claude session id, and
-no `LocalWorktree`. Making the renderer provider-fed means introducing a second
-keying axis through the poll loop, the transcript store, the overlay coordinator
-and the row-height cache — a change to a load-bearing local rendering path, which
-under the repository's own rules would itself want a default-off flag and a soak.
+takes a `terminalID` and a `worktreeID` and resolves content along one fixed
+chain: `appState.terminals[worktreeID]` → the terminal with that id (:67-69) →
+`terminal.claudeSessionID` (:71-73) → `appState.sessionTranscripts[sessionID]`
+(:75-78). Its poll loop (:264-275) fetches through `terminal.transcript`, keyed on
+the same terminal id (:294-295). It is hosted from exactly one place,
+`PanePlaceholder.swift`:352, and `PanePlaceholder` takes a `LocalWorktree` (:49).
+A cloud lane has no terminal row, no Claude session id, and no `LocalWorktree`,
+so that chain cannot serve it.
 
-So slice 1 adds `RemoteTranscriptTabView` beside `RemoteLogTabView`: it calls
-`remote.transcript` on appear and on a refresh token, receives already-parsed
-`TranscriptItem`s, and renders them with the same `SelectableTranscriptRow` used
-by the table renderer, inside a plain scroll view.
+### The transcript source
 
-**The honest cost.** There are then two renderers over the same record format, so
-an improvement to a tool card lands in one and not the other until they converge;
-and the remote view has no height cache, so a very long cloud conversation scrolls
-less smoothly than a local one. Both are visible, neither is silent, and neither
-loses data. The convergence path, when a second provider declares `transcript` or
-when a cloud conversation gets long enough to hurt, is to re-key
-`TableTranscriptPaneView` on a transcript *source* rather than on a terminal — at
-which point the remote view becomes a second caller of one renderer rather than a
-second renderer.
+`TableTranscriptPaneView` is keyed on a **source** rather than on a terminal:
 
-Daemon-side, `handleRemoteTranscript` invokes the verb, appends stdout to the
-TBD-owned transcript root `~/tbd/remote-transcripts/<provider>/<sessionID>/`
-(path helper in `TBDConstants`, honoring `TBD_HOME`), stores the cursor returned
-in the stderr envelope for the next call, and parses the accumulated file through
+```swift
+enum TranscriptSource: Equatable, Hashable {
+    case terminal(terminalID: UUID, worktreeID: UUID)
+    case remote(provider: String, sessionID: String)
+}
+```
+
+Exactly three things in that view are a function of the source, and everything
+else in it is untouched:
+
+- **The store key.** `.terminal` walks today's chain to `claudeSessionID`;
+  `.remote` is the provider session id verbatim. Both answer with a `String?`,
+  and `AppState.sessionTranscripts` is already `[String: [TranscriptItem]]`
+  (`AppState.swift`:788) with an LRU eviction keyed the same way (:1068-1087).
+  So the remote path is a **third writer into one store**, beside the live pane
+  and `AppState+History.swift`:147-152 — not a second store. Every downstream
+  consumer of that key — the rollover guard, the LRU touch, the `PaneIdentity`
+  the table is `.id()`-keyed on — keeps working unchanged. The two id spaces do
+  not overlap (a Claude session id is a UUID, a cloud session id is
+  `session_`-prefixed), so one key space stays one key space; the store's
+  fifty-entry LRU is shared, which is correct — a cloud transcript the user is
+  reading deserves the same residency as a local one.
+- **The fetch.** `.terminal` calls `terminal.transcript` with its tail-first
+  two-phase open as it does now. `.remote` calls `remote.transcript` with the
+  continuation cursor the daemon returned last time, and the daemon answers with
+  the full accumulated item list plus the next cursor. The cursor lives daemon-side
+  beside the spooled JSONL, not in the view, so it survives the pane being closed
+  and reopened and survives a daemon restart.
+- **The card terminal.** `TranscriptCardContext.terminalID` is already `UUID?`
+  (`TranscriptCardContext.swift`:8). `.remote` supplies `nil`, which is exactly
+  what `HistoryPaneView` supplies, and the cards already do the right thing with
+  it: the truncation footers that would fetch a longer body over
+  `terminal.transcriptItemFullBody` are gated on `terminalID != nil` and simply
+  do not render (`GenericToolCardBody.swift`:30 and :47, with the fetches
+  guarding again at :72 and :79).
+
+**Hosting needs no new machinery, and `PanePlaceholder`'s `LocalWorktree`
+constraint never binds**, because the remote path does not go through
+`PanePlaceholder` at all. The Transcript tab hosts `TableTranscriptPaneView`
+directly, which is precisely how `HistoryPaneView` hosts the table today. Two
+environment values `PanePlaceholder` injects need answers at the new host, and
+both are answered by what a remote transcript honestly is:
+
+- **`\.openFilePreview` is not injected.** The Write, Edit and Read cards already
+  gate their preview affordance on `openFilePreview != nil`
+  (`WriteCardBody.swift`:42 and :45, `EditCardBody.swift`:74 and :77), so a path
+  naming a file on another machine offers no button rather than a broken one.
+- **`\.openTranscriptOverlay` is injected**, opening
+  `overlayCoordinator.open(terminalID: nil, itemID:, sessionID: <session id>)`.
+  `TranscriptOverlayView.lookupItem()` already has a second resolution path for
+  exactly that shape — no terminal, a session id, items read from
+  `AppState.sessionTranscripts` (:321-332) — so drilling into a tool card works
+  with no new resolution. The parameter is called `historySessionID` today, which
+  names its first caller rather than its meaning: it is the *session-keyed* path,
+  and any non-terminal source uses it. It is renamed `sessionID` in this edit
+  across its three sites (`TranscriptOverlayCoordinator.swift`:8-18 and :47,
+  `TranscriptOverlayView.swift`:329, `HistoryPaneView.swift`:523-529).
+
+**Local file links are suppressed for a remote transcript, and suppressed means
+inert.** `overlayFileLinkAction`
+(`Sources/TBDApp/Panes/Transcript/OverlayFileLinkAction.swift`:12-24) turns
+`tbd-file:` and `file:` URLs into overlay file frames and lets everything else
+fall through to the system handler. For a remote transcript both of those
+outcomes are wrong — one opens an unrelated local file in the overlay, the other
+hands it to Finder — so the action takes an `allowsLocalFiles` flag and returns
+`.discarded` for both schemes when it is false. A path that names another
+machine's disk does nothing when clicked, which is the only honest behavior
+available.
+
+### What the pane shows while it is not yet complete
+
+Three states, and none of them may be silent:
+
+- **Before the first page arrives**, the pane shows the same
+  "Waiting for Claude to start the conversation…" empty state the live pane
+  already renders before its first fetch (:140-152), so a fresh cloud lane reads
+  as loading rather than as empty.
+- **When the provider returns an incomplete stream** — a cursor came back and the
+  provider has more to give — the pane renders what it has and keeps fetching. It
+  never blocks on completeness, because a long conversation's first page is
+  useful immediately and the tail is what the user is usually reading anyway.
+- **When a fetch fails**, the pane shows the existing error state with a Retry
+  button (`TableTranscriptPaneView.swift`:154-175) rather than an empty list. An
+  empty transcript and an unreachable provider look identical otherwise, and the
+  cloud lane has no second surface to disambiguate them.
+
+**Every delay in this path takes an injected clock.** The pane's poll loop sleeps
+through a bare `Task.sleep` carrying a legacy `swiftlint:disable no_raw_task_sleep`
+suppression (:272-273); adding a second cadence for the remote source behind that
+same suppression would be adding a new violation under cover of an old one. The
+loop moves onto `clock: any Clock<Duration> = ContinuousClock()` as the view's
+last initializer parameter, defaulted so no call site changes, and the
+suppression is deleted rather than duplicated.
+
+**The renderer's existing performance constraints hold unchanged**, and nothing
+here relaxes them. Row cards must have no direct `ScrollView` child — the rule
+that outlived the original renderer and is enforced by the
+`no_scrollview_in_transcript_cards` SwiftLint rule
+(`Sources/TBDApp/Panes/Transcript/CLAUDE.md`,
+`docs/superpowers/specs/2026-05-23-transcript-card-rework-design.md`) — and the
+remote path adds no card of its own, so there is nothing new to violate it. The
+height cache measures each row once through `NSHostingController.sizeThatFits`,
+and because the remote path feeds the same `TranscriptRenderNode`s through the
+same `TranscriptPresentation.build`, it measures cloud rows on exactly the terms
+it measures local ones.
+
+**What this costs relative to a second, simpler view.** More of the pane view
+changes: a source enum, three branch points inside it, one renamed overlay
+parameter, one flag on the file-link action. What it does not cost is a second
+renderer — no duplicate row cards to keep in step, no second height-cache story,
+no surface where an improvement to a tool card lands in one place and not the
+other. The daemon work, the RPC, the cursor and the store writes are identical
+under either choice; they are not what the two options differ on.
+
+### Daemon side
+
+`handleRemoteTranscript` invokes the verb, appends stdout to the TBD-owned
+transcript root `~/tbd/remote-transcripts/<provider>/<sessionID>/` (path helper in
+`TBDConstants`, honoring `TBD_HOME`), stores the cursor returned in the stderr
+envelope for the next call, and parses the accumulated file through
 `TranscriptParser`. Parsing stays daemon-side, as `session.messages` already does.
+
+`handleSessionMessages` (`RPCRouter+SessionHandlers.swift`:24) is not the model
+for this handler and cannot be extended into it: it takes a **file path** from the
+caller and constrains it to the Claude projects store (:49-55). A cloud session
+has no local file and no Claude session id, so `remote.transcript` takes
+`(provider, sessionID)` and resolves the path itself — the caller never names one.
 
 **The parent design's single-choke-point resolver is a prerequisite of this
 slice**, not a follow-up. `TranscriptParser` is reached from several handlers that
@@ -489,11 +763,14 @@ path and returning either a validated path under one of the two permitted roots 
 a refusal, with `TranscriptParser`'s entry points reachable only through it —
 ships before the TBD-owned root is admitted to it.
 
-Because a remote transcript's file paths refer to a different machine, the
-renderer suppresses its clickable local file links for remote rows rather than
-dead-ending or opening an unrelated local file.
-
 ### Must fix in this slice: attach announces contract major 1
+
+**This is a correctness bug with nothing to do with cloud.** The app-side attach
+spawn announces a contract major of `1` unconditionally while the daemon
+negotiates one per provider, so the two disagree for any provider that declares
+anything but `[1]` — a divergence that is wrong whichever provider is attached,
+and would stay wrong if the cloud work were abandoned tomorrow. Cloud is what
+makes it reachable, not what makes it wrong.
 
 `RemoteAttachTerminalView.attachEnvironment`
 (`Sources/TBDApp/Remote/RemoteAttachTerminalView.swift`:78-84) hardcodes
@@ -540,6 +817,153 @@ regression test that matters is that the negotiated major reaches
 `RemoteProviderStatus` and is what the attach environment emits — that path
 crosses a process boundary and is the one that would otherwise go on announcing
 `1` forever.
+
+### Attach is an entitlement question, not a capability question
+
+Attaching to an existing cloud session is gated per account by the vendor, and
+the gate is off by default (§10). The distinction that decides where this lands
+in TBD's model:
+
+- **A capability is what a provider implements.** `describe` answers it
+  statically and offline, exactly as the parent design fixes it. The built-in
+  provider implements `attach` — it knows the command, it composes the argv, it
+  spawns on the pane's PTY — so it **declares** `attach`, and `describe` stays
+  static. No probe, no network call, no dynamic capability list.
+- **An entitlement is a runtime condition of the account.** It is the same kind
+  of fact as "this provider's credential expired": nothing about what the
+  provider can do, everything about whether this invocation will be permitted
+  right now. TBD already has a path for exactly that kind of fact, and it is not
+  the capability list.
+
+Making `describe` dynamic would be the wrong answer twice over: it would put a
+network call inside a verb the contract requires to answer offline, and it would
+make a stable declaration flicker with an account setting — so the Attach tab
+would appear and disappear rather than explaining itself.
+
+**So the entitlement rides the provider call-to-action machinery that already
+exists.** `RemoteProviderAuthCTAView`
+(`Sources/TBDApp/Remote/RemoteProviderAuthCTAView.swift`) is the shared surface
+for "a condition a retry cannot fix, with the provider's own words and its own
+remediation", rendered from the pure
+`RemoteProviderAuthPresentation`
+(`Sources/TBDApp/Remote/RemoteProviderAuthPresentation.swift`:70-85) by two
+call sites: the session detail pane's `authPrompt`
+(`RemoteSessionDetailView.swift`:514-527) and the sidebar provider header's
+popover (`RemoteSectionView.swift`:259-260). Its whole reason for existing is
+that a user should see an explanation instead of an action that can only fail.
+
+#### How TBD learns the condition
+
+The app spawns attach directly on the pane's PTY, and per the contract and the
+no-screen-scraping rule it may not read what that process prints — so the exit
+code is the entire signal, and the failing attach exits **1**. Exit 1 is the
+contract's catch-all permanent class, which is enough to know *that* retrying is
+futile and not enough to know *why*. The "why" has to come from the daemon,
+which is where the built-in provider lives.
+
+`markRemoteSessionDetached` (`AppState.swift`:939-957) already reports an
+auth-class exit to the daemon fire-and-forget so provider health moves without
+waiting for the next 60s poll; the permanent class reports the same way.
+`RemoteProviderManager.recordAttachExit` (:479-491) returns early today for
+everything but `.authNeeded`, and gains a branch for the permanent class that
+records an **attach-scoped block** against that provider.
+
+**That block is deliberately not provider health.** `ProviderHealth.needsAuth`
+says the provider itself cannot authenticate, and it has consequences — it
+suppresses auto-attach for every session and blocks reconnect
+(`AppState+RemoteAttach.swift`:48-59, `RemoteReconnectPolicy.isBlocked`:76-79).
+A cloud provider whose `create`, `send`, `list` and `transcript` all work
+perfectly is not in that state, and saying so would be a lie that also disables
+nothing useful. The block is scoped to attach; the other tabs, the send field
+and every non-attach verb are untouched.
+
+`RemoteProviderStatus` therefore gains a third field beside the two above, read
+at the same one lookup:
+
+- **`attachBlocked: ProviderAttachBlock?`** — `nil` when attach is expected to
+  work, and otherwise a small shared value carrying a title, a message, and an
+  optional remediation label and command. Held in memory beside health rather
+  than persisted: a daemon restart costs at most one more doomed attach, and a
+  stale persisted block would outlive an entitlement the user was granted in
+  between.
+
+**The words come from the provider, which is TBD here, and that is consistent
+rather than a loophole.** `RemoteProviderAuthPresentation` renders a provider's
+message and remediation verbatim and keeps *TBD's own* fallback strings generic,
+naming only the contract-level condition. The built-in provider is a provider, so
+the entitlement's wording is its message on the same terms an external
+provider's would be, and the generic fallbacks stay generic. The CTA's headline
+is a literal today (`RemoteProviderAuthCTAView.swift`:31), so the presentation
+gains a `title` defaulting to that string — every existing call site unchanged,
+and the entitlement case supplying its own. There is no remediation command:
+nothing TBD can run turns the entitlement on, so `command` is `nil` and the CTA
+renders its label as plain text rather than a button, which it already does
+(:57-64).
+
+#### What renders, and what does not get spawned
+
+- **The Attach segment stays in the picker.** The capability is declared and the
+  tab list is a function of capabilities, so the segment is present and
+  selecting it explains the condition. Removing the segment would leave the user
+  wondering why a documented feature is absent.
+- **Selecting it shows the CTA in place of the attach slot.** `contentArea`
+  already controls attach visibility through `showsAttachSlot` while keeping
+  `RemoteAttachPager` itself mounted unconditionally — the invariant its comment
+  at :419-437 exists to protect — so the block makes `showsAttachSlot` (:485)
+  false for
+  this selection and renders the CTA where the terminal would be. No tab is
+  added or removed and no host is remounted.
+- **No further attach is spawned.** `attachEligibleRemoteSelections`
+  (`AppState+RemoteAttach.swift`:48-59) excludes a selection whose provider
+  carries an attach block, the same shape as its existing `.needsAuth` guard at
+  :52 and
+  for the same stated reason: a fresh attach would die on connect.
+
+#### `RemoteAttachExitClass` must stop collapsing permanent into unexpected
+
+`RemoteAttachExitClass.classify` (`Sources/TBDApp/Remote/RemoteAttachExitClass.swift`:33-40)
+maps `.permanent`, `.contractBug` and `.transient` all onto `.unexpected`, and
+`.unexpected` is the class that **arms automatic reconnect**. An entitlement
+failure would therefore be read as a transport blip: retried at 5s, then 10s, 20s
+and so on to the 300s cap (`RemoteReconnectPolicy.backoffInterval`:61-67), each
+round spawning a process that cannot succeed, and each round worded on screen as
+"Attach ended unexpectedly" (`RemoteSessionDetailView.swift`:535-540). It also
+happens without the user ever opening the Attach tab, because auto-attach follows
+selection rather than the selected tab.
+
+So the class gains the `permanent` case the parent design specifies.
+`ProviderFailureClass.permanent` and `.contractBug` map onto it; `.transient`
+alone keeps `.unexpected`. Neither of the two is fixed by waiting, which is the
+only thing automatic reconnect can offer.
+
+The blocking rule lands in exactly one pure function rather than a fourth state
+store. `RemoteReconnectPolicy.isBlocked` (:76-79) already receives the pending
+entry, which carries the `exitCode` that created it (:12-26), so a permanent exit
+is blocked regardless of provider health and regardless of elapsed time. Nothing
+un-blocks it on its own; the explicit Reattach gesture clears the entry outright
+(`AppState.swift`:966-970), which is the one path that should be able to try
+again. `RemoteAttachTerminalView.isUnexpectedExit` (:50) keeps testing for
+`.unexpected` exactly, so a permanent exit is never worded as a surprise.
+
+**This changes reconnect behavior for external providers too, and that is the
+point.** Exit 1 is the catch-all for a shim that failed for any reason it did not
+classify, so a shim that dies transiently at exit 1 will now wait for a user
+gesture instead of coming back on its own. That is a real cost and the right
+trade: the contract gives a provider exit 3 to say "transient, retry me", and
+retrying forever on the class that means the opposite is the defect. Both
+branches are asserted.
+
+#### What is not in this slice
+
+The parent design also specifies a **cached eligibility preflight** — one check
+against the undocumented surface at describe time, reflected by disabling the
+affordance before anything is spawned, failing open when it cannot run. That
+would remove the single doomed attach the exit-driven path spends to learn the
+condition. It is not in this slice, because it needs an undocumented endpoint the
+rest of slice 1 does not, and its whole benefit is one wasted process per account
+per daemon lifetime. The exit-driven path is the floor and needs nothing
+undocumented; the preflight is the improvement on top, and the evidence for
+promoting it is a user meeting the dead terminal more than once.
 
 ## 6. Land
 
@@ -622,7 +1046,15 @@ still yields an empty menu rather than a partial one.
    another worktree — `git worktree add <path> <branch>` refuses to check one
    branch out twice.
 4. Materializes the worktree through the existing lifecycle path, checks out the
-   branch, and spawns the first pane running `resume_command`.
+   branch, and spawns the first pane running `resume_command` —
+   `claude --teleport <id>`.
+
+   **That first pane opens on Claude Code's folder-trust prompt**, because a
+   freshly materialized worktree is a directory it has never seen (§10). The user
+   answers it. TBD does not suppress it, pre-answer it, or type into the pane:
+   trusting a checkout just pulled from a remote branch is a security decision,
+   and this is the moment to ask. Land is complete when the pane is spawned with
+   the resume command.
 5. Writes the row: `location` becomes `.local`, `localPath` becomes the real path
    in place of the synthetic `remote://` URI, and `origin` keeps the provider and
    session id — which is what §2 exists for, what keeps `findRemote` from
@@ -664,7 +1096,7 @@ reasoning that applies unchanged here. NULL means nobody has chosen; `0` and `1`
 mean somebody did.
 
 The shipped default therefore lives in exactly one place:
-`ConfigRecord.toModel()` (`Sources/TBDDaemon/Database/ConfigStore.swift`:68-116)
+`ConfigRecord.toModel()` (`Sources/TBDDaemon/Database/ConfigStore.swift`:68-117)
 resolving `claude_cloud_enabled ?? claudeCloudEnabledDefault`, where that
 parameter defaults to `Config.claudeCloudEnabledDefault` and is overridable in
 tests — the same shape `queuedPromptDefault` and `supervisionEnabledDefault`
@@ -743,6 +1175,10 @@ network nor a real credential store: the vendor transport sits behind an injecte
 client protocol and credential reads behind an injected seam.
 `FakeProviderInvoker` (`Tests/TBDDaemonTests/RemoteProviderManagerTests.swift`:21)
 is the seam for provider behavior, standing in for either arm of the dispatcher.
+The built-in provider's own vendor-CLI invocations sit behind an injected spawn
+seam, so no test runs a real `claude` binary; the PTY-mode assertions below drive
+the bounded runner directly with a scripted child of their own, which is the one
+place a real process is spawned and it is never the vendor's.
 
 **The flag's three states are distinguishable.** A pre-migration row reads NULL
 rather than `0`; a NULL row follows a change to `Config.claudeCloudEnabledDefault`
@@ -768,12 +1204,59 @@ multi-selection including the row derives `nil`. Deselecting derives `nil`. A
 disconnect routes to `.other` regardless of the derived value.
 
 **The picker's shape for a `transcript`-without-`log` provider.** `available`
-returns `[.attach, .transcript]` for a live cloud lane and `[.transcript]` for a
+returns `[.transcript, .attach]` for a live cloud lane and `[.transcript]` for a
 gone one; `showsPicker` is true in the first case and false in the second;
-`initialTab` lands on Attach in the first and Transcript in the second, and a
-one-shot Log hint against a provider that does not declare `log` is discarded
-rather than producing a blank pane. A provider declaring `log` and not
-`transcript` behaves exactly as it does now.
+`initialTab` lands on Transcript in both, with no tab requested — the assertion
+that would fail against the `.attach` placeholder, since `.attach` is available
+in the first case and would win. A one-shot Log hint against a provider that
+does not declare `log` is discarded rather than producing a blank pane, and an
+explicit Attach hint is honored. A provider declaring `log` and not `transcript`
+behaves exactly as it does now, on both the tab list and the landing tab.
+
+**`create` on a pseudo-terminal.** The bounded runner's PTY mode hands the child
+a terminal — asserted by spawning a probe that reports whether its stdout is a
+tty and requiring the answer to be yes, with the same probe under the pipe mode
+answering no, so the test discriminates rather than merely passing. The deadline,
+the incremental drain and the single-resume guard are asserted to hold in PTY
+mode as they do in pipe mode, including a child that outruns a pipe buffer and
+one that never exits.
+
+**Parsing `create`'s output.** The three-line success form yields the session id.
+Output carrying ANSI control sequences around the same three lines yields the
+same id. Output naming two different session ids, and output naming none, each
+produce a `create` failure classified as `contractBug` with the received text in
+the message — never a success with an empty id — and each leaves the ledger row
+`pending` so a later complete snapshot can still adopt the session. A create
+whose response carries a title unlike the submitted prompt still names the row
+from the provider's `title`, and a create never writes a display name of its own.
+
+**The entitlement path.** A permanent attach exit reported to the daemon records
+an attach block on that provider and leaves its health untouched, so the send
+field, the transcript tab and every non-attach verb stay available. The block
+suppresses `showsAttachSlot` for that selection and renders the CTA in its place
+while `RemoteAttachPager` stays mounted. `attachEligibleRemoteSelections` drops
+a session whose provider carries a block and keeps one whose provider does not.
+`RemoteAttachExitClass.classify` returns `.permanent` for exit 1 and exit 2,
+`.unexpected` for exit 3, `.authNeeded` for exit 4 and `.clean` for 0 and `nil`;
+`isBlocked` refuses a permanent entry against healthy provider health and an
+elapsed backoff window, admits a transient one under the same conditions, and
+Reattach clears either. A provider with no block behaves exactly as it does now,
+reconnect included.
+
+**The provider-fed renderer.** A `.remote` source resolves its store key to the
+provider session id and renders the same nodes the local source renders from the
+same items, asserted by building both presentations from one fixture and
+comparing them. The remote source supplies `terminalID: nil` to the card
+context, so no truncation footer renders and no item-full-body RPC is issued
+even for an item marked truncated. Opening an item from a remote transcript
+resolves through the session-keyed overlay path and finds the item, including one
+nested in a subagent thread. A `file:` link in a remote transcript is discarded
+rather than pushing a file frame or reaching the system handler, while the same
+link in a local transcript still pushes a frame. The first fetch renders the
+loading state rather than an empty list, an incomplete stream renders what
+arrived and fetches again from the returned cursor, and a failed fetch renders
+the error state with Retry rather than an empty list. The poll cadence is driven
+through the injected clock in virtual time, with no wall-clock sleep in the test.
 
 **Land's precondition failures each leave the row unchanged.** A remote mismatch,
 a branch missing on the remote, an occupied target path, and a branch already
@@ -801,7 +1284,8 @@ Branch Name. A local row's menu is byte-identical to what it produces today, and
 `.creating` row still yields an empty menu.
 
 **The dispatcher.** A verb naming the reserved provider is served in-process and
-never spawns a subprocess; a verb naming a registered provider still spawns one; a
+never reaches `ProviderRunner`, so no registered-provider executable is spawned
+for it; a verb naming a registered provider still goes through the runner; a
 registry entry claiming the reserved name is skipped and flagged while every other
 entry in the file still loads, with and without the cloud flag on.
 
@@ -827,17 +1311,23 @@ provider with no flag to gate it.
    on `RemoteProviderStatus`. The cloud provider cannot be described at all until
    this lands, so writing it first means writing it against a guard that rejects
    it.
-3. **The transcript-root choke point (§5).** One resolver, every `TranscriptParser`
+3. **Pseudo-terminal mode in the bounded process runner (§3).** One opt-in stdio
+   mode on `runBoundedProcess`, with its deadline, drain and single-resume
+   properties re-asserted under it. `create` cannot be written against a pipe at
+   all, so writing the provider first would mean writing it against a spawn that
+   refuses every invocation.
+4. **The transcript-root choke point (§5).** One resolver, every `TranscriptParser`
    entry point behind it. The TBD-owned root cannot be admitted safely before the
    boundary is actually checked.
-4. **The flag and its capabilities plumbing (§7).** Migration, record, model,
+5. **The flag and its capabilities plumbing (§7).** Migration, record, model,
    `DaemonCapabilitiesResult`, Settings toggle. The provider is constructed behind
    this flag, so the flag exists first or the construction has to be rewired.
-5. **The dispatcher and the provider's `describe`, `create` and `list` (§3).**
-   Including the ledger table and its union rules. Until a cloud session can be
-   created and enumerated there is no row to route, watch or land, so this is the
-   step that makes every later one testable by hand.
-6. **The create surface.** A repository already has a remote-create entry point:
+6. **The dispatcher and the provider's `describe`, `create` and `list` (§3).**
+   Including the ledger table, its union rules, the create-output parse and the
+   one out-of-band `list` a successful create triggers. Until a cloud session can
+   be created and enumerated there is no row to route, watch or land, so this is
+   the step that makes every later one testable by hand.
+7. **The create surface.** A repository already has a remote-create entry point:
    `RepoSectionView.newRemoteSessionMenuItem`
    (`Sources/TBDApp/Sidebar/RepoSectionView.swift`:430-444) enumerates
    `appState.remoteProviders` and opens `RemoteCreateSheet` prefilled with the
@@ -847,21 +1337,140 @@ provider with no flag to gate it.
    — the affordance a user already reaches for to start a lane. Both entries are
    omitted, not disabled, when the flag is off, matching how capability-gated
    remote items are already omitted rather than grayed out.
-7. **Routing (§4).** The derived remote selection and its two call sites. Only
-   observable once a cloud row exists, which is why it follows step 5.
-8. **The watch surface (§5).** The `transcript` verb, the `remote.transcript`
-   handler, the new tab and its gate arm, and — in the same pass, because they
-   share the one `RemoteProviderStatus` lookup — the negotiated major and the
-   attach argv reaching the attach environment.
-9. **Land (§6).** The `Context` plumbing with the filesystem fix in the same edit,
-   the `worktree.land` RPC, preconditions, in-place conversion, and the follow-up
-   archive.
+8. **Routing (§4).** The derived remote selection and its two call sites. Only
+   observable once a cloud row exists, which is why it follows step 6.
+9. **The transcript source seam (§5).** Re-key `TableTranscriptPaneView` on a
+   `TranscriptSource`, rename the overlay's session parameter, add the
+   file-link flag, move the poll loop onto an injected clock — all with the
+   local source as the only case that exists. This is a change to a load-bearing
+   local rendering path, so it lands and is proven against the path it already
+   serves *before* a second source can be blamed for a regression in it.
+10. **The watch surface (§5).** The `transcript` verb, the `remote.transcript`
+    handler, the remote source arm, the new tab with its gate arm and the
+    placeholder-tab change, and — in the same pass, because they share the one
+    `RemoteProviderStatus` lookup — the negotiated major, the attach argv and the
+    attach block reaching the app, alongside the attach exit-class correction the
+    block depends on.
+11. **Land (§6).** The `Context` plumbing with the filesystem fix in the same edit,
+    the `worktree.land` RPC, preconditions, in-place conversion, and the follow-up
+    archive.
 
-Step 9 last because it is the only step that mutates a row's location, so every
+Step 11 last because it is the only step that mutates a row's location, so every
 earlier step is exercised against a stable lane before the conversion is
 introduced into the mix.
 
-## 10. Rejected alternatives
+## 10. The vendor CLI surface, as measured
+
+Everything in this section is measured behavior of `claude` 2.1.233 on macOS.
+The rest of this document is written to it, and each finding's consequence is
+stated in the section that owns it; this section is the single record of what
+the surface does.
+
+### `create` requires an interactive terminal
+
+`claude --cloud "<description>"` with stdout piped creates nothing and says why:
+
+```
+Error: --cloud requires an interactive terminal. Non-interactive invocations (piped stdout, --init-only, --sdk-url) run locally and would silently ignore --cloud. Drop --cloud, or run from a TTY.
+```
+
+That is the good failure mode — the CLI refuses rather than quietly running the
+work locally under a flag that asked for the cloud — but it means the obvious
+provider implementation, spawning `claude` and reading its pipe, does not partly
+work. It never works. §3 specifies the pseudo-terminal the provider allocates
+for this one verb.
+
+### `create` is fire-and-forget, and answers in three lines of prose
+
+It does not attach. It exits 0 immediately, having printed exactly:
+
+```
+Created cloud session: Add probe pong reply
+View: https://claude.ai/code/session_01AAAAAAAAAAAAAAAAAAAAAA?from=cli&m=0
+Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA
+```
+
+There is no structured form — `--print` is refused alongside `--cloud` — so
+those lines are the only channel the session id travels on. §3 specifies the
+parse and what a change in that format costs.
+
+**The title is derived server-side, not echoed back.** A description of
+"transcript persistence probe: reply with the single word pong" comes back
+titled "Add probe pong reply". A
+cloud session's name is the vendor's summary of the instruction, not the
+instruction, so TBD reads it from `list`/discovery and never assumes it matches
+what was sent (§3).
+
+### `send` behaves exactly as the parent design specifies
+
+`claude -p "<msg>" --cloud <session_id> --output-format json` returns:
+
+```json
+{"ok":true,"session_id":"session_01AAAAAAAAAAAAAAAAAAAAAA","url":"https://claude.ai/code/session_01AAAAAAAAAAAAAAAAAAAAAA?from=cli&m=0"}
+```
+
+An ordinary pipe, no terminal needed. The id form is the only valid one: `-p`
+with a *description* rather than a session id is refused with "--cloud cannot be
+combined with --print", so the argument's meaning is never ambiguous.
+
+### `claude --teleport <id>` exists and prompts for folder trust
+
+The command is available and reaches Claude Code's folder-trust prompt. That is
+`land`'s `resume_command` (§6), so the landing path is sound as designed — with
+one consequence worth stating rather than discovering: a landed lane's worktree
+is a directory Claude Code has never seen, so **the first pane opens on the
+folder-trust prompt**.
+
+The user answers it. TBD neither suppresses it nor answers it on the user's
+behalf: it is a security decision about a checkout just materialized from a
+remote branch, which is exactly the moment the question is worth asking. Land is
+complete when the pane is spawned with the resume command; what the agent asks
+inside that pane is between the agent and the user.
+
+### Attaching is gated per account, and the gate defaults off
+
+`claude --cloud <session_id>` exits 1 with:
+
+```
+Error: Attaching to an existing cloud session is not enabled for your account.
+```
+
+The binary gates the attach branch on a server-side feature flag named
+`tengu_remote_backend` that defaults off — `let Dt = rt("tengu_remote_backend", !1)`,
+consulted before attach is taken — and carries no local override for it. The same
+gate is what makes `--cloud` require a description when it is off. §5 specifies
+how TBD reads this as an entitlement rather than as a missing capability.
+
+### No local transcript JSONL is written
+
+Across a create and an attach attempt, **zero** new `*.jsonl` files appeared
+under either projects root: 4179 files before, 4179 after. Both roots were
+checked, because TBD points `CLAUDE_CONFIG_DIR` at a per-profile directory — so
+the host store (`~/.claude/projects`) and the profile store
+(`$CLAUDE_CONFIG_DIR/projects`) are two different places a session could have
+landed.
+
+So **the `transcript` verb carries the entire watch story.** Nothing is seeded
+locally for free, and nothing has to be redirected to keep a cloud conversation
+out of the local session store. That is why §5's transcript path is the only
+source of conversation data, and why the Transcript tab is the watch surface
+rather than a convenience beside attach.
+
+Whether a *successful* attach would write one is untested rather than refuted —
+attach could not run at all under the account gate above. It is moot for the
+default state, since an account without the entitlement never attaches and so
+never writes. If the entitlement is granted and an attach does write locally, the
+consequence is the parent design's: the attach process must be pointed at the
+TBD-owned root, or a cloud conversation surfaces as a local session of whichever
+worktree the pane ran in. `handleSessionList`
+(`Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift`:9-22) resolves a
+projects directory from the worktree's path (:16) and hands it to
+`ClaudeSessionScanner.listSessions(projectDir:)` (:20), so anything written under
+that resolved root is indistinguishable from a local session of that lane.
+Pointing attach elsewhere is one environment entry on the attach spawn, and the
+TBD-owned root already exists for the verb's output.
+
+## 11. Rejected alternatives
 
 **Provenance as a payload on `WorktreeLocation.local`.** The same fact expressed
 in the same enum, which is superficially tidier — one value answers both
@@ -901,6 +1510,35 @@ worth building when the resolution ladder's lower tiers land and there is
 something for it to resolve; until then it would be a second surface with one
 option on it.
 
+**A second, simpler transcript view for remote lanes.** A `RemoteTranscriptTabView`
+beside `RemoteLogTabView` — call `remote.transcript`, receive parsed
+`TranscriptItem`s, render them in a plain scroll view — touches none of the local
+rendering path and would ship sooner. Rejected on what the cloud lane would then
+be: a session with no `log`, no attach guarantee, and a transcript that is its
+entire watch surface, shown through a renderer with no tool cards. A local lane's
+Edit card carries a diff, its Bash card a command and its output, its Agent card a
+drill-in to the subagent thread; a cloud lane would get prose in place of every
+one of those, which would not read as a lesser second view — it would read as the
+feature. Two renderers over one record format is also a standing tax: every tool
+card improvement lands in one of them, and the other decays quietly until someone
+notices. The cost that made this look attractive is smaller than it appears —
+`TableTranscriptView` and its height cache are already source-agnostic and already
+serve a non-terminal caller in `HistoryPaneView`, so what has to change is the
+resolution above the renderer, not the renderer. The field evidence that would
+reopen it: the source seam proving unable to express a provider that reports
+something the local path cannot, which would mean the two paths were never one.
+
+**Making `describe` dynamic so `attach` is declared only when the account is
+entitled.** The capability list would then tell the exact truth about what is
+possible right now, and no CTA would be needed. Rejected because it breaks
+`describe`'s defining property — the parent design fixes it as static and
+offline — by putting a network round trip inside the one verb that must answer
+without one, and because a capability that flickers with an account setting makes
+the Attach segment appear and vanish rather than explain itself. Capability
+answers what a provider implements; entitlement answers whether this account may
+use it, which is the same shape as a credential having expired and belongs on the
+same runtime path.
+
 **A per-provider streaming transcript follow instead of cursor polling.** A live
 stream would remove the refresh latency the tab has. Rejected on supervision
 shape: a per-session stream is one process per session rather than one per
@@ -915,39 +1553,3 @@ would spell `claude --cloud attach <id>`, and any arrangement that did compose
 correctly would do so by coincidence, breaking silently the next time either side
 changed a flag. An explicit `attachArgv` says what is being spawned instead of
 encoding it in the interaction of two fields that mean something else.
-
-## Open question: does `claude --cloud <id>` write a local transcript?
-
-**Unresolved. This slice is written so it works either way, and the answer changes
-only how much the `transcript` verb has to carry.**
-
-Interactive Claude Code sessions always persist to disk — `--no-session-persistence`
-is documented as working only with `--print` — so attaching to a cloud session
-with `claude --cloud <id>` may already write an ordinary transcript JSONL locally,
-under the Claude projects store for whatever directory the pane ran in.
-
-**If it does**, two things follow. Attaching once seeds a session's transcript for
-free, so the `transcript` verb becomes the path for *never-attached* sessions
-rather than the only path — which makes the verb's cursor-tailing a latency
-optimization rather than the sole source of conversation data. And the attach
-process **must** be pointed at the TBD-owned transcript root rather than the
-default store, or a cloud conversation surfaces as a local session of whichever
-worktree the pane ran in: `handleSessionList`
-(`Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift`:9-22) resolves a
-projects directory from the worktree's path (:16) and hands it to
-`ClaudeSessionScanner.listSessions(projectDir:)` (:20), so anything the attach
-process writes under that resolved root is indistinguishable from a local session
-of that lane. Pointing attach elsewhere is one environment entry on the attach
-spawn, and the TBD-owned root already exists for the verb's output.
-
-**If it does not**, the `transcript` verb is the only source of conversation data,
-the attach pane contributes nothing to it, and no redirection is needed.
-
-Either way the transcript tab reads from the TBD-owned root and never from the
-Claude projects store, so nothing in §5 depends on the answer. What depends on it
-is whether the attach spawn carries a redirection, and how quickly a
-freshly-attached lane's transcript fills in.
-
-**The test that settles it** is one command on a Mac: attach to a cloud session
-with `claude --cloud <id>`, then look for a new JSONL file appearing under
-`~/.claude/projects/`. It is worth running before step 8 of the work order.

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -1,0 +1,953 @@
+# Claude cloud sessions, slice 1 — create, watch, land
+
+**Date:** 2026-08-15
+**Status:** Design, not yet implemented.
+**Scope:** The first end-to-end path through the cloud-sessions design: create a
+cloud session from a repo's `+` menu, see it as a row in that repo's tree, watch
+it (attach and transcript), and land it into a local worktree.
+**Parent design:** [`2026-08-07-claude-cloud-sessions-design.md`](2026-08-07-claude-cloud-sessions-design.md).
+Everything here is downstream of that document and contradicts none of it.
+**Also depends on:**
+[`2026-08-10-remote-sessions-in-worktree-tree-design.md`](2026-08-10-remote-sessions-in-worktree-tree-design.md)
+(adoption, the local/remote boundary, archive composition),
+[`../remote-provider-contract.md`](../remote-provider-contract.md) (contract v2),
+[`../theory-placement.md`](../theory-placement.md) (the placement battery).
+
+## 1. Summary and non-goals
+
+A **cloud session** is a Claude Code session running on Anthropic's hosted
+infrastructure, reachable from `claude --cloud` in a terminal. The parent design
+makes such sessions ordinary remote sessions: TBD talks to them through a
+provider named `claude-cloud` that is compiled into the daemon rather than
+registered as an executable, and a session that resolves to a registered
+repository becomes a worktree row in that repository's tree like any other lane.
+
+This slice builds the shortest path that is genuinely useful, end to end:
+
+- **Create.** A cloud session is created from the repository's `+` menu, behind
+  a flag that ships off.
+- **Appear.** The session is adopted as a worktree row in that repository's
+  tree, nested and sorted like every other lane.
+- **Watch.** Selecting that row shows an attach terminal and a structured
+  transcript of the conversation.
+- **Land.** A row action converts the lane in place from remote to local:
+  the branch is checked out on this machine, the row keeps its identity, and
+  the conversation resumes in the first pane.
+
+Four things the parent design specifies are deliberately **out of scope here**,
+each for a reason that is about sequencing rather than doubt:
+
+- **`.tbd-remotes.json` and its trust-on-first-use gate** (parent design Part 4).
+  Repository-declared remotes are a second, independent decision surface with its
+  own approval flow; nothing in create-watch-land needs it, because slice 1's
+  create is always an explicit per-creation choice.
+- **Resolution ladder tiers 2 through 4** (the repository declaration, the user's
+  global default, provider `describe` defaults). Tier 1 — the explicit choice in
+  the create sheet — always wins and is always available, so the ladder's lower
+  tiers add convenience to a surface that already works without them.
+- **Archive and unarchive for remote lanes.** `worktree.archive`, `worktree.forget`
+  and the auto-archive-on-merge rail each refuse a remote row today, and teaching
+  all three the capability composition from the 08-10 design is a self-contained
+  piece of work that a lane can live without while it is being watched and landed.
+  The one exception is the retirement that follows a successful land, specified
+  in §6.
+- **Retiring the flat Remote section** (`RemoteSectionView`). It stays as it is.
+  Removing it is a sidebar change whose risk is unrelated to anything here, and
+  keeping it costs a duplicate surface for sessions that resolve to no registered
+  repository — which is what it is for anyway.
+
+**Delivery is one branch and one pull request, opened when the whole path works
+end to end.** §9 orders the work to minimize rework, not to produce a sequence of
+independently shippable increments; several of the steps below are unobservable
+on their own, and splitting them would mean shipping code paths with nothing
+behind them.
+
+## 2. The shared model change
+
+This is the foundation, and it is the one piece nothing else can be built on top
+of.
+
+`Worktree` gains an optional **origin** field beside `location`:
+
+```swift
+public struct WorktreeOrigin: Codable, Equatable, Hashable, Sendable {
+    public let provider: String
+    public let sessionID: String
+}
+
+// on Worktree, beside `location`:
+public var origin: WorktreeOrigin?
+```
+
+`location` answers *where this lane's files are now*. `origin` answers *which
+provider session this lane came from*. A lane that has been landed answers the
+first with `.local` and the second with the cloud session it was reconstructed
+from, and until this field exists there is nowhere to put that second answer.
+
+**The round trip destroys provenance in both directions today**, so this is not
+merely a missing field:
+
+- **Erased on write.** `WorktreeRecord.init(from:)`
+  (`Sources/TBDDaemon/Database/WorktreeStore.swift`:86-95) switches on
+  `wt.location` and sets `providerName` and `providerSessionID` to `nil` for the
+  `.local` case. Writing a landed row through the domain model clears its origin
+  columns.
+- **Dropped on read.** `WorktreeRecord.toModel()` (same file, :139-144) rebuilds
+  `.remote(provider:sessionID:)` only when the stored `location` string is
+  `"remote"` **and** both columns are present, and falls through to `.local`
+  otherwise — so whatever survived a write is discarded on the way back.
+
+A landed row would therefore round-trip clean, and the sidebar would forget which
+cloud session it had reconstructed the moment the daemon reloaded it.
+
+**Why provenance becomes its own field rather than a payload on `.local`.**
+`WorktreeLocation` (`Sources/TBDShared/Models.swift`:126-167) is `.local` |
+`.remote(provider:sessionID:)`, and `.local` carries no associated values. The two
+facts are orthogonal — where the files are now, and which session the lane came
+from — and the reason neither can be expressed today is exactly that the enum
+conflates them. Keeping `.local` payload-free means every existing `switch` over
+`WorktreeLocation` across the daemon and the app compiles untouched; only the
+record mapping and the model change. Adding associated values to `.local` would
+express the same fact while forcing every match site to be revisited, which is
+the more invasive answer to a smaller question.
+
+**No new column, and no migration for this.** `v70_worktree_location`
+(`Sources/TBDDaemon/Database/Database.swift`:1231-1238) already added
+`providerName` and `providerSessionID`, and `v72_worktree_provider_session_index`
+(:1301-1307) indexes the pair non-uniquely where `providerName IS NOT NULL`. What
+widens is the **invariant** those columns obey: they are set whenever a row has a
+provider session behind it, **past or present**, rather than only alongside
+`location = 'remote'`. The record type's own comments on those two properties
+(:41-42, "set only alongside location == \"remote\"") state the narrow rule and
+are part of the edit.
+
+The mapping becomes symmetric and single-sourced:
+
+- **Write.** `providerName` / `providerSessionID` come from `wt.origin`, whatever
+  `wt.location` says. `location` is written from `wt.location` as it is today.
+- **Read.** `origin` is reconstructed from the two columns whenever both are
+  present. `location` is `.remote(...)` when the stored string is `"remote"` and
+  an origin exists, and `.local` otherwise — the existing rule, unchanged.
+- **Consistency.** A `.remote` location without a matching origin is a
+  programming error, not a state to handle. `Worktree`'s initializer defaults
+  `origin` to the location's pair when the caller passes none, so all 158 existing
+  construction sites keep compiling and keep satisfying the invariant by
+  construction.
+
+`Worktree.providerBinding` (`Models.swift`:261-266) currently derives the pair
+from `location` and returns `nil` for a local row. It reads `origin` instead, so
+it keeps meaning "the provider session behind this row" across the landing.
+
+The wire format needs nothing new: `Worktree`'s hand-written `CodingKeys` already
+carry `locationKind`, `providerName` and `providerSessionID` (`Models.swift`:360),
+and the origin rides those same two keys. A landed row encodes as
+`locationKind: "local"` with the pair set, which an older peer reads exactly as it
+reads a local row today.
+
+Per the shared-model rule, the record change, the `TBDShared` model change, and
+the flag's migration (§7) land in one commit, with `origin` optional so existing
+rows and existing JSON still decode.
+
+`WorktreeStore.findRemote(provider:sessionID:)` (`WorktreeStore.swift`:579-587)
+filters on the two columns directly and never consults `location`, so it keeps
+matching a landed row and keeps adoption from minting a second row for a session
+whose lane has already landed. That property is why the columns are the right
+place for provenance and not merely an available one.
+
+## 3. The compiled `claude-cloud` provider
+
+Most of this is transcription from the parent design's Part 2, restated here only
+so this document stands alone. The parent is the authority for the full rules;
+nothing below re-decides any of them.
+
+**Why it is compiled.** How to talk to one vendor's session API is a mechanism,
+not a theory: there is one API, and no project's convention changes its shape
+([`../theory-placement.md`](../theory-placement.md), the two-reasonable-projects
+test). Mechanisms compile.
+
+**What `describe` declares.** `contract_versions: [2]` only — nothing exposed
+terminates a running cloud session, so the provider cannot implement `stop`, and
+major 1 requires it. Capabilities are `send`, `attach`, `transcript`, `land`,
+`archive` and `unarchive`; neither `stop` nor `log` is declared. `create_params`
+are `repo`, `branch`, `prompt` and `environment`, the last typed `string` because
+`describe` answers offline and the set of configured cloud environments is
+knowable only from the account.
+
+**Verbs.** `create` runs `claude --cloud "<prompt>"` from the repository
+checkout. `list` returns the union of a `claude_cloud_session` ledger (what this
+machine started) with discovered sessions, under the parent design's three union
+rules: two consecutive complete snapshots retire a resolved ledger row, a
+ledger-only row carries `state: "unknown"` rather than a fabricated `running`,
+and a discovered row always wins over a ledger row for the same id. `send` posts
+one message, stripping a single trailing `\r` or `\n` as the submit gesture it is
+and preserving interior newlines. `attach` runs `claude --cloud <id>` on the
+pane's PTY. `transcript` reads the server-stored conversation, cursor-tailed.
+`land` reports the session's repository and branch with a `resume_command` of
+`claude --teleport <id>` and `forks: true`. Create idempotency is the parent
+design's: the key and its state are written to the ledger before the invocation,
+a pending row is expected during the daemon's single same-key retry, and a
+pending row is resolved by the next complete discovery.
+
+**The reserved name.** `claude-cloud` is reserved. A registry entry claiming it is
+skipped with a visible flag rather than rejecting the whole file — the loader
+currently throws for the entire registry on a duplicate name, and two of its three
+call sites swallow that, so one bad entry silently removes every provider. The
+reservation is unconditional and does not depend on the flag in §7: a name that
+became available when a feature was off, and unavailable when it was turned on,
+would change which providers load as a side effect of a toggle.
+
+### How the dispatcher selects the built-in conformance
+
+This is the part that is genuinely new here, because the parent design names the
+shape without saying where it attaches.
+
+`RemoteProviderInvoking` (`Sources/TBDDaemon/Remote/ProviderRunner.swift`:42-45)
+is a one-method protocol with exactly one production conformance —
+`ProviderRunner` (:58), which spawns the registered executable — and exactly one
+injection site: `RemoteProviderManager`'s `runner` property (`RemoteProviderManager.swift`:18,
+assigned from the initializer at :53-59). Every verb the manager issues goes
+through that one property (:122 for `describe`, :260 for `list`, :388 for the
+pass-through path).
+
+The built-in provider is a second conformance, and the selection lands at that
+single injection site rather than at each call:
+
+```swift
+struct ProviderDispatcher: RemoteProviderInvoking {
+    let subprocess: any RemoteProviderInvoking   // ProviderRunner
+    let builtIns: [String: any RemoteProviderInvoking]
+
+    func run(_ config: RemoteProviderConfig, verb: [String], stdin: Data?,
+             timeout: TimeInterval, contractVersion: Int) async throws -> ProviderResult {
+        let target = builtIns[config.name] ?? subprocess
+        return try await target.run(config, verb: verb, stdin: stdin,
+                                    timeout: timeout, contractVersion: contractVersion)
+    }
+}
+```
+
+Three properties make this the right seam:
+
+- **One place decides.** The manager holds a dispatcher instead of a runner and
+  is otherwise unchanged, so no verb path grows a "is this the built-in one"
+  branch that a later verb could forget.
+- **The built-in provider is put through the same machinery.** It synthesizes the
+  same `ProviderResult` envelope a subprocess produces, including a fabricated
+  exit code, so it passes through `ProviderFailureClass.classify` and the same
+  health, auth-banner and staleness handling as an external provider.
+- **The test seam is unchanged.** `FakeProviderInvoker`
+  (`Tests/TBDDaemonTests/RemoteProviderManagerTests.swift`:21) conforms to the
+  same protocol and can stand in either for the subprocess arm or for a built-in
+  entry, so cloud behavior is testable with no network and no credential store.
+
+`RemoteProviderConfig` (`Sources/TBDShared/RemoteProvider.swift`:6-14) requires
+`exec`, which the built-in provider has no honest value for. The manager
+synthesizes a config for the reserved name whose `exec` is the resolved `claude`
+executable — resolved daemon-side through a `ClaudeExecutableResolver` in the
+shape `CodexExecutableResolver` (`Sources/TBDDaemon/Codex/CodexHomeManager.swift`:343)
+already establishes for the other vendor CLI. That value is never used to compose
+a verb invocation, because the dispatcher routes the reserved name in-process
+before `exec` is read; it exists so the app-side attach path in §5 has a real
+path to spawn, and §5 specifies how that path is composed.
+
+**Version negotiation is a prerequisite inside this slice, not an assumption.**
+`RemoteProviderManager.describeProvider` currently hard-requires that
+`describe.contractVersions` contains `1` (:139-142) and fails the provider with
+"no common contract version" otherwise, so a `[2]`-only provider is refused by the
+daemon as it stands. That guard becomes an intersection with TBD's own supported
+set, taking the highest common major and failing only on an empty intersection.
+The negotiated major is stored per provider beside `describes` and reaches all
+three emitters of `TBD_CONTRACT_VERSION`:
+
+- `ProviderRunner.run` (`ProviderRunner.swift`:64) — a parameter on
+  `RemoteProviderInvoking`, so both conformances receive it.
+- `ProviderEventsSupervisor` (`ProviderEventsSupervisor.swift`:253) — the same
+  value, threaded when the manager spawns the stream.
+- `RemoteAttachTerminalView.attachEnvironment`
+  (`Sources/TBDApp/Remote/RemoteAttachTerminalView.swift`:82) — see §5, which is
+  where that one is a must-fix rather than a parameter change.
+
+## 4. Routing an adopted lane to a detail pane
+
+An adopted remote row today shows an **empty detail area**. The path is:
+
+`OtherSectionContent` (`Sources/TBDApp/ContentView.swift`:699-721) falls through
+its section conditions to `WorktreeDetailAreaView` (:808) whenever a worktree is
+selected; that view renders `TerminalContainerView`
+(`Sources/TBDApp/Terminal/TerminalContainerView.swift`:29), which at :204 calls
+`layoutContent(worktree: LocalWorktree(worktree))`. `LocalWorktree.init?`
+(`Sources/TBDShared/LocalWorktree.swift`:34-39) returns `nil` for a row whose
+location is remote, so `layoutContent` (:285-300) takes its final arm and renders
+the "No terminals" placeholder. There is nothing wrong with any of that — it is
+the local/remote boundary doing its job — but it means a cloud lane's own detail
+area has nothing to say about the session behind it.
+
+Meanwhile `RemoteSessionDetailView`, which has everything to say about it, is
+reachable only through `AppState.selectedRemoteSession`: `DetailSectionHostPager.targetTab`
+(`ContentView.swift`:640-649) returns `.remote` whenever that value is non-nil,
+which routes to `RemoteSessionHostSlot` (:660-670) and thence to the detail view.
+`selectRemoteSession` (`Sources/TBDApp/AppState+Navigation.swift`:305-309) is the
+only writer, and it is called only from the flat section's rows.
+
+**The decision: selecting an adopted cloud row also marks it the selected remote
+session, so the detail area swaps to `RemoteSessionDetailView`.**
+
+### The remote selection is derived, not separately maintained
+
+The two selections are kept consistent by making one a function of the other
+rather than by writing both at every gesture.
+
+`AppState.selectedWorktreeIDs`'s `didSet` (`Sources/TBDApp/AppState.swift`:224-230)
+unconditionally clears `selectedRemoteSession` whenever a worktree becomes
+selected. That single line becomes a call to a pure derivation:
+
+```swift
+nonisolated static func remoteSelection(
+    forSelection ids: Set<UUID>, worktrees: [Worktree]
+) -> RemoteSessionSelection? {
+    guard ids.count == 1, let id = ids.first,
+          let wt = worktrees.first(where: { $0.id == id }),
+          case let .remote(provider, sessionID) = wt.location
+    else { return nil }
+    return RemoteSessionSelection(provider: provider, sessionID: sessionID)
+}
+```
+
+Single-selection only: a multi-selection has no one session to show, and every
+other case — a local row, an empty selection, an unknown id — yields `nil`, which
+is exactly today's behavior. The derivation keys on `location`, not on `origin`:
+a landed row has an origin but its files are here, so it belongs to the worktree
+detail area.
+
+`AppState.reconcileRemoteSelection()` applies that derivation and is called from
+**two** places, which is what makes each of the consistency questions answer
+itself:
+
+- The `didSet` above, so a selection change re-derives.
+- Every path that replaces the worktree list — the connect-time refresh and each
+  worktree delta — so a change to a *selected row's own location* re-derives even
+  though the selection did not move.
+
+That second call site is what clears the remote-session selection when Land
+converts the row. Land does not clear anything itself. The daemon converts the
+row and broadcasts it, the app applies the delta, the derivation re-runs, the
+selected row is now `.local`, `selectedRemoteSession` becomes `nil`, `targetTab`
+returns `.other`, and the detail area is the worktree detail area — which now has
+real terminal panes to render, because `LocalWorktree.init?` succeeds. There is no
+window in which a lane with local panes is showing a remote session view, and no
+second piece of code that has to remember to clear a selection.
+
+The remaining transitions fall out of the same rule:
+
+- **Selecting a different row** — the `didSet` re-derives from the new selection.
+- **Deselecting** — an empty set derives `nil`.
+- **The row disappearing** — the worktree list no longer contains the id, so the
+  derivation finds no row and yields `nil`.
+- **The session leaving the provider's inventory** — `pruneRemoteSessionState`
+  (`Sources/TBDApp/AppState+Remote.swift`:81-89) already clears
+  `selectedRemoteSession` when the selected session is absent from a successful
+  refresh, and keeps doing so.
+- **The daemon dropping** — `targetTab` checks `isConnected` first and returns
+  `.other` regardless of any selection, so a stale remote selection cannot
+  survive a disconnect on screen.
+
+### Two selections that are no longer mutually exclusive
+
+An adopted cloud row is selected in `selectedWorktreeIDs` *and* named by
+`selectedRemoteSession` at the same time. That combination cannot arise today, so
+it needs stating:
+
+- **The sidebar keeps highlighting the worktree row**, because the row's id stays
+  in `selectedWorktreeIDs`. Nothing strips it. This is the opposite of the flat
+  section's rows, whose ids are stripped back out of the set in the same `didSet`
+  (:196-208) precisely because they are not real `Worktree.id`s. An adopted lane's
+  id is a real one, and every consumer of `selectedWorktreeIDs` continues to hold.
+- **Navigation records a worktree entry**, not a remote-session entry — the
+  `recordNavigation(.worktrees(...))` at :230 is unchanged. Back and forward
+  replay the worktree selection, and the derivation re-runs on replay, so the
+  detail pane comes back with it. The flat section's own entry point keeps
+  recording `.remoteSession` entries for sessions that own no row.
+- **`selectRemoteSession` is untouched.** It still clears `selectedWorktreeIDs`
+  (via `activateRemoteSession`, :351-366) because the sessions it is called for
+  have no worktree row to keep selected. The two entry points therefore do not
+  fight: one is for lanes, one is for the sessions that never became lanes.
+- **Attach keep-alive is unaffected.** `attachedRemoteSelections`
+  (`Sources/TBDApp/AppState+RemoteAttach.swift`:134-152) and
+  `remoteSessionHostSelection` (:166-168) read `selectedRemoteSession` and the
+  recency log exactly as they do now, so a cloud lane joins the bounded keep-alive
+  set on the same terms as any other remote session.
+
+### The pager's invariant is preserved
+
+`DetailSectionHostPager` (`ContentView.swift`:509-560 doc comment, :561 onward) is
+an `NSTabViewController` with `tabStyle = .unspecified` (:578) — an invisible
+pager holding exactly three tab items. Two distinct properties depend on that
+shape, and this change must break neither:
+
+- **The `.remote` tab item is mounted once and never removed**, so
+  `RemoteAttachPager` and every live attach connection it holds survive an
+  excursion to a worktree or repo section. Unmounting it would turn "switch back"
+  into a full reconnect.
+- **The non-selected tab's content view is genuinely detached from the window**
+  (`window == nil`), which a SwiftUI `ZStack` with `.opacity(0)` would not do.
+  `TBDTerminalView`'s shared click-passthrough `NSEvent` monitor decides whether
+  to fire from `window != nil` plus a geometric bounds check rather than from
+  SwiftUI hit-testing, so a merely-invisible remote terminal sharing a screen rect
+  with a visible page would swallow clicks meant for the other page.
+
+Nothing here adds a tab, removes one, reassigns a host's `rootView`, or
+`.id()`-keys anything. The change is confined to which value `selectedRemoteSession`
+holds; `targetTab` is a pure function of that value and already routes correctly
+once it is set, and its unit tests extend to the new case without new machinery.
+
+## 5. The watch surface
+
+`RemoteSessionDetailView` gains a **Transcript** segment beside Attach and Log.
+
+`RemoteSessionDetailTab` (`Sources/TBDApp/Remote/RemoteSessionDetailView.swift`:11-14)
+is a two-case enum today (`attach`, `log`) and gains `transcript`. The four pure
+gates that decide what renders live in
+`Sources/TBDApp/Remote/RemoteSessionDetailGates.swift` and are unit-tested in
+`Tests/TBDAppTests/RemoteSessionDetailGatesTests.swift`:
+
+- `available(capabilities:gone:)` (:40-45) builds the ordered tab list. It gains a
+  `transcript` arm between attach and log. **Attach is dropped when the session is
+  `gone`; transcript is not** — reading a retired session's conversation is still
+  useful, which is exactly the reasoning that already keeps `log` available for a
+  tombstoned row.
+- `initialTab(available:requested:)` (:55-60) honors a one-shot navigation hint
+  when it names an available tab and otherwise takes the list's first entry. It
+  needs no change; the new case flows through it.
+- `showsPicker(available:)` (:66-68) renders the segmented control only when there
+  is a real choice — `available.count > 1`. No change.
+- `showsSendField(capabilities:gone:snapshotFresh:)` (:75-79) is independent of
+  the tab list. No change; cloud declares `send`, so the send field renders for a
+  live cloud lane with a fresh snapshot.
+
+The picker itself is at `RemoteSessionDetailView.swift`:173-182, the send field
+is gated just below it at :186-192, and `RemoteLogTabView` (:607-659) is the
+existing read-only scrollback pane the new tab sits beside.
+
+**What a cloud lane's picker shows.** Cloud declares `transcript` and `attach`
+but not `log`, so `available` returns `[.attach, .transcript]`, `showsPicker` is
+true, and the segmented control offers exactly those two, in that order, with
+Attach selected by default. A **gone** cloud lane returns `[.transcript]` alone —
+one tab, so no picker renders and the transcript content fills the pane
+unconditionally, which is the shape a single-tab provider already gets. A provider
+declaring none of the three still reaches the existing empty state.
+
+### The `transcript` data path
+
+`remote.transcript` does not exist. `RPCRouter+RemoteHandlers.swift` has
+handlers for providers, sessions, create, stop, send, log, rename, dismiss,
+setPin and reportAttachExit (:57, :64, :86, :152, :189, :225, :263, :293, :315,
+:341) and nothing else. A new `handleRemoteTranscript` joins them, gated by the
+same `remoteGate()` (:26-29) as every sibling.
+
+**The Transcript segment renders provider JSONL through a simpler path in this
+slice, rather than reusing the structured table renderer.** The recommendation is
+the cheaper option, and the trade-off is real.
+
+`TableTranscriptPaneView` (`Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift`:12-14)
+is terminal-and-session-keyed end to end. It takes a `terminalID` and a
+`worktreeID`, and resolves content by looking up the terminal in
+`appState.terminals[worktreeID]`, reading `terminal.claudeSessionID` off it, and
+indexing `appState.sessionTranscripts` by that session id (:68-79). It is hosted
+from exactly one place, `PanePlaceholder.swift`:352, and `PanePlaceholder` takes a
+`LocalWorktree` (:49). A cloud lane has no terminal row, no Claude session id, and
+no `LocalWorktree`. Making the renderer provider-fed means introducing a second
+keying axis through the poll loop, the transcript store, the overlay coordinator
+and the row-height cache — a change to a load-bearing local rendering path, which
+under the repository's own rules would itself want a default-off flag and a soak.
+
+So slice 1 adds `RemoteTranscriptTabView` beside `RemoteLogTabView`: it calls
+`remote.transcript` on appear and on a refresh token, receives already-parsed
+`TranscriptItem`s, and renders them with the same `SelectableTranscriptRow` used
+by the table renderer, inside a plain scroll view.
+
+**The honest cost.** There are then two renderers over the same record format, so
+an improvement to a tool card lands in one and not the other until they converge;
+and the remote view has no height cache, so a very long cloud conversation scrolls
+less smoothly than a local one. Both are visible, neither is silent, and neither
+loses data. The convergence path, when a second provider declares `transcript` or
+when a cloud conversation gets long enough to hurt, is to re-key
+`TableTranscriptPaneView` on a transcript *source* rather than on a terminal — at
+which point the remote view becomes a second caller of one renderer rather than a
+second renderer.
+
+Daemon-side, `handleRemoteTranscript` invokes the verb, appends stdout to the
+TBD-owned transcript root `~/tbd/remote-transcripts/<provider>/<sessionID>/`
+(path helper in `TBDConstants`, honoring `TBD_HOME`), stores the cursor returned
+in the stderr envelope for the next call, and parses the accumulated file through
+`TranscriptParser`. Parsing stays daemon-side, as `session.messages` already does.
+
+**The parent design's single-choke-point resolver is a prerequisite of this
+slice**, not a follow-up. `TranscriptParser` is reached from several handlers that
+are not guarded alike, and admitting a second permitted root is only safe where
+the boundary is actually checked. The resolver — one function taking an untrusted
+path and returning either a validated path under one of the two permitted roots or
+a refusal, with `TranscriptParser`'s entry points reachable only through it —
+ships before the TBD-owned root is admitted to it.
+
+Because a remote transcript's file paths refer to a different machine, the
+renderer suppresses its clickable local file links for remote rows rather than
+dead-ending or opening an unrelated local file.
+
+### Must fix in this slice: attach announces contract major 1
+
+`RemoteAttachTerminalView.attachEnvironment`
+(`Sources/TBDApp/Remote/RemoteAttachTerminalView.swift`:78-84) hardcodes
+`env["TBD_CONTRACT_VERSION"] = "1"` at :82. The comment directly above it
+(:62-77) already states the hazard: the contract requires the variable on every
+invocation, the daemon's two emitters set it, and this is the third and only
+app-side spawn site, so a provider that branches on the contract version would see
+a different answer for `attach` than for every other verb.
+
+That hazard becomes an actual failure for cloud. The `claude-cloud` provider
+declares `contract_versions: [2]` **only** — it cannot implement `stop`, which
+major 1 requires — so attaching to a cloud session with this constant in place
+hands a v2-only provider a `1`. The app spawns `attach` itself, directly on the
+pane's PTY, and never passes through `RemoteProviderInvoking`, so negotiated state
+held in `RemoteProviderManager` is invisible to it.
+
+**How the app learns the negotiated major.** `RemoteProviderStatus`
+(`Sources/TBDShared/RemoteProvider.swift`:276-296) already crosses the wire on
+`remote.providers` carrying `config`, `describe` and `health` (:277-279), and
+`RemoteAttachPager` already has the status in hand one frame above the attach view:
+at `Sources/TBDApp/Remote/RemoteAttachPager.swift`:58 it looks the status up by
+provider name and takes `.config` off it to build the argv. So the status gains
+two fields, both read at that same lookup:
+
+- **`contractVersion: Int?`** — the major the daemon negotiated for this provider.
+  `attachEnvironment` takes it as a parameter and emits it. Absent (an older
+  daemon) falls back to `1`, matching what the constant emits today, which is the
+  conservative reading rather than a new behavior.
+- **`attachArgv: [String]?`** — the invocation prefix for a provider whose attach
+  is not `<exec> [args…] attach <id>`. The app appends the session id and spawns
+  it. Absent for every registered provider, where the app keeps composing
+  `provider.argv + ["attach", sessionID]` exactly as it does now.
+
+The second field exists because the built-in provider's attach is
+`claude --cloud <id>`, and `RemoteProviderConfig.argv + ["attach", sessionID]`
+would spell a command the vendor CLI does not have. Synthesizing an `exec` that
+happens to compose correctly would be a coincidence that a later flag rename
+breaks silently. Trust-wise `attachArgv` is a `resume_command`-class value: it
+comes from the daemon's own built-in provider, never from repository content,
+which is what the contract's `resume_command` rule permits.
+
+One resolved value per concern, one lookup, no second source of truth. The
+regression test that matters is that the negotiated major reaches
+`RemoteProviderStatus` and is what the attach environment emits — that path
+crosses a process boundary and is the one that would otherwise go on announcing
+`1` forever.
+
+## 6. Land
+
+Land is an action on the adopted worktree row, enabled when the row's provider
+declares the `land` capability. It converts the row **in place**: `.remote`
+becomes `.local`, the git worktree is materialized, and the row keeps its id, its
+display name, its PR badge, its position in the tree, and its children. One lane
+throughout — landing is where a lane's files arrive on this machine, not where a
+second lane begins.
+
+### Row actions are assembled in exactly one place
+
+`Sources/TBDApp/Helpers/RowActionMenu.swift` is the single source of truth for a
+worktree row's actions, and it is pure: `items(context:)` (:230-238) branches on
+the row's kind into `scratchItems` (:321), `mainItems` (:349-355) or `regularItems`
+(:357-390), all as a function of a `Context` value (:105-181) built by
+`RowActionMenuActions.context()` (`Sources/TBDApp/Sidebar/RowActionMenuActions.swift`:70-95).
+`RowActionMenuActions.run(_:)` (:104-214) runs the side effect for a typed kind,
+and the whole thing is mounted from `WorktreeRowView.swift`:468-470 through
+`SidebarContextMenu`.
+
+`RowActionMenu.Kind` (:20-52) gains `case land`, and `regularItems` places it in
+the first section beside Rename and Archive.
+
+**`RowActionMenu.Context` carries no notion of location, provider or
+capabilities today**, so it gains two fields:
+
+- **`isRemote: Bool`** — the row's location is `.remote`. Populated from
+  `worktree.location`.
+- **`providerCapabilities: [String]`** — the declared capabilities of the row's
+  provider, or empty when the provider is unknown. Populated from
+  `appState.remoteProviders`, matching on the row's provider name.
+
+Land is offered when both are satisfied: `isRemote && providerCapabilities.contains("land")`.
+Following the existing convention that capability-gated items are omitted rather
+than grayed out, a remote row whose provider does not declare `land` simply has no
+Land item.
+
+### The same `Context` edit fixes a latent silent failure
+
+`regularItems` (:357-390) appends `filesystemActions(context:)` **unconditionally**.
+`pathIsEmpty` — which `RowActionMenuActions` populates as `localWorktree == nil`
+(:84), and which is therefore true for every remote row — is consulted in exactly
+one place in the whole file: the `guard` at :353 inside `mainItems`. So an adopted
+remote row today offers "Open in Finder" and "Copy Path", and `run(_:)` silently
+does nothing for both, because each arm is written `if let local = localWorktree`
+(:111-120). The comment above those arms asserts that "both path actions are
+hidden when `pathIsEmpty`, so the nil arm is unreachable through the menu — the
+binding is what proves it." That assertion is true for main and creating rows and
+false for remote ones, which is precisely how the gap stayed invisible.
+
+The fix belongs in this edit and not in a separate change, for three reasons: it
+is the same `Context` and the same two functions; the actions it removes are the
+ones a *cloud lane in particular* will be right-clicked with, so shipping Land
+next to two dead items would be shipping the bug into the feature; and the failure
+is silent, which the repository's review gate treats as its own category.
+
+`filesystemActions` (:309-319) splits by what each action actually needs. Open in
+Finder and Copy Path need a directory on this disk and go behind `!pathIsEmpty`.
+Copy Link (a deep link keyed on the worktree UUID) and Copy Branch Name need no
+directory at all and stay unconditional — a remote lane has a branch worth copying
+and a link worth sharing. `mainItems` keeps its own `guard`, so a `.creating` row
+still yields an empty menu rather than a partial one.
+
+### What Land does
+
+`run(.land)` calls a new `worktree.land` RPC. The daemon:
+
+1. Loads the row and refuses unless its location is `.remote`.
+2. Invokes the provider's `land` verb and validates every returned field per the
+   contract before any of it reaches git: `branch` must satisfy the contract's
+   conservative ref-name pattern and must not begin with `-`; `remote_url` is only
+   ever **compared** against the local repository's configured remote and never
+   passed to git as a remote argument, which is what rules out the `ext::`
+   transport family and its command execution; `resume_command` is accepted only
+   because it came from the daemon's own built-in provider.
+3. **Checks every precondition before creating anything**: the local repository's
+   configured remote matches `remote_url`, the branch exists on the remote, the
+   target worktree path is free, and the branch is not already checked out in
+   another worktree — `git worktree add <path> <branch>` refuses to check one
+   branch out twice.
+4. Materializes the worktree through the existing lifecycle path, checks out the
+   branch, and spawns the first pane running `resume_command`.
+5. Writes the row: `location` becomes `.local`, `localPath` becomes the real path
+   in place of the synthetic `remote://` URI, and `origin` keeps the provider and
+   session id — which is what §2 exists for, what keeps `findRemote` from
+   re-adopting the session into a fresh row, and what lets the row render where it
+   came from.
+
+**A failure at any step leaves the row `.remote` and unchanged.** Preconditions
+are checked before anything is created, so there is never a half-built worktree or
+a half-converted row, and the lane is exactly as it was.
+
+Landing is always a user gesture and is never triggered by session state.
+
+**After the conversion, the provider session is archived** — one verb call,
+because `claude-cloud` declares `archive` and reports `forks: true`, so the work
+has moved to this machine and a session nobody will return to should not sit in
+the working set. It is never *stopped*, whatever a provider declares: landing is
+a "bring this home" gesture, not a teardown, and the remote box may still hold
+work that was never pushed. This is the only archive path slice 1 wires; the
+row-level archive composition stays out of scope per §1. The archive runs after
+the row has already converted and is best-effort: its failure is reported and does
+not un-land the lane.
+
+That archive does not travel back to the row. Mirroring a provider's `archived`
+flag onto a row's status applies while the row is remote, and the lane is local
+now — its filing state is TBD's own from that point.
+
+## 7. The flag
+
+`claude_cloud_enabled` — a new `config` column, **default OFF**. The behavior is
+autonomous background polling against a network service, squarely inside the
+default-off rule.
+
+**The column is added with no SQL default**, so unset stays a genuine third
+state. Migration `v78_config_claude_cloud` calls
+`addColumnIfMissing(table:column:type:)` with `defaults:` **omitted** —
+`v73_config_queued_prompt` (`Database.swift`:1334) and `v77_config_supervision_enabled`
+(:1406) are the precedents, and the long comment above the former states the
+reasoning that applies unchanged here. NULL means nobody has chosen; `0` and `1`
+mean somebody did.
+
+The shipped default therefore lives in exactly one place:
+`ConfigRecord.toModel()` (`Sources/TBDDaemon/Database/ConfigStore.swift`:68-116)
+resolving `claude_cloud_enabled ?? claudeCloudEnabledDefault`, where that
+parameter defaults to `Config.claudeCloudEnabledDefault` and is overridable in
+tests — the same shape `queuedPromptDefault` and `supervisionEnabledDefault`
+already take on that function (:68-71), which exists so a test can prove that NULL
+*follows* a changed default while an explicit `false` does not. Graduation is a
+one-line edit to that constant. It reaches everyone who never touched the toggle
+and preserves every explicit opt-out, which matters more here than for most flags,
+because this feature calls a network service on a schedule and somebody who turned
+it off did so deliberately.
+
+### How it reaches the app
+
+The path is the established one, and it is additive at every hop:
+
+- **`ConfigRecord.toModel()`** resolves the tri-state into `Config.claudeCloudEnabled`.
+- **`DaemonCapabilitiesResult`** (`Sources/TBDShared/RPCProtocol.swift`:2622-2733)
+  gains the field, built at `RPCRouter.swift`:661-672 beside
+  `remoteBackendsEnabled` (:670) and `remoteBackendsLive` (:671). Its hand-written
+  `init(from decoder:)` (:2705-2732) decodes it as
+  `decodeIfPresent(...) ?? Config.claudeCloudEnabledDefault`, following how
+  `queuedPromptEnabled` is decoded rather than the `?? false` the older flags use:
+  a daemon that does not send the field cannot serve the feature either, so
+  falling through to the shipped default is the honest reading.
+- **`AppState.daemonCapabilities`** (`Sources/TBDApp/AppState.swift`:1144) holds
+  it. It is fetched on connect (:2389, deliberately before `refreshAll`) and
+  re-fetched on config deltas through `refreshDaemonCapabilities()` (:1361-1364),
+  called from the `.modelProfilesChanged` handler (:1930) — which the daemon
+  reuses for config changes — so a toggle from another client propagates without
+  a reconnect.
+- **The view site reads it.** The create entry point in §1 is omitted when the
+  flag is off, following `queuedPromptEnabled`'s gate
+  (`Sources/TBDApp/AppState+Worktrees.swift`:74) and `remoteBackendsEnabled`'s
+  toggle and caption (`Sources/TBDApp/Settings/SettingsView.swift`:499-512); the
+  new Settings toggle follows `queuedPromptToggle` (:283-292).
+
+### It needs the live/restart distinction
+
+`remoteBackendsEnabled` is paired with `remoteBackendsLive` because the daemon
+builds its provider manager only at boot: `Daemon.swift`:496-502 constructs
+`RemoteProviderManager` inside `if mockMode == nil, config.remoteBackendsEnabled`,
+so a user who flips the flag on without restarting still has a `nil` manager, and
+`remoteBackendsLive` is what lets the app say "on, but needs a restart" without
+calling a `remote.*` verb and parsing its error string.
+
+**`claude_cloud_enabled` has the same shape and gets the same treatment**, because
+the built-in provider is registered into the dispatcher at the same moment, inside
+the same boot-time construction. A manager built while the cloud flag was off has
+no `claude-cloud` entry at all, and flipping the flag cannot conjure one into a
+running actor. So `DaemonCapabilitiesResult` carries `claudeCloudLive` alongside
+`claudeCloudEnabled`, and the Settings caption distinguishes the two exactly as
+`AppState.remoteBackendsStatusCaption` already does for the outer flag.
+
+### It is a second gate inside the first, never a bypass
+
+Every `remote.*` handler gates on `remoteBackendsEnabled` through `remoteGate()`
+(`Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift`:26-29), and cloud is
+reached through those same verbs, so `claude_cloud_enabled` is checked **inside**
+that gate for invocations naming the reserved provider. Cloud requires both flags.
+Tests assert all four combinations, not two.
+
+The two stay separate rather than merging because `remote_backends_enabled` was
+written to be *deletable* after soak, on the reasoning that the feature is inert
+without a registered provider file. A provider compiled into the daemon is never
+inert, so folding this into it would silently convert a disposable flag into a
+permanent one. When `remote_backends_enabled` is eventually deleted, its gate is
+removed and `claude_cloud_enabled` becomes the sole gate for cloud, with the
+external-provider path ungated as the v1 rollout intends — and that deletion
+migration leaves `claude_cloud_enabled` untouched, so turning the outer flag off
+by deleting it cannot turn cloud on for anyone.
+
+## 8. Testing
+
+Every gated conditional gets a test per branch. All tests run under
+`scripts/test.sh`, use the `TBD_HOME` isolation seams, and reach neither the
+network nor a real credential store: the vendor transport sits behind an injected
+client protocol and credential reads behind an injected seam.
+`FakeProviderInvoker` (`Tests/TBDDaemonTests/RemoteProviderManagerTests.swift`:21)
+is the seam for provider behavior, standing in for either arm of the dispatcher.
+
+**The flag's three states are distinguishable.** A pre-migration row reads NULL
+rather than `0`; a NULL row follows a change to `Config.claudeCloudEnabledDefault`
+(asserted through `toModel`'s injectable default parameter); an explicit `false`
+survives that same change. All four combinations of `remote_backends_enabled` and
+`claude_cloud_enabled` are asserted, including that cloud verbs refuse when the
+outer flag is on and the inner one is off. The live/enabled distinction is
+asserted separately: a flag turned on after boot reports enabled-but-not-live.
+
+**The model round-trip.** A landed row — `.local` location, origin set — survives
+a write and a read with its provider and session id intact, which is the assertion
+that would have caught both halves of the current erasure. A `.remote` row still
+round-trips as it does now. `findRemote` matches a landed row, so a later snapshot
+containing that session adopts nothing new. A row with neither column set reads
+back with a `nil` origin and a `.local` location.
+
+**The routing transition on Land.** Selecting an adopted remote row derives a
+remote-session selection and routes `targetTab` to `.remote`; the worktree row
+stays selected in `selectedWorktreeIDs`. Applying a worktree delta that flips that
+same row to `.local` re-derives to `nil` and routes to `.other`, with no
+intervening state in which a local row is showing a remote detail view. A
+multi-selection including the row derives `nil`. Deselecting derives `nil`. A
+disconnect routes to `.other` regardless of the derived value.
+
+**The picker's shape for a `transcript`-without-`log` provider.** `available`
+returns `[.attach, .transcript]` for a live cloud lane and `[.transcript]` for a
+gone one; `showsPicker` is true in the first case and false in the second;
+`initialTab` lands on Attach in the first and Transcript in the second, and a
+one-shot Log hint against a provider that does not declare `log` is discarded
+rather than producing a blank pane. A provider declaring `log` and not
+`transcript` behaves exactly as it does now.
+
+**Land's precondition failures each leave the row unchanged.** A remote mismatch,
+a branch missing on the remote, an occupied target path, and a branch already
+checked out in another worktree are each reported without creating a worktree, and
+each leaves the row `.remote` at its synthetic path with its origin, display name,
+parent edge and children intact. A `branch` beginning with `-` and an
+`ext::`-style `remote_url` are both rejected before reaching git. On success the
+same row id comes back `.local` at a real path with everything else preserved and
+no second row for the session; the provider session is archived and never stopped;
+a failed archive after a successful conversion leaves the row landed and reports.
+
+**Version negotiation.** A provider declaring `[1, 2]` negotiates 2, one declaring
+`[1]` negotiates 1, one declaring `[2]` alone negotiates 2 rather than being
+refused, and one declaring `[3]` alone is refused with a clear error. All three
+emitters agree for a given provider — and the one that matters is the third: the
+negotiated major reaches `RemoteProviderStatus` and is what the attach environment
+emits, since that path crosses a process boundary. A status without
+`contractVersion` yields `1`. A status with `attachArgv` spawns it verbatim plus
+the session id; without it, the composed `argv + ["attach", id]` is unchanged.
+
+**Row actions.** A remote row whose provider declares `land` offers Land; one
+whose provider does not, or whose provider is unknown, does not. A remote row
+offers neither Open in Finder nor Copy Path, and still offers Copy Link and Copy
+Branch Name. A local row's menu is byte-identical to what it produces today, and a
+`.creating` row still yields an empty menu.
+
+**The dispatcher.** A verb naming the reserved provider is served in-process and
+never spawns a subprocess; a verb naming a registered provider still spawns one; a
+registry entry claiming the reserved name is skipped and flagged while every other
+entry in the file still loads, with and without the cloud flag on.
+
+**The transcript boundary.** Every read reaches `TranscriptParser` through the one
+resolver; a path under the Claude projects store and a path under the TBD-owned
+root are both accepted; anything else is refused, including a traversal that
+escapes either root after normalization; the refusal holds for every entry point
+alike, so one added later cannot be reached unguarded.
+
+## 9. Work order
+
+**Nothing opens a pull request until the whole path works end to end.** The order
+below minimizes rework; it is not a sequence of independently shippable
+increments, and several steps are unobservable on their own. Building it as
+increments would mean shipping the routing change with nothing to route and the
+provider with no flag to gate it.
+
+1. **The shared model change (§2).** Origin field, record mapping, round-trip
+   tests. Everything downstream reads provenance, and every later step written
+   against the current erasing mapping would have to be rewritten.
+2. **Contract v2 negotiation (§3).** Accept a `[2]`-only provider, store the
+   negotiated major, thread it to the runner and the events supervisor, publish it
+   on `RemoteProviderStatus`. The cloud provider cannot be described at all until
+   this lands, so writing it first means writing it against a guard that rejects
+   it.
+3. **The transcript-root choke point (§5).** One resolver, every `TranscriptParser`
+   entry point behind it. The TBD-owned root cannot be admitted safely before the
+   boundary is actually checked.
+4. **The flag and its capabilities plumbing (§7).** Migration, record, model,
+   `DaemonCapabilitiesResult`, Settings toggle. The provider is constructed behind
+   this flag, so the flag exists first or the construction has to be rewired.
+5. **The dispatcher and the provider's `describe`, `create` and `list` (§3).**
+   Including the ledger table and its union rules. Until a cloud session can be
+   created and enumerated there is no row to route, watch or land, so this is the
+   step that makes every later one testable by hand.
+6. **The create surface.** A repository already has a remote-create entry point:
+   `RepoSectionView.newRemoteSessionMenuItem`
+   (`Sources/TBDApp/Sidebar/RepoSectionView.swift`:430-444) enumerates
+   `appState.remoteProviders` and opens `RemoteCreateSheet` prefilled with the
+   repository (:453-462), and the cloud provider joins that list for free once
+   the dispatcher registers it. What this step adds is the same entry on the
+   repository's `+` button, which today opens `WorktreeProfilePickerView` (:256-268)
+   — the affordance a user already reaches for to start a lane. Both entries are
+   omitted, not disabled, when the flag is off, matching how capability-gated
+   remote items are already omitted rather than grayed out.
+7. **Routing (§4).** The derived remote selection and its two call sites. Only
+   observable once a cloud row exists, which is why it follows step 5.
+8. **The watch surface (§5).** The `transcript` verb, the `remote.transcript`
+   handler, the new tab and its gate arm, and — in the same pass, because they
+   share the one `RemoteProviderStatus` lookup — the negotiated major and the
+   attach argv reaching the attach environment.
+9. **Land (§6).** The `Context` plumbing with the filesystem fix in the same edit,
+   the `worktree.land` RPC, preconditions, in-place conversion, and the follow-up
+   archive.
+
+Step 9 last because it is the only step that mutates a row's location, so every
+earlier step is exercised against a stable lane before the conversion is
+introduced into the mix.
+
+## 10. Rejected alternatives
+
+**Provenance as a payload on `WorktreeLocation.local`.** The same fact expressed
+in the same enum, which is superficially tidier — one value answers both
+questions. Rejected on what it costs to read: `.local` is matched throughout the
+daemon and the app, and giving it an associated value makes every one of those
+sites a compile error to be revisited, for a question none of them are asking.
+The two facts are also genuinely orthogonal — where the files are, and where the
+lane came from — and an enum that conflates them will conflate them again the next
+time a lane acquires a third kind of history. A separate optional field leaves
+every existing match site untouched and confines the change to the record mapping
+and the model. The field-evidence signature that would reopen this: a third
+location case whose provenance rules differ from `.local`'s, which would make one
+optional field the thing that is conflating.
+
+**Teaching the worktree detail area to render remote lanes.** `WorktreeDetailAreaView`
+already has the selected worktree in hand, so branching there on location and
+rendering the remote view instead of `TerminalContainerView` looks like the
+smaller change. Rejected because `DetailSectionHostPager` exists specifically to
+keep the remote host mounted across excursions to other sections, and rendering
+`RemoteSessionDetailView` inside the `.other` tab would put it back in the tab
+that is cheap to recreate on every switch — tearing down `RemoteAttachPager` and
+every live attach connection it holds each time the user glances at a repo. It
+would also mean two mount points for one view, whose keep-alive behavior would
+then differ by which row selected it. Routing the selection instead reuses the
+whole existing pager, adds no host, and leaves the detach invariant that protects
+against cross-page keystroke leakage exactly where it is.
+
+**A unified create sheet spanning local and remote lanes.** One dialog offering
+"local worktree or cloud session" reads well and would put the resolution ladder
+in one place. Rejected for this slice because it replaces a working create path
+with a new one for every user, including everyone who will never turn the cloud
+flag on — the ratio of risk to benefit is backwards when the whole cloud feature
+is still behind a default-off flag. The repository's `+` menu is where a lane is
+created today, cloud lanes are lanes, and adding an entry to a menu that already
+enumerates ways to start one is additive and reversible. A unified sheet becomes
+worth building when the resolution ladder's lower tiers land and there is
+something for it to resolve; until then it would be a second surface with one
+option on it.
+
+**A per-provider streaming transcript follow instead of cursor polling.** A live
+stream would remove the refresh latency the tab has. Rejected on supervision
+shape: a per-session stream is one process per session rather than one per
+provider, which the contract's `events` design already declined for the same
+reason. Cursor polling first; the evidence that would justify a stream is the
+polling interval being visibly wrong in use.
+
+**Synthesizing a `RemoteProviderConfig.exec` that composes into the right attach
+command.** Setting `exec` to the resolved `claude` path and `args` to `["--cloud"]`
+would make `argv + ["attach", sessionID]` almost work, which is the problem — it
+would spell `claude --cloud attach <id>`, and any arrangement that did compose
+correctly would do so by coincidence, breaking silently the next time either side
+changed a flag. An explicit `attachArgv` says what is being spawned instead of
+encoding it in the interaction of two fields that mean something else.
+
+## Open question: does `claude --cloud <id>` write a local transcript?
+
+**Unresolved. This slice is written so it works either way, and the answer changes
+only how much the `transcript` verb has to carry.**
+
+Interactive Claude Code sessions always persist to disk — `--no-session-persistence`
+is documented as working only with `--print` — so attaching to a cloud session
+with `claude --cloud <id>` may already write an ordinary transcript JSONL locally,
+under the Claude projects store for whatever directory the pane ran in.
+
+**If it does**, two things follow. Attaching once seeds a session's transcript for
+free, so the `transcript` verb becomes the path for *never-attached* sessions
+rather than the only path — which makes the verb's cursor-tailing a latency
+optimization rather than the sole source of conversation data. And the attach
+process **must** be pointed at the TBD-owned transcript root rather than the
+default store, or a cloud conversation surfaces as a local session of whichever
+worktree the pane ran in: `handleSessionList`
+(`Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift`:9-22) resolves a
+projects directory from the worktree's path (:16) and hands it to
+`ClaudeSessionScanner.listSessions(projectDir:)` (:20), so anything the attach
+process writes under that resolved root is indistinguishable from a local session
+of that lane. Pointing attach elsewhere is one environment entry on the attach
+spawn, and the TBD-owned root already exists for the verb's output.
+
+**If it does not**, the `transcript` verb is the only source of conversation data,
+the attach pane contributes nothing to it, and no redirection is needed.
+
+Either way the transcript tab reads from the TBD-owned root and never from the
+Claude projects store, so nothing in §5 depends on the answer. What depends on it
+is whether the attach spawn carries a redirection, and how quickly a
+freshly-attached lane's transcript fills in.
+
+**The test that settles it** is one command on a Mac: attach to a cloud session
+with `claude --cloud <id>`, then look for a new JSONL file appearing under
+`~/.claude/projects/`. It is worth running before step 8 of the work order.

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -241,8 +241,8 @@ provider implements it. Whether a given account is permitted to use it is a
 separate, runtime question, and §5 is where that is answered.
 
 **Verbs.** `create` runs `claude --cloud "<prompt>"` from the repository
-checkout, on a pseudo-terminal, and reads the session id out of what it prints
-(below). `list` returns the `claude_cloud_session` ledger — what this machine
+checkout, on a pseudo-terminal, and reads the session id and its title out of
+what it prints (below). `list` returns the `claude_cloud_session` ledger — what this machine
 started — and nothing else; it is always `complete: false`, which the next
 subsection specifies. `send` posts one message through
 `claude -p "<msg>" --cloud <id> --output-format json`; the response is
@@ -277,8 +277,9 @@ may have started a real session outlives the judgement that it did not.
 
 No supported interface enumerates an account's cloud sessions (§1), so `list`
 answers from the `claude_cloud_session` ledger alone: one row per session this
-machine created, carrying the session id, the idempotency key and its state, the
-creation time, the repository path, the branch, and the parameters used. Every
+machine created, carrying the session id, the title parsed at create time
+(below), the idempotency key and its state, the creation time, the repository
+path, the branch, and the parameters used. Every
 snapshot it returns declares **`complete: false`**, permanently and by
 construction, because the ledger is a record of what TBD started and never a
 claim about the account's inventory.
@@ -319,17 +320,10 @@ cloud-shaped exception.
 
 ### What a cloud lane cannot know about itself
 
-Three degradations follow from a ledger-only `list`. Each is stated on screen
+Two degradations follow from a ledger-only `list`. Each is stated on screen
 rather than papered over, because the alternative in every case is a cheerier
 fiction the user would act on.
 
-- **A lane's display name is its session id.** A title only ever arrives from
-  discovery, and `RemoteSessionAdopter.displayName(session:)`
-  (`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:228-232) already falls
-  back to the session id when the provider reports none — which is short, stable
-  and honest. The submitted `prompt` is never used as a name (below), so a cloud
-  row reads as `session_01…` until the user renames it. Rename is TBD's own
-  display name and works on a cloud row exactly as on any other.
 - **`agent_state` is always `unknown`, and so is `state`.** The ledger knows a
   session was created; it does not know whether it lives, and the contract is
   explicit that `unknown` means only that no machine-readable state is available
@@ -396,17 +390,26 @@ and none of that separation survives a PTY. So the mode is opt-in per invocation
 rather than a property of the provider, and `create`, whose whole answer is three
 lines of prose on stdout, is the only verb that sets it.
 
-### Reading the session id out of `create`'s output
+### Reading the session id and the title out of `create`'s output
 
 `create` is fire-and-forget: it exits 0 immediately without attaching, having
 printed three lines naming the created session, its web URL, and the command
 that would resume it (§11). There is no JSON form — `--print` is refused
-alongside `--cloud` — so those lines are the only channel the id travels on.
+alongside `--cloud` — so those lines are the only channel either the id or the
+title travels on.
 
 The provider strips ANSI control sequences from the captured output and takes
 the first token matching `session_[A-Za-z0-9]+`, requiring that every match in
 the output name the **same** id. All three printed lines carry it, so a single
 distinct id is the healthy case and disagreement is a signal, not noise.
+
+The same parse reads the title off the first line: everything after its
+`Created cloud session: ` prefix, trimmed. That line is prose, not a value with
+a shape to check, so the title parse cannot tell a reworded sentence from a
+missing one — it can only tell whether *this* prefix matched. Where the id parse
+protects itself with a strict shape checked three times over, the title parse
+has no such cross-check, and it does not need one: below is why the two failure
+postures diverge instead of both failing loud.
 
 **Reading a command's own stdout is not screen-scraping.** The repository's rule
 forbids inferring an agent's state from a rendered terminal screen; this reads
@@ -416,16 +419,23 @@ here infers state — liveness and agent state are whatever `list`'s payload
 reports, which for a ledger row is `unknown` (above), exactly as the contract
 requires.
 
-**A parse that finds nothing fails loudly and is classified.** Zero matches, or
-more than one distinct id, is a `create` failure: the provider synthesizes exit
-code 2 with an error object whose message quotes what it received, which
-`ProviderFailureClass.classify` (`Sources/TBDShared/RemoteProvider.swift`:99-103)
-reads as `contractBug` and `RemoteProviderManager.recordFailure` turns into
-`.error` health with that message on screen. `contractBug` is the honest class:
-the built-in provider could not satisfy the contract, and the remedy is a fix to
-TBD rather than a retry or a re-authentication.
+**The id and the title fail in opposite directions, because losing each costs a
+different thing.** Zero matches, or more than one distinct id, is a `create`
+failure: the provider synthesizes exit code 2 with an error object whose message
+quotes what it received, which `ProviderFailureClass.classify`
+(`Sources/TBDShared/RemoteProvider.swift`:99-103) reads as `contractBug` and
+`RemoteProviderManager.recordFailure` turns into `.error` health with that
+message on screen. `contractBug` is the honest class: the built-in provider
+could not satisfy the contract, and the remedy is a fix to TBD rather than a
+retry or a re-authentication. An unreadable id costs the lane its identity —
+there is no session to record — so it must fail loudly. A missing or empty
+title costs nothing but friendliness: the row still gets named, just from its
+id instead (below), so parsing it is never a reason to fail a create that
+otherwise succeeded. The prefix not matching, the line being absent, and the
+remainder being empty or whitespace after trimming are the same outcome —
+silently take the fallback — not three cases to distinguish on screen.
 
-The ledger is what keeps that failure from being silent. The idempotency key and
+The ledger is what keeps an id failure from being silent. The idempotency key and
 its state are written **before** the invocation, so a create whose output could
 not be read leaves a `pending` row rather than nothing, carrying the repository,
 the branch and the prompt that were submitted. With no discovery to match such a
@@ -435,22 +445,39 @@ names what was asked for and links to claude.ai, where the session — if it
 exists — is listed. An unreadable answer costs the lane, not silently but
 visibly, and the parent design's pending-row adoption arrives with discovery.
 
-### The lane's name is never what was submitted
+### The lane's name is the title `create` prints, falling back to its id
 
 The vendor derives a session's title server-side; it is a summary of the opening
 instruction, not that instruction's text (§11 records the measured pair). So
-nothing in TBD may treat the submitted `prompt` as the lane's name.
+nothing in TBD may treat the submitted `prompt` as the lane's name — the title
+has to come from the vendor, never from what was sent.
 
-Nothing does, and this slice must not change that. Adoption reads the title off
-the provider's own payload: `RemoteSessionAdopter.displayName(session:)`
-(`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:228-232) takes
-`session.title` when the provider reports one and falls back to the session id,
-and `claude-cloud`'s `create_params` are `repo`, `branch`, `prompt` and
-`environment` — no `title` among them, so there is nothing for TBD to have
-submitted and nothing to reconcile. A ledger row reports no title at all, so the
-fallback is what every cloud lane wears until the user renames it (above). The
-create surface (§10, step 7) writes no display name of its own; the row's name
-arrives with the row.
+`create`'s own output is where that title is available in this slice: the
+ledger row records the parsed title alongside the session id and the other
+create parameters, and the built-in provider's `list` reports it as that row's
+`title` field. `RemoteSessionAdopter.displayName(session:)`
+(`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:228-232) already
+implements exactly the rule this needs — `session.title` when the provider
+reports a non-empty one, the session id otherwise — so no change to adoption is
+required; the built-in provider only has to start putting a title in the
+payload it already returns. A create whose output carried no readable title
+reports none, and the row is named from its id exactly as it would be with no
+title logic at all: the degradation is silent and cosmetic, never a reason to
+mark the create a failure. `claude-cloud`'s `create_params` remain `repo`,
+`branch`, `prompt` and `environment` — the title travels from the vendor's
+output back to the ledger, never from what TBD submitted.
+
+**The name, once set, is the user's to change.** `RemoteSessionAdopter` mints a
+worktree row for a session exactly once and skips adoption whole for a session
+that already owns one — reparenting, renaming and rebranching a row on a later
+poll are explicitly not adoption's to do, because those are the user's choices
+to make. A row named from the parsed title, or from the id fallback, is named at
+that one minting and never renamed by anything TBD does afterward — the same
+rule an ordinary worktree row's display name already follows, and Rename is
+still how the user changes it, exactly as on any other row. The create surface
+(§10, step 7) itself writes no display name — the row is minted by adoption,
+and the title reaches it through the ledger and the payload as described
+above, not by the create surface setting a field directly.
 
 **Create asks for one out-of-band `list`.** Because the row arrives by adoption
 rather than being minted by the create call, and the poll loop's interval is 60
@@ -1218,7 +1245,8 @@ then materializes a directory — so revive branches on location exactly as arch
 does, and the remote arm is the row flip alone.
 
 The lane comes back saying what it knew before: its state is `unknown`, its name
-is its session id, and whether the session is still there is what the mirror row
+is whatever it was minted with — the parsed title or the session id fallback
+(§3) — and whether the session is still there is what the mirror row
 answers. The 08-10 design's other revive cases — an `unarchive` verb, a
 terminated session, a retirement TBD cannot lift — describe providers cloud is
 not, and they arrive with the providers that declare those capabilities.
@@ -1418,10 +1446,16 @@ Output carrying ANSI control sequences around the same three lines yields the
 same id. Output naming two different session ids, and output naming none, each
 produce a `create` failure classified as `contractBug` with the received text in
 the message — never a success with an empty id — and each leaves the ledger row
-`pending` and surfaced as an unresolved create rather than silently dropped. A
-create never writes a display name of its own, so the row is named from the
-provider's payload — the session id, for a ledger row — and never from the
-submitted prompt.
+`pending` and surfaced as an unresolved create rather than silently dropped.
+
+**Naming the row from `create`'s output.** The three-line success form yields
+the title after the `Created cloud session: ` prefix, and the row `list` later
+adopts is named from it. Output whose first line lacks that prefix, or lacks a
+first line at all, still produces a successful create — the session id parse is
+what governs success — and the row is named from the id instead. A title line
+present but whitespace-only falls back the same way, so trimming to empty is
+handled identically to the line being absent. No case exercised here treats the
+submitted prompt as a name.
 
 **The entitlement path.** A permanent attach exit reported to the daemon records
 an attach block on that provider and leaves its health untouched, so the send
@@ -1600,20 +1634,26 @@ Resume with: claude --teleport session_01AAAAAAAAAAAAAAAAAAAAAA
 ```
 
 There is no structured form — `--print` is refused alongside `--cloud` — so
-those lines are the only channel the session id travels on. §3 specifies the
-parse and what a change in that format costs.
+those lines are the only channel either the session id or the title travels on.
+§3 specifies the parse and what a change in that format costs.
 
 **The title is derived server-side, not echoed back.** A description of
 "transcript persistence probe: reply with the single word pong" comes back titled
 "Add probe pong reply", and that title is on the created-session line rather than
 in any structured field TBD can read. A cloud session's name is the vendor's
 summary of the instruction rather than the instruction, so TBD takes a name only
-from a provider payload that carries one and never from what was sent — which in
-this slice means every cloud lane wears its session id (§3). Taking the
-title out of that line instead is a format dependency with no cross-check: the id
-has a strict shape and appears three times, so a parse that finds none or finds
-two different ones is detectable, while a display string lifted out of prose is
-wrong silently the first time the sentence is reworded.
+from a provider payload that carries one and never from what was sent (§3) — the
+first line's `Created cloud session: ` prefix is that payload in this slice, and
+what follows it, trimmed, is the lane's name. The id parse and the title parse
+read the same three lines but answer to different stakes: the id has a strict
+shape and appears three times, so a parse that finds none or finds two
+different ones is detectable and is treated as a `create` failure, while the
+title is a display string lifted out of prose with no such cross-check — wrong
+silently the first time the sentence is reworded, or absent outright if the
+line is missing. That is exactly why the title parse never fails a create: a
+prefix that does not match, a missing line, or an empty remainder after
+trimming all fall back to the session id — the same name every cloud lane would
+wear if no title were parsed at all.
 
 ### `send` behaves exactly as the parent design specifies
 

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -11,7 +11,10 @@ lane when it is done.
 Everything here is downstream of that document and contradicts none of it.
 **Also depends on:**
 [`2026-08-10-remote-sessions-in-worktree-tree-design.md`](2026-08-10-remote-sessions-in-worktree-tree-design.md)
-(adoption, the local/remote boundary, archive composition),
+(adoption, the local/remote boundary),
+[`2026-08-16-remote-lane-archive-design.md`](2026-08-16-remote-lane-archive-design.md)
+(how archiving and reviving a remote lane compose over what its provider
+declares — the authority for every rule §7 defers to),
 [`../remote-provider-contract.md`](../remote-provider-contract.md) (contract v2),
 [`../theory-placement.md`](../theory-placement.md) (the placement battery).
 
@@ -298,6 +301,19 @@ ground that a session filtered out of successive snapshots is indistinguishable
 from a deleted one and would be silently marked gone. So archiving a session
 flags its ledger row and never removes it, and every later `list` keeps
 reporting that id with `archived: true`.
+
+**`archived` is emitted on every session, `false` included.** The field is
+optional on the wire, and a caller reads an absent one as `false` for display —
+but the filing sync that carries a provider's decision back onto a row treats
+the two differently, moving a row only on a claim that is actually present,
+because absent means no claim was made
+([`2026-08-16-remote-lane-archive-design.md`](2026-08-16-remote-lane-archive-design.md)).
+Omitting the field while a session is active would therefore be contract-legal
+and still wrong here: TBD would never observe the transition back from `true` to
+`false`, so a session unarchived on the provider's side would leave its lane
+filed away with nothing to return it. The ledger has the flag for every row it
+holds, so writing it into every payload costs nothing and is the only form that
+says what the provider means.
 
 **That is safe by construction rather than by care.** The contract's rule for an
 incomplete snapshot is that a caller may add, update and adopt on the strength of
@@ -1083,9 +1099,9 @@ Landing is always a user gesture and is never triggered by session state.
 **Landing archives the session it came from, and never stops it.** `land`
 reports `forks: true`, so the landed checkout and the session diverge from this
 moment: the work is on this machine now, and a session nobody will return to
-should not sit in the working inventory. The parent design's rule is to retire it
-where the provider declares `archive`, and cloud declares it (§3), so landing
-calls that verb — one invocation, on the same in-process ledger path §7
+should not sit in the working inventory. A session is retired through the
+`archive` verb where its provider declares one, and cloud declares it (§3), so
+landing calls that verb — one invocation, on the same in-process ledger path §7
 specifies, marking the ledger row archived. TBD never *stops* a session on
 landing whatever a provider declares: landing is a "bring this home" gesture,
 not a teardown, and the remote box may still hold work that was never pushed.
@@ -1125,8 +1141,10 @@ section of every non-scratch, non-main row's menu, gated only on
 `hasActiveChildren`, so an adopted remote row shows it; `run(.archive)`
 (`Sources/TBDApp/Sidebar/RowActionMenuActions.swift`:184-186) calls
 `AppState.archiveWorktree`, which calls `worktree.archive`, which refuses. The
-menu item is not the defect and does not change: what changes is that the daemon
-stops refusing.
+menu item is not the defect: what changes is that the daemon stops refusing. How
+the item presents for a provider that cannot archive is the 08-16 design's; a
+cloud lane's provider declares the capability, so for a cloud lane the item is
+live exactly as it looks today.
 
 ### The fences, and why lifting them is not enough
 
@@ -1176,37 +1194,39 @@ lifecycle entry that shares only what is genuinely about the row:
    remote lane with an active child is refused exactly as a local one is — and a
    remote lane can have children, since adoption nests rows on
    `parentWorktreeID`.
-4. Compose over the provider's declared capabilities (next subsection), then flip
-   the row through `WorktreeStore.archive(id:)`.
+4. Compose over the provider's declared capabilities as the 08-16 design
+   specifies (next subsection places cloud within it), then flip the row through
+   `WorktreeStore.archive(id:)`.
 
 No tmux, no scrollback capture, no git, no phase 2, no archive hook. The hook is
 worth naming: it runs with the worktree's path as its working directory, and a
 remote lane has no directory to run it in.
 
-### The composition, and which branch `claude-cloud` takes
+### Where `claude-cloud` lands in the archive composition
 
-What archive does to the session behind the row is the three-way composition the
-08-10 design specifies, and this document does not restate the rule beyond naming
-its branches: a provider declaring `archive` has the verb called and then the row
-marked; one declaring only `stop` has the session stopped and then the row
-marked; one declaring neither has the row marked and nothing else, with the
-session left running and the UI saying so.
+How archive composes over a provider's declared capabilities — which branch a
+gesture takes, the `gone` exemption, the termination guards, the refusal, and the
+revive cases — is specified by
+[`2026-08-16-remote-lane-archive-design.md`](2026-08-16-remote-lane-archive-design.md),
+and this document does not restate any of it. What follows is only what is
+particular to this provider.
 
-**`claude-cloud` takes the first branch.** It declares `archive` and `unarchive`
-(§3), so archiving a cloud lane calls the verb and then marks the row. The verb
-is implemented against the provider's own ledger: it sets the archived flag on
-the `claude_cloud_session` row, and every subsequent `list` reports that session
-with `archived: true`. Nothing is sent to Anthropic. `unarchive` clears the flag.
+**`claude-cloud` takes the verb path.** It declares `archive` and `unarchive`
+(§3), so archiving a cloud lane invokes `archive` and then marks the row, and
+reviving one invokes `unarchive` and then flips the row back. It reaches neither
+of the other branches: the `gone` exemption is for a session the provider has
+stopped enumerating, which a cloud session never becomes (§3), and the refusal is
+for a provider that declares no `archive`, which this one always does — the
+declaration is a compiled constant rather than a runtime answer.
 
-Four properties make that a real retirement rather than a costume:
+**Both verbs run against the provider's own ledger and send nothing to
+Anthropic.** `archive` sets the archived flag on the `claude_cloud_session` row;
+`unarchive` clears it. Every later `list` returns that session carrying the flag
+it now holds — `archived: true` after an archive, `archived: false` after an
+unarchive (§3).
 
-- **`archived` is defined as retirement from the working inventory.** The
-  contract states it as a filing axis orthogonal to liveness — a session may be
-  archived while its machine is still winding down, and may never become archived
-  implicitly because it exited, went idle, or aged out. So a provider that
-  archives without touching liveness is doing precisely what the field means, and
-  a caller is forbidden from reading `archived: true` as "stopped" in the first
-  place.
+Three properties make that a real retirement rather than a costume:
+
 - **The row is flagged, never removed.** Contract v2 requires archived sessions
   to stay enumerated by `list` and in the `events` snapshot, because a session
   filtered out of successive snapshots is indistinguishable from a deleted one
@@ -1218,12 +1238,14 @@ Four properties make that a real retirement rather than a costume:
   ever holds — which is why `list` is permanently `complete: false` (§3). The
   retirement is therefore real within the only inventory that exists for it, and
   no layer contradicts another: `list` says `archived: true`, the worktree row
-  says archived, and the two agree.
+  says archived, and the two agree. The contract defines `archived` as retirement
+  from the working inventory rather than as a claim about liveness, so a provider
+  that files without touching liveness is doing exactly what the field means.
 - **The capability is already the right shape for more.** If a supported endpoint
   for retiring a cloud session appears, the same declared capability calls it
-  instead and nothing else in this design moves — not the composition, not the
-  row, not revive. That is why the contract is capability-gated rather than
-  assuming every provider can do everything.
+  instead and nothing else moves — not the branch cloud takes, not the row, not
+  revive. That is why the contract is capability-gated rather than assuming every
+  provider can do everything.
 
 **What it does not do, stated plainly.** It does not archive the session on
 Anthropic's side. The cloud session keeps running there, keeps whatever work it
@@ -1243,24 +1265,25 @@ earns: nothing was stopped, closed, torn down, or cleaned up, and a user is neve
 left believing the cloud session was retired or halted. The one sentence a user
 needs is that TBD filed the lane away and Anthropic did not stop the session.
 
-**The termination guards do not apply.** The 08-10 design scopes the `working`
-guard and the dirty-remote-checkout guard to the paths that actually end a
-session — the `stop` path always, and the `archive`-verb path where the same
-provider also declares `stop` — because destroying unpushed work is the only
-thing they defend against. A provider declaring `archive` without `stop` is taken
-at its word: it has said it cannot terminate a session, so archiving through it
-is a filing change and is not guarded. `claude-cloud` is exactly that provider,
-and its archive destroys nothing. Nothing here relaxes a guard; the guarded
-branches are simply not the branch cloud takes.
+**The termination guards are live on this path and never trip.** They guard the
+verb path, which is the path a cloud lane takes, so archiving a cloud lane is
+checked exactly as archiving any other lane through a declared `archive` is —
+nothing here is exempt, and no `--force` is a normal part of the gesture. Neither
+guard has anything to fire on, for a reason that is a property of the provider
+rather than a coincidence: a cloud lane's `agent_state` is permanently `unknown`
+(§3), which is not `working`, and the dirty-remote-checkout guard reads an
+optional well-known `meta` key that this provider has no supported way to learn
+and therefore never sets. The practical consequence is that the guards are
+unobservable for cloud — but they sit in the path, so the day a supported
+interface lets this provider report either fact, they start refusing without
+anything in this design moving.
 
-**Which branches write an actuation row.** `.worktreeArchive` maps to the
+**A cloud archive writes an actuation row.** `.worktreeArchive` maps to the
 `dispose` kind (`Sources/TBDDaemon/Actuation/ActuationSurface.swift`:150-151), and
-the record may only claim acts that were attempted. The branches that call a
-provider verb record theirs as they would for any other actuated act, cloud
-included — its `archive` was invoked and it acted on the inventory it owns. The
-branch that calls nothing writes nothing: the precedent is the 08-10 design's
-forced `repo.remove`, which cascades local worktrees and writes no actuation row
-for the remote lanes it drops, because none of their sessions were touched.
+the record may only claim acts that were attempted. Cloud's archive invokes a
+provider verb that acts on the inventory it owns, so it records its request and
+its outcome as any other actuated act does. Which of the composition's other
+branches write a row is the 08-16 design's.
 
 ### What happens to the mirror row, and to the next `list`
 
@@ -1278,17 +1301,15 @@ any session that already has a row — "created once, never re-derived, whatever
 the payload now says" — so a session that keeps appearing in every `list` after
 its lane was archived mints nothing and changes nothing.
 
-**Nor does it un-archive it.** The parent design's mirroring of a payload's
-`archived` flag onto the row is not in this slice. When it does land it carries a
-provider's own filing state, and for a cloud lane that is still remote the two
-sides agree by construction: the archive gesture wrote the ledger flag, so every
-later `list` reports `archived: true` for a lane whose row is archived, and
-`archived: false` for one whose row is active. Mirroring reaches remote rows only,
-which is what keeps the session archived by a landing (§6) from filing away the
-local lane the user is about to work in. A provider that could not hold the filing
-state — one declaring no `archive` — is the case mirroring must leave alone,
-because it would report `archived: false` forever about a lane a person
-deliberately filed.
+**Nor does it un-archive it.** The filing sync that carries a payload's
+`archived` flag back onto a row — its rules, and the stale-response protection it
+needs — is the 08-16 design's, and it is not in this slice. When it lands, the
+two sides agree for a cloud lane by construction: the archive gesture wrote the
+ledger flag, so every later `list` reports `archived: true` for a lane whose row
+is archived and `archived: false` for one whose row is active, which is why `list`
+emits the field on every session rather than only when it is set (§3). The sync
+reaches remote rows only, which is what keeps the session archived by a landing
+(§6) from filing away the local lane the user is about to work in.
 
 `remote.dismiss`'s `dismissed` column stays a separate axis: it hides a bare
 session row from the Provider Desk and says nothing about a lane. Archiving a
@@ -1313,12 +1334,11 @@ unconditionally, the way an in-flight revive already does. The filter's premise 
 "no conversations means nothing to come back to" — is a statement about local
 sessions, and it is simply not true of a lane whose conversation is on a server.
 
-### Unarchive is the same branch, run backwards
+### Reviving a cloud lane is the same path, run backwards
 
-Reviving a cloud lane calls `unarchive` and then flips the row back to `active`,
-which is the 08-10 design's `unarchive` revive case: the retirement was a fact on
-the provider's inventory, and lifting it there is what makes both sides agree
-again. `WorktreeStore.revive(id:)`
+Reviving a cloud lane calls `unarchive` and then flips the row back to `active`.
+The retirement was a fact on the provider's inventory, and lifting it there is
+what makes both sides agree again. `WorktreeStore.revive(id:)`
 (`Sources/TBDDaemon/Database/WorktreeStore.swift`:709-721) is location-blind and
 does the flip; `beginReviveWorktree` is not — it resolves through `getLocal` and
 then materializes a directory — so revive branches on location exactly as archive
@@ -1328,10 +1348,9 @@ directory to materialize.
 The lane comes back saying what it knew before: its state is `unknown`, its name
 is whatever it was minted with — the parsed title or the session id fallback
 (§3) — and whether the session is still there is what the mirror row answers.
-Nothing had to be restarted, because nothing was ever stopped. The 08-10 design's
-other revive cases — a provider that retired nothing, a terminated session, a
-retirement TBD cannot lift — describe providers cloud is not, and they arrive
-with the providers that declare those capability shapes.
+Nothing had to be restarted, because nothing was ever stopped. The 08-16 design's
+other revive cases describe providers cloud is not, and they arrive with the
+providers that declare those capability shapes.
 
 ### `worktree.forget` stays refused
 
@@ -1340,29 +1359,27 @@ remote lane has no checkout here to leave alone. That is a category error rather
 than an unimplemented feature, and it is how the 08-10 design classifies forget,
 alongside hibernate, relocate, scratch promote and adopt-existing-directory:
 operations with no remote meaning, kept unreachable through `LocalWorktree`. The
-fence stays exactly as it is, comment included — it already states that ground
-rather than a missing capability. Archive is the retirement gesture for a lane,
-and archive is the one this section makes work on a remote row.
+fence stays, on the ground the 08-16 design states for it: retiring a lane is
+archive's job. Archive is the retirement gesture for a lane, and archive is the
+one this section makes work on a remote row.
 
-### The auto-archive-on-merge rail does not take remote lanes
+### The auto-archive-on-merge rail reaches a cloud lane
 
-The rail's guard stays, and a remote lane does not participate.
+Whether the merged-transition rail retires a remote lane is the 08-16 design's:
+the coordinator's location guard becomes a branch into the same remote path the
+manual gesture takes, and the rail participates under the per-worktree opt-in it
+already has. A cloud lane is reachable by it — PR polling is keyed on the branch
+and runs `git` and `gh` in the repository's own checkout, so a remote row carries
+a PR badge like any other (`RPCRouter.pollableWorktrees`,
+`Sources/TBDDaemon/Server/RPCRouter.swift`:946) — and its provider declares
+`archive`, so nothing declines on cloud's behalf.
 
-Two reasons, and the second is the one that would still hold if the first were
-fixed. First, the rail has no signal for a remote lane: it fires on a merged PR
-transition, and PR polling is fenced away from remote rows because everything
-below it is keyed on the worktree's path — `git` and `gh` both run inside a
-directory that does not exist for a remote lane. The 08-10 design's answer is to
-re-key that poll on the branch rather than to relax the fence, and until that
-lands a remote lane carries no PR status and reaches no merged transition.
-
-Second, when the badge does come back, an automatic archive of a lane whose
-session keeps running is a background mutation with no user gesture behind it —
-filing away a lane whose agent may still be working, and for a cloud lane whose
-`agent_state` is permanently `unknown` (§3), TBD cannot even ask what state it is
-in. That is the shape the repository's default-off rule exists for, and the
-honest row state ("archived here, still running there") is one a person should be
-choosing. The guard's comment changes to say this; the guard does not.
+**The arming gesture is therefore the whole of what stands between a merged PR
+and a filed cloud lane.** Neither termination guard fires for a cloud lane
+(above), so the opt-in is the only judgement in the path — which is the right
+place for it, because it is a deliberate per-worktree choice made with the honest
+row state in view: archived here, still running there. A cloud lane the user has
+not armed is filed by a person or not at all.
 
 ## 8. The flag
 
@@ -1552,18 +1569,15 @@ elapsed backoff window, admits a transient one under the same conditions, and
 Reattach clears either. A provider with no block behaves exactly as it does now,
 reconnect included.
 
-**Archive's three branches.** A provider declaring `archive` has the verb called
-and then its row marked `archived`; one declaring only `stop` has `stop` called
-and then its row marked; one declaring neither has its row marked with **no**
-provider invocation at all, asserted against a fake invoker that records every
-verb it was asked for. Each branch ends with the row `archived`. The branch that
-calls nothing writes no actuation row, while the two verb branches write theirs.
-The `working` and dirty-checkout guards refuse the `stop` branch and the
-`archive`-with-`stop` branch, and never refuse either unguarded branch — the
-provider declaring `archive` without `stop`, which is cloud's shape, and the
-provider declaring neither. That is asserted against a lane whose `agent_state`
-is `working`, which is the case that would fail if the guards were applied to a
-path that ends nothing.
+**A cloud lane archives through the verb.** Archiving one invokes `archive` and
+then marks the row, asserted against a fake invoker that records every verb it
+was asked for — so a `stop`, which this provider does not declare, fails the
+test — and the archive writes its actuation row. A cloud lane whose `agent_state`
+is `unknown`, which is every cloud lane, is not refused by the `working` guard,
+while a lane reporting `working` through the same code path still is, so the
+assertion discriminates between "the guard is inert for cloud" and "the guard was
+removed". The composition's other branches belong to the 08-16 design and are
+tested there.
 
 **The cloud ledger's archive round trip.** Archiving a cloud lane invokes
 `archive` on the built-in provider, the ledger row's archived flag is set, and
@@ -1573,7 +1587,11 @@ enumeration rule needs and the one whose failure would drive the session toward
 `gone`. `unarchive` clears the flag and the following `list` reports
 `archived: false`. Both verbs are idempotent: a second `archive` and a second
 `unarchive` each exit 0 and leave the flag where it was. Neither verb invokes the
-vendor CLI, asserted against the injected spawn seam.
+vendor CLI, asserted against the injected spawn seam. Every session the ledger
+returns carries an **explicit** `archived`, `false` included — asserted on the
+encoded payload rather than on the decoded value, since what the filing sync
+distinguishes is presence rather than truth, and a decoded `false` looks the same
+either way.
 
 **The cloud archive is honest on screen.** The archived cloud lane's copy, and
 the confirmation copy shown before the gesture, both name the session as still
@@ -1583,16 +1601,16 @@ substring blacklist, so a rewording that reintroduces the claim fails.
 
 **Unarchiving a cloud lane.** Revive on that lane invokes `unarchive` and flips
 the row back to `active`, and the lane returns with the same id, origin, branch,
-parent edge and children. Revive on a lane whose provider declares no `unarchive`
-flips the row and invokes nothing. Revive on a local worktree still runs the whole
-local path, so the branch did not swallow it.
+parent edge and children. Revive on a local worktree still runs the whole local
+path, so the branch did not swallow it.
 
-**Each fence, after.** `worktree.archive` on a remote row archives it instead of
+**Each fence, after.** `worktree.archive` on a cloud row archives it instead of
 returning its refusal string; on a local row it behaves exactly as today. A
 remote row with an active child is refused by `assertArchivable` in both the
 local and remote arms alike. `worktree.forget` on a remote row still refuses.
-`AutoArchiveOnMergeCoordinator.handleMergedTransition` still returns `false` for
-a remote row and still archives a local one.
+`AutoArchiveOnMergeCoordinator.handleMergedTransition` archives an armed cloud
+lane whose PR merged, leaves an unarmed one alone, and still archives a local
+one.
 
 **`visibleWorktrees` drops an archived remote row.** A remote row flipped to
 `archived` leaves the visible set, and the same row while `active` stays in it —
@@ -1691,8 +1709,8 @@ provider with no flag to gate it.
    together because they share that lookup.
 10. **Archive (§7).** The built-in provider's `archive` and `unarchive` verbs
     over the ledger column from step 6, the remote arm of `worktree.archive` and of
-    revive, the capability composition, the row copy, the Archived list's filter,
-    and the two fences that stay. It precedes Land because Land calls `archive`
+    revive on the 08-16 design's composition, the row copy, the Archived list's
+    filter, and the `worktree.forget` fence that stays. It precedes Land because Land calls `archive`
     on the session it just landed and states the same thing about the surviving
     cloud session that this step has to get right, and because a lane created in
     step 6 is otherwise stuck in the tree for the rest of the build.

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -1,11 +1,12 @@
-# Claude cloud sessions, slice 1 — create, watch, land
+# Claude cloud sessions, slice 1 — create, send, land, archive
 
 **Date:** 2026-08-15
 **Status:** Design, not yet implemented.
 **Scope:** The first end-to-end path through the cloud-sessions design: create a
-cloud session from a repo's `+` menu, see it as a row in that repo's tree, watch
-it through a structured transcript (with an attach terminal beside it where the
-account is entitled to one), and land it into a local worktree.
+cloud session from a repo's `+` menu, see it as a row in that repo's tree, steer
+it by sending it messages (with an attach terminal beside the send field where
+the account is entitled to one), land it into a local worktree, and archive the
+lane when it is done.
 **Parent design:** [`2026-08-07-claude-cloud-sessions-design.md`](2026-08-07-claude-cloud-sessions-design.md).
 Everything here is downstream of that document and contradicts none of it.
 **Also depends on:**
@@ -29,45 +30,84 @@ This slice builds the shortest path that is genuinely useful, end to end:
   a flag that ships off.
 - **Appear.** The session is adopted as a worktree row in that repository's
   tree, nested and sorted like every other lane.
-- **Watch.** Selecting that row shows a structured transcript of the
-  conversation — the same renderer a local lane gets, tool cards and all —
-  with an attach terminal beside it.
+- **Send.** Selecting that row shows the remote session detail surface, whose
+  send field posts a message to the session — the same field every other remote
+  provider gets, over the provider's `send` verb. Where the account is entitled
+  to it, an attach terminal sits beside it.
 - **Land.** A row action converts the lane in place from remote to local:
   the branch is checked out on this machine, the row keeps its identity, and
   the conversation resumes in the first pane.
+- **Archive.** A row action retires the lane from the working set, composing over
+  what the provider declares, and says honestly what it did and did not do to the
+  session behind it (§7).
 
-**Done is create → transcript → land.** Attach is implemented and declared, but
-whether a given account may attach to a running cloud session is an entitlement
-the vendor grants server-side, and it is off by default (§10). On an account
-without it the Attach segment is present and shows a call to action naming the
-condition, rather than a terminal that dies on connect; on an account with it,
-attach works. The slice is complete either way, because the transcript — not
-the attach pane — is the watch surface, and it depends on nothing attach needs.
+**Done is create → send → land → archive.** Attach is implemented and declared,
+but whether a given account may attach to a running cloud session is an
+entitlement the vendor grants server-side, and it is off by default (§11). On an
+account without it the Attach pane shows a call to action naming the condition,
+rather than a terminal that dies on connect; on an account with it, attach works.
+The slice is complete either way — each of those four gestures works without
+attach — with one honest consequence: on an unentitled account TBD shows no reply
+to a send, because the reply is on Anthropic's servers and nothing supported
+reads it back (below).
 
-Four things the parent design specifies are deliberately **out of scope here**,
-each for a reason that is about sequencing rather than doubt:
+### What the platform exposes, and what TBD builds against
 
+Three facts about the vendor's surface decide the shape of this slice, and they
+are the reason the watch surface is not in it.
+
+- **No supported interface enumerates an account's cloud sessions or reads a
+  cloud session's conversation.** The Compliance API's remote-session endpoints
+  return Cowork sessions and exclude Claude Code on the web by name. The
+  documented `/v1/claude_code/` namespace has a single endpoint, whose token
+  grants no read access and no access to account data. Managed Agents is a
+  separate product with its own session identifiers rather than a view onto
+  these sessions.
+- **Undocumented claude.ai endpoints exist, and TBD does not build against
+  them.** Anthropic's Consumer Terms bar automated access to the Services
+  outside the carve-out for use of an Anthropic API key, and a cloud session
+  requires subscription login — so there is no API-key-shaped route to the same
+  data, and no arrangement in which such a client is inside the terms. Driving
+  those endpoints would put TBD's users outside the terms of the account they
+  are signed into, for a feature they can already reach in a browser. This is a
+  design constraint rather than a gap awaiting an implementation: `list` is
+  ledger-only (§3) because of it, and adding a scraper is not the fix.
+- **Interactive attach is gated per account.** The vendor CLI branches on a
+  server-side flag (`tengu_remote_backend`) that defaults off and carries no
+  local override; the documented remedy is to ask the account team to enable it
+  (§11).
+
+What is left is exactly the documented CLI — create, send, resume by teleport,
+and attach where the account is entitled — and that is enough for create → send
+→ land → archive.
+
+Five things the parent design specifies are deliberately **out of scope here**:
+
+- **The watch surface.** Reading a cloud session's conversation needs an
+  interface that does not exist (above), so a lane's transcript is not TBD's to
+  render. The parent design's `transcript` verb, the TBD-owned transcript root
+  it spools into, and the single-choke-point path resolver that must precede
+  admitting a second permitted root all arrive together, with a supported way to
+  read a conversation. Until then a cloud lane is watched through the attach
+  terminal where the account is entitled to one, and on claude.ai otherwise.
 - **`.tbd-remotes.json` and its trust-on-first-use gate** (parent design Part 4).
   Repository-declared remotes are a second, independent decision surface with its
-  own approval flow; nothing in create-watch-land needs it, because slice 1's
-  create is always an explicit per-creation choice.
+  own approval flow; nothing here needs it, because slice 1's create is always an
+  explicit per-creation choice.
 - **Resolution ladder tiers 2 through 4** (the repository declaration, the user's
   global default, provider `describe` defaults). Tier 1 — the explicit choice in
   the create sheet — always wins and is always available, so the ladder's lower
   tiers add convenience to a surface that already works without them.
-- **Archive and unarchive for remote lanes.** `worktree.archive`, `worktree.forget`
-  and the auto-archive-on-merge rail each refuse a remote row today, and teaching
-  all three the capability composition from the 08-10 design is a self-contained
-  piece of work that a lane can live without while it is being watched and landed.
-  The one exception is the retirement that follows a successful land, specified
-  in §6.
+- **Reviving a landed lane onto a fresh branch.** Land plus TBD's existing
+  revive-fresh composes into it, and composing them is a second gesture rather
+  than a second mechanism.
 - **Retiring the flat Remote section** (`RemoteSectionView`). It stays as it is.
   Removing it is a sidebar change whose risk is unrelated to anything here, and
   keeping it costs a duplicate surface for sessions that resolve to no registered
   repository — which is what it is for anyway.
 
 **Delivery is one branch and one pull request, opened when the whole path works
-end to end.** §9 orders the work to minimize rework, not to produce a sequence of
+end to end.** §10 orders the work to minimize rework, not to produce a sequence of
 independently shippable increments; several of the steps below are unobservable
 on their own, and splitting them would mean shipping code paths with nothing
 behind them.
@@ -155,7 +195,7 @@ and the origin rides those same two keys. A landed row encodes as
 reads a local row today.
 
 Per the shared-model rule, the record change, the `TBDShared` model change, and
-the flag's migration (§7) land in one commit, with `origin` optional so existing
+the flag's migration (§8) land in one commit, with `origin` optional so existing
 rows and existing JSON still decode.
 
 `WorktreeStore.findRemote(provider:sessionID:)` (`WorktreeStore.swift`:579-587)
@@ -177,11 +217,22 @@ test). Mechanisms compile.
 
 **What `describe` declares.** `contract_versions: [2]` only — nothing exposed
 terminates a running cloud session, so the provider cannot implement `stop`, and
-major 1 requires it. Capabilities are `send`, `attach`, `transcript`, `land`,
-`archive` and `unarchive`; neither `stop` nor `log` is declared. `create_params`
-are `repo`, `branch`, `prompt` and `environment`, the last typed `string` because
-`describe` answers offline and the set of configured cloud environments is
-knowable only from the account.
+major 1 requires it. Capabilities are `send`, `attach` and `land`. Five
+capability names are deliberately **not** declared, and each absence is a fact
+about the surface rather than an unimplemented verb:
+
+- **`stop`** — nothing exposed terminates a running cloud session.
+- **`log`** — a cloud session has no terminal to scroll.
+- **`transcript`** — no supported interface reads a cloud session's conversation
+  (§1).
+- **`archive` and `unarchive`** — the account's archive operation lives on the
+  undocumented surface TBD does not use (§1). Archiving a cloud lane is
+  therefore a filing change in TBD alone, which is exactly the third branch of
+  the archive composition and is specified in §7.
+
+`create_params` are `repo`, `branch`, `prompt` and `environment`, the last typed
+`string` because `describe` answers offline and the set of configured cloud
+environments is knowable only from the account.
 
 `describe` is **static and offline**, exactly as the parent design fixes it. It
 answers from compiled constants, touches no network, and its answer does not vary
@@ -191,36 +242,130 @@ separate, runtime question, and §5 is where that is answered.
 
 **Verbs.** `create` runs `claude --cloud "<prompt>"` from the repository
 checkout, on a pseudo-terminal, and reads the session id out of what it prints
-(below). `list` returns the union of a `claude_cloud_session` ledger (what this
-machine started) with discovered sessions, under the parent design's three union
-rules: two consecutive complete snapshots retire a resolved ledger row, a
-ledger-only row carries `state: "unknown"` rather than a fabricated `running`,
-and a discovered row always wins over a ledger row for the same id. `send` posts
-one message through `claude -p "<msg>" --cloud <id> --output-format json`,
-stripping a single trailing `\r` or `\n` as the submit gesture it is and
-preserving interior newlines; the response is
+(below). `list` returns the `claude_cloud_session` ledger — what this machine
+started — and nothing else; it is always `complete: false`, which the next
+subsection specifies. `send` posts one message through
+`claude -p "<msg>" --cloud <id> --output-format json`; the response is
 `{"ok": true, "session_id": "…", "url": "…"}`, and `ok` plus a `session_id`
 matching the id sent is the success condition. `attach` runs
-`claude --cloud <id>` on the pane's PTY. `transcript` reads the server-stored
-conversation, cursor-tailed. `land` reports the session's repository and branch
-with a `resume_command` of `claude --teleport <id>` and `forks: true`. Create
-idempotency is the parent design's: the key and its state are written to the
-ledger before the invocation, a pending row is expected during the daemon's
-single same-key retry, and a pending row is resolved by the next complete
-discovery.
+`claude --cloud <id>` on the pane's PTY. `land` reports the session's repository
+and branch with a `resume_command` of `claude --teleport <id>` and `forks: true`.
+
+**`send` implements the contract's byte interface on top of that call.** The
+contract's `send` takes stdin bytes destined for a terminal and requires the
+caller to append `\r` when it means Enter, and TBD sends a cloud session exactly
+the bytes it sends any provider. The provider decodes them as UTF-8, strips a
+single trailing `\r` or `\n` as the submit gesture it is, and passes the
+remainder as one message — so a byte stream carrying interior newlines becomes
+one multi-line message rather than several. What the contract fixes is the
+caller's side of the wire; how a provider delivers those bytes to a session with
+no terminal is the provider's business, and here it means enqueuing a message.
+Exit 0 keeps its contract meaning: handed to the transport, not acted upon.
+
+Create idempotency is the parent design's: the key and its state are written to
+the ledger before the invocation, and a pending row is expected during the
+daemon's single same-key retry rather than a reason to refuse it. What resolves a
+pending row here is the create that wrote it, since the parent design's
+discovery-driven resolution has no discovery to run against in this slice: a row
+whose create returned a readable session id resolves immediately, and one whose
+create failed both attempts stays `pending`, transitions to `failed` after ten
+minutes, and is surfaced as an unresolved create the user can act on. The row is
+retained rather than deleted on that transition, so the record of a create that
+may have started a real session outlives the judgement that it did not.
+
+### `list` is the ledger, and is permanently incomplete
+
+No supported interface enumerates an account's cloud sessions (§1), so `list`
+answers from the `claude_cloud_session` ledger alone: one row per session this
+machine created, carrying the session id, the idempotency key and its state, the
+creation time, the repository path, the branch, and the parameters used. Every
+snapshot it returns declares **`complete: false`**, permanently and by
+construction, because the ledger is a record of what TBD started and never a
+claim about the account's inventory.
+
+**That is safe by construction rather than by care.** The contract's rule for an
+incomplete snapshot is that a caller may add, update and adopt on the strength of
+it, and must not retire anything on it: no session may be advanced toward `gone`,
+and freshness must not be refreshed. A provider that never claims completeness
+therefore cannot cause a false retirement however wrong its view is — and a view
+consisting only of what this machine started is exactly the case that rule exists
+for. The parent design's ledger-retirement rule keys on two consecutive
+**complete** snapshots, so it is inert here; a cloud lane leaves the working set
+by the user archiving it (§7), which is the gesture that replaces the retirement
+discovery would otherwise have driven.
+
+**Honoring `complete` is a prerequisite of this slice, not a later refinement.**
+`RemoteSessionStore.applySnapshot`
+(`Sources/TBDDaemon/Database/RemoteSessionStore.swift`:176-223) increments
+`missingCount` for every row absent from a snapshot (:205-210) and writes the
+per-provider freshness key (:216-220) unconditionally, neither of which is
+conditioned on completeness today. With a provider whose snapshots are always
+incomplete, applying it as written would mark every cloud lane `gone` two polls
+after it stopped being the only row returned. So `complete` reaches the store and
+splits the three things a snapshot does, per the parent design: an incomplete
+snapshot still **adopts** the sessions it sighted and still **clears degraded
+health** — the provider answered — while advancing neither `missingCount` nor
+freshness in either store.
+
+**Mutations stay available against a provider that never completes a snapshot**,
+which the freshness gate already gets right for its own reasons.
+`RemoteProviderStatus.isStaleSnapshot`
+(`Sources/TBDShared/RemoteProvider.swift`:344-348) is
+`health != .ok && (lastSuccessfulSnapshotAt != nil || freshnessUnreadable)`, so a
+provider confirmed never to have held a complete inventory is not stale: there
+are no cached rows being projected as current, which is the thing staleness
+suppresses. Send therefore renders for a cloud lane, and the send gate needs no
+cloud-shaped exception.
+
+### What a cloud lane cannot know about itself
+
+Three degradations follow from a ledger-only `list`. Each is stated on screen
+rather than papered over, because the alternative in every case is a cheerier
+fiction the user would act on.
+
+- **A lane's display name is its session id.** A title only ever arrives from
+  discovery, and `RemoteSessionAdopter.displayName(session:)`
+  (`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:228-232) already falls
+  back to the session id when the provider reports none — which is short, stable
+  and honest. The submitted `prompt` is never used as a name (below), so a cloud
+  row reads as `session_01…` until the user renames it. Rename is TBD's own
+  display name and works on a cloud row exactly as on any other.
+- **`agent_state` is always `unknown`, and so is `state`.** The ledger knows a
+  session was created; it does not know whether it lives, and the contract is
+  explicit that `unknown` means only that no machine-readable state is available
+  — never healthy, idle, or finished. The row must therefore not render like an
+  idle local lane, and today it would: `RowStatusIndicator.suffix`
+  (`Sources/TBDApp/Sidebar/RowStatusIndicator.swift`:125-143) has no case for
+  "cannot vouch", and `WorktreeRowView.suffixIcon()`
+  (`Sources/TBDApp/Sidebar/WorktreeRowView.swift`:287-313) derives `isWorking`
+  from `hasWorkingTerminal`, which a row with no terminals answers `false`. A
+  row with no suffix already means "idle, nothing happening" to every local
+  sibling beside it. So this slice implements the uncertainty indicator the
+  08-10 design specifies — a `SuffixRowIndicator` case rendered whenever TBD
+  cannot vouch for a row's state, sitting in the attention slot — because for a
+  cloud lane that is the steady state rather than an edge. The leading `.remote`
+  marker (`LeadingRowIndicator.remote`, already rendered via
+  `RowStatusIndicator.leading(isRemote:)`) keeps saying *where*; the suffix says
+  *we do not know what*.
+- **Sessions created outside TBD are invisible to it.** A session started on
+  claude.ai, from the mobile app, or by `claude --cloud` in a terminal TBD did
+  not spawn has no ledger row, so it is never listed, never adopted, and has no
+  lane. There is no partial rendering of it to get wrong: it is simply absent,
+  and the Settings caption for the flag says so in one sentence, so the absence
+  reads as a property of the feature rather than as a bug.
 
 ### `create` needs a pseudo-terminal; nothing else does
 
 This is the one place the built-in provider cannot be a plain subprocess. The
 vendor CLI refuses `--cloud` creation when stdout is not a terminal, by design
-and loudly (§10), so the obvious implementation — spawn `claude`, capture the
+and loudly (§11), so the obvious implementation — spawn `claude`, capture the
 pipe, read the id — does not merely degrade, it never works.
 
 The asymmetry is worth stating because it decides where the complexity goes:
-**`send`, `land`, `transcript`, `archive` and `unarchive` need no terminal**;
-`send`'s `--print` form is explicitly a non-interactive invocation and returns
-JSON on an ordinary pipe. Only `create` needs a PTY, and only on the daemon
-side — `attach` runs on the pane's own PTY, which the app already allocates.
+**`send`, `list` and `land` need no terminal**; `send`'s `--print` form is
+explicitly a non-interactive invocation and returns JSON on an ordinary pipe.
+Only `create` needs a PTY, and only on the daemon side — `attach` runs on the
+pane's own PTY, which the app already allocates.
 
 **The provider allocates the PTY through the engine that already bounds every
 other spawn.** `runBoundedProcess`
@@ -243,18 +388,19 @@ suite to get right, and a PTY-shaped copy of it would be a second place for that
 to rot.
 
 **PTY mode is create-only, and the reason is a real loss.** A pseudo-terminal is
-one file descriptor, so the child's stdout and stderr merge on it. `transcript`
-returns its continuation cursor in a stderr envelope precisely so a control
-record never mixes into the JSONL data stream, and that separation cannot
-survive a PTY. So the mode is opt-in per invocation rather than a property of
-the provider, and `create` — which returns no envelope — is the only verb that
-sets it.
+one file descriptor, so the child's stdout and stderr merge on it. The contract
+keeps those channels distinct deliberately — stdout carries the records or the
+JSON envelope a verb answers with, stderr carries diagnostics and, for
+`transcript`, the continuation cursor that must never mix into the data stream —
+and none of that separation survives a PTY. So the mode is opt-in per invocation
+rather than a property of the provider, and `create`, whose whole answer is three
+lines of prose on stdout, is the only verb that sets it.
 
 ### Reading the session id out of `create`'s output
 
 `create` is fire-and-forget: it exits 0 immediately without attaching, having
 printed three lines naming the created session, its web URL, and the command
-that would resume it (§10). There is no JSON form — `--print` is refused
+that would resume it (§11). There is no JSON form — `--print` is refused
 alongside `--cloud` — so those lines are the only channel the id travels on.
 
 The provider strips ANSI control sequences from the captured output and takes
@@ -266,8 +412,9 @@ distinct id is the healthy case and disagreement is a signal, not noise.
 forbids inferring an agent's state from a rendered terminal screen; this reads
 the result line of a non-interactive command TBD itself invoked, which is the
 same category as parsing `git`'s output. Nothing here reads a TUI, and nothing
-here infers state — liveness and agent state come from `list`, exactly as the
-contract requires.
+here infers state — liveness and agent state are whatever `list`'s payload
+reports, which for a ledger row is `unknown` (above), exactly as the contract
+requires.
 
 **A parse that finds nothing fails loudly and is classified.** Zero matches, or
 more than one distinct id, is a `create` failure: the provider synthesizes exit
@@ -278,28 +425,32 @@ reads as `contractBug` and `RemoteProviderManager.recordFailure` turns into
 the built-in provider could not satisfy the contract, and the remedy is a fix to
 TBD rather than a retry or a re-authentication.
 
-The ledger is what makes that failure safe. The idempotency key and its state
-are written **before** the invocation, so a create whose output could not be
-read leaves a `pending` row rather than nothing — and the session, which very
-likely exists, is adopted by the next complete discovery through the parent
-design's pending-row matching. An unreadable answer costs the provenance link,
-never the session.
+The ledger is what keeps that failure from being silent. The idempotency key and
+its state are written **before** the invocation, so a create whose output could
+not be read leaves a `pending` row rather than nothing, carrying the repository,
+the branch and the prompt that were submitted. With no discovery to match such a
+row against, nothing adopts the session later, so the row is what the user is
+shown: a create that may well have started a real session TBD cannot name. It
+names what was asked for and links to claude.ai, where the session — if it
+exists — is listed. An unreadable answer costs the lane, not silently but
+visibly, and the parent design's pending-row adoption arrives with discovery.
 
-### The session title comes from discovery, never from what was submitted
+### The lane's name is never what was submitted
 
 The vendor derives a session's title server-side; it is a summary of the opening
-instruction, not that instruction's text (§10 records the measured pair). So
+instruction, not that instruction's text (§11 records the measured pair). So
 nothing in TBD may treat the submitted `prompt` as the lane's name.
 
-Nothing does, and this slice must not change that. Adoption already reads the
-title off the provider's own payload:
-`RemoteSessionAdopter.displayName(session:)`
+Nothing does, and this slice must not change that. Adoption reads the title off
+the provider's own payload: `RemoteSessionAdopter.displayName(session:)`
 (`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:228-232) takes
 `session.title` when the provider reports one and falls back to the session id,
 and `claude-cloud`'s `create_params` are `repo`, `branch`, `prompt` and
 `environment` — no `title` among them, so there is nothing for TBD to have
-submitted and nothing to reconcile. The create surface (§9, step 7) therefore
-writes no display name of its own; the row's name arrives with the row.
+submitted and nothing to reconcile. A ledger row reports no title at all, so the
+fallback is what every cloud lane wears until the user renames it (above). The
+create surface (§10, step 7) writes no display name of its own; the row's name
+arrives with the row.
 
 **Create asks for one out-of-band `list`.** Because the row arrives by adoption
 rather than being minted by the create call, and the poll loop's interval is 60
@@ -317,7 +468,7 @@ skipped with a visible flag rather than rejecting the whole file — the loader
 currently throws for the entire registry on a duplicate name (:372-374), and two of
 its three call sites swallow that, so one bad entry silently removes every
 provider. The
-reservation is unconditional and does not depend on the flag in §7: a name that
+reservation is unconditional and does not depend on the flag in §8: a name that
 became available when a feature was off, and unavailable when it was turned on,
 would change which providers load as a side effect of a toggle.
 
@@ -526,242 +677,60 @@ Nothing here adds a tab, removes one, reassigns a host's `rootView`, or
 holds; `targetTab` is a pure function of that value and already routes correctly
 once it is set, and its unit tests extend to the new case without new machinery.
 
-## 5. The watch surface
+## 5. Steering, and getting attach ready
 
-`RemoteSessionDetailView` gains a **Transcript** segment beside Attach and Log.
+Selecting an adopted cloud row shows `RemoteSessionDetailView` (§4). Two things
+render there in this slice: the **send field**, which is how a user steers the
+session, and the **Attach** pane, which works where the account is entitled to
+it and explains itself where it is not.
 
-`RemoteSessionDetailTab` (`Sources/TBDApp/Remote/RemoteSessionDetailView.swift`:11-14)
-is a two-case enum today (`attach`, `log`) and gains `transcript`. The four pure
-gates that decide what renders live in
-`Sources/TBDApp/Remote/RemoteSessionDetailGates.swift` and are unit-tested in
-`Tests/TBDAppTests/RemoteSessionDetailGatesTests.swift`:
+### The send field is the steering path
 
-- `available(capabilities:gone:)` (:40-46) builds the ordered tab list. It gains
-  a `transcript` arm, placed **first** — ahead of attach and log — so a provider
-  that offers a structured conversation lands the user there rather than in a
-  terminal. **Attach is dropped when the session is `gone`; transcript is not** —
-  reading a retired session's conversation is still useful, which is exactly the
-  reasoning that already keeps `log` available for a tombstoned row.
-- `initialTab(available:requested:)` (:55-62) honors a one-shot navigation hint
-  when it names an available tab and otherwise takes the list's first entry. It
-  needs no change; the new case flows through it, and the ordering above is what
-  makes Transcript the landing tab.
-- `showsPicker(available:)` (:66-68) renders the segmented control only when there
-  is a real choice — `available.count > 1`. No change.
-- `showsSendField(capabilities:gone:snapshotFresh:)` (:75-79) is independent of
-  the tab list. No change; cloud declares `send`, so the send field renders for a
-  live cloud lane with a fresh snapshot.
+`showsSendField(capabilities:gone:snapshotFresh:)`
+(`Sources/TBDApp/Remote/RemoteSessionDetailGates.swift`:75-79) gates the field on
+three things — the provider declaring `send`, the session not being `gone`, and
+the provider's snapshot not being stale — and the view renders it from that gate
+at `Sources/TBDApp/Remote/RemoteSessionDetailView.swift`:186-192. All three hold
+for a cloud lane: cloud declares `send`; a cloud lane is never `gone`, because
+retiring a session takes a complete snapshot and there is never one; and a
+provider that has never held a complete inventory is not stale (§3 argues both).
+So the field renders for every live cloud lane, and the gate needs no
+cloud-shaped exception.
 
-The picker itself is at `RemoteSessionDetailView.swift`:173-182, the send field
-is gated just below it at :186-192, and `RemoteLogTabView` (:607-659) is the
-existing read-only scrollback pane the new tab sits beside.
+What the field posts travels the ordinary path. The app sends the same bytes it
+sends any provider through `remote.send`
+(`Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift`:189); the provider
+implements the contract's byte interface on top of
+`claude -p "<msg>" --cloud <id> --output-format json` (§3 specifies the byte
+handling, §11 records the measured call and its response).
 
-Ordering `transcript` first changes nothing for any provider registered today,
-because `transcript` is a v2 capability and no external provider declares it —
-the first provider to reach that arm is the built-in one.
+**What happens after a send is the honest limit of this slice.** There is no
+reply for TBD to render: the conversation lives on Anthropic's servers and no
+supported interface reads it (§1). So a successful send confirms the message was
+accepted and says where the answer will appear — in the attach terminal on an
+entitled account, and on claude.ai otherwise, at the session URL the send
+response itself returns (§11). It never implies TBD will show the answer, and the
+send field is not styled as one half of a conversation view.
 
-**The view's placeholder tab has to stop naming a real tab, or the ordering
-above means nothing.** `selectedTab` is `@State` defaulting to `.attach` (:112),
-reset to `.attach` on every selection change (:230), and `effectiveTab` (:159-161)
-passes it to `initialTab` as `requested` — which honors a requested tab whenever
-it is available. So a placeholder that names `.attach` beats the list's own first
-entry for any provider that declares attach. It works today only because the
-one provider shape that exercises the fallback is `log`-only, where `.attach` is
-absent from the list by luck rather than by design, and the doc comment at
-:152-158 says as much. `selectedTab` therefore becomes optional with `nil` as the
-placeholder, reset to `nil` rather than `.attach`, and the Picker binds through a
-computed binding over `effectiveTab`. "No tab has been chosen yet" then has a
-representation, and `available`'s ordering decides the landing tab for every
-provider rather than for one shape of provider.
+### What the tab list comes to for a cloud lane
 
-**What a cloud lane's picker shows.** Cloud declares `transcript` and `attach`
-but not `log`, so `available` returns `[.transcript, .attach]`, `showsPicker` is
-true, and the segmented control offers exactly those two, in that order, with
-Transcript selected by default. A **gone** cloud lane returns `[.transcript]`
-alone — one tab, so no picker renders and the transcript content fills the pane
-unconditionally, which is the shape a single-tab provider already gets. A provider
-declaring none of the three still reaches the existing empty state.
+`RemoteSessionDetailTab`
+(`Sources/TBDApp/Remote/RemoteSessionDetailView.swift`:11-14) is `attach` and
+`log`, and `available(capabilities:gone:)`
+(`Sources/TBDApp/Remote/RemoteSessionDetailGates.swift`:40-45) builds the tab
+list from the provider's declared capabilities. Cloud declares `attach` and not
+`log`, so the list is `[.attach]` — a single entry, so `showsPicker` (:66-68) is
+false and the attach content fills the pane with no segmented control, which is
+the shape a single-tab provider already gets. None of the four gates changes
+here; the cloud provider is a third capability shape flowing through them
+unmodified.
 
-### The `transcript` data path
-
-`remote.transcript` does not exist. `RPCRouter+RemoteHandlers.swift` has
-handlers for providers, sessions, create, stop, send, log, rename, dismiss,
-setPin and reportAttachExit (:57, :64, :86, :152, :189, :225, :263, :293, :315,
-:341) and nothing else. A new `handleRemoteTranscript` joins them, gated by the
-same `remoteGate()` (:25-28) as every sibling.
-
-**The Transcript segment renders through the real structured renderer — the same
-tool cards, the same row-height cache, the same overlay a local lane gets.** A
-cloud lane has no attach guarantee and no `log`, so the transcript is not a
-secondary view of the conversation; it is the *only* watch surface. A degraded
-renderer would therefore not be a lesser second opinion, it would be the whole
-experience — a wall of prose where a local lane shows an Edit card with a diff, a
-Bash card with its command and output, an Agent card that drills into a subagent
-thread. That is the argument for paying the seam's cost rather than the simpler
-view's.
-
-**The seam already exists one layer down, which is what makes this affordable.**
-The renderer proper — `TableTranscriptView`, the view-based `NSTableView` that
-hosts one `SelectableTranscriptRow` per cell behind an explicit height cache —
-takes render nodes and a `TranscriptCardContext`, and neither mentions a terminal
-or a worktree. It already has a **second, non-terminal caller**:
-`HistoryPaneView` (`Sources/TBDApp/Panes/HistoryPaneView.swift`:452-471) builds
-the same `TranscriptPresentation` and hosts the same table with
-`TranscriptCardContext(terminalID: nil, …)`, over messages it fetched by file
-path rather than from a terminal. So the cards, the presentation build, the
-height cache and the workbench index are already source-agnostic in production,
-not merely in principle.
-
-What is terminal-keyed is the pane *above* it.
-`TableTranscriptPaneView` (`Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift`:12-14)
-takes a `terminalID` and a `worktreeID` and resolves content along one fixed
-chain: `appState.terminals[worktreeID]` → the terminal with that id (:67-69) →
-`terminal.claudeSessionID` (:71-73) → `appState.sessionTranscripts[sessionID]`
-(:75-78). Its poll loop (:264-275) fetches through `terminal.transcript`, keyed on
-the same terminal id (:294-295). It is hosted from exactly one place,
-`PanePlaceholder.swift`:352, and `PanePlaceholder` takes a `LocalWorktree` (:49).
-A cloud lane has no terminal row, no Claude session id, and no `LocalWorktree`,
-so that chain cannot serve it.
-
-### The transcript source
-
-`TableTranscriptPaneView` is keyed on a **source** rather than on a terminal:
-
-```swift
-enum TranscriptSource: Equatable, Hashable {
-    case terminal(terminalID: UUID, worktreeID: UUID)
-    case remote(provider: String, sessionID: String)
-}
-```
-
-Exactly three things in that view are a function of the source, and everything
-else in it is untouched:
-
-- **The store key.** `.terminal` walks today's chain to `claudeSessionID`;
-  `.remote` is the provider session id verbatim. Both answer with a `String?`,
-  and `AppState.sessionTranscripts` is already `[String: [TranscriptItem]]`
-  (`AppState.swift`:788) with an LRU eviction keyed the same way (:1068-1087).
-  So the remote path is a **third writer into one store**, beside the live pane
-  and `AppState+History.swift`:147-152 — not a second store. Every downstream
-  consumer of that key — the rollover guard, the LRU touch, the `PaneIdentity`
-  the table is `.id()`-keyed on — keeps working unchanged. The two id spaces do
-  not overlap (a Claude session id is a UUID, a cloud session id is
-  `session_`-prefixed), so one key space stays one key space; the store's
-  fifty-entry LRU is shared, which is correct — a cloud transcript the user is
-  reading deserves the same residency as a local one.
-- **The fetch.** `.terminal` calls `terminal.transcript` with its tail-first
-  two-phase open as it does now. `.remote` calls `remote.transcript` with the
-  continuation cursor the daemon returned last time, and the daemon answers with
-  the full accumulated item list plus the next cursor. The cursor lives daemon-side
-  beside the spooled JSONL, not in the view, so it survives the pane being closed
-  and reopened and survives a daemon restart.
-- **The card terminal.** `TranscriptCardContext.terminalID` is already `UUID?`
-  (`TranscriptCardContext.swift`:8). `.remote` supplies `nil`, which is exactly
-  what `HistoryPaneView` supplies, and the cards already do the right thing with
-  it: the truncation footers that would fetch a longer body over
-  `terminal.transcriptItemFullBody` are gated on `terminalID != nil` and simply
-  do not render (`GenericToolCardBody.swift`:30 and :47, with the fetches
-  guarding again at :72 and :79).
-
-**Hosting needs no new machinery, and `PanePlaceholder`'s `LocalWorktree`
-constraint never binds**, because the remote path does not go through
-`PanePlaceholder` at all. The Transcript tab hosts `TableTranscriptPaneView`
-directly, which is precisely how `HistoryPaneView` hosts the table today. Two
-environment values `PanePlaceholder` injects need answers at the new host, and
-both are answered by what a remote transcript honestly is:
-
-- **`\.openFilePreview` is not injected.** The Write, Edit and Read cards already
-  gate their preview affordance on `openFilePreview != nil`
-  (`WriteCardBody.swift`:42 and :45, `EditCardBody.swift`:74 and :77), so a path
-  naming a file on another machine offers no button rather than a broken one.
-- **`\.openTranscriptOverlay` is injected**, opening
-  `overlayCoordinator.open(terminalID: nil, itemID:, sessionID: <session id>)`.
-  `TranscriptOverlayView.lookupItem()` already has a second resolution path for
-  exactly that shape — no terminal, a session id, items read from
-  `AppState.sessionTranscripts` (:321-332) — so drilling into a tool card works
-  with no new resolution. The parameter is called `historySessionID` today, which
-  names its first caller rather than its meaning: it is the *session-keyed* path,
-  and any non-terminal source uses it. It is renamed `sessionID` in this edit
-  across its three sites (`TranscriptOverlayCoordinator.swift`:8-18 and :47,
-  `TranscriptOverlayView.swift`:329, `HistoryPaneView.swift`:523-529).
-
-**Local file links are suppressed for a remote transcript, and suppressed means
-inert.** `overlayFileLinkAction`
-(`Sources/TBDApp/Panes/Transcript/OverlayFileLinkAction.swift`:12-24) turns
-`tbd-file:` and `file:` URLs into overlay file frames and lets everything else
-fall through to the system handler. For a remote transcript both of those
-outcomes are wrong — one opens an unrelated local file in the overlay, the other
-hands it to Finder — so the action takes an `allowsLocalFiles` flag and returns
-`.discarded` for both schemes when it is false. A path that names another
-machine's disk does nothing when clicked, which is the only honest behavior
-available.
-
-### What the pane shows while it is not yet complete
-
-Three states, and none of them may be silent:
-
-- **Before the first page arrives**, the pane shows the same
-  "Waiting for Claude to start the conversation…" empty state the live pane
-  already renders before its first fetch (:140-152), so a fresh cloud lane reads
-  as loading rather than as empty.
-- **When the provider returns an incomplete stream** — a cursor came back and the
-  provider has more to give — the pane renders what it has and keeps fetching. It
-  never blocks on completeness, because a long conversation's first page is
-  useful immediately and the tail is what the user is usually reading anyway.
-- **When a fetch fails**, the pane shows the existing error state with a Retry
-  button (`TableTranscriptPaneView.swift`:154-175) rather than an empty list. An
-  empty transcript and an unreachable provider look identical otherwise, and the
-  cloud lane has no second surface to disambiguate them.
-
-**Every delay in this path takes an injected clock.** The pane's poll loop sleeps
-through a bare `Task.sleep` carrying a legacy `swiftlint:disable no_raw_task_sleep`
-suppression (:272-273); adding a second cadence for the remote source behind that
-same suppression would be adding a new violation under cover of an old one. The
-loop moves onto `clock: any Clock<Duration> = ContinuousClock()` as the view's
-last initializer parameter, defaulted so no call site changes, and the
-suppression is deleted rather than duplicated.
-
-**The renderer's existing performance constraints hold unchanged**, and nothing
-here relaxes them. Row cards must have no direct `ScrollView` child — the rule
-that outlived the original renderer and is enforced by the
-`no_scrollview_in_transcript_cards` SwiftLint rule
-(`Sources/TBDApp/Panes/Transcript/CLAUDE.md`,
-`docs/superpowers/specs/2026-05-23-transcript-card-rework-design.md`) — and the
-remote path adds no card of its own, so there is nothing new to violate it. The
-height cache measures each row once through `NSHostingController.sizeThatFits`,
-and because the remote path feeds the same `TranscriptRenderNode`s through the
-same `TranscriptPresentation.build`, it measures cloud rows on exactly the terms
-it measures local ones.
-
-**What this costs relative to a second, simpler view.** More of the pane view
-changes: a source enum, three branch points inside it, one renamed overlay
-parameter, one flag on the file-link action. What it does not cost is a second
-renderer — no duplicate row cards to keep in step, no second height-cache story,
-no surface where an improvement to a tool card lands in one place and not the
-other. The daemon work, the RPC, the cursor and the store writes are identical
-under either choice; they are not what the two options differ on.
-
-### Daemon side
-
-`handleRemoteTranscript` invokes the verb, appends stdout to the TBD-owned
-transcript root `~/tbd/remote-transcripts/<provider>/<sessionID>/` (path helper in
-`TBDConstants`, honoring `TBD_HOME`), stores the cursor returned in the stderr
-envelope for the next call, and parses the accumulated file through
-`TranscriptParser`. Parsing stays daemon-side, as `session.messages` already does.
-
-`handleSessionMessages` (`RPCRouter+SessionHandlers.swift`:24) is not the model
-for this handler and cannot be extended into it: it takes a **file path** from the
-caller and constrains it to the Claude projects store (:49-55). A cloud session
-has no local file and no Claude session id, so `remote.transcript` takes
-`(provider, sessionID)` and resolves the path itself — the caller never names one.
-
-**The parent design's single-choke-point resolver is a prerequisite of this
-slice**, not a follow-up. `TranscriptParser` is reached from several handlers that
-are not guarded alike, and admitting a second permitted root is only safe where
-the boundary is actually checked. The resolver — one function taking an untrusted
-path and returning either a validated path under one of the two permitted roots or
-a refusal, with `TranscriptParser`'s entry points reachable only through it —
-ships before the TBD-owned root is admitted to it.
+The one case worth naming is a **gone** cloud lane, which drops attach and leaves
+the tab list empty, reaching the view's existing "doesn't support attach or a log
+view" empty state. That state is not reachable in practice, since nothing retires
+a cloud session (§3), and it is the right answer if it ever is: with attach gone
+there is genuinely nothing to put in the content area, while the row itself goes
+on saying what it knows.
 
 ### Must fix in this slice: attach announces contract major 1
 
@@ -821,7 +790,7 @@ crosses a process boundary and is the one that would otherwise go on announcing
 ### Attach is an entitlement question, not a capability question
 
 Attaching to an existing cloud session is gated per account by the vendor, and
-the gate is off by default (§10). The distinction that decides where this lands
+the gate is off by default (§11). The distinction that decides where this lands
 in TBD's model:
 
 - **A capability is what a provider implements.** `describe` answers it
@@ -872,10 +841,10 @@ records an **attach-scoped block** against that provider.
 says the provider itself cannot authenticate, and it has consequences — it
 suppresses auto-attach for every session and blocks reconnect
 (`AppState+RemoteAttach.swift`:48-59, `RemoteReconnectPolicy.isBlocked`:76-79).
-A cloud provider whose `create`, `send`, `list` and `transcript` all work
-perfectly is not in that state, and saying so would be a lie that also disables
-nothing useful. The block is scoped to attach; the other tabs, the send field
-and every non-attach verb are untouched.
+A cloud provider whose `create`, `send`, `list` and `land` all work perfectly is
+not in that state, and saying so would be a lie that also disables nothing
+useful. The block is scoped to attach; the send field and every non-attach verb
+are untouched.
 
 `RemoteProviderStatus` therefore gains a third field beside the two above, read
 at the same one lookup:
@@ -902,11 +871,11 @@ renders its label as plain text rather than a button, which it already does
 
 #### What renders, and what does not get spawned
 
-- **The Attach segment stays in the picker.** The capability is declared and the
-  tab list is a function of capabilities, so the segment is present and
-  selecting it explains the condition. Removing the segment would leave the user
-  wondering why a documented feature is absent.
-- **Selecting it shows the CTA in place of the attach slot.** `contentArea`
+- **Attach stays in the tab list.** The capability is declared and the tab list
+  is a function of capabilities, so the tab is present — for a cloud lane it is
+  the only one, rendered without a picker — and it explains the condition.
+  Dropping it would leave the user wondering why a documented feature is absent.
+- **The pane shows the CTA in place of the attach slot.** `contentArea`
   already controls attach visibility through `showsAttachSlot` while keeping
   `RemoteAttachPager` itself mounted unconditionally — the invariant its comment
   at :419-437 exists to protect — so the block makes `showsAttachSlot` (:485)
@@ -953,17 +922,17 @@ trade: the contract gives a provider exit 3 to say "transient, retry me", and
 retrying forever on the class that means the opposite is the defect. Both
 branches are asserted.
 
-#### What is not in this slice
+#### The exit-driven path is the whole of what is available
 
-The parent design also specifies a **cached eligibility preflight** — one check
-against the undocumented surface at describe time, reflected by disabling the
-affordance before anything is spawned, failing open when it cannot run. That
-would remove the single doomed attach the exit-driven path spends to learn the
-condition. It is not in this slice, because it needs an undocumented endpoint the
-rest of slice 1 does not, and its whole benefit is one wasted process per account
-per daemon lifetime. The exit-driven path is the floor and needs nothing
-undocumented; the preflight is the improvement on top, and the evidence for
-promoting it is a user meeting the dead terminal more than once.
+The parent design also describes a **cached eligibility preflight** — one check
+at describe time, reflected by disabling the affordance before anything is
+spawned, failing open when it cannot run — which would save the single doomed
+attach the exit-driven path spends to learn the condition. That check has no
+supported interface behind it: the only surface that answers it is the
+undocumented one TBD does not build against (§1). So the exit-driven path is not
+a floor beneath a planned improvement; it is what a supported interface allows,
+and it costs one process per account per daemon lifetime to learn a fact the
+vendor exposes no other way.
 
 ## 6. Land
 
@@ -1050,7 +1019,7 @@ still yields an empty menu rather than a partial one.
    `claude --teleport <id>`.
 
    **That first pane opens on Claude Code's folder-trust prompt**, because a
-   freshly materialized worktree is a directory it has never seen (§10). The user
+   freshly materialized worktree is a directory it has never seen (§11). The user
    answers it. TBD does not suppress it, pre-answer it, or type into the pane:
    trusting a checkout just pulled from a remote branch is a security decision,
    and this is the moment to ask. Land is complete when the pane is spawned with
@@ -1067,21 +1036,225 @@ a half-converted row, and the lane is exactly as it was.
 
 Landing is always a user gesture and is never triggered by session state.
 
-**After the conversion, the provider session is archived** — one verb call,
-because `claude-cloud` declares `archive` and reports `forks: true`, so the work
-has moved to this machine and a session nobody will return to should not sit in
-the working set. It is never *stopped*, whatever a provider declares: landing is
-a "bring this home" gesture, not a teardown, and the remote box may still hold
-work that was never pushed. This is the only archive path slice 1 wires; the
-row-level archive composition stays out of scope per §1. The archive runs after
-the row has already converted and is best-effort: its failure is reported and does
-not un-land the lane.
+**After the conversion, the cloud session keeps running, and the lane says so.**
+`land` reports `forks: true`, so the landed checkout and the session diverge from
+this moment; the parent design's answer to that is to retire the session where
+the provider can, and to leave it running and say so where it cannot. Cloud
+cannot: it declares neither `archive` nor `stop` (§3), so there is nothing to
+call. The landed row therefore carries its origin (§2) and states plainly that
+the session it came from is still in the account's working set, where the user
+can archive it on claude.ai. TBD never *stops* a session on landing whatever a
+provider declares — landing is a "bring this home" gesture, not a teardown, and
+the remote box may still hold work that was never pushed.
 
-That archive does not travel back to the row. Mirroring a provider's `archived`
-flag onto a row's status applies while the row is remote, and the lane is local
-now — its filing state is TBD's own from that point.
+Nothing about the session travels back to the row after the conversion. A row
+whose files are on this machine takes its status from TBD alone, whatever a
+provider later reports about the session that row once ran on.
 
-## 7. The flag
+## 7. Archiving a remote lane
+
+Archive retires a lane from the working set, and a cloud lane needs the gesture
+more than a local one does: nothing else takes it out of the tree. Retirement
+driven by the provider needs a complete snapshot and there is never one (§3), so
+a cloud lane that has been landed, abandoned, or answered stays in the active
+tree until a person files it away.
+
+**TBD offers that gesture today and refuses it.** `RowActionMenu.regularItems`
+(`Sources/TBDApp/Helpers/RowActionMenu.swift`:357-390) puts Archive in the first
+section of every non-scratch, non-main row's menu, gated only on
+`hasActiveChildren`, so an adopted remote row shows it; `run(.archive)`
+(`Sources/TBDApp/Sidebar/RowActionMenuActions.swift`:184-186) calls
+`AppState.archiveWorktree`, which calls `worktree.archive`, which refuses. The
+menu item is not the defect and does not change: what changes is that the daemon
+stops refusing.
+
+### The fences, and why lifting them is not enough
+
+Three explicit fences refuse a remote row, each deliberate and each placed above
+the row so the actuation record never claims an act that could not be attempted:
+
+- **`worktree.archive`**
+  (`Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift`:217-221) — refuses
+  loudly, with a message naming the lane, because it answers a user gesture.
+- **`worktree.forget`** (same file, :324-328) — the same shape, on the stated
+  ground that a remote lane has no checkout here to leave alone.
+- **`AutoArchiveOnMergeCoordinator.handleMergedTransition`**
+  (`Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift`:54-57) — skips
+  silently rather than loudly, because it is a background rail rather than a
+  gesture.
+
+Underneath them the refusal is structural rather than conditional.
+`beginArchiveWorktree`
+(`Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift`:47-49),
+`forgetWorktree` (`.../WorktreeLifecycle+Forget.swift`:38) and
+`beginReviveWorktree` (`.../WorktreeLifecycle+Archive.swift`:292-295) all resolve
+their row through `WorktreeStore.getLocal`, and `LocalWorktree.init?`
+(`Sources/TBDShared/LocalWorktree.swift`:34-39) returns nil for a remote row. So
+deleting a fence would convert a clear refusal into `worktreeNotFound`, and
+nothing more.
+
+That is the right structure, because the local archive path is local all the way
+down: it syncs the branch from `git worktree list`, captures HEAD from the
+directory, captures each terminal's scrollback into Closed Terminals, kills the
+tmux windows, deletes the terminal and tab rows, and — in phase 2 — runs the
+archive hook and removes the git worktree. Not one of those has a meaning for a
+lane whose files are on another machine.
+
+### A remote lane archives through its own path
+
+`handleWorktreeArchive` branches on location instead of refusing on it. The
+`.local` arm is today's path, untouched. The `.remote` arm calls a second
+lifecycle entry that shares only what is genuinely about the row:
+
+1. Load the row through `WorktreeStore.get` — not `getLocal`, which is the whole
+   point of a separate path.
+2. Refuse `.main` and `.creating`, which `WorktreeStore.archive`
+   (`Sources/TBDDaemon/Database/WorktreeStore.swift`:646-672) already enforces in
+   the same transaction that flips the status.
+3. Honor `assertArchivable` (:686-703) unless forced. Its SQL counts direct
+   children with status `.active` or `.creating` and is location-blind, so a
+   remote lane with an active child is refused exactly as a local one is — and a
+   remote lane can have children, since adoption nests rows on
+   `parentWorktreeID`.
+4. Compose over the provider's declared capabilities (next subsection), then flip
+   the row through `WorktreeStore.archive(id:)`.
+
+No tmux, no scrollback capture, no git, no phase 2, no archive hook. The hook is
+worth naming: it runs with the worktree's path as its working directory, and a
+remote lane has no directory to run it in.
+
+### The composition, and which branch `claude-cloud` takes
+
+What archive does to the session behind the row is the three-way composition the
+08-10 design specifies, and this document does not restate the rule beyond naming
+its branches: a provider declaring `archive` has the verb called and then the row
+marked; one declaring only `stop` has the session stopped and then the row
+marked; one declaring neither has the row marked and nothing else, with the
+session left running and the UI saying so.
+
+**`claude-cloud` takes the third branch, and takes it permanently.** It declares
+neither `archive` nor `unarchive` — the account's archive operation lives on the
+undocumented surface TBD does not build against (§1) — and it declares no `stop`,
+because nothing exposed terminates a running cloud session. So archiving a cloud
+lane calls nothing at all: it is a filing change inside TBD, and the session goes
+on existing exactly as it did.
+
+**What the row shows, so nobody reads it as a teardown.** An archived cloud lane
+says, in the Archived list and in its detail header, that it was filed away here
+and that the cloud session is still in the account's working set, naming
+claude.ai as where to retire it for real. The words to avoid are the ones the
+local path earns: nothing was stopped, closed, torn down, or cleaned up. The one
+sentence a user needs is that TBD stopped showing the lane and Anthropic did not
+stop the session.
+
+**The termination guards do not apply.** The 08-10 design scopes the `working`
+guard and the dirty-remote-checkout guard to the paths that actually end a
+session — the `stop` path always, and the `archive`-verb path where the same
+provider also declares `stop` — because destroying unpushed work is the only
+thing they defend against. A row-only archive destroys nothing, so it is never
+refused on those grounds. Nothing here relaxes a guard; the guarded branches are
+simply not the branch cloud takes.
+
+**No actuation row is written for a row-only archive.** `.worktreeArchive` maps
+to the `dispose` kind (`Sources/TBDDaemon/Actuation/ActuationSurface.swift`:150-151),
+and this branch disposes of nothing: it kills no process and ends no session. The
+precedent is the 08-10 design's forced `repo.remove`, which cascades local
+worktrees and writes no actuation row for the remote lanes it drops, because none
+of their sessions were torn down and the record may only claim acts that were
+attempted. The branches that do call a provider verb record theirs as they would
+for any other actuated act.
+
+### What happens to the mirror row, and to the next `list`
+
+**The `remote_session` mirror row is untouched.** It is provider-owned liveness —
+what the manager last observed — while `worktree.status` is TBD's own filing
+decision, and archiving a lane is the second of those. Keeping the mirror is what
+lets an archived lane still say whether its session is still being listed.
+
+**The next snapshot does not resurrect the lane.** `RemoteSessionAdopter.adoptOne`
+(`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:98-102) ends adoption for
+any session that already has a row — "created once, never re-derived, whatever
+the payload now says" — so a session that keeps appearing in every `list` after
+its lane was archived mints nothing and changes nothing.
+
+**Nor does it un-archive it.** The parent design's mirroring of a payload's
+`archived` flag onto the row is not in this slice, and could not act here if it
+were: the ledger reports no such flag, and a provider that never learns TBD filed
+a lane away would report `archived: false` forever. When that mirroring does land
+with discovery, it carries a provider's own filing state and therefore applies
+only where the provider holds one — which is to say, where it declares `archive`.
+
+`remote.dismiss`'s `dismissed` column stays a separate axis: it hides a bare
+session row from the Provider Desk and says nothing about a lane. Archiving a
+lane does not set it, and dismissing a session does not archive a lane.
+
+### Where an archived remote lane shows up
+
+`AppState.visibleWorktrees`
+(`Sources/TBDApp/AppState+ArchiveTombstones.swift`:39-44) filters on
+`status != .archived` and the tombstone set alone — no reference to location — so
+an archived remote row leaves the tree the moment its status flips, with no
+change to that function. It is confirmed rather than modified.
+
+**The Archived list needs one change, and without it the lane would vanish
+entirely.** `ArchivedWorktreesView` hides rows with no conversations by default
+(`Sources/TBDApp/ArchivedWorktreesView.swift`:136, filter at :251-256), where
+"conversations" means `liveClaudeSessionCount ?? archivedClaudeSessions?.count`
+(:677-679) — local Claude sessions, of which a remote lane has none. A cloud lane
+would therefore leave the tree and not appear in the list that is supposed to
+have received it. So a row with a provider origin passes that filter
+unconditionally, the way an in-flight revive already does. The filter's premise —
+"no conversations means nothing to come back to" — is a statement about local
+sessions, and it is simply not true of a lane whose conversation is on a server.
+
+### Unarchive is the same branch, run backwards
+
+Reviving a lane archived by the row-only branch flips the row back and calls
+nothing, which is the 08-10 design's first revive case: nothing was retired on
+the provider, so there is nothing to undo there. `WorktreeStore.revive(id:)`
+(`Sources/TBDDaemon/Database/WorktreeStore.swift`:709-721) is location-blind and
+does the flip; `beginReviveWorktree` is not — it resolves through `getLocal` and
+then materializes a directory — so revive branches on location exactly as archive
+does, and the remote arm is the row flip alone.
+
+The lane comes back saying what it knew before: its state is `unknown`, its name
+is its session id, and whether the session is still there is what the mirror row
+answers. The 08-10 design's other revive cases — an `unarchive` verb, a
+terminated session, a retirement TBD cannot lift — describe providers cloud is
+not, and they arrive with the providers that declare those capabilities.
+
+### `worktree.forget` stays refused
+
+Forget means "stop tracking this checkout but leave its files alone", and a
+remote lane has no checkout here to leave alone. That is a category error rather
+than an unimplemented feature, and it is how the 08-10 design classifies forget,
+alongside hibernate, relocate, scratch promote and adopt-existing-directory:
+operations with no remote meaning, kept unreachable through `LocalWorktree`. The
+fence stays exactly as it is, comment included — it already states that ground
+rather than a missing capability. Archive is the retirement gesture for a lane,
+and archive is the one this section makes work on a remote row.
+
+### The auto-archive-on-merge rail does not take remote lanes
+
+The rail's guard stays, and a remote lane does not participate.
+
+Two reasons, and the second is the one that would still hold if the first were
+fixed. First, the rail has no signal for a remote lane: it fires on a merged PR
+transition, and PR polling is fenced away from remote rows because everything
+below it is keyed on the worktree's path — `git` and `gh` both run inside a
+directory that does not exist for a remote lane. The 08-10 design's answer is to
+re-key that poll on the branch rather than to relax the fence, and until that
+lands a remote lane carries no PR status and reaches no merged transition.
+
+Second, when the badge does come back, an automatic archive of a lane whose
+session keeps running is a background mutation with no user gesture behind it —
+filing away a lane whose agent may still be working, in the one branch of the
+composition where TBD cannot even ask the provider what state it is in. That is
+the shape the repository's default-off rule exists for, and the honest row state
+("archived here, still running there") is one a person should be choosing. The
+guard's comment changes to say this; the guard does not.
+
+## 8. The flag
 
 `claude_cloud_enabled` — a new `config` column, **default OFF**. The behavior is
 autonomous background polling against a network service, squarely inside the
@@ -1167,7 +1340,7 @@ external-provider path ungated as the v1 rollout intends — and that deletion
 migration leaves `claude_cloud_enabled` untouched, so turning the outer flag off
 by deleting it cannot turn cloud on for anyone.
 
-## 8. Testing
+## 9. Testing
 
 Every gated conditional gets a test per branch. All tests run under
 `scripts/test.sh`, use the `TBD_HOME` isolation seams, and reach neither the
@@ -1203,15 +1376,34 @@ intervening state in which a local row is showing a remote detail view. A
 multi-selection including the row derives `nil`. Deselecting derives `nil`. A
 disconnect routes to `.other` regardless of the derived value.
 
-**The picker's shape for a `transcript`-without-`log` provider.** `available`
-returns `[.transcript, .attach]` for a live cloud lane and `[.transcript]` for a
-gone one; `showsPicker` is true in the first case and false in the second;
-`initialTab` lands on Transcript in both, with no tab requested — the assertion
-that would fail against the `.attach` placeholder, since `.attach` is available
-in the first case and would win. A one-shot Log hint against a provider that
-does not declare `log` is discarded rather than producing a blank pane, and an
-explicit Attach hint is honored. A provider declaring `log` and not `transcript`
-behaves exactly as it does now, on both the tab list and the landing tab.
+**The detail surface's shape for an `attach`-only provider.** `available`
+returns `[.attach]` for a live cloud lane and `[]` for a gone one; `showsPicker`
+is false in both, so the attach content fills the pane in the first case and the
+empty state fills it in the second. `showsSendField` is true for a live cloud
+lane whose provider has never recorded a complete snapshot — the case that would
+regress if freshness were conflated with "has answered" — and false once the
+session is `gone`. A one-shot Log hint against a provider that does not declare
+`log` is discarded rather than producing a blank pane. A provider declaring `log`
+and not `attach` behaves exactly as it does now, on both the tab list and the
+landing tab.
+
+**The row states its uncertainty.** A row whose agent state is `unknown` renders
+the uncertainty suffix rather than nothing, and a local row with an idle session
+still renders nothing — the pair that discriminates, since the defect being fixed
+is the two looking identical. A row whose agent state is `working` still renders
+the working indicator, so the new case did not take the slot from an existing
+one.
+
+**The ledger's snapshots never retire anything.** An always-`complete: false`
+provider whose `list` omits a session it sighted on an earlier poll leaves that
+row's `missingCount` where it was, never marks it `gone` however many polls it
+takes, and never
+advances freshness in either the in-memory stamp or the persisted `tbd_meta` key
+— asserted across a manager restart, so the recovered value is still absent.
+The same snapshot still adopts a session it has not seen before and still clears
+a degraded health state, so a provider whose steady state is incomplete recovers
+from a transport failure and keeps Send available. A `complete: true` snapshot
+from any other provider retires on the existing two-absence rule, unchanged.
 
 **`create` on a pseudo-terminal.** The bounded runner's PTY mode hands the child
 a terminal — asserted by spawning a probe that reports whether its stdout is a
@@ -1226,13 +1418,14 @@ Output carrying ANSI control sequences around the same three lines yields the
 same id. Output naming two different session ids, and output naming none, each
 produce a `create` failure classified as `contractBug` with the received text in
 the message — never a success with an empty id — and each leaves the ledger row
-`pending` so a later complete snapshot can still adopt the session. A create
-whose response carries a title unlike the submitted prompt still names the row
-from the provider's `title`, and a create never writes a display name of its own.
+`pending` and surfaced as an unresolved create rather than silently dropped. A
+create never writes a display name of its own, so the row is named from the
+provider's payload — the session id, for a ledger row — and never from the
+submitted prompt.
 
 **The entitlement path.** A permanent attach exit reported to the daemon records
 an attach block on that provider and leaves its health untouched, so the send
-field, the transcript tab and every non-attach verb stay available. The block
+field and every non-attach verb stay available. The block
 suppresses `showsAttachSlot` for that selection and renders the CTA in its place
 while `RemoteAttachPager` stays mounted. `attachEligibleRemoteSelections` drops
 a session whose provider carries a block and keeps one whose provider does not.
@@ -1243,20 +1436,39 @@ elapsed backoff window, admits a transient one under the same conditions, and
 Reattach clears either. A provider with no block behaves exactly as it does now,
 reconnect included.
 
-**The provider-fed renderer.** A `.remote` source resolves its store key to the
-provider session id and renders the same nodes the local source renders from the
-same items, asserted by building both presentations from one fixture and
-comparing them. The remote source supplies `terminalID: nil` to the card
-context, so no truncation footer renders and no item-full-body RPC is issued
-even for an item marked truncated. Opening an item from a remote transcript
-resolves through the session-keyed overlay path and finds the item, including one
-nested in a subagent thread. A `file:` link in a remote transcript is discarded
-rather than pushing a file frame or reaching the system handler, while the same
-link in a local transcript still pushes a frame. The first fetch renders the
-loading state rather than an empty list, an incomplete stream renders what
-arrived and fetches again from the returned cursor, and a failed fetch renders
-the error state with Retry rather than an empty list. The poll cadence is driven
-through the injected clock in virtual time, with no wall-clock sleep in the test.
+**Archive's three branches.** A provider declaring `archive` has the verb called
+and then its row marked `archived`; one declaring only `stop` has `stop` called
+and then its row marked; one declaring neither has its row marked with **no**
+provider invocation at all, asserted against a fake invoker that records every
+verb it was asked for. Each branch ends with the row `archived`. The row-only
+branch writes no actuation row, while the two verb branches write theirs. The
+`working` and dirty-checkout guards refuse the `stop` branch and the
+`archive`-with-`stop` branch, and never refuse the row-only branch — including
+against a lane whose `agent_state` is `working`, which is the assertion that
+would fail if the guards were applied to the path that ends nothing.
+
+**The row-only branch is honest on screen.** The archived cloud lane's copy names
+the session as still running and never claims a stop, a teardown or a
+provider-side retirement — asserted on the composed string rather than on a
+substring blacklist, so a rewording that reintroduces the claim fails.
+
+**Unarchiving a row-only archive.** Revive on that lane flips the row back to
+`active` and invokes nothing on the provider, and the lane returns with the same
+id, origin, branch, parent edge and children. Revive on a local worktree still
+runs the whole local path, so the branch did not swallow it.
+
+**Each fence, after.** `worktree.archive` on a remote row archives it instead of
+returning its refusal string; on a local row it behaves exactly as today. A
+remote row with an active child is refused by `assertArchivable` in both the
+local and remote arms alike. `worktree.forget` on a remote row still refuses.
+`AutoArchiveOnMergeCoordinator.handleMergedTransition` still returns `false` for
+a remote row and still archives a local one.
+
+**`visibleWorktrees` drops an archived remote row.** A remote row flipped to
+`archived` leaves the visible set, and the same row while `active` stays in it —
+the assertion that the location-blind filter needed no change. The archived
+lane then appears in the Archived list under the default `hideEmpty` filter,
+which it would not under the filter as written today.
 
 **Land's precondition failures each leave the row unchanged.** A remote mismatch,
 a branch missing on the remote, an occupied target path, and a branch already
@@ -1265,8 +1477,9 @@ each leaves the row `.remote` at its synthetic path with its origin, display nam
 parent edge and children intact. A `branch` beginning with `-` and an
 `ext::`-style `remote_url` are both rejected before reaching git. On success the
 same row id comes back `.local` at a real path with everything else preserved and
-no second row for the session; the provider session is archived and never stopped;
-a failed archive after a successful conversion leaves the row landed and reports.
+no second row for the session. No provider verb is invoked by the landing at
+all — asserted against a fake invoker — since cloud declares neither `archive`
+nor `stop`, and the landed row states that its session is still running.
 
 **Version negotiation.** A provider declaring `[1, 2]` negotiates 2, one declaring
 `[1]` negotiates 1, one declaring `[2]` alone negotiates 2 rather than being
@@ -1289,13 +1502,7 @@ for it; a verb naming a registered provider still goes through the runner; a
 registry entry claiming the reserved name is skipped and flagged while every other
 entry in the file still loads, with and without the cloud flag on.
 
-**The transcript boundary.** Every read reaches `TranscriptParser` through the one
-resolver; a path under the Claude projects store and a path under the TBD-owned
-root are both accepted; anything else is refused, including a traversal that
-escapes either root after normalization; the refusal holds for every entry point
-alike, so one added later cannot be reached unguarded.
-
-## 9. Work order
+## 10. Work order
 
 **Nothing opens a pull request until the whole path works end to end.** The order
 below minimizes rework; it is not a sequence of independently shippable
@@ -1305,28 +1512,30 @@ provider with no flag to gate it.
 
 1. **The shared model change (§2).** Origin field, record mapping, round-trip
    tests. Everything downstream reads provenance, and every later step written
-   against the current erasing mapping would have to be rewritten.
+   against the erasing mapping would have to be rewritten.
 2. **Contract v2 negotiation (§3).** Accept a `[2]`-only provider, store the
    negotiated major, thread it to the runner and the events supervisor, publish it
    on `RemoteProviderStatus`. The cloud provider cannot be described at all until
    this lands, so writing it first means writing it against a guard that rejects
    it.
-3. **Pseudo-terminal mode in the bounded process runner (§3).** One opt-in stdio
+3. **Snapshot completeness (§3).** `complete` on the `list` envelope, honored in
+   `RemoteSessionStore.applySnapshot`: no `missingCount`, no freshness in either
+   store, adoption and health unchanged. The built-in provider's snapshots are
+   always incomplete, so a provider written before this lands would mark its own
+   lanes `gone` two polls after creating them.
+4. **Pseudo-terminal mode in the bounded process runner (§3).** One opt-in stdio
    mode on `runBoundedProcess`, with its deadline, drain and single-resume
    properties re-asserted under it. `create` cannot be written against a pipe at
    all, so writing the provider first would mean writing it against a spawn that
    refuses every invocation.
-4. **The transcript-root choke point (§5).** One resolver, every `TranscriptParser`
-   entry point behind it. The TBD-owned root cannot be admitted safely before the
-   boundary is actually checked.
-5. **The flag and its capabilities plumbing (§7).** Migration, record, model,
+5. **The flag and its capabilities plumbing (§8).** Migration, record, model,
    `DaemonCapabilitiesResult`, Settings toggle. The provider is constructed behind
    this flag, so the flag exists first or the construction has to be rewired.
-6. **The dispatcher and the provider's `describe`, `create` and `list` (§3).**
-   Including the ledger table, its union rules, the create-output parse and the
-   one out-of-band `list` a successful create triggers. Until a cloud session can
-   be created and enumerated there is no row to route, watch or land, so this is
-   the step that makes every later one testable by hand.
+6. **The dispatcher and the provider's `describe`, `create`, `list` and `send`
+   (§3).** Including the ledger table, the create-output parse and the one
+   out-of-band `list` a successful create triggers. Until a cloud session can be
+   created and enumerated there is no row to route, steer, land or archive, so
+   this is the step that makes every later one testable by hand.
 7. **The create surface.** A repository already has a remote-create entry point:
    `RepoSectionView.newRemoteSessionMenuItem`
    (`Sources/TBDApp/Sidebar/RepoSectionView.swift`:430-444) enumerates
@@ -1337,29 +1546,29 @@ provider with no flag to gate it.
    — the affordance a user already reaches for to start a lane. Both entries are
    omitted, not disabled, when the flag is off, matching how capability-gated
    remote items are already omitted rather than grayed out.
-8. **Routing (§4).** The derived remote selection and its two call sites. Only
-   observable once a cloud row exists, which is why it follows step 6.
-9. **The transcript source seam (§5).** Re-key `TableTranscriptPaneView` on a
-   `TranscriptSource`, rename the overlay's session parameter, add the
-   file-link flag, move the poll loop onto an injected clock — all with the
-   local source as the only case that exists. This is a change to a load-bearing
-   local rendering path, so it lands and is proven against the path it already
-   serves *before* a second source can be blamed for a regression in it.
-10. **The watch surface (§5).** The `transcript` verb, the `remote.transcript`
-    handler, the remote source arm, the new tab with its gate arm and the
-    placeholder-tab change, and — in the same pass, because they share the one
-    `RemoteProviderStatus` lookup — the negotiated major, the attach argv and the
-    attach block reaching the app, alongside the attach exit-class correction the
-    block depends on.
-11. **Land (§6).** The `Context` plumbing with the filesystem fix in the same edit,
-    the `worktree.land` RPC, preconditions, in-place conversion, and the follow-up
-    archive.
+8. **Routing, and the row's uncertainty indicator (§4, §3).** The derived remote
+   selection and its two call sites, plus the suffix indicator that keeps a
+   permanently `unknown` lane from rendering as an idle one. Only observable once
+   a cloud row exists, which is why it follows step 6 — and the send field needs
+   nothing beyond the routing, since its gate already passes for this provider.
+9. **Attach readiness (§5).** The negotiated major, the attach argv and the
+   attach block reaching the app through the one `RemoteProviderStatus` lookup,
+   alongside the attach exit-class correction the block depends on. They land
+   together because they share that lookup.
+10. **Archive (§7).** The remote arm of `worktree.archive` and of revive, the
+    capability composition, the row copy, the Archived list's filter, and the two
+    fences that stay. It precedes Land because Land's honesty about the surviving
+    cloud session is the same statement this step has to get right, and because a
+    lane created in step 6 is otherwise stuck in the tree for the rest of the
+    build.
+11. **Land (§6).** The `Context` plumbing with the filesystem fix in the same
+    edit, the `worktree.land` RPC, preconditions, and the in-place conversion.
 
 Step 11 last because it is the only step that mutates a row's location, so every
 earlier step is exercised against a stable lane before the conversion is
 introduced into the mix.
 
-## 10. The vendor CLI surface, as measured
+## 11. The vendor CLI surface, as measured
 
 Everything in this section is measured behavior of `claude` 2.1.233 on macOS.
 The rest of this document is written to it, and each finding's consequence is
@@ -1395,11 +1604,16 @@ those lines are the only channel the session id travels on. §3 specifies the
 parse and what a change in that format costs.
 
 **The title is derived server-side, not echoed back.** A description of
-"transcript persistence probe: reply with the single word pong" comes back
-titled "Add probe pong reply". A
-cloud session's name is the vendor's summary of the instruction, not the
-instruction, so TBD reads it from `list`/discovery and never assumes it matches
-what was sent (§3).
+"transcript persistence probe: reply with the single word pong" comes back titled
+"Add probe pong reply", and that title is on the created-session line rather than
+in any structured field TBD can read. A cloud session's name is the vendor's
+summary of the instruction rather than the instruction, so TBD takes a name only
+from a provider payload that carries one and never from what was sent — which in
+this slice means every cloud lane wears its session id (§3). Taking the
+title out of that line instead is a format dependency with no cross-check: the id
+has a strict shape and appears three times, so a parse that finds none or finds
+two different ones is detectable, while a display string lifted out of prose is
+wrong silently the first time the sentence is reworded.
 
 ### `send` behaves exactly as the parent design specifies
 
@@ -1450,27 +1664,28 @@ the host store (`~/.claude/projects`) and the profile store
 (`$CLAUDE_CONFIG_DIR/projects`) are two different places a session could have
 landed.
 
-So **the `transcript` verb carries the entire watch story.** Nothing is seeded
-locally for free, and nothing has to be redirected to keep a cloud conversation
-out of the local session store. That is why §5's transcript path is the only
-source of conversation data, and why the Transcript tab is the watch surface
-rather than a convenience beside attach.
+So **nothing about a cloud conversation reaches this machine on its own.**
+Nothing is seeded locally for free, and nothing has to be redirected to keep a
+cloud conversation out of the local session store. That is the other half of why
+there is no watch surface in this slice (§1): not only is there no supported
+interface to read the conversation from, there is no local artifact of it either.
 
 Whether a *successful* attach would write one is untested rather than refuted —
 attach could not run at all under the account gate above. It is moot for the
 default state, since an account without the entitlement never attaches and so
 never writes. If the entitlement is granted and an attach does write locally, the
-consequence is the parent design's: the attach process must be pointed at the
+consequence is the parent design's: the attach process must be pointed at a
 TBD-owned root, or a cloud conversation surfaces as a local session of whichever
 worktree the pane ran in. `handleSessionList`
 (`Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift`:9-22) resolves a
 projects directory from the worktree's path (:16) and hands it to
 `ClaudeSessionScanner.listSessions(projectDir:)` (:20), so anything written under
 that resolved root is indistinguishable from a local session of that lane.
-Pointing attach elsewhere is one environment entry on the attach spawn, and the
-TBD-owned root already exists for the verb's output.
+Pointing attach elsewhere is one environment entry on the attach spawn, and it
+is the first thing to check on an entitled account rather than something to
+discover from a stray session row.
 
-## 11. Rejected alternatives
+## 12. Rejected alternatives
 
 **Provenance as a payload on `WorktreeLocation.local`.** The same fact expressed
 in the same enum, which is superficially tidier — one value answers both
@@ -1510,23 +1725,29 @@ worth building when the resolution ladder's lower tiers land and there is
 something for it to resolve; until then it would be a second surface with one
 option on it.
 
-**A second, simpler transcript view for remote lanes.** A `RemoteTranscriptTabView`
-beside `RemoteLogTabView` — call `remote.transcript`, receive parsed
-`TranscriptItem`s, render them in a plain scroll view — touches none of the local
-rendering path and would ship sooner. Rejected on what the cloud lane would then
-be: a session with no `log`, no attach guarantee, and a transcript that is its
-entire watch surface, shown through a renderer with no tool cards. A local lane's
-Edit card carries a diff, its Bash card a command and its output, its Agent card a
-drill-in to the subagent thread; a cloud lane would get prose in place of every
-one of those, which would not read as a lesser second view — it would read as the
-feature. Two renderers over one record format is also a standing tax: every tool
-card improvement lands in one of them, and the other decays quietly until someone
-notices. The cost that made this look attractive is smaller than it appears —
-`TableTranscriptView` and its height cache are already source-agnostic and already
-serve a non-terminal caller in `HistoryPaneView`, so what has to change is the
-resolution above the renderer, not the renderer. The field evidence that would
-reopen it: the source seam proving unable to express a provider that reports
-something the local path cannot, which would mean the two paths were never one.
+**Building against the undocumented claude.ai endpoints.** They are there, the
+web client uses them, and they would answer every question this slice has to do
+without: which sessions the account has, what each one is called, what its agent
+is doing, what the conversation says, and whether attach is permitted. Taking
+them would turn a ledger into an inventory and a blank pane into a transcript.
+
+Rejected on terms rather than on taste. Anthropic's Consumer Terms bar automated
+access to the Services outside the carve-out for use of an Anthropic API key, and
+a cloud session is reachable only under a subscription login — so there is no
+key-shaped route to the same data and no configuration in which such a client is
+inside the terms. A tool that quietly puts its users outside the terms of the
+account they are signed into is not a tool this repository ships, and the cost
+falls on the user rather than on TBD.
+
+Two lesser reasons agree with the first without being needed by it. An
+undocumented endpoint has no compatibility promise, so the feature would break on
+a deployment nobody announced, in a way the user would read as TBD being broken.
+And the boundary is the load-bearing part of the design: the whole point of
+`describe` being static, `list` being ledger-only and attach being learned from
+an exit code is that every one of them holds against a supported interface. What
+would reopen this is a supported interface — a documented endpoint, an
+API-key-authenticated route, or a stated permission — not a smaller or more
+careful scraper. Anything short of that changes the risk's size, not its kind.
 
 **Making `describe` dynamic so `attach` is declared only when the account is
 entitled.** The capability list would then tell the exact truth about what is
@@ -1538,13 +1759,6 @@ the Attach segment appear and vanish rather than explain itself. Capability
 answers what a provider implements; entitlement answers whether this account may
 use it, which is the same shape as a credential having expired and belongs on the
 same runtime path.
-
-**A per-provider streaming transcript follow instead of cursor polling.** A live
-stream would remove the refresh latency the tab has. Rejected on supervision
-shape: a per-session stream is one process per session rather than one per
-provider, which the contract's `events` design already declined for the same
-reason. Cursor polling first; the evidence that would justify a stream is the
-polling interval being visibly wrong in use.
 
 **Synthesizing a `RemoteProviderConfig.exec` that composes into the right attach
 command.** Setting `exec` to the resolved `claude` path and `args` to `["--cloud"]`

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -71,7 +71,8 @@ are the reason the watch surface is not in it.
   those endpoints would put TBD's users outside the terms of the account they
   are signed into, for a feature they can already reach in a browser. This is a
   design constraint rather than a gap awaiting an implementation: `list` is
-  ledger-only (§3) because of it, and adding a scraper is not the fix.
+  ledger-only (§3) because of it, and archive retires a session from that same
+  ledger rather than from the account (§7), and adding a scraper is not the fix.
 - **Interactive attach is gated per account.** The vendor CLI branches on a
   server-side flag (`tengu_remote_backend`) that defaults off and carries no
   local override; the documented remedy is to ask the account team to enable it
@@ -217,18 +218,22 @@ test). Mechanisms compile.
 
 **What `describe` declares.** `contract_versions: [2]` only — nothing exposed
 terminates a running cloud session, so the provider cannot implement `stop`, and
-major 1 requires it. Capabilities are `send`, `attach` and `land`. Five
-capability names are deliberately **not** declared, and each absence is a fact
-about the surface rather than an unimplemented verb:
+major 1 requires it. Capabilities are `send`, `attach`, `land`, `archive` and
+`unarchive`. Three capability names are deliberately **not** declared, and each
+absence is a fact about the surface rather than an unimplemented verb:
 
 - **`stop`** — nothing exposed terminates a running cloud session.
 - **`log`** — a cloud session has no terminal to scroll.
 - **`transcript`** — no supported interface reads a cloud session's conversation
   (§1).
-- **`archive` and `unarchive`** — the account's archive operation lives on the
-  undocumented surface TBD does not use (§1). Archiving a cloud lane is
-  therefore a filing change in TBD alone, which is exactly the third branch of
-  the archive composition and is specified in §7.
+
+**`archive` and `unarchive` are implemented against the provider's own ledger.**
+`archive` sets the archived flag on the `claude_cloud_session` row named by the
+id and returns the updated session; `unarchive` clears it. Both are idempotent,
+neither removes the row, and `list` goes on enumerating the session — reporting
+it with `archived: true` — which is what the contract requires of every provider.
+§7 carries the reasoning, including what this does not do to the session on
+Anthropic's side.
 
 `create_params` are `repo`, `branch`, `prompt` and `environment`, the last typed
 `string` because `describe` answers offline and the set of configured cloud
@@ -250,6 +255,9 @@ subsection specifies. `send` posts one message through
 matching the id sent is the success condition. `attach` runs
 `claude --cloud <id>` on the pane's PTY. `land` reports the session's repository
 and branch with a `resume_command` of `claude --teleport <id>` and `forks: true`.
+`archive` and `unarchive` write the archived flag on the ledger row and return
+the updated session; neither invokes the vendor CLI at all, because the ledger is
+the inventory they file within (§7).
 
 **`send` implements the contract's byte interface on top of that call.** The
 contract's `send` takes stdin bytes destined for a terminal and requires the
@@ -279,10 +287,17 @@ No supported interface enumerates an account's cloud sessions (§1), so `list`
 answers from the `claude_cloud_session` ledger alone: one row per session this
 machine created, carrying the session id, the title parsed at create time
 (below), the idempotency key and its state, the creation time, the repository
-path, the branch, and the parameters used. Every
-snapshot it returns declares **`complete: false`**, permanently and by
-construction, because the ledger is a record of what TBD started and never a
-claim about the account's inventory.
+path, the branch, the parameters used, and the archived flag that `archive` and
+`unarchive` write (§7). Every snapshot it returns declares **`complete: false`**,
+permanently and by construction, because the ledger is a record of what TBD
+started and never a claim about the account's inventory.
+
+**Archived sessions stay in that answer.** The contract requires a provider to
+return archived sessions from `list` exactly as it returns active ones, on the
+ground that a session filtered out of successive snapshots is indistinguishable
+from a deleted one and would be silently marked gone. So archiving a session
+flags its ledger row and never removes it, and every later `list` keeps
+reporting that id with `archived: true`.
 
 **That is safe by construction rather than by care.** The contract's rule for an
 incomplete snapshot is that a caller may add, update and adopt on the strength of
@@ -754,8 +769,10 @@ unmodified.
 
 The one case worth naming is a **gone** cloud lane, which drops attach and leaves
 the tab list empty, reaching the view's existing "doesn't support attach or a log
-view" empty state. That state is not reachable in practice, since nothing retires
-a cloud session (§3), and it is the right answer if it ever is: with attach gone
+view" empty state. That state is not reachable in practice, since a cloud session
+never stops being listed (§3) — archiving one leaves it enumerated with
+`archived: true`, and `gone` is a different axis — and it is the right answer if
+it ever is reached: with attach gone
 there is genuinely nothing to put in the content area, while the row itself goes
 on saying what it knows.
 
@@ -1063,28 +1080,44 @@ a half-converted row, and the lane is exactly as it was.
 
 Landing is always a user gesture and is never triggered by session state.
 
-**After the conversion, the cloud session keeps running, and the lane says so.**
-`land` reports `forks: true`, so the landed checkout and the session diverge from
-this moment; the parent design's answer to that is to retire the session where
-the provider can, and to leave it running and say so where it cannot. Cloud
-cannot: it declares neither `archive` nor `stop` (§3), so there is nothing to
-call. The landed row therefore carries its origin (§2) and states plainly that
-the session it came from is still in the account's working set, where the user
-can archive it on claude.ai. TBD never *stops* a session on landing whatever a
-provider declares — landing is a "bring this home" gesture, not a teardown, and
-the remote box may still hold work that was never pushed.
+**Landing archives the session it came from, and never stops it.** `land`
+reports `forks: true`, so the landed checkout and the session diverge from this
+moment: the work is on this machine now, and a session nobody will return to
+should not sit in the working inventory. The parent design's rule is to retire it
+where the provider declares `archive`, and cloud declares it (§3), so landing
+calls that verb — one invocation, on the same in-process ledger path §7
+specifies, marking the ledger row archived. TBD never *stops* a session on
+landing whatever a provider declares: landing is a "bring this home" gesture,
+not a teardown, and the remote box may still hold work that was never pushed.
+
+**That retirement is within TBD's inventory, not Anthropic's, and the lane says
+so.** The cloud session keeps running on Anthropic's infrastructure and keeps
+consuming whatever it consumes; nothing in the landing reaches it. The landed row
+therefore carries its origin (§2) and states plainly that the session it came
+from is still running, naming claude.ai as where a person can retire it there. §7
+carries the whole of why the ledger is the inventory a cloud archive files within.
+
+**The archive follows step 5 and cannot undo it.** It is the one part of landing
+that runs after the row is converted, and a failure there is reported on the row
+rather than rolled back: the files are here and the lane is local, so unwinding a
+completed landing over a bookkeeping call would be the worse outcome. That is
+also why the preconditions above are checked before anything is created — every
+step that *can* fail the landing does so before the row moves.
 
 Nothing about the session travels back to the row after the conversion. A row
 whose files are on this machine takes its status from TBD alone, whatever a
-provider later reports about the session that row once ran on.
+provider later reports about the session that row once ran on — including the
+`archived: true` the landing itself just wrote, which is why the landed lane stays
+`active` and in the working set rather than following that flag into the Archived
+list.
 
 ## 7. Archiving a remote lane
 
 Archive retires a lane from the working set, and a cloud lane needs the gesture
 more than a local one does: nothing else takes it out of the tree. Retirement
-driven by the provider needs a complete snapshot and there is never one (§3), so
-a cloud lane that has been landed, abandoned, or answered stays in the active
-tree until a person files it away.
+driven by drift needs a complete snapshot and there is never one (§3), so a cloud
+lane that has been abandoned or answered stays in the active tree until a person
+files it away.
 
 **TBD offers that gesture today and refuses it.** `RowActionMenu.regularItems`
 (`Sources/TBDApp/Helpers/RowActionMenu.swift`:357-390) puts Archive in the first
@@ -1159,44 +1192,85 @@ marked; one declaring only `stop` has the session stopped and then the row
 marked; one declaring neither has the row marked and nothing else, with the
 session left running and the UI saying so.
 
-**`claude-cloud` takes the third branch, and takes it permanently.** It declares
-neither `archive` nor `unarchive` — the account's archive operation lives on the
-undocumented surface TBD does not build against (§1) — and it declares no `stop`,
-because nothing exposed terminates a running cloud session. So archiving a cloud
-lane calls nothing at all: it is a filing change inside TBD, and the session goes
-on existing exactly as it did.
+**`claude-cloud` takes the first branch.** It declares `archive` and `unarchive`
+(§3), so archiving a cloud lane calls the verb and then marks the row. The verb
+is implemented against the provider's own ledger: it sets the archived flag on
+the `claude_cloud_session` row, and every subsequent `list` reports that session
+with `archived: true`. Nothing is sent to Anthropic. `unarchive` clears the flag.
 
-**What the row shows, so nobody reads it as a teardown.** An archived cloud lane
-says, in the Archived list and in its detail header, that it was filed away here
-and that the cloud session is still in the account's working set, naming
-claude.ai as where to retire it for real. The words to avoid are the ones the
-local path earns: nothing was stopped, closed, torn down, or cleaned up. The one
-sentence a user needs is that TBD stopped showing the lane and Anthropic did not
-stop the session.
+Four properties make that a real retirement rather than a costume:
+
+- **`archived` is defined as retirement from the working inventory.** The
+  contract states it as a filing axis orthogonal to liveness — a session may be
+  archived while its machine is still winding down, and may never become archived
+  implicitly because it exited, went idle, or aged out. So a provider that
+  archives without touching liveness is doing precisely what the field means, and
+  a caller is forbidden from reading `archived: true` as "stopped" in the first
+  place.
+- **The row is flagged, never removed.** Contract v2 requires archived sessions
+  to stay enumerated by `list` and in the `events` snapshot, because a session
+  filtered out of successive snapshots is indistinguishable from a deleted one
+  and would be silently marked gone, and because an inventory a caller cannot
+  enumerate is an inventory it cannot browse to revive from. The ledger honors
+  that by construction: archiving writes a column.
+- **For this provider the ledger is the whole inventory.** No supported interface
+  enumerates an account's cloud sessions, so what TBD started is all the provider
+  ever holds — which is why `list` is permanently `complete: false` (§3). The
+  retirement is therefore real within the only inventory that exists for it, and
+  no layer contradicts another: `list` says `archived: true`, the worktree row
+  says archived, and the two agree.
+- **The capability is already the right shape for more.** If a supported endpoint
+  for retiring a cloud session appears, the same declared capability calls it
+  instead and nothing else in this design moves — not the composition, not the
+  row, not revive. That is why the contract is capability-gated rather than
+  assuming every provider can do everything.
+
+**What it does not do, stated plainly.** It does not archive the session on
+Anthropic's side. The cloud session keeps running there, keeps whatever work it
+was doing, and keeps consuming whatever it consumes. The reason is a platform
+constraint: no programmatically reachable and permitted surface retires a cloud
+session. The claude.ai web application does retire them, through an undocumented
+endpoint authenticated by a subscription session cookie, which Anthropic's
+Consumer Terms bar automated access to outside the API-key carve-out — so TBD
+does not build against it (§1, §12).
+
+**So the row and the confirmation say both halves.** An archived cloud lane says,
+in the Archived list and in its detail header, that it was filed away in TBD and
+that the cloud session is still running on Anthropic, naming claude.ai as where a
+person can retire it there. The confirmation copy for the gesture says the same
+before the user commits to it. The words to avoid are the ones the local path
+earns: nothing was stopped, closed, torn down, or cleaned up, and a user is never
+left believing the cloud session was retired or halted. The one sentence a user
+needs is that TBD filed the lane away and Anthropic did not stop the session.
 
 **The termination guards do not apply.** The 08-10 design scopes the `working`
 guard and the dirty-remote-checkout guard to the paths that actually end a
 session — the `stop` path always, and the `archive`-verb path where the same
 provider also declares `stop` — because destroying unpushed work is the only
-thing they defend against. A row-only archive destroys nothing, so it is never
-refused on those grounds. Nothing here relaxes a guard; the guarded branches are
-simply not the branch cloud takes.
+thing they defend against. A provider declaring `archive` without `stop` is taken
+at its word: it has said it cannot terminate a session, so archiving through it
+is a filing change and is not guarded. `claude-cloud` is exactly that provider,
+and its archive destroys nothing. Nothing here relaxes a guard; the guarded
+branches are simply not the branch cloud takes.
 
-**No actuation row is written for a row-only archive.** `.worktreeArchive` maps
-to the `dispose` kind (`Sources/TBDDaemon/Actuation/ActuationSurface.swift`:150-151),
-and this branch disposes of nothing: it kills no process and ends no session. The
-precedent is the 08-10 design's forced `repo.remove`, which cascades local
-worktrees and writes no actuation row for the remote lanes it drops, because none
-of their sessions were torn down and the record may only claim acts that were
-attempted. The branches that do call a provider verb record theirs as they would
-for any other actuated act.
+**Which branches write an actuation row.** `.worktreeArchive` maps to the
+`dispose` kind (`Sources/TBDDaemon/Actuation/ActuationSurface.swift`:150-151), and
+the record may only claim acts that were attempted. The branches that call a
+provider verb record theirs as they would for any other actuated act, cloud
+included — its `archive` was invoked and it acted on the inventory it owns. The
+branch that calls nothing writes nothing: the precedent is the 08-10 design's
+forced `repo.remove`, which cascades local worktrees and writes no actuation row
+for the remote lanes it drops, because none of their sessions were touched.
 
 ### What happens to the mirror row, and to the next `list`
 
-**The `remote_session` mirror row is untouched.** It is provider-owned liveness —
-what the manager last observed — while `worktree.status` is TBD's own filing
-decision, and archiving a lane is the second of those. Keeping the mirror is what
-lets an archived lane still say whether its session is still being listed.
+**The archive gesture writes no `remote_session` mirror row.** The mirror is
+provider-owned liveness — what the manager last observed — while
+`worktree.status` is TBD's own filing decision, and archiving a lane is the
+second of those. The mirror moves only when a snapshot moves it, so the flag the
+provider's `archive` set reaches it on the next `list` like any other payload
+field, and the two then agree. Keeping the mirror is what lets an archived lane
+still say whether its session is still being listed.
 
 **The next snapshot does not resurrect the lane.** `RemoteSessionAdopter.adoptOne`
 (`Sources/TBDDaemon/Remote/RemoteSessionAdopter.swift`:98-102) ends adoption for
@@ -1205,11 +1279,16 @@ the payload now says" — so a session that keeps appearing in every `list` afte
 its lane was archived mints nothing and changes nothing.
 
 **Nor does it un-archive it.** The parent design's mirroring of a payload's
-`archived` flag onto the row is not in this slice, and could not act here if it
-were: the ledger reports no such flag, and a provider that never learns TBD filed
-a lane away would report `archived: false` forever. When that mirroring does land
-with discovery, it carries a provider's own filing state and therefore applies
-only where the provider holds one — which is to say, where it declares `archive`.
+`archived` flag onto the row is not in this slice. When it does land it carries a
+provider's own filing state, and for a cloud lane that is still remote the two
+sides agree by construction: the archive gesture wrote the ledger flag, so every
+later `list` reports `archived: true` for a lane whose row is archived, and
+`archived: false` for one whose row is active. Mirroring reaches remote rows only,
+which is what keeps the session archived by a landing (§6) from filing away the
+local lane the user is about to work in. A provider that could not hold the filing
+state — one declaring no `archive` — is the case mirroring must leave alone,
+because it would report `archived: false` forever about a lane a person
+deliberately filed.
 
 `remote.dismiss`'s `dismissed` column stays a separate axis: it hides a bare
 session row from the Provider Desk and says nothing about a lane. Archiving a
@@ -1236,20 +1315,23 @@ sessions, and it is simply not true of a lane whose conversation is on a server.
 
 ### Unarchive is the same branch, run backwards
 
-Reviving a lane archived by the row-only branch flips the row back and calls
-nothing, which is the 08-10 design's first revive case: nothing was retired on
-the provider, so there is nothing to undo there. `WorktreeStore.revive(id:)`
+Reviving a cloud lane calls `unarchive` and then flips the row back to `active`,
+which is the 08-10 design's `unarchive` revive case: the retirement was a fact on
+the provider's inventory, and lifting it there is what makes both sides agree
+again. `WorktreeStore.revive(id:)`
 (`Sources/TBDDaemon/Database/WorktreeStore.swift`:709-721) is location-blind and
 does the flip; `beginReviveWorktree` is not — it resolves through `getLocal` and
 then materializes a directory — so revive branches on location exactly as archive
-does, and the remote arm is the row flip alone.
+does, and the remote arm is the provider call plus the row flip, with no
+directory to materialize.
 
 The lane comes back saying what it knew before: its state is `unknown`, its name
 is whatever it was minted with — the parsed title or the session id fallback
-(§3) — and whether the session is still there is what the mirror row
-answers. The 08-10 design's other revive cases — an `unarchive` verb, a
-terminated session, a retirement TBD cannot lift — describe providers cloud is
-not, and they arrive with the providers that declare those capabilities.
+(§3) — and whether the session is still there is what the mirror row answers.
+Nothing had to be restarted, because nothing was ever stopped. The 08-10 design's
+other revive cases — a provider that retired nothing, a terminated session, a
+retirement TBD cannot lift — describe providers cloud is not, and they arrive
+with the providers that declare those capability shapes.
 
 ### `worktree.forget` stays refused
 
@@ -1276,11 +1358,11 @@ lands a remote lane carries no PR status and reaches no merged transition.
 
 Second, when the badge does come back, an automatic archive of a lane whose
 session keeps running is a background mutation with no user gesture behind it —
-filing away a lane whose agent may still be working, in the one branch of the
-composition where TBD cannot even ask the provider what state it is in. That is
-the shape the repository's default-off rule exists for, and the honest row state
-("archived here, still running there") is one a person should be choosing. The
-guard's comment changes to say this; the guard does not.
+filing away a lane whose agent may still be working, and for a cloud lane whose
+`agent_state` is permanently `unknown` (§3), TBD cannot even ask what state it is
+in. That is the shape the repository's default-off rule exists for, and the
+honest row state ("archived here, still running there") is one a person should be
+choosing. The guard's comment changes to say this; the guard does not.
 
 ## 8. The flag
 
@@ -1474,22 +1556,36 @@ reconnect included.
 and then its row marked `archived`; one declaring only `stop` has `stop` called
 and then its row marked; one declaring neither has its row marked with **no**
 provider invocation at all, asserted against a fake invoker that records every
-verb it was asked for. Each branch ends with the row `archived`. The row-only
-branch writes no actuation row, while the two verb branches write theirs. The
-`working` and dirty-checkout guards refuse the `stop` branch and the
-`archive`-with-`stop` branch, and never refuse the row-only branch — including
-against a lane whose `agent_state` is `working`, which is the assertion that
-would fail if the guards were applied to the path that ends nothing.
+verb it was asked for. Each branch ends with the row `archived`. The branch that
+calls nothing writes no actuation row, while the two verb branches write theirs.
+The `working` and dirty-checkout guards refuse the `stop` branch and the
+`archive`-with-`stop` branch, and never refuse either unguarded branch — the
+provider declaring `archive` without `stop`, which is cloud's shape, and the
+provider declaring neither. That is asserted against a lane whose `agent_state`
+is `working`, which is the case that would fail if the guards were applied to a
+path that ends nothing.
 
-**The row-only branch is honest on screen.** The archived cloud lane's copy names
-the session as still running and never claims a stop, a teardown or a
-provider-side retirement — asserted on the composed string rather than on a
+**The cloud ledger's archive round trip.** Archiving a cloud lane invokes
+`archive` on the built-in provider, the ledger row's archived flag is set, and
+the next `list` still returns that session — present in the snapshot, with
+`archived: true` — rather than omitting it, which is the assertion the contract's
+enumeration rule needs and the one whose failure would drive the session toward
+`gone`. `unarchive` clears the flag and the following `list` reports
+`archived: false`. Both verbs are idempotent: a second `archive` and a second
+`unarchive` each exit 0 and leave the flag where it was. Neither verb invokes the
+vendor CLI, asserted against the injected spawn seam.
+
+**The cloud archive is honest on screen.** The archived cloud lane's copy, and
+the confirmation copy shown before the gesture, both name the session as still
+running on Anthropic and never claim a stop, a teardown, or a retirement of the
+session on Anthropic's side — asserted on the composed string rather than on a
 substring blacklist, so a rewording that reintroduces the claim fails.
 
-**Unarchiving a row-only archive.** Revive on that lane flips the row back to
-`active` and invokes nothing on the provider, and the lane returns with the same
-id, origin, branch, parent edge and children. Revive on a local worktree still
-runs the whole local path, so the branch did not swallow it.
+**Unarchiving a cloud lane.** Revive on that lane invokes `unarchive` and flips
+the row back to `active`, and the lane returns with the same id, origin, branch,
+parent edge and children. Revive on a lane whose provider declares no `unarchive`
+flips the row and invokes nothing. Revive on a local worktree still runs the whole
+local path, so the branch did not swallow it.
 
 **Each fence, after.** `worktree.archive` on a remote row archives it instead of
 returning its refusal string; on a local row it behaves exactly as today. A
@@ -1511,9 +1607,12 @@ each leaves the row `.remote` at its synthetic path with its origin, display nam
 parent edge and children intact. A `branch` beginning with `-` and an
 `ext::`-style `remote_url` are both rejected before reaching git. On success the
 same row id comes back `.local` at a real path with everything else preserved and
-no second row for the session. No provider verb is invoked by the landing at
-all — asserted against a fake invoker — since cloud declares neither `archive`
-nor `stop`, and the landed row states that its session is still running.
+no second row for the session. The landing invokes `archive` and nothing else —
+asserted against a fake invoker that records every verb, so a `stop` would fail
+the test — the session's ledger row comes back `archived: true`, and the landed
+row stays `active` rather than following that flag into the Archived list. A
+landing whose `archive` fails still leaves the row converted and local. The landed
+row states that its session is still running on Anthropic.
 
 **Version negotiation.** A provider declaring `[1, 2]` negotiates 2, one declaring
 `[1]` negotiates 1, one declaring `[2]` alone negotiates 2 rather than being
@@ -1566,7 +1665,8 @@ provider with no flag to gate it.
    `DaemonCapabilitiesResult`, Settings toggle. The provider is constructed behind
    this flag, so the flag exists first or the construction has to be rewired.
 6. **The dispatcher and the provider's `describe`, `create`, `list` and `send`
-   (§3).** Including the ledger table, the create-output parse and the one
+   (§3).** Including the ledger table — with its archived column, so step 10 adds
+   verbs rather than a second migration — the create-output parse and the one
    out-of-band `list` a successful create triggers. Until a cloud session can be
    created and enumerated there is no row to route, steer, land or archive, so
    this is the step that makes every later one testable by hand.
@@ -1589,14 +1689,16 @@ provider with no flag to gate it.
    attach block reaching the app through the one `RemoteProviderStatus` lookup,
    alongside the attach exit-class correction the block depends on. They land
    together because they share that lookup.
-10. **Archive (§7).** The remote arm of `worktree.archive` and of revive, the
-    capability composition, the row copy, the Archived list's filter, and the two
-    fences that stay. It precedes Land because Land's honesty about the surviving
-    cloud session is the same statement this step has to get right, and because a
-    lane created in step 6 is otherwise stuck in the tree for the rest of the
-    build.
+10. **Archive (§7).** The built-in provider's `archive` and `unarchive` verbs
+    over the ledger column from step 6, the remote arm of `worktree.archive` and of
+    revive, the capability composition, the row copy, the Archived list's filter,
+    and the two fences that stay. It precedes Land because Land calls `archive`
+    on the session it just landed and states the same thing about the surviving
+    cloud session that this step has to get right, and because a lane created in
+    step 6 is otherwise stuck in the tree for the rest of the build.
 11. **Land (§6).** The `Context` plumbing with the filesystem fix in the same
-    edit, the `worktree.land` RPC, preconditions, and the in-place conversion.
+    edit, the `worktree.land` RPC, preconditions, the in-place conversion, and
+    the follow-up `archive` of the landed session.
 
 Step 11 last because it is the only step that mutates a row's location, so every
 earlier step is exercised against a stable lane before the conversion is
@@ -1768,8 +1870,10 @@ option on it.
 **Building against the undocumented claude.ai endpoints.** They are there, the
 web client uses them, and they would answer every question this slice has to do
 without: which sessions the account has, what each one is called, what its agent
-is doing, what the conversation says, and whether attach is permitted. Taking
-them would turn a ledger into an inventory and a blank pane into a transcript.
+is doing, what the conversation says, whether attach is permitted, and how to
+retire a session on Anthropic's side. Taking them would turn a ledger into an
+inventory, a blank pane into a transcript, and a filing decision held here into
+one the account holds.
 
 Rejected on terms rather than on taste. Anthropic's Consumer Terms bar automated
 access to the Services outside the carve-out for use of an Anthropic API key, and
@@ -1778,6 +1882,16 @@ key-shaped route to the same data and no configuration in which such a client is
 inside the terms. A tool that quietly puts its users outside the terms of the
 account they are signed into is not a tool this repository ships, and the cost
 falls on the user rather than on TBD.
+
+**Declaring `archive` is not a way around that.** The verb files a session within
+the provider's own ledger — the only inventory this provider has, since nothing
+supported enumerates the account's (§3) — and sends nothing to Anthropic. The
+retirement the rejected endpoints would perform is the one the row explicitly
+says did *not* happen (§7). The two positions are the same position: TBD retires
+what it holds, states what it does not, and reaches no unsupported surface to
+close the gap. What would let a cloud archive reach Anthropic is the same thing
+that would reopen this alternative — a supported interface — and the declared
+capability is already the shape that would call it.
 
 Two lesser reasons agree with the first without being needed by it. An
 undocumented endpoint has no compatibility promise, so the feature would break on

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -1388,7 +1388,7 @@ autonomous background polling against a network service, squarely inside the
 default-off rule.
 
 **The column is added with no SQL default**, so unset stays a genuine third
-state. Migration `v78_config_claude_cloud` calls
+state. Migration `v80_config_claude_cloud` calls
 `addColumnIfMissing(table:column:type:)` with `defaults:` **omitted** —
 `v73_config_queued_prompt` (`Database.swift`:1334) and `v77_config_supervision_enabled`
 (:1406) are the precedents, and the long comment above the former states the

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -274,15 +274,26 @@ no terminal is the provider's business, and here it means enqueuing a message.
 Exit 0 keeps its contract meaning: handed to the transport, not acted upon.
 
 Create idempotency is the parent design's: the key and its state are written to
-the ledger before the invocation, and a pending row is expected during the
-daemon's single same-key retry rather than a reason to refuse it. What resolves a
-pending row here is the create that wrote it, since the parent design's
-discovery-driven resolution has no discovery to run against in this slice: a row
-whose create returned a readable session id resolves immediately, and one whose
-create failed both attempts stays `pending`, transitions to `failed` after ten
-minutes, and is surfaced as an unresolved create the user can act on. The row is
-retained rather than deleted on that transition, so the record of a create that
-may have started a real session outlives the judgement that it did not.
+the ledger before the invocation. A same-key replay never spawns the vendor CLI
+a second time — there is no discovery to reconcile two live cloud sessions
+started under one key, so a duplicate spawn would orphan whichever one the
+ledger does not end up naming, permanently. A replay against an already-
+`resolved` row returns the recorded session without spawning anything. A
+replay against a still-`pending` row — including the daemon's single same-key
+retry after a timeout — is refused with a transient (exit 3) failure instead,
+because the first attempt behind that row may still be running and there is no
+discovery to check either way; guessing by spawning again is exactly the
+duplicate this rule exists to prevent. What resolves a pending row is the
+create that wrote it, since the parent design's discovery-driven resolution has
+no discovery to run against in this slice: a row whose create returned a
+readable session id resolves immediately, and one whose create failed both
+attempts stays `pending`, transitions to `failed` after ten minutes, and is
+surfaced as an unresolved create the user can act on. Only once a row has
+reached `failed` — meaning the ledger has given up without ever recording a
+session — does a replay under the same key spawn again, reusing that row. The
+row is retained rather than deleted on the `failed` transition, so the record
+of a create that may have started a real session outlives the judgement that
+it did not.
 
 ### `list` is the ledger, and is permanently incomplete
 
@@ -429,16 +440,27 @@ that would resume it (§11). There is no JSON form — `--print` is refused
 alongside `--cloud` — so those lines are the only channel either the id or the
 title travels on.
 
-The provider strips ANSI control sequences from the captured output and takes
-the first token matching `session_[A-Za-z0-9]+`, requiring that every match in
-the output name the **same** id. All three printed lines carry it, so a single
-distinct id is the healthy case and disagreement is a signal, not noise.
+The provider strips ANSI control sequences from the captured output and reads
+the id only off the two lines whose id is structural — the ones beginning
+`View:` and `Resume with:` — taking the first token matching
+`session_[A-Za-z0-9]+` on each and requiring the two matches to agree. The
+first line, `Created cloud session: <title>`, is deliberately excluded from
+this scan even though it usually carries the same id: its `<title>` is the
+vendor's own server-derived summary of the user's submitted prompt, not a
+value with a fixed shape, and a prompt that itself names a
+`session_`-prefixed identifier — a filename, a variable, a session the user
+asked to resume — would otherwise produce a second, spurious match and fail a
+create that actually succeeded, orphaning a real cloud session with no
+discovery to ever recover it. Two independent witnesses that must agree is
+still the cross-check this design wants; it is just never in a position to
+read the user's own words as if they were the vendor's identifier.
 
 The same parse reads the title off the first line: everything after its
 `Created cloud session: ` prefix, trimmed. That line is prose, not a value with
 a shape to check, so the title parse cannot tell a reworded sentence from a
 missing one — it can only tell whether *this* prefix matched. Where the id parse
-protects itself with a strict shape checked three times over, the title parse
+protects itself with a strict shape checked twice over on the two structural
+lines, the title parse
 has no such cross-check, and it does not need one: below is why the two failure
 postures diverge instead of both failing loud.
 

--- a/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
+++ b/docs/specs/2026-08-15-cloud-sessions-slice-1-design.md
@@ -1,12 +1,18 @@
 # Claude cloud sessions, slice 1 — create, send, land, archive
 
 **Date:** 2026-08-15
-**Status:** Design, not yet implemented.
+**Status:** `describe`, `create`, `list` and `send` are shipped, with `attach`
+declared and implemented through a separate TTY-exec path. `land`, `archive` and
+`unarchive` are designed here (§6, §7) but ship in a later slice: `describe`
+deliberately does not declare either yet, because a capability list is the
+contract the app reads to decide which actions to offer, and declaring a verb
+that answers `not_implemented` would mean offering an action that always fails.
 **Scope:** The first end-to-end path through the cloud-sessions design: create a
-cloud session from a repo's `+` menu, see it as a row in that repo's tree, steer
-it by sending it messages (with an attach terminal beside the send field where
-the account is entitled to one), land it into a local worktree, and archive the
-lane when it is done.
+cloud session from a repo's `+` menu, see it as a row in that repo's tree, and
+steer it by sending it messages (with an attach terminal beside the send field
+where the account is entitled to one). Landing it into a local worktree and
+archiving the lane when it is done are designed in the same document, and ship
+once a later slice declares those two capabilities on the provider.
 **Parent design:** [`2026-08-07-claude-cloud-sessions-design.md`](2026-08-07-claude-cloud-sessions-design.md).
 Everything here is downstream of that document and contradicts none of it.
 **Also depends on:**
@@ -27,7 +33,7 @@ provider named `claude-cloud` that is compiled into the daemon rather than
 registered as an executable, and a session that resolves to a registered
 repository becomes a worktree row in that repository's tree like any other lane.
 
-This slice builds the shortest path that is genuinely useful, end to end:
+This document designs the shortest end-to-end path that is genuinely useful:
 
 - **Create.** A cloud session is created from the repository's `+` menu, behind
   a flag that ships off.
@@ -37,22 +43,30 @@ This slice builds the shortest path that is genuinely useful, end to end:
   send field posts a message to the session — the same field every other remote
   provider gets, over the provider's `send` verb. Where the account is entitled
   to it, an attach terminal sits beside it.
-- **Land.** A row action converts the lane in place from remote to local:
-  the branch is checked out on this machine, the row keeps its identity, and
-  the conversation resumes in the first pane.
-- **Archive.** A row action retires the lane from the working set, composing over
-  what the provider declares, and says honestly what it did and did not do to the
-  session behind it (§7).
+- **Land** (§6, a later slice). A row action would convert the lane in place
+  from remote to local: the branch checked out on this machine, the row
+  keeping its identity, and the conversation resuming in the first pane.
+- **Archive** (§7, a later slice). A row action would retire the lane from the
+  working set, composing over what the provider declares, and say honestly
+  what it did and did not do to the session behind it.
 
-**Done is create → send → land → archive.** Attach is implemented and declared,
-but whether a given account may attach to a running cloud session is an
-entitlement the vendor grants server-side, and it is off by default (§11). On an
-account without it the Attach pane shows a call to action naming the condition,
-rather than a terminal that dies on connect; on an account with it, attach works.
-The slice is complete either way — each of those four gestures works without
-attach — with one honest consequence: on an unentitled account TBD shows no reply
-to a send, because the reply is on Anthropic's servers and nothing supported
-reads it back (below).
+**This slice ships create → send, with attach declared and implemented through
+a separate TTY-exec path.** Whether a given account may attach to a running
+cloud session is an entitlement the vendor grants server-side, and it is off by
+default (§11). On an account without it the Attach pane shows a call to action
+naming the condition, rather than a terminal that dies on connect; on an account
+with it, attach works. The slice is complete either way — create and send both
+work without attach — with one honest consequence: on an unentitled account TBD
+shows no reply to a send, because the reply is on Anthropic's servers and
+nothing supported reads it back (below).
+
+**Land and archive are designed in this document (§6, §7) but ship in a later
+slice.** `describe` does not declare either capability yet: a capability list
+is the contract the app reads to decide which actions to offer, and declaring a
+verb that answers `not_implemented` would mean offering an action that always
+fails. The missing declaration makes those two paths fail closed correctly
+rather than reaching a stub. §6 and §7 exist so that later slice is a
+capability declaration and an implementation, not a redesign.
 
 ### What the platform exposes, and what TBD builds against
 
@@ -82,8 +96,9 @@ are the reason the watch surface is not in it.
   (§11).
 
 What is left is exactly the documented CLI — create, send, resume by teleport,
-and attach where the account is entitled — and that is enough for create → send
-→ land → archive.
+and attach where the account is entitled — and that is enough for this slice's
+create → send, and enough to design land and archive (§6, §7) against, even
+though declaring and shipping those two verbs is a later slice's work.
 
 Five things the parent design specifies are deliberately **out of scope here**:
 
@@ -221,22 +236,30 @@ test). Mechanisms compile.
 
 **What `describe` declares.** `contract_versions: [2]` only — nothing exposed
 terminates a running cloud session, so the provider cannot implement `stop`, and
-major 1 requires it. Capabilities are `send`, `attach`, `land`, `archive` and
-`unarchive`. Three capability names are deliberately **not** declared, and each
-absence is a fact about the surface rather than an unimplemented verb:
+major 1 requires it. Capabilities are `send` and `attach`. Five capability names
+are deliberately **not** declared, for two different reasons:
 
-- **`stop`** — nothing exposed terminates a running cloud session.
-- **`log`** — a cloud session has no terminal to scroll.
-- **`transcript`** — no supported interface reads a cloud session's conversation
-  (§1).
+- **`stop`, `log` and `transcript` are absent because of a fact about the vendor
+  surface, not because of anything left to build.** Nothing exposed terminates
+  a running cloud session (`stop`); a cloud session has no terminal to scroll
+  (`log`); no supported interface reads a cloud session's conversation
+  (`transcript`, §1). No future slice of this feature changes any of that.
+- **`land`, `archive` and `unarchive` are absent because this is a real gap in
+  the current build, not a fact about the vendor.** `ClaudeCloudInvoker.run`
+  answers all three with `not_implemented`. They are a later slice of this
+  feature (§6, §7), which will declare each capability string together with
+  its implementation in the same change. Declaring them ahead of that would
+  offer the app an action — Land, Archive, Unarchive on a cloud lane — that
+  always fails.
 
-**`archive` and `unarchive` are implemented against the provider's own ledger.**
-`archive` sets the archived flag on the `claude_cloud_session` row named by the
-id and returns the updated session; `unarchive` clears it. Both are idempotent,
-neither removes the row, and `list` goes on enumerating the session — reporting
-it with `archived: true` — which is what the contract requires of every provider.
-§7 carries the reasoning, including what this does not do to the session on
-Anthropic's side.
+**`archive` and `unarchive` are designed to run against the provider's own
+ledger, in the later slice that declares them.** `archive` will set the
+archived flag on the `claude_cloud_session` row named by the id and return the
+updated session; `unarchive` will clear it. Both are designed idempotent,
+neither removing the row, with `list` going on enumerating the session —
+reporting it with `archived: true` — which is what the contract requires of
+every provider. §7 carries the reasoning, including what this will not do to
+the session on Anthropic's side.
 
 `create_params` are `repo`, `branch`, `prompt` and `environment`, the last typed
 `string` because `describe` answers offline and the set of configured cloud
@@ -248,19 +271,26 @@ with the signed-in account — including for `attach`, which is declared because
 provider implements it. Whether a given account is permitted to use it is a
 separate, runtime question, and §5 is where that is answered.
 
-**Verbs.** `create` runs `claude --cloud "<prompt>"` from the repository
-checkout, on a pseudo-terminal, and reads the session id and its title out of
-what it prints (below). `list` returns the `claude_cloud_session` ledger — what this machine
-started — and nothing else; it is always `complete: false`, which the next
-subsection specifies. `send` posts one message through
-`claude -p "<msg>" --cloud <id> --output-format json`; the response is
-`{"ok": true, "session_id": "…", "url": "…"}`, and `ok` plus a `session_id`
-matching the id sent is the success condition. `attach` runs
-`claude --cloud <id>` on the pane's PTY. `land` reports the session's repository
-and branch with a `resume_command` of `claude --teleport <id>` and `forks: true`.
-`archive` and `unarchive` write the archived flag on the ledger row and return
-the updated session; neither invokes the vendor CLI at all, because the ledger is
-the inventory they file within (§7).
+**Verbs, shipped.** `create` runs `claude --cloud "<prompt>"` from the
+repository checkout, on a pseudo-terminal, and reads the session id and its
+title out of what it prints (below). `list` returns the `claude_cloud_session`
+ledger — what this machine started — and nothing else; it is always
+`complete: false`, which the next subsection specifies. `send` posts one
+message through `claude -p "<msg>" --cloud <id> --output-format json`; the
+response is `{"ok": true, "session_id": "…", "url": "…"}`, and `ok` plus a
+`session_id` matching the id sent is the success condition. `attach` runs
+`claude --cloud <id>` on the pane's PTY.
+
+**Verbs, designed for the later slice that declares them.** `land` will report
+the session's repository and branch with a `resume_command` of
+`claude --teleport <id>` and `forks: true`. `archive` and `unarchive` will
+write the archived flag on the ledger row and return the updated session;
+neither will invoke the vendor CLI, because the ledger is the inventory they
+file within (§7). Until that slice declares them, a caller that reaches any of
+the three anyway — a stale capability cache, a call that skips the capability
+check — gets a `not_implemented` contract-bug exit rather than a silent
+success: `ClaudeCloudInvoker.run` answers `land`, `archive` and `unarchive`
+that way today.
 
 **`send` implements the contract's byte interface on top of that call.** The
 contract's `send` takes stdin bytes destined for a terminal and requires the
@@ -1087,6 +1117,13 @@ vendor exposes no other way.
 
 ## 6. Land
 
+**This section designs Land; it ships in the later slice that declares `land`
+on the provider (§3), not in this one.** `claude-cloud`'s `describe` does not
+yet declare `land`, and `ClaudeCloudInvoker.run` answers it with
+`not_implemented`, so nothing below is reachable through today's build. It is
+specified here so the later slice is a capability declaration and an RPC, not
+a redesign.
+
 Land is an action on the adopted worktree row, enabled when the row's provider
 declares the `land` capability. It converts the row **in place**: `.remote`
 becomes `.local`, the git worktree is materialized, and the row keeps its id, its
@@ -1191,11 +1228,12 @@ Landing is always a user gesture and is never triggered by session state.
 reports `forks: true`, so the landed checkout and the session diverge from this
 moment: the work is on this machine now, and a session nobody will return to
 should not sit in the working inventory. A session is retired through the
-`archive` verb where its provider declares one, and cloud declares it (§3), so
-landing calls that verb — one invocation, on the same in-process ledger path §7
-specifies, marking the ledger row archived. TBD never *stops* a session on
-landing whatever a provider declares: landing is a "bring this home" gesture,
-not a teardown, and the remote box may still hold work that was never pushed.
+`archive` verb where its provider declares one, and once cloud declares it
+(§3), landing calls that verb — one invocation, on the same in-process ledger
+path §7 specifies, marking the ledger row archived. TBD never *stops* a
+session on landing whatever a provider declares: landing is a "bring this
+home" gesture, not a teardown, and the remote box may still hold work that was
+never pushed.
 
 **That retirement is within TBD's inventory, not Anthropic's, and the lane says
 so.** The cloud session keeps running on Anthropic's infrastructure and keeps
@@ -1220,6 +1258,13 @@ list.
 
 ## 7. Archiving a remote lane
 
+**This section designs Archive for a remote lane; it ships in the later slice
+that declares `archive` and `unarchive` on the provider (§3), not in this
+one.** `claude-cloud`'s `describe` does not yet declare either capability, and
+`ClaudeCloudInvoker.run` answers both with `not_implemented`. It is specified
+here for the same reason §6 is: so the later slice is a capability declaration
+and an implementation, not a redesign.
+
 Archive retires a lane from the working set, and a cloud lane needs the gesture
 more than a local one does: nothing else takes it out of the tree. Retirement
 driven by drift needs a complete snapshot and there is never one (§3), so a cloud
@@ -1232,10 +1277,11 @@ section of every non-scratch, non-main row's menu, gated only on
 `hasActiveChildren`, so an adopted remote row shows it; `run(.archive)`
 (`Sources/TBDApp/Sidebar/RowActionMenuActions.swift`:184-186) calls
 `AppState.archiveWorktree`, which calls `worktree.archive`, which refuses. The
-menu item is not the defect: what changes is that the daemon stops refusing. How
-the item presents for a provider that cannot archive is the 08-16 design's; a
-cloud lane's provider declares the capability, so for a cloud lane the item is
-live exactly as it looks today.
+menu item is not the defect: what changes, once the later slice declares
+`archive`, is that the daemon stops refusing. How the item presents for a
+provider that cannot archive is the 08-16 design's; once a cloud lane's
+provider declares the capability, the item will be live for a cloud lane
+exactly as it looks today.
 
 ### The fences, and why lifting them is not enough
 
@@ -1302,19 +1348,21 @@ revive cases — is specified by
 and this document does not restate any of it. What follows is only what is
 particular to this provider.
 
-**`claude-cloud` takes the verb path.** It declares `archive` and `unarchive`
-(§3), so archiving a cloud lane invokes `archive` and then marks the row, and
-reviving one invokes `unarchive` and then flips the row back. It reaches neither
-of the other branches: the `gone` exemption is for a session the provider has
-stopped enumerating, which a cloud session never becomes (§3), and the refusal is
-for a provider that declares no `archive`, which this one always does — the
-declaration is a compiled constant rather than a runtime answer.
+**`claude-cloud` will take the verb path, once it declares `archive` and
+`unarchive`.** Archiving a cloud lane will invoke `archive` and then mark the
+row, and reviving one will invoke `unarchive` and then flip the row back (§3).
+It reaches neither of the other branches: the `gone` exemption is for a
+session the provider has stopped enumerating, which a cloud session never
+becomes (§3), and the refusal is for a provider that declares no `archive` —
+once cloud declares it, the declaration is a compiled constant rather than a
+runtime answer, so the refusal branch stays permanently unreached for this
+provider.
 
-**Both verbs run against the provider's own ledger and send nothing to
-Anthropic.** `archive` sets the archived flag on the `claude_cloud_session` row;
-`unarchive` clears it. Every later `list` returns that session carrying the flag
-it now holds — `archived: true` after an archive, `archived: false` after an
-unarchive (§3).
+**Both verbs will run against the provider's own ledger and send nothing to
+Anthropic.** `archive` will set the archived flag on the `claude_cloud_session`
+row; `unarchive` will clear it. Every later `list` will return that session
+carrying the flag it now holds — `archived: true` after an archive,
+`archived: false` after an unarchive (§3).
 
 Three properties make that a real retirement rather than a costume:
 
@@ -1462,8 +1510,8 @@ manual gesture takes, and the rail participates under the per-worktree opt-in it
 already has. A cloud lane is reachable by it — PR polling is keyed on the branch
 and runs `git` and `gh` in the repository's own checkout, so a remote row carries
 a PR badge like any other (`RPCRouter.pollableWorktrees`,
-`Sources/TBDDaemon/Server/RPCRouter.swift`:946) — and its provider declares
-`archive`, so nothing declines on cloud's behalf.
+`Sources/TBDDaemon/Server/RPCRouter.swift`:946) — and once its provider
+declares `archive`, nothing will decline on cloud's behalf.
 
 **The arming gesture is therefore the whole of what stands between a merged PR
 and a filed cloud lane.** Neither termination guard fires for a cloud lane
@@ -1660,6 +1708,17 @@ elapsed backoff window, admits a transient one under the same conditions, and
 Reattach clears either. A provider with no block behaves exactly as it does now,
 reconnect included.
 
+**What this slice actually tests for cloud's three deferred verbs.**
+`describe`'s JSON lists exactly `send` and `attach`, never `land`, `archive` or
+`unarchive`. `ClaudeCloudInvoker.run` answers all three deferred verbs with a
+`not_implemented` contract-bug exit rather than a silent success, asserted
+against every verb `describe` does not declare — the assertion that would fail
+if a capability were ever declared without `run` answering it.
+
+**Land's and archive's own tests belong to the later slice that declares those
+capabilities, and are specified below for the same reason §6 and §7 are: so
+that slice is a capability declaration and an implementation, not a redesign.**
+
 **A cloud lane archives through the verb.** Archiving one invokes `archive` and
 then marks the row, asserted against a fake invoker that records every verb it
 was asked for — so a `stop`, which this provider does not declare, fails the
@@ -1746,11 +1805,14 @@ entry in the file still loads, with and without the cloud flag on.
 
 ## 10. Work order
 
-**Nothing opens a pull request until the whole path works end to end.** The order
-below minimizes rework; it is not a sequence of independently shippable
-increments, and several steps are unobservable on their own. Building it as
-increments would mean shipping the routing change with nothing to route and the
-provider with no flag to gate it.
+**This slice's pull request does not open until steps 1 through 9 work end to
+end.** The order below minimizes rework; it is not a sequence of independently
+shippable increments, and several steps are unobservable on their own.
+Building it as increments would mean shipping the routing change with nothing
+to route and the provider with no flag to gate it. Steps 10 and 11 — archive
+and land — are the later slice's work order (§6, §7), sequenced here for
+continuity with the steps this slice ships; that slice opens its own pull
+request once its own path works end to end.
 
 1. **The shared model change (§2).** Origin field, record mapping, round-trip
    tests. Everything downstream reads provenance, and every later step written
@@ -1798,6 +1860,10 @@ provider with no flag to gate it.
    attach block reaching the app through the one `RemoteProviderStatus` lookup,
    alongside the attach exit-class correction the block depends on. They land
    together because they share that lookup.
+
+Steps 10 and 11 belong to the later slice that declares `archive`, `unarchive`
+and `land` on the provider:
+
 10. **Archive (§7).** The built-in provider's `archive` and `unarchive` verbs
     over the ledger column from step 6, the remote arm of `worktree.archive` and of
     revive on the 08-16 design's composition, the row copy, the Archived list's


### PR DESCRIPTION
## Summary

You can start a Claude cloud session from TBD and talk to it, without leaving the app for claude.ai. Pick "New cloud session…" from a repository's create menu or its `+` button, describe the work, and the session starts on Anthropic's infrastructure and appears as a row you can send messages to.

The point is that a cloud session stops being a thing you open a browser tab for. It becomes a lane in the same tree as your local worktrees, created the same way and steered the same way.

One property of this feature is unusual enough to state up front, because it looks like a bug and is not: **TBD can only ever show cloud sessions that TBD itself started on this Mac.** A session you began on claude.ai, in the mobile app, or from a terminal TBD did not spawn will never appear in the list. Settings says so in a caption, because an absence nobody explains reads as breakage.

## Why this shape

The provider is **compiled into the daemon** rather than shipped as an external subprocess like the registry-file providers. It still reaches the daemon through the same `RemoteProviderInvoking` contract, so it gets the same result envelope, failure classification, health handling and poll loop an external provider gets — a `ProviderDispatcher` picks the in-process conformance by provider name and sends everything else to the subprocess runner. Nothing downstream knows the difference.

**There is no discovery, and that is a boundary rather than a gap.** No supported interface enumerates an account's cloud sessions: the Compliance API excludes Claude Code on the web by name, the documented `/v1/claude_code/` namespace grants no read access, and the undocumented claude.ai endpoints are barred by Anthropic's Consumer Terms outside an API-key carve-out that a subscription-login cloud session can never be inside. So `list` answers from a local ledger of what this machine started and reports itself **permanently incomplete**. What would reopen this is a supported interface, not a more careful scraper.

That incompleteness is load-bearing in a way worth flagging to reviewers: under the ordinary drift rule, a provider whose snapshot is always incomplete would have its own live lanes tombstoned two polls after creating them. Snapshot completeness (`complete` on the list envelope, honored by `RemoteSessionStore.applySnapshot`) is what prevents that, and it is why a successful create also triggers one out-of-band `list`.

Two vendor facts shaped the implementation, both measured against `claude` 2.1.233 rather than assumed. `create` requires a TTY — the CLI refuses `--cloud` on a pipe — so it runs under a pseudo-terminal and TBD parses the session id out of the prose it prints. `send` must **not** use a pseudo-terminal, because under one stdout and stderr merge onto a single descriptor and would corrupt the JSON it returns.

Spec: [`docs/specs/2026-08-15-cloud-sessions-slice-1-design.md`](docs/specs/2026-08-15-cloud-sessions-slice-1-design.md).

### Who reclaims the process a create spawns

A create spawns the vendor CLI outside tmux, and its deadline is held by a watchdog living inside the daemon. So a daemon that dies mid-create leaves the child reparented to pid 1 with nothing supervising it, and no `SIGHUP` reaches it — the runner never makes the pty the child's *controlling* terminal. That was reproduced rather than assumed: a child holding a pty replica, parent `SIGKILL`ed, survived and was observed reparented to pid 1 still running. `AgentReaper` does not cover it, since it only walks children of a known `tbd-*` tmux server.

Per the reconciler doctrine this takes the third of its three answers — a committed spec that deliberately chose otherwise, in [the spec's §3](docs/specs/2026-08-15-cloud-sessions-slice-1-design.md). No sweep reclaims it, because the process is a single short-lived invocation bounded by its own work, holding no lock, lease, git ref, tmux resource, or file that outlives it — a different shape from the unbounded accumulations the doctrine was written for (2,804 leaked branches, ~7,100 dead sockets). The spec states plainly what that does **not** claim: a child that hangs before it ever writes has no `EIO` to trip over and can linger. Observed orphans during the soak reverse the decision, and the spec names the remedy's shape.

## What this PR does

- **`Sources/TBDDaemon/Remote/ClaudeCloud/`** — the provider: `describe` (static and offline), `create` (pseudo-terminal, prose parsing, idempotency), `list` (ledger-only, permanently incomplete), `send` (JSON over a plain pipe), the spawn seam, and the executable resolver.
- **`ProviderDispatcher`** — routes a verb to the in-process provider by reserved name, everything else to `ProviderRunner`.
- **`RemoteProviderManager`** — registers built-in providers alongside registry entries and describes them identically; threads snapshot completeness; refreshes once after a create.
- **`claude_cloud_session` ledger** (migration `v82`) — what this machine started, with a pending→failed window for creates that never resolve.
- **Create surfaces** — the repository create menu, the `+` button, and the Remote section all enumerate through one pure function so they cannot disagree about what is on offer.
- **Settings** — the flag toggle plus the caption describing what the list covers.

## Flag & rollout

- **Flag:** `claude_cloud_enabled` (migration `v81`), **default OFF**, nested under `remote_backends_enabled` — cloud is live only when both are on.
- The column carries **no SQL default**, so NULL means "nobody has chosen" and the shipped default lives in exactly one place, `ConfigRecord.toModel()`'s `?? Config.claudeCloudEnabledDefault`. Graduation is a one-line change to that constant that reaches everyone who never touched the toggle while preserving every explicit opt-out.
- **To soak:** enable Remote backends, then Claude cloud sessions, in Settings, and restart the daemon (the provider is constructed at boot).
- **Graduation:** flip the default constant after the soak, then delete the flag.

## Assumptions

- Assumes the vendor `claude` CLI keeps `create`'s three-line output shape and `send`'s `{"ok":true,…}` response. If the prose changes, creates fail loudly as contract bugs rather than silently — but they do fail.
- Assumes `claude` is on the daemon's PATH. If it is not, the provider does not register and Settings reports it as not running; the underlying reason is only in `os_log`. Worth improving before graduation.
- Assumes a cloud session outlives the create call. TBD records the id and never polls the vendor for liveness, because nothing supported would answer.

## Evidence & verification

- **Full suite green:** 7146 tests in 721 suites, 70 known issues, no failures. `swiftlint --strict` clean. Verified after rebasing onto current `main`.
- **Every gated branch is tested on both sides** — flag off, flag on, and ungated behavior unaffected — for the RPC gate, the boot wiring, and all three create surfaces.
- **Discriminating tests, not just passing ones.** Several tests here exist specifically because a plausible-looking implementation would pass without them: `archived` is asserted on raw JSON, because a decoded `nil` and `false` are indistinguishable through the display accessor; the create parser's CRLF test builds its input by explicit concatenation, because Swift normalizes triple-quoted literals to bare `\n` and a literal-based test cannot detect the bug it targets; the caption test pins the sentence, because an *overclaiming* rewrite passed the previous keyword assertions.
- **A final review found a Critical the tests did not.** The create parser cross-checked the session id across the whole output including the title line — which echoes the user's prompt — so a prompt mentioning something like `session_store_test.py` produced a second id match and reported a *successful* create as a contract bug, orphaning a real cloud session with no discovery to recover it. Fixed to scan only the lines that structurally carry the id, with a test that fails against the previous implementation. The same review found a same-key replay could start a second cloud session; a resolved key now returns what was recorded and a pending one refuses rather than guessing.

**Not verified live.** This has not been exercised against the real `claude` CLI in a running TBD, because doing so means restarting the daemon, which would disrupt the sessions currently running on this machine. The flag is off by default, so nothing changes for anyone until someone opts in — but the first soak run should be a live create → send round trip, and that is the gap in this evidence.

## Follow-ups, deliberately not in this PR

- `archive`, `unarchive` and `land` are **not implemented**, and `describe` no longer advertises them — capabilities are a contract the app reads to decide what to offer, so advertising an unimplemented verb means offering an action that always fails. A later PR adds each capability together with its implementation.
- The app-surfaces work — the transcript pane, landed-row rendering, the trust-on-first-use approval prompt — is a separate plan and a separate PR.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=BBA22690-7E4E-4F7F-A4F8-A71351FA5FD5)
