### PR TITLE
Feat: GitLab merge requests bind, poll, and render like pull requests

### DIFF
--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -528,7 +528,10 @@ extension AppState {
             let tab = TBDShared.Tab(
                 id: UUID(),
                 content: .webview(id: UUID(), url: url),
-                label: "PR #\(number)"
+                // One tab names one request, so it speaks that request's own
+                // forge. The URL is the only forge coordinate this signature
+                // carries, and it is the very URL the tab will show.
+                label: Forge.forHost(url.host ?? "github.com").refLabel(number: number)
             )
             tabs[worktreeID, default: []].append(tab)
             activeTabIndices[worktreeID] = (tabs[worktreeID]?.count ?? 1) - 1

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -529,9 +529,11 @@ extension AppState {
                 id: UUID(),
                 content: .webview(id: UUID(), url: url),
                 // One tab names one request, so it speaks that request's own
-                // forge. The URL is the only forge coordinate this signature
-                // carries, and it is the very URL the tab will show.
-                label: Forge.forHost(url.host ?? "github.com").refLabel(number: number)
+                // forge, read from the very URL the tab will show: GitLab's
+                // `/-/merge_requests/` marks a merge request and every other
+                // shape is a pull request. The host would be the wrong
+                // coordinate — see `Forge.forURL`.
+                label: Forge.forURL(url.absoluteString).refLabel(number: number)
             )
             tabs[worktreeID, default: []].append(tab)
             activeTabIndices[worktreeID] = (tabs[worktreeID]?.count ?? 1) - 1

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -484,8 +484,10 @@ struct ContentView: View {
             // when there IS one — a lone binding whose URL will not parse gets
             // named, not offered.
             clauses.append(prPrimaryActionURL(bindings) == nil
-                           ? "PR #\(bindings[0].number)"
-                           : "Open PR #\(bindings[0].number)")
+                           ? bindings[0].refLabel
+                           : "Open \(bindings[0].refLabel)")
+        // Neutral wording, deliberately: a worktree can hold bindings on both
+        // forges, so no single vocabulary would be true of the whole set.
         default: clauses.append("\(bindings.count) pull requests")
         }
         if armed && blocked {
@@ -1061,8 +1063,10 @@ struct PRButtonLabel: View {
     private var accessibilityLabel: String {
         var clauses: [String] = []
         switch bindings.count {
+        // The zero and several arms keep neutral wording — a worktree can span
+        // forges, so only the single-binding arm can speak one forge's dialect.
         case 0: clauses.append("No pull requests")
-        case 1: clauses.append("PR #\(bindings[0].number)")
+        case 1: clauses.append(bindings[0].refLabel)
         default: clauses.append("\(bindings.count) pull requests")
         }
         if isAutoArchiveArmed { clauses.append("auto-archive on merge is on") }

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -91,6 +91,11 @@ struct StatusBarView: View {
         /// the PR names its tab `PR #N` and must not have to re-parse "#412".
         let number: Int
         let label: String
+        /// The binding named in its own forge's vocabulary (`PR #412` /
+        /// `MR !412`), for the tooltip. Carried on the chip rather than
+        /// recomposed in the view because the binding — the only thing that
+        /// knows the host — does not reach the view.
+        let refLabel: String
         let url: URL?
         let state: PRMergeableState?
     }
@@ -131,6 +136,7 @@ struct StatusBarView: View {
                 id: binding.id,
                 number: binding.number,
                 label: "#\(binding.number)",
+                refLabel: binding.refLabel,
                 url: URL(string: binding.url),
                 state: binding.status?.state
             )
@@ -286,10 +292,11 @@ private struct PRChipView: View {
 
     @State private var isHovering = false
 
-    /// Tooltip and accessibility hint, e.g. `Open PR #412 — Checks failing`.
+    /// Tooltip and accessibility hint, e.g. `Open PR #412 — Checks failing`,
+    /// or `Open MR !412 — Checks failing` for a GitLab binding.
     private var tooltip: String {
-        guard let state = chip.state else { return "Open PR \(chip.label)" }
-        return "Open PR \(chip.label) — \(state.displayReason)"
+        guard let state = chip.state else { return "Open \(chip.refLabel)" }
+        return "Open \(chip.refLabel) — \(state.displayReason)"
     }
 
     /// The dot color, taken from the shared PR palette so a chip cannot drift

--- a/Sources/TBDApp/PRBindingPresentation.swift
+++ b/Sources/TBDApp/PRBindingPresentation.swift
@@ -68,9 +68,15 @@ enum PRBindingPresentation {
         guard bindings.isEmpty else { return bindings }
         guard detachedCount == 0 else { return [] }
         guard let status = legacyStatus else { return [] }
+        // The status URL is the only forge coordinate a legacy status carries,
+        // so the host comes from it rather than from `PRBinding`'s github.com
+        // default — a GitLab status lifted with that default would describe
+        // itself as a GitHub PR.
+        let syntheticHost = URL(string: status.url)?.host ?? "github.com"
         return [PRBinding(
             id: worktreeID,
             worktreeID: worktreeID,
+            host: syntheticHost,
             owner: "",
             repo: "",
             number: status.number,

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -201,7 +201,12 @@ struct WorktreeRowView: View {
             hasUndeterminedPR: prUnknownTooltip != nil
         ) {
         case .prStatus:
-            if let presentation = prPresentation, let status = prStatus {
+            // The binding, not just its status, because the row names the
+            // request in its own forge's vocabulary and only the binding
+            // carries the host. `prStatus` IS `indicatorBinding?.status`, so
+            // this cannot select a different request.
+            if let presentation = prPresentation, let binding = indicatorBinding,
+               let status = binding.status {
                 // A queued PR describes itself by its queue position, not its
                 // underlying (UNKNOWN→pending) check reason.
                 let detail = presentation.badge.map { "in merge queue, position \($0)" }
@@ -210,7 +215,7 @@ struct WorktreeRowView: View {
                 // never hides that its last re-read failed.
                 let freshness = PRFreshness.clauses(
                     status: status, observation: prObservation, now: Date())
-                let tooltip = (["PR #\(status.number)", detail] + freshness)
+                let tooltip = ([binding.refLabel, detail] + freshness)
                     .joined(separator: " · ")
                 Button(action: openPR) {
                     prGlyph(presentation)
@@ -220,7 +225,7 @@ struct WorktreeRowView: View {
                 .buttonStyle(.plain)
                 .onHover { isPRIconHovered = $0 }
                 .accessibilityLabel(
-                    "PR #\(status.number): \(([detail] + freshness).joined(separator: ", "))")
+                    "\(binding.refLabel): \(([detail] + freshness).joined(separator: ", "))")
                 .anchorPreference(key: RowTooltipPreferenceKey.self, value: .bounds) { anchor in
                     isPRIconHovered ? RowTooltipPreference(text: tooltip, anchor: anchor) : nil
                 }

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -131,21 +131,27 @@ public enum ClaudeHookOverlay {
     ///
     /// **Deliberately permissive, and it must stay that way.** The prefilter is
     /// a COST OPTIMIZATION, never a gate: `PRBindingExtractor`'s tokenizer is
-    /// the sole authority on what counts as a `gh pr create`, and it can only
-    /// judge payloads this pattern lets through. A payload the grep drops never
-    /// reaches `tbd` at all, so a false negative loses the bind in silence.
+    /// the sole authority on what counts as a `gh pr create` or a
+    /// `glab mr create`, and it can only judge payloads this pattern lets
+    /// through. A payload the grep drops never reaches `tbd` at all, so a false
+    /// negative loses the bind in silence.
     ///
-    /// **What it guarantees:** every command the tokenizer accepts with `pr` and
-    /// `create` as *adjacent* subcommand words is admitted — however the segment
-    /// is quoted, whichever global flags precede the subcommand, and whether or
-    /// not `gh` is path-qualified. Two properties carry that, and neither is
-    /// obvious from the pattern alone.
+    /// **What it guarantees:** every command the tokenizer accepts with its
+    /// forge's verb (`pr` for `gh`, `mr` for `glab`) and `create` as *adjacent*
+    /// subcommand words is admitted — however the segment is quoted, whichever
+    /// global flags precede the subcommand, and whether or not the CLI is
+    /// path-qualified. Two properties carry that, and neither is obvious from
+    /// the pattern alone.
     ///
-    /// It does not require `gh` adjacency, because
+    /// It does not require the CLI name to be adjacent, because
     /// `gh -R acme/acme-prod pr create` and `gh --repo acme/acme-prod pr create`
     /// are exactly the flagged forms the tokenizer was built to accept, and a
     /// `gh[[:space:]]+pr` requirement here silently dropped every one of them
-    /// before the tokenizer ever ran.
+    /// before the tokenizer ever ran. The same holds for `glab -R … mr create`.
+    /// A consequence is that the two verbs are not tied to their own CLI here:
+    /// `gh mr create` and `glab pr create`, which the tokenizer rejects, are
+    /// admitted. That is the cheap direction — one short-lived `tbd` that then
+    /// declines to bind.
     ///
     /// And it separates the two words by any run of non-alphanumeric characters
     /// rather than by whitespace, because the tokenizer *strips quotes* while
@@ -160,7 +166,7 @@ public enum ClaudeHookOverlay {
     ///
     /// **What it does not guarantee**, so the invariant is stated rather than
     /// implied: a flag word *between* the two subcommand words
-    /// (`gh pr --draft create`, `gh pr -R acme/acme-prod create`), which the
+    /// (`gh pr --draft create`, `glab mr -R acme/acme-prod create`), which the
     /// tokenizer skips over but which no pattern can span without also matching
     /// ordinary prose — the intervening flag and its value are alphanumeric
     /// words indistinguishable from any other; and quoting *inside* a word
@@ -179,9 +185,10 @@ public enum ClaudeHookOverlay {
     /// shell command runs — hand-copying it into the test is how the two drift
     /// apart. It is embedded in a single-quoted shell word, so it must never
     /// contain a `'`.
-    static let prBindGrepPattern = #"pr([^[:alnum:]]|\\[tr])+create"#
+    static let prBindGrepPattern = #"(pr|mr)([^[:alnum:]]|\\[tr])+create"#
 
-    /// Binds any PR created by a `gh pr create` in this session.
+    /// Binds any PR or MR created by a `gh pr create` or `glab mr create` in
+    /// this session.
     ///
     /// The `grep -qE` is a deliberate prefilter: this hook fires on EVERY Bash
     /// tool call across the whole fleet, and without it each one would spawn a

--- a/Sources/TBDDaemon/PR/GitLabHostResolver.swift
+++ b/Sources/TBDDaemon/PR/GitLabHostResolver.swift
@@ -20,11 +20,37 @@ typealias GLRunner = @Sendable (_ args: [String], _ repoPath: String) async -> G
 /// succeeding, never by this output.
 actor GitLabHostResolver {
     private let glRunner: GLRunner?
+
+    /// Date seam for the one timestamp this actor keeps: when `glab` last ran
+    /// and named no host. It is compared, not slept on, so it is data and takes
+    /// `now:` rather than a `Clock` (`Duration` is behavior, `Date` is data).
+    /// This actor schedules nothing, so it has no clock at all.
+    private let now: @Sendable () -> Date
+
     private var cachedHosts: Set<String>?
+
+    /// When `glab` last ran to completion and named no host, or nil if that has
+    /// not happened (or the answer has since aged out).
+    private var lastEmptyStatusAt: Date?
+
     private static let log = Logger(subsystem: "com.tbd.daemon", category: "pr.gitlab")
 
-    init(glRunner: GLRunner? = nil) {
+    /// How long "glab ran and named no host" is believed before it is asked
+    /// again.
+    ///
+    /// This is the only knob trading two costs against each other. Below it
+    /// sits the poll cadence — `GitPollCadence.prInterval` is 30 s in the
+    /// foreground, and every distinct worktree path on the tick asks this
+    /// actor — so a window of one full interval already collapses a fleet's
+    /// worth of `glab auth status` spawns per tick into one. Above it sits how
+    /// long a user who has just run `glab auth login --hostname …` waits for
+    /// TBD to notice. Five minutes is ten foreground ticks of silence for a
+    /// wait no longer than the background poll interval itself.
+    static let emptyStatusLifetime: TimeInterval = 300
+
+    init(glRunner: GLRunner? = nil, now: @escaping @Sendable () -> Date = { Date() }) {
         self.glRunner = glRunner
+        self.now = now
     }
 
     func isGitLabHost(_ host: String, repoPath: String) async -> Bool {
@@ -35,38 +61,67 @@ actor GitLabHostResolver {
         return await hosts(repoPath: repoPath).contains(normalized)
     }
 
-    /// Only a non-empty derivation is cached. An empty set is never an
-    /// observation that the fleet has no GitLab hosts — `fetchHosts` returns it
-    /// just as readily when `glab` is absent, fails to launch, or prints
-    /// something unparseable — so remembering it would mean a user who runs
-    /// `glab auth login --hostname …` after the daemon started, or one
-    /// transient failure on the first poll after boot, gets no GitLab until the
-    /// next restart, with no message anywhere. The spec's "cached for the
-    /// daemon run, so nothing needs invalidating" reasons about caching a
-    /// derived truth; it does not license caching a failure to derive.
+    /// Three outcomes, remembered for three different spans, because they are
+    /// three different facts.
     ///
-    /// Retrying costs nothing on the fleet this cache exists for: `github.com`
-    /// short-circuits in `isGitLabHost` before reaching here, so a GitHub-only
-    /// fleet still spawns no `glab` at all. Only a host that is neither
-    /// `github.com` nor a declared GitLab host re-probes, and it does so
-    /// precisely because the answer for it is still unknown.
+    /// **A non-empty derivation is cached for the resolver's life.** It is a
+    /// derived truth about a declaration the user made; nothing invalidates it.
+    ///
+    /// **`glab` failing to launch is never remembered.** It is not an
+    /// observation that the fleet has no GitLab hosts, just a failure to ask —
+    /// the binary is absent, or one exec failed transiently. Remembering it
+    /// would mean a user who installs `glab` mid-run, or one bad first poll
+    /// after boot, gets no GitLab until the next restart with no message
+    /// anywhere. Retrying costs nothing in the case that dominates: `glab`
+    /// absent resolves to a static nil path, so no subprocess is spawned at
+    /// all.
+    ///
+    /// **`glab` running and naming no host ages out after
+    /// `emptyStatusLifetime`.** That one *is* an observation, and it is the
+    /// steady state of every fleet with `glab` installed and no GitLab host
+    /// configured — so re-deriving it per call means one subprocess per
+    /// worktree per poll tick, forever, for an answer that has not changed.
+    /// It cannot be cached for the run either: the same user is one
+    /// `glab auth login --hostname …` away from making it wrong. A bounded
+    /// window is what both facts allow, and it is bounded on the side that
+    /// matters — the answer is at worst `emptyStatusLifetime` stale, never
+    /// stale until restart.
+    ///
+    /// Note also that `github.com` short-circuits in `isGitLabHost` before
+    /// reaching here, so none of this is on a pure GitHub.com fleet's path. It
+    /// is on a GitHub Enterprise, Bitbucket, gitea or codeberg fleet's path,
+    /// which is why the empty answer has to be cheap.
     private func hosts(repoPath: String) async -> Set<String> {
         if let cachedHosts { return cachedHosts }
-        let resolved = await fetchHosts(repoPath: repoPath)
-        guard !resolved.isEmpty else { return resolved }
-        cachedHosts = resolved
-        return resolved
-    }
+        if let lastEmptyStatusAt, !isStale(lastEmptyStatusAt) { return [] }
 
-    private func fetchHosts(repoPath: String) async -> Set<String> {
-        guard let glRunner else { return [] }
-        // The exit status is ignored deliberately: glab exits 1 when ANY
-        // configured host fails to authenticate, so a perfectly good setup
-        // reports failure whenever an unused gitlab.com entry shares the config.
-        guard let result = await glRunner(["auth", "status"], repoPath) else {
+        guard let derived = await fetchHosts(repoPath: repoPath) else {
             Self.log.debug("glab did not launch; no GitLab hosts derived")
             return []
         }
+        guard !derived.isEmpty else {
+            lastEmptyStatusAt = now()
+            return []
+        }
+        cachedHosts = derived
+        return derived
+    }
+
+    /// `abs`, because the wall clock this reads can step backwards. A magnitude
+    /// test makes a backwards jump re-derive early — the safe direction —
+    /// rather than pinning the empty answer in place until the clock catches up.
+    private func isStale(_ stamp: Date) -> Bool {
+        abs(now().timeIntervalSince(stamp)) >= Self.emptyStatusLifetime
+    }
+
+    /// The host list `glab` named, or nil if `glab` did not launch — a
+    /// distinction the caller pays attention to, so it must not collapse here.
+    private func fetchHosts(repoPath: String) async -> Set<String>? {
+        guard let glRunner else { return nil }
+        // The exit status is ignored deliberately: glab exits 1 when ANY
+        // configured host fails to authenticate, so a perfectly good setup
+        // reports failure whenever an unused gitlab.com entry shares the config.
+        guard let result = await glRunner(["auth", "status"], repoPath) else { return nil }
         let parsed = Set(Self.parseAuthStatusHosts(result.stdout + "\n" + result.stderr)
             .map { $0.lowercased() })
         Self.log.debug("derived GitLab hosts: \(parsed.sorted().joined(separator: ","), privacy: .public)")

--- a/Sources/TBDDaemon/PR/GitLabHostResolver.swift
+++ b/Sources/TBDDaemon/PR/GitLabHostResolver.swift
@@ -61,9 +61,16 @@ actor GitLabHostResolver {
     /// is indented beneath it.
     static func parseAuthStatusHosts(_ output: String) -> [String] {
         var out: [String] = []
-        for line in output.split(separator: "\n", omittingEmptySubsequences: true) {
+        // Split on any newline, and trim newlines as well as spaces. CRLF is
+        // the reason for both. Swift reads "\r\n" as ONE Character, so
+        // `split(separator: "\n")` finds no separator in CRLF output at all and
+        // hands the whole transcript back as a single "line" — which the
+        // no-spaces guard then rejects, leaving no hosts and GitLab silently
+        // off with no error anywhere. `\r` alone would survive
+        // `.whitespaces` too, which is spaces and tabs only.
+        for line in output.split(whereSeparator: \.isNewline) {
             guard let first = line.first, !first.isWhitespace else { continue }
-            let candidate = line.trimmingCharacters(in: .whitespaces)
+            let candidate = line.trimmingCharacters(in: .whitespacesAndNewlines)
             // A hostname line has no spaces and at least one dot.
             guard !candidate.isEmpty, !candidate.contains(" "), candidate.contains(".") else { continue }
             if !out.contains(candidate) { out.append(candidate) }

--- a/Sources/TBDDaemon/PR/GitLabHostResolver.swift
+++ b/Sources/TBDDaemon/PR/GitLabHostResolver.swift
@@ -35,9 +35,25 @@ actor GitLabHostResolver {
         return await hosts(repoPath: repoPath).contains(normalized)
     }
 
+    /// Only a non-empty derivation is cached. An empty set is never an
+    /// observation that the fleet has no GitLab hosts — `fetchHosts` returns it
+    /// just as readily when `glab` is absent, fails to launch, or prints
+    /// something unparseable — so remembering it would mean a user who runs
+    /// `glab auth login --hostname …` after the daemon started, or one
+    /// transient failure on the first poll after boot, gets no GitLab until the
+    /// next restart, with no message anywhere. The spec's "cached for the
+    /// daemon run, so nothing needs invalidating" reasons about caching a
+    /// derived truth; it does not license caching a failure to derive.
+    ///
+    /// Retrying costs nothing on the fleet this cache exists for: `github.com`
+    /// short-circuits in `isGitLabHost` before reaching here, so a GitHub-only
+    /// fleet still spawns no `glab` at all. Only a host that is neither
+    /// `github.com` nor a declared GitLab host re-probes, and it does so
+    /// precisely because the answer for it is still unknown.
     private func hosts(repoPath: String) async -> Set<String> {
         if let cachedHosts { return cachedHosts }
         let resolved = await fetchHosts(repoPath: repoPath)
+        guard !resolved.isEmpty else { return resolved }
         cachedHosts = resolved
         return resolved
     }

--- a/Sources/TBDDaemon/PR/GitLabHostResolver.swift
+++ b/Sources/TBDDaemon/PR/GitLabHostResolver.swift
@@ -46,6 +46,16 @@ actor GitLabHostResolver {
     /// long a user who has just run `glab auth login --hostname …` waits for
     /// TBD to notice. Five minutes is ten foreground ticks of silence for a
     /// wait no longer than the background poll interval itself.
+    ///
+    /// That wait is not merely cosmetic, which is what keeps the window short.
+    /// For its duration the newly configured checkout is still classified
+    /// non-GitLab, so `fetchNumberedMatches` will offer its stored `prNumber`
+    /// to gh's by-number query — and on a flat GitLab namespace those
+    /// coordinates can be answered by a same-named GitHub repository, the
+    /// hazard `PRStatusManager` warns about at that call site. Here it is
+    /// bounded to at most `emptyStatusLifetime` and self-heals on the first
+    /// re-derivation; unbounded caching of the empty answer would leave it
+    /// standing until restart.
     static let emptyStatusLifetime: TimeInterval = 300
 
     init(glRunner: GLRunner? = nil, now: @escaping @Sendable () -> Date = { Date() }) {

--- a/Sources/TBDDaemon/PR/GitLabHostResolver.swift
+++ b/Sources/TBDDaemon/PR/GitLabHostResolver.swift
@@ -1,0 +1,73 @@
+import Foundation
+import os
+
+/// Behavior seam for the `glab` subprocess, mirroring `GHRunner`. Production
+/// leaves it nil and shells out; tests inject a runner so host derivation can
+/// be driven without a `glab` binary. `nil` means "glab did not launch".
+typealias GLRunner = @Sendable (_ args: [String], _ repoPath: String) async -> GHCommandResult?
+
+/// Answers "is this host a GitLab instance?" by reading what the user already
+/// told `glab`.
+///
+/// The declaration and the capability are one precondition: a host appears in
+/// `glab auth status` only because someone ran `glab auth login --hostname`,
+/// and that same act is what makes API calls work. So TBD can never conclude
+/// "this is GitLab" for a host it then cannot query.
+///
+/// Only the host LIST is read. The per-host verdict text is not trustworthy —
+/// a working host has been observed printing "Logged in" and "Invalid token"
+/// together while every call succeeded — so authentication is proven by a call
+/// succeeding, never by this output.
+actor GitLabHostResolver {
+    private let glRunner: GLRunner?
+    private var cachedHosts: Set<String>?
+    private static let log = Logger(subsystem: "com.tbd.daemon", category: "pr.gitlab")
+
+    init(glRunner: GLRunner? = nil) {
+        self.glRunner = glRunner
+    }
+
+    func isGitLabHost(_ host: String, repoPath: String) async -> Bool {
+        // github.com short-circuits before any subprocess, so a GitHub-only
+        // fleet never spawns glab.
+        let normalized = host.lowercased()
+        guard normalized != "github.com" else { return false }
+        return await hosts(repoPath: repoPath).contains(normalized)
+    }
+
+    private func hosts(repoPath: String) async -> Set<String> {
+        if let cachedHosts { return cachedHosts }
+        let resolved = await fetchHosts(repoPath: repoPath)
+        cachedHosts = resolved
+        return resolved
+    }
+
+    private func fetchHosts(repoPath: String) async -> Set<String> {
+        guard let glRunner else { return [] }
+        // The exit status is ignored deliberately: glab exits 1 when ANY
+        // configured host fails to authenticate, so a perfectly good setup
+        // reports failure whenever an unused gitlab.com entry shares the config.
+        guard let result = await glRunner(["auth", "status"], repoPath) else {
+            Self.log.debug("glab did not launch; no GitLab hosts derived")
+            return []
+        }
+        let parsed = Set(Self.parseAuthStatusHosts(result.stdout + "\n" + result.stderr)
+            .map { $0.lowercased() })
+        Self.log.debug("derived GitLab hosts: \(parsed.sorted().joined(separator: ","), privacy: .public)")
+        return parsed
+    }
+
+    /// Host names are the flush-left lines; everything glab knows about a host
+    /// is indented beneath it.
+    static func parseAuthStatusHosts(_ output: String) -> [String] {
+        var out: [String] = []
+        for line in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let first = line.first, !first.isWhitespace else { continue }
+            let candidate = line.trimmingCharacters(in: .whitespaces)
+            // A hostname line has no spaces and at least one dot.
+            guard !candidate.isEmpty, !candidate.contains(" "), candidate.contains(".") else { continue }
+            if !out.contains(candidate) { out.append(candidate) }
+        }
+        return out
+    }
+}

--- a/Sources/TBDDaemon/PR/GitLabQueries.swift
+++ b/Sources/TBDDaemon/PR/GitLabQueries.swift
@@ -16,8 +16,14 @@ enum GitLabQueries {
 
     /// The tier-1 selection. `headPipeline { status }` rides along in the same
     /// batch — the fact GitHub needs a separate per-PR check query for.
+    ///
+    /// Every field here is read by `node(from:)`. Nothing else may be asked
+    /// for: an unread field buys no information and still carries the whole
+    /// query's schema risk. `conflicts` was requested and never read —
+    /// `detailedMergeStatus` already reports CONFLICT, and that is the only
+    /// conflict signal the mapper consults.
     static let nodeSelection = """
-    iid state draft detailedMergeStatus conflicts
+    iid state draft detailedMergeStatus
     sourceBranch targetBranch createdAt webUrl
     headPipeline { status }
     """

--- a/Sources/TBDDaemon/PR/GitLabQueries.swift
+++ b/Sources/TBDDaemon/PR/GitLabQueries.swift
@@ -70,22 +70,49 @@ enum GitLabQueries {
         return out + "\""
     }
 
-    /// Never throws. Any malformed or unexpected shape degrades to no nodes,
-    /// matching the `gh` layer's never-error-just-degrade contract.
-    static func parseMergeRequests(from data: Data) -> (nodes: [PRNode], pipelineGated: Bool) {
+    /// What one GraphQL response settled.
+    ///
+    /// The two cases are the whole point of the type. "The project answered and
+    /// listed no merge requests" is a fact about the project; "the response did
+    /// not carry a project at all" is the forge failing to answer, and letting
+    /// the second read as the first turns a rename, or a token that lost
+    /// `read_api` on one project, into "no merge request here" for every
+    /// worktree on it — silently and permanently.
+    enum ParseOutcome {
+        /// The response carried a project. `nodes` may legitimately be empty.
+        case answered(nodes: [PRNode], pipelineGated: Bool)
+        /// The response could not be understood: unparseable JSON, `data: null`,
+        /// a null project, or a `mergeRequests` block with no node list. The
+        /// caller must record this as undetermined, never as no merge request.
+        case unreadable
+    }
+
+    /// Never throws — a poll must not be interrupted by a bad response, so the
+    /// failure is returned rather than raised.
+    static func parseMergeRequests(from data: Data) -> ParseOutcome {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return ([], false)
+            log.warning("GitLab GraphQL response was not a JSON object")
+            return .unreadable
         }
-        if let errors = root["errors"] as? [[String: Any]], !errors.isEmpty {
-            let codes = errors.compactMap { ($0["extensions"] as? [String: Any])?["code"] as? String }
-            log.debug("GitLab GraphQL errors: \(codes.joined(separator: ","), privacy: .public)")
-        }
+        let errorCodes = (root["errors"] as? [[String: Any]] ?? [])
+            .compactMap { ($0["extensions"] as? [String: Any])?["code"] as? String }
         guard let dataObj = root["data"] as? [String: Any],
-              let project = dataObj["project"] as? [String: Any] else { return ([], false) }
+              let project = dataObj["project"] as? [String: Any],
+              let mrs = project["mergeRequests"] as? [String: Any],
+              let raw = mrs["nodes"] as? [[String: Any]] else {
+            // Warning, not debug: this is the shape a project rename or a
+            // per-project permission loss takes, and it degrades a whole
+            // project's worth of worktrees at once.
+            log.warning("GitLab GraphQL response carried no merge request list; errors: \(errorCodes.joined(separator: ","), privacy: .public)")
+            return .unreadable
+        }
+        if !errorCodes.isEmpty {
+            // Partial data: the list is present, so it is used, the same way
+            // the `gh` by-number arm uses partial stdout.
+            log.debug("GitLab GraphQL errors alongside usable data: \(errorCodes.joined(separator: ","), privacy: .public)")
+        }
         let gated = project["onlyAllowMergeIfPipelineSucceeds"] as? Bool ?? false
-        guard let mrs = project["mergeRequests"] as? [String: Any],
-              let raw = mrs["nodes"] as? [[String: Any]] else { return ([], gated) }
-        return (raw.compactMap(node(from:)), gated)
+        return .answered(nodes: raw.compactMap(node(from:)), pipelineGated: gated)
     }
 
     static func node(from obj: [String: Any]) -> PRNode? {

--- a/Sources/TBDDaemon/PR/GitLabQueries.swift
+++ b/Sources/TBDDaemon/PR/GitLabQueries.swift
@@ -1,0 +1,128 @@
+import Foundation
+import os
+
+/// GraphQL construction and response parsing for GitLab merge requests.
+///
+/// Every field requested here exists on every GitLab edition and predates any
+/// instance likely to be in service. That is load-bearing: GraphQL rejects the
+/// whole query for one unknown field, returning `data: null`, which on a
+/// batched read turns a single schema mismatch into zero merge requests.
+enum GitLabQueries {
+    /// Parsing produces the same node type the `gh` layer produces, so the
+    /// heal, map and persist logic downstream is forge-agnostic.
+    typealias PRNode = PRStatusManager.PRNode
+
+    private static let log = Logger(subsystem: "com.tbd.daemon", category: "pr.gitlab")
+
+    /// The tier-1 selection. `headPipeline { status }` rides along in the same
+    /// batch — the fact GitHub needs a separate per-PR check query for.
+    static let nodeSelection = """
+    iid state draft detailedMergeStatus conflicts
+    sourceBranch targetBranch createdAt webUrl
+    headPipeline { status }
+    """
+
+    /// One batched read of several merge requests by iid.
+    ///
+    /// iids are Int literals, so they are injection-safe by construction — the
+    /// same reason GitHub's `numberedPRQuery` embeds numbers rather than
+    /// binding them. `fullPath` is a variable because it is user data.
+    static func mergeRequestsByIIDQuery(iids: [Int]) -> String {
+        let list = iids.map { "\"\($0)\"" }.joined(separator: ", ")
+        return """
+        query($fullPath: ID!) {
+          project(fullPath: $fullPath) {
+            onlyAllowMergeIfPipelineSucceeds
+            mergeRequests(iids: [\(list)]) {
+              nodes { \(nodeSelection) }
+            }
+          }
+        }
+        """
+    }
+
+    /// Branch matching, server-side and author-blind — so a merge request
+    /// opened by anyone, including through the web UI, is still found.
+    static func mergeRequestsByBranchQuery(branches: [String]) -> String {
+        let list = branches.map(jsonQuoted).joined(separator: ", ")
+        return """
+        query($fullPath: ID!) {
+          project(fullPath: $fullPath) {
+            onlyAllowMergeIfPipelineSucceeds
+            mergeRequests(sourceBranches: [\(list)], state: opened) {
+              nodes { \(nodeSelection) }
+            }
+          }
+        }
+        """
+    }
+
+    private static func jsonQuoted(_ s: String) -> String {
+        var out = "\""
+        for ch in s {
+            switch ch {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            default: out.append(ch)
+            }
+        }
+        return out + "\""
+    }
+
+    /// Never throws. Any malformed or unexpected shape degrades to no nodes,
+    /// matching the `gh` layer's never-error-just-degrade contract.
+    static func parseMergeRequests(from data: Data) -> (nodes: [PRNode], pipelineGated: Bool) {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return ([], false)
+        }
+        if let errors = root["errors"] as? [[String: Any]], !errors.isEmpty {
+            let codes = errors.compactMap { ($0["extensions"] as? [String: Any])?["code"] as? String }
+            log.debug("GitLab GraphQL errors: \(codes.joined(separator: ","), privacy: .public)")
+        }
+        guard let dataObj = root["data"] as? [String: Any],
+              let project = dataObj["project"] as? [String: Any] else { return ([], false) }
+        let gated = project["onlyAllowMergeIfPipelineSucceeds"] as? Bool ?? false
+        guard let mrs = project["mergeRequests"] as? [String: Any],
+              let raw = mrs["nodes"] as? [[String: Any]] else { return ([], gated) }
+        return (raw.compactMap(node(from:)), gated)
+    }
+
+    static func node(from obj: [String: Any]) -> PRNode? {
+        guard let iidString = obj["iid"] as? String, let iid = Int(iidString),
+              let state = obj["state"] as? String,
+              let url = obj["webUrl"] as? String else { return nil }
+        // A null headPipeline is normal on very old merge requests; it means
+        // "no CI signal", not "malformed node".
+        let pipeline = (obj["headPipeline"] as? [String: Any])?["status"] as? String
+        return PRNode(
+            number: iid,
+            url: url,
+            state: state,
+            mergeVerdictRaw: obj["detailedMergeStatus"] as? String ?? "",
+            reviewVerdictRaw: "",
+            headRefName: obj["sourceBranch"] as? String ?? "",
+            createdAt: obj["createdAt"] as? String ?? "",
+            isDraft: obj["draft"] as? Bool ?? false,
+            statusCheckRollupState: pipeline,
+            mergeQueuePosition: nil,
+            baseRefName: obj["targetBranch"] as? String ?? "",
+            forge: .gitlab)
+    }
+
+    /// The REST path that asks GitLab to recompute mergeability.
+    ///
+    /// GitLab computes mergeability asynchronously and does not recompute on
+    /// read, so a merge request can report UNCHECKED indefinitely. GraphQL has
+    /// no equivalent argument; REST's list endpoint does. Scoped to bound
+    /// merge requests only, because it queues background work on someone
+    /// else's server. Params live in the path so the request stays a GET —
+    /// `glab api` switches to POST as soon as a `-f` field is present.
+    static func recheckPath(projectPath: String, iids: [Int]) -> String {
+        let encoded = projectPath.addingPercentEncoding(
+            withAllowedCharacters: CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+        ) ?? projectPath
+        let params = iids.map { "iids%5B%5D=\($0)" } + ["with_merge_status_recheck=true"]
+        return "projects/\(encoded)/merge_requests?" + params.joined(separator: "&")
+    }
+}

--- a/Sources/TBDDaemon/PR/GitLabQueries.swift
+++ b/Sources/TBDDaemon/PR/GitLabQueries.swift
@@ -85,8 +85,11 @@ enum GitLabQueries {
     /// `read_api` on one project, into "no merge request here" for every
     /// worktree on it — silently and permanently.
     enum ParseOutcome {
-        /// The response carried a project. `nodes` may legitimately be empty.
-        case answered(nodes: [PRNode], pipelineGated: Bool)
+        /// The response carried a project. `nodes` may legitimately be empty,
+        /// and `pipelineGated` is nil when the project did not say — see the
+        /// `gated` binding in `parseMergeRequests` for why that stays a third
+        /// state instead of collapsing to false.
+        case answered(nodes: [PRNode], pipelineGated: Bool?)
         /// The response could not be understood: unparseable JSON, `data: null`,
         /// a null project, or a `mergeRequests` block with no node list. The
         /// caller must record this as undetermined, never as no merge request.
@@ -117,7 +120,16 @@ enum GitLabQueries {
             // the `gh` by-number arm uses partial stdout.
             log.debug("GitLab GraphQL errors alongside usable data: \(errorCodes.joined(separator: ","), privacy: .public)")
         }
-        let gated = project["onlyAllowMergeIfPipelineSucceeds"] as? Bool ?? false
+        // Three shapes reach nil here and all three mean the same thing: the
+        // field was null, absent, or something this build cannot read as a
+        // Bool. None of them is evidence that the project does not gate merges
+        // on its pipelines, and `?? false` would make them indistinguishable
+        // from a project that answered "no" — which switches the whole CI
+        // branch of the mapper off and, because NOT_APPROVED maps to
+        // .mergeable, renders a failing gated pipeline as "Ready to merge".
+        // It stays a scalar rather than making the response unreadable: one
+        // null field must not discard the merge requests that came with it.
+        let gated = project["onlyAllowMergeIfPipelineSucceeds"] as? Bool
         // Element-wise, because a `[[String: Any]]` cast fails whole: one null
         // element — how GraphQL reports a per-node error — would discard every
         // sibling node. Same shape as the `gh` parser after PR #208.

--- a/Sources/TBDDaemon/PR/GitLabQueries.swift
+++ b/Sources/TBDDaemon/PR/GitLabQueries.swift
@@ -99,7 +99,7 @@ enum GitLabQueries {
         guard let dataObj = root["data"] as? [String: Any],
               let project = dataObj["project"] as? [String: Any],
               let mrs = project["mergeRequests"] as? [String: Any],
-              let raw = mrs["nodes"] as? [[String: Any]] else {
+              let raw = mrs["nodes"] as? [Any] else {
             // Warning, not debug: this is the shape a project rename or a
             // per-project permission loss takes, and it degrades a whole
             // project's worth of worktrees at once.
@@ -112,7 +112,11 @@ enum GitLabQueries {
             log.debug("GitLab GraphQL errors alongside usable data: \(errorCodes.joined(separator: ","), privacy: .public)")
         }
         let gated = project["onlyAllowMergeIfPipelineSucceeds"] as? Bool ?? false
-        return .answered(nodes: raw.compactMap(node(from:)), pipelineGated: gated)
+        // Element-wise, because a `[[String: Any]]` cast fails whole: one null
+        // element — how GraphQL reports a per-node error — would discard every
+        // sibling node. Same shape as the `gh` parser after PR #208.
+        let nodes = raw.compactMap { $0 as? [String: Any] }.compactMap(node(from:))
+        return .answered(nodes: nodes, pipelineGated: gated)
     }
 
     static func node(from obj: [String: Any]) -> PRNode? {

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -37,10 +37,9 @@ public actor PRBindingCoordinator {
 
     /// - Parameter resolveRepo: the worktree's own `owner`/`name` and host, or
     ///   nil when they cannot be determined (no remote, git failure, unknown
-    ///   worktree). Validation compares `owner`/`name` only: the host is
-    ///   carried for the callers that must *compose* a reference, and folding
-    ///   it into the wrong-repo check would start rejecting bindings that are
-    ///   accepted today, which is a policy change and not this one.
+    ///   worktree). Validation always compares `owner`/`name`, and compares the
+    ///   host under the rule `hostsAgree` states — the host also rides along for
+    ///   the callers that must *compose* a reference.
     public init(store: PRBindingStore,
                 resolveRepo: @escaping @Sendable (UUID) async -> (owner: String, name: String, host: String)?) {
         self.store = store
@@ -86,6 +85,13 @@ public actor PRBindingCoordinator {
               own.name.lowercased() == parsed.repo.lowercased() else {
             logger.debug("rejecting PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): PR is in \(other, privacy: .public), worktree is in \(own.owner, privacy: .public)/\(own.name, privacy: .public)")
             return .rejectedWrongRepo(other)
+        }
+        guard Self.hostsAgree(own: own.host, parsed: parsed.host) else {
+            // The owner and name are identical here, so naming them alone would
+            // read as nonsense — the host is the whole disagreement.
+            let elsewhere = "\(parsed.host)/\(other)"
+            logger.debug("rejecting PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): PR is on \(elsewhere, privacy: .public), worktree is on \(own.host, privacy: .public)")
+            return .rejectedWrongRepo(elsewhere)
         }
 
         let candidate = PRBinding(
@@ -161,6 +167,60 @@ public actor PRBindingCoordinator {
                                     identityKey: identityKey(worktreeID: worktreeID,
                                                              parsed: parsed),
                                     detached: true)
+    }
+
+    /// The host `PRBindingExtractor`'s GitHub pattern hard-codes. Because that
+    /// pattern is host-locked, a parsed `github.com` is the pattern's own
+    /// constant rather than something read off the URL's forge — which is what
+    /// `hostsAgree` leans on. When enterprise support lands and that pattern
+    /// starts *capturing* a host, this constant and the exemption it drives go
+    /// with it.
+    private static let patternAssumedGitHubHost = "github.com"
+
+    /// Whether a request's host may name the same repo the worktree checks out.
+    ///
+    /// Two identically named projects on two different forges are two different
+    /// projects. `PRBinding.identityKey` and the `worktree_pull_request` unique
+    /// index both key on the host; the wrong-repo guard is the one place that
+    /// does not, and comparing `owner`/`name` alone lets a GitLab merge request
+    /// for `acme/proj` bind to a `github.com/acme/proj` worktree. A false bind
+    /// is the expensive direction — when that foreign request merges,
+    /// `allResolved` can auto-archive a worktree that never had anything to do
+    /// with it, while a missed bind costs one `tbd pr attach`.
+    ///
+    /// So hosts agree when they are the same host (case-insensitively;
+    /// hostnames are), when either side has no host at all, or when the URL's
+    /// host is the `github.com` every GitHub URL carries by construction.
+    ///
+    /// That last clause is the trade-off, and it is deliberate. A *captured*
+    /// host is evidence about where a request lives; a hard-coded one is an
+    /// assumption the pattern made, and rejecting on it would refuse bindings
+    /// that work today — a `github.com` URL attached to a GitHub Enterprise or
+    /// self-hosted-mirror checkout with the same `owner/name`, the same
+    /// same-org/same-name-across-hosts collision `RemoteRepoMatching` documents
+    /// as deliberately tolerated. The cost is that this rule does not close
+    /// that older, narrower hole; it closes the one this coordinator can
+    /// actually see, which is a URL that *did* observe its host disagreeing
+    /// with the host the worktree resolved.
+    ///
+    /// An absent host on either side is treated as unknown, not as a mismatch —
+    /// the same reason an unresolvable repo defers instead of rejecting. Absent
+    /// is unreachable from the shipping call paths (the extractor always names a
+    /// host, and a bare-number attach composes the worktree's own), so it is
+    /// belt-and-braces rather than a live case; `owner`/`name` still have to
+    /// match either way.
+    ///
+    /// Deliberately not `Forge.forHost`: it classifies every non-`github.com`
+    /// host as GitLab, so a GitHub Enterprise checkout would read as a different
+    /// forge from a `github.com` URL and this guard would reject exactly the
+    /// binding the exemption above exists to keep. Its own doc calls that out —
+    /// it is a composition fallback, not host discovery, and a validation gate
+    /// must not borrow a guess.
+    private static func hostsAgree(own: String, parsed: String) -> Bool {
+        let own = own.lowercased()
+        let parsed = parsed.lowercased()
+        guard !own.isEmpty, !parsed.isEmpty else { return true }
+        return parsed == own || parsed == patternAssumedGitHubHost
     }
 
     private func identityKey(worktreeID: UUID, parsed: ParsedPRURL) -> String {

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -210,12 +210,10 @@ public actor PRBindingCoordinator {
     /// belt-and-braces rather than a live case; `owner`/`name` still have to
     /// match either way.
     ///
-    /// Deliberately not `Forge.forHost`: it classifies every non-`github.com`
-    /// host as GitLab, so a GitHub Enterprise checkout would read as a different
-    /// forge from a `github.com` URL and this guard would reject exactly the
-    /// binding the exemption above exists to keep. Its own doc calls that out —
-    /// it is a composition fallback, not host discovery, and a validation gate
-    /// must not borrow a guess.
+    /// Hosts are compared as strings, and no forge classification enters this
+    /// guard at all. A forge is derived from a URL's shape (`Forge.forURL`) or
+    /// established by asking which hosts speak GitLab; neither is a licence to
+    /// call two hosts the same host, and a validation gate needs the hosts.
     private static func hostsAgree(own: String, parsed: String) -> Bool {
         let own = own.lowercased()
         let parsed = parsed.lowercased()

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -34,16 +34,24 @@ public actor PRBindingCoordinator {
 
     private let store: PRBindingStore
     private let resolveRepo: @Sendable (UUID) async -> (owner: String, name: String, host: String)?
+    private let isGitLabHost: @Sendable (UUID, String) async -> Bool?
 
     /// - Parameter resolveRepo: the worktree's own `owner`/`name` and host, or
     ///   nil when they cannot be determined (no remote, git failure, unknown
     ///   worktree). Validation always compares `owner`/`name`, and compares the
-    ///   host under the rule `hostsAgree` states — the host also rides along for
-    ///   the callers that must *compose* a reference.
+    ///   host under the rule `hostAgreement` states — the host also rides along
+    ///   for the callers that must *compose* a reference.
+    /// - Parameter isGitLabHost: whether the worktree's own host is one the
+    ///   user has configured `glab` for, or nil when the question could not be
+    ///   put at all (no directory on this machine to ask in). Only the
+    ///   `github.com` exemption in `hostAgreement` consults it, so a worktree
+    ///   whose host already matches the URL's never pays for the answer.
     public init(store: PRBindingStore,
-                resolveRepo: @escaping @Sendable (UUID) async -> (owner: String, name: String, host: String)?) {
+                resolveRepo: @escaping @Sendable (UUID) async -> (owner: String, name: String, host: String)?,
+                isGitLabHost: @escaping @Sendable (UUID, String) async -> Bool?) {
         self.store = store
         self.resolveRepo = resolveRepo
+        self.isGitLabHost = isGitLabHost
     }
 
     public func bind(worktreeID: UUID, parsed: ParsedPRURL,
@@ -86,12 +94,18 @@ public actor PRBindingCoordinator {
             logger.debug("rejecting PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): PR is in \(other, privacy: .public), worktree is in \(own.owner, privacy: .public)/\(own.name, privacy: .public)")
             return .rejectedWrongRepo(other)
         }
-        guard Self.hostsAgree(own: own.host, parsed: parsed.host) else {
+        switch await hostAgreement(worktreeID: worktreeID, own: own.host, parsed: parsed.host) {
+        case .agree:
+            break
+        case .disagree:
             // The owner and name are identical here, so naming them alone would
             // read as nonsense — the host is the whole disagreement.
             let elsewhere = "\(parsed.host)/\(other)"
             logger.debug("rejecting PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): PR is on \(elsewhere, privacy: .public), worktree is on \(own.host, privacy: .public)")
             return .rejectedWrongRepo(elsewhere)
+        case .undetermined:
+            logger.debug("deferring PR #\(parsed.number, privacy: .public) for worktree \(worktreeID.uuidString, privacy: .public): the forge of \(own.host, privacy: .public) could not be determined")
+            return .deferredUnknownRepo
         }
 
         let candidate = PRBinding(
@@ -172,10 +186,20 @@ public actor PRBindingCoordinator {
     /// The host `PRBindingExtractor`'s GitHub pattern hard-codes. Because that
     /// pattern is host-locked, a parsed `github.com` is the pattern's own
     /// constant rather than something read off the URL's forge — which is what
-    /// `hostsAgree` leans on. When enterprise support lands and that pattern
+    /// `hostAgreement` leans on. When enterprise support lands and that pattern
     /// starts *capturing* a host, this constant and the exemption it drives go
     /// with it.
     private static let patternAssumedGitHubHost = "github.com"
+
+    /// Whether a request's host may name the same repo the worktree checks out,
+    /// or whether nothing could answer.
+    private enum HostAgreement {
+        case agree
+        case disagree
+        /// The worktree's forge could not be established, and the answer would
+        /// have decided the `github.com` exemption.
+        case undetermined
+    }
 
     /// Whether a request's host may name the same repo the worktree checks out.
     ///
@@ -189,36 +213,61 @@ public actor PRBindingCoordinator {
     /// with it, while a missed bind costs one `tbd pr attach`.
     ///
     /// So hosts agree when they are the same host (case-insensitively;
-    /// hostnames are), when either side has no host at all, or when the URL's
-    /// host is the `github.com` every GitHub URL carries by construction.
+    /// hostnames are), and when either side has no host at all.
     ///
-    /// That last clause is the trade-off, and it is deliberate. A *captured*
-    /// host is evidence about where a request lives; a hard-coded one is an
-    /// assumption the pattern made, and rejecting on it would refuse bindings
-    /// that work today — a `github.com` URL attached to a GitHub Enterprise or
-    /// self-hosted-mirror checkout with the same `owner/name`, the same
+    /// **The `github.com` exemption, and where it stops.** A parsed
+    /// `github.com` is a constant `PRBindingExtractor`'s host-locked GitHub
+    /// pattern supplies rather than a host it read off the URL, so on its own it
+    /// is not evidence about where the request lives. Rejecting on it would
+    /// refuse bindings that work today — a `github.com` URL attached to a GitHub
+    /// Enterprise or self-hosted-mirror checkout with the same `owner/name`, the
     /// same-org/same-name-across-hosts collision `RemoteRepoMatching` documents
-    /// as deliberately tolerated. The cost is that this rule does not close
-    /// that older, narrower hole; it closes the one this coordinator can
-    /// actually see, which is a URL that *did* observe its host disagreeing
-    /// with the host the worktree resolved.
+    /// as deliberately tolerated. Such a worktree therefore still binds.
+    ///
+    /// A worktree whose own host speaks **GitLab** does not. Its merge requests
+    /// live on that host, so a `github.com` pull request sharing an `owner/name`
+    /// with it is a different project by construction — and binding it would
+    /// poll a stranger's PR through `gh` and let that stranger's merge
+    /// auto-archive this worktree. That is the cross-forge collision this guard
+    /// exists to close, and it is the whole of what the exemption gives up.
+    ///
+    /// **The forge is asked, never read off the hostname.** "Not github.com"
+    /// describes GitHub Enterprise, Bitbucket, Gitea and Codeberg as readily as
+    /// a self-managed GitLab, so a host-keyed classifier would refuse all four
+    /// of those fleets a binding they should get. The answer comes from the same
+    /// seam the rest of the daemon uses — the hosts the user configured `glab`
+    /// for, a declaration rather than an inference.
+    ///
+    /// **An undetermined forge defers rather than binds.** Nothing has answered
+    /// there, and the two ways to be wrong are not symmetric: binding invents a
+    /// row that can auto-archive a worktree on someone else's merge, while
+    /// deferring writes nothing and the next poll or attach asks again. The
+    /// caller turns it into `.deferredUnknownRepo`, the same outcome an
+    /// unresolvable repo already gets. Like an absent host it is belt-and-braces
+    /// rather than a live case: the forge is unaskable only for a worktree with
+    /// no directory on this machine, and such a worktree cannot resolve its own
+    /// repo either, so `bind` has already deferred before reaching here.
     ///
     /// An absent host on either side is treated as unknown, not as a mismatch —
     /// the same reason an unresolvable repo defers instead of rejecting. Absent
     /// is unreachable from the shipping call paths (the extractor always names a
-    /// host, and a bare-number attach composes the worktree's own), so it is
-    /// belt-and-braces rather than a live case; `owner`/`name` still have to
-    /// match either way.
+    /// host, and a bare-number attach composes the worktree's own), so it too is
+    /// belt-and-braces; `owner`/`name` still have to match either way.
     ///
-    /// Hosts are compared as strings, and no forge classification enters this
-    /// guard at all. A forge is derived from a URL's shape (`Forge.forURL`) or
-    /// established by asking which hosts speak GitLab; neither is a licence to
-    /// call two hosts the same host, and a validation gate needs the hosts.
-    private static func hostsAgree(own: String, parsed: String) -> Bool {
+    /// Hosts themselves are compared as strings, and no forge classification
+    /// derived from a URL's shape (`Forge.forURL`) enters this guard: that
+    /// answers what a request is, not whether two hosts are one host, and a
+    /// validation gate needs the hosts.
+    private func hostAgreement(worktreeID: UUID, own: String, parsed: String) async -> HostAgreement {
         let own = own.lowercased()
         let parsed = parsed.lowercased()
-        guard !own.isEmpty, !parsed.isEmpty else { return true }
-        return parsed == own || parsed == patternAssumedGitHubHost
+        guard !own.isEmpty, !parsed.isEmpty else { return .agree }
+        if parsed == own { return .agree }
+        // Every other disagreement is a disagreement; only the pattern's own
+        // constant earns a second question, and only that question spawns work.
+        guard parsed == Self.patternAssumedGitHubHost else { return .disagree }
+        guard let ownIsGitLab = await isGitLabHost(worktreeID, own) else { return .undetermined }
+        return ownIsGitLab ? .disagree : .agree
     }
 
     private func identityKey(worktreeID: UUID, parsed: ParsedPRURL) -> String {

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -33,12 +33,16 @@ public actor PRBindingCoordinator {
     }
 
     private let store: PRBindingStore
-    private let resolveRepo: @Sendable (UUID) async -> (owner: String, name: String)?
+    private let resolveRepo: @Sendable (UUID) async -> (owner: String, name: String, host: String)?
 
-    /// - Parameter resolveRepo: the worktree's own GitHub `owner`/`name`, or nil
-    ///   when it cannot be determined (no remote, git failure, unknown worktree).
+    /// - Parameter resolveRepo: the worktree's own `owner`/`name` and host, or
+    ///   nil when they cannot be determined (no remote, git failure, unknown
+    ///   worktree). Validation compares `owner`/`name` only: the host is
+    ///   carried for the callers that must *compose* a reference, and folding
+    ///   it into the wrong-repo check would start rejecting bindings that are
+    ///   accepted today, which is a policy change and not this one.
     public init(store: PRBindingStore,
-                resolveRepo: @escaping @Sendable (UUID) async -> (owner: String, name: String)?) {
+                resolveRepo: @escaping @Sendable (UUID) async -> (owner: String, name: String, host: String)?) {
         self.store = store
         self.resolveRepo = resolveRepo
     }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -2554,10 +2554,22 @@ public actor PRStatusManager {
 
     /// The host, namespace and project of a git remote URL.
     ///
-    /// Accepts the three shapes a remote can take — `https://host/a/b`,
-    /// `ssh://git@host:22/a/b`, and the scp-like `git@host:a/b` — and keeps the
-    /// FULL namespace, because a GitLab project can nest (`acme/platform/api`)
-    /// and the owner is everything before the last segment.
+    /// Accepts the three shapes a remote that names a NETWORK HOST can take —
+    /// `https://host/a/b`, `ssh://git@host:22/a/b`, and the scp-like
+    /// `git@host:a/b` — and keeps the FULL namespace, because a GitLab project
+    /// can nest (`acme/platform/api`) and the owner is everything before the
+    /// last segment.
+    ///
+    /// A remote that names no host is rejected outright rather than having its
+    /// first path segment read as one. `file:///Users/me/repo.git` would
+    /// otherwise resolve to the host "Users" and `/srv/git/acme/repo.git` to
+    /// "srv" — identities that are not merely useless but harmful. They are
+    /// cached like any other; `Forge.forHost` classifies anything that is not
+    /// `github.com` as GitLab, so `tbd pr attach` composes merge-request URLs
+    /// against them; and `poisonedCacheEntries` rests on "both sides resolved"
+    /// meaning both sides are KNOWN, so a fabricated identity turns a
+    /// legitimately cached PR status into a cross-repo poisoning and clears it,
+    /// persistently.
     ///
     /// `RemoteRepoMatching` in TBDShared parses the same three shapes and is
     /// deliberately not reused: it drops the host by design, and it keeps only
@@ -2569,10 +2581,22 @@ public actor PRStatusManager {
         var rest = remote.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !rest.isEmpty else { return nil }
         if let scheme = rest.range(of: "://") {
+            // Only the schemes that carry a network host. `file://` names a
+            // path on this machine, and a path's first segment is not a host.
+            guard Self.networkRemoteSchemes.contains(String(rest[..<scheme.lowerBound]).lowercased()) else {
+                return nil
+            }
             rest = String(rest[scheme.upperBound...])
-        } else if let colon = rest.firstIndex(of: ":") {
-            // scp-like syntax puts ':' where a URL puts the first '/'.
+        } else if let colon = rest.firstIndex(of: ":"), !rest[..<colon].contains("/"),
+                  colon != rest.startIndex {
+            // scp-like syntax puts ':' where a URL puts the first '/'. The
+            // colon must come before any '/', or this is a local path with a
+            // colon somewhere in it rather than `host:namespace/project`.
             rest.replaceSubrange(colon...colon, with: "/")
+        } else {
+            // A bare local path — `/srv/git/acme/repo.git`, `../sibling` — names
+            // no host at all, and its first segment must never be read as one.
+            return nil
         }
         var segments = rest.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
         guard segments.count >= 3 else { return nil }
@@ -2586,6 +2610,11 @@ public actor PRStatusManager {
         guard !host.isEmpty, !owner.isEmpty, !name.isEmpty else { return nil }
         return (owner: owner, name: name, host: host.lowercased())
     }
+
+    /// The URL schemes that put a network host where this parser reads one.
+    /// `file` is deliberately absent, and so is every scheme nobody has seen on
+    /// a forge remote: an unknown scheme is not evidence of a host.
+    private static let networkRemoteSchemes: Set<String> = ["ssh", "git", "git+ssh", "http", "https"]
 
     /// `resolveNameWithOwner` behind a ~15-min TTL cache so the periodic poll
     /// (by-number query) and picker (open-PR query) stop spawning a `gh repo

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1158,7 +1158,36 @@ public actor PRStatusManager {
         reviewVerdictRaw: String = "",
         isDraft: Bool = false,
         requiredChecksFailing: Bool = false,
-        requiredChecksPending: Bool = false
+        requiredChecksPending: Bool = false,
+        pipelineGated: Bool = false,
+        pipelineStatus: String? = nil
+    ) -> (state: PRMergeableState, reason: String) {
+        switch forge {
+        case .github:
+            return mapGitHubStateAndReason(
+                ghState: ghState,
+                mergeVerdictRaw: mergeVerdictRaw,
+                reviewVerdictRaw: reviewVerdictRaw,
+                isDraft: isDraft,
+                requiredChecksFailing: requiredChecksFailing,
+                requiredChecksPending: requiredChecksPending)
+        case .gitlab:
+            return mapGitLabStateAndReason(
+                state: ghState,
+                detailed: mergeVerdictRaw,
+                isDraft: isDraft,
+                pipelineGated: pipelineGated,
+                pipelineStatus: pipelineStatus)
+        }
+    }
+
+    private static func mapGitHubStateAndReason(
+        ghState: String,
+        mergeVerdictRaw: String,
+        reviewVerdictRaw: String,
+        isDraft: Bool,
+        requiredChecksFailing: Bool,
+        requiredChecksPending: Bool
     ) -> (state: PRMergeableState, reason: String) {
         switch ghState {
         case "MERGED": return (.merged, "Merged")
@@ -1188,6 +1217,69 @@ public actor PRStatusManager {
             default:
                 return (.blocked, "Blocked")
             }
+        }
+    }
+
+    /// GitLab's merge vocabulary.
+    ///
+    /// The CI signal is computed independently of `detailedMergeStatus`, which
+    /// reports only ONE blocker by a precedence GitLab owns and in which CI
+    /// ranks below approval, draft and unchecked. Field measurement: 33 failing
+    /// pipelines across 71 merge requests on a pipeline-gated project produced
+    /// zero CI_MUST_PASS. Reading CI off the merge status would therefore show
+    /// red essentially never, and — since NOT_APPROVED maps to .mergeable —
+    /// would render a merge request with a failing pipeline as "Ready to merge".
+    ///
+    /// Precedence mirrors the GitHub arm exactly: terminal, then draft, then
+    /// the CI signal, then the merge-status switch.
+    private static func mapGitLabStateAndReason(
+        state: String,
+        detailed: String,
+        isDraft: Bool,
+        pipelineGated: Bool,
+        pipelineStatus: String?
+    ) -> (state: PRMergeableState, reason: String) {
+        switch state.lowercased() {
+        case "merged": return (.merged, "Merged")
+        case "closed": return (.closed, "Closed")
+        default: break
+        }
+
+        if isDraft || detailed == "DRAFT_STATUS" { return (.draft, "Draft") }
+
+        // `onlyAllowMergeIfPipelineSucceeds` is the faithful analogue of
+        // GitHub's "required check". A failing pipeline on a project that does
+        // not gate merges is GitHub's UNSTABLE, which TBD does not colour.
+        if pipelineGated, let pipelineStatus {
+            switch pipelineStatus {
+            case "FAILED": return (.checksFailed, "Pipeline failed")
+            case "RUNNING", "PENDING", "CREATED", "WAITING_FOR_RESOURCE", "PREPARING":
+                return (.pending, "Pipeline running")
+            case "MANUAL": return (.pending, "Pipeline awaiting manual action")
+            default: break
+            }
+        }
+
+        switch detailed {
+        case "MERGEABLE": return (.mergeable, "Ready to merge")
+        // Checks are settled and the only blocker is an approval nobody has
+        // given — the same reading the GitHub arm gives BLOCKED + REVIEW_REQUIRED.
+        case "NOT_APPROVED": return (.mergeable, "Ready to merge")
+        case "DISCUSSIONS_NOT_RESOLVED": return (.changesRequested, "Unresolved discussions")
+        case "REQUESTED_CHANGES": return (.changesRequested, "Changes requested")
+        case "CONFLICT": return (.blocked, "Merge conflicts")
+        case "NEED_REBASE": return (.blocked, "Behind base branch")
+        case "BLOCKED_STATUS": return (.blocked, "Blocked by another merge request")
+        case "CHECKING", "PREPARING": return (.pending, "Checks pending")
+        // Not transient: GitLab leaves a stale merge request unchecked until
+        // something re-triggers the computation, so the wording must not imply
+        // it is about to resolve.
+        case "UNCHECKED": return (.pending, "Mergeability not checked")
+        default:
+            // The enum grows between releases. Unknown means unknown — treating
+            // it as blocked would let a future GitLab version paint merge
+            // requests red for saying something new.
+            return (.pending, "Mergeability not checked")
         }
     }
 

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -31,6 +31,20 @@ enum PRUndeterminedCause {
     /// truncated or malformed blob. Not the absence of a record: an attempt was
     /// made, and only what it concluded is lost.
     static let unreadableRecord = "the recorded outcome could not be read"
+    /// The CLI ran and reached the host, which refused the credentials. Named
+    /// separately from `cliUnavailable` because the remedy differs: a token
+    /// expired, and only re-authenticating that specific host fixes it. A
+    /// personal access token has no refresh, so a host that answered yesterday
+    /// starts refusing today — and letting that read as "there is no merge
+    /// request here" is the silent degradation this whole vocabulary exists to
+    /// prevent.
+    ///
+    /// The host is the one piece of forge detail this vocabulary does carry,
+    /// and deliberately: the remedy is `glab auth login --hostname <host>`, so
+    /// a report that withheld the host would name a fix nobody could apply.
+    static func forgeAuthFailed(host: String) -> String {
+        "the forge rejected the credentials for \(host)"
+    }
 }
 
 /// In-memory cache of GitHub PR status per worktree.
@@ -130,6 +144,31 @@ public actor PRStatusManager {
 
     private let ghRunner: GHRunner?
 
+    /// Behavior seam for the `glab` subprocess, mirroring `ghRunner`. Nil means
+    /// "shell out to the real `glab`"; a test injects one so the whole GitLab
+    /// path runs with no binary, no credentials and no network.
+    private let glRunner: GLRunner?
+
+    /// Hosts known to speak GitLab, stated outright. Tests pass the set
+    /// directly so the resolver — and the `glab auth status` subprocess behind
+    /// it — stays out of the loop; production leaves it empty and lets
+    /// `gitLabHostResolver` answer.
+    private let gitLabHosts: Set<String>
+
+    /// Production's answer to "is this host GitLab?", read from what the user
+    /// already told `glab`. Nil in the injecting init: a test that hands over
+    /// `gitLabHosts` has stated the whole answer, and consulting a resolver
+    /// behind its back would spawn `glab auth status` from a unit test.
+    private let gitLabHostResolver: GitLabHostResolver?
+
+    /// The last authentication refusal observed per forge host, lowercased.
+    ///
+    /// Keyed by host rather than by worktree or binding because that is the
+    /// scope of both the fault and its remedy: one expired token silences every
+    /// project on that instance at once, and one `glab auth login` restores
+    /// them all. Cleared the moment a call to that host succeeds.
+    private var forgeAuthFailures: [String: String] = [:]
+
     /// Behavior seam for reading a checkout's `origin` remote URL — the second
     /// identity source, used only when `gh` cannot name the repo, which is
     /// every checkout on a host `gh` does not speak to. Production leaves it
@@ -149,13 +188,28 @@ public actor PRStatusManager {
     public init(now: @escaping @Sendable () -> Date = { Date() }) {
         self.ghRunner = nil
         self.remoteURLReader = nil
+        self.glRunner = nil
+        self.gitLabHosts = []
+        // The resolver needs a runner of its own: it is constructed here, before
+        // any instance exists to capture, so it gets the static `glab` spawner
+        // rather than `runGLResult`.
+        self.gitLabHostResolver = GitLabHostResolver(glRunner: { args, repoPath in
+            await PRStatusManager.runGlab(args: args, repoPath: repoPath)
+        })
         self.now = now
     }
 
+    /// `glRunner` and `gitLabHosts` are defaulted so every existing call site
+    /// stays a GitHub-only manager that can never spawn `glab`.
     init(ghRunner: @escaping GHRunner,
+         glRunner: GLRunner? = nil,
+         gitLabHosts: Set<String> = [],
          remoteURLReader: @escaping RemoteURLReader = { _ in nil },
          now: @escaping @Sendable () -> Date = { Date() }) {
         self.ghRunner = ghRunner
+        self.glRunner = glRunner
+        self.gitLabHosts = Set(gitLabHosts.map { $0.lowercased() })
+        self.gitLabHostResolver = nil
         self.remoteURLReader = remoteURLReader
         self.now = now
     }
@@ -263,6 +317,44 @@ public actor PRStatusManager {
     /// runner counts as available: it is what stands in for the binary.
     private var forgeCLIAvailable: Bool {
         ghRunner != nil || Self.resolvedGHPath != nil
+    }
+
+    /// The same question for `glab`. `nonisolated` because the GitLab fetch
+    /// paths are, and it reads only immutable state.
+    private nonisolated var gitLabCLIAvailable: Bool {
+        glRunner != nil || Self.resolvedGlabPath != nil
+    }
+
+    /// Whether this host speaks GitLab.
+    ///
+    /// An injected set is the whole answer when there is one, so a test never
+    /// reaches the resolver; production injects nothing and the resolver reads
+    /// `glab auth status` (cached, and short-circuited for github.com before
+    /// any subprocess).
+    private nonisolated func isGitLabHost(_ host: String, repoPath: String) async -> Bool {
+        if gitLabHosts.contains(host.lowercased()) { return true }
+        guard let gitLabHostResolver else { return false }
+        return await gitLabHostResolver.isGitLabHost(host, repoPath: repoPath)
+    }
+
+    /// The credential refusal last observed for a host, or nil if its most
+    /// recent call succeeded. The report is per host because the fault is:
+    /// every project on that instance goes dark together.
+    public func lastUndeterminedCause(forHost host: String) -> String? {
+        forgeAuthFailures[host.lowercased()]
+    }
+
+    /// Record — or, on `failed: false`, retract — a host's credential refusal.
+    /// A single successful call is proof the token works again, which is the
+    /// only evidence this actor ever accepts for authentication (never status
+    /// text; see `GitLabHostResolver`).
+    private func setForgeAuthFailure(_ failed: Bool, host: String) {
+        let key = host.lowercased()
+        if failed {
+            forgeAuthFailures[key] = PRUndeterminedCause.forgeAuthFailed(host: host)
+        } else {
+            forgeAuthFailures.removeValue(forKey: key)
+        }
     }
 
     /// Record one attempt's outcome and persist it — unless a newer attempt is
@@ -483,14 +575,26 @@ public actor PRStatusManager {
         /// rather than collapsed to a Bool so an unnumbered worktree's
         /// `.undetermined` names what actually went wrong.
         var batchFailureCause = PRUndeterminedCause.queryFailed
+        /// Which unnumbered worktrees are on a GitLab host, which of those a
+        /// project query actually answered for, and — for the ones it matched —
+        /// whether their project gates merges on the pipeline. The GitLab side
+        /// is judged per project rather than by one fleet-wide batch, so
+        /// `batchSucceeded` cannot speak for it.
+        var gitLabUnnumberedIDs: Set<UUID> = []
+        var gitLabAnsweredIDs: Set<UUID> = []
+        var gitLabPipelineGated: [UUID: Bool] = [:]
+        var gitLabFailureCause = PRUndeterminedCause.queryFailed
         if !unnumbered.isEmpty {
             // Resolve each unnumbered worktree's own repo once, mirroring the
             // numbered path's `resolved` dictionary. TTL-cached, so the poll
             // doesn't spawn a `gh repo view` subprocess per worktree per tick.
+            // The host rides along because it is what decides which forge to ask.
             var unnumberedRepos: [String: (owner: String, name: String)] = [:]
+            var unnumberedHosts: [String: String] = [:]
             for path in Set(unnumbered.map(\.worktreePath)) {
                 if let ownerRepo = await cachedNameWithOwner(repoPath: path) {
                     unnumberedRepos[path] = (owner: ownerRepo.owner, name: ownerRepo.name)
+                    unnumberedHosts[path] = ownerRepo.host
                 } else {
                     logger.debug("fetchAll: could not resolve owner/name for unnumbered worktree at \(path, privacy: .public)")
                 }
@@ -525,21 +629,50 @@ public actor PRStatusManager {
                 poisoned.map { (worktreeID: $0.worktreeID, url: $0.cachedURL) },
                 context: "cross-repo heal")
 
-            if let jsonData = await runGHGraphQL(repoPath: repoPath) {
-                if let nodes = try? Self.parsePRNodes(from: jsonData) {
-                    batchSucceeded = true   // empty nodes is still a valid answer (viewer has no PRs)
-                    let branchMatches = Self.matchUnnumbered(unnumbered, nodes: nodes,
-                                                             resolveRepo: { unnumberedRepos[$0] })
-                    branchMatchedIDs.formUnion(branchMatches.map(\.worktreeID))
-                    matches += branchMatches
+            // Split the by-branch path by forge. A worktree whose repo would
+            // not name itself has no host either, so it stays on the GitHub
+            // side — the pre-GitLab behavior, where it simply matches nothing.
+            var gitLabPaths: Set<String> = []
+            for (path, host) in unnumberedHosts where await isGitLabHost(host, repoPath: path) {
+                gitLabPaths.insert(path)
+            }
+            let gitLabUnnumbered = unnumbered.filter { gitLabPaths.contains($0.worktreePath) }
+            let gitHubUnnumbered = unnumbered.filter { !gitLabPaths.contains($0.worktreePath) }
+            gitLabUnnumberedIDs = Set(gitLabUnnumbered.map(\.id))
+
+            // The viewer batch is GitHub's only branch-matching route, and it is
+            // skipped outright when no worktree is on GitHub — a GitLab-only
+            // fleet never spawns `gh`.
+            if !gitHubUnnumbered.isEmpty {
+                if let jsonData = await runGHGraphQL(repoPath: repoPath) {
+                    if let nodes = try? Self.parsePRNodes(from: jsonData) {
+                        batchSucceeded = true   // empty nodes is still a valid answer (viewer has no PRs)
+                        let branchMatches = Self.matchUnnumbered(gitHubUnnumbered, nodes: nodes,
+                                                                 resolveRepo: { unnumberedRepos[$0] })
+                        branchMatchedIDs.formUnion(branchMatches.map(\.worktreeID))
+                        matches += branchMatches
+                    } else {
+                        logger.warning("Failed to parse GraphQL response")
+                        batchFailureCause = PRUndeterminedCause.unparseableResponse
+                    }
                 } else {
-                    logger.warning("Failed to parse GraphQL response")
-                    batchFailureCause = PRUndeterminedCause.unparseableResponse
+                    batchFailureCause = forgeCLIAvailable
+                        ? PRUndeterminedCause.queryFailed
+                        : PRUndeterminedCause.cliUnavailable
                 }
-            } else {
-                batchFailureCause = forgeCLIAvailable
-                    ? PRUndeterminedCause.queryFailed
-                    : PRUndeterminedCause.cliUnavailable
+            }
+
+            // GitLab asks the server for the branches instead, one query per
+            // project — author-blind, so a merge request opened through the web
+            // UI or by a teammate is found, which the viewer batch can never do.
+            if !gitLabUnnumbered.isEmpty {
+                let gitLab = await fetchGitLabBranchMatches(
+                    gitLabUnnumbered, repos: unnumberedRepos, hosts: unnumberedHosts)
+                branchMatchedIDs.formUnion(gitLab.matches.map(\.worktreeID))
+                matches += gitLab.matches
+                gitLabAnsweredIDs = gitLab.answeredIDs
+                gitLabPipelineGated = gitLab.pipelineGated
+                gitLabFailureCause = gitLab.failureCause
             }
         }
 
@@ -547,8 +680,15 @@ public actor PRStatusManager {
         // whose cached status still carries a PR number — resolve those by
         // number (one extra aliased round trip, only when such worktrees
         // exist). See `cachedNumberFallback` for the gating rationale.
+        //
+        // GitHub worktrees only: both this fallback and the head-ref
+        // verification below resolve their numbers through the `gh` by-number
+        // query, which would offer a GitLab project path to GitHub. A GitLab
+        // worktree therefore keeps its cached status when the branch query
+        // leaves it unmatched, which is the conservative direction.
+        let gitHubUnnumberedEntries = unnumbered.filter { !gitLabUnnumberedIDs.contains($0.id) }
         let fallback = Self.cachedNumberFallback(
-            unnumbered: unnumbered,
+            unnumbered: gitHubUnnumberedEntries,
             matchedIDs: Set(matches.map(\.worktreeID)),
             batchSucceeded: batchSucceeded,
             cachedStatus: { cache[$0] })
@@ -590,7 +730,7 @@ public actor PRStatusManager {
         // numbers a second time in the same tick would buy nothing. They are
         // retried on the next poll like any other unresolved entry.
         let verificationTargets = Self.headRefVerificationTargets(
-            unnumbered: unnumbered,
+            unnumbered: gitHubUnnumberedEntries,
             matchedIDs: Set(matches.map(\.worktreeID)).union(fallback.map(\.id)),
             batchSucceeded: batchSucceeded,
             verifiedIDs: headRefVerifiedIDs,
@@ -617,7 +757,10 @@ public actor PRStatusManager {
             for match in matches {
                 let node = match.node
                 let id = match.worktreeID
-                if node.state != "OPEN" || !Self.aggregateRollupIsNonSuccess(node.statusCheckRollupState) {
+                // A GitLab node carried its pipeline status in the same batch,
+                // so it never pays for GitHub's per-request check query.
+                if node.forge != .github || node.state != "OPEN"
+                    || !Self.aggregateRollupIsNonSuccess(node.statusCheckRollupState) {
                     group.addTask { (id, (failing: false, pending: false)) }
                 } else {
                     group.addTask {
@@ -648,12 +791,15 @@ public actor PRStatusManager {
                 signals = Self.aggregateFallbackSignals(match.node.statusCheckRollupState)
             }
             let (state, reason) = Self.mapStateAndReason(
+                forge: match.node.forge,
                 ghState: match.node.state,
                 mergeVerdictRaw: match.node.mergeVerdictRaw,
                 reviewVerdictRaw: match.node.reviewVerdictRaw,
                 isDraft: match.node.isDraft,
                 requiredChecksFailing: signals.failing,
-                requiredChecksPending: signals.pending
+                requiredChecksPending: signals.pending,
+                pipelineGated: gitLabPipelineGated[match.worktreeID] ?? false,
+                pipelineStatus: match.node.statusCheckRollupState
             )
             let status = PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason,
                                   mergeQueuePosition: match.node.mergeQueuePosition,
@@ -681,8 +827,17 @@ public actor PRStatusManager {
             outcomes[wt.id] = .undetermined(cause: PRUndeterminedCause.queryFailed)
         }
         for wt in unnumbered where outcomes[wt.id] == nil && !directRefreshLanded(wt.id, after: batchStartedAt) {
-            outcomes[wt.id] = batchSucceeded ? PRObservation.Outcome.none
-                                             : .undetermined(cause: batchFailureCause)
+            if gitLabUnnumberedIDs.contains(wt.id) {
+                // Judged by the project query that covered THIS worktree, never
+                // by the viewer batch — which was not asked about it, and on a
+                // GitLab-only fleet was not run at all.
+                outcomes[wt.id] = gitLabAnsweredIDs.contains(wt.id)
+                    ? PRObservation.Outcome.none
+                    : .undetermined(cause: gitLabFailureCause)
+            } else {
+                outcomes[wt.id] = batchSucceeded ? PRObservation.Outcome.none
+                                                 : .undetermined(cause: batchFailureCause)
+            }
         }
         for (id, observedOutcome) in outcomes {
             await record(observedOutcome, for: id, at: batchStartedAt)
@@ -827,14 +982,17 @@ public actor PRStatusManager {
     /// `worktreeID`; here it carries a BINDING id. That is the whole point of
     /// this path — several bindings of one worktree must stay distinguishable.
     ///
-    /// `group.host` is not passed to `gh`: binding creation is host-locked to
-    /// github.com today (`PRBindingExtractor`), so every group resolves against
-    /// gh's default host. It still keys the grouping, so the day an enterprise
-    /// host can be bound, two hosts' repos cannot land in one query.
+    /// `group.host` chooses the forge. `groupBindingsByRepo` already keys on it,
+    /// so a group is one repo on one host and the whole group takes one path:
+    /// a GitLab host goes to `refreshGitLabBindingGroup`, everything else stays
+    /// on `gh`, whose auth is host-scoped and therefore needs no host argument.
     private nonisolated func refreshBindingGroup(
         _ group: (host: String, owner: String, name: String, bindings: [PRBinding]),
         repoPath: String
     ) async -> [UUID: PRBindingObservation] {
+        if await isGitLabHost(group.host, repoPath: repoPath) {
+            return await refreshGitLabBindingGroup(group, repoPath: repoPath)
+        }
         let aliased = group.bindings.enumerated().map {
             (alias: "pr\($0.offset)", bindingID: $0.element.id, number: $0.element.number)
         }
@@ -924,6 +1082,135 @@ public actor PRStatusManager {
                 baseRef: Self.refOrNil(node.baseRefName))
         }
         return observations
+    }
+
+    /// One GitLab project group: one batched `mergeRequests(iids:)` read, then a
+    /// fire-and-forget mergeability recheck.
+    ///
+    /// Structurally the twin of the `gh` arm above, with one shape difference
+    /// that is the point of the GitLab transport: the pipeline status rides in
+    /// the same response, so there is no per-request check query and no second
+    /// round trip to fail separately.
+    private nonisolated func refreshGitLabBindingGroup(
+        _ group: (host: String, owner: String, name: String, bindings: [PRBinding]),
+        repoPath: String
+    ) async -> [UUID: PRBindingObservation] {
+        let projectPath = "\(group.owner)/\(group.name)"
+        let iids = group.bindings.map(\.number)
+        let fetched = await fetchGitLabNodes(
+            query: GitLabQueries.mergeRequestsByIIDQuery(iids: iids),
+            host: group.host, projectPath: projectPath, repoPath: repoPath)
+        guard case .success(let nodes, let pipelineGated) = fetched else {
+            if case .failure(let cause) = fetched {
+                logger.debug("refreshBindings: GitLab query for \(projectPath, privacy: .public) settled nothing (\(cause, privacy: .public)); keeping previous statuses")
+            }
+            // Including the authentication path: an expired token proves
+            // nothing about the merge requests, so every binding keeps the
+            // value it had rather than being cleared.
+            return Self.previousStatuses(group.bindings)
+        }
+
+        // GitLab computes mergeability asynchronously and never recomputes on
+        // read, so a merge request can report UNCHECKED indefinitely. This asks
+        // it to recompute; the answer is deliberately dropped, and its failure
+        // cannot disturb the poll — the value it produces is read by the NEXT
+        // tick's GraphQL call, not by this one.
+        _ = await runGLResult(
+            args: ["api", "--hostname", group.host,
+                   GitLabQueries.recheckPath(projectPath: projectPath, iids: iids)],
+            repoPath: repoPath)
+
+        let byIID = Dictionary(nodes.map { ($0.number, $0) }, uniquingKeysWith: { first, _ in first })
+        var observations: [UUID: PRBindingObservation] = [:]
+        for binding in group.bindings {
+            guard let node = byIID[binding.number] else {
+                logger.debug("refreshBindings: merge request !\(binding.number, privacy: .public) did not resolve by iid; keeping previous status")
+                observations[binding.id] = binding.status.map { PRBindingObservation(status: $0) }
+                continue
+            }
+            let (state, reason) = Self.mapStateAndReason(
+                forge: .gitlab,
+                ghState: node.state,
+                mergeVerdictRaw: node.mergeVerdictRaw,
+                isDraft: node.isDraft,
+                pipelineGated: pipelineGated,
+                pipelineStatus: node.statusCheckRollupState)
+            observations[binding.id] = PRBindingObservation(
+                status: PRStatus(number: node.number, url: node.url, state: state,
+                                 reason: reason, mergeQueuePosition: node.mergeQueuePosition,
+                                 observedAt: now()),
+                headBranch: Self.refOrNil(node.headRefName),
+                baseRef: Self.refOrNil(node.baseRefName))
+        }
+        return observations
+    }
+
+    /// What one GitLab GraphQL read settled.
+    private enum GitLabFetchOutcome {
+        case success(nodes: [PRNode], pipelineGated: Bool)
+        /// A failure class from `PRUndeterminedCause`.
+        case failure(cause: String)
+    }
+
+    /// Run one GitLab GraphQL query and classify what came back.
+    ///
+    /// `--hostname` is on every invocation and must stay there: outside a GitLab
+    /// checkout `glab api` silently defaults to gitlab.com, so a missing flag
+    /// does not fail — it confidently answers about the wrong instance.
+    /// `fullPath` is bound as a variable because it is user data; iids and
+    /// branches are quoted into the query by `GitLabQueries`.
+    private nonisolated func fetchGitLabNodes(
+        query: String, host: String, projectPath: String, repoPath: String
+    ) async -> GitLabFetchOutcome {
+        let args = ["api", "graphql", "--hostname", host,
+                    "-f", "query=\(query)", "-f", "fullPath=\(projectPath)"]
+        guard let result = await runGLResult(args: args, repoPath: repoPath) else {
+            return .failure(cause: gitLabCLIAvailable
+                ? PRUndeterminedCause.queryFailed
+                : PRUndeterminedCause.cliUnavailable)
+        }
+        if Self.isForgeAuthFailure(result) {
+            await setForgeAuthFailure(true, host: host)
+            logger.debug("GitLab host \(host, privacy: .public) refused the credentials")
+            return .failure(cause: PRUndeterminedCause.forgeAuthFailed(host: host))
+        }
+        guard let data = Self.graphQLOutputData(stdout: result.stdout) else {
+            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.debug("GitLab query for \(projectPath, privacy: .public) produced no output (exit \(result.exitStatus, privacy: .public)): \(errSuffix, privacy: .public)")
+            return .failure(cause: PRUndeterminedCause.queryFailed)
+        }
+        // The call reached the host and the host answered, which is the only
+        // evidence this actor accepts that the credentials work.
+        await setForgeAuthFailure(false, host: host)
+        let parsed = GitLabQueries.parseMergeRequests(from: data)
+        return .success(nodes: parsed.nodes, pipelineGated: parsed.pipelineGated)
+    }
+
+    /// Whether a forge invocation was refused for want of valid credentials.
+    ///
+    /// Two shapes, because `glab` reports the same fault two ways: a transport
+    /// refusal exits non-zero with the status line on stderr, while a request
+    /// that reached GraphQL comes back exit-zero with an error object. Both are
+    /// an expired token, and neither may read as "this project has no merge
+    /// requests".
+    static func isForgeAuthFailure(_ result: GHCommandResult) -> Bool {
+        let stderr = result.stderr.lowercased()
+        if result.exitStatus != 0 && (stderr.contains("401") || stderr.contains("unauthorized")) {
+            return true
+        }
+        return graphQLReportsUnauthenticated(result.stdout)
+    }
+
+    private static func graphQLReportsUnauthenticated(_ stdout: String) -> Bool {
+        guard let data = graphQLOutputData(stdout: stdout),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let errors = root["errors"] as? [[String: Any]] else { return false }
+        return errors.contains { error in
+            let code = ((error["extensions"] as? [String: Any])?["code"] as? String)?.lowercased() ?? ""
+            let message = (error["message"] as? String)?.lowercased() ?? ""
+            return code.contains("unauthenticated") || code.contains("authentication")
+                || message.contains("unauthenticated")
+        }
     }
 
     /// A branch name the response actually carried, or nil. An empty string is
@@ -2325,6 +2612,84 @@ public actor PRStatusManager {
         return matches
     }
 
+    /// Branch matching on GitLab: one `sourceBranches` query per project.
+    ///
+    /// The counterpart of `runGHGraphQL` + `matchUnnumbered`, and deliberately
+    /// shaped differently. GitHub can only be asked for the *viewer's* pull
+    /// requests, so branch matching there is a local join over whatever the
+    /// authenticated account happens to have authored. GitLab takes the branch
+    /// list as a query argument with no author filter, so the instance does the
+    /// matching and a merge request opened by a teammate or through the web UI
+    /// is found — the coverage gap that makes this the discovery route worth
+    /// having.
+    ///
+    /// Degrades per project: a project whose query fails contributes no matches
+    /// and no answered ids, so its worktrees keep whatever they had and record
+    /// `.undetermined` rather than "no merge request".
+    private nonisolated func fetchGitLabBranchMatches(
+        _ unnumbered: [PollWorktree],
+        repos: [String: (owner: String, name: String)],
+        hosts: [String: String]
+    ) async -> (matches: [(worktreeID: UUID, node: PRNode)],
+                answeredIDs: Set<UUID>,
+                pipelineGated: [UUID: Bool],
+                failureCause: String) {
+        var matches: [(worktreeID: UUID, node: PRNode)] = []
+        var answered: Set<UUID> = []
+        var gated: [UUID: Bool] = [:]
+        var failureCause = PRUndeterminedCause.queryFailed
+
+        // One query per project, so several worktrees on one project cost one
+        // round trip — the same economy the aliased by-number query buys on the
+        // GitHub side.
+        var order: [String] = []
+        var groups: [String: (host: String, owner: String, name: String, entries: [PollWorktree])] = [:]
+        for wt in unnumbered {
+            guard let repo = repos[wt.worktreePath], let host = hosts[wt.worktreePath] else { continue }
+            let key = "\(host.lowercased())\u{1}\(repo.owner.lowercased())\u{1}\(repo.name.lowercased())"
+            if groups[key] == nil {
+                groups[key] = (host, repo.owner, repo.name, [])
+                order.append(key)
+            }
+            groups[key]?.entries.append(wt)
+        }
+
+        for key in order {
+            guard let group = groups[key] else { continue }
+            let branches = Self.orderedUniqueBranches(group.entries.flatMap(Self.candidatesFor))
+            guard !branches.isEmpty else { continue }
+            let fetched = await fetchGitLabNodes(
+                query: GitLabQueries.mergeRequestsByBranchQuery(branches: branches),
+                host: group.host,
+                projectPath: "\(group.owner)/\(group.name)",
+                repoPath: group.entries[0].worktreePath)
+            switch fetched {
+            case .failure(let cause):
+                failureCause = cause
+            case .success(let nodes, let pipelineGated):
+                answered.formUnion(group.entries.map(\.id))
+                let groupMatches = Self.matchUnnumbered(group.entries, nodes: nodes,
+                                                        resolveRepo: { repos[$0] })
+                for match in groupMatches { gated[match.worktreeID] = pipelineGated }
+                matches += groupMatches
+            }
+        }
+        return (matches, answered, gated, failureCause)
+    }
+
+    /// The branch list one project query asks about: every candidate of every
+    /// worktree in it, first-seen order kept and duplicates dropped — several
+    /// worktrees legitimately share a candidate.
+    static func orderedUniqueBranches(_ branches: [String]) -> [String] {
+        var seen: Set<String> = []
+        var out: [String] = []
+        for branch in branches {
+            guard !branch.isEmpty, seen.insert(branch).inserted else { continue }
+            out.append(branch)
+        }
+        return out
+    }
+
     private nonisolated func runGHGraphQL(repoPath: String) async -> Data? {
         let query = """
         {
@@ -2407,10 +2772,32 @@ public actor PRStatusManager {
             logger.debug("gh CLI not found in PATH")
             return nil
         }
+        return await Self.runCLI(executable: ghPath, args: args, repoPath: repoPath)
+    }
 
-        return await withCheckedContinuation { continuation in
+    /// One `glab` invocation, through the injected seam when a test supplied one.
+    private nonisolated func runGLResult(args: [String], repoPath: String) async -> GHCommandResult? {
+        if let glRunner {
+            return await glRunner(args, repoPath)
+        }
+        return await Self.runGlab(args: args, repoPath: repoPath)
+    }
+
+    /// The real `glab` subprocess. Static because `GitLabHostResolver` is handed
+    /// this same runner while the manager is still being initialized, so there
+    /// is no instance yet for it to capture.
+    private static func runGlab(args: [String], repoPath: String) async -> GHCommandResult? {
+        guard let glabPath = resolvedGlabPath else {
+            logger.debug("glab CLI not found in PATH")
+            return nil
+        }
+        return await runCLI(executable: glabPath, args: args, repoPath: repoPath)
+    }
+
+    private static func runCLI(executable: String, args: [String], repoPath: String) async -> GHCommandResult? {
+        await withCheckedContinuation { continuation in
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: ghPath)
+            process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = args
             process.currentDirectoryURL = URL(fileURLWithPath: repoPath)
 
@@ -2432,27 +2819,31 @@ public actor PRStatusManager {
             do {
                 try process.run()
             } catch {
-                logger.debug("Failed to launch gh: \(error)")
+                logger.debug("Failed to launch \(executable, privacy: .public): \(error)")
                 continuation.resume(returning: nil)
             }
         }
     }
 
-    /// Resolved once per process — gh's location doesn't change mid-process.
-    private static let resolvedGHPath: String? = {
-        let candidates = ["/usr/local/bin/gh", "/opt/homebrew/bin/gh", "/usr/bin/gh"]
+    /// Resolved once per process — a CLI's location doesn't change mid-process.
+    private static let resolvedGHPath: String? = resolveCLIPath("gh")
+
+    private static let resolvedGlabPath: String? = resolveCLIPath("glab")
+
+    private static func resolveCLIPath(_ tool: String) -> String? {
+        let candidates = ["/usr/local/bin/\(tool)", "/opt/homebrew/bin/\(tool)", "/usr/bin/\(tool)"]
         for path in candidates {
             if FileManager.default.isExecutableFile(atPath: path) { return path }
         }
         // Fall back to PATH search
         if let pathEnv = ProcessInfo.processInfo.environment["PATH"] {
             for dir in pathEnv.split(separator: ":") {
-                let full = "\(dir)/gh"
+                let full = "\(dir)/\(tool)"
                 if FileManager.default.isExecutableFile(atPath: full) { return full }
             }
         }
         return nil
-    }()
+    }
 }
 
 /// One `gh` invocation's outcome. Internal (not private) so the injected-runner

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -2614,33 +2614,78 @@ public actor PRStatusManager {
     private nonisolated func resolveNameWithOwner(
         repoPath: String
     ) async -> (owner: String, name: String, host: String)? {
+        let unservable: GHUnservable
         switch await resolveViaGH(repoPath: repoPath) {
         case .resolved(let owner, let name, let host):
             return (owner: owner, name: name, host: host)
         case .transientFailure:
             logger.debug("gh could not name the repo at \(repoPath, privacy: .public) this time; deferring rather than reading its origin remote")
             return nil
-        case .unservable:
-            break
+        case .unservable(let reason):
+            unservable = reason
         }
         guard let remote = await readRemoteURL(repoPath: repoPath),
               let identity = Self.parseRemoteIdentity(remote) else {
             logger.debug("could not name the repo at \(repoPath, privacy: .public) from gh or from its origin remote")
             return nil
         }
+        if unservable == .noCredentials, Self.ghWouldServe(host: identity.host) {
+            // gh holds no credentials, and the remote names the one host gh is
+            // certain to speak for — so gh, not `origin`, was the right source
+            // and it simply could not answer. Defer, exactly as before the
+            // exit-4 clause existed. See `ghExitNoCredentials` for why naming
+            // the fork here is worse than naming nothing.
+            logger.debug("gh holds no credentials and \(repoPath, privacy: .public) is on \(identity.host, privacy: .public), which gh would have answered for; deferring rather than letting origin name it")
+            return nil
+        }
         return identity
+    }
+
+    /// Whether gh would have been the authoritative source for this host, had
+    /// it any credentials.
+    ///
+    /// `github.com` and nothing else, deliberately. A gh configured for a
+    /// GitHub Enterprise host would speak for that host too, but with no
+    /// credentials there is no configuration to read it out of, and a GHES
+    /// hostname is indistinguishable from any other self-hosted forge in a
+    /// remote URL. That residual is accepted: a GHES checkout on a machine
+    /// whose gh has never been logged in still resolves through the remote
+    /// parse and can still name a fork instead of its parent. GHES cannot form
+    /// a binding today, and the alternative — treating every unknown host as
+    /// gh's — is the fabricated `github.com` identity this whole path exists to
+    /// refuse.
+    private static func ghWouldServe(host: String) -> Bool {
+        host.lowercased() == "github.com"
     }
 
     /// What one `gh repo view` settled about a checkout.
     private enum GHRepoResolution {
         case resolved(owner: String, name: String, host: String)
-        /// gh cannot serve this checkout at all: no binary, or it ran and said
-        /// none of the checkout's remotes name a GitHub host it knows. The only
-        /// state in which the `origin` remote may speak for the repo instead.
-        case unservable
+        /// gh cannot serve this checkout, for one of two reasons that are NOT
+        /// interchangeable — see `GHUnservable`. The only state in which the
+        /// `origin` remote may speak for the repo instead.
+        case unservable(GHUnservable)
         /// gh ran and failed at something it does serve. Says nothing about the
         /// checkout, so it settles nothing about the checkout.
         case transientFailure
+    }
+
+    /// Why gh cannot serve a checkout. Both license the `origin` parse, but
+    /// only one of them licenses it for a host gh itself would have answered
+    /// for.
+    private enum GHUnservable {
+        /// There is no gh binary, or gh ran with credentials in hand and said
+        /// none of this checkout's remotes name a GitHub host it knows. Either
+        /// way the answer is about the CHECKOUT: gh will never speak for it, on
+        /// this host or any other, so `origin` may. This is the route every
+        /// GitLab checkout with a working gh takes, and it must keep behaving
+        /// exactly as it does.
+        case cannotServeThisCheckout
+        /// gh holds no credentials for anywhere, so it never got as far as the
+        /// checkout. The answer is about the MACHINE, and it is silence about
+        /// this repo — which is why the parse it licenses is withheld for a
+        /// host gh would have served.
+        case noCredentials
     }
 
     private nonisolated func resolveViaGH(repoPath: String) async -> GHRepoResolution {
@@ -2648,13 +2693,17 @@ public actor PRStatusManager {
         guard let result = await runGHResult(args: args, repoPath: repoPath) else {
             // gh never launched — it is absent, or the spawn itself failed.
             // There is nobody to ask, on this checkout or any other.
-            return .unservable
+            return .unservable(.cannotServeThisCheckout)
         }
         let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
         guard result.exitStatus == 0 else {
-            if result.exitStatus == Self.ghExitNoCredentials || Self.ghDisownsCheckout(errSuffix) {
-                logger.debug("gh does not speak for the repo at \(repoPath, privacy: .public) (exit \(result.exitStatus, privacy: .public)): \(errSuffix, privacy: .public)")
-                return .unservable
+            if result.exitStatus == Self.ghExitNoCredentials {
+                logger.debug("gh holds no credentials at all, so it speaks for no checkout including \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
+                return .unservable(.noCredentials)
+            }
+            if Self.ghDisownsCheckout(errSuffix) {
+                logger.debug("gh does not speak for the repo at \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
+                return .unservable(.cannotServeThisCheckout)
             }
             logger.debug("gh repo view exited \(result.exitStatus, privacy: .public) for \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
             return .transientFailure
@@ -2689,26 +2738,23 @@ public actor PRStatusManager {
     /// exit 1. That stays transient, which is what keeps a fork checkout from
     /// being renamed by a flaky token.
     ///
-    /// **The trade-off, accepted deliberately, and its one sharp edge:** on a
-    /// GITHUB fork checkout with no credentials, resolution falls through to
-    /// the `origin` parse and names the fork rather than the parent gh would
-    /// have named. Every gh query on that checkout fails anyway, so no PR
-    /// feature works there under either reading and the identity buys nothing —
-    /// while for a GitLab checkout the remote parse is the ONLY route that ever
-    /// works. The cost is a wrong answer nobody can act on; the benefit is the
-    /// whole feature for the people it was built for.
+    /// **What this exit code does NOT license:** naming a `github.com` checkout
+    /// from its `origin` remote. On a fork, gh names the parent — where the
+    /// fork's pull requests live — and `origin` names the fork, and that
+    /// disagreement is not harmless. `poisonedCacheEntries` rests on "both
+    /// sides resolved" meaning both are KNOWN, so a fork identity makes a
+    /// cached pull request living in the parent read as cross-repo: it is
+    /// cleared, the clear is PERSISTED, and the heal reports a binding it never
+    /// disproved. Deferring costs that checkout nothing, because with no
+    /// credentials every gh query fails anyway. So `resolveNameWithOwner`
+    /// withholds the parse on this route for any host gh would have served
+    /// (`ghWouldServe`), and grants it everywhere else — which is where the
+    /// whole benefit is: for a GitLab checkout the remote parse is the ONLY
+    /// route that ever works.
     ///
-    /// The edge is that the answer is not quite inert: `poisonedCacheEntries`
-    /// rests on "both sides resolved" meaning both are KNOWN, so on such a
-    /// checkout a cached pull request living in the PARENT now reads as
-    /// cross-repo against the fork and is cleared, persistently, and reported
-    /// as a disproved binding. It is bounded — only while gh holds no
-    /// credentials at all, only for a worktree with no stored PR number, and a
-    /// re-login re-finds any pull request still inside the 100-PR viewer batch
-    /// — and the same edge already existed for a checkout with no `gh`
-    /// installed. Narrowing it (declining the parse when the parsed host is one
-    /// gh would have served) is a separate change to `poisonedCacheEntries`'s
-    /// premise, not to this discriminator.
+    /// The disownment route below is untouched by that rule and must stay so:
+    /// there gh has credentials and is speaking about the checkout, so its
+    /// silence really is a fact about the repo.
     private static let ghExitNoCredentials: Int32 = 4
 
     /// Whether gh's own refusal says it does not serve this checkout, as opposed

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -229,7 +229,7 @@ public actor PRStatusManager {
         // rather than `runGLResult`.
         self.gitLabHostResolver = GitLabHostResolver(glRunner: { args, repoPath in
             await PRStatusManager.runGlab(args: args, repoPath: repoPath)
-        })
+        }, now: now)
         self.now = now
     }
 

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1182,8 +1182,16 @@ public actor PRStatusManager {
         // The call reached the host and the host answered, which is the only
         // evidence this actor accepts that the credentials work.
         await setForgeAuthFailure(false, host: host)
-        let parsed = GitLabQueries.parseMergeRequests(from: data)
-        return .success(nodes: parsed.nodes, pipelineGated: parsed.pipelineGated)
+        switch GitLabQueries.parseMergeRequests(from: data) {
+        case .answered(let nodes, let pipelineGated):
+            return .success(nodes: nodes, pipelineGated: pipelineGated)
+        case .unreadable:
+            // The same outcome the `gh` arm reaches when `parsePRNodes` throws.
+            // A response nobody could read settles nothing, so the worktrees it
+            // covers record undetermined rather than "no merge request".
+            logger.warning("GitLab query for \(projectPath, privacy: .public) returned a response this build could not read")
+            return .failure(cause: PRUndeterminedCause.unparseableResponse)
+        }
     }
 
     /// Whether a forge invocation was refused for want of valid credentials.

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -364,6 +364,29 @@ public actor PRStatusManager {
         }
     }
 
+    /// Report a host's credential refusal as a per-worktree `PRObservation` —
+    /// the fact `pr.list` already carries to the sidebar and its tooltip, and
+    /// the same rail the branch-match path reports an auth failure on.
+    ///
+    /// Without this the binding path — the main path once a GitLab worktree has
+    /// a binding — keeps every chip at its last value with nothing anywhere
+    /// saying why. Keeping the values is right; an expired token proves nothing
+    /// about the merge requests. Saying nothing about them is the gap.
+    ///
+    /// Deliberately narrow: only the credential refusal is reported, not every
+    /// failure class. A query that failed once is reconfirmed by the next tick,
+    /// whereas a personal access token has no refresh — once it expires, every
+    /// later tick refuses too and nothing else will ever surface it. Reporting
+    /// the transient classes here would also relabel a worktree whose other
+    /// bindings, on another host, were read perfectly well this pass.
+    private func reportAuthFailure(host: String, bindings: [PRBinding]) async {
+        let cause = PRUndeterminedCause.forgeAuthFailed(host: host)
+        let observedAt = now()
+        for worktreeID in Set(bindings.map(\.worktreeID)) {
+            await record(.undetermined(cause: cause), for: worktreeID, at: observedAt)
+        }
+    }
+
     /// Record one attempt's outcome and persist it — unless a newer attempt is
     /// already on record.
     ///
@@ -934,7 +957,9 @@ public actor PRStatusManager {
     /// `nonisolated` on purpose: this path must not touch `cache`,
     /// `lastDirectUpdate`, `headRefVerifiedIDs`, `onStatusPersist` or
     /// `onMergedTransition`. Persisting a binding's status — and deciding what a
-    /// merge means across several of them — belongs to the caller.
+    /// merge means across several of them — belongs to the caller. The one piece
+    /// of actor state it does write is `reportAuthFailure`'s observation, which
+    /// is an *attempt* fact about a worktree rather than any binding's value.
     ///
     /// A transient failure at any stage (gh did not launch, no data, the number
     /// did not resolve, the check query failed) yields the binding's PREVIOUS
@@ -1107,13 +1132,21 @@ public actor PRStatusManager {
         let fetched = await fetchGitLabNodes(
             query: GitLabQueries.mergeRequestsByIIDQuery(iids: iids),
             host: group.host, projectPath: projectPath, repoPath: repoPath)
-        guard case .success(let nodes, let pipelineGated) = fetched else {
-            if case .failure(let cause) = fetched {
-                logger.debug("refreshBindings: GitLab query for \(projectPath, privacy: .public) settled nothing (\(cause, privacy: .public)); keeping previous statuses")
-            }
-            // Including the authentication path: an expired token proves
-            // nothing about the merge requests, so every binding keeps the
-            // value it had rather than being cleared.
+        let nodes: [PRNode]
+        let pipelineGated: Bool
+        switch fetched {
+        case .success(let fetchedNodes, let gated):
+            nodes = fetchedNodes
+            pipelineGated = gated
+        case .failure(let cause):
+            logger.debug("refreshBindings: GitLab query for \(projectPath, privacy: .public) settled nothing (\(cause, privacy: .public)); keeping previous statuses")
+            return Self.previousStatuses(group.bindings)
+        case .authenticationFailed(let host):
+            logger.debug("refreshBindings: \(host, privacy: .public) refused the credentials for \(projectPath, privacy: .public); keeping previous statuses and reporting the refusal")
+            // An expired token proves nothing about the merge requests, so every
+            // binding keeps the value it had rather than being cleared — but the
+            // worktree is told why its values stopped moving.
+            await reportAuthFailure(host: host, bindings: group.bindings)
             return Self.previousStatuses(group.bindings)
         }
 
@@ -1185,6 +1218,12 @@ public actor PRStatusManager {
         case success(nodes: [PRNode], pipelineGated: Bool)
         /// A failure class from `PRUndeterminedCause`.
         case failure(cause: String)
+        /// The host refused the credentials. A case of its own because it is the
+        /// failure that does not resolve itself: a personal access token has no
+        /// refresh, so a host that answered yesterday refuses today and every
+        /// day after, and every caller that merely keeps its previous values
+        /// would go quiet forever.
+        case authenticationFailed(host: String)
     }
 
     /// Run one GitLab GraphQL query and classify what came back.
@@ -1207,7 +1246,7 @@ public actor PRStatusManager {
         if Self.isForgeAuthFailure(result) {
             await setForgeAuthFailure(true, host: host)
             logger.debug("GitLab host \(host, privacy: .public) refused the credentials")
-            return .failure(cause: PRUndeterminedCause.forgeAuthFailed(host: host))
+            return .authenticationFailed(host: host)
         }
         guard let data = Self.graphQLOutputData(stdout: result.stdout) else {
             let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2850,6 +2889,11 @@ public actor PRStatusManager {
             switch fetched {
             case .failure(let cause):
                 failureCause = cause
+            case .authenticationFailed(let host):
+                // Reported here as the cause every worktree of this project
+                // records; the binding path has to report it separately,
+                // because nothing there records an outcome per worktree.
+                failureCause = PRUndeterminedCause.forgeAuthFailed(host: host)
             case .success(let nodes, let pipelineGated):
                 answered.formUnion(group.entries.map(\.id))
                 let groupMatches = Self.matchUnnumbered(group.entries, nodes: nodes,

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1115,10 +1115,28 @@ public actor PRStatusManager {
         // it to recompute; the answer is deliberately dropped, and its failure
         // cannot disturb the poll — the value it produces is read by the NEXT
         // tick's GraphQL call, not by this one.
-        _ = await runGLResult(
-            args: ["api", "--hostname", group.host,
-                   GitLabQueries.recheckPath(projectPath: projectPath, iids: iids)],
-            repoPath: repoPath)
+        //
+        // Detached, and that is load-bearing rather than tidy. `runCLI` imposes
+        // no timeout, `refreshBindings` walks its groups one at a time, and
+        // `fetchAll` skips the next poll while one is still in flight — so a
+        // `glab` that hangs here stalls PR polling for the entire fleet, with no
+        // deadline to end it. Hanging is the plausible failure for this call in
+        // particular: it exists to queue work on someone else's server. Nothing
+        // in this pass reads the result, so nothing in this pass may wait for
+        // it.
+        //
+        // Only non-terminal merge requests are asked. A merged or closed one has
+        // a mergeability nobody will recompute and nobody will read, so
+        // including it spends a server-side job to learn nothing.
+        let recheckIIDs = nodes.filter { !Self.isTerminalGitLabState($0.state) }.map(\.number)
+        if !recheckIIDs.isEmpty {
+            let host = group.host
+            let recheckPath = GitLabQueries.recheckPath(projectPath: projectPath, iids: recheckIIDs)
+            Task.detached { [self] in
+                _ = await runGLResult(args: ["api", "--hostname", host, recheckPath],
+                                      repoPath: repoPath)
+            }
+        }
 
         let byIID = Dictionary(nodes.map { ($0.number, $0) }, uniquingKeysWith: { first, _ in first })
         var observations: [UUID: PRBindingObservation] = [:]
@@ -1143,6 +1161,16 @@ public actor PRStatusManager {
                 baseRef: Self.refOrNil(node.baseRefName))
         }
         return observations
+    }
+
+    /// Whether a merge request's state is settled for good.
+    ///
+    /// Compared case-insensitively because the two GitLab transports disagree:
+    /// GraphQL answers `merged`/`closed` in lower case and REST in upper, and
+    /// `PRNode.state` carries whichever the response used.
+    static func isTerminalGitLabState(_ state: String) -> Bool {
+        let normalized = state.lowercased()
+        return normalized == "merged" || normalized == "closed"
     }
 
     /// What one GitLab GraphQL read settled.

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1338,11 +1338,24 @@ public actor PRStatusManager {
         return PRCheckDetail(contexts: result, rollupState: rollupState, truncated: truncated)
     }
 
-    /// Parse `owner` and `name` from a PR URL like
-    /// `https://github.com/<owner>/<name>/pull/<n>`.
+    /// Parse `owner` and `name` from a pull- or merge-request URL.
+    ///
+    /// GitHub: `/owner/name/pull/<n>`, matched positionally.
+    /// GitLab:  `/<namespace…>/<project>/-/merge_requests/<n>`, split at the
+    /// `/-/` separator so nesting depth is irrelevant — the namespace may run
+    /// to twenty levels, and nesting is the common case rather than the edge.
     static func parseOwnerRepo(fromURL url: String) -> (owner: String, name: String)? {
         guard let components = URLComponents(string: url) else { return nil }
-        let parts = components.path.split(separator: "/", omittingEmptySubsequences: true)
+        let path = components.path
+        if let range = path.range(of: "/-/merge_requests/") {
+            let project = path[path.startIndex..<range.lowerBound]
+                .split(separator: "/", omittingEmptySubsequences: true)
+                .map(String.init)
+            guard project.count >= 2 else { return nil }
+            return (owner: project.dropLast().joined(separator: "/"),
+                    name: project[project.count - 1])
+        }
+        let parts = path.split(separator: "/", omittingEmptySubsequences: true)
         // Expect: [owner, name, "pull", <n>]
         guard parts.count >= 4, parts[2] == "pull" else { return nil }
         return (owner: String(parts[0]), name: String(parts[1]))

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -2674,12 +2674,29 @@ public actor PRStatusManager {
     /// only one of them licenses it for a host gh itself would have answered
     /// for.
     private enum GHUnservable {
-        /// There is no gh binary, or gh ran with credentials in hand and said
-        /// none of this checkout's remotes name a GitHub host it knows. Either
-        /// way the answer is about the CHECKOUT: gh will never speak for it, on
-        /// this host or any other, so `origin` may. This is the route every
+        /// gh ran with credentials in hand and said none of this checkout's
+        /// remotes name a GitHub host it knows — or there is no gh binary at
+        /// all.
+        ///
+        /// The first route is about the CHECKOUT: gh will never speak for it,
+        /// on this host or any other, so `origin` may. This is the route every
         /// GitLab checkout with a working gh takes, and it must keep behaving
         /// exactly as it does.
+        ///
+        /// The second route is not. "No gh binary" is a fact about the MACHINE,
+        /// by exactly the argument `.noCredentials` makes for itself, and it is
+        /// grouped here pragmatically rather than because it belongs. The
+        /// residual that grouping accepts: a daemon whose PATH lacks `gh`, on a
+        /// `github.com` fork checkout with an `upstream` remote, resolves to the
+        /// fork via `origin` — so a hydrated parent-repo PR can be cleared, and
+        /// the clear persists.
+        ///
+        /// It is not fixed by routing the no-binary case to `.noCredentials`,
+        /// because that withholds the `origin` parse on every `github.com`
+        /// checkout of a gh-less machine, and the parse is also what composes
+        /// attach-by-number URLs there. Trading a working feature on every
+        /// gh-less GitHub checkout against a fork-with-upstream corner is the
+        /// worse deal.
         case cannotServeThisCheckout
         /// gh holds no credentials for anywhere, so it never got as far as the
         /// checkout. The answer is about the MACHINE, and it is silence about

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -365,7 +365,12 @@ public actor PRStatusManager {
     /// reaches the resolver; production injects nothing and the resolver reads
     /// `glab auth status` (cached, and short-circuited for github.com before
     /// any subprocess).
-    private nonisolated func isGitLabHost(_ host: String, repoPath: String) async -> Bool {
+    ///
+    /// Reachable from outside this actor because `RPCRouter` composes a URL for
+    /// `tbd pr attach <number>`, the one path with no URL to read the forge
+    /// from, and a hostname's shape is not an acceptable substitute for this
+    /// answer.
+    nonisolated func isGitLabHost(_ host: String, repoPath: String) async -> Bool {
         if gitLabHosts.contains(host.lowercased()) { return true }
         guard let gitLabHostResolver else { return false }
         return await gitLabHostResolver.isGitLabHost(host, repoPath: repoPath)
@@ -2813,12 +2818,11 @@ public actor PRStatusManager {
     /// first path segment read as one. `file:///Users/me/repo.git` would
     /// otherwise resolve to the host "Users" and `/srv/git/acme/repo.git` to
     /// "srv" — identities that are not merely useless but harmful. They are
-    /// cached like any other; `Forge.forHost` classifies anything that is not
-    /// `github.com` as GitLab, so `tbd pr attach` composes merge-request URLs
-    /// against them; and `poisonedCacheEntries` rests on "both sides resolved"
-    /// meaning both sides are KNOWN, so a fabricated identity turns a
-    /// legitimately cached PR status into a cross-repo poisoning and clears it,
-    /// persistently.
+    /// cached like any other, so `tbd pr attach <number>` composes a binding URL
+    /// against a host that answers nothing; and `poisonedCacheEntries` rests on
+    /// "both sides resolved" meaning both sides are KNOWN, so a fabricated
+    /// identity turns a legitimately cached PR status into a cross-repo
+    /// poisoning and clears it, persistently.
     ///
     /// `RemoteRepoMatching` in TBDShared parses the same three shapes and is
     /// deliberately not reused: it drops the host by design, and it keeps only

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -206,6 +206,23 @@ public actor PRStatusManager {
     /// reclaim either.
     static let recheckTimeout: Duration = .seconds(60)
 
+    /// How long a forge CLI child is given to exit on its own after SIGTERM
+    /// before it is killed outright.
+    ///
+    /// `terminate()` is a request, not an outcome: a child that installs a
+    /// handler, ignores the signal, or sits in an uninterruptible state simply
+    /// stays — and `runGLBounded`'s task group awaits it before returning, so
+    /// the recheck task and that project's single-flight gate would both stay
+    /// wedged past `recheckTimeout` on a bound that only looks like one.
+    /// SIGKILL is what makes the deadline a deadline.
+    ///
+    /// Short, because everything the grace protects is already being
+    /// discarded: the deadline has fired and nobody will read this child's
+    /// output. Its only job is to let a well-behaved `glab` close its
+    /// connection and exit on its own rather than be killed for being a moment
+    /// slow about it.
+    static let childKillGrace: Duration = .seconds(5)
+
     /// Clock seam for that deadline — existential, defaulted, and last, so no
     /// call site changes and this actor's `Sendable` conformances are not
     /// infected by a generic parameter. `Duration` is behavior, `Date` is data:
@@ -248,7 +265,7 @@ public actor PRStatusManager {
         // any instance exists to capture, so it gets the static `glab` spawner
         // rather than `runGLResult`.
         self.gitLabHostResolver = GitLabHostResolver(glRunner: { args, repoPath in
-            await PRStatusManager.runGlab(args: args, repoPath: repoPath)
+            await PRStatusManager.runGlab(args: args, repoPath: repoPath, clock: clock)
         }, now: now)
         self.now = now
     }
@@ -3201,7 +3218,7 @@ public actor PRStatusManager {
             logger.debug("gh CLI not found in PATH")
             return nil
         }
-        return await Self.runCLI(executable: ghPath, args: args, repoPath: repoPath)
+        return await Self.runCLI(executable: ghPath, args: args, repoPath: repoPath, clock: clock)
     }
 
     /// One `glab` invocation, through the injected seam when a test supplied one.
@@ -3209,7 +3226,7 @@ public actor PRStatusManager {
         if let glRunner {
             return await glRunner(args, repoPath)
         }
-        return await Self.runGlab(args: args, repoPath: repoPath)
+        return await Self.runGlab(args: args, repoPath: repoPath, clock: clock)
     }
 
     /// One `glab` invocation that cannot outlive `timeout`, for the detached
@@ -3217,10 +3234,11 @@ public actor PRStatusManager {
     ///
     /// The deadline is a race, not a poll: whichever of the call and the sleep
     /// finishes first wins, and cancelling the group ends the other. On a
-    /// timeout that cancellation reaches `runCLI`, which terminates the child —
-    /// the bound is on the subprocess itself rather than merely on the task
-    /// awaiting it, because a task that stops waiting leaves a `glab` nothing
-    /// reclaims. Returns nil when the deadline fired; every caller of this is
+    /// timeout that cancellation reaches `runCLI`, which terminates the child
+    /// and, if it is still there `childKillGrace` later, kills it — the bound
+    /// is on the subprocess itself rather than merely on the task awaiting it,
+    /// because a task that stops waiting leaves a `glab` nothing reclaims, and
+    /// a child that ignores SIGTERM would leave this group waiting on it. Returns nil when the deadline fired; every caller of this is
     /// discarding the answer anyway.
     private nonisolated func runGLBounded(args: [String], repoPath: String,
                                           timeout: Duration) async -> GHCommandResult? {
@@ -3254,12 +3272,13 @@ public actor PRStatusManager {
     /// The real `glab` subprocess. Static because `GitLabHostResolver` is handed
     /// this same runner while the manager is still being initialized, so there
     /// is no instance yet for it to capture.
-    private static func runGlab(args: [String], repoPath: String) async -> GHCommandResult? {
+    private static func runGlab(args: [String], repoPath: String,
+                                clock: any Clock<Duration> = ContinuousClock()) async -> GHCommandResult? {
         guard let glabPath = resolvedGlabPath else {
             logger.debug("glab CLI not found in PATH")
             return nil
         }
-        return await runCLI(executable: glabPath, args: args, repoPath: repoPath)
+        return await runCLI(executable: glabPath, args: args, repoPath: repoPath, clock: clock)
     }
 
     /// Runs a forge CLI and answers what it printed.
@@ -3272,8 +3291,9 @@ public actor PRStatusManager {
     /// two orderings that could otherwise let one slip: a cancel that lands
     /// before `run()` prevents the launch outright, and one that lands during
     /// `run()` is re-checked immediately afterwards.
-    private static func runCLI(executable: String, args: [String], repoPath: String) async -> GHCommandResult? {
-        let handle = ChildProcessHandle()
+    static func runCLI(executable: String, args: [String], repoPath: String,
+                       clock: any Clock<Duration> = ContinuousClock()) async -> GHCommandResult? {
+        let handle = ChildProcessHandle(clock: clock, killGrace: childKillGrace)
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 let process = Process()
@@ -3366,6 +3386,16 @@ private final class ChildProcessHandle: @unchecked Sendable {
     private var process: Process?
     private var cancelled = false
 
+    /// Clock seam for the SIGTERM-to-SIGKILL grace — the only delay this type
+    /// has, and a delay is behavior, so it takes a clock rather than a date.
+    private let clock: any Clock<Duration>
+    private let killGrace: Duration
+
+    init(clock: any Clock<Duration>, killGrace: Duration) {
+        self.clock = clock
+        self.killGrace = killGrace
+    }
+
     /// Takes the process, or answers false because cancellation already
     /// arrived — in which case the caller must not launch it at all.
     func adopt(_ process: Process) -> Bool {
@@ -3381,7 +3411,7 @@ private final class ChildProcessHandle: @unchecked Sendable {
         cancelled = true
         let launched = process
         lock.unlock()
-        Self.terminate(launched)
+        terminate(launched)
     }
 
     /// Re-checked right after `run()` returns, for the cancellation that landed
@@ -3390,12 +3420,35 @@ private final class ChildProcessHandle: @unchecked Sendable {
         lock.lock()
         let launched = cancelled ? process : nil
         lock.unlock()
-        Self.terminate(launched)
+        terminate(launched)
     }
 
-    private static func terminate(_ process: Process?) {
+    /// Asks, then insists. SIGTERM first, and if the child is still there after
+    /// the grace, SIGKILL — the one signal it cannot catch, handle or ignore,
+    /// and so the only thing that turns the caller's deadline into a bound on
+    /// the process rather than on the wait.
+    private func terminate(_ process: Process?) {
         guard let process, process.isRunning else { return }
         process.terminate()
+        // Detached deliberately: this runs from a cancellation handler, and a
+        // sleep on a cancelled task returns at once — the escalation has to
+        // outlive the cancellation that armed it or it would fire immediately
+        // and give the child no grace at all.
+        Task.detached { [self] in
+            try? await clock.sleep(for: killGrace)
+            killIfStillRunning()
+        }
+    }
+
+    private func killIfStillRunning() {
+        lock.lock()
+        let launched = process
+        lock.unlock()
+        // Foundation reaps the child itself and clears `isRunning` when it
+        // does, so the pid read here is still this child's rather than one the
+        // system has since handed to somebody else.
+        guard let launched, launched.isRunning else { return }
+        kill(launched.processIdentifier, SIGKILL)
     }
 }
 

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -636,8 +636,8 @@ public actor PRStatusManager {
             }
             let (state, reason) = Self.mapStateAndReason(
                 ghState: match.node.state,
-                mergeStateStatus: match.node.mergeStateStatus,
-                reviewDecision: match.node.reviewDecision,
+                mergeVerdictRaw: match.node.mergeVerdictRaw,
+                reviewVerdictRaw: match.node.reviewVerdictRaw,
                 isDraft: match.node.isDraft,
                 requiredChecksFailing: signals.failing,
                 requiredChecksPending: signals.pending
@@ -891,8 +891,8 @@ public actor PRStatusManager {
             }
             let (state, reason) = Self.mapStateAndReason(
                 ghState: node.state,
-                mergeStateStatus: node.mergeStateStatus,
-                reviewDecision: node.reviewDecision,
+                mergeVerdictRaw: node.mergeVerdictRaw,
+                reviewVerdictRaw: node.reviewVerdictRaw,
                 isDraft: node.isDraft,
                 requiredChecksFailing: signals.failing,
                 requiredChecksPending: signals.pending
@@ -1068,7 +1068,7 @@ public actor PRStatusManager {
         }
         return await applyRefreshedNode(
             worktreeID: worktreeID, number: node.number, url: node.url, state: node.state,
-            mergeStateStatus: node.mergeStateStatus, reviewDecision: node.reviewDecision,
+            mergeStateStatus: node.mergeVerdictRaw, reviewDecision: node.reviewVerdictRaw,
             isDraft: node.isDraft, mergeQueuePosition: node.mergeQueuePosition, repoPath: repoPath)
     }
 
@@ -1100,8 +1100,8 @@ public actor PRStatusManager {
         }
         let (mappedState, reason) = Self.mapStateAndReason(
             ghState: state,
-            mergeStateStatus: mergeStateStatus,
-            reviewDecision: reviewDecision,
+            mergeVerdictRaw: mergeStateStatus,
+            reviewVerdictRaw: reviewDecision,
             isDraft: isDraft,
             requiredChecksFailing: signals.failing,
             requiredChecksPending: signals.pending
@@ -1139,9 +1139,10 @@ public actor PRStatusManager {
     /// Required-check awareness: a failing *required* check is red and a pending *required*
     /// check is yellow regardless of merge state; non-required checks never color the icon.
     public static func mapStateAndReason(
+        forge: Forge = .github,
         ghState: String,
-        mergeStateStatus: String,
-        reviewDecision: String = "",
+        mergeVerdictRaw: String,
+        reviewVerdictRaw: String = "",
         isDraft: Bool = false,
         requiredChecksFailing: Bool = false,
         requiredChecksPending: Bool = false
@@ -1150,21 +1151,21 @@ public actor PRStatusManager {
         case "MERGED": return (.merged, "Merged")
         case "CLOSED": return (.closed, "Closed")
         default:
-            if isDraft || mergeStateStatus == "DRAFT" { return (.draft, "Draft") }
-            if reviewDecision == "CHANGES_REQUESTED" { return (.changesRequested, "Changes requested") }
+            if isDraft || mergeVerdictRaw == "DRAFT" { return (.draft, "Draft") }
+            if reviewVerdictRaw == "CHANGES_REQUESTED" { return (.changesRequested, "Changes requested") }
             // Uniform precedence: failing required check → red, pending required check → yellow,
             // regardless of merge state. With no required checks both are false and the
-            // mergeStateStatus switch below decides (see checkSignals).
+            // merge-verdict switch below decides (see checkSignals).
             if requiredChecksFailing { return (.checksFailed, "Checks failing") }
             if requiredChecksPending { return (.pending, "Checks pending") }
 
-            switch mergeStateStatus {
+            switch mergeVerdictRaw {
             case "CLEAN", "HAS_HOOKS", "UNSTABLE":
                 // UNSTABLE = mergeable with only non-required checks failing → not red.
                 return (.mergeable, "Ready to merge")
             case "BLOCKED":
                 // Checks are settled and passing; the only blocker is a not-yet-given review.
-                return reviewDecision == "REVIEW_REQUIRED" ? (.mergeable, "Ready to merge") : (.blocked, "Blocked")
+                return reviewVerdictRaw == "REVIEW_REQUIRED" ? (.mergeable, "Ready to merge") : (.blocked, "Blocked")
             case "DIRTY":
                 return (.blocked, "Merge conflicts")
             case "BEHIND":
@@ -1178,17 +1179,19 @@ public actor PRStatusManager {
     }
 
     public static func mapState(
+        forge: Forge = .github,
         ghState: String,
-        mergeStateStatus: String,
-        reviewDecision: String = "",
+        mergeVerdictRaw: String,
+        reviewVerdictRaw: String = "",
         isDraft: Bool = false,
         requiredChecksFailing: Bool = false,
         requiredChecksPending: Bool = false
     ) -> PRMergeableState {
         Self.mapStateAndReason(
+            forge: forge,
             ghState: ghState,
-            mergeStateStatus: mergeStateStatus,
-            reviewDecision: reviewDecision,
+            mergeVerdictRaw: mergeVerdictRaw,
+            reviewVerdictRaw: reviewVerdictRaw,
             isDraft: isDraft,
             requiredChecksFailing: requiredChecksFailing,
             requiredChecksPending: requiredChecksPending
@@ -1408,17 +1411,19 @@ public actor PRStatusManager {
     /// Compute human-readable reason string for the PR merge state.
     /// Delegates to mapStateAndReason() for the single source of truth.
     public static func computeReason(
+        forge: Forge = .github,
         ghState: String,
-        mergeStateStatus: String,
-        reviewDecision: String = "",
+        mergeVerdictRaw: String,
+        reviewVerdictRaw: String = "",
         isDraft: Bool = false,
         requiredChecksFailing: Bool = false,
         requiredChecksPending: Bool = false
     ) -> String {
         Self.mapStateAndReason(
+            forge: forge,
             ghState: ghState,
-            mergeStateStatus: mergeStateStatus,
-            reviewDecision: reviewDecision,
+            mergeVerdictRaw: mergeVerdictRaw,
+            reviewVerdictRaw: reviewVerdictRaw,
             isDraft: isDraft,
             requiredChecksFailing: requiredChecksFailing,
             requiredChecksPending: requiredChecksPending
@@ -1524,8 +1529,10 @@ public actor PRStatusManager {
         public let number: Int
         public let url: String
         public let state: String
-        public let mergeStateStatus: String
-        public let reviewDecision: String   // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", or ""
+        public let mergeVerdictRaw: String
+        /// The forge's own verdict on review state, in whatever vocabulary that
+        /// forge speaks — never normalized here.
+        public let reviewVerdictRaw: String
         public let headRefName: String
         public let createdAt: String        // ISO 8601, e.g. "2026-03-24T15:58:27Z"
         public let isDraft: Bool
@@ -1536,25 +1543,30 @@ public actor PRStatusManager {
         /// The PR's base branch. Descriptive only — nothing matches on it — so
         /// it defaults to empty rather than being a required parse field, and a
         /// response that omits it degrades to "unknown" instead of dropping the
-        /// whole node. Declared last so the memberwise init stays
+        /// whole node. Declared late so the memberwise init stays
         /// source-compatible.
         public let baseRefName: String
+        /// The forge that produced this node. Declared last with a default so
+        /// the memberwise init stays source-compatible, the same reason
+        /// `baseRefName` is declared where it is.
+        public let forge: Forge
 
-        init(number: Int, url: String, state: String, mergeStateStatus: String,
-             reviewDecision: String, headRefName: String, createdAt: String, isDraft: Bool,
+        init(number: Int, url: String, state: String, mergeVerdictRaw: String,
+             reviewVerdictRaw: String, headRefName: String, createdAt: String, isDraft: Bool,
              statusCheckRollupState: String?, mergeQueuePosition: Int?,
-             baseRefName: String = "") {
+             baseRefName: String = "", forge: Forge = .github) {
             self.number = number
             self.url = url
             self.state = state
-            self.mergeStateStatus = mergeStateStatus
-            self.reviewDecision = reviewDecision
+            self.mergeVerdictRaw = mergeVerdictRaw
+            self.reviewVerdictRaw = reviewVerdictRaw
             self.headRefName = headRefName
             self.createdAt = createdAt
             self.isDraft = isDraft
             self.statusCheckRollupState = statusCheckRollupState
             self.mergeQueuePosition = mergeQueuePosition
             self.baseRefName = baseRefName
+            self.forge = forge
         }
     }
 
@@ -1875,8 +1887,8 @@ public actor PRStatusManager {
         let mergeQueueEntry = node["mergeQueueEntry"] as? [String: Any]
         let mergeQueuePosition = mergeQueueEntry?["position"] as? Int
         return PRNode(number: number, url: url, state: state,
-                      mergeStateStatus: mergeStateStatus,
-                      reviewDecision: reviewDecision,
+                      mergeVerdictRaw: mergeStateStatus,
+                      reviewVerdictRaw: reviewDecision,
                       headRefName: headRefName,
                       createdAt: createdAt,
                       isDraft: isDraft,

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -166,21 +166,22 @@ public actor PRStatusManager {
     ///
     /// The recheck is deliberately fire-and-forget — nothing in the pass reads
     /// its answer, so nothing in the pass may wait for it — but detaching it
-    /// removed the only thing that used to bound it. `runCLI` imposes no
-    /// timeout and a detached task inherits no cancellation, so before this
-    /// gate a hung endpoint accumulated one `glab`, one `Process` and its file
-    /// descriptors per project per tick, without limit: ~288 of them overnight
-    /// at a five-minute cadence. A forge CLI subprocess is covered by no
-    /// reconciler — `AgentReaper` reaps agent processes, not these — so the
-    /// bound has to be here, at the only place that creates one.
+    /// removed the only thing that used to bound it. A detached task inherits
+    /// no cancellation, so without a bound a hung endpoint accumulated one
+    /// `glab`, one `Process` and its file descriptors per project per tick,
+    /// without limit: ~288 of them overnight at a five-minute cadence. A forge
+    /// CLI subprocess is covered by no reconciler — `AgentReaper` reaps agent
+    /// processes, not these — so the bound has to be here, at the only place
+    /// that creates one.
     ///
-    /// Single-flight rather than a timeout: it needs no clock seam, and it is
-    /// the stronger statement. A second recheck for a project whose first is
-    /// still outstanding asks the server to redo work it has not finished, so
-    /// skipping it loses nothing even when the endpoint is healthy; a timeout
-    /// would still allow one outstanding process per tick until it fired.
-    /// Outstanding-forever is the intended reading of a hung recheck: the
-    /// project simply stops asking until that process ends.
+    /// This gate is half of that bound and answers "how many": a project with
+    /// a recheck outstanding issues no second one, so a tick cannot multiply a
+    /// stuck endpoint. `recheckTimeout` is the other half and answers "for how
+    /// long": the detached call is raced against that deadline and the child is
+    /// terminated when it fires, so no recheck is outstanding forever. Both are
+    /// needed — the gate alone leaves one process per project pinned for the
+    /// life of the daemon, and the deadline alone still admits a new process
+    /// per tick until it fires.
     private actor GitLabRecheckGate {
         private var outstanding: Set<String> = []
 
@@ -194,6 +195,23 @@ public actor PRStatusManager {
     /// `let` of a `Sendable` type, so the `nonisolated` GitLab paths reach it
     /// without hopping onto this actor.
     private let gitLabRecheckGate = GitLabRecheckGate()
+
+    /// How long a detached mergeability recheck may run before its `glab` is
+    /// terminated.
+    ///
+    /// Generous on purpose: the call exists to queue work on someone else's
+    /// server, so a slow instance must be allowed to finish rather than be
+    /// killed and retried on the next tick. What the deadline rules out is the
+    /// unbounded case — a process nothing ever ends, which no sweep would
+    /// reclaim either.
+    static let recheckTimeout: Duration = .seconds(60)
+
+    /// Clock seam for that deadline — existential, defaulted, and last, so no
+    /// call site changes and this actor's `Sendable` conformances are not
+    /// infected by a generic parameter. `Duration` is behavior, `Date` is data:
+    /// the deadline sleeps, so it takes a clock, while `now` above stamps facts
+    /// that get persisted and compared, so it stays a date seam.
+    private let clock: any Clock<Duration>
 
     /// The last authentication refusal observed per forge host, lowercased.
     ///
@@ -219,7 +237,9 @@ public actor PRStatusManager {
     /// data). This actor schedules nothing, so it has no clock at all.
     private let now: @Sendable () -> Date
 
-    public init(now: @escaping @Sendable () -> Date = { Date() }) {
+    public init(now: @escaping @Sendable () -> Date = { Date() },
+                clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
         self.ghRunner = nil
         self.remoteURLReader = nil
         self.glRunner = nil
@@ -239,7 +259,9 @@ public actor PRStatusManager {
          glRunner: GLRunner? = nil,
          gitLabHosts: Set<String> = [],
          remoteURLReader: @escaping RemoteURLReader = { _ in nil },
-         now: @escaping @Sendable () -> Date = { Date() }) {
+         now: @escaping @Sendable () -> Date = { Date() },
+         clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
         self.ghRunner = ghRunner
         self.glRunner = glRunner
         self.gitLabHosts = Set(gitLabHosts.map { $0.lowercased() })
@@ -1188,18 +1210,20 @@ public actor PRStatusManager {
         // cannot disturb the poll — the value it produces is read by the NEXT
         // tick's GraphQL call, not by this one.
         //
-        // Detached, and that is load-bearing rather than tidy. `runCLI` imposes
-        // no timeout, `refreshBindings` walks its groups one at a time, and
-        // `fetchAll` skips the next poll while one is still in flight — so a
-        // `glab` that hangs here stalls PR polling for the entire fleet, with no
-        // deadline to end it. Hanging is the plausible failure for this call in
-        // particular: it exists to queue work on someone else's server. Nothing
-        // in this pass reads the result, so nothing in this pass may wait for
-        // it.
+        // Detached, and that is load-bearing rather than tidy.
+        // `refreshBindings` walks its groups one at a time and `fetchAll` skips
+        // the next poll while one is still in flight — so a `glab` that hangs
+        // here would stall PR polling for the entire fleet. Hanging is the
+        // plausible failure for this call in particular: it exists to queue work
+        // on someone else's server. Nothing in this pass reads the result, so
+        // nothing in this pass may wait for it.
         //
         // Detaching removes the stall and would, unbounded, replace it with a
-        // subprocess leak — so the issue is single-flighted per project by
-        // `gitLabRecheckGate`, which is where that reasoning is written down.
+        // subprocess leak, so the detached call is bounded twice at this one
+        // creation site: `gitLabRecheckGate` caps how many are live (one per
+        // project) and `recheckTimeout` caps how long any one of them lives,
+        // terminating the child when it fires. Both bounds are reasoned about
+        // where the gate is declared.
         //
         // Only non-terminal merge requests are asked. A merged or closed one has
         // a mergeability nobody will recompute and nobody will read, so
@@ -1210,8 +1234,8 @@ public actor PRStatusManager {
             let host = group.host
             let recheckPath = GitLabQueries.recheckPath(projectPath: projectPath, iids: recheckIIDs)
             Task.detached { [self] in
-                _ = await runGLResult(args: ["api", "--hostname", host, recheckPath],
-                                      repoPath: repoPath)
+                _ = await runGLBounded(args: ["api", "--hostname", host, recheckPath],
+                                       repoPath: repoPath, timeout: Self.recheckTimeout)
                 await gitLabRecheckGate.finish(gateKey)
             }
         }
@@ -3164,6 +3188,45 @@ public actor PRStatusManager {
         return await Self.runGlab(args: args, repoPath: repoPath)
     }
 
+    /// One `glab` invocation that cannot outlive `timeout`, for the detached
+    /// call nobody is waiting on.
+    ///
+    /// The deadline is a race, not a poll: whichever of the call and the sleep
+    /// finishes first wins, and cancelling the group ends the other. On a
+    /// timeout that cancellation reaches `runCLI`, which terminates the child —
+    /// the bound is on the subprocess itself rather than merely on the task
+    /// awaiting it, because a task that stops waiting leaves a `glab` nothing
+    /// reclaims. Returns nil when the deadline fired; every caller of this is
+    /// discarding the answer anyway.
+    private nonisolated func runGLBounded(args: [String], repoPath: String,
+                                          timeout: Duration) async -> GHCommandResult? {
+        enum Outcome: Sendable {
+            case finished(GHCommandResult?)
+            case timedOut
+        }
+        return await withTaskGroup(of: Outcome.self, returning: GHCommandResult?.self) { group in
+            group.addTask {
+                .finished(await self.runGLResult(args: args, repoPath: repoPath))
+            }
+            group.addTask {
+                // A cancelled sleep also reports `.timedOut`, and that is
+                // harmless: it can only happen after the other task already
+                // produced the value this returns.
+                try? await self.clock.sleep(for: timeout)
+                return .timedOut
+            }
+            defer { group.cancelAll() }
+            guard let first = await group.next() else { return nil }
+            switch first {
+            case .finished(let result):
+                return result
+            case .timedOut:
+                logger.debug("glab call exceeded \(timeout, privacy: .public); terminating it")
+                return nil
+            }
+        }
+    }
+
     /// The real `glab` subprocess. Static because `GitLabHostResolver` is handed
     /// this same runner while the manager is still being initialized, so there
     /// is no instance yet for it to capture.
@@ -3175,34 +3238,57 @@ public actor PRStatusManager {
         return await runCLI(executable: glabPath, args: args, repoPath: repoPath)
     }
 
+    /// Runs a forge CLI and answers what it printed.
+    ///
+    /// **Cancelling the calling task terminates the child.** Without that, a
+    /// caller that stops waiting — the deadline in `runGLBounded` is the one
+    /// that does — abandons a live subprocess that no reconciler reclaims, so
+    /// the deadline would bound the wait and not the leak. `ChildProcessHandle`
+    /// carries the process across to the cancellation handler and closes the
+    /// two orderings that could otherwise let one slip: a cancel that lands
+    /// before `run()` prevents the launch outright, and one that lands during
+    /// `run()` is re-checked immediately afterwards.
     private static func runCLI(executable: String, args: [String], repoPath: String) async -> GHCommandResult? {
-        await withCheckedContinuation { continuation in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: executable)
-            process.arguments = args
-            process.currentDirectoryURL = URL(fileURLWithPath: repoPath)
+        let handle = ChildProcessHandle()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: executable)
+                process.arguments = args
+                process.currentDirectoryURL = URL(fileURLWithPath: repoPath)
 
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.standardOutput = stdout
+                process.standardError = stderr
 
-            process.terminationHandler = { p in
-                let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-                let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
-                continuation.resume(returning: GHCommandResult(
-                    stdout: String(data: stdoutData, encoding: .utf8) ?? "",
-                    stderr: String(data: stderrData, encoding: .utf8) ?? "",
-                    exitStatus: p.terminationStatus
-                ))
+                process.terminationHandler = { p in
+                    let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                    let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                    continuation.resume(returning: GHCommandResult(
+                        stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+                        stderr: String(data: stderrData, encoding: .utf8) ?? "",
+                        exitStatus: p.terminationStatus
+                    ))
+                }
+
+                guard handle.adopt(process) else {
+                    // Cancelled before the launch: the cheapest possible
+                    // termination is never starting.
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                do {
+                    try process.run()
+                    handle.terminateIfCancelled()
+                } catch {
+                    logger.debug("Failed to launch \(executable, privacy: .public): \(error)")
+                    continuation.resume(returning: nil)
+                }
             }
-
-            do {
-                try process.run()
-            } catch {
-                logger.debug("Failed to launch \(executable, privacy: .public): \(error)")
-                continuation.resume(returning: nil)
-            }
+        } onCancel: {
+            handle.cancel()
         }
     }
 
@@ -3242,6 +3328,52 @@ struct GHCommandResult: Sendable {
 }
 
 // MARK: - Supporting types
+
+/// The child a `runCLI` call launched, shared with that call's cancellation
+/// handler so a caller that stops waiting can end the process rather than
+/// abandon it.
+///
+/// `withCheckedContinuation`'s body and `withTaskCancellationHandler`'s
+/// `onCancel` run on different threads and either may go first, so the handoff
+/// is lock-guarded and remembers a cancellation that arrived before there was
+/// anything yet to cancel.
+private final class ChildProcessHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+
+    /// Takes the process, or answers false because cancellation already
+    /// arrived — in which case the caller must not launch it at all.
+    func adopt(_ process: Process) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled else { return false }
+        self.process = process
+        return true
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let launched = process
+        lock.unlock()
+        Self.terminate(launched)
+    }
+
+    /// Re-checked right after `run()` returns, for the cancellation that landed
+    /// mid-launch and so found nothing running to signal.
+    func terminateIfCancelled() {
+        lock.lock()
+        let launched = cancelled ? process : nil
+        lock.unlock()
+        Self.terminate(launched)
+    }
+
+    private static func terminate(_ process: Process?) {
+        guard let process, process.isRunning else { return }
+        process.terminate()
+    }
+}
 
 /// Result of the single-PR refresh query, populated by `parsePRByBranch`.
 /// (No longer `Codable`: the refresh path moved from `gh pr view --json` to

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -31,13 +31,6 @@ enum PRUndeterminedCause {
     /// truncated or malformed blob. Not the absence of a record: an attempt was
     /// made, and only what it concluded is lost.
     static let unreadableRecord = "the recorded outcome could not be read"
-    /// The worktree lives on a forge this path cannot ask. The direct refresh
-    /// speaks GitHub's API alone, and a GitLab worktree is refreshed through
-    /// its bindings instead — so one with no binding yet has no direct-refresh
-    /// route at all. Named rather than folded into `queryFailed` because
-    /// nothing failed and retrying changes nothing; the alternative to saying
-    /// so is letting a same-named GitHub repository answer in its place.
-    static let forgeNotQueryableDirectly = "this worktree's forge cannot be queried directly"
     /// The CLI ran and reached the host, which refused the credentials. Named
     /// separately from `cliUnavailable` because the remedy differs: a token
     /// expired, and only re-authenticating that specific host fixes it. A
@@ -1381,13 +1374,18 @@ public actor PRStatusManager {
         // against a pull request from another forge. `poisonedCacheEntries`
         // compares owner and name only, so it cannot catch that either.
         //
-        // The cache is left exactly as it was; only the outcome is recorded, and
-        // it says the forge cannot be asked rather than that the query failed.
+        // Nothing is written at all: not the cache, and not the outcome either.
+        // Declining to ask is not an attempt that failed, and this path is
+        // reached by a USER GESTURE — `pr.refresh` and the on-select refresh.
+        // Recording `.undetermined` here would answer a GitLab worktree whose
+        // bindings poll perfectly with "last check did not resolve" — stomping
+        // a good `.observed`, and on a worktree with no status yet lighting the
+        // "PR status unknown" indicator at the exact moment the user asked for
+        // reassurance. The binding poll is what settles this worktree, and
+        // its last word stands until it has a new one.
         if let identity = await cachedNameWithOwner(repoPath: repoPath),
            await isGitLabHost(identity.host, repoPath: repoPath) {
             logger.debug("refresh: worktree \(worktreeID, privacy: .public) is on GitLab host \(identity.host, privacy: .public); its merge request is refreshed through its bindings, not by gh")
-            await record(.undetermined(cause: PRUndeterminedCause.forgeNotQueryableDirectly),
-                         for: worktreeID, at: now())
             return cache[worktreeID]
         }
 

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -1661,8 +1661,23 @@ public actor PRStatusManager {
     /// red essentially never, and — since NOT_APPROVED maps to .mergeable —
     /// would render a merge request with a failing pipeline as "Ready to merge".
     ///
-    /// Precedence mirrors the GitHub arm exactly: terminal, then draft, then
-    /// the CI signal, then the merge-status switch.
+    /// Precedence: terminal, then draft, then an explicit change request, then
+    /// the CI signal, then the merge-status switch. The first three slots are
+    /// the GitHub arm's own order, with `REQUESTED_CHANGES` standing where
+    /// `CHANGES_REQUESTED` stands there.
+    ///
+    /// `DISCUSSIONS_NOT_RESOLVED` deliberately sits *after* the CI signal,
+    /// inside the merge-status switch, and the two must not be lumped together:
+    /// an explicit change request outranks CI, an unresolved thread does not.
+    /// The GitHub arm privileges only the explicit review decision, and an open
+    /// discussion thread is not a rejection — so when a pipeline is also
+    /// failing, the pipeline is the more actionable thing to show the author.
+    ///
+    /// Ranking a change request above a failing pipeline deliberately yields
+    /// the *lower*-severity `.changesRequested` (attention severity 4) rather
+    /// than `.checksFailed` (6) when both hold. That is what the GitHub arm
+    /// already does, and the product stance behind it is that an explicit human
+    /// rejection is the thing to tell the author about.
     private static func mapGitLabStateAndReason(
         state: String,
         detailed: String,
@@ -1677,6 +1692,12 @@ public actor PRStatusManager {
         }
 
         if isDraft || detailed == "DRAFT_STATUS" { return (.draft, "Draft") }
+
+        // Ahead of the CI signal, where the GitHub arm puts CHANGES_REQUESTED:
+        // an explicit rejection must not be masked by a red pipeline. Handled
+        // here rather than in the switch below, which is why that switch has no
+        // REQUESTED_CHANGES case.
+        if detailed == "REQUESTED_CHANGES" { return (.changesRequested, "Changes requested") }
 
         // `onlyAllowMergeIfPipelineSucceeds` is the faithful analogue of
         // GitHub's "required check". A failing pipeline on a project that does
@@ -1696,8 +1717,9 @@ public actor PRStatusManager {
         // Checks are settled and the only blocker is an approval nobody has
         // given — the same reading the GitHub arm gives BLOCKED + REVIEW_REQUIRED.
         case "NOT_APPROVED": return (.mergeable, "Ready to merge")
+        // Ranks below the CI signal above, unlike REQUESTED_CHANGES: a thread
+        // nobody has resolved is not an explicit rejection.
         case "DISCUSSIONS_NOT_RESOLVED": return (.changesRequested, "Unresolved discussions")
-        case "REQUESTED_CHANGES": return (.changesRequested, "Changes requested")
         case "CONFLICT": return (.blocked, "Merge conflicts")
         case "NEED_REBASE": return (.blocked, "Behind base branch")
         case "BLOCKED_STATUS": return (.blocked, "Blocked by another merge request")

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -31,6 +31,13 @@ enum PRUndeterminedCause {
     /// truncated or malformed blob. Not the absence of a record: an attempt was
     /// made, and only what it concluded is lost.
     static let unreadableRecord = "the recorded outcome could not be read"
+    /// The worktree lives on a forge this path cannot ask. The direct refresh
+    /// speaks GitHub's API alone, and a GitLab worktree is refreshed through
+    /// its bindings instead — so one with no binding yet has no direct-refresh
+    /// route at all. Named rather than folded into `queryFailed` because
+    /// nothing failed and retrying changes nothing; the alternative to saying
+    /// so is letting a same-named GitHub repository answer in its place.
+    static let forgeNotQueryableDirectly = "this worktree's forge cannot be queried directly"
     /// The CLI ran and reached the host, which refused the credentials. Named
     /// separately from `cliUnavailable` because the remedy differs: a token
     /// expired, and only re-authenticating that specific host fixes it. A
@@ -1286,6 +1293,25 @@ public actor PRStatusManager {
     public func refresh(worktreeID: UUID, branch: String, upstreamBranch: String?, defaultBranch: String?,
                         pushBranch: GitManager.PushBranchResolution,
                         repoPath: String, prNumber: Int? = nil) async -> PRStatus? {
+        // A GitLab worktree must never be answered by `gh`. Both routes below
+        // speak GitHub's API alone, and on a FLAT GitLab namespace the
+        // worktree's owner/name are valid GitHub coordinates too: with a
+        // same-named repository on github.com, `applyRefreshedNode` would write
+        // a GitHub pull request's status onto a GitLab worktree and, on a merged
+        // one, run the merged-transition machinery — auto-archive included —
+        // against a pull request from another forge. `poisonedCacheEntries`
+        // compares owner and name only, so it cannot catch that either.
+        //
+        // The cache is left exactly as it was; only the outcome is recorded, and
+        // it says the forge cannot be asked rather than that the query failed.
+        if let identity = await cachedNameWithOwner(repoPath: repoPath),
+           await isGitLabHost(identity.host, repoPath: repoPath) {
+            logger.debug("refresh: worktree \(worktreeID, privacy: .public) is on GitLab host \(identity.host, privacy: .public); its merge request is refreshed through its bindings, not by gh")
+            await record(.undetermined(cause: PRUndeterminedCause.forgeNotQueryableDirectly),
+                         for: worktreeID, at: now())
+            return cache[worktreeID]
+        }
+
         // A stored PR number (fork PRs, or a PR whose head we renamed locally)
         // can't be found by head branch — resolve it directly, mirroring
         // fetchAll's number-first path. Only fall back to the branch path when no
@@ -2393,6 +2419,21 @@ public actor PRStatusManager {
             logger.debug("listOpenPRs: could not resolve owner/name for \(repoPath, privacy: .public)")
             return []
         }
+        if await isGitLabHost(ownerRepo.host, repoPath: repoPath) {
+            // Not merely fruitless — actively wrong. What follows is a GitHub
+            // GraphQL query, and on a flat GitLab namespace the same owner/name
+            // is a valid GitHub coordinate: a same-named repository on
+            // github.com would fill the picker with pull requests this repo has
+            // nothing to do with, and creating a worktree from one would check
+            // out a branch from another forge.
+            //
+            // Listing GitLab merge requests is not built, so the picker is empty
+            // for a GitLab repo — but not silently: `.warning` is recorded by
+            // default where `.debug` is not, so "the picker shows nothing" has
+            // an answer in the log without turning debug logging on first.
+            logger.warning("listOpenPRs: \(repoPath, privacy: .public) lives on GitLab host \(ownerRepo.host, privacy: .public); listing merge requests is not implemented, so the picker stays empty")
+            return []
+        }
         let args = [
             "api", "graphql",
             "-f", "query=\(Self.openPRsQuery())",
@@ -2709,11 +2750,21 @@ public actor PRStatusManager {
     ) async -> [(worktreeID: UUID, node: PRNode)] {
         var resolved: [String: (owner: String, name: String)] = [:]
         for path in Set(numbered.map(\.worktreePath)) {
-            if let ownerRepo = await cachedNameWithOwner(repoPath: path) {
-                resolved[path] = (owner: ownerRepo.owner, name: ownerRepo.name)
-            } else {
+            guard let ownerRepo = await cachedNameWithOwner(repoPath: path) else {
                 logger.debug("fetchAll: could not resolve owner/name for numbered PRs at \(path, privacy: .public)")
+                continue
             }
+            // The by-number query is GitHub's. Offering a GitLab checkout's
+            // coordinates to it is not merely fruitless on a flat namespace —
+            // a same-named GitHub repository answers, and a MERGED answer fires
+            // auto-archive on a worktree whose merge request is somewhere else
+            // entirely. Dropping the entry degrades exactly as an unresolvable
+            // repo does: the worktree keeps its cached status.
+            guard !(await isGitLabHost(ownerRepo.host, repoPath: path)) else {
+                logger.debug("fetchAll: not offering the stored number at \(path, privacy: .public) to gh — \(ownerRepo.host, privacy: .public) is a GitLab host")
+                continue
+            }
+            resolved[path] = (owner: ownerRepo.owner, name: ownerRepo.name)
         }
         var matches: [(worktreeID: UUID, node: PRNode)] = []
         for group in Self.groupNumberedByRepo(numbered, resolve: { resolved[$0] }) {

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -2555,9 +2555,10 @@ public actor PRStatusManager {
     ///    live — so replacing it with a remote parse would silently break every
     ///    fork checkout.
     /// 2. The `origin` remote, parsed directly, and **only when gh cannot serve
-    ///    this checkout at all** — it is not installed, or it ran and disowned
-    ///    the checkout because no remote names a GitHub host it knows. That is
-    ///    the case every GitLab checkout is in, and it is the only route by
+    ///    this checkout at all** — it is not installed, it holds no credentials
+    ///    for anywhere (`ghExitNoCredentials`), or it ran and disowned the
+    ///    checkout because no remote names a GitHub host it knows. Those are
+    ///    the cases every GitLab checkout is in, and this is the only route by
     ///    which one can ever name itself.
     ///
     /// A gh failure that says nothing about the checkout — an expired token, a
@@ -2613,8 +2614,8 @@ public actor PRStatusManager {
         }
         let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
         guard result.exitStatus == 0 else {
-            if Self.ghDisownsCheckout(errSuffix) {
-                logger.debug("gh does not speak for the repo at \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
+            if result.exitStatus == Self.ghExitNoCredentials || Self.ghDisownsCheckout(errSuffix) {
+                logger.debug("gh does not speak for the repo at \(repoPath, privacy: .public) (exit \(result.exitStatus, privacy: .public)): \(errSuffix, privacy: .public)")
                 return .unservable
             }
             logger.debug("gh repo view exited \(result.exitStatus, privacy: .public) for \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
@@ -2632,6 +2633,45 @@ public actor PRStatusManager {
         guard parts.count == 2 else { return .transientFailure }
         return .resolved(owner: String(parts[0]), name: String(parts[1]), host: host)
     }
+
+    /// gh's exit code for "there are no credentials on this machine at all"
+    /// (`exitAuth` in gh's own `main.go`). It is a cleaner discriminator than
+    /// any stderr string, and the only route to this state gh has: it runs its
+    /// auth check BEFORE it resolves a base repo, so an unauthenticated gh
+    /// **never** emits the disownment message below — not for a GitLab remote,
+    /// not for any remote. Reading exit 4 as transient therefore left every
+    /// checkout on a machine with an unused `gh` unnameable forever (a nil is
+    /// not cached, so it re-failed on every tick), which takes down GitLab
+    /// branch matching, provenance seeding, the open-PR picker and every hook
+    /// or `tbd pr attach` bind — for exactly the population this path exists
+    /// to serve.
+    ///
+    /// An expired or rejected token is a different state and is NOT this one:
+    /// credentials exist, gh runs the command, and the HTTP 401 comes back as
+    /// exit 1. That stays transient, which is what keeps a fork checkout from
+    /// being renamed by a flaky token.
+    ///
+    /// **The trade-off, accepted deliberately, and its one sharp edge:** on a
+    /// GITHUB fork checkout with no credentials, resolution falls through to
+    /// the `origin` parse and names the fork rather than the parent gh would
+    /// have named. Every gh query on that checkout fails anyway, so no PR
+    /// feature works there under either reading and the identity buys nothing —
+    /// while for a GitLab checkout the remote parse is the ONLY route that ever
+    /// works. The cost is a wrong answer nobody can act on; the benefit is the
+    /// whole feature for the people it was built for.
+    ///
+    /// The edge is that the answer is not quite inert: `poisonedCacheEntries`
+    /// rests on "both sides resolved" meaning both are KNOWN, so on such a
+    /// checkout a cached pull request living in the PARENT now reads as
+    /// cross-repo against the fork and is cleared, persistently, and reported
+    /// as a disproved binding. It is bounded — only while gh holds no
+    /// credentials at all, only for a worktree with no stored PR number, and a
+    /// re-login re-finds any pull request still inside the 100-PR viewer batch
+    /// — and the same edge already existed for a checkout with no `gh`
+    /// installed. Narrowing it (declining the parse when the parsed host is one
+    /// gh would have served) is a separate change to `poisonedCacheEntries`'s
+    /// premise, not to this discriminator.
+    private static let ghExitNoCredentials: Int32 = 4
 
     /// Whether gh's own refusal says it does not serve this checkout, as opposed
     /// to failing at something it does serve.

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -89,7 +89,7 @@ public actor PRStatusManager {
     /// one repo) sharing an entry is the cache working, not a collision. Entries
     /// are only ever added and expire on time; nothing prunes by row, so no
     /// worktree can evict another's.
-    private var ownerRepoCache: [String: (value: (owner: String, name: String), expiry: Date)] = [:]
+    private var ownerRepoCache: [String: (value: (owner: String, name: String, host: String), expiry: Date)] = [:]
 
     /// Reentrancy guard: a previous poll still running means a new `fetchAll` is skipped
     /// so two generations of batch data can't interleave their cache writes.
@@ -130,6 +130,15 @@ public actor PRStatusManager {
 
     private let ghRunner: GHRunner?
 
+    /// Behavior seam for reading a checkout's `origin` remote URL — the second
+    /// identity source, used only when `gh` cannot name the repo, which is
+    /// every checkout on a host `gh` does not speak to. Production leaves it
+    /// nil and runs `GitManager`; the injecting init defaults it to "no
+    /// remote", so a test that stubs `gh` never spawns a `git` subprocess.
+    typealias RemoteURLReader = @Sendable (_ repoPath: String) async -> String?
+
+    private let remoteURLReader: RemoteURLReader?
+
     /// Date seam for the observed-at this actor *stamps* on the facts it
     /// records — `PRStatus.observedAt` and `PRObservation.observedAt`. Both are
     /// persisted and later compared to age a cache, so they are data, and take
@@ -139,11 +148,15 @@ public actor PRStatusManager {
 
     public init(now: @escaping @Sendable () -> Date = { Date() }) {
         self.ghRunner = nil
+        self.remoteURLReader = nil
         self.now = now
     }
 
-    init(ghRunner: @escaping GHRunner, now: @escaping @Sendable () -> Date = { Date() }) {
+    init(ghRunner: @escaping GHRunner,
+         remoteURLReader: @escaping RemoteURLReader = { _ in nil },
+         now: @escaping @Sendable () -> Date = { Date() }) {
         self.ghRunner = ghRunner
+        self.remoteURLReader = remoteURLReader
         self.now = now
     }
 
@@ -477,7 +490,7 @@ public actor PRStatusManager {
             var unnumberedRepos: [String: (owner: String, name: String)] = [:]
             for path in Set(unnumbered.map(\.worktreePath)) {
                 if let ownerRepo = await cachedNameWithOwner(repoPath: path) {
-                    unnumberedRepos[path] = ownerRepo
+                    unnumberedRepos[path] = (owner: ownerRepo.owner, name: ownerRepo.name)
                 } else {
                     logger.debug("fetchAll: could not resolve owner/name for unnumbered worktree at \(path, privacy: .public)")
                 }
@@ -2035,22 +2048,95 @@ public actor PRStatusManager {
 
     // MARK: - Shell helpers
 
-    /// Resolve the checkout's `owner/name` for repo-scoped GraphQL queries.
-    /// Uses `gh repo view` (git-remote resolution) so `refresh` need not already
-    /// hold a PR URL to parse.
-    private nonisolated func resolveNameWithOwner(repoPath: String) async -> (owner: String, name: String)? {
-        let args = ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
-        guard let output = await runGH(args: args, repoPath: repoPath) else { return nil }
-        let parts = output.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "/")
+    /// Resolve the checkout's `owner/name` and the host it lives on, for
+    /// repo-scoped queries and for composing a reference from a bare number.
+    ///
+    /// Two sources, in this order, and the order is the whole design:
+    ///
+    /// 1. `gh repo view`, which is asked for `url` alongside `nameWithOwner` so
+    ///    the host is gh's own answer rather than an assumption. gh resolves a
+    ///    *base* repo, not merely `origin` — with an `upstream` remote present
+    ///    it names the parent, which is where a fork's pull requests actually
+    ///    live — so replacing it with a remote parse would silently break every
+    ///    fork checkout.
+    /// 2. The `origin` remote, parsed directly, when gh cannot answer. gh
+    ///    refuses outright on a host it does not recognise, so this is the only
+    ///    route by which a GitLab checkout can ever name itself.
+    ///
+    /// Returns nil when neither source yields a host — a caller that cannot
+    /// name the repo defers, and must never fall back to guessing `github.com`.
+    private nonisolated func resolveNameWithOwner(
+        repoPath: String
+    ) async -> (owner: String, name: String, host: String)? {
+        if let identity = await resolveViaGH(repoPath: repoPath) { return identity }
+        guard let remote = await readRemoteURL(repoPath: repoPath),
+              let identity = Self.parseRemoteIdentity(remote) else {
+            logger.debug("could not name the repo at \(repoPath, privacy: .public) from gh or from its origin remote")
+            return nil
+        }
+        return identity
+    }
+
+    private nonisolated func resolveViaGH(
+        repoPath: String
+    ) async -> (owner: String, name: String, host: String)? {
+        let args = ["repo", "view", "--json", "nameWithOwner,url"]
+        guard let output = await runGH(args: args, repoPath: repoPath),
+              let data = output.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let nameWithOwner = root["nameWithOwner"] as? String,
+              let url = root["url"] as? String,
+              let host = URLComponents(string: url)?.host, !host.isEmpty else { return nil }
+        let parts = nameWithOwner.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "/")
         guard parts.count == 2 else { return nil }
-        return (owner: String(parts[0]), name: String(parts[1]))
+        return (owner: String(parts[0]), name: String(parts[1]), host: host)
+    }
+
+    private nonisolated func readRemoteURL(repoPath: String) async -> String? {
+        if let remoteURLReader { return await remoteURLReader(repoPath) }
+        return await GitManager().getRemoteURL(repoPath: repoPath)
+    }
+
+    /// The host, namespace and project of a git remote URL.
+    ///
+    /// Accepts the three shapes a remote can take — `https://host/a/b`,
+    /// `ssh://git@host:22/a/b`, and the scp-like `git@host:a/b` — and keeps the
+    /// FULL namespace, because a GitLab project can nest (`acme/platform/api`)
+    /// and the owner is everything before the last segment.
+    ///
+    /// `RemoteRepoMatching` in TBDShared parses the same three shapes and is
+    /// deliberately not reused: it drops the host by design, and it keeps only
+    /// the last two segments, so it reads `acme/platform/backend/api` as
+    /// `backend/api`. Both choices are correct for what it does — matching a
+    /// provider's `meta["repo"]` against registered repos — and wrong for
+    /// naming a repo to its own forge.
+    static func parseRemoteIdentity(_ remote: String) -> (owner: String, name: String, host: String)? {
+        var rest = remote.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rest.isEmpty else { return nil }
+        if let scheme = rest.range(of: "://") {
+            rest = String(rest[scheme.upperBound...])
+        } else if let colon = rest.firstIndex(of: ":") {
+            // scp-like syntax puts ':' where a URL puts the first '/'.
+            rest.replaceSubrange(colon...colon, with: "/")
+        }
+        var segments = rest.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard segments.count >= 3 else { return nil }
+        var host = segments.removeFirst()
+        if let at = host.lastIndex(of: "@") { host = String(host[host.index(after: at)...]) }
+        // An `ssh://git@host:22/…` port is not part of the host name.
+        if let portColon = host.firstIndex(of: ":") { host = String(host[host.startIndex..<portColon]) }
+        var name = segments.removeLast()
+        if name.lowercased().hasSuffix(".git") { name = String(name.dropLast(4)) }
+        let owner = segments.joined(separator: "/")
+        guard !host.isEmpty, !owner.isEmpty, !name.isEmpty else { return nil }
+        return (owner: owner, name: name, host: host.lowercased())
     }
 
     /// `resolveNameWithOwner` behind a ~15-min TTL cache so the periodic poll
     /// (by-number query) and picker (open-PR query) stop spawning a `gh repo
     /// view` subprocess on every call. A checkout's owner/name is effectively
     /// immutable, so a stale entry is harmless within the TTL.
-    private func cachedNameWithOwner(repoPath: String) async -> (owner: String, name: String)? {
+    private func cachedNameWithOwner(repoPath: String) async -> (owner: String, name: String, host: String)? {
         if let entry = ownerRepoCache[repoPath], entry.expiry > Date() {
             return entry.value
         }
@@ -2059,12 +2145,15 @@ public actor PRStatusManager {
         return resolved
     }
 
-    /// The checkout's own GitHub `owner`/`name`, through the same TTL cache the
-    /// poll and picker use. Exposed for PR *binding* validation, which has to
-    /// ask the same question on every hook fire and manual attach — resolving
-    /// it independently would both double the `gh repo view` subprocesses and
-    /// let the two answers disagree inside a TTL window.
-    public func repoIdentity(repoPath: String) async -> (owner: String, name: String)? {
+    /// The checkout's own `owner`/`name` and the host they live on, through the
+    /// same TTL cache the poll and picker use. Exposed for PR *binding*
+    /// validation, which has to ask the same question on every hook fire and
+    /// manual attach — resolving it independently would both double the `gh
+    /// repo view` subprocesses and let the two answers disagree inside a TTL
+    /// window. The host rides along because a bare number has to be composed
+    /// into a reference, and the shape of that reference is the host's to
+    /// decide.
+    public func repoIdentity(repoPath: String) async -> (owner: String, name: String, host: String)? {
         await cachedNameWithOwner(repoPath: repoPath)
     }
 
@@ -2109,7 +2198,7 @@ public actor PRStatusManager {
         var resolved: [String: (owner: String, name: String)] = [:]
         for path in Set(numbered.map(\.worktreePath)) {
             if let ownerRepo = await cachedNameWithOwner(repoPath: path) {
-                resolved[path] = ownerRepo
+                resolved[path] = (owner: ownerRepo.owner, name: ownerRepo.name)
             } else {
                 logger.debug("fetchAll: could not resolve owner/name for numbered PRs at \(path, privacy: .public)")
             }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -168,6 +168,40 @@ public actor PRStatusManager {
     /// behind its back would spawn `glab auth status` from a unit test.
     private let gitLabHostResolver: GitLabHostResolver?
 
+    /// Single-flight admission for the detached GitLab mergeability recheck,
+    /// keyed by the project it is issued against.
+    ///
+    /// The recheck is deliberately fire-and-forget — nothing in the pass reads
+    /// its answer, so nothing in the pass may wait for it — but detaching it
+    /// removed the only thing that used to bound it. `runCLI` imposes no
+    /// timeout and a detached task inherits no cancellation, so before this
+    /// gate a hung endpoint accumulated one `glab`, one `Process` and its file
+    /// descriptors per project per tick, without limit: ~288 of them overnight
+    /// at a five-minute cadence. A forge CLI subprocess is covered by no
+    /// reconciler — `AgentReaper` reaps agent processes, not these — so the
+    /// bound has to be here, at the only place that creates one.
+    ///
+    /// Single-flight rather than a timeout: it needs no clock seam, and it is
+    /// the stronger statement. A second recheck for a project whose first is
+    /// still outstanding asks the server to redo work it has not finished, so
+    /// skipping it loses nothing even when the endpoint is healthy; a timeout
+    /// would still allow one outstanding process per tick until it fired.
+    /// Outstanding-forever is the intended reading of a hung recheck: the
+    /// project simply stops asking until that process ends.
+    private actor GitLabRecheckGate {
+        private var outstanding: Set<String> = []
+
+        /// True for the caller that may issue the recheck for `key`; false when
+        /// one is still outstanding for that project.
+        func admit(_ key: String) -> Bool { outstanding.insert(key).inserted }
+
+        func finish(_ key: String) { outstanding.remove(key) }
+    }
+
+    /// `let` of a `Sendable` type, so the `nonisolated` GitLab paths reach it
+    /// without hopping onto this actor.
+    private let gitLabRecheckGate = GitLabRecheckGate()
+
     /// The last authentication refusal observed per forge host, lowercased.
     ///
     /// Keyed by host rather than by worktree or binding because that is the
@@ -1165,16 +1199,22 @@ public actor PRStatusManager {
         // in this pass reads the result, so nothing in this pass may wait for
         // it.
         //
+        // Detaching removes the stall and would, unbounded, replace it with a
+        // subprocess leak — so the issue is single-flighted per project by
+        // `gitLabRecheckGate`, which is where that reasoning is written down.
+        //
         // Only non-terminal merge requests are asked. A merged or closed one has
         // a mergeability nobody will recompute and nobody will read, so
         // including it spends a server-side job to learn nothing.
         let recheckIIDs = nodes.filter { !Self.isTerminalGitLabState($0.state) }.map(\.number)
-        if !recheckIIDs.isEmpty {
+        let gateKey = "\(group.host)\u{1}\(projectPath)"
+        if !recheckIIDs.isEmpty, await gitLabRecheckGate.admit(gateKey) {
             let host = group.host
             let recheckPath = GitLabQueries.recheckPath(projectPath: projectPath, iids: recheckIIDs)
             Task.detached { [self] in
                 _ = await runGLResult(args: ["api", "--hostname", host, recheckPath],
                                       repoPath: repoPath)
+                await gitLabRecheckGate.finish(gateKey)
             }
         }
 

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -2446,16 +2446,36 @@ public actor PRStatusManager {
     ///    it names the parent, which is where a fork's pull requests actually
     ///    live — so replacing it with a remote parse would silently break every
     ///    fork checkout.
-    /// 2. The `origin` remote, parsed directly, when gh cannot answer. gh
-    ///    refuses outright on a host it does not recognise, so this is the only
-    ///    route by which a GitLab checkout can ever name itself.
+    /// 2. The `origin` remote, parsed directly, and **only when gh cannot serve
+    ///    this checkout at all** — it is not installed, or it ran and disowned
+    ///    the checkout because no remote names a GitHub host it knows. That is
+    ///    the case every GitLab checkout is in, and it is the only route by
+    ///    which one can ever name itself.
+    ///
+    /// A gh failure that says nothing about the checkout — an expired token, a
+    /// 401, a rate limit, a network blip — is NOT licence to parse the remote.
+    /// The two sources disagree on exactly the checkout where it matters: on a
+    /// fork with an `upstream` remote gh names the parent, where the fork's pull
+    /// requests live, while `origin` names the fork. And this answer is cached
+    /// for fifteen minutes (`cachedNameWithOwner`), while a nil is not cached at
+    /// all — so a wrong answer is durable and a deferral self-heals on the next
+    /// tick. Deferring is therefore the only safe reading of a transient
+    /// failure.
     ///
     /// Returns nil when neither source yields a host — a caller that cannot
     /// name the repo defers, and must never fall back to guessing `github.com`.
     private nonisolated func resolveNameWithOwner(
         repoPath: String
     ) async -> (owner: String, name: String, host: String)? {
-        if let identity = await resolveViaGH(repoPath: repoPath) { return identity }
+        switch await resolveViaGH(repoPath: repoPath) {
+        case .resolved(let owner, let name, let host):
+            return (owner: owner, name: name, host: host)
+        case .transientFailure:
+            logger.debug("gh could not name the repo at \(repoPath, privacy: .public) this time; deferring rather than reading its origin remote")
+            return nil
+        case .unservable:
+            break
+        }
         guard let remote = await readRemoteURL(repoPath: repoPath),
               let identity = Self.parseRemoteIdentity(remote) else {
             logger.debug("could not name the repo at \(repoPath, privacy: .public) from gh or from its origin remote")
@@ -2464,19 +2484,67 @@ public actor PRStatusManager {
         return identity
     }
 
-    private nonisolated func resolveViaGH(
-        repoPath: String
-    ) async -> (owner: String, name: String, host: String)? {
+    /// What one `gh repo view` settled about a checkout.
+    private enum GHRepoResolution {
+        case resolved(owner: String, name: String, host: String)
+        /// gh cannot serve this checkout at all: no binary, or it ran and said
+        /// none of the checkout's remotes name a GitHub host it knows. The only
+        /// state in which the `origin` remote may speak for the repo instead.
+        case unservable
+        /// gh ran and failed at something it does serve. Says nothing about the
+        /// checkout, so it settles nothing about the checkout.
+        case transientFailure
+    }
+
+    private nonisolated func resolveViaGH(repoPath: String) async -> GHRepoResolution {
         let args = ["repo", "view", "--json", "nameWithOwner,url"]
-        guard let output = await runGH(args: args, repoPath: repoPath),
-              let data = output.data(using: .utf8),
+        guard let result = await runGHResult(args: args, repoPath: repoPath) else {
+            // gh never launched — it is absent, or the spawn itself failed.
+            // There is nobody to ask, on this checkout or any other.
+            return .unservable
+        }
+        let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard result.exitStatus == 0 else {
+            if Self.ghDisownsCheckout(errSuffix) {
+                logger.debug("gh does not speak for the repo at \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
+                return .unservable
+            }
+            logger.debug("gh repo view exited \(result.exitStatus, privacy: .public) for \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
+            return .transientFailure
+        }
+        guard let data = result.stdout.data(using: .utf8),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let nameWithOwner = root["nameWithOwner"] as? String,
               let url = root["url"] as? String,
-              let host = URLComponents(string: url)?.host, !host.isEmpty else { return nil }
+              let host = URLComponents(string: url)?.host, !host.isEmpty else {
+            logger.debug("gh repo view answered for \(repoPath, privacy: .public) in a shape this build could not read")
+            return .transientFailure
+        }
         let parts = nameWithOwner.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "/")
-        guard parts.count == 2 else { return nil }
-        return (owner: String(parts[0]), name: String(parts[1]), host: host)
+        guard parts.count == 2 else { return .transientFailure }
+        return .resolved(owner: String(parts[0]), name: String(parts[1]), host: host)
+    }
+
+    /// Whether gh's own refusal says it does not serve this checkout, as opposed
+    /// to failing at something it does serve.
+    ///
+    /// A whitelist of gh's disownment messages, deliberately not a blacklist of
+    /// failures: an unrecognised message must read as "ask again later", because
+    /// the alternative reading is cached for fifteen minutes and points every
+    /// query at the wrong repository (see `resolveNameWithOwner`). A message gh
+    /// rewords therefore costs a GitLab checkout one poll's deferral until this
+    /// list is updated; the opposite default would cost a fork checkout a wrong,
+    /// cached identity on every transient 401.
+    static func ghDisownsCheckout(_ stderr: String) -> Bool {
+        let text = stderr.lowercased()
+        // "none of the git remotes configured for this repository point to a
+        // known GitHub host" — every GitLab checkout, and the steady state this
+        // fallback exists for.
+        return text.contains("known github host")
+            // Nothing to point anywhere, and nothing for gh to be authoritative
+            // about; the remote parse will fail too, harmlessly.
+            || text.contains("no git remotes found")
+            || text.contains("not a git repository")
     }
 
     private nonisolated func readRemoteURL(repoPath: String) async -> String? {
@@ -2750,20 +2818,6 @@ public actor PRStatusManager {
             return Self.aggregateFallbackSignals(detail.rollupState)
         }
         return Self.checkSignals(contexts: detail.contexts, aggregateRollupState: detail.rollupState)
-    }
-
-    private nonisolated func runGH(args: [String], repoPath: String) async -> String? {
-        guard let result = await runGHResult(args: args, repoPath: repoPath) else {
-            return nil
-        }
-
-        guard result.exitStatus == 0 else {
-            let errStr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            logger.debug("gh exited \(result.exitStatus, privacy: .public): \(errStr, privacy: .public)")
-            return nil
-        }
-
-        return result.stdout
     }
 
     static func graphQLOutputData(stdout: String) -> Data? {

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -666,6 +666,7 @@ public actor PRStatusManager {
         /// `batchSucceeded` cannot speak for it.
         var gitLabUnnumberedIDs: Set<UUID> = []
         var gitLabAnsweredIDs: Set<UUID> = []
+        // Keyed only where the project said; see `fetchGitLabBranchMatches`.
         var gitLabPipelineGated: [UUID: Bool] = [:]
         var gitLabFailureCause = PRUndeterminedCause.queryFailed
         if !unnumbered.isEmpty {
@@ -882,7 +883,10 @@ public actor PRStatusManager {
                 isDraft: match.node.isDraft,
                 requiredChecksFailing: signals.failing,
                 requiredChecksPending: signals.pending,
-                pipelineGated: gitLabPipelineGated[match.worktreeID] ?? false,
+                // Absent means the project never said, which the mapper reads
+                // as gated. A GitHub match is absent too and its arm ignores
+                // the value entirely.
+                pipelineGated: gitLabPipelineGated[match.worktreeID],
                 pipelineStatus: match.node.statusCheckRollupState
             )
             let status = PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason,
@@ -1187,7 +1191,7 @@ public actor PRStatusManager {
             query: GitLabQueries.mergeRequestsByIIDQuery(iids: iids),
             host: group.host, projectPath: projectPath, repoPath: repoPath)
         let nodes: [PRNode]
-        let pipelineGated: Bool
+        let pipelineGated: Bool?
         switch fetched {
         case .success(let fetchedNodes, let gated):
             nodes = fetchedNodes
@@ -1277,7 +1281,9 @@ public actor PRStatusManager {
 
     /// What one GitLab GraphQL read settled.
     private enum GitLabFetchOutcome {
-        case success(nodes: [PRNode], pipelineGated: Bool)
+        /// `pipelineGated` is nil when the project did not say whether merges
+        /// are gated on pipelines; the mapper reads that as gated.
+        case success(nodes: [PRNode], pipelineGated: Bool?)
         /// A failure class from `PRUndeterminedCause`.
         case failure(cause: String)
         /// The host refused the credentials. A case of its own because it is the
@@ -1614,7 +1620,7 @@ public actor PRStatusManager {
         isDraft: Bool = false,
         requiredChecksFailing: Bool = false,
         requiredChecksPending: Bool = false,
-        pipelineGated: Bool = false,
+        pipelineGated: Bool? = nil,
         pipelineStatus: String? = nil
     ) -> (state: PRMergeableState, reason: String) {
         switch forge {
@@ -1706,7 +1712,7 @@ public actor PRStatusManager {
         state: String,
         detailed: String,
         isDraft: Bool,
-        pipelineGated: Bool,
+        pipelineGated: Bool?,
         pipelineStatus: String?
     ) -> (state: PRMergeableState, reason: String) {
         switch state.lowercased() {
@@ -1726,7 +1732,16 @@ public actor PRStatusManager {
         // `onlyAllowMergeIfPipelineSucceeds` is the faithful analogue of
         // GitHub's "required check". A failing pipeline on a project that does
         // not gate merges is GitHub's UNSTABLE, which TBD does not colour.
-        if pipelineGated, let pipelineStatus {
+        //
+        // A nil gating answer is read as gated, so only an explicit `false`
+        // switches this branch off. The asymmetry is the whole reason the value
+        // is optional: over-colouring a project that turns out not to gate
+        // costs the reader a glance at a merge request that was fine, while
+        // under-colouring costs them the failure itself — with NOT_APPROVED
+        // mapping to .mergeable below, an unread gating answer would render a
+        // merge request with a failing pipeline as "Ready to merge". The same
+        // reading covers the pending statuses for one rule rather than two.
+        if pipelineGated != false, let pipelineStatus {
             switch pipelineStatus {
             case "FAILED": return (.checksFailed, "Pipeline failed")
             case "RUNNING", "PENDING", "CREATED", "WAITING_FOR_RESOURCE", "PREPARING":
@@ -3040,6 +3055,10 @@ public actor PRStatusManager {
     /// Degrades per project: a project whose query fails contributes no matches
     /// and no answered ids, so its worktrees keep whatever they had and record
     /// `.undetermined` rather than "no merge request".
+    ///
+    /// `pipelineGated` is keyed only for worktrees whose project stated whether
+    /// merges are gated on pipelines. An absent key is "nobody could read it",
+    /// which the mapper reads as gated.
     private nonisolated func fetchGitLabBranchMatches(
         _ unnumbered: [PollWorktree],
         repos: [String: (owner: String, name: String)],
@@ -3089,7 +3108,12 @@ public actor PRStatusManager {
                 answered.formUnion(group.entries.map(\.id))
                 let groupMatches = Self.matchUnnumbered(group.entries, nodes: nodes,
                                                         resolveRepo: { repos[$0] })
-                for match in groupMatches { gated[match.worktreeID] = pipelineGated }
+                // Keyed only when the project stated it: a worktree missing
+                // from this table is one whose gating nobody could read, and
+                // the mapper reads that absence as gated.
+                if let pipelineGated {
+                    for match in groupMatches { gated[match.worktreeID] = pipelineGated }
+                }
                 matches += groupMatches
             }
         }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -184,6 +184,12 @@ public final class RPCRouter: Sendable {
     /// TTL cache; tests inject a stub through the init parameter of the same
     /// name.
     let prBindingRepoResolver: @Sendable (UUID) async -> (owner: String, name: String, host: String)?
+    /// Whether a worktree's host is one the user configured `glab` for — nil
+    /// when there is no local directory to put the question in. The coordinator
+    /// is built on this same closure, so the guard that refuses a `github.com`
+    /// URL on a GitLab checkout and the composer that picks `/-/merge_requests/`
+    /// over `/pull/` agree about the forge.
+    let prBindingForgeResolver: @Sendable (UUID, String) async -> Bool?
     /// Queues concurrent `terminal.send` RPCs per terminal so two payloads
     /// never interleave in one composer. Different terminals still send in
     /// parallel — see `TerminalSendSerializer`.
@@ -265,8 +271,17 @@ public final class RPCRouter: Sendable {
             return await prManager.repoIdentity(repoPath: worktree.path)
         }
         self.prBindingRepoResolver = repoResolver
+        // The forge half of the same seam, captured the same way. `getLocal`
+        // again, and its nil is the same "nothing here to ask in": `glab` reads
+        // its configuration from the checkout's own directory, which a remote
+        // row does not have on this machine.
+        let forgeResolver: @Sendable (UUID, String) async -> Bool? = { [db, prManager] worktreeID, host in
+            guard let worktree = try? await db.worktrees.getLocal(id: worktreeID) else { return nil }
+            return await prManager.isGitLabHost(host, repoPath: worktree.path)
+        }
+        self.prBindingForgeResolver = forgeResolver
         self.prBindingCoordinator = PRBindingCoordinator(
-            store: db.prBindings, resolveRepo: repoResolver)
+            store: db.prBindings, resolveRepo: repoResolver, isGitLabHost: forgeResolver)
         self.pendingQuestions = pendingQuestions
         self.repoSerializer = repoSerializer
         self.configDirManager = configDirManager
@@ -1302,7 +1317,6 @@ public final class RPCRouter: Sendable {
     /// Codeberg checkout serves. `github.com` never reaches a subprocess: the
     /// resolver short-circuits it.
     private func isGitLabWorktree(worktreeID: UUID, host: String) async -> Bool? {
-        guard let worktree = try? await db.worktrees.getLocal(id: worktreeID) else { return nil }
-        return await prManager.isGitLabHost(host, repoPath: worktree.path)
+        await prBindingForgeResolver(worktreeID, host)
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -1270,8 +1270,14 @@ public final class RPCRouter: Sendable {
     /// merge-request URL that 404s.
     private func prRef(worktreeID: UUID, number: Int) async -> ParsedPRURL? {
         guard let own = await prBindingRepoResolver(worktreeID) else { return nil }
+        // Two independent lookups have to succeed, and this is the second: the
+        // repo names the coordinate, the forge names the shape. Either one
+        // failing leaves a URL that could only be guessed.
+        guard let isGitLab = await isGitLabWorktree(worktreeID: worktreeID, host: own.host) else {
+            return nil
+        }
         let path = "https://\(own.host)/\(own.owner)/\(own.name)"
-        let url = await isGitLabWorktree(worktreeID: worktreeID, host: own.host)
+        let url = isGitLab
             ? "\(path)/-/merge_requests/\(number)"
             : "\(path)/pull/\(number)"
         return ParsedPRURL(
@@ -1279,15 +1285,24 @@ public final class RPCRouter: Sendable {
     }
 
     /// Whether this worktree's host speaks GitLab, asked in the worktree's own
-    /// directory because that is where `glab` reads its configuration from.
+    /// directory because that is where `glab` reads its configuration from —
+    /// or nil when the question could not be put at all.
     ///
-    /// A worktree with no local row — a remote one, or one deleted between the
-    /// resolve and this call — cannot supply that directory, so the question
-    /// goes unasked and the answer is the unchanged GitHub shape. That is the
-    /// same "defer rather than guess" the callers of `prRef` already take.
-    /// `github.com` never reaches a subprocess: the resolver short-circuits it.
-    private func isGitLabWorktree(worktreeID: UUID, host: String) async -> Bool {
-        guard let worktree = try? await db.worktrees.getLocal(id: worktreeID) else { return false }
+    /// Nil is a third answer and not a soft "no". A worktree with no local row
+    /// — a remote one, or one deleted between the resolve and this call —
+    /// cannot supply that directory, so nothing has answered, and answering
+    /// "not GitLab" there is a guess that composes `/pull/<n>` on a host that
+    /// may well serve `/-/merge_requests/<n>`: a binding whose URL 404s and
+    /// whose label reads "PR", persisted. `prRef` defers on nil instead, the
+    /// same way it defers when the repo cannot be named.
+    ///
+    /// A resolver that positively answers "this host is not GitLab" returns
+    /// `false` and still gets `/pull/<n>` — the shape github.com has always
+    /// been given and the one a GitHub Enterprise, Bitbucket, Gitea or
+    /// Codeberg checkout serves. `github.com` never reaches a subprocess: the
+    /// resolver short-circuits it.
+    private func isGitLabWorktree(worktreeID: UUID, host: String) async -> Bool? {
+        guard let worktree = try? await db.worktrees.getLocal(id: worktreeID) else { return nil }
         return await prManager.isGitLabHost(host, repoPath: worktree.path)
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -1254,20 +1254,40 @@ public final class RPCRouter: Sendable {
     /// wrong-repo. Returns nil when the worktree's repo cannot be named — the
     /// caller defers rather than guessing an owner or a host.
     ///
-    /// The URL's shape is the host's to decide: GitLab writes
-    /// `/<namespace…>/<project>/-/merge_requests/<iid>`, GitHub writes
-    /// `/owner/name/pull/<n>`. Composing the GitHub shape for every host, as
-    /// this did, produced a URL that pointed at nothing on a GitLab instance.
+    /// This is the one path that must establish the forge rather than read it,
+    /// because there is no URL yet to read it from: GitLab writes
+    /// `/<namespace…>/<project>/-/merge_requests/<iid>` where GitHub writes
+    /// `/owner/name/pull/<n>`, and composing one shape for every host yields a
+    /// URL that points at nothing on the hosts that speak the other.
+    ///
+    /// So it asks the only component that can know. `PRStatusManager` answers
+    /// from `GitLabHostResolver`, which reads the hosts the user configured
+    /// `glab` for — a declaration, not an inference. The GitLab shape is
+    /// composed only for a host named there; every other host keeps `/pull/`,
+    /// which is what a GitHub Enterprise, Bitbucket, Gitea or Codeberg
+    /// checkout serves and what github.com has always been given. Reading the
+    /// hostname's own shape instead would hand all four of those fleets a
+    /// merge-request URL that 404s.
     private func prRef(worktreeID: UUID, number: Int) async -> ParsedPRURL? {
         guard let own = await prBindingRepoResolver(worktreeID) else { return nil }
-        let url: String
-        switch Forge.forHost(own.host) {
-        case .gitlab:
-            url = "https://\(own.host)/\(own.owner)/\(own.name)/-/merge_requests/\(number)"
-        case .github:
-            url = "https://\(own.host)/\(own.owner)/\(own.name)/pull/\(number)"
-        }
+        let path = "https://\(own.host)/\(own.owner)/\(own.name)"
+        let url = await isGitLabWorktree(worktreeID: worktreeID, host: own.host)
+            ? "\(path)/-/merge_requests/\(number)"
+            : "\(path)/pull/\(number)"
         return ParsedPRURL(
             host: own.host, owner: own.owner, repo: own.name, number: number, url: url)
+    }
+
+    /// Whether this worktree's host speaks GitLab, asked in the worktree's own
+    /// directory because that is where `glab` reads its configuration from.
+    ///
+    /// A worktree with no local row — a remote one, or one deleted between the
+    /// resolve and this call — cannot supply that directory, so the question
+    /// goes unasked and the answer is the unchanged GitHub shape. That is the
+    /// same "defer rather than guess" the callers of `prRef` already take.
+    /// `github.com` never reaches a subprocess: the resolver short-circuits it.
+    private func isGitLabWorktree(worktreeID: UUID, host: String) async -> Bool {
+        guard let worktree = try? await db.worktrees.getLocal(id: worktreeID) else { return false }
+        return await prManager.isGitLabHost(host, repoPath: worktree.path)
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -177,12 +177,13 @@ public final class RPCRouter: Sendable {
     /// Binding policy for the multi-PR-per-worktree bindings — repo validation,
     /// dedupe, tombstones, cap.
     let prBindingCoordinator: PRBindingCoordinator
-    /// The worktree's own GitHub `owner`/`name`. The coordinator is built on
-    /// this same closure, so a caller that must name a repo before it can form a
-    /// PR reference (`pr.attach 412`) agrees with the policy that validates it.
-    /// Production resolves it via `PRStatusManager`'s `gh repo view` TTL cache;
-    /// tests inject a stub through the init parameter of the same name.
-    let prBindingRepoResolver: @Sendable (UUID) async -> (owner: String, name: String)?
+    /// The worktree's own `owner`/`name` and the host they live on. The
+    /// coordinator is built on this same closure, so a caller that must name a
+    /// repo before it can form a PR reference (`pr.attach 412`) agrees with the
+    /// policy that validates it. Production resolves it via `PRStatusManager`'s
+    /// TTL cache; tests inject a stub through the init parameter of the same
+    /// name.
+    let prBindingRepoResolver: @Sendable (UUID) async -> (owner: String, name: String, host: String)?
     /// Queues concurrent `terminal.send` RPCs per terminal so two payloads
     /// never interleave in one composer. Different terminals still send in
     /// parallel — see `TerminalSendSerializer`.
@@ -223,7 +224,7 @@ public final class RPCRouter: Sendable {
         remoteManager: RemoteProviderManager? = nil,
         codexExecutableResolver: (@Sendable () throws -> String)? = nil,
         codexHomeEnsurer: (@Sendable () throws -> URL)? = nil,
-        prBindingRepoResolver: (@Sendable (UUID) async -> (owner: String, name: String)?)? = nil,
+        prBindingRepoResolver: (@Sendable (UUID) async -> (owner: String, name: String, host: String)?)? = nil,
         now: @escaping @Sendable () -> Date = { Date() },
         actuationLog: ActuationLog
     ) {
@@ -1246,16 +1247,27 @@ public final class RPCRouter: Sendable {
         return .resolved(parsed)
     }
 
-    /// A bare PR number as a `ParsedPRURL` in the worktree's own repo.
+    /// A bare PR or MR number as a `ParsedPRURL` in the worktree's own repo.
     ///
     /// Resolved through the same seam the coordinator validates with, so a
     /// number can never synthesise a URL the policy would then reject as
     /// wrong-repo. Returns nil when the worktree's repo cannot be named — the
-    /// caller defers rather than guessing an owner.
+    /// caller defers rather than guessing an owner or a host.
+    ///
+    /// The URL's shape is the host's to decide: GitLab writes
+    /// `/<namespace…>/<project>/-/merge_requests/<iid>`, GitHub writes
+    /// `/owner/name/pull/<n>`. Composing the GitHub shape for every host, as
+    /// this did, produced a URL that pointed at nothing on a GitLab instance.
     private func prRef(worktreeID: UUID, number: Int) async -> ParsedPRURL? {
         guard let own = await prBindingRepoResolver(worktreeID) else { return nil }
+        let url: String
+        switch Forge.forHost(own.host) {
+        case .gitlab:
+            url = "https://\(own.host)/\(own.owner)/\(own.name)/-/merge_requests/\(number)"
+        case .github:
+            url = "https://\(own.host)/\(own.owner)/\(own.name)/pull/\(number)"
+        }
         return ParsedPRURL(
-            host: "github.com", owner: own.owner, repo: own.name, number: number,
-            url: "https://github.com/\(own.owner)/\(own.name)/pull/\(number)")
+            host: own.host, owner: own.owner, repo: own.name, number: number, url: url)
     }
 }

--- a/Sources/TBDShared/Forge.swift
+++ b/Sources/TBDShared/Forge.swift
@@ -26,4 +26,18 @@ public extension Forge {
     static func forHost(_ host: String) -> Forge {
         host.lowercased() == "github.com" ? .github : .gitlab
     }
+
+    /// How this forge names ONE request in its own vocabulary — `PR #412` on
+    /// GitHub, `MR !412` on GitLab, which is the reference syntax GitLab itself
+    /// uses everywhere from commit messages to its own UI.
+    ///
+    /// Only per-binding text may use this. Anything summarising SEVERAL
+    /// bindings keeps neutral wording, because one worktree can hold bindings
+    /// on both forges at once and no single vocabulary would be true of them.
+    func refLabel(number: Int) -> String {
+        switch self {
+        case .github: return "PR #\(number)"
+        case .gitlab: return "MR !\(number)"
+        }
+    }
 }

--- a/Sources/TBDShared/Forge.swift
+++ b/Sources/TBDShared/Forge.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Which forge a pull request or merge request lives on.
+///
+/// Derived at parse time and carried on `PRNode`; never persisted. The
+/// `worktree_pull_request.host` column is the durable fact, and the forge is
+/// recomputed from it, so adding a case here needs no migration.
+public enum Forge: String, Codable, Sendable, CaseIterable {
+    case github
+    case gitlab
+}

--- a/Sources/TBDShared/Forge.swift
+++ b/Sources/TBDShared/Forge.swift
@@ -9,3 +9,21 @@ public enum Forge: String, Codable, Sendable, CaseIterable {
     case github
     case gitlab
 }
+
+public extension Forge {
+    /// Classify a host. `github.com` is GitHub; every other host is treated as
+    /// GitLab here.
+    ///
+    /// This is a *composition* fallback, not host discovery — the only thing
+    /// that can really know which self-managed hosts are GitLab is
+    /// `GitLabHostResolver`, reading what the user already told `glab`. The
+    /// callers of this function have already been handed a host that came from
+    /// a repo identity or from a URL a GitLab pattern matched, and they need a
+    /// shape to write, not a fact to establish. The known limitation is a
+    /// GitHub Enterprise host, which classifies as `.gitlab`; the paths that
+    /// call this previously hardcoded `github.com` outright, so Enterprise was
+    /// already unserved and is not newly broken.
+    static func forHost(_ host: String) -> Forge {
+        host.lowercased() == "github.com" ? .github : .gitlab
+    }
+}

--- a/Sources/TBDShared/Forge.swift
+++ b/Sources/TBDShared/Forge.swift
@@ -11,20 +11,29 @@ public enum Forge: String, Codable, Sendable, CaseIterable {
 }
 
 public extension Forge {
-    /// Classify a host. `github.com` is GitHub; every other host is treated as
-    /// GitLab here.
+    /// Classify a request from its own URL.
     ///
-    /// This is a *composition* fallback, not host discovery — the only thing
-    /// that can really know which self-managed hosts are GitLab is
-    /// `GitLabHostResolver`, reading what the user already told `glab`. The
-    /// callers of this function have already been handed a host that came from
-    /// a repo identity or from a URL a GitLab pattern matched, and they need a
-    /// shape to write, not a fact to establish. The known limitation is a
-    /// GitHub Enterprise host, which classifies as `.gitlab`; the paths that
-    /// call this previously hardcoded `github.com` outright, so Enterprise was
-    /// already unserved and is not newly broken.
-    static func forHost(_ host: String) -> Forge {
-        host.lowercased() == "github.com" ? .github : .gitlab
+    /// `/-/merge_requests/` is the coordinate, because it is a fact about the
+    /// request rather than a guess about where it lives: GitLab always inserts
+    /// `/-/` between a project path and a resource, and no other forge uses
+    /// that segment — which is why `PRBindingExtractor` anchors its GitLab
+    /// pattern on the same literal. Every URL that reaches here was either
+    /// matched by one of those patterns or composed alongside one, so the
+    /// marker is present exactly when the request is a merge request. Matched
+    /// case-insensitively, and `.github` when the marker is absent.
+    ///
+    /// The HOST cannot answer this question. "Not github.com" describes GitHub
+    /// Enterprise, Bitbucket, Gitea and Codeberg as readily as it describes a
+    /// self-managed GitLab, and all of them serve `/pull/<n>`, so a
+    /// host-shaped classifier mislabels every non-GitLab fleet that is not on
+    /// github.com — including the label under a binding a user attached by
+    /// number. A host is only ever evidence of GitLab when someone declared it
+    /// so: where no URL exists yet, because the daemon is composing one for a
+    /// bare `tbd pr attach <number>`, the shape comes from
+    /// `GitLabHostResolver` reading what the user already told `glab`, never
+    /// from the hostname's shape.
+    static func forURL(_ url: String) -> Forge {
+        url.lowercased().contains("/-/merge_requests/") ? .gitlab : .github
     }
 
     /// How this forge names ONE request in its own vocabulary — `PR #412` on

--- a/Sources/TBDShared/PRBinding.swift
+++ b/Sources/TBDShared/PRBinding.swift
@@ -95,10 +95,16 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
     /// How this one binding is named in the UI: `PR #412` on GitHub, `MR !412`
     /// on GitLab, whose own reference syntax is `!iid`.
     ///
+    /// Read from the binding's own `url`, which carries GitLab's
+    /// `/-/merge_requests/` marker, and not from its `host` — a host is not
+    /// evidence of a forge, so a `host`-shaped derivation renames every
+    /// GitHub Enterprise, Bitbucket, Gitea and Codeberg pull request a merge
+    /// request. `Forge.forURL` documents the coordinate.
+    ///
     /// Per-binding text only. Anything summarising several bindings keeps the
     /// neutral wording, because a worktree can span forges.
     public var refLabel: String {
-        Forge.forHost(host).refLabel(number: number)
+        Forge.forURL(url).refLabel(number: number)
     }
 
     /// Identity for deduplication — matches the table's UNIQUE constraint.

--- a/Sources/TBDShared/PRBinding.swift
+++ b/Sources/TBDShared/PRBinding.swift
@@ -92,6 +92,15 @@ public struct PRBinding: Codable, Sendable, Equatable, Identifiable {
                         headBranch: headBranch, baseRef: baseRef)
     }
 
+    /// How this one binding is named in the UI: `PR #412` on GitHub, `MR !412`
+    /// on GitLab, whose own reference syntax is `!iid`.
+    ///
+    /// Per-binding text only. Anything summarising several bindings keeps the
+    /// neutral wording, because a worktree can span forges.
+    public var refLabel: String {
+        Forge.forHost(host).refLabel(number: number)
+    }
+
     /// Identity for deduplication — matches the table's UNIQUE constraint.
     /// Owner and repo compare case-insensitively because GitHub treats them so.
     public var identityKey: String {

--- a/Sources/TBDShared/PRBindingExtractor.swift
+++ b/Sources/TBDShared/PRBindingExtractor.swift
@@ -21,16 +21,29 @@ public struct ParsedPRURL: Sendable, Equatable, Hashable {
 ///
 /// This reads the hook's structured `tool_input` / `tool_response` JSON — a
 /// machine interface — and never inspects rendered terminal output. The rule is
-/// deliberately narrow: the *command* must be a `gh pr create`, and URLs are
-/// taken from the *result*. A PR URL merely mentioned in unrelated output must
-/// not bind, or every `git log` that quotes a PR link would attach one.
+/// deliberately narrow: the *command* must be a `gh pr create` or a
+/// `glab mr create`, and URLs are taken from the *result*. A PR URL merely
+/// mentioned in unrelated output must not bind, or every `git log` that quotes
+/// a PR link would attach one.
 public enum PRBindingExtractor {
 
-    /// Host-locked to github.com for now; the binding's `host` column exists so
-    /// enterprise support is a later additive change. The lookaheads reject `.`
-    /// and `..` segments, which would otherwise parse as an owner or repo name.
-    private static let urlPattern =
+    /// GitHub pull-request URLs. Host-locked to github.com; the binding's `host`
+    /// column exists so enterprise support is a later additive change. The
+    /// lookaheads reject `.` and `..` segments, which would otherwise parse as
+    /// an owner or repo name.
+    private static let githubURLPattern =
         #"https://github\.com/(?!\.{1,2}/)([\w.-]+)/(?!\.{1,2}/)([\w.-]+)/pull/(\d+)"#
+
+    /// GitLab merge-request URLs on any host. `/-/merge_requests/` is the
+    /// anchor: GitLab always inserts `/-/` between the project path and the
+    /// resource, and no other forge uses that segment, so the URL identifies
+    /// its own forge with no host list. Group 1 is the host, group 2 the
+    /// namespace path — which may nest, GitLab allows up to 20 levels and the
+    /// pattern does not cap it — group 3 the project, group 4 the number.
+    /// Every segment gets the same dot-segment rejection the GitHub pattern
+    /// applies to two, so no level of a nested namespace can smuggle a `..`.
+    private static let gitlabURLPattern =
+        #"https://([\w.-]+)/((?:(?!\.{1,2}/)[\w.-]+/)*?(?!\.{1,2}/)[\w.-]+)/(?!\.{1,2}/)([\w.-]+)/-/merge_requests/(\d+)"#
 
     /// Shell metacharacters that end one command and begin the next. Runs of
     /// them collapse on their own, so `&&`, `||` and `|` need no special case.
@@ -40,8 +53,8 @@ public enum PRBindingExtractor {
     /// path of `gh --repo acme/acme-prod pr create` still reads `pr create`.
     private static let valueTakingFlags: Set<String> = ["-R", "--repo", "--hostname"]
 
-    /// True when the command actually *runs* `gh pr create`, as opposed to
-    /// merely containing that phrase.
+    /// True when the command actually *runs* `gh pr create` or
+    /// `glab mr create`, as opposed to merely containing that phrase.
     ///
     /// Substring matching was wrong in both directions. It fired on
     /// `git log --grep 'gh pr create'` — a false positive that can bind a
@@ -58,7 +71,7 @@ public enum PRBindingExtractor {
     /// pragmatic tokenizer, not a shell parser: an unusual construction fails
     /// closed.
     public static func isPRCreateCommand(_ command: String) -> Bool {
-        commandSegments(of: withoutHeredocBodies(command)).contains(where: isGHPRCreateSegment)
+        commandSegments(of: withoutHeredocBodies(command)).contains(where: isForgeCreateSegment)
     }
 
     /// Drop every heredoc *body* from a command, keeping the lines that really
@@ -204,12 +217,20 @@ public enum PRBindingExtractor {
         return segments
     }
 
-    /// One segment invokes `gh pr create`: `gh` (or a path ending in `/gh`) is
-    /// the command word, and the first two non-flag words after it are `pr`
-    /// then `create`.
-    private static func isGHPRCreateSegment(_ words: [String]) -> Bool {
-        guard let command = words.first,
-              command == "gh" || command.hasSuffix("/gh") else { return false }
+    /// One segment invokes a merge-request create: `gh` (or a path ending in
+    /// `/gh`) followed by `pr create`, or `glab` (or `/glab`) followed by
+    /// `mr create`. The verb must match its own CLI — `gh mr create` and
+    /// `glab pr create` are both rejected, and so is any other command word.
+    private static func isForgeCreateSegment(_ words: [String]) -> Bool {
+        guard let command = words.first else { return false }
+        let expected: [String]
+        if command == "gh" || command.hasSuffix("/gh") {
+            expected = ["pr", "create"]
+        } else if command == "glab" || command.hasSuffix("/glab") {
+            expected = ["mr", "create"]
+        } else {
+            return false
+        }
         var path: [String] = []
         var index = 1
         while index < words.count && path.count < 2 {
@@ -221,27 +242,45 @@ public enum PRBindingExtractor {
                 index += 1
             }
         }
-        return path == ["pr", "create"]
+        return path == expected
     }
 
-    /// Every distinct PR URL in `text`, in first-seen order.
+    /// Every distinct PR or MR URL in `text`, in first-seen order. The two
+    /// patterns are scanned separately, so the results are re-sorted by where
+    /// they were found rather than by which forge matched them.
     public static func parsePRURLs(in text: String) -> [ParsedPRURL] {
-        guard let regex = try? NSRegularExpression(pattern: urlPattern) else { return [] }
         let ns = text as NSString
         var seen = Set<String>()
-        var out: [ParsedPRURL] = []
-        for match in regex.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
-            guard match.numberOfRanges == 4,
-                  let number = Int(ns.substring(with: match.range(at: 3))) else { continue }
-            let owner = ns.substring(with: match.range(at: 1))
-            let repo = ns.substring(with: match.range(at: 2))
-            let url = ns.substring(with: match.range(at: 0))
-            let parsed = ParsedPRURL(host: "github.com", owner: owner, repo: repo,
-                                     number: number, url: url)
-            guard seen.insert(parsed.url.lowercased()).inserted else { continue }
-            out.append(parsed)
+        var out: [(location: Int, parsed: ParsedPRURL)] = []
+
+        func collect(_ pattern: String, groups: Int,
+                     build: (NSTextCheckingResult, NSString) -> ParsedPRURL?) {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+            for match in regex.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
+                guard match.numberOfRanges == groups, let parsed = build(match, ns) else { continue }
+                guard seen.insert(parsed.url.lowercased()).inserted else { continue }
+                out.append((match.range.location, parsed))
+            }
         }
-        return out
+
+        collect(githubURLPattern, groups: 4) { match, ns in
+            guard let number = Int(ns.substring(with: match.range(at: 3))) else { return nil }
+            return ParsedPRURL(host: "github.com",
+                               owner: ns.substring(with: match.range(at: 1)),
+                               repo: ns.substring(with: match.range(at: 2)),
+                               number: number,
+                               url: ns.substring(with: match.range(at: 0)))
+        }
+        collect(gitlabURLPattern, groups: 5) { match, ns in
+            guard let number = Int(ns.substring(with: match.range(at: 4))) else { return nil }
+            return ParsedPRURL(host: ns.substring(with: match.range(at: 1)),
+                               owner: ns.substring(with: match.range(at: 2)),
+                               repo: ns.substring(with: match.range(at: 3)),
+                               number: number,
+                               url: ns.substring(with: match.range(at: 0)))
+        }
+
+        return out.sorted { $0.location < $1.location }.map(\.parsed)
     }
 
     /// Extract bindings from a raw hook payload. Returns empty for anything

--- a/Tests/TBDAppTests/OpenPRTabTests.swift
+++ b/Tests/TBDAppTests/OpenPRTabTests.swift
@@ -54,7 +54,8 @@ struct OpenPRTabTests {
     }
 
     /// One tab names one request, so it takes that request's forge vocabulary.
-    /// The host in the URL is the only forge coordinate `openPR` receives.
+    /// The URL's own shape is the forge coordinate — `/-/merge_requests/` is
+    /// GitLab's and nobody else's.
     @Test("a GitLab merge request names its tab in GitLab's syntax")
     func gitLabTabLabel() {
         withAppState { state in
@@ -63,6 +64,22 @@ struct OpenPRTabTests {
                 "https://git.acme.example/acme/platform/api-gateway/-/merge_requests/412")!
             state.openPR(url: url, number: 412, worktreeID: worktreeID, inBrowser: false)
             #expect(state.tabs[worktreeID]?.first?.label == "MR !412")
+        }
+    }
+
+    /// The other half of that rule, and the one a host-shaped classifier gets
+    /// wrong: a self-hosted host is not evidence of GitLab. GitHub Enterprise,
+    /// Bitbucket, Gitea and Codeberg all serve pull requests from hosts that
+    /// are not `github.com`, and a `/pull/` URL says so.
+    @Test("a pull request on a self-hosted host still names its tab PR")
+    func selfHostedPullRequestTabLabel() {
+        withAppState { state in
+            for host in ["github.acme.example", "bitbucket.acme.example", "codeberg.org"] {
+                let worktreeID = UUID()
+                let url = URL(string: "https://\(host)/acme/acme-prod/pull/412")!
+                state.openPR(url: url, number: 412, worktreeID: worktreeID, inBrowser: false)
+                #expect(state.tabs[worktreeID]?.first?.label == "PR #412")
+            }
         }
     }
 

--- a/Tests/TBDAppTests/OpenPRTabTests.swift
+++ b/Tests/TBDAppTests/OpenPRTabTests.swift
@@ -53,6 +53,19 @@ struct OpenPRTabTests {
         }
     }
 
+    /// One tab names one request, so it takes that request's forge vocabulary.
+    /// The host in the URL is the only forge coordinate `openPR` receives.
+    @Test("a GitLab merge request names its tab in GitLab's syntax")
+    func gitLabTabLabel() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let url = URL(string:
+                "https://git.acme.example/acme/platform/api-gateway/-/merge_requests/412")!
+            state.openPR(url: url, number: 412, worktreeID: worktreeID, inBrowser: false)
+            #expect(state.tabs[worktreeID]?.first?.label == "MR !412")
+        }
+    }
+
     @Test("a tab already on that URL is focused, and nothing new is created")
     func reusesExistingTab() {
         withAppState { state in

--- a/Tests/TBDAppTests/PRBindingPresentationTests.swift
+++ b/Tests/TBDAppTests/PRBindingPresentationTests.swift
@@ -82,6 +82,48 @@ struct PRBindingPresentationTests {
         #expect(PRBindingPresentation.menuRows(bindings).map(\.number) == [412])
     }
 
+    // MARK: - Per-binding wording versus aggregate wording
+
+    private func gitLabBinding(_ n: Int) -> PRBinding {
+        let url = "https://git.acme.example/acme/platform/api-gateway/-/merge_requests/\(n)"
+        return PRBinding(worktreeID: UUID(), host: "git.acme.example",
+                         owner: "acme/platform", repo: "api-gateway",
+                         number: n, url: url,
+                         status: PRStatus(number: n, url: url, state: .mergeable),
+                         source: .hook)
+    }
+
+    @Test("a lone GitLab binding is described in GitLab's own syntax")
+    func gitLabSplitButtonHelp() {
+        let help = ContentView.prSplitButtonHelp(
+            bindings: [gitLabBinding(412)], armed: false, hibernateArmed: false, blocked: false)
+        #expect(help.hasPrefix("Open MR !412"))
+        #expect(!help.contains("PR #"))
+    }
+
+    /// The reason aggregates stay neutral: one worktree can hold a GitHub PR
+    /// and a GitLab MR at once, and no single vocabulary is true of both.
+    @Test("a worktree spanning both forges keeps neutral aggregate wording")
+    func mixedForgeAggregateStaysNeutral() {
+        let help = ContentView.prSplitButtonHelp(
+            bindings: [binding(412, .mergeable), gitLabBinding(7)],
+            armed: false, hibernateArmed: false, blocked: false)
+        #expect(help.hasPrefix("2 pull requests"))
+        #expect(!help.contains("MR !"))
+        // And the count label, which the same set feeds.
+        #expect(PRBindingPresentation.buttonLabel(
+            [binding(412, .mergeable), gitLabBinding(7)]) == "2 PRs")
+    }
+
+    @Test("a status-bar chip carries its binding's own forge vocabulary")
+    func chipRefLabelPerForge() {
+        let chips = StatusBarView.prChips([binding(412, .mergeable), gitLabBinding(7)]).chips
+        #expect(chips.map(\.refLabel) == ["PR #412", "MR !7"])
+        // The visible chip text stays the bare number on both forges — only the
+        // tooltip, which names the thing in words, speaks a dialect.
+        #expect(chips.map(\.label) == ["#412", "#7"])
+    }
+
     @Test("several bindings never get a primary action")
     func noPrimaryActionForSeveral() {
         let bindings = [binding(412, url: "https://github.com/acme/acme-prod/pull/412"),

--- a/Tests/TBDAppTests/PRLegacyStatusFallbackTests.swift
+++ b/Tests/TBDAppTests/PRLegacyStatusFallbackTests.swift
@@ -29,6 +29,29 @@ struct PRLegacyStatusFallbackTests {
                          source: .hook)
     }
 
+    /// `PRBinding.host` defaults to github.com, and a lifted legacy status used
+    /// to take that default whatever forge it came from — so a GitLab status
+    /// described itself as living on GitHub. The status URL is the only forge
+    /// coordinate the legacy shape carries, so the host comes from there.
+    @Test("a lifted legacy status takes its host from its own URL")
+    func syntheticHostFollowsTheStatusURL() {
+        let wt = UUID()
+        let gitlab = PRStatus(
+            number: 412,
+            url: "https://git.acme.example/acme/platform/api-gateway/-/merge_requests/412",
+            state: .mergeable)
+        let lifted = PRBindingPresentation.effectiveBindings(
+            [], legacyStatus: gitlab, worktreeID: wt)
+        #expect(lifted.first?.host == "git.acme.example")
+
+        // A GitHub status is unchanged, and so is a URL nothing can parse.
+        #expect(PRBindingPresentation.effectiveBindings(
+            [], legacyStatus: status(99), worktreeID: wt).first?.host == "github.com")
+        let unparseable = PRStatus(number: 5, url: "", state: .mergeable)
+        #expect(PRBindingPresentation.effectiveBindings(
+            [], legacyStatus: unparseable, worktreeID: wt).first?.host == "github.com")
+    }
+
     @Test("one binding and no legacy status: the binding drives the control")
     func bindingOnly() {
         let wt = UUID()

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -134,7 +134,20 @@ extension TBDHomeSerialized {
             "gh pr 'create'",
             "gh 'pr' 'create'",
             "gh pr\tcreate",
-            "gh pr    create"
+            "gh pr    create",
+            // The GitLab half. `glab`'s verb is `mr`, and every property above
+            // has to hold for it too — the prefilter is one pattern serving
+            // both forges.
+            "glab mr create --fill",
+            "glab -R acme/acme-prod mr create",
+            "glab --repo acme/acme-prod mr create --fill",
+            "cd /tmp && glab mr create -t x",
+            "/usr/local/bin/glab mr create",
+            #"glab "mr" create"#,
+            #"glab mr "create""#,
+            "glab 'mr' 'create'",
+            "glab mr\tcreate",
+            "glab  mr   create -t x"
         ]
         for command in bindable {
             #expect(PRBindingExtractor.isPRCreateCommand(command),
@@ -160,6 +173,8 @@ extension TBDHomeSerialized {
         #expect(try prefilterAdmits("ls -la /tmp") == false)
         #expect(try prefilterAdmits("git status --short") == false)
         #expect(try prefilterAdmits("gh pr view 12 --json state") == false)
+        #expect(try prefilterAdmits("glab mr view 12") == false)
+        #expect(try prefilterAdmits("glab mr list") == false)
     }
 
     @Test func registersStopFailureNotifyHook() throws {

--- a/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
+++ b/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
@@ -65,6 +65,25 @@ struct GitLabHostResolverTests {
         #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
     }
 
+    /// A derivation that produced nothing is not an answer, it is a failed
+    /// question. `glab` may be installed, or authenticated against a new host,
+    /// at any point during a daemon run that lasts days — and one transient
+    /// launch failure on the first poll after boot must not disable GitLab
+    /// until the next restart.
+    @Test("an empty derivation is retried, not remembered")
+    func emptyDerivationIsRetried() async {
+        let attempts = Probe()
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            let seen = await attempts.mark()
+            // First call: glab is not on PATH. Afterwards the user has run
+            // `glab auth login --hostname git.acme.example`.
+            return seen == 1 ? nil : GHCommandResult(stdout: Self.realOutput)
+        })
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x"))
+        #expect(await attempts.count == 2)
+    }
+
     @Test("the host list is fetched once and cached for the resolver's life")
     func cachesAcrossCalls() async {
         let probed = Probe()
@@ -114,5 +133,9 @@ struct GitLabHostResolverTests {
 
 private actor Probe {
     private(set) var count = 0
-    func mark() { count += 1 }
+    @discardableResult
+    func mark() -> Int {
+        count += 1
+        return count
+    }
 }

--- a/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
+++ b/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 @testable import TBDDaemonLib
 
@@ -65,7 +66,7 @@ struct GitLabHostResolverTests {
         #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
     }
 
-    /// A derivation that produced nothing is not an answer, it is a failed
+    /// A `glab` that never launched produced no answer, only a failed
     /// question. `glab` may be installed, or authenticated against a new host,
     /// at any point during a daemon run that lasts days — and one transient
     /// launch failure on the first poll after boot must not disable GitLab
@@ -80,6 +81,93 @@ struct GitLabHostResolverTests {
             return seen == 1 ? nil : GHCommandResult(stdout: Self.realOutput)
         })
         #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x"))
+        #expect(await attempts.count == 2)
+    }
+
+    /// The steady state of every fleet that has `glab` installed and no GitLab
+    /// host configured. `glab` ran, answered, and named nobody — an
+    /// observation, unlike a launch failure — so asking again on the next call
+    /// buys nothing. `github.com` short-circuits before the probe, but a GitHub
+    /// Enterprise, Bitbucket, gitea or codeberg host does not, so without this
+    /// the fleet pays one `glab auth status` per worktree per poll tick forever.
+    @Test("a configured-nothing answer is not re-probed on every call")
+    func emptyStatusIsNotReprobedEveryCall() async {
+        let probed = Probe()
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            await probed.mark()
+            return GHCommandResult(stdout: "",
+                                   stderr: "You are not logged into any GitLab hosts. Run glab auth login\n",
+                                   exitStatus: 1)
+        })
+        for _ in 0..<3 {
+            #expect(await resolver.isGitLabHost("ghe.acme.example", repoPath: "/tmp/x") == false)
+        }
+        #expect(await probed.count == 1)
+    }
+
+    /// The other half of the same knob: the answer is remembered for a bounded
+    /// window, never for the run, so `glab auth login --hostname …` mid-run
+    /// still takes effect without restarting TBD. Driven through the `now:`
+    /// date seam — the value is compared, not slept on.
+    @Test("a configured-nothing answer is re-derived once its window passes")
+    func emptyStatusAgesOut() async {
+        let dates = TestDateSource()
+        let attempts = Probe()
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            let seen = await attempts.mark()
+            // The user runs `glab auth login --hostname git.acme.example`
+            // somewhere between the first probe and the second.
+            return seen == 1
+                ? GHCommandResult(stdout: "", exitStatus: 1)
+                : GHCommandResult(stdout: Self.realOutput)
+        }, now: dates.provider)
+
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
+
+        dates.advance(by: GitLabHostResolver.emptyStatusLifetime - 1)
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
+        #expect(await attempts.count == 1)
+
+        dates.advance(by: 2)
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x"))
+        #expect(await attempts.count == 2)
+    }
+
+    /// The window covers only an answer. A `glab` that did not launch is
+    /// retried on the very next call even with the clock held still, because
+    /// nothing was observed — and in the case that dominates, `glab` absent,
+    /// the retry resolves a static nil path and spawns nothing.
+    @Test("a launch failure is retried inside the window an answer would hold")
+    func launchFailureIsNotHeldByTheWindow() async {
+        let dates = TestDateSource()
+        let attempts = Probe()
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            let seen = await attempts.mark()
+            return seen == 1 ? nil : GHCommandResult(stdout: Self.realOutput)
+        }, now: dates.provider)
+
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x"))
+        #expect(await attempts.count == 2)
+    }
+
+    /// The window is a magnitude, so a wall clock that steps backwards
+    /// re-derives early rather than pinning the empty answer in place until the
+    /// clock catches up.
+    @Test("a backwards wall-clock step re-derives rather than extending the window")
+    func backwardsClockStepRederives() async {
+        let dates = TestDateSource()
+        let attempts = Probe()
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            let seen = await attempts.mark()
+            return seen == 1
+                ? GHCommandResult(stdout: "", exitStatus: 1)
+                : GHCommandResult(stdout: Self.realOutput)
+        }, now: dates.provider)
+
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
+        dates.advance(by: -(GitLabHostResolver.emptyStatusLifetime + 1))
         #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x"))
         #expect(await attempts.count == 2)
     }

--- a/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
+++ b/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
@@ -95,6 +95,21 @@ struct GitLabHostResolverTests {
         """)
         #expect(hosts == ["git.acme.example"])
     }
+
+    /// CRLF is not exotic here: `glab auth status` is read through a pipe whose
+    /// contents come from whatever the host and the user's terminal settings
+    /// produced. A trailing `\r` clears both guards below the split — it is not
+    /// a space and it is not a dot — so the parse "succeeds" with a host name
+    /// nobody will ever ask about, and GitLab is silently off with no error
+    /// anywhere.
+    @Test("a CRLF-terminated host line still resolves")
+    func crlfTerminatedHostResolves() async {
+        let crlf = "git.acme.example\r\n  ✓ Logged in to git.acme.example as someone\r\n"
+        #expect(GitLabHostResolver.parseAuthStatusHosts(crlf) == ["git.acme.example"])
+
+        let resolver = GitLabHostResolver(glRunner: { _, _ in GHCommandResult(stdout: crlf) })
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x"))
+    }
 }
 
 private actor Probe {

--- a/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
+++ b/Tests/TBDDaemonTests/GitLabHostResolverTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("GitLab host resolution")
+struct GitLabHostResolverTests {
+
+    /// Real `glab auth status` output shape: host lines are flush-left, detail
+    /// lines are indented. Reproduced from a self-managed instance (#673).
+    static let realOutput = """
+    git.acme.example
+      ✓ Logged in to git.acme.example as someone (/Users/x/.config/glab-cli/config.yml)
+      ! Invalid token provided in configuration file
+      ✓ Git operations for git.acme.example configured to use ssh protocol.
+    gitlab.com
+      x gitlab.com: API call failed: GET https://gitlab.com/api/v4/user: 401 {message: 401 Unauthorized}
+      ! No token found (checked config file, keyring, and environment variables).
+    """
+
+    @Test("extracts every configured host from flush-left lines")
+    func parsesHosts() {
+        let hosts = GitLabHostResolver.parseAuthStatusHosts(Self.realOutput)
+        #expect(hosts == ["git.acme.example", "gitlab.com"])
+    }
+
+    @Test("a host reporting both logged-in and invalid-token is still a GitLab host")
+    func contradictoryBlockStillYieldsHost() {
+        // TBD reads the host LIST, never the auth verdict — the verdict text is
+        // measurably self-contradictory while calls succeed (#673).
+        #expect(GitLabHostResolver.parseAuthStatusHosts(Self.realOutput).contains("git.acme.example"))
+    }
+
+    @Test("exit status 1 does not suppress the host list")
+    func exitOneStillYieldsHosts() async {
+        // glab exits 1 if ANY configured host fails, so a working setup reports
+        // failure whenever an unused gitlab.com entry sits alongside it.
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            GHCommandResult(stdout: Self.realOutput, stderr: "", exitStatus: 1)
+        })
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x"))
+    }
+
+    @Test("github.com is never probed")
+    func githubIsNotProbed() async {
+        let probed = Probe()
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            await probed.mark()
+            return GHCommandResult(stdout: Self.realOutput)
+        })
+        #expect(await resolver.isGitLabHost("github.com", repoPath: "/tmp/x") == false)
+        #expect(await probed.count == 0)
+    }
+
+    @Test("an unlisted host is not GitLab")
+    func unlistedHostIsNotGitLab() async {
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            GHCommandResult(stdout: Self.realOutput)
+        })
+        #expect(await resolver.isGitLabHost("git.other.example", repoPath: "/tmp/x") == false)
+    }
+
+    @Test("absent glab yields no hosts")
+    func absentGlab() async {
+        let resolver = GitLabHostResolver(glRunner: { _, _ in nil })
+        #expect(await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x") == false)
+    }
+
+    @Test("the host list is fetched once and cached for the resolver's life")
+    func cachesAcrossCalls() async {
+        let probed = Probe()
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            await probed.mark()
+            return GHCommandResult(stdout: Self.realOutput)
+        })
+        _ = await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x")
+        _ = await resolver.isGitLabHost("git.acme.example", repoPath: "/tmp/x")
+        #expect(await probed.count == 1)
+    }
+
+    @Test("host matching is case-insensitive in both directions")
+    func hostMatchingIsCaseInsensitive() async {
+        let resolver = GitLabHostResolver(glRunner: { _, _ in
+            GHCommandResult(stdout: "GIT.Acme.Example\n  ✓ Logged in\n")
+        })
+        #expect(await resolver.isGitLabHost("git.ACME.example", repoPath: "/tmp/x"))
+    }
+
+    @Test("indented detail lines never become hosts")
+    func indentedLinesAreNotHosts() {
+        // The failing host's detail line contains a bare "gitlab.com:" token and
+        // a full URL; neither may be mistaken for a declared host.
+        let hosts = GitLabHostResolver.parseAuthStatusHosts("""
+        git.acme.example
+          x gitlab.com: API call failed: GET https://gitlab.com/api/v4/user
+        """)
+        #expect(hosts == ["git.acme.example"])
+    }
+}
+
+private actor Probe {
+    private(set) var count = 0
+    func mark() { count += 1 }
+}

--- a/Tests/TBDDaemonTests/GitLabMappingTests.swift
+++ b/Tests/TBDDaemonTests/GitLabMappingTests.swift
@@ -34,6 +34,38 @@ struct GitLabMappingTests {
         #expect(map("REQUESTED_CHANGES", pipeline: "SUCCESS").state == .changesRequested)
     }
 
+    @Test("an explicit change request outranks a failing gated pipeline")
+    func requestedChangesBeatsFailingPipeline() {
+        // The GitHub arm puts CHANGES_REQUESTED ahead of its required-check
+        // signals, so a reviewer's explicit rejection is what the author is
+        // told about even when CI is also red. This arm must agree, otherwise
+        // the rejection is masked and never surfaces anywhere in the UI.
+        // Note the deliberate severity inversion: .changesRequested (4) ranks
+        // below .checksFailed (6), and is still the state we want here.
+        let r = map("REQUESTED_CHANGES", pipeline: "FAILED")
+        #expect(r.state == .changesRequested)
+        #expect(r.reason == "Changes requested")
+    }
+
+    @Test("an unresolved discussion does not outrank a failing gated pipeline")
+    func discussionsDoNotBeatFailingPipeline() {
+        // The deliberate other half of the rule above, pinned so that a future
+        // edit made in the name of consistency cannot quietly promote
+        // DISCUSSIONS_NOT_RESOLVED alongside REQUESTED_CHANGES. An open thread
+        // is not an explicit rejection, and a failing pipeline is the more
+        // actionable thing to show the author.
+        let r = map("DISCUSSIONS_NOT_RESOLVED", pipeline: "FAILED")
+        #expect(r.state == .checksFailed)
+        #expect(r.reason == "Pipeline failed")
+    }
+
+    @Test("a draft outranks both an explicit change request and a failing pipeline")
+    func draftBeatsRequestedChanges() {
+        // Draft sits above the change-request slot, so hoisting
+        // REQUESTED_CHANGES over the CI signal must not disturb it.
+        #expect(map("REQUESTED_CHANGES", draft: true, pipeline: "FAILED").state == .draft)
+    }
+
     @Test("MERGEABLE reads as ready")
     func mergeable() {
         #expect(map("MERGEABLE", pipeline: "SUCCESS").state == .mergeable)

--- a/Tests/TBDDaemonTests/GitLabMappingTests.swift
+++ b/Tests/TBDDaemonTests/GitLabMappingTests.swift
@@ -59,6 +59,20 @@ struct GitLabMappingTests {
         #expect(r.reason == "Pipeline failed")
     }
 
+    @Test("a merge conflict does not outrank a failing gated pipeline")
+    func conflictDoesNotBeatFailingPipeline() {
+        // The ordering is deliberate, not an oversight: the CI signal is
+        // computed ahead of the merge-status switch, so CONFLICT reports the
+        // pipeline rather than the conflict. Both are true and both block, and
+        // the pipeline is the signal GitLab's own detailedMergeStatus is least
+        // able to report — it ranks CI below almost everything, which is why
+        // the CI signal is computed separately at all. Pinned so a future
+        // reader does not "fix" the precedence into the switch.
+        let r = map("CONFLICT", pipeline: "FAILED")
+        #expect(r.state == .checksFailed)
+        #expect(r.reason == "Pipeline failed")
+    }
+
     @Test("a draft outranks both an explicit change request and a failing pipeline")
     func draftBeatsRequestedChanges() {
         // Draft sits above the change-request slot, so hoisting

--- a/Tests/TBDDaemonTests/GitLabMappingTests.swift
+++ b/Tests/TBDDaemonTests/GitLabMappingTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("GitLab state mapping")
+struct GitLabMappingTests {
+
+    private func map(
+        _ verdict: String, state: String = "opened", draft: Bool = false,
+        pipeline: String? = nil, gated: Bool = true
+    ) -> (state: PRMergeableState, reason: String) {
+        PRStatusManager.mapStateAndReason(
+            forge: .gitlab, ghState: state, mergeVerdictRaw: verdict,
+            isDraft: draft, pipelineGated: gated, pipelineStatus: pipeline)
+    }
+
+    @Test("NOT_APPROVED reads as ready, mirroring GitHub BLOCKED + REVIEW_REQUIRED")
+    func notApproved() {
+        // The single most common state in the field (#673). Mapping it to
+        // .blocked would paint most of a healthy fleet as needing attention.
+        #expect(map("NOT_APPROVED", pipeline: "SUCCESS").state == .mergeable)
+    }
+
+    @Test("DISCUSSIONS_NOT_RESOLVED reads as changes requested")
+    func discussions() {
+        let r = map("DISCUSSIONS_NOT_RESOLVED", pipeline: "SUCCESS")
+        #expect(r.state == .changesRequested)
+        #expect(r.reason == "Unresolved discussions")
+    }
+
+    @Test("REQUESTED_CHANGES reads as changes requested")
+    func requestedChanges() {
+        #expect(map("REQUESTED_CHANGES", pipeline: "SUCCESS").state == .changesRequested)
+    }
+
+    @Test("MERGEABLE reads as ready")
+    func mergeable() {
+        #expect(map("MERGEABLE", pipeline: "SUCCESS").state == .mergeable)
+    }
+
+    @Test("CONFLICT, NEED_REBASE and BLOCKED_STATUS each block with their own reason")
+    func blockers() {
+        #expect(map("CONFLICT", pipeline: "SUCCESS") == (.blocked, "Merge conflicts"))
+        #expect(map("NEED_REBASE", pipeline: "SUCCESS") == (.blocked, "Behind base branch"))
+        #expect(map("BLOCKED_STATUS", pipeline: "SUCCESS")
+                == (.blocked, "Blocked by another merge request"))
+    }
+
+    @Test("UNCHECKED is distinguishable from the transient checking states")
+    func uncheckedIsNotTransient() {
+        // 21 of 71 observed merge requests sat here, some for months (#673), so
+        // the reason must not imply it is about to resolve.
+        let unchecked = map("UNCHECKED", pipeline: "SUCCESS")
+        #expect(unchecked.state == .pending)
+        #expect(unchecked.reason == "Mergeability not checked")
+        #expect(map("CHECKING", pipeline: "SUCCESS").reason == "Checks pending")
+        #expect(unchecked.reason != map("CHECKING", pipeline: "SUCCESS").reason)
+    }
+
+    @Test("an unrecognised value is pending, never blocked")
+    func unknownIsPending() {
+        // DetailedMergeStatus grows between releases; unknown-means-blocked
+        // would make future GitLab versions silently paint MRs red.
+        #expect(map("SOME_FUTURE_STATUS", pipeline: "SUCCESS").state == .pending)
+    }
+
+    @Test("a failing pipeline on a gating project is red")
+    func failingGated() {
+        // detailedMergeStatus masks CI behind higher-precedence blockers: 33
+        // failing pipelines produced zero CI_MUST_PASS (#673), so the CI signal
+        // must be computed independently of the merge status.
+        #expect(map("NOT_APPROVED", pipeline: "FAILED").state == .checksFailed)
+    }
+
+    @Test("UNCHECKED with a failing pipeline on a gating project is red, not pending")
+    func uncheckedWithFailingPipeline() {
+        // Observed live against gitlab.com on a gated project: the shipped query
+        // returns detailedMergeStatus UNCHECKED alongside headPipeline FAILED.
+        // UNCHECKED is the second most common verdict in the field, so if the CI
+        // signal were read off the merge status this pairing would render a
+        // broken merge request as merely "not checked yet".
+        let r = map("UNCHECKED", pipeline: "FAILED")
+        #expect(r.state == .checksFailed)
+        #expect(r.reason == "Pipeline failed")
+    }
+
+    @Test("a failing pipeline on a non-gating project is not red")
+    func failingNotGated() {
+        // The same situation as GitHub's UNSTABLE, which TBD does not colour.
+        #expect(map("NOT_APPROVED", pipeline: "FAILED", gated: false).state != .checksFailed)
+    }
+
+    @Test("a draft with a failing pipeline stays draft")
+    func draftBeatsFailingPipeline() {
+        // 15 of 17 observed drafts had failing pipelines; work in progress must
+        // not turn the fleet red.
+        #expect(map("DRAFT_STATUS", draft: true, pipeline: "FAILED").state == .draft)
+    }
+
+    @Test("MANUAL is pending with its own reason")
+    func manualPipeline() {
+        let r = map("NOT_APPROVED", pipeline: "MANUAL")
+        #expect(r.state == .pending)
+        #expect(r.reason == "Pipeline awaiting manual action")
+    }
+
+    @Test("a null pipeline leaves the merge status to decide")
+    func nullPipeline() {
+        #expect(map("MERGEABLE", pipeline: nil).state == .mergeable)
+    }
+
+    @Test("merged and closed come from state, not the verdict")
+    func terminalStates() {
+        #expect(map("NOT_OPEN", state: "merged").state == .merged)
+        #expect(map("NOT_OPEN", state: "closed").state == .closed)
+    }
+
+    @Test("the GitHub arm is unaffected by the new parameters")
+    func githubArmUnchanged() {
+        let r = PRStatusManager.mapStateAndReason(
+            forge: .github, ghState: "OPEN", mergeVerdictRaw: "CLEAN")
+        #expect(r == (.mergeable, "Ready to merge"))
+    }
+}

--- a/Tests/TBDDaemonTests/GitLabMappingTests.swift
+++ b/Tests/TBDDaemonTests/GitLabMappingTests.swift
@@ -8,7 +8,7 @@ struct GitLabMappingTests {
 
     private func map(
         _ verdict: String, state: String = "opened", draft: Bool = false,
-        pipeline: String? = nil, gated: Bool = true
+        pipeline: String? = nil, gated: Bool? = true
     ) -> (state: PRMergeableState, reason: String) {
         PRStatusManager.mapStateAndReason(
             forge: .gitlab, ghState: state, mergeVerdictRaw: verdict,
@@ -121,6 +121,36 @@ struct GitLabMappingTests {
     func failingNotGated() {
         // The same situation as GitHub's UNSTABLE, which TBD does not colour.
         #expect(map("NOT_APPROVED", pipeline: "FAILED", gated: false).state != .checksFailed)
+    }
+
+    @Test("a failing pipeline stays red when nobody could read whether merges are gated")
+    func failingWithUnknownGating() {
+        // nil is "the project did not tell us", which only `false` may
+        // silence. The witness for why: the line below is what the same merge
+        // request maps to when unknown is collapsed to false — .mergeable,
+        // "Ready to merge", printed against a failed pipeline. Over-colouring
+        // an ungated project costs a glance; this costs a bad merge.
+        let unknown = map("NOT_APPROVED", pipeline: "FAILED", gated: nil)
+        #expect(unknown.state == .checksFailed)
+        #expect(unknown.reason == "Pipeline failed")
+        #expect(map("NOT_APPROVED", pipeline: "FAILED", gated: false) == (.mergeable, "Ready to merge"))
+    }
+
+    @Test("unknown gating reads as gated for the pending statuses too, not only for failures")
+    func pendingWithUnknownGating() {
+        // One rule rather than two: the whole CI branch is entered on anything
+        // but an explicit false.
+        #expect(map("NOT_APPROVED", pipeline: "RUNNING", gated: nil)
+                == (.pending, "Pipeline running"))
+        #expect(map("NOT_APPROVED", pipeline: "RUNNING", gated: false).state == .mergeable)
+    }
+
+    @Test("unknown gating does not colour a merge request with no pipeline at all")
+    func noPipelineWithUnknownGating() {
+        // The CI branch needs a status to read; an unknown gating answer is not
+        // itself evidence of anything to show.
+        #expect(map("MERGEABLE", pipeline: nil, gated: nil).state == .mergeable)
+        #expect(map("CONFLICT", pipeline: nil, gated: nil) == (.blocked, "Merge conflicts"))
     }
 
     @Test("a draft with a failing pipeline stays draft")

--- a/Tests/TBDDaemonTests/GitLabQueriesTests.swift
+++ b/Tests/TBDDaemonTests/GitLabQueriesTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import TBDDaemonLib
+@testable import TBDShared
 
 @Suite("GitLab queries and parsing")
 struct GitLabQueriesTests {
@@ -17,15 +18,41 @@ struct GitLabQueriesTests {
     }
 
     static func response(_ nodes: String, gated: Bool = true) -> Data {
+        responseWithGating("\"onlyAllowMergeIfPipelineSucceeds\":\(gated),", nodes: nodes)
+    }
+
+    /// A response whose gating field is written verbatim, for the three shapes
+    /// a `Bool` literal cannot express: present-and-null, absent entirely, and
+    /// present with the wrong type. Pass "" to omit the field.
+    static func responseWithGating(_ field: String, nodes: String) -> Data {
         Data("""
-        {"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":\(gated),
+        {"data":{"project":{\(field)
         "mergeRequests":{"nodes":[\(nodes)]}}}}
         """.utf8)
     }
 
+    /// The node with a failing pipeline, for the pairing that matters: gating
+    /// nobody could read plus CI that is definitely red.
+    static var failingNode: String {
+        oneNode.replacingOccurrences(of: #""status":"SUCCESS""#, with: #""status":"FAILED""#)
+    }
+
+    /// What the mapper makes of the first node of a parsed response.
+    ///
+    /// The composition is the property under test, not the parse alone: the
+    /// gating flag exists only to reach this call, and a parser that answers
+    /// nil is only useful if the mapper still refuses to say "Ready to merge".
+    static func mappedFirstNode(_ data: Data) -> (state: PRMergeableState, reason: String)? {
+        guard let (nodes, gated) = answered(data), let node = nodes.first else { return nil }
+        return PRStatusManager.mapStateAndReason(
+            forge: .gitlab, ghState: node.state, mergeVerdictRaw: node.mergeVerdictRaw,
+            isDraft: node.isDraft, pipelineGated: gated,
+            pipelineStatus: node.statusCheckRollupState)
+    }
+
     /// The parsed nodes, or nil when the response was refused as unreadable —
     /// so a test that expects an answer can `#require` it.
-    static func answered(_ data: Data) -> (nodes: [GitLabQueries.PRNode], gated: Bool)? {
+    static func answered(_ data: Data) -> (nodes: [GitLabQueries.PRNode], gated: Bool?)? {
         guard case .answered(let nodes, let gated) = GitLabQueries.parseMergeRequests(from: data)
         else { return nil }
         return (nodes, gated)
@@ -74,7 +101,7 @@ struct GitLabQueriesTests {
     @Test("parses a node into a PRNode tagged gitlab")
     func parsesNode() throws {
         let (nodes, gated) = try #require(Self.answered(Self.response(Self.oneNode)))
-        #expect(gated)
+        #expect(gated == true)
         #expect(nodes.count == 1)
         let n = nodes[0]
         #expect(n.forge == .gitlab)
@@ -112,7 +139,60 @@ struct GitLabQueriesTests {
     @Test("a non-gating project reports pipelineGated false")
     func nonGatingProject() throws {
         let (_, gated) = try #require(Self.answered(Self.response(Self.oneNode, gated: false)))
-        #expect(!gated)
+        #expect(gated == false)
+        // An explicit false is a fact the project stated, and it still switches
+        // the CI branch off — the tri-state must not have turned into "always
+        // gated".
+        #expect(Self.mappedFirstNode(Self.response(Self.failingNode, gated: false))?.state
+                == .mergeable)
+    }
+
+    @Test("a null gating field is unknown, and a failing pipeline stays red under it")
+    func gatingFieldNull() throws {
+        // `?? false` read this as "this project does not gate merges", which
+        // switches the whole CI branch of the mapper off. With NOT_APPROVED
+        // mapping to .mergeable, the merge request below then rendered "Ready
+        // to merge" with a failed pipeline — the fail-open this work exists to
+        // remove, in its worst form, because the user is told to go merge.
+        let data = Self.responseWithGating(
+            #""onlyAllowMergeIfPipelineSucceeds":null,"#, nodes: Self.failingNode)
+        let (_, gated) = try #require(Self.answered(data))
+        #expect(gated == nil)
+        #expect(Self.mappedFirstNode(data)?.state == .checksFailed)
+    }
+
+    @Test("an absent gating field is unknown, and a failing pipeline stays red under it")
+    func gatingFieldAbsent() throws {
+        // The shape a GitLab edition that does not expose the field takes, and
+        // the one a narrowed token can produce.
+        let data = Self.responseWithGating("", nodes: Self.failingNode)
+        let (_, gated) = try #require(Self.answered(data))
+        #expect(gated == nil)
+        #expect(Self.mappedFirstNode(data)?.state == .checksFailed)
+    }
+
+    @Test("a wrong-typed gating field is unknown, and a failing pipeline stays red under it")
+    func gatingFieldWrongTyped() throws {
+        let data = Self.responseWithGating(
+            #""onlyAllowMergeIfPipelineSucceeds":"yes","#, nodes: Self.failingNode)
+        let (_, gated) = try #require(Self.answered(data))
+        #expect(gated == nil)
+        #expect(Self.mappedFirstNode(data)?.state == .checksFailed)
+    }
+
+    @Test("an unreadable gating field costs the gating answer only, not the merge requests")
+    func unknownGatingKeepsTheNodes() throws {
+        // The previous fix in this area exists to stop one null field zeroing a
+        // whole batch, so the tri-state must not have re-introduced that: the
+        // merge requests still arrive, and only the gating answer is missing.
+        let other = Self.failingNode.replacingOccurrences(
+            of: #""iid":"412""#, with: #""iid":"7""#)
+        let data = Self.responseWithGating(
+            #""onlyAllowMergeIfPipelineSucceeds":null,"#,
+            nodes: "\(Self.failingNode), \(other)")
+        let (nodes, gated) = try #require(Self.answered(data))
+        #expect(nodes.map(\.number) == [412, 7])
+        #expect(gated == nil)
     }
 
     @Test("an errors-only response is unreadable, never an answered empty project")
@@ -139,7 +219,7 @@ struct GitLabQueriesTests {
     func emptyNodeList() throws {
         let (nodes, gated) = try #require(Self.answered(Self.response("")))
         #expect(nodes.isEmpty)
-        #expect(gated)
+        #expect(gated == true)
     }
 
     @Test("garbage that is not JSON is unreadable")

--- a/Tests/TBDDaemonTests/GitLabQueriesTests.swift
+++ b/Tests/TBDDaemonTests/GitLabQueriesTests.swift
@@ -12,6 +12,19 @@ struct GitLabQueriesTests {
         """.utf8)
     }
 
+    /// The parsed nodes, or nil when the response was refused as unreadable —
+    /// so a test that expects an answer can `#require` it.
+    static func answered(_ data: Data) -> (nodes: [GitLabQueries.PRNode], gated: Bool)? {
+        guard case .answered(let nodes, let gated) = GitLabQueries.parseMergeRequests(from: data)
+        else { return nil }
+        return (nodes, gated)
+    }
+
+    static func isUnreadable(_ data: Data) -> Bool {
+        if case .unreadable = GitLabQueries.parseMergeRequests(from: data) { return true }
+        return false
+    }
+
     static let oneNode = """
     {"iid":"412","state":"opened","draft":false,
      "detailedMergeStatus":"NOT_APPROVED","conflicts":false,
@@ -44,8 +57,8 @@ struct GitLabQueriesTests {
     }
 
     @Test("parses a node into a PRNode tagged gitlab")
-    func parsesNode() {
-        let (nodes, gated) = GitLabQueries.parseMergeRequests(from: Self.response(Self.oneNode))
+    func parsesNode() throws {
+        let (nodes, gated) = try #require(Self.answered(Self.response(Self.oneNode)))
         #expect(gated)
         #expect(nodes.count == 1)
         let n = nodes[0]
@@ -60,27 +73,50 @@ struct GitLabQueriesTests {
     }
 
     @Test("a null headPipeline yields a nil rollup state rather than dropping the node")
-    func nullPipeline() {
+    func nullPipeline() throws {
         let node = Self.oneNode.replacingOccurrences(
             of: #""headPipeline":{"status":"SUCCESS"}"#, with: #""headPipeline":null"#)
-        let (nodes, _) = GitLabQueries.parseMergeRequests(from: Self.response(node))
+        let (nodes, _) = try #require(Self.answered(Self.response(node)))
         #expect(nodes.count == 1)
         #expect(nodes[0].statusCheckRollupState == nil)
     }
 
     @Test("a non-gating project reports pipelineGated false")
-    func nonGatingProject() {
-        let (_, gated) = GitLabQueries.parseMergeRequests(
-            from: Self.response(Self.oneNode, gated: false))
+    func nonGatingProject() throws {
+        let (_, gated) = try #require(Self.answered(Self.response(Self.oneNode, gated: false)))
         #expect(!gated)
     }
 
-    @Test("an errors-only response yields no nodes and does not throw")
+    @Test("an errors-only response is unreadable, never an answered empty project")
     func errorsResponse() {
+        // `data: null` is what a rejected query looks like. Reading it as "this
+        // project has no merge requests" is what turns one bad token or one
+        // renamed project into every worktree on it reporting no merge request.
         let data = Data(#"{"errors":[{"message":"x","extensions":{"code":"undefinedField"}}],"data":null}"#.utf8)
-        let (nodes, gated) = GitLabQueries.parseMergeRequests(from: data)
+        #expect(Self.isUnreadable(data))
+    }
+
+    @Test("a null project is unreadable — the project rename and lost-permission shape")
+    func nullProject() {
+        #expect(Self.isUnreadable(Data(#"{"data":{"project":null}}"#.utf8)))
+    }
+
+    @Test("a mergeRequests block with no node list is unreadable")
+    func missingNodeList() {
+        let data = Data(#"{"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":true,"mergeRequests":{}}}}"#.utf8)
+        #expect(Self.isUnreadable(data))
+    }
+
+    @Test("an empty node list is an answer: this project genuinely has no merge requests")
+    func emptyNodeList() throws {
+        let (nodes, gated) = try #require(Self.answered(Self.response("")))
         #expect(nodes.isEmpty)
-        #expect(!gated)
+        #expect(gated)
+    }
+
+    @Test("garbage that is not JSON is unreadable")
+    func notJSON() {
+        #expect(Self.isUnreadable(Data("not json at all".utf8)))
     }
 
     @Test("the recheck path percent-encodes the project path and stays a GET")

--- a/Tests/TBDDaemonTests/GitLabQueriesTests.swift
+++ b/Tests/TBDDaemonTests/GitLabQueriesTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("GitLab queries and parsing")
+struct GitLabQueriesTests {
+
+    static func response(_ nodes: String, gated: Bool = true) -> Data {
+        Data("""
+        {"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":\(gated),
+        "mergeRequests":{"nodes":[\(nodes)]}}}}
+        """.utf8)
+    }
+
+    static let oneNode = """
+    {"iid":"412","state":"opened","draft":false,
+     "detailedMergeStatus":"NOT_APPROVED","conflicts":false,
+     "sourceBranch":"feat/x","targetBranch":"main",
+     "createdAt":"2026-08-01T10:00:00Z",
+     "webUrl":"https://git.acme.example/acme/platform/api/-/merge_requests/412",
+     "headPipeline":{"status":"SUCCESS"}}
+    """
+
+    @Test("the iid query embeds validated integers and takes fullPath as a variable")
+    func iidQueryShape() {
+        let q = GitLabQueries.mergeRequestsByIIDQuery(iids: [412, 7])
+        #expect(q.contains(#"iids: ["412", "7"]"#))
+        #expect(q.contains("$fullPath: ID!"))
+        #expect(q.contains("onlyAllowMergeIfPipelineSucceeds"))
+        #expect(q.contains("headPipeline { status }"))
+        // No paid-tier field may appear: one unknown field returns data: null
+        // for the whole batch.
+        #expect(!q.contains("mergeTrainCar"))
+        #expect(!q.contains("approvalsRequired"))
+        #expect(!q.contains("externalStatusChecks"))
+    }
+
+    @Test("the branch query JSON-escapes branch names")
+    func branchQueryEscapes() {
+        let q = GitLabQueries.mergeRequestsByBranchQuery(branches: ["feat/a", "weird\"name"])
+        #expect(q.contains(#""feat/a""#))
+        #expect(q.contains(#"weird\"name"#))
+        #expect(q.contains("state: opened"))
+    }
+
+    @Test("parses a node into a PRNode tagged gitlab")
+    func parsesNode() {
+        let (nodes, gated) = GitLabQueries.parseMergeRequests(from: Self.response(Self.oneNode))
+        #expect(gated)
+        #expect(nodes.count == 1)
+        let n = nodes[0]
+        #expect(n.forge == .gitlab)
+        #expect(n.number == 412)
+        #expect(n.state == "opened")
+        #expect(n.mergeVerdictRaw == "NOT_APPROVED")
+        #expect(n.headRefName == "feat/x")
+        #expect(n.baseRefName == "main")
+        #expect(n.statusCheckRollupState == "SUCCESS")
+        #expect(n.url.hasSuffix("/-/merge_requests/412"))
+    }
+
+    @Test("a null headPipeline yields a nil rollup state rather than dropping the node")
+    func nullPipeline() {
+        let node = Self.oneNode.replacingOccurrences(
+            of: #""headPipeline":{"status":"SUCCESS"}"#, with: #""headPipeline":null"#)
+        let (nodes, _) = GitLabQueries.parseMergeRequests(from: Self.response(node))
+        #expect(nodes.count == 1)
+        #expect(nodes[0].statusCheckRollupState == nil)
+    }
+
+    @Test("a non-gating project reports pipelineGated false")
+    func nonGatingProject() {
+        let (_, gated) = GitLabQueries.parseMergeRequests(
+            from: Self.response(Self.oneNode, gated: false))
+        #expect(!gated)
+    }
+
+    @Test("an errors-only response yields no nodes and does not throw")
+    func errorsResponse() {
+        let data = Data(#"{"errors":[{"message":"x","extensions":{"code":"undefinedField"}}],"data":null}"#.utf8)
+        let (nodes, gated) = GitLabQueries.parseMergeRequests(from: data)
+        #expect(nodes.isEmpty)
+        #expect(!gated)
+    }
+
+    @Test("the recheck path percent-encodes the project path and stays a GET")
+    func recheckPathShape() {
+        let path = GitLabQueries.recheckPath(
+            projectPath: "acme/platform/backend/api-gateway", iids: [412, 7])
+        #expect(path.hasPrefix("projects/acme%2Fplatform%2Fbackend%2Fapi-gateway/merge_requests?"))
+        #expect(path.contains("iids%5B%5D=412"))
+        #expect(path.contains("iids%5B%5D=7"))
+        #expect(path.contains("with_merge_status_recheck=true"))
+    }
+}

--- a/Tests/TBDDaemonTests/GitLabQueriesTests.swift
+++ b/Tests/TBDDaemonTests/GitLabQueriesTests.swift
@@ -5,6 +5,17 @@ import Testing
 @Suite("GitLab queries and parsing")
 struct GitLabQueriesTests {
 
+    /// The exact GraphQL field set every merge-request query may ask for.
+    static let expectedNodeFields =
+        "iid state draft detailedMergeStatus sourceBranch targetBranch createdAt webUrl "
+        + "headPipeline { status }"
+
+    /// Runs of whitespace collapsed to one space, so a query pin survives
+    /// reformatting without loosening which fields it names.
+    static func normalized(_ query: String) -> String {
+        query.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+
     static func response(_ nodes: String, gated: Bool = true) -> Data {
         Data("""
         {"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":\(gated),
@@ -27,25 +38,26 @@ struct GitLabQueriesTests {
 
     static let oneNode = """
     {"iid":"412","state":"opened","draft":false,
-     "detailedMergeStatus":"NOT_APPROVED","conflicts":false,
+     "detailedMergeStatus":"NOT_APPROVED",
      "sourceBranch":"feat/x","targetBranch":"main",
      "createdAt":"2026-08-01T10:00:00Z",
      "webUrl":"https://git.acme.example/acme/platform/api/-/merge_requests/412",
      "headPipeline":{"status":"SUCCESS"}}
     """
 
-    @Test("the iid query embeds validated integers and takes fullPath as a variable")
+    @Test("the iid query emits exactly the tier-1 field set, with fullPath as a variable")
     func iidQueryShape() {
-        let q = GitLabQueries.mergeRequestsByIIDQuery(iids: [412, 7])
-        #expect(q.contains(#"iids: ["412", "7"]"#))
-        #expect(q.contains("$fullPath: ID!"))
-        #expect(q.contains("onlyAllowMergeIfPipelineSucceeds"))
-        #expect(q.contains("headPipeline { status }"))
-        // No paid-tier field may appear: one unknown field returns data: null
-        // for the whole batch.
-        #expect(!q.contains("mergeTrainCar"))
-        #expect(!q.contains("approvalsRequired"))
-        #expect(!q.contains("externalStatusChecks"))
+        // A whitelist, because the hazard is a field appearing, not a
+        // particular field appearing: one unknown field returns data: null for
+        // the whole batch, and a test naming today's forbidden fields would
+        // pass on tomorrow's. Whitespace is normalized so the pin survives
+        // reformatting while the field set itself stays exact.
+        let q = Self.normalized(GitLabQueries.mergeRequestsByIIDQuery(iids: [412, 7]))
+        #expect(q == """
+        query($fullPath: ID!) { project(fullPath: $fullPath) { \
+        onlyAllowMergeIfPipelineSucceeds mergeRequests(iids: ["412", "7"]) { \
+        nodes { \(Self.expectedNodeFields) } } } }
+        """)
     }
 
     @Test("the branch query JSON-escapes branch names")
@@ -54,6 +66,9 @@ struct GitLabQueriesTests {
         #expect(q.contains(#""feat/a""#))
         #expect(q.contains(#"weird\"name"#))
         #expect(q.contains("state: opened"))
+        // The same pinned field set the iid query emits — both interpolate one
+        // selection, and that is worth keeping true.
+        #expect(Self.normalized(q).contains("nodes { \(Self.expectedNodeFields) }"))
     }
 
     @Test("parses a node into a PRNode tagged gitlab")

--- a/Tests/TBDDaemonTests/GitLabQueriesTests.swift
+++ b/Tests/TBDDaemonTests/GitLabQueriesTests.swift
@@ -81,6 +81,19 @@ struct GitLabQueriesTests {
         #expect(nodes[0].statusCheckRollupState == nil)
     }
 
+    @Test("a null node element costs that node only, not the whole batch")
+    func nullNodeElement() throws {
+        // Nulling one element is how GraphQL surfaces a per-node error, and a
+        // whole-array cast fails on it and discards every sibling — the defect
+        // PR #208 fixed on the GitHub side. Siblings on both sides of the null
+        // must survive.
+        let other = Self.oneNode.replacingOccurrences(
+            of: #""iid":"412""#, with: #""iid":"7""#)
+        let (nodes, _) = try #require(
+            Self.answered(Self.response("\(Self.oneNode), null, \(other)")))
+        #expect(nodes.map(\.number) == [412, 7])
+    }
+
     @Test("a non-gating project reports pipelineGated false")
     func nonGatingProject() throws {
         let (_, gated) = try #require(Self.answered(Self.response(Self.oneNode, gated: false)))

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -74,6 +74,92 @@ struct PRBindingCoordinatorTests {
         }
     }
 
+    /// Extraction is the production source of every `ParsedPRURL` a hook or a
+    /// URL-shaped attach binds, so the host under test is the one the extractor
+    /// really reports rather than one this file made up.
+    private func parseOne(_ url: String) throws -> ParsedPRURL {
+        try #require(PRBindingExtractor.parsePRURLs(in: url).first)
+    }
+
+    /// The wrong-repo guard used to compare `owner`/`name` and nothing else,
+    /// which was inert only while every parsed URL was on `github.com`. Now that
+    /// a GitLab merge-request URL carries its own captured host, two different
+    /// projects that merely share an `owner/name` across two hosts would bind to
+    /// each other — and a foreign merge then satisfies `allResolved` and
+    /// auto-archives the worktree.
+    ///
+    /// Against the guard as it stood, both rows below returned `.bound` and
+    /// wrote a row.
+    @Test("rejects a merge request whose captured host is not the worktree's")
+    func rejectsRequestFromAnotherHost() async throws {
+        let cases: [(own: (owner: String, name: String, host: String), url: String, detail: String)] = [
+            // Cross-forge: the hole this closes.
+            (("acme", "acme-prod", "github.com"),
+             "https://git.acme.example/acme/acme-prod/-/merge_requests/412",
+             "git.acme.example/acme/acme-prod"),
+            // Same forge, two instances — one org name on two GitLab hosts.
+            (("acme", "acme-prod", "gitlab.acme.example"),
+             "https://git.other.example/acme/acme-prod/-/merge_requests/412",
+             "git.other.example/acme/acme-prod"),
+        ]
+        for testCase in cases {
+            let fixture = try await Fixture(repo: testCase.own)
+            let wt = try await fixture.newWorktree()
+            let parsed = try parseOne(testCase.url)
+            let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed,
+                                                         source: .hook)
+            guard case .rejectedWrongRepo(let named) = outcome else {
+                Issue.record("expected .rejectedWrongRepo for \(testCase.url), got \(outcome)")
+                continue  // each row is an independent case; don't mask the second
+            }
+            // Owner and name agree here, so the rejection has to name the host
+            // or it reads as a repo rejecting itself.
+            #expect(named == testCase.detail)
+            #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+        }
+    }
+
+    /// The other half of the trade-off, and the reason the host check is not a
+    /// plain equality: `PRBindingExtractor`'s GitHub pattern is host-locked, so
+    /// `github.com` is a constant it supplies for every GitHub URL rather than
+    /// an observation about the forge. A GitHub Enterprise or self-hosted-mirror
+    /// checkout with the same `owner/name` may therefore still take such a URL,
+    /// which is what `RemoteRepoMatching` documents as a deliberately tolerated
+    /// collision.
+    ///
+    /// This passes against the pre-fix guard too — that is the point: it pins
+    /// the binding the fix must not take away. Comparing hosts for plain
+    /// equality instead turns it into `.rejectedWrongRepo`.
+    @Test("still binds a github.com URL to an enterprise or mirror checkout")
+    func bindsGitHubURLAgainstAnotherHostCheckout() async throws {
+        for host in ["ghe.acme.example", "gitlab.acme.example"] {
+            let fixture = try await Fixture(repo: ("acme", "acme-prod", host))
+            let wt = try await fixture.newWorktree()
+            let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed,
+                                                         source: .manual)
+            guard case .bound(let binding) = outcome else {
+                Issue.record("expected .bound on \(host), got \(outcome)"); continue
+            }
+            // The URL's host is what gets recorded — the binding is re-queried
+            // by `(host, owner, repo, number)` and must reach the real request.
+            #expect(binding.host == "github.com")
+        }
+    }
+
+    /// Hostnames are case-insensitive, so a resolver that reports the host with
+    /// the casing `gh repo view`'s URL happened to use must not reject an
+    /// otherwise identical merge request. Comparing the raw strings fails here.
+    @Test("host comparison is case-insensitive")
+    func hostCaseInsensitive() async throws {
+        let fixture = try await Fixture(repo: ("acme", "acme-prod", "Git.ACME.Example"))
+        let wt = try await fixture.newWorktree()
+        let parsed = try parseOne("https://git.acme.example/acme/acme-prod/-/merge_requests/412")
+        let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
+        guard case .bound = outcome else {
+            Issue.record("expected .bound, got \(outcome)"); return
+        }
+    }
+
     @Test("defers rather than rejects when the repo cannot be resolved")
     func defersUnknownRepo() async throws {
         let fixture = try await Fixture(repo: nil)

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -16,7 +16,8 @@ struct PRBindingCoordinatorTests {
         let coordinator: PRBindingCoordinator
         let repoID: UUID
 
-        init(repo: (owner: String, name: String)? = ("acme", "acme-prod")) async throws {
+        init(repo: (owner: String, name: String, host: String)? =
+            ("acme", "acme-prod", "github.com")) async throws {
             db = try TBDDatabase(inMemory: true)
             let created = try await db.repos.create(
                 path: "/tmp/prbinding-coord-repo-\(UUID().uuidString)",
@@ -53,7 +54,7 @@ struct PRBindingCoordinatorTests {
 
     @Test("rejects a PR belonging to a different repo")
     func rejectsWrongRepo() async throws {
-        let fixture = try await Fixture(repo: ("acme", "other-repo"))
+        let fixture = try await Fixture(repo: ("acme", "other-repo", "github.com"))
         let wt = try await fixture.newWorktree()
         let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
         guard case .rejectedWrongRepo(let named) = outcome else {
@@ -65,7 +66,7 @@ struct PRBindingCoordinatorTests {
 
     @Test("repo comparison is case-insensitive")
     func repoCaseInsensitive() async throws {
-        let fixture = try await Fixture(repo: ("ACME", "ACME-PROD"))
+        let fixture = try await Fixture(repo: ("ACME", "ACME-PROD", "github.com"))
         let wt = try await fixture.newWorktree()
         let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
         guard case .bound = outcome else {

--- a/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingCoordinatorTests.swift
@@ -16,15 +16,23 @@ struct PRBindingCoordinatorTests {
         let coordinator: PRBindingCoordinator
         let repoID: UUID
 
+        /// - Parameter gitLabHosts: the hosts the user configured `glab` for.
+        ///   Empty — the default — stands for every non-GitLab fleet at once:
+        ///   github.com, GitHub Enterprise, Bitbucket, Gitea, Codeberg. `nil` is
+        ///   the third answer, the state in which nothing could establish the
+        ///   worktree's forge at all.
         init(repo: (owner: String, name: String, host: String)? =
-            ("acme", "acme-prod", "github.com")) async throws {
+            ("acme", "acme-prod", "github.com"),
+             gitLabHosts: Set<String>? = []) async throws {
             db = try TBDDatabase(inMemory: true)
             let created = try await db.repos.create(
                 path: "/tmp/prbinding-coord-repo-\(UUID().uuidString)",
                 displayName: "acme-prod", defaultBranch: "main")
             repoID = created.id
             store = db.prBindings
-            coordinator = PRBindingCoordinator(store: store, resolveRepo: { _ in repo })
+            coordinator = PRBindingCoordinator(
+                store: store, resolveRepo: { _ in repo },
+                isGitLabHost: { _, host in gitLabHosts.map { $0.contains(host.lowercased()) } })
         }
 
         func newWorktree() async throws -> UUID {
@@ -127,12 +135,13 @@ struct PRBindingCoordinatorTests {
     /// which is what `RemoteRepoMatching` documents as a deliberately tolerated
     /// collision.
     ///
-    /// This passes against the pre-fix guard too — that is the point: it pins
-    /// the binding the fix must not take away. Comparing hosts for plain
-    /// equality instead turns it into `.rejectedWrongRepo`.
+    /// Neither host below is configured for `glab`, which is what makes them
+    /// *not* GitLab — the exemption survives on that answer, not on the shape of
+    /// their names. These two stand for every non-GitLab fleet off github.com:
+    /// GitHub Enterprise, Bitbucket, Gitea, Codeberg, and a mirror.
     @Test("still binds a github.com URL to an enterprise or mirror checkout")
     func bindsGitHubURLAgainstAnotherHostCheckout() async throws {
-        for host in ["ghe.acme.example", "gitlab.acme.example"] {
+        for host in ["ghe.acme.example", "git.acme.example"] {
             let fixture = try await Fixture(repo: ("acme", "acme-prod", host))
             let wt = try await fixture.newWorktree()
             let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed,
@@ -143,6 +152,61 @@ struct PRBindingCoordinatorTests {
             // The URL's host is what gets recorded — the binding is re-queried
             // by `(host, owner, repo, number)` and must reach the real request.
             #expect(binding.host == "github.com")
+        }
+    }
+
+    /// Where that exemption stops, and the collision it would otherwise leave
+    /// open. This worktree's host speaks GitLab, so its requests live there and
+    /// a `github.com` pull request sharing an `owner/name` is a different
+    /// project by construction. Binding it would poll a stranger's PR through
+    /// `gh` and let that stranger's merge auto-archive this worktree.
+    ///
+    /// Against the exemption as it stood — unconditional on any `github.com`
+    /// URL — this returned `.bound` and wrote a row.
+    @Test("rejects a github.com URL on a checkout whose own host speaks GitLab")
+    func rejectsGitHubURLAgainstGitLabCheckout() async throws {
+        let fixture = try await Fixture(repo: ("acme", "acme-prod", "gitlab.acme.example"),
+                                        gitLabHosts: ["gitlab.acme.example"])
+        let wt = try await fixture.newWorktree()
+        let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed,
+                                                     source: .hook)
+        guard case .rejectedWrongRepo(let named) = outcome else {
+            Issue.record("expected .rejectedWrongRepo, got \(outcome)"); return
+        }
+        // Owner and name agree, so the rejection has to name the host.
+        #expect(named == "github.com/acme/acme-prod")
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+    }
+
+    /// The third answer. A worktree whose forge nothing could establish gets no
+    /// binding invented for it: the two ways to be wrong are not symmetric, and
+    /// a deferral writes nothing and is retried on the next poll or attach,
+    /// while a bind can auto-archive this worktree on a stranger's merge.
+    @Test("defers a github.com URL when the checkout's forge cannot be determined")
+    func defersWhenForgeUndetermined() async throws {
+        let fixture = try await Fixture(repo: ("acme", "acme-prod", "git.acme.example"),
+                                        gitLabHosts: nil)
+        let wt = try await fixture.newWorktree()
+        let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed,
+                                                     source: .hook)
+        guard case .deferredUnknownRepo = outcome else {
+            Issue.record("expected .deferredUnknownRepo, got \(outcome)"); return
+        }
+        #expect(try await fixture.store.list(worktreeID: wt, includeDetached: true).isEmpty)
+    }
+
+    /// A worktree already on the URL's own host never reaches the forge
+    /// question at all — the hosts are equal, so nothing is asked and no `glab`
+    /// subprocess could be spawned. Pinned because an undetermined forge now
+    /// defers, and a guard that asked first would turn every github.com bind
+    /// into a deferral wherever the answer is unavailable.
+    @Test("a matching host binds without consulting the forge")
+    func matchingHostSkipsForgeQuestion() async throws {
+        let fixture = try await Fixture(gitLabHosts: nil)
+        let wt = try await fixture.newWorktree()
+        let outcome = await fixture.coordinator.bind(worktreeID: wt, parsed: parsed, source: .hook)
+        guard case .bound = outcome else {
+            Issue.record("expected .bound, got \(outcome)"); return
         }
     }
 

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -78,6 +78,17 @@ private struct PRBindingRPCHarness {
             path: "/tmp/prbinding-rpc-wt-\(suffix)", tmuxServer: "tbd-prbinding-rpc").id
     }
 
+    /// A remote lane's row in the same repo. It exists — so a binding's foreign
+    /// key holds and the injected repo resolver still answers for it — but it
+    /// has no directory on this machine, which is the state in which the forge
+    /// cannot be determined.
+    func addRemoteWorktree() async throws -> UUID {
+        let suffix = UUID().uuidString
+        return try await db.worktrees.createRemote(
+            repoID: repoID, name: "remote-\(suffix)", branch: "branch-\(suffix)",
+            provider: "acme-cloud", sessionID: "session-\(suffix)").id
+    }
+
     func bindings() async throws -> PRBindingsResult {
         let request = try RPCRequest(method: RPCMethod.prBindings,
                                      params: PRBindingsParams(worktreeID: worktreeID))
@@ -212,6 +223,30 @@ struct PRBindingRPCTests {
             gitLabHosts: ["git.acme.example"])
         #expect(try await known.attach(number: 412).binding?.url
                 == "https://git.acme.example/acme/acme-prod/-/merge_requests/412")
+    }
+
+    /// The forge shape comes from a second lookup, independent of the repo
+    /// resolver: the worktree's own directory is where `glab` reads its
+    /// configuration from, and a worktree with no local row — a remote lane, or
+    /// one deleted between the two awaits — has no directory here to ask in.
+    /// Nothing has then answered "GitLab" or "not GitLab", and either shape is
+    /// a guess.
+    ///
+    /// `/pull/<n>` is the damaging guess, which is why the resolver here names
+    /// the host as GitLab while the worktree is remote: composing GitHub's
+    /// shape then persists a binding whose URL 404s and whose label reads "PR".
+    /// So the call defers, exactly as it does when the repo cannot be named —
+    /// and the repo *is* nameable here, so the deferral can only come from the
+    /// forge lookup.
+    @Test("pr.attach by number defers when the worktree's forge cannot be determined")
+    func attachByNumberUndeterminedForge() async throws {
+        let harness = try await PRBindingRPCHarness(
+            repo: ("acme", "acme-prod", "git.acme.example"),
+            gitLabHosts: ["git.acme.example"])
+        let remote = try await harness.addRemoteWorktree()
+        let attach = try await harness.attach(number: 412, worktreeID: remote)
+        #expect(attach.outcome == "deferredUnknownRepo")
+        #expect(attach.binding == nil)
     }
 
     /// github.com short-circuits inside the resolver before any subprocess, so

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -14,6 +14,12 @@ import TestSupport
 /// `prBindingRepoResolver` seam — production resolves it with `gh repo view`
 /// (or the `origin` remote) behind `PRStatusManager`'s TTL cache, which a unit
 /// test must not spawn.
+///
+/// `gitLabHosts` is the other injected fact: composing a URL for a bare number
+/// asks `PRStatusManager` which hosts speak GitLab, and the injecting init
+/// answers from a set rather than from `glab auth status`. A harness that names
+/// no host therefore stands for every non-GitLab fleet at once — github.com,
+/// GitHub Enterprise, Bitbucket, Gitea, Codeberg.
 private struct PRBindingRPCHarness {
     enum HarnessError: Error, CustomStringConvertible {
         case rpcFailed(String)
@@ -30,7 +36,8 @@ private struct PRBindingRPCHarness {
     let worktreeID: UUID
     let repoID: UUID
 
-    init(repo: (owner: String, name: String, host: String)?) async throws {
+    init(repo: (owner: String, name: String, host: String)?,
+         gitLabHosts: Set<String> = []) async throws {
         let db = try TBDDatabase(inMemory: true)
         self.db = db
         let suffix = UUID().uuidString
@@ -49,6 +56,15 @@ private struct PRBindingRPCHarness {
                 hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
+            // `ghRunner` is required by the injecting init and must never be
+            // reached from these paths; failing loudly is the assertion that it
+            // is not.
+            prManager: PRStatusManager(
+                ghRunner: { _, _ in
+                    Issue.record("pr.attach must not spawn gh")
+                    return nil
+                },
+                gitLabHosts: gitLabHosts),
             prBindingRepoResolver: { _ in repo },
             actuationLog: makeTestActuationLog())
     }
@@ -136,7 +152,8 @@ struct PRBindingRPCTests {
     @Test("pr.attach by number composes a merge-request URL on a GitLab host")
     func attachByNumberGitLab() async throws {
         let harness = try await PRBindingRPCHarness(
-            repo: ("acme/platform", "api-gateway", "git.acme.example"))
+            repo: ("acme/platform", "api-gateway", "git.acme.example"),
+            gitLabHosts: ["git.acme.example"])
         let attach = try await harness.attach(number: 412)
         #expect(attach.outcome == "bound")
         #expect(attach.binding?.url
@@ -151,23 +168,62 @@ struct PRBindingRPCTests {
     @Test("pr.attach by number keeps a deeply nested GitLab namespace intact")
     func attachByNumberNestedNamespace() async throws {
         let harness = try await PRBindingRPCHarness(
-            repo: ("acme/platform/backend", "api-gateway", "git.acme.example"))
+            repo: ("acme/platform/backend", "api-gateway", "git.acme.example"),
+            gitLabHosts: ["git.acme.example"])
         let attach = try await harness.attach(number: 7)
         #expect(attach.binding?.url
                 == "https://git.acme.example/acme/platform/backend/api-gateway/-/merge_requests/7")
         #expect(attach.binding?.owner == "acme/platform/backend")
     }
 
-    /// A GitHub Enterprise-shaped host is not github.com, so the composed URL
-    /// must at least stay on the worktree's own host rather than silently
-    /// naming github.com — which is what the hardcoded composition did.
-    @Test("pr.attach by number never composes a github.com URL for another host")
-    func attachByNumberKeepsItsOwnHost() async throws {
-        let harness = try await PRBindingRPCHarness(
+    /// A self-hosted host is not github.com, so the composed URL must stay on
+    /// the worktree's own host rather than silently naming github.com — which
+    /// is what the hardcoded composition did.
+    ///
+    /// It must equally not become a merge request. "Not github.com" is not
+    /// evidence of GitLab: GitHub Enterprise, Bitbucket, Gitea and Codeberg all
+    /// live on their own hosts and all serve `/pull/<n>`. Only a host the
+    /// resolver actually names gets GitLab's shape, and this harness names
+    /// none, so `/pull/` is the whole answer — and the URL is asserted entire,
+    /// because a prefix check passes for a merge-request URL too.
+    @Test("pr.attach by number composes /pull/ for a self-hosted non-GitLab host")
+    func attachByNumberSelfHostedPullRequest() async throws {
+        for host in ["github.acme.example", "bitbucket.acme.example", "codeberg.org"] {
+            let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", host))
+            let attach = try await harness.attach(number: 412)
+            #expect(attach.outcome == "bound")
+            #expect(attach.binding?.url == "https://\(host)/acme/acme-prod/pull/412")
+            #expect(attach.binding?.host == host)
+        }
+    }
+
+    /// The same host, classified both ways, so the branch is pinned rather than
+    /// the string: `git.acme.example` is a merge request only when the resolver
+    /// names it GitLab.
+    @Test("pr.attach by number follows the resolver, not the hostname")
+    func attachByNumberFollowsTheResolver() async throws {
+        let unknown = try await PRBindingRPCHarness(
             repo: ("acme", "acme-prod", "git.acme.example"))
-        let attach = try await harness.attach(number: 412)
-        #expect(attach.binding?.url.hasPrefix("https://git.acme.example/") == true)
-        #expect(attach.binding?.url.contains("github.com") == false)
+        #expect(try await unknown.attach(number: 412).binding?.url
+                == "https://git.acme.example/acme/acme-prod/pull/412")
+
+        let known = try await PRBindingRPCHarness(
+            repo: ("acme", "acme-prod", "git.acme.example"),
+            gitLabHosts: ["git.acme.example"])
+        #expect(try await known.attach(number: 412).binding?.url
+                == "https://git.acme.example/acme/acme-prod/-/merge_requests/412")
+    }
+
+    /// github.com short-circuits inside the resolver before any subprocess, so
+    /// the unchanged GitHub shape is not merely the fallback here — it is the
+    /// answer a GitHub fleet reaches without asking anything.
+    @Test("pr.attach by number on github.com composes /pull/ even with GitLab hosts known")
+    func attachByNumberGitHubUnchanged() async throws {
+        let harness = try await PRBindingRPCHarness(
+            repo: ("acme", "acme-prod", "github.com"),
+            gitLabHosts: ["git.acme.example"])
+        #expect(try await harness.attach(number: 412).binding?.url
+                == "https://github.com/acme/acme-prod/pull/412")
     }
 
     @Test("pr.attach reports a wrong-repo rejection instead of binding")

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -10,9 +10,10 @@ import TestSupport
 ///
 /// `worktree_pull_request.worktreeID` is an enforced foreign key, so the harness
 /// seeds a real repo and worktree instead of inventing a bare UUID. The
-/// worktree's own `owner/name` comes from the router's injected
+/// worktree's own `owner/name/host` comes from the router's injected
 /// `prBindingRepoResolver` seam — production resolves it with `gh repo view`
-/// behind `PRStatusManager`'s TTL cache, which a unit test must not spawn.
+/// (or the `origin` remote) behind `PRStatusManager`'s TTL cache, which a unit
+/// test must not spawn.
 private struct PRBindingRPCHarness {
     enum HarnessError: Error, CustomStringConvertible {
         case rpcFailed(String)
@@ -29,7 +30,7 @@ private struct PRBindingRPCHarness {
     let worktreeID: UUID
     let repoID: UUID
 
-    init(repo: (owner: String, name: String)?) async throws {
+    init(repo: (owner: String, name: String, host: String)?) async throws {
         let db = try TBDDatabase(inMemory: true)
         self.db = db
         let suffix = UUID().uuidString
@@ -113,7 +114,7 @@ struct PRBindingRPCTests {
 
     @Test("pr.attach with a URL binds and pr.bindings returns it")
     func attachThenList() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         let attach = try await harness.attach(url: "https://github.com/acme/acme-prod/pull/412")
         #expect(attach.outcome == "bound")
         #expect(attach.binding?.number == 412)
@@ -124,14 +125,54 @@ struct PRBindingRPCTests {
 
     @Test("pr.attach accepts a bare number and resolves the worktree's repo")
     func attachByNumber() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         let attach = try await harness.attach(number: 77)
         #expect(attach.binding?.url == "https://github.com/acme/acme-prod/pull/77")
     }
 
+    /// The bug this closes: a bare number on a GitLab checkout used to compose
+    /// `https://github.com/<namespace>/<project>/pull/<n>` — a github.com URL
+    /// for a repo that does not exist there, bound and then polled forever.
+    @Test("pr.attach by number composes a merge-request URL on a GitLab host")
+    func attachByNumberGitLab() async throws {
+        let harness = try await PRBindingRPCHarness(
+            repo: ("acme/platform", "api-gateway", "git.acme.example"))
+        let attach = try await harness.attach(number: 412)
+        #expect(attach.outcome == "bound")
+        #expect(attach.binding?.url
+                == "https://git.acme.example/acme/platform/api-gateway/-/merge_requests/412")
+        #expect(attach.binding?.host == "git.acme.example")
+        #expect(attach.binding?.owner == "acme/platform")
+        #expect(attach.binding?.repo == "api-gateway")
+    }
+
+    /// A namespace nests arbitrarily on GitLab, and every level of it belongs
+    /// to the owner — the project is only ever the last segment.
+    @Test("pr.attach by number keeps a deeply nested GitLab namespace intact")
+    func attachByNumberNestedNamespace() async throws {
+        let harness = try await PRBindingRPCHarness(
+            repo: ("acme/platform/backend", "api-gateway", "git.acme.example"))
+        let attach = try await harness.attach(number: 7)
+        #expect(attach.binding?.url
+                == "https://git.acme.example/acme/platform/backend/api-gateway/-/merge_requests/7")
+        #expect(attach.binding?.owner == "acme/platform/backend")
+    }
+
+    /// A GitHub Enterprise-shaped host is not github.com, so the composed URL
+    /// must at least stay on the worktree's own host rather than silently
+    /// naming github.com — which is what the hardcoded composition did.
+    @Test("pr.attach by number never composes a github.com URL for another host")
+    func attachByNumberKeepsItsOwnHost() async throws {
+        let harness = try await PRBindingRPCHarness(
+            repo: ("acme", "acme-prod", "git.acme.example"))
+        let attach = try await harness.attach(number: 412)
+        #expect(attach.binding?.url.hasPrefix("https://git.acme.example/") == true)
+        #expect(attach.binding?.url.contains("github.com") == false)
+    }
+
     @Test("pr.attach reports a wrong-repo rejection instead of binding")
     func attachWrongRepo() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "other-repo"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "other-repo", "github.com"))
         let attach = try await harness.attach(url: "https://github.com/acme/acme-prod/pull/412")
         #expect(attach.outcome == "rejectedWrongRepo")
         #expect(attach.detail == "acme/acme-prod")
@@ -141,7 +182,7 @@ struct PRBindingRPCTests {
 
     @Test("pr.detach tombstones and pr.bindings stops returning it")
     func detach() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         _ = try await harness.attach(number: 412)
         #expect(try await harness.detach(number: 412))
         #expect(try await harness.bindings().bindings.isEmpty)
@@ -159,7 +200,7 @@ struct PRBindingRPCTests {
     /// the second must drop it.
     @Test("pr.bindings reports how many bindings are tombstoned")
     func bindingsReportDetachedCount() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         #expect(try await harness.bindings().detachedCount == 0)
 
         _ = try await harness.attach(number: 412)
@@ -195,7 +236,7 @@ struct PRBindingRPCTests {
     /// fan-out never reaches it. One call reports the whole table.
     @Test("pr.bindingsAll returns several worktrees' bindings in one call")
     func bindingsAllAcrossWorktrees() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         let second = try await harness.addWorktree()
         try await harness.attach(number: 412)
         try await harness.attach(number: 413)
@@ -217,7 +258,7 @@ struct PRBindingRPCTests {
     /// legacy-status fallback, so a detach is not silently undone.
     @Test("pr.bindingsAll excludes tombstoned rows and still reports a tombstone-only worktree")
     func bindingsAllReportsTombstones() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         let tombstonedOnly = try await harness.addWorktree()
         try await harness.attach(number: 412)
         try await harness.attach(number: 413)
@@ -239,7 +280,7 @@ struct PRBindingRPCTests {
     /// the response does not grow one entry per worktree in the fleet.
     @Test("pr.bindingsAll omits a worktree that has no bindings at all")
     func bindingsAllOmitsUnboundWorktrees() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         _ = try await harness.addWorktree()
         #expect(try await harness.bindingsAll().worktrees.isEmpty)
 
@@ -250,13 +291,13 @@ struct PRBindingRPCTests {
 
     @Test("pr.detach of an unbound PR reports false rather than erroring")
     func detachUnknown() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         #expect(try await harness.detach(number: 999) == false)
     }
 
     @Test("pr.attach with neither url nor number is an RPC error")
     func attachMissingArgs() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         await #expect(throws: (any Error).self) {
             _ = try await harness.attachRaw(url: nil, number: nil)
         }
@@ -276,7 +317,7 @@ struct PRBindingRPCTests {
 
     @Test("a malformed url is still reported as unusable input")
     func attachRejectsMalformedURL() async throws {
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         await #expect(throws: (any Error).self) {
             _ = try await harness.attachRaw(url: "https://example.com/not/a/pr", number: nil)
         }
@@ -294,7 +335,7 @@ struct PRBindingRPCTests {
     func detachTwiceReportsFalse() async throws {
         // `updateAll` counts matched rows, so the second detach used to print
         // "Detached." for a no-op.
-        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod"))
+        let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))
         _ = try await harness.attach(number: 412)
         #expect(try await harness.detach(number: 412))
         #expect(try await harness.detach(number: 412) == false)

--- a/Tests/TBDDaemonTests/PRBindingRPCTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingRPCTests.swift
@@ -271,6 +271,38 @@ struct PRBindingRPCTests {
         #expect(try await harness.bindings().bindings.isEmpty)
     }
 
+    /// The router half of the cross-forge guard: the coordinator only knows a
+    /// worktree's forge because the router hands it a closure over the same
+    /// `glab`-derived answer `pr.attach <number>` composes URLs from. A closure
+    /// wired to the wrong thing — or to nothing — passes every coordinator-level
+    /// test and still binds here.
+    @Test("pr.attach of a github.com URL is rejected on a GitLab checkout")
+    func attachGitHubURLOnGitLabCheckout() async throws {
+        let harness = try await PRBindingRPCHarness(
+            repo: ("acme", "acme-prod", "git.acme.example"),
+            gitLabHosts: ["git.acme.example"])
+        let attach = try await harness.attach(url: "https://github.com/acme/acme-prod/pull/412")
+        #expect(attach.outcome == "rejectedWrongRepo")
+        // Owner and name match, so the host is the whole disagreement.
+        #expect(attach.detail == "github.com/acme/acme-prod")
+        #expect(attach.binding == nil)
+        #expect(try await harness.bindings().bindings.isEmpty)
+    }
+
+    /// The same URL on a self-hosted host that speaks no GitLab still binds —
+    /// the exemption a host-locked GitHub pattern earns, and the reason the
+    /// rejection above is keyed on the declared forge rather than on the
+    /// hostname not being github.com.
+    @Test("pr.attach of a github.com URL still binds on a non-GitLab self-hosted checkout")
+    func attachGitHubURLOnEnterpriseCheckout() async throws {
+        let harness = try await PRBindingRPCHarness(
+            repo: ("acme", "acme-prod", "ghe.acme.example"),
+            gitLabHosts: ["git.acme.example"])
+        let attach = try await harness.attach(url: "https://github.com/acme/acme-prod/pull/412")
+        #expect(attach.outcome == "bound")
+        #expect(attach.binding?.host == "github.com")
+    }
+
     @Test("pr.detach tombstones and pr.bindings stops returning it")
     func detach() async throws {
         let harness = try await PRBindingRPCHarness(repo: ("acme", "acme-prod", "github.com"))

--- a/Tests/TBDDaemonTests/PRBindingStoreTests.swift
+++ b/Tests/TBDDaemonTests/PRBindingStoreTests.swift
@@ -260,4 +260,43 @@ struct PRBindingStoreTests {
         for n in [30, 10, 20] { _ = try await fixture.store.upsert(binding(n, worktreeID: wt)) }
         #expect(try await fixture.store.list(worktreeID: wt).map(\.number) == [30, 10, 20])
     }
+
+    @Test("a nested namespace survives the identity key, the parse and the unique index")
+    func nestedNamespaceIdentityRoundTrip() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        let url = "https://git.acme.example/acme/platform/backend/api-gateway/-/merge_requests/412"
+        let nested = PRBinding(
+            worktreeID: wt, host: "git.acme.example",
+            owner: "acme/platform/backend", repo: "api-gateway", number: 412,
+            url: url, source: .manual)
+        // Four parts even though the namespace contains slashes — the key is
+        // \u{1}-delimited, so `/` is ordinary data.
+        #expect(nested.identityKey.split(separator: "\u{1}").count == 4)
+        _ = try await fixture.store.upsert(nested)
+        _ = try await fixture.store.upsert(nested)   // idempotent under the unique index
+        let loaded = try await fixture.store.list(worktreeID: wt)
+        #expect(loaded.count == 1)
+        #expect(loaded[0].owner == "acme/platform/backend")
+        #expect(loaded[0].repo == "api-gateway")
+
+        let parsed = PRStatusManager.parseOwnerRepo(fromURL: loaded[0].url)
+        #expect(parsed?.owner == loaded[0].owner)
+        #expect(parsed?.name == loaded[0].repo)
+    }
+
+    @Test("two projects differing only in namespace depth are distinct bindings")
+    func namespaceDepthDistinguishes() async throws {
+        let fixture = try await Fixture()
+        let wt = try await fixture.newWorktree()
+        func nested(owner: String) -> PRBinding {
+            PRBinding(worktreeID: wt, host: "git.acme.example",
+                      owner: owner, repo: "api", number: 1,
+                      url: "https://git.acme.example/\(owner)/api/-/merge_requests/1",
+                      source: .manual)
+        }
+        _ = try await fixture.store.upsert(nested(owner: "acme"))
+        _ = try await fixture.store.upsert(nested(owner: "acme/platform"))
+        #expect(try await fixture.store.list(worktreeID: wt).count == 2)
+    }
 }

--- a/Tests/TBDDaemonTests/PRBranchFactsLiveGitTests.swift
+++ b/Tests/TBDDaemonTests/PRBranchFactsLiveGitTests.swift
@@ -87,7 +87,7 @@ struct PRBranchFactsLiveGitTests {
     private static func node(number: Int, head: String, state: String = "OPEN") -> PRStatusManager.PRNode {
         PRStatusManager.PRNode(
             number: number, url: "https://github.com/acme/acme-prod/pull/\(number)", state: state,
-            mergeStateStatus: "CLEAN", reviewDecision: "", headRefName: head,
+            mergeVerdictRaw: "CLEAN", reviewVerdictRaw: "", headRefName: head,
             createdAt: "2026-07-01T00:00:00Z", isDraft: false,
             statusCheckRollupState: nil, mergeQueuePosition: nil)
     }

--- a/Tests/TBDDaemonTests/PRObservationRecordingTests.swift
+++ b/Tests/TBDDaemonTests/PRObservationRecordingTests.swift
@@ -48,7 +48,7 @@ private actor ScriptedGH {
     func replaceViewer(_ answer: Answer) { viewer = answer }
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
-        if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+        if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
         if query.contains("viewer {") {
             switch viewer {
@@ -311,7 +311,7 @@ struct PRObservationRecordingTests {
         let interrupt = OneShot()
         let manager = PRStatusManager(
             ghRunner: { args, _ in
-                if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+                if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
                 guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
                 // Everything except the viewer batch fails: that outage is what
                 // the user's refresh runs into.

--- a/Tests/TBDDaemonTests/PRPollReconcileTests.swift
+++ b/Tests/TBDDaemonTests/PRPollReconcileTests.swift
@@ -35,7 +35,12 @@ struct PRPollReconcileTests {
         func set(nodesByNumber: [Int: String]) { self.nodesByNumber = nodesByNumber }
 
         func run(args: [String], repoPath: String) -> GHCommandResult? {
-            if args.first == "repo" { return GHCommandResult(stdout: nameWithOwner + "\n") }
+            if args.first == "repo" {
+                // `gh repo view --json nameWithOwner,url` — the url is what
+                // names the host the checkout lives on.
+                return GHCommandResult(stdout: #"{"nameWithOwner":"\#(nameWithOwner)","#
+                    + #""url":"https://github.com/\#(nameWithOwner)"}"#)
+            }
             guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
             if query.contains("commits(last: 1)") { return nil }
             if query.contains("viewer {") {
@@ -135,7 +140,7 @@ struct PRPollReconcileTests {
                 tmux: TmuxManager(dryRun: true),
                 startTime: Date(),
                 prManager: manager,
-                prBindingRepoResolver: { _ in ("acme", "acme-prod") },
+                prBindingRepoResolver: { _ in ("acme", "acme-prod", "github.com") },
                 actuationLog: makeTestActuationLog())
             // Production wires this in `Daemon.swift` too. Without it the poll
             // judges no merge rule at all, and the two ordering findings below

--- a/Tests/TBDDaemonTests/PRPollRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/PRPollRemoteLaneTests.swift
@@ -314,7 +314,7 @@ private actor RecordingGH {
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
         recordedPaths.append(repoPath)
-        if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+        if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
         if query.contains("pullRequests(headRefName:") {
             guard let branch = args.first(where: { $0.hasPrefix("branch=") })?

--- a/Tests/TBDDaemonTests/PRPollerTests.swift
+++ b/Tests/TBDDaemonTests/PRPollerTests.swift
@@ -34,7 +34,7 @@ private actor CountingGH {
     }
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
-        if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+        if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
         guard query.contains("viewer {") else { return nil }
         viewerQueries += 1

--- a/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
+++ b/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
@@ -34,7 +34,11 @@ struct PRProvenanceSeedingTests {
                 displayName: "acme-prod", defaultBranch: "main")
             repoID = created.id
             store = db.prBindings
-            coordinator = PRBindingCoordinator(store: store, resolveRepo: { _ in repo })
+            // No host is configured for `glab`, which is every non-GitLab fleet
+            // at once; seeding never turns on the forge anyway, since the
+            // worktree's own host is what these fixtures parse.
+            coordinator = PRBindingCoordinator(store: store, resolveRepo: { _ in repo },
+                                               isGitLabHost: { _, _ in false })
         }
 
         func newWorktree(prNumber: Int? = nil) async throws -> UUID {

--- a/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
+++ b/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
@@ -26,7 +26,8 @@ struct PRProvenanceSeedingTests {
         let coordinator: PRBindingCoordinator
         let repoID: UUID
 
-        init(repo: (owner: String, name: String)? = ("acme", "acme-prod")) async throws {
+        init(repo: (owner: String, name: String, host: String)? =
+            ("acme", "acme-prod", "github.com")) async throws {
             db = try TBDDatabase(inMemory: true)
             let created = try await db.repos.create(
                 path: "/tmp/prseed-repo-\(UUID().uuidString)",
@@ -120,7 +121,7 @@ struct PRProvenanceSeedingTests {
 
     @Test("a PR number whose PR belongs to a different repo is rejected, not bound")
     func seedingRejectsWrongRepo() async throws {
-        let fixture = try await Fixture(repo: ("acme", "other-repo"))
+        let fixture = try await Fixture(repo: ("acme", "other-repo", "github.com"))
         let wt = try await fixture.newWorktree(prNumber: 412)
 
         let outcome = await fixture.coordinator.seedProvenance(worktreeID: wt, parsed: parsed)
@@ -143,7 +144,8 @@ struct PRProvenanceSeedingTests {
         let router: RPCRouter
         let repoID: UUID
 
-        init(repo: (owner: String, name: String)? = ("acme", "acme-prod")) async throws {
+        init(repo: (owner: String, name: String, host: String)? =
+            ("acme", "acme-prod", "github.com")) async throws {
             let db = try TBDDatabase(inMemory: true)
             self.db = db
             let created = try await db.repos.create(

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -40,7 +40,7 @@ private actor BindingGH {
     }
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
-        if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+        if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
 
         // The per-PR check query interpolates owner/name into the query text and

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -226,10 +226,26 @@ private actor GHCallLog {
 private actor HangingRecheck {
     private var entered = false
     private var released = false
+    /// How many rechecks were issued, so a test can assert a second one never
+    /// was — the whole point of the single-flight gate.
+    private(set) var issued = 0
 
     func hang() async {
         entered = true
+        issued += 1
         while !released { try? await Task.sleep(for: .milliseconds(5)) }
+    }
+
+    /// Whether the issued count is still `count` after `grace`. A recheck is
+    /// issued from a detached task nobody schedules, so "a second one never
+    /// appeared" can only be asserted by giving it a window to appear in.
+    func issuedStayedAt(_ count: Int, for grace: Duration = .milliseconds(500)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: grace)
+        while ContinuousClock.now < deadline {
+            if issued != count { return false }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return issued == count
     }
 
     func release() { released = true }
@@ -804,6 +820,42 @@ struct PRStatusManagerBindingTests {
         // green merely because nothing was ever asked.
         #expect(await recheck.wasEntered())
         await recheck.release()
+    }
+
+    @Test("a project whose recheck is still outstanding is not issued another")
+    func recheckIsSingleFlightPerProject() async throws {
+        // The detached recheck inherits no cancellation and `runCLI` imposes no
+        // timeout, so without a gate a hung endpoint accumulates one `glab`,
+        // one `Process` and its descriptors per tick, forever — and no
+        // reconciler covers a forge CLI subprocess.
+        let gl = GitLabFake()
+        let recheck = HangingRecheck()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in
+                if args.contains(where: { $0.contains("with_merge_status_recheck=true") }) {
+                    await recheck.hang()
+                    return GHCommandResult(stdout: "[]")
+                }
+                return await gl.run(args: args, repoPath: path)
+            },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding()
+
+        _ = await manager.refreshBindings([binding])
+        #expect(await recheck.wasEntered(), "the first poll issued no recheck to be blocked by")
+
+        // A second poll of the same project, while the first recheck hangs.
+        _ = await manager.refreshBindings([binding])
+        #expect(await recheck.issuedStayedAt(1))
+
+        // …and the gate re-arms when the outstanding one ends, so this is a
+        // bound rather than a one-shot.
+        await recheck.release()
+        try await waitFor("the gate to re-arm once the outstanding recheck ended") {
+            _ = await manager.refreshBindings([binding])
+            return await recheck.issued >= 2
+        }
     }
 
     @Test("the recheck asks only about merge requests that can still change")

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -1054,8 +1054,33 @@ struct PRStatusManagerBindingTests {
         #expect(await manager.allStatuses()[wt] == nil)
         #expect(await merges.count == 0)
         #expect(await gh.graphQLQueries.isEmpty)
-        #expect(await manager.observation(for: wt)?.outcome
-                == .undetermined(cause: PRUndeterminedCause.forgeNotQueryableDirectly))
+        // Declining to ask gh is not an attempt that failed. A worktree with no
+        // outcome on record still has none — asserting one would light the "PR
+        // status unknown" indicator on a worktree nothing was ever asked about.
+        #expect(await manager.observation(for: wt) == nil)
+    }
+
+    @Test("a manual refresh on a GitLab worktree leaves its last observation standing")
+    func refreshKeepsTheGitLabObservation() async {
+        // `pr.refresh` is a user gesture. A GitLab worktree whose bindings poll
+        // perfectly must not answer it with "last check did not resolve" — the
+        // binding poll settles this worktree, and its word stands until it has
+        // a new one.
+        let gh = MirrorGH()
+        let manager = Self.mirrorManager(gh)
+        let wt = UUID()
+        let polled = Date(timeIntervalSince1970: 1_770_000_000)
+        await manager.hydrateObservations([wt: PRObservation(outcome: .observed, observedAt: polled)])
+
+        _ = await manager.refresh(
+            worktreeID: wt, branch: "tbd/my-branch", upstreamBranch: "main",
+            defaultBranch: "main", pushBranch: .noPushDestination,
+            repoPath: "/wt/api-gateway")
+
+        let observation = await manager.observation(for: wt)
+        #expect(observation?.outcome == .observed)
+        #expect(observation?.observedAt == polled)
+        #expect(await gh.graphQLQueries.isEmpty)
     }
 
     @Test("a stored number on a GitLab worktree is never offered to gh")

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -1,7 +1,9 @@
+import Clocks
 import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 // MARK: - Injected `gh`
 
@@ -258,6 +260,43 @@ private actor HangingRecheck {
             try? await Task.sleep(for: .milliseconds(5))
         }
         return entered
+    }
+}
+
+/// A mergeability recheck that never answers until something cancels it.
+///
+/// Cancellation is the observable stand-in for the kill: production's `runCLI`
+/// turns exactly this cancellation into a `terminate()` on the `glab` child, so
+/// a recheck that observes it is one whose subprocess ends.
+private actor CancellableRecheck {
+    private var entered = false
+    private var cancelled = false
+
+    func hangUntilCancelled() async {
+        entered = true
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        cancelled = true
+    }
+
+    /// Polled, because the recheck is issued from a detached task whose
+    /// scheduling no test owns. The bound under test is virtual time; these
+    /// waits only cover that scheduling.
+    func wasEntered(within timeout: Duration = .seconds(10)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !entered && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return entered
+    }
+
+    func wasCancelled(within timeout: Duration = .seconds(10)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !cancelled && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return cancelled
     }
 }
 
@@ -856,6 +895,40 @@ struct PRStatusManagerBindingTests {
             _ = await manager.refreshBindings([binding])
             return await recheck.issued >= 2
         }
+    }
+
+    @Test("a hung mergeability recheck is terminated once its deadline elapses",
+          .clockDriven)
+    func recheckIsBoundedByADeadline() async {
+        // Single-flight caps how MANY rechecks are live and can never end one:
+        // a `glab` that hangs stays for the life of the daemon, and no
+        // reconciler covers a forge CLI subprocess. The deadline is the half
+        // that caps the LIFETIME, and it has to reach the call itself —
+        // cancellation, which `runCLI` turns into a terminate on the child —
+        // rather than merely stop this side waiting for it.
+        let clock = TestClock()
+        let gl = GitLabFake()
+        let recheck = CancellableRecheck()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in
+                if args.contains(where: { $0.contains("with_merge_status_recheck=true") }) {
+                    await recheck.hangUntilCancelled()
+                    return nil
+                }
+                return await gl.run(args: args, repoPath: path)
+            },
+            gitLabHosts: [Self.gitLabHost],
+            clock: clock)
+
+        _ = await manager.refreshBindings([Self.gitLabBinding()])
+        #expect(await recheck.wasEntered(), "no recheck was issued for a deadline to bound")
+
+        // Virtual time: the bound is proven without spending it.
+        await clock.advanceWhenSuspended(by: PRStatusManager.recheckTimeout)
+
+        #expect(await recheck.wasCancelled(),
+                "the recheck was still running after its deadline elapsed")
     }
 
     @Test("the recheck asks only about merge requests that can still change")

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -172,7 +172,7 @@ private actor GitLabFake {
         """
         {"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":true,
         "mergeRequests":{"nodes":[{"iid":"\(iid)","state":"opened","draft":false,
-        "detailedMergeStatus":"\(detailedMergeStatus)","conflicts":false,
+        "detailedMergeStatus":"\(detailedMergeStatus)",
         "sourceBranch":"\(sourceBranch)","targetBranch":"main",
         "createdAt":"2026-08-01T10:00:00Z",
         "webUrl":"https://\(host)/\(projectPath)/-/merge_requests/\(iid)",

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -262,6 +262,60 @@ private actor OneShot<Value: Sendable> {
     }
 }
 
+/// A `gh` that disowns the checkout — as it does on every GitLab remote — and
+/// would still answer any GraphQL query put to it, because a FLAT GitLab
+/// namespace is a valid GitHub coordinate and a same-named repository on
+/// github.com really does answer for it.
+///
+/// Every answer here is MERGED: on the wrong forge that is the destructive one,
+/// since it drives the merged-transition machinery (auto-archive included).
+private actor MirrorGH {
+    private(set) var graphQLQueries: [String] = []
+
+    private static let disownment = GHCommandResult(
+        stdout: "",
+        stderr: "none of the git remotes configured for this repository point to a known GitHub host",
+        exitStatus: 1)
+
+    func run(args: [String]) -> GHCommandResult? {
+        if args.first == "repo" { return Self.disownment }
+        guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
+        graphQLQueries.append(query)
+        if query.contains("title") {
+            // `openPRsQuery` — the branch picker's list.
+            return GHCommandResult(stdout: """
+            {"data":{"repository":{"pullRequests":{"nodes":[
+            {"number":77,"title":"Mirror pull request","headRefName":"tbd/my-branch",
+             "isDraft":false,"isCrossRepository":false,
+             "headRepositoryOwner":{"login":"acme"}}]}}}}
+            """)
+        }
+        if query.contains("pullRequest(number:") {
+            return GHCommandResult(stdout: """
+            {"data":{"repository":{"pr0":\(Self.mergedNode)}}}
+            """)
+        }
+        return GHCommandResult(stdout: """
+        {"data":{"repository":{"pullRequests":{"nodes":[\(Self.mergedNode)]}}}}
+        """)
+    }
+
+    private static let mergedNode = """
+    {"number":77,"url":"https://github.com/acme/api-gateway/pull/77","state":"MERGED",
+     "mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","headRefName":"tbd/my-branch",
+     "baseRefName":"main","createdAt":"2026-08-01T00:00:00Z","isDraft":false,
+     "statusCheckRollup":{"state":"SUCCESS"}}
+    """
+}
+
+/// Records every merged transition the manager fires — the edge that reaches
+/// auto-archive and auto-hibernate.
+private actor MergedTransitions {
+    private(set) var fired: [(worktreeID: UUID, number: Int)] = []
+    func record(_ worktreeID: UUID, _ number: Int) { fired.append((worktreeID, number)) }
+    var count: Int { fired.count }
+}
+
 /// A token that expires and is later re-issued, so one test can watch a host
 /// go dark and come back.
 private actor AuthGate {
@@ -907,6 +961,98 @@ struct PRStatusManagerBindingTests {
 
         let outcome = await manager.observation(for: wt)?.outcome
         #expect(outcome == .undetermined(cause: PRUndeterminedCause.unparseableResponse))
+    }
+
+    // MARK: - Cross-forge containment
+
+    /// A GitLab project whose namespace is FLAT, so its owner/name are also
+    /// valid GitHub coordinates — 21% of sampled projects, and the shape where
+    /// a wrong-forge query does not fail but answers.
+    private static func flatGitLabWorktree(
+        _ id: UUID, prNumber: Int? = nil
+    ) -> PRStatusManager.PollWorktree {
+        (id: id, branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: "main",
+         pushBranch: .noPushDestination, worktreePath: "/wt/api-gateway", prNumber: prNumber)
+    }
+
+    private static func mirrorManager(
+        _ gh: MirrorGH
+    ) -> PRStatusManager {
+        PRStatusManager(
+            ghRunner: { args, _ in await gh.run(args: args) },
+            glRunner: { _, _ in nil },
+            gitLabHosts: [Self.gitLabHost],
+            remoteURLReader: { _ in "https://git.acme.example/acme/api-gateway.git" })
+    }
+
+    @Test("an on-select refresh never writes a GitHub pull request onto a GitLab worktree")
+    func refreshDoesNotCrossForges() async {
+        let gh = MirrorGH()
+        let manager = Self.mirrorManager(gh)
+        let merges = MergedTransitions()
+        await manager.setOnMergedTransition { id, number in await merges.record(id, number) }
+        let wt = UUID()
+
+        let status = await manager.refresh(
+            worktreeID: wt, branch: "tbd/my-branch", upstreamBranch: "main",
+            defaultBranch: "main", pushBranch: .noPushDestination,
+            repoPath: "/wt/api-gateway")
+
+        #expect(status == nil)
+        #expect(await manager.allStatuses()[wt] == nil)
+        #expect(await merges.count == 0)
+        #expect(await gh.graphQLQueries.isEmpty)
+        #expect(await manager.observation(for: wt)?.outcome
+                == .undetermined(cause: PRUndeterminedCause.forgeNotQueryableDirectly))
+    }
+
+    @Test("a stored number on a GitLab worktree is never offered to gh")
+    func refreshByNumberDoesNotCrossForges() async {
+        // The by-number route is the one that reaches a pull request the branch
+        // query cannot, so it is also the one that reaches the wrong forge's.
+        let gh = MirrorGH()
+        let manager = Self.mirrorManager(gh)
+        let merges = MergedTransitions()
+        await manager.setOnMergedTransition { id, number in await merges.record(id, number) }
+        let wt = UUID()
+
+        let status = await manager.refresh(
+            worktreeID: wt, branch: "tbd/my-branch", upstreamBranch: "main",
+            defaultBranch: "main", pushBranch: .noPushDestination,
+            repoPath: "/wt/api-gateway", prNumber: 77)
+
+        #expect(status == nil)
+        #expect(await merges.count == 0)
+        #expect(await gh.graphQLQueries.isEmpty)
+    }
+
+    @Test("the poll's by-number path cannot auto-archive a GitLab worktree on a GitHub PR")
+    func pollByNumberDoesNotCrossForges() async {
+        let gh = MirrorGH()
+        let manager = Self.mirrorManager(gh)
+        let merges = MergedTransitions()
+        await manager.setOnMergedTransition { id, number in await merges.record(id, number) }
+        let wt = UUID()
+
+        _ = await manager.fetchAll(worktrees: [Self.flatGitLabWorktree(wt, prNumber: 77)])
+
+        #expect(await manager.allStatuses()[wt] == nil)
+        #expect(await merges.count == 0)
+        #expect(await gh.graphQLQueries.isEmpty)
+    }
+
+    @Test("the open-PR picker does not offer a GitLab repo another forge's pull requests")
+    func openPRPickerDoesNotCrossForges() async {
+        // Listing GitLab merge requests is not built, so an empty list is the
+        // honest answer — a list of somebody else's pull requests is not, and
+        // creating a worktree from one would check out a foreign branch.
+        let gh = MirrorGH()
+        let manager = Self.mirrorManager(gh)
+
+        let prs = await manager.fetchOpenPRs(repoPath: "/wt/api-gateway")
+
+        #expect(prs.isEmpty)
+        #expect(await gh.graphQLQueries.isEmpty)
     }
 
     // MARK: - Authentication failure

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -1112,6 +1112,40 @@ struct PRStatusManagerBindingTests {
         #expect(observed[binding.id]?.status == previous)
     }
 
+    @Test("a credential refusal on the binding path reaches the worktree, not just a log")
+    func authFailureIsReportedOnTheBindingPath() async {
+        // Once a GitLab worktree has a binding, this is the path that polls it.
+        // A personal access token has no refresh, so an expired one refuses
+        // every tick from here on: keeping the last value is right, and saying
+        // nothing about it is what leaves every chip frozen and unexplained.
+        let wt = UUID()
+        let previous = PRStatus(number: 412, url: Self.gitLabMRURL, state: .mergeable)
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { _, _ in
+                GHCommandResult(stdout: "", stderr: "401 Unauthorized", exitStatus: 1)
+            },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding(worktreeID: wt, status: previous)
+
+        let observed = await manager.refreshBindings([binding])
+
+        #expect(observed[binding.id]?.status == previous)
+        #expect(await manager.observation(for: wt)?.outcome
+                == .undetermined(cause: PRUndeterminedCause.forgeAuthFailed(host: Self.gitLabHost)))
+
+        // And deliberately only the refusal: a query that merely failed is
+        // reconfirmed by the next tick, and recording it here would relabel a
+        // worktree whose other bindings were read perfectly well this pass.
+        let other = UUID()
+        let quiet = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { _, _ in nil },
+            gitLabHosts: [Self.gitLabHost])
+        _ = await quiet.refreshBindings([Self.gitLabBinding(worktreeID: other)])
+        #expect(await quiet.observation(for: other) == nil)
+    }
+
     @Test("a host that answers again retracts its recorded refusal")
     func successClearsAuthFailure() async {
         // A token is re-issued and the host works; only a call succeeding is

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -931,6 +931,126 @@ struct PRStatusManagerBindingTests {
                 "the recheck was still running after its deadline elapsed")
     }
 
+    @Test("a recheck child that ignores SIGTERM is killed by its deadline",
+          .clockDriven)
+    func recheckChildIsKilledWhenItIgnoresSIGTERM() async throws {
+        // The deadline above proves the Swift task stops waiting. This proves
+        // the thing that actually matters: a real OS process is gone by the
+        // bound. The injected runner drives `runCLI` — the production
+        // subprocess path, cancellation handler and all — with a child that
+        // installs SIG_IGN for SIGTERM and then `exec`s, so the ignore survives
+        // into a single long-lived process whose pid never changes. SIGTERM
+        // alone leaves it running, `withTaskGroup` awaits it before returning,
+        // and the recheck task plus that project's single-flight gate stay
+        // wedged for as long as it lives — well past the 60 s the design leans
+        // on to argue no reconciler is needed.
+        let clock = TestClock()
+        let gl = GitLabFake()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-glab-kill-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // The child reports its own pid: `$$` is the shell's, and `exec` keeps
+        // it, so this is the pid of the `sleep` the deadline has to reach.
+        let pidFile = dir.appendingPathComponent("child.pid")
+        // Nothing reclaims a forge CLI subprocess, this suite included: if the
+        // assertion below fails the child is still out there, so end it here.
+        defer {
+            if let text = try? String(contentsOf: pidFile, encoding: .utf8),
+               let leaked = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                kill(leaked, SIGKILL)
+            }
+        }
+
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in
+                guard args.contains(where: { $0.contains("with_merge_status_recheck=true") })
+                else { return await gl.run(args: args, repoPath: path) }
+                return await PRStatusManager.runCLI(
+                    executable: "/bin/sh",
+                    args: ["-c", "trap '' TERM; echo $$ > '\(pidFile.path)'; exec sleep 120"],
+                    repoPath: dir.path,
+                    clock: clock)
+            },
+            gitLabHosts: [Self.gitLabHost],
+            clock: clock)
+
+        _ = await manager.refreshBindings([Self.gitLabBinding()])
+
+        try await waitFor("the recheck child to report its pid") {
+            (try? String(contentsOf: pidFile, encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        }
+        let childPID = try #require(pid_t(
+            String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)))
+        #expect(kill(childPID, 0) == 0, "the child was not running for the deadline to end")
+
+        // Virtual time: the deadline fires, then the grace after SIGTERM.
+        await clock.advanceWhenSuspended(by: PRStatusManager.recheckTimeout)
+        let died = await clock.advanceUntil(
+            "the SIGTERM-immune recheck child to be killed", by: PRStatusManager.childKillGrace
+        ) { kill(childPID, 0) != 0 && errno == ESRCH }
+
+        #expect(died, "the child outlived its deadline: SIGTERM alone cannot end it")
+    }
+
+    @Test("a recheck child that honours SIGTERM ends without waiting out the grace",
+          .clockDriven)
+    func recheckChildThatHonoursSIGTERMIsNotWaitedOn() async throws {
+        // The other branch of the escalation, and the reason it is a grace
+        // rather than an immediate SIGKILL: the ordinary child — a `glab` that
+        // takes the signal and exits — is gone the moment the deadline fires,
+        // with no advance past it. The wait below spends real time and no
+        // virtual time at all, so a build that had started killing children
+        // outright would still pass here while the previous test is what pins
+        // the grace being spent only on a child that needs it.
+        let clock = TestClock()
+        let gl = GitLabFake()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-glab-term-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pidFile = dir.appendingPathComponent("child.pid")
+        defer {
+            if let text = try? String(contentsOf: pidFile, encoding: .utf8),
+               let leaked = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                kill(leaked, SIGKILL)
+            }
+        }
+
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in
+                guard args.contains(where: { $0.contains("with_merge_status_recheck=true") })
+                else { return await gl.run(args: args, repoPath: path) }
+                return await PRStatusManager.runCLI(
+                    executable: "/bin/sh",
+                    args: ["-c", "echo $$ > '\(pidFile.path)'; exec sleep 120"],
+                    repoPath: dir.path,
+                    clock: clock)
+            },
+            gitLabHosts: [Self.gitLabHost],
+            clock: clock)
+
+        _ = await manager.refreshBindings([Self.gitLabBinding()])
+
+        try await waitFor("the recheck child to report its pid") {
+            (try? String(contentsOf: pidFile, encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        }
+        let childPID = try #require(pid_t(
+            String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)))
+
+        await clock.advanceWhenSuspended(by: PRStatusManager.recheckTimeout)
+
+        try await waitFor("the recheck child to exit on SIGTERM alone") {
+            kill(childPID, 0) != 0 && errno == ESRCH
+        }
+    }
+
     @Test("the recheck asks only about merge requests that can still change")
     func recheckSkipsTerminalMergeRequests() async {
         // A merged merge request has a mergeability nobody will recompute and

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -739,6 +739,33 @@ struct PRStatusManagerBindingTests {
         #expect(await manager.observation(for: wt)?.outcome == PRObservation.Outcome.none)
     }
 
+    @Test("a GitLab project the query could not read records undetermined, not none")
+    func gitLabProjectErrorIsUndetermined() async {
+        // A renamed project, or a token that lost read_api on this one, comes
+        // back as a GraphQL errors array with `data: null`. The forge did not
+        // answer the question, so recording "this worktree has no merge
+        // request" would flip every worktree on the project dark and silent.
+        let wt = UUID()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, _ in
+                guard args.contains(where: { $0.hasPrefix("query=") }) else { return nil }
+                return GHCommandResult(stdout: """
+                {"errors":[{"message":"unknown project","extensions":{"code":"undefinedField"}}],
+                "data":null}
+                """)
+            },
+            gitLabHosts: [Self.gitLabHost],
+            remoteURLReader: { _ in
+                "https://git.acme.example/acme/platform/api-gateway.git"
+            })
+
+        _ = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
+
+        let outcome = await manager.observation(for: wt)?.outcome
+        #expect(outcome == .undetermined(cause: PRUndeterminedCause.unparseableResponse))
+    }
+
     // MARK: - Authentication failure
 
     @Test("an auth failure names the host instead of degrading to no-forge")

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -123,18 +123,38 @@ private actor GitLabFake {
     private(set) var hostnameFlagAlwaysPresent = true
     private(set) var hostnamesSeen: [String] = []
 
+    /// The state of the merge request this project answers with, and — when
+    /// set — a second, already-merged one beside it.
+    private let state: String
+    private let mergedIID: Int?
+
     init(host: String = "git.acme.example",
          projectPath: String = "acme/platform/api-gateway",
          iid: Int = 412,
          sourceBranch: String = "tbd/my-branch",
          detailedMergeStatus: String = "NOT_APPROVED",
+         state: String = "opened",
+         mergedIID: Int? = nil,
          refusal: GHCommandResult? = nil) {
         self.host = host
         self.projectPath = projectPath
         self.iid = iid
         self.sourceBranch = sourceBranch
         self.detailedMergeStatus = detailedMergeStatus
+        self.state = state
+        self.mergedIID = mergedIID
         self.refusal = refusal
+    }
+
+    /// Wait for the mergeability recheck to arrive, up to `timeout`. It is
+    /// issued from a detached task, so a test that asserts on it must wait for
+    /// it rather than assume the refresh already ran it.
+    func waitForRecheck(within timeout: Duration = .seconds(10)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !sawRecheck && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return sawRecheck
     }
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
@@ -169,14 +189,22 @@ private actor GitLabFake {
     /// escapes — so a mis-escaped fixture cannot silently exercise the
     /// parse-failure path instead of the one under test.
     private var nodeResponse: String {
-        """
+        let nodes = [node(iid: iid, state: state)]
+            + (mergedIID.map { [node(iid: $0, state: "merged")] } ?? [])
+        return """
         {"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":true,
-        "mergeRequests":{"nodes":[{"iid":"\(iid)","state":"opened","draft":false,
+        "mergeRequests":{"nodes":[\(nodes.joined(separator: ","))]}}}}
+        """
+    }
+
+    private func node(iid: Int, state: String) -> String {
+        """
+        {"iid":"\(iid)","state":"\(state)","draft":false,
         "detailedMergeStatus":"\(detailedMergeStatus)",
         "sourceBranch":"\(sourceBranch)","targetBranch":"main",
         "createdAt":"2026-08-01T10:00:00Z",
         "webUrl":"https://\(host)/\(projectPath)/-/merge_requests/\(iid)",
-        "headPipeline":{"status":"SUCCESS"}}]}}}}
+        "headPipeline":{"status":"SUCCESS"}}
         """
     }
 }
@@ -190,6 +218,47 @@ private actor GHCallLog {
             viewerQueries += 1
         }
         return nil
+    }
+}
+
+/// A mergeability recheck that never returns until the test lets it, so a test
+/// can assert what the poll does *while* one is outstanding.
+private actor HangingRecheck {
+    private var entered = false
+    private var released = false
+
+    func hang() async {
+        entered = true
+        while !released { try? await Task.sleep(for: .milliseconds(5)) }
+    }
+
+    func release() { released = true }
+
+    /// Whether the recheck was reached within `timeout`. Polled, because it is
+    /// issued from a detached task whose scheduling no test owns.
+    func wasEntered(within timeout: Duration = .seconds(10)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !entered && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return entered
+    }
+}
+
+/// A value some other task produces, awaited with a deadline — so a test that
+/// asserts "this call does not wait for that one" fails on a timer instead of
+/// hanging the whole suite when it does.
+private actor OneShot<Value: Sendable> {
+    private var stored: Value?
+
+    func fulfil(_ value: Value) { stored = value }
+
+    func value(within timeout: Duration = .seconds(10)) async -> Value? {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while stored == nil && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return stored
     }
 }
 
@@ -602,7 +671,7 @@ struct PRStatusManagerBindingTests {
         #expect(observed[binding.id]?.headBranch == "tbd/my-branch")
         #expect(observed[binding.id]?.baseRef == "main")
         #expect(await gl.sawGraphQL)
-        #expect(await gl.sawRecheck)
+        #expect(await gl.waitForRecheck())
         // Outside a GitLab checkout `glab api` defaults to gitlab.com, so a
         // missing --hostname would answer confidently about the wrong instance.
         #expect(await gl.hostnameFlagAlwaysPresent)
@@ -619,6 +688,7 @@ struct PRStatusManagerBindingTests {
 
         _ = await manager.refreshBindings([Self.gitLabBinding()])
 
+        #expect(await gl.waitForRecheck())
         let args = await gl.recheckArgs
         // A `-f` would flip `glab api` from GET to POST, which this endpoint
         // does not answer.
@@ -647,6 +717,79 @@ struct PRStatusManagerBindingTests {
         let observed = await manager.refreshBindings([binding])
 
         #expect(observed[binding.id]?.status.state == .mergeable)
+    }
+
+    @Test("a hanging mergeability recheck cannot stall the poll that issued it")
+    func recheckDoesNotBlockThePoll() async {
+        // `runCLI` imposes no timeout, `refreshBindings` walks its groups one at
+        // a time and `fetchAll` skips its next poll while one is running — so a
+        // recheck that hangs would stop PR polling for the whole fleet with no
+        // deadline to end it. Nothing in the pass reads its answer, so nothing
+        // in the pass may wait for it.
+        let gl = GitLabFake()
+        let recheck = HangingRecheck()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in
+                if args.contains(where: { $0.contains("with_merge_status_recheck=true") }) {
+                    await recheck.hang()
+                    return GHCommandResult(stdout: "[]")
+                }
+                return await gl.run(args: args, repoPath: path)
+            },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding()
+        let refreshed = OneShot<[UUID: PRStatusManager.PRBindingObservation]>()
+
+        Task { await refreshed.fulfil(await manager.refreshBindings([binding])) }
+        let observed = await refreshed.value()
+
+        #expect(observed?[binding.id]?.status.state == .mergeable,
+                "refreshBindings did not return while the recheck was still outstanding")
+        // …and the recheck really was outstanding, so the pass above is not
+        // green merely because nothing was ever asked.
+        #expect(await recheck.wasEntered())
+        await recheck.release()
+    }
+
+    @Test("the recheck asks only about merge requests that can still change")
+    func recheckSkipsTerminalMergeRequests() async {
+        // A merged merge request has a mergeability nobody will recompute and
+        // nobody will read, so asking for it spends a job on someone else's
+        // server to learn nothing.
+        let gl = GitLabFake(mergedIID: 500)
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost])
+        let wt = UUID()
+
+        _ = await manager.refreshBindings([
+            Self.gitLabBinding(worktreeID: wt, number: 412),
+            Self.gitLabBinding(worktreeID: wt, number: 500)
+        ])
+
+        #expect(await gl.waitForRecheck())
+        let args = await gl.recheckArgs
+        #expect(args.contains { $0.contains("iids%5B%5D=412") })
+        #expect(!args.contains { $0.contains("iids%5B%5D=500") })
+    }
+
+    @Test("a group with nothing left to settle issues no recheck at all")
+    func terminalOnlyGroupSkipsTheRecheck() async {
+        let gl = GitLabFake(state: "merged")
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding()
+
+        let observed = await manager.refreshBindings([binding])
+
+        #expect(observed[binding.id]?.status.state == .merged)
+        // No task is created, so there is nothing to race: the recheck the old
+        // code awaited inline would already have been seen by now.
+        #expect(await gl.sawRecheck == false)
     }
 
     @Test("a GitHub binding group never invokes glab")

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -97,6 +97,109 @@ private actor BindingGH {
     }
 }
 
+// MARK: - Injected `glab`
+
+/// A stand-in for the `glab` CLI answering the three shapes the GitLab path
+/// issues: the batched `mergeRequests(iids:)` read, the author-blind
+/// `sourceBranches` read, and the REST mergeability recheck.
+///
+/// It records which shapes it saw and whether `--hostname` was on every one of
+/// them — the flag whose absence would not fail but would silently answer about
+/// gitlab.com instead of the configured instance.
+private actor GitLabFake {
+    private let host: String
+    private let projectPath: String
+    private let iid: Int
+    private let sourceBranch: String
+    private let detailedMergeStatus: String
+    /// When set, every call answers with this instead — the expired-token shape.
+    private let refusal: GHCommandResult?
+
+    private(set) var callCount = 0
+    private(set) var sawGraphQL = false
+    private(set) var sawSourceBranches = false
+    private(set) var sawRecheck = false
+    private(set) var recheckArgs: [String] = []
+    private(set) var hostnameFlagAlwaysPresent = true
+    private(set) var hostnamesSeen: [String] = []
+
+    init(host: String = "git.acme.example",
+         projectPath: String = "acme/platform/api-gateway",
+         iid: Int = 412,
+         sourceBranch: String = "tbd/my-branch",
+         detailedMergeStatus: String = "NOT_APPROVED",
+         refusal: GHCommandResult? = nil) {
+        self.host = host
+        self.projectPath = projectPath
+        self.iid = iid
+        self.sourceBranch = sourceBranch
+        self.detailedMergeStatus = detailedMergeStatus
+        self.refusal = refusal
+    }
+
+    func run(args: [String], repoPath: String) -> GHCommandResult? {
+        callCount += 1
+        if let index = args.firstIndex(of: "--hostname"), index + 1 < args.count {
+            hostnamesSeen.append(args[index + 1])
+        } else {
+            hostnameFlagAlwaysPresent = false
+        }
+        if let refusal { return refusal }
+
+        if let query = args.first(where: { $0.hasPrefix("query=") }) {
+            sawGraphQL = true
+            if query.contains("sourceBranches:") {
+                sawSourceBranches = true
+                guard query.contains("\"\(sourceBranch)\"") else { return Self.emptyProject }
+            }
+            return GHCommandResult(stdout: nodeResponse)
+        }
+        if args.contains(where: { $0.contains("with_merge_status_recheck=true") }) {
+            sawRecheck = true
+            recheckArgs = args
+            return GHCommandResult(stdout: "[]")
+        }
+        return nil
+    }
+
+    private static let emptyProject = GHCommandResult(
+        stdout: #"{"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":true,"mergeRequests":{"nodes":[]}}}}"#)
+
+    /// Written with a plain `"""` literal and interpolation — no backslash
+    /// escapes — so a mis-escaped fixture cannot silently exercise the
+    /// parse-failure path instead of the one under test.
+    private var nodeResponse: String {
+        """
+        {"data":{"project":{"onlyAllowMergeIfPipelineSucceeds":true,
+        "mergeRequests":{"nodes":[{"iid":"\(iid)","state":"opened","draft":false,
+        "detailedMergeStatus":"\(detailedMergeStatus)","conflicts":false,
+        "sourceBranch":"\(sourceBranch)","targetBranch":"main",
+        "createdAt":"2026-08-01T10:00:00Z",
+        "webUrl":"https://\(host)/\(projectPath)/-/merge_requests/\(iid)",
+        "headPipeline":{"status":"SUCCESS"}}]}}}}
+        """
+    }
+}
+
+/// A `gh` that can answer nothing, only count what it was asked.
+private actor GHCallLog {
+    private(set) var viewerQueries = 0
+
+    func record(_ args: [String]) -> GHCommandResult? {
+        if args.contains(where: { $0.hasPrefix("query=") && $0.contains("viewer {") }) {
+            viewerQueries += 1
+        }
+        return nil
+    }
+}
+
+/// A token that expires and is later re-issued, so one test can watch a host
+/// go dark and come back.
+private actor AuthGate {
+    private(set) var refuses = true
+    func reissueToken() { refuses = false }
+}
+
 @Suite("PRStatusManager binding refresh")
 struct PRStatusManagerBindingTests {
 
@@ -460,6 +563,287 @@ struct PRStatusManagerBindingTests {
 
         #expect(emitted.isEmpty)
         #expect(await manager.allStatuses()[wt]?.number == 77)
+    }
+
+    // MARK: - GitLab routing
+
+    private static let gitLabHost = "git.acme.example"
+    private static let gitLabNamespace = "acme/platform"
+    private static let gitLabProject = "api-gateway"
+    private static let gitLabMRURL =
+        "https://git.acme.example/acme/platform/api-gateway/-/merge_requests/412"
+
+    private static func gitLabBinding(
+        worktreeID: UUID = UUID(), number: Int = 412, status: PRStatus? = nil
+    ) -> PRBinding {
+        PRBinding(
+            worktreeID: worktreeID, host: gitLabHost, owner: gitLabNamespace,
+            repo: gitLabProject, number: number, url: gitLabMRURL,
+            status: status, source: .manual)
+    }
+
+    @Test("a GitLab binding group queries glab and maps through the GitLab arm")
+    func gitLabGroupRefresh() async {
+        let gl = GitLabFake()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding()
+
+        let observed = await manager.refreshBindings([binding])
+
+        // NOT_APPROVED with a green gating pipeline is GitLab's "only an
+        // approval is missing" — the GitHub arm would read the same string as
+        // an unknown merge state and never produce this.
+        #expect(observed[binding.id]?.status.state == .mergeable)
+        #expect(observed[binding.id]?.status.number == 412)
+        #expect(observed[binding.id]?.status.url == Self.gitLabMRURL)
+        #expect(observed[binding.id]?.headBranch == "tbd/my-branch")
+        #expect(observed[binding.id]?.baseRef == "main")
+        #expect(await gl.sawGraphQL)
+        #expect(await gl.sawRecheck)
+        // Outside a GitLab checkout `glab api` defaults to gitlab.com, so a
+        // missing --hostname would answer confidently about the wrong instance.
+        #expect(await gl.hostnameFlagAlwaysPresent)
+        #expect(Set(await gl.hostnamesSeen) == [Self.gitLabHost])
+    }
+
+    @Test("the mergeability recheck carries its parameters in the path, not as fields")
+    func recheckStaysAGet() async {
+        let gl = GitLabFake()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost])
+
+        _ = await manager.refreshBindings([Self.gitLabBinding()])
+
+        let args = await gl.recheckArgs
+        // A `-f` would flip `glab api` from GET to POST, which this endpoint
+        // does not answer.
+        #expect(!args.contains("-f"))
+        #expect(args.contains { $0.contains("iids%5B%5D=412") })
+        #expect(args.contains { $0.hasPrefix("projects/") })
+    }
+
+    @Test("a failing recheck cannot disturb the statuses the poll already read")
+    func recheckFailureIsDiscarded() async {
+        // The recheck queues work on someone else's server and returns nothing
+        // TBD reads, so its failure is not this poll's business.
+        let gl = GitLabFake()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in
+                if args.contains(where: { $0.contains("with_merge_status_recheck=true") }) {
+                    return GHCommandResult(stdout: "", stderr: "500 Internal Server Error",
+                                           exitStatus: 1)
+                }
+                return await gl.run(args: args, repoPath: path)
+            },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding()
+
+        let observed = await manager.refreshBindings([binding])
+
+        #expect(observed[binding.id]?.status.state == .mergeable)
+    }
+
+    @Test("a GitHub binding group never invokes glab")
+    func gitHubGroupSkipsGlab() async {
+        let gl = GitLabFake()
+        let gh = BindingGH(nodes: [
+            BindingGH.key(owner: "acme", repo: "acme-prod", number: 412):
+                Self.nodeJSON(number: 412)
+        ])
+        let manager = PRStatusManager(
+            ghRunner: { args, path in await gh.run(args: args, repoPath: path) },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.binding(412, worktreeID: UUID())
+
+        let observed = await manager.refreshBindings([binding])
+
+        #expect(observed[binding.id]?.status.state == .mergeable)
+        #expect(await gl.callCount == 0)
+        #expect(await gh.aliasedQueries.count == 1)
+    }
+
+    @Test("branch matching finds a GitLab merge request opened by someone else")
+    func gitLabBranchMatch() async {
+        // `sourceBranches` has no author filter, so this is the route that finds
+        // a merge request opened through the web UI or by another account —
+        // GitHub's viewer batch structurally cannot.
+        let gl = GitLabFake()
+        let wt = UUID()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost],
+            remoteURLReader: { _ in
+                "https://git.acme.example/acme/platform/api-gateway.git"
+            })
+
+        let outcome = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
+
+        #expect(await gl.sawSourceBranches)
+        #expect(await manager.allStatuses()[wt]?.number == 412)
+        #expect(await manager.allStatuses()[wt]?.state == .mergeable)
+        #expect(outcome.discovered.count == 1)
+        #expect(outcome.discovered.first?.worktreeID == wt)
+        #expect(outcome.discovered.first?.parsed.number == 412)
+        #expect(outcome.discovered.first?.parsed.host == Self.gitLabHost)
+        #expect(outcome.discovered.first?.parsed.owner == Self.gitLabNamespace)
+        #expect(outcome.discovered.first?.parsed.repo == Self.gitLabProject)
+        #expect(await manager.observation(for: wt)?.outcome == .observed)
+    }
+
+    @Test("a GitLab-only fleet never asks gh for the viewer batch")
+    func gitLabOnlyFleetSkipsViewerBatch() async {
+        // `gh` cannot name this checkout — it is not a host it speaks to — so
+        // identity comes from the remote, and nothing on this fleet is GitHub.
+        // The viewer batch is then not merely fruitless but never issued.
+        let gl = GitLabFake()
+        let gh = GHCallLog()
+        let manager = PRStatusManager(
+            ghRunner: { args, _ in await gh.record(args) },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost],
+            remoteURLReader: { _ in
+                "https://git.acme.example/acme/platform/api-gateway.git"
+            })
+
+        let wt = UUID()
+        _ = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
+
+        #expect(await gh.viewerQueries == 0)
+        // And the GitLab side still answered, so this is not a vacuous pass.
+        #expect(await manager.allStatuses()[wt]?.number == 412)
+    }
+
+    @Test("an unmatched GitLab branch query reports none, not a failure")
+    func gitLabBranchQueryAnsweredNothing() async {
+        // The project answered; it simply has no merge request on this branch.
+        let gl = GitLabFake(sourceBranch: "someone-elses-branch")
+        let wt = UUID()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in await gl.run(args: args, repoPath: path) },
+            gitLabHosts: [Self.gitLabHost],
+            remoteURLReader: { _ in
+                "https://git.acme.example/acme/platform/api-gateway.git"
+            })
+
+        _ = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
+
+        #expect(await manager.observation(for: wt)?.outcome == PRObservation.Outcome.none)
+    }
+
+    // MARK: - Authentication failure
+
+    @Test("an auth failure names the host instead of degrading to no-forge")
+    func authFailureNamesHost() async {
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { _, _ in
+                GHCommandResult(stdout: "", stderr: "401 Unauthorized", exitStatus: 1)
+            },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding()
+
+        let observed = await manager.refreshBindings([binding])
+
+        #expect(observed[binding.id] == nil)
+        #expect(await manager.lastUndeterminedCause(forHost: Self.gitLabHost)
+                == PRUndeterminedCause.forgeAuthFailed(host: Self.gitLabHost))
+        // The remedy is host-shaped, so the report must name the host.
+        #expect(await manager.lastUndeterminedCause(forHost: Self.gitLabHost)?
+                .contains(Self.gitLabHost) == true)
+    }
+
+    @Test("a GraphQL authentication error is an auth failure too, not an empty project")
+    func graphQLAuthErrorNamesHost() async {
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { _, _ in
+                GHCommandResult(stdout: """
+                {"errors":[{"message":"invalid token",
+                "extensions":{"code":"UNAUTHENTICATED"}}]}
+                """)
+            },
+            gitLabHosts: [Self.gitLabHost])
+
+        _ = await manager.refreshBindings([Self.gitLabBinding()])
+
+        #expect(await manager.lastUndeterminedCause(forHost: Self.gitLabHost)
+                == PRUndeterminedCause.forgeAuthFailed(host: Self.gitLabHost))
+    }
+
+    @Test("an auth failure keeps every existing binding rather than clearing it")
+    func authFailureKeepsBindings() async {
+        let previous = PRStatus(number: 412, url: Self.gitLabMRURL, state: .pending,
+                                reason: "Checks pending")
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { _, _ in
+                GHCommandResult(stdout: "", stderr: "401 Unauthorized", exitStatus: 1)
+            },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding(status: previous)
+
+        let observed = await manager.refreshBindings([binding])
+
+        #expect(observed[binding.id]?.status == previous)
+    }
+
+    @Test("a host that answers again retracts its recorded refusal")
+    func successClearsAuthFailure() async {
+        // A token is re-issued and the host works; only a call succeeding is
+        // ever accepted as proof, and it must clear the stale report.
+        let gl = GitLabFake()
+        let gate = AuthGate()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            glRunner: { args, path in
+                if await gate.refuses {
+                    return GHCommandResult(stdout: "", stderr: "401 Unauthorized", exitStatus: 1)
+                }
+                return await gl.run(args: args, repoPath: path)
+            },
+            gitLabHosts: [Self.gitLabHost])
+        let binding = Self.gitLabBinding()
+
+        _ = await manager.refreshBindings([binding])
+        #expect(await manager.lastUndeterminedCause(forHost: Self.gitLabHost) != nil)
+
+        await gate.reissueToken()
+        let observed = await manager.refreshBindings([binding])
+
+        #expect(observed[binding.id]?.status.state == .mergeable)
+        #expect(await manager.lastUndeterminedCause(forHost: Self.gitLabHost) == nil)
+    }
+
+    @Test("a GitHub host never gets a GitLab auth report")
+    func gitHubHostHasNoForgeAuthReport() async {
+        let gh = BindingGH()
+        let manager = PRStatusManager(
+            ghRunner: { args, path in await gh.run(args: args, repoPath: path) },
+            glRunner: { _, _ in
+                GHCommandResult(stdout: "", stderr: "401 Unauthorized", exitStatus: 1)
+            },
+            gitLabHosts: [Self.gitLabHost])
+
+        _ = await manager.refreshBindings([Self.binding(412, worktreeID: UUID())])
+
+        #expect(await manager.lastUndeterminedCause(forHost: "github.com") == nil)
+    }
+
+    // MARK: - Branch list composition (pure)
+
+    @Test("one project query asks about each branch once, in first-seen order")
+    func branchListDeduplicates() {
+        #expect(PRStatusManager.orderedUniqueBranches(
+            ["tbd/a", "release/1", "tbd/a", "", "tbd/b"]) == ["tbd/a", "release/1", "tbd/b"])
     }
 
     private static func pollWorktree(

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -2730,6 +2730,39 @@ struct PRStatusManagerRepoIdentityTests {
         #expect(await absent.repoIdentity(repoPath: "/wt/api-gateway")?.host == "git.acme.example")
     }
 
+    @Test("a gh holding no credentials at all cannot speak for any checkout")
+    func unauthenticatedGHLicensesTheRemoteParse() async {
+        // gh runs its auth check BEFORE it resolves a base repo, so a gh that
+        // is installed but never logged in NEVER emits the disownment message
+        // — not on a GitLab remote, not on any remote. It exits 4 with the
+        // login prompt instead. Reading that as transient left a GitLab-only
+        // developer with an unused gh unable to name their repo on any tick,
+        // which is the whole GitLab path.
+        let gitLabRemote = "git@git.acme.example:acme/platform/api-gateway.git"
+        let loginPrompt = """
+        To get started with GitHub CLI, please run:  gh auth login
+        Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.
+        """
+        let unauthenticated = PRStatusManager(
+            ghRunner: { _, _ in GHCommandResult(stdout: "", stderr: loginPrompt, exitStatus: 4) },
+            remoteURLReader: { _ in gitLabRemote })
+
+        let identity = await unauthenticated.repoIdentity(repoPath: "/wt/api-gateway")
+        #expect(identity?.host == "git.acme.example")
+        #expect(identity?.owner == "acme/platform")
+        #expect(identity?.name == "api-gateway")
+
+        // The exit code is what settles it, not the wording: gh's own
+        // `exitAuth` means "no credentials anywhere", while a REJECTED
+        // credential is exit 1 and stays transient. A stderr whitelist would
+        // have to guess which is which, so an unrecognised failure carrying
+        // the same words still defers rather than renaming a fork.
+        let rejected = PRStatusManager(
+            ghRunner: { _, _ in GHCommandResult(stdout: "", stderr: loginPrompt, exitStatus: 1) },
+            remoteURLReader: { _ in gitLabRemote })
+        #expect(await rejected.repoIdentity(repoPath: "/wt/api-gateway") == nil)
+    }
+
     @Test("a hostless remote cannot fabricate an identity that clears a cached PR")
     func hostlessRemoteDoesNotPoisonTheCache() async {
         // `poisonedCacheEntries` clears a cached PR whose repo differs from the

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -2628,3 +2628,87 @@ struct PRStatusManagerInvalidateReentrancyTests {
         #expect(await manager.observation(for: wt) == nil)
     }
 }
+
+/// A `gh repo view` whose answer a test can change between calls, so one test
+/// can watch a checkout go dark and come back.
+private actor RepoViewGH {
+    private var result: GHCommandResult?
+    private(set) var calls = 0
+
+    init(_ result: GHCommandResult?) { self.result = result }
+
+    func answer(_ next: GHCommandResult?) { result = next }
+
+    func run(_ args: [String]) -> GHCommandResult? {
+        calls += 1
+        return result
+    }
+}
+
+@Suite("PRStatusManager repo identity")
+struct PRStatusManagerRepoIdentityTests {
+
+    private static let forkRemote = "https://github.com/contributor/acme-prod.git"
+
+    /// gh's own wording when no remote names a host it speaks to — every GitLab
+    /// checkout, and the state the `origin` fallback exists for.
+    private static let disownment = """
+    none of the git remotes configured for this repository point to a known \
+    GitHub host. To tell gh about a new GitHub host, please use `gh auth login`
+    """
+
+    @Test("a transient gh failure defers rather than letting origin name the fork")
+    func transientGHFailureDefers() async {
+        // On a fork checkout gh resolves the PARENT repo — where the fork's
+        // pull requests live — while `origin` names the fork. A 401 is no
+        // evidence about which of those is right, and the answer would be
+        // cached for fifteen minutes, so the only safe reading is "ask again".
+        let gh = RepoViewGH(GHCommandResult(
+            stdout: "", stderr: "HTTP 401: Bad credentials (https://api.github.com/graphql)",
+            exitStatus: 1))
+        let manager = PRStatusManager(
+            ghRunner: { args, _ in await gh.run(args) },
+            remoteURLReader: { _ in Self.forkRemote })
+
+        #expect(await manager.repoIdentity(repoPath: "/wt/acme-prod") == nil)
+
+        // A deferral is never cached, so the next attempt gets gh's answer —
+        // the parent, not the fork.
+        await gh.answer(GHCommandResult(
+            stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#))
+        let healed = await manager.repoIdentity(repoPath: "/wt/acme-prod")
+        #expect(healed?.owner == "acme")
+        #expect(healed?.name == "acme-prod")
+        #expect(healed?.host == "github.com")
+    }
+
+    @Test("only gh disowning the checkout lets the origin remote name it")
+    func onlyDisownmentLicensesTheRemoteParse() async {
+        let gitLabRemote = "git@git.acme.example:acme/platform/api-gateway.git"
+        let disowned = PRStatusManager(
+            ghRunner: { _, _ in GHCommandResult(stdout: "", stderr: Self.disownment, exitStatus: 1) },
+            remoteURLReader: { _ in gitLabRemote })
+
+        let identity = await disowned.repoIdentity(repoPath: "/wt/api-gateway")
+        #expect(identity?.host == "git.acme.example")
+        #expect(identity?.owner == "acme/platform")
+        #expect(identity?.name == "api-gateway")
+
+        // The same checkout and the same remote, behind a failure that says
+        // nothing about either: no identity at all rather than a guessed one.
+        let refused = PRStatusManager(
+            ghRunner: { _, _ in
+                GHCommandResult(stdout: "", stderr: "error connecting to api.github.com",
+                                exitStatus: 1)
+            },
+            remoteURLReader: { _ in gitLabRemote })
+        #expect(await refused.repoIdentity(repoPath: "/wt/api-gateway") == nil)
+
+        // And the GitLab-only fleet with no `gh` installed at all: nobody to
+        // ask, on this checkout or any other, so the remote speaks.
+        let absent = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            remoteURLReader: { _ in gitLabRemote })
+        #expect(await absent.repoIdentity(repoPath: "/wt/api-gateway")?.host == "git.acme.example")
+    }
+}

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -2761,6 +2761,47 @@ struct PRStatusManagerRepoIdentityTests {
             ghRunner: { _, _ in GHCommandResult(stdout: "", stderr: loginPrompt, exitStatus: 1) },
             remoteURLReader: { _ in gitLabRemote })
         #expect(await rejected.repoIdentity(repoPath: "/wt/api-gateway") == nil)
+
+        // …and the same credential-less gh over a `github.com` remote names
+        // NOTHING. gh would have been the authoritative source for that host —
+        // on a fork it names the parent while `origin` names the fork — so its
+        // silence about the machine is not licence for `origin` to answer.
+        let onGitHub = PRStatusManager(
+            ghRunner: { _, _ in GHCommandResult(stdout: "", stderr: loginPrompt, exitStatus: 4) },
+            remoteURLReader: { _ in Self.forkRemote })
+        #expect(await onGitHub.repoIdentity(repoPath: "/wt/acme-prod") == nil)
+    }
+
+    @Test("a credential-less gh cannot let a fork's origin clear its parent's cached PR")
+    func unauthenticatedGHDoesNotPoisonAForkCheckout() async {
+        // The reason the parse is withheld for `github.com`, stated as the
+        // damage it would do rather than as a preference. `poisonedCacheEntries`
+        // judges an entry cross-repo when BOTH sides resolved; a fork identity
+        // read off `origin` makes the parent's pull request — where a fork's
+        // pull requests actually live — look like another repo's, and the clear
+        // is persisted, so a restart cannot bring it back.
+        let wt = UUID()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in
+                GHCommandResult(stdout: "",
+                                stderr: "To get started with GitHub CLI, please run:  gh auth login",
+                                exitStatus: 4)
+            },
+            remoteURLReader: { _ in Self.forkRemote })
+        await manager.seedForTesting(
+            worktreeID: wt,
+            status: PRStatus(number: 412, url: "https://github.com/acme/acme-prod/pull/412",
+                             state: .mergeable))
+        let recorder = PersistedClearRecorder()
+        await manager.setOnStatusPersist { id, status in
+            await recorder.record(id, isClear: status == nil)
+        }
+
+        let outcome = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
+
+        #expect(await manager.allStatuses()[wt]?.number == 412)
+        #expect(await recorder.clears.isEmpty)
+        #expect(outcome.disproved.isEmpty)
     }
 
     @Test("a hostless remote cannot fabricate an identity that clears a cached PR")

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -956,6 +956,24 @@ struct PRStatusManagerTests {
         #expect(parsed?.name == "api")
     }
 
+    @Test("parseRemoteIdentity rejects a remote that names no network host")
+    func parseRemoteIdentityRejectsHostlessRemotes() {
+        // Split into segments these fabricate the hosts "Users", "srv" and
+        // ".." — each cached like a real one, each classified as a GitLab
+        // instance by `Forge.forHost`, and each enough to make
+        // `poisonedCacheEntries` clear a legitimately cached PR status.
+        #expect(PRStatusManager.parseRemoteIdentity("file:///Users/me/acme-prod.git") == nil)
+        #expect(PRStatusManager.parseRemoteIdentity("/srv/git/acme/acme-prod.git") == nil)
+        #expect(PRStatusManager.parseRemoteIdentity("../sibling/acme-prod.git") == nil)
+        // …while the three shapes that do name one still parse.
+        #expect(PRStatusManager.parseRemoteIdentity(
+            "https://github.com/acme/acme-prod.git")?.host == "github.com")
+        #expect(PRStatusManager.parseRemoteIdentity(
+            "git@git.acme.example:acme/api.git")?.host == "git.acme.example")
+        #expect(PRStatusManager.parseRemoteIdentity(
+            "ssh://git@git.acme.example:2222/acme/api.git")?.host == "git.acme.example")
+    }
+
     @Test("parseRemoteIdentity returns nil rather than guessing a host")
     func parseRemoteIdentityRejectsIncomplete() {
         // Nothing here names a host, and a caller that cannot name the host
@@ -2710,5 +2728,38 @@ struct PRStatusManagerRepoIdentityTests {
             ghRunner: { _, _ in nil },
             remoteURLReader: { _ in gitLabRemote })
         #expect(await absent.repoIdentity(repoPath: "/wt/api-gateway")?.host == "git.acme.example")
+    }
+
+    @Test("a hostless remote cannot fabricate an identity that clears a cached PR")
+    func hostlessRemoteDoesNotPoisonTheCache() async {
+        // `poisonedCacheEntries` clears a cached PR whose repo differs from the
+        // worktree's own, on the premise that both sides are KNOWN. An identity
+        // invented out of a local path's first segments makes every cached PR
+        // look cross-repo — and the clear is persisted, so a restart cannot
+        // bring it back.
+        let wt = UUID()
+        let manager = PRStatusManager(
+            ghRunner: { _, _ in nil },
+            remoteURLReader: { _ in "file:///Users/me/acme-prod.git" })
+        await manager.seedForTesting(
+            worktreeID: wt,
+            status: PRStatus(number: 412, url: "https://github.com/acme/acme-prod/pull/412",
+                             state: .mergeable))
+        let recorder = PersistedClearRecorder()
+        await manager.setOnStatusPersist { id, status in
+            await recorder.record(id, isClear: status == nil)
+        }
+
+        let outcome = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
+
+        #expect(await manager.allStatuses()[wt]?.number == 412)
+        #expect(await recorder.clears.isEmpty)
+        // Nor may the heal report a binding it never disproved.
+        #expect(outcome.disproved.isEmpty)
+    }
+
+    private static func pollWorktree(_ id: UUID) -> PRStatusManager.PollWorktree {
+        (id: id, branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: "main",
+         pushBranch: .noPushDestination, worktreePath: "/wt/acme-prod", prNumber: nil)
     }
 }

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -959,8 +959,8 @@ struct PRStatusManagerTests {
     @Test("parseRemoteIdentity rejects a remote that names no network host")
     func parseRemoteIdentityRejectsHostlessRemotes() {
         // Split into segments these fabricate the hosts "Users", "srv" and
-        // ".." — each cached like a real one, each classified as a GitLab
-        // instance by `Forge.forHost`, and each enough to make
+        // ".." — each cached like a real one, each composed into an attach URL
+        // that points at nothing, and each enough to make
         // `poisonedCacheEntries` clear a legitimately cached PR status.
         #expect(PRStatusManager.parseRemoteIdentity("file:///Users/me/acme-prod.git") == nil)
         #expect(PRStatusManager.parseRemoteIdentity("/srv/git/acme/acme-prod.git") == nil)

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -899,6 +899,28 @@ struct PRStatusManagerTests {
         #expect(PRStatusManager.parseOwnerRepo(fromURL: "https://example.com/not-a-pr") == nil)
     }
 
+    @Test("parseOwnerRepo splits a nested GitLab URL at the /-/ separator")
+    func parseOwnerRepoGitLab() {
+        let parsed = PRStatusManager.parseOwnerRepo(
+            fromURL: "https://git.acme.example/acme/platform/backend/api-gateway/-/merge_requests/412")
+        #expect(parsed?.owner == "acme/platform/backend")
+        #expect(parsed?.name == "api-gateway")
+    }
+
+    @Test("parseOwnerRepo still handles GitHub URLs")
+    func parseOwnerRepoGitHub() {
+        let parsed = PRStatusManager.parseOwnerRepo(
+            fromURL: "https://github.com/acme/acme-prod/pull/412")
+        #expect(parsed?.owner == "acme")
+        #expect(parsed?.name == "acme-prod")
+    }
+
+    @Test("parseOwnerRepo rejects a GitLab URL with no project segment")
+    func parseOwnerRepoGitLabTooShort() {
+        #expect(PRStatusManager.parseOwnerRepo(
+            fromURL: "https://git.acme.example/acme/-/merge_requests/1") == nil)
+    }
+
     // MARK: - GraphQL query builder
 
     /// A malformed (unbalanced) GraphQL query is rejected by the server at parse time,

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -921,6 +921,51 @@ struct PRStatusManagerTests {
             fromURL: "https://git.acme.example/acme/-/merge_requests/1") == nil)
     }
 
+    // MARK: - Remote identity
+
+    @Test("parseRemoteIdentity reads host, owner and name from an https remote")
+    func parseRemoteIdentityHTTPS() {
+        let parsed = PRStatusManager.parseRemoteIdentity("https://github.com/acme/acme-prod.git")
+        #expect(parsed?.host == "github.com")
+        #expect(parsed?.owner == "acme")
+        #expect(parsed?.name == "acme-prod")
+    }
+
+    @Test("parseRemoteIdentity reads an scp-style remote")
+    func parseRemoteIdentitySCP() {
+        let parsed = PRStatusManager.parseRemoteIdentity("git@git.acme.example:acme/platform/api-gateway.git")
+        #expect(parsed?.host == "git.acme.example")
+        // Everything before the last segment is the namespace, however deep.
+        #expect(parsed?.owner == "acme/platform")
+        #expect(parsed?.name == "api-gateway")
+    }
+
+    @Test("parseRemoteIdentity keeps a deeply nested GitLab namespace whole")
+    func parseRemoteIdentityNested() {
+        let parsed = PRStatusManager.parseRemoteIdentity(
+            "https://git.acme.example/acme/platform/backend/api-gateway.git")
+        #expect(parsed?.owner == "acme/platform/backend")
+        #expect(parsed?.name == "api-gateway")
+    }
+
+    @Test("parseRemoteIdentity drops an ssh port from the host")
+    func parseRemoteIdentitySSHPort() {
+        let parsed = PRStatusManager.parseRemoteIdentity("ssh://git@git.acme.example:2222/acme/api.git")
+        #expect(parsed?.host == "git.acme.example")
+        #expect(parsed?.owner == "acme")
+        #expect(parsed?.name == "api")
+    }
+
+    @Test("parseRemoteIdentity returns nil rather than guessing a host")
+    func parseRemoteIdentityRejectsIncomplete() {
+        // Nothing here names a host, and a caller that cannot name the host
+        // must defer — never default to github.com.
+        #expect(PRStatusManager.parseRemoteIdentity("acme/acme-prod") == nil)
+        #expect(PRStatusManager.parseRemoteIdentity("") == nil)
+        #expect(PRStatusManager.parseRemoteIdentity("   ") == nil)
+        #expect(PRStatusManager.parseRemoteIdentity("https://github.com/acme") == nil)
+    }
+
     // MARK: - GraphQL query builder
 
     /// A malformed (unbalanced) GraphQL query is rejected by the server at parse time,
@@ -2220,7 +2265,7 @@ private actor FakeGH {
     }
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
-        if args.first == "repo" { return GHCommandResult(stdout: "acme/acme-prod\n") }
+        if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
         if query.contains("viewer {") {
             viewerQueries += 1

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -10,31 +10,31 @@ struct PRStatusManagerTests {
 
     @Test("maps OPEN + CLEAN to .mergeable")
     func mapsMergeableState() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "CLEAN")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "CLEAN")
         #expect(status == .mergeable)
     }
 
     @Test("maps OPEN + BLOCKED to .blocked")
     func mapsBlocked() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "BLOCKED")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "BLOCKED")
         #expect(status == .blocked)
     }
 
     @Test("maps OPEN + DIRTY to .blocked")
     func mapsDirty() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "DIRTY")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "DIRTY")
         #expect(status == .blocked)
     }
 
     @Test("maps OPEN + BEHIND to .blocked")
     func mapsBehind() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "BEHIND")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "BEHIND")
         #expect(status == .blocked)
     }
 
     @Test("maps OPEN + UNKNOWN to .pending")
     func mapsPendingUnknown() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "UNKNOWN")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "UNKNOWN")
         #expect(status == .pending)
     }
 
@@ -42,7 +42,7 @@ struct PRStatusManagerTests {
     func mapsPendingChecks() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "UNKNOWN",
+            mergeVerdictRaw: "UNKNOWN",
             requiredChecksPending: true
         )
         #expect(status == .pending)
@@ -52,7 +52,7 @@ struct PRStatusManagerTests {
     func mapsPendingChecksOverClean() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
+            mergeVerdictRaw: "CLEAN",
             requiredChecksPending: true
         )
         #expect(status == .pending)
@@ -62,7 +62,7 @@ struct PRStatusManagerTests {
     func mapsPendingChecksOverBlocked() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
+            mergeVerdictRaw: "BLOCKED",
             requiredChecksPending: true
         )
         #expect(status == .pending)
@@ -72,8 +72,8 @@ struct PRStatusManagerTests {
     func mapsReviewRequiredWithPassingChecksToMergeable() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
-            reviewDecision: "REVIEW_REQUIRED",
+            mergeVerdictRaw: "BLOCKED",
+            reviewVerdictRaw: "REVIEW_REQUIRED",
             requiredChecksFailing: false,
             requiredChecksPending: false
         )
@@ -84,8 +84,8 @@ struct PRStatusManagerTests {
     func mapsReviewRequiredWithPendingChecksToPending() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
-            reviewDecision: "REVIEW_REQUIRED",
+            mergeVerdictRaw: "BLOCKED",
+            reviewVerdictRaw: "REVIEW_REQUIRED",
             requiredChecksPending: true
         )
         #expect(status == .pending)
@@ -95,21 +95,21 @@ struct PRStatusManagerTests {
     func mapsBlockedWithEmptyReviewDecisionToBlocked() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
-            reviewDecision: ""
+            mergeVerdictRaw: "BLOCKED",
+            reviewVerdictRaw: ""
         )
         #expect(status == .blocked)
     }
 
     @Test("maps HAS_HOOKS to .mergeable")
     func mapsHasHooks() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "HAS_HOOKS")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "HAS_HOOKS")
         #expect(status == .mergeable)
     }
 
     @Test("maps UNSTABLE (non-required checks failing) to .mergeable")
     func mapsUnstable() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "UNSTABLE")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "UNSTABLE")
         #expect(status == .mergeable)
     }
 
@@ -117,7 +117,7 @@ struct PRStatusManagerTests {
     func mapsUnstablePendingChecks() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "UNSTABLE",
+            mergeVerdictRaw: "UNSTABLE",
             requiredChecksPending: true
         )
         #expect(status == .pending)
@@ -125,7 +125,7 @@ struct PRStatusManagerTests {
 
     @Test("maps unknown future merge state to .blocked")
     func mapsUnknownFutureMergeState() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "SOME_FUTURE_STATE")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "SOME_FUTURE_STATE")
         #expect(status == .blocked)
     }
 
@@ -133,7 +133,7 @@ struct PRStatusManagerTests {
     func mapsPendingUnknownFutureMergeState() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "SOME_FUTURE_STATE",
+            mergeVerdictRaw: "SOME_FUTURE_STATE",
             requiredChecksPending: true
         )
         #expect(status == .pending)
@@ -141,31 +141,31 @@ struct PRStatusManagerTests {
 
     @Test("maps MERGED to .merged")
     func mapsMerged() {
-        let status = PRStatusManager.mapState(ghState: "MERGED", mergeStateStatus: "UNKNOWN")
+        let status = PRStatusManager.mapState(ghState: "MERGED", mergeVerdictRaw: "UNKNOWN")
         #expect(status == .merged)
     }
 
     @Test("maps CLOSED to .closed")
     func mapsClosed() {
-        let status = PRStatusManager.mapState(ghState: "CLOSED", mergeStateStatus: "BLOCKED")
+        let status = PRStatusManager.mapState(ghState: "CLOSED", mergeVerdictRaw: "BLOCKED")
         #expect(status == .closed)
     }
 
     @Test("maps OPEN + CHANGES_REQUESTED to .changesRequested")
     func mapsChangesRequested() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "BLOCKED", reviewDecision: "CHANGES_REQUESTED")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "BLOCKED", reviewVerdictRaw: "CHANGES_REQUESTED")
         #expect(status == .changesRequested)
     }
 
     @Test("maps OPEN + CLEAN + CHANGES_REQUESTED to .changesRequested (review wins)")
     func mapsChangesRequestedOverClean() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "CLEAN", reviewDecision: "CHANGES_REQUESTED")
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "CLEAN", reviewVerdictRaw: "CHANGES_REQUESTED")
         #expect(status == .changesRequested)
     }
 
     @Test("maps draft PRs to .draft")
     func mapsDraft() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "CLEAN", isDraft: true)
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeVerdictRaw: "CLEAN", isDraft: true)
         #expect(status == .draft)
     }
 
@@ -173,7 +173,7 @@ struct PRStatusManagerTests {
     func mapsNonRequiredFailingCheckStaysMergeable() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
+            mergeVerdictRaw: "CLEAN",
             requiredChecksFailing: false
         )
         #expect(status == .mergeable)
@@ -183,7 +183,7 @@ struct PRStatusManagerTests {
     func mapsRequiredFailingCheckToChecksFailed() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
+            mergeVerdictRaw: "BLOCKED",
             requiredChecksFailing: true
         )
         #expect(status == .checksFailed)
@@ -193,7 +193,7 @@ struct PRStatusManagerTests {
     func mapsDraftOverFailingChecks() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
+            mergeVerdictRaw: "CLEAN",
             isDraft: true,
             requiredChecksFailing: true
         )
@@ -204,7 +204,7 @@ struct PRStatusManagerTests {
     func mapsFailingOverPendingBlocked() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
+            mergeVerdictRaw: "BLOCKED",
             requiredChecksFailing: true,
             requiredChecksPending: true
         )
@@ -215,7 +215,7 @@ struct PRStatusManagerTests {
     func mapsFailingOverPendingClean() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
+            mergeVerdictRaw: "CLEAN",
             requiredChecksFailing: true,
             requiredChecksPending: true
         )
@@ -226,7 +226,7 @@ struct PRStatusManagerTests {
     func mapsUnstableRequiredFailingToChecksFailed() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "UNSTABLE",
+            mergeVerdictRaw: "UNSTABLE",
             requiredChecksFailing: true
         )
         #expect(status == .checksFailed)
@@ -236,7 +236,7 @@ struct PRStatusManagerTests {
     func mapsDirtyRequiredFailingToChecksFailed() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "DIRTY",
+            mergeVerdictRaw: "DIRTY",
             requiredChecksFailing: true
         )
         #expect(status == .checksFailed)
@@ -246,7 +246,7 @@ struct PRStatusManagerTests {
     func mapsBehindRequiredFailingToChecksFailed() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "BEHIND",
+            mergeVerdictRaw: "BEHIND",
             requiredChecksFailing: true
         )
         #expect(status == .checksFailed)
@@ -256,7 +256,7 @@ struct PRStatusManagerTests {
     func mapsUnknownFutureMergeStateRequiredFailingToChecksFailed() {
         let status = PRStatusManager.mapState(
             ghState: "OPEN",
-            mergeStateStatus: "SOME_FUTURE_STATE",
+            mergeVerdictRaw: "SOME_FUTURE_STATE",
             requiredChecksFailing: true
         )
         #expect(status == .checksFailed)
@@ -312,7 +312,7 @@ struct PRStatusManagerTests {
         #expect(nodes.count == 3)
         #expect(nodes[0].headRefName == "tbd/cool-feature")
         #expect(nodes[0].state == "OPEN")
-        #expect(nodes[0].mergeStateStatus == "CLEAN")
+        #expect(nodes[0].mergeVerdictRaw == "CLEAN")
         #expect(nodes[0].isDraft == true)
         #expect(nodes[0].statusCheckRollupState == "FAILURE")
         #expect(nodes[1].headRefName == "tbd/old-feature")
@@ -981,8 +981,8 @@ struct PRStatusManagerTests {
     func reasonForMerged() {
         let reason = PRStatusManager.computeReason(
             ghState: "MERGED",
-            mergeStateStatus: "UNKNOWN",
-            reviewDecision: "",
+            mergeVerdictRaw: "UNKNOWN",
+            reviewVerdictRaw: "",
             isDraft: false
         )
         #expect(reason == "Merged")
@@ -992,8 +992,8 @@ struct PRStatusManagerTests {
     func reasonForClosed() {
         let reason = PRStatusManager.computeReason(
             ghState: "CLOSED",
-            mergeStateStatus: "UNKNOWN",
-            reviewDecision: "",
+            mergeVerdictRaw: "UNKNOWN",
+            reviewVerdictRaw: "",
             isDraft: false
         )
         #expect(reason == "Closed")
@@ -1003,8 +1003,8 @@ struct PRStatusManagerTests {
     func reasonForDraft() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
-            reviewDecision: "",
+            mergeVerdictRaw: "CLEAN",
+            reviewVerdictRaw: "",
             isDraft: true
         )
         #expect(reason == "Draft")
@@ -1014,8 +1014,8 @@ struct PRStatusManagerTests {
     func reasonForMergeable() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
-            reviewDecision: "",
+            mergeVerdictRaw: "CLEAN",
+            reviewVerdictRaw: "",
             isDraft: false
         )
         #expect(reason == "Ready to merge")
@@ -1025,8 +1025,8 @@ struct PRStatusManagerTests {
     func reasonForConflicts() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "DIRTY",
-            reviewDecision: "",
+            mergeVerdictRaw: "DIRTY",
+            reviewVerdictRaw: "",
             isDraft: false
         )
         #expect(reason == "Merge conflicts")
@@ -1036,8 +1036,8 @@ struct PRStatusManagerTests {
     func reasonForBehind() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "BEHIND",
-            reviewDecision: "",
+            mergeVerdictRaw: "BEHIND",
+            reviewVerdictRaw: "",
             isDraft: false
         )
         #expect(reason == "Behind base branch")
@@ -1047,8 +1047,8 @@ struct PRStatusManagerTests {
     func reasonForFailingChecks() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
-            reviewDecision: "",
+            mergeVerdictRaw: "CLEAN",
+            reviewVerdictRaw: "",
             isDraft: false,
             requiredChecksFailing: true
         )
@@ -1059,8 +1059,8 @@ struct PRStatusManagerTests {
     func reasonForPendingChecks() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN",
-            reviewDecision: "",
+            mergeVerdictRaw: "CLEAN",
+            reviewVerdictRaw: "",
             isDraft: false,
             requiredChecksPending: true
         )
@@ -1071,7 +1071,7 @@ struct PRStatusManagerTests {
     func reasonForRequiredFailingUnderUnstable() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "UNSTABLE",
+            mergeVerdictRaw: "UNSTABLE",
             requiredChecksFailing: true
         )
         #expect(reason == "Checks failing")
@@ -1081,8 +1081,8 @@ struct PRStatusManagerTests {
     func reasonForRequiredPendingUnderBlocked() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
-            reviewDecision: "REVIEW_REQUIRED",
+            mergeVerdictRaw: "BLOCKED",
+            reviewVerdictRaw: "REVIEW_REQUIRED",
             requiredChecksPending: true
         )
         #expect(reason == "Checks pending")
@@ -1092,8 +1092,8 @@ struct PRStatusManagerTests {
     func reasonForChangesRequested() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
-            reviewDecision: "CHANGES_REQUESTED",
+            mergeVerdictRaw: "BLOCKED",
+            reviewVerdictRaw: "CHANGES_REQUESTED",
             isDraft: false
         )
         #expect(reason == "Changes requested")
@@ -1103,8 +1103,8 @@ struct PRStatusManagerTests {
     func reasonForReviewRequired() {
         let reason = PRStatusManager.computeReason(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
-            reviewDecision: "REVIEW_REQUIRED",
+            mergeVerdictRaw: "BLOCKED",
+            reviewVerdictRaw: "REVIEW_REQUIRED",
             isDraft: false
         )
         // REVIEW_REQUIRED with passing checks is actually mergeable (green), never shows a red/yellow warning
@@ -1117,8 +1117,8 @@ struct PRStatusManagerTests {
     func stateAndReasonBlockedReviewRequiredMergeable() {
         let (state, reason) = PRStatusManager.mapStateAndReason(
             ghState: "OPEN",
-            mergeStateStatus: "BLOCKED",
-            reviewDecision: "REVIEW_REQUIRED"
+            mergeVerdictRaw: "BLOCKED",
+            reviewVerdictRaw: "REVIEW_REQUIRED"
         )
         #expect(state == .mergeable)
         #expect(reason == "Ready to merge")
@@ -1128,7 +1128,7 @@ struct PRStatusManagerTests {
     func stateAndReasonUnstableNilChecksMergeable() {
         let (state, reason) = PRStatusManager.mapStateAndReason(
             ghState: "OPEN",
-            mergeStateStatus: "UNSTABLE"
+            mergeVerdictRaw: "UNSTABLE"
         )
         #expect(state == .mergeable)
         #expect(reason == "Ready to merge")
@@ -1138,7 +1138,7 @@ struct PRStatusManagerTests {
     func stateAndReasonCleanMergeable() {
         let (state, reason) = PRStatusManager.mapStateAndReason(
             ghState: "OPEN",
-            mergeStateStatus: "CLEAN"
+            mergeVerdictRaw: "CLEAN"
         )
         #expect(state == .mergeable)
         #expect(reason == "Ready to merge")
@@ -1148,7 +1148,7 @@ struct PRStatusManagerTests {
     func stateAndReasonDirtyConflicts() {
         let (state, reason) = PRStatusManager.mapStateAndReason(
             ghState: "OPEN",
-            mergeStateStatus: "DIRTY"
+            mergeVerdictRaw: "DIRTY"
         )
         #expect(state == .blocked)
         #expect(reason == "Merge conflicts")
@@ -1158,7 +1158,7 @@ struct PRStatusManagerTests {
     func stateAndReasonBehind() {
         let (state, reason) = PRStatusManager.mapStateAndReason(
             ghState: "OPEN",
-            mergeStateStatus: "BEHIND"
+            mergeVerdictRaw: "BEHIND"
         )
         #expect(state == .blocked)
         #expect(reason == "Behind base branch")
@@ -1473,8 +1473,8 @@ struct PRStatusManagerTests {
     /// Convenience PRNode factory for the matching tests.
     private func prNode(number: Int, url: String, branch: String, state: String = "OPEN",
                         createdAt: String = "2026-07-01T00:00:00Z") -> PRStatusManager.PRNode {
-        PRStatusManager.PRNode(number: number, url: url, state: state, mergeStateStatus: "CLEAN",
-                               reviewDecision: "", headRefName: branch, createdAt: createdAt,
+        PRStatusManager.PRNode(number: number, url: url, state: state, mergeVerdictRaw: "CLEAN",
+                               reviewVerdictRaw: "", headRefName: branch, createdAt: createdAt,
                                isDraft: false, statusCheckRollupState: nil, mergeQueuePosition: nil)
     }
 

--- a/Tests/TBDSharedTests/PRBindingExtractorTests.swift
+++ b/Tests/TBDSharedTests/PRBindingExtractorTests.swift
@@ -226,4 +226,56 @@ struct PRBindingExtractorTests {
         let data = try! JSONSerialization.data(withJSONObject: obj)
         #expect(PRBindingExtractor.extract(fromHookPayload: data).first?.number == 9)
     }
+
+    @Test("parses a GitLab merge request URL with a nested namespace")
+    func parsesGitLabNested() {
+        let found = PRBindingExtractor.parsePRURLs(
+            in: "https://git.acme.example/acme/platform/backend/api-gateway/-/merge_requests/412\n")
+        #expect(found.count == 1)
+        #expect(found[0].host == "git.acme.example")
+        #expect(found[0].owner == "acme/platform/backend")
+        #expect(found[0].repo == "api-gateway")
+        #expect(found[0].number == 412)
+    }
+
+    @Test("parses a flat GitLab namespace")
+    func parsesGitLabFlat() {
+        let found = PRBindingExtractor.parsePRURLs(
+            in: "https://gitlab.com/acme/api-gateway/-/merge_requests/7")
+        #expect(found.count == 1)
+        #expect(found[0].owner == "acme")
+        #expect(found[0].repo == "api-gateway")
+        #expect(found[0].number == 7)
+    }
+
+    @Test("rejects merge_requests paths without the /-/ separator")
+    func rejectsMergeRequestsWithoutSeparator() {
+        #expect(PRBindingExtractor.parsePRURLs(
+            in: "https://git.acme.example/acme/api/merge_requests/412").isEmpty)
+    }
+
+    @Test("rejects dot segments in a GitLab namespace")
+    func rejectsGitLabDotSegments() {
+        #expect(PRBindingExtractor.parsePRURLs(
+            in: "https://git.acme.example/acme/../evil/-/merge_requests/1").isEmpty)
+    }
+
+    @Test("still parses GitHub URLs with github.com as the host")
+    func githubStillParses() {
+        let found = PRBindingExtractor.parsePRURLs(
+            in: "https://github.com/acme/acme-prod/pull/412")
+        #expect(found.count == 1)
+        #expect(found[0].host == "github.com")
+        #expect(found[0].owner == "acme")
+    }
+
+    @Test("recognizes glab mr create and rejects other glab verbs")
+    func recognizesGlabCreate() {
+        #expect(PRBindingExtractor.isPRCreateCommand("glab mr create --fill"))
+        #expect(PRBindingExtractor.isPRCreateCommand("cd /tmp && glab  mr   create -t x"))
+        #expect(!PRBindingExtractor.isPRCreateCommand("glab mr view 12"))
+        #expect(!PRBindingExtractor.isPRCreateCommand("glab mr list"))
+        #expect(!PRBindingExtractor.isPRCreateCommand("gh mr create"))
+        #expect(!PRBindingExtractor.isPRCreateCommand("glab pr create"))
+    }
 }

--- a/Tests/TBDSharedTests/PRBindingTests.swift
+++ b/Tests/TBDSharedTests/PRBindingTests.swift
@@ -36,8 +36,8 @@ struct PRBindingTests {
         #expect(gl.refLabel == "MR !412")
     }
 
-    /// The host decides, not the URL: a binding's `host` column is the durable
-    /// fact and `refLabel` must not quietly re-derive the forge from the URL.
+    /// The marker travels with the URL, not with the host, so GitLab's own
+    /// SaaS host reads the same way a self-managed one does.
     @Test("gitlab.com bindings read as merge requests too")
     func refLabelGitLabDotCom() {
         let gl = PRBinding(id: UUID(), worktreeID: UUID(), host: "gitlab.com",
@@ -45,6 +45,31 @@ struct PRBindingTests {
                            url: "https://gitlab.com/acme/api-gateway/-/merge_requests/7",
                            source: .manual, boundAt: Date(timeIntervalSince1970: 0))
         #expect(gl.refLabel == "MR !7")
+    }
+
+    /// The URL decides, not the host — because "not github.com" is not evidence
+    /// of GitLab. GitHub Enterprise, Bitbucket, Gitea and Codeberg all serve
+    /// pull requests from their own hosts, and a binding on one of them must
+    /// not be relabelled a merge request.
+    @Test("a pull request on a self-hosted host is still a PR")
+    func refLabelSelfHostedPullRequest() {
+        for host in ["github.acme.example", "bitbucket.acme.example",
+                     "git.acme.example", "codeberg.org"] {
+            let binding = PRBinding(id: UUID(), worktreeID: UUID(), host: host,
+                                    owner: "acme", repo: "acme-prod", number: 412,
+                                    url: "https://\(host)/acme/acme-prod/pull/412",
+                                    source: .manual, boundAt: Date(timeIntervalSince1970: 0))
+            #expect(binding.refLabel == "PR #412")
+        }
+    }
+
+    /// The marker is matched case-insensitively so an odd-cased URL cannot flip
+    /// a merge request into a pull request in the UI.
+    @Test("forge derivation ignores URL case")
+    func forgeDerivationIgnoresCase() {
+        #expect(Forge.forURL(
+            "https://GIT.ACME.EXAMPLE/acme/api/-/MERGE_REQUESTS/7") == .gitlab)
+        #expect(Forge.forURL("https://GITHUB.COM/acme/acme-prod/PULL/7") == .github)
     }
 
     @Test("terminal states are merged and closed only")

--- a/Tests/TBDSharedTests/PRBindingTests.swift
+++ b/Tests/TBDSharedTests/PRBindingTests.swift
@@ -19,6 +19,34 @@ struct PRBindingTests {
         )
     }
 
+    /// Per-binding text speaks the binding's own forge. Aggregate wording ("2
+    /// pull requests") deliberately does not, because a worktree can span
+    /// forges — that is asserted where the aggregates live, in TBDApp.
+    @Test("per-binding label uses each forge's own reference syntax")
+    func refLabelPerForge() {
+        let gh = PRBinding(id: UUID(), worktreeID: UUID(), host: "github.com",
+                           owner: "acme", repo: "acme-prod", number: 412,
+                           url: "https://github.com/acme/acme-prod/pull/412",
+                           source: .manual, boundAt: Date(timeIntervalSince1970: 0))
+        let gl = PRBinding(id: UUID(), worktreeID: UUID(), host: "git.acme.example",
+                           owner: "acme/platform", repo: "api-gateway", number: 412,
+                           url: "https://git.acme.example/acme/platform/api-gateway/-/merge_requests/412",
+                           source: .manual, boundAt: Date(timeIntervalSince1970: 0))
+        #expect(gh.refLabel == "PR #412")
+        #expect(gl.refLabel == "MR !412")
+    }
+
+    /// The host decides, not the URL: a binding's `host` column is the durable
+    /// fact and `refLabel` must not quietly re-derive the forge from the URL.
+    @Test("gitlab.com bindings read as merge requests too")
+    func refLabelGitLabDotCom() {
+        let gl = PRBinding(id: UUID(), worktreeID: UUID(), host: "gitlab.com",
+                           owner: "acme", repo: "api-gateway", number: 7,
+                           url: "https://gitlab.com/acme/api-gateway/-/merge_requests/7",
+                           source: .manual, boundAt: Date(timeIntervalSince1970: 0))
+        #expect(gl.refLabel == "MR !7")
+    }
+
     @Test("terminal states are merged and closed only")
     func terminalStates() {
         #expect(PRMergeableState.merged.isTerminal)

--- a/docs/research/2026-08-16-gitlab-pr-support/findings.md
+++ b/docs/research/2026-08-16-gitlab-pr-support/findings.md
@@ -31,6 +31,9 @@ The probes were:
   multi-project-aliased.
 - **A REST `iids[]` batch** against the same project.
 - **A host-fingerprint sweep** of `/api/v4/version` across five hosts.
+- **Schema introspection** of the live GraphQL endpoint, and a query naming a
+  field that does not exist, to observe the failure shape.
+- **Response-header inspection** on both a REST `GET` and a GraphQL `POST`.
 
 Facts about `glab` come from the installed binary's help output and from its
 source; facts about GitLab's API come from documentation, from GitLab's own
@@ -920,7 +923,66 @@ field GitLab removes in future — which is the property a version-keyed table
 does not have.
 
 The remaining judgement is what "remember" means — process lifetime, a TTL, or a
-persisted per-host capability row — and that is a design call, not a fact.
+persisted per-host capability row — and that is a design call, not a fact. What
+follows is the evidence bearing on it, because a persisted row raises a question
+a process-lifetime cache does not: when is it wrong, and what notices?
+
+**The two directions are not symmetric, which halves the problem.**
+
+- **Capability lost** — the instance is downgraded, or GitLab removes a field —
+  is **self-healing at zero cost**. The next poll's rich query returns
+  `undefinedField`, the row is rewritten, and the staleness window is one poll.
+  Nothing needs to trigger it.
+- **Capability gained** — the instance is upgraded, or a license is added — is
+  **silent indefinitely**, because the lean query keeps succeeding and no error
+  ever reports that the field became available.
+
+Only the second direction needs a mechanism, so the question is not cache
+coherence but "how often is one optimistic attempt re-armed".
+
+**The version cannot ride along free — measured.** GitLab sends no instance
+version header. Response headers on both a REST `GET` and a GraphQL `POST`
+carry `x-gitlab-meta: {"correlation_id":"…","version":"1"}`, but that `version`
+is the meta envelope's own schema version, not the GitLab release; nothing else
+in the header set names a release. So keying a capability row on version costs a
+deliberate extra call to `/api/v4/metadata`.
+
+**And a hostname is not necessarily one version — measured.** Consecutive
+requests to gitlab.com reported `gitlab-sv: gke-cny-api` and then
+`gitlab-sv: api-gke-us-east1-b`, i.e. they landed on different backends, one of
+them labelled as a canary. On a deployment that runs mixed versions behind one
+name, a version-keyed row can thrash between two answers for a host that is, as
+far as the user is concerned, one host.
+
+That leaves three shapes, and TBD has direct precedent for the second:
+
+- **Version-keyed** — store the observed version beside the capability and
+  discard the row when it moves. Causally correct, and it is what Renovate does
+  (fetching the server version once per run, not per request). Costs one
+  authenticated call per host per daemon run, and inherits the canary hazard
+  above.
+- **TTL re-arm** — after some interval, attempt the rich query again regardless
+  of what the row says. **No extra call at all**: the retry is the poll, and the
+  cost is one failed round trip per host per interval. Immune to version skew,
+  needs no version tracking, and self-heals for causes nobody enumerated.
+  `PRStatusManager.headRefVerifiedIDs` (`:107-122`) is the same trade already
+  made in this codebase — a negative remembered per daemon run rather than
+  forever, with the rationale stated on the property: a transient failure "costs
+  re-verification until the next daemon run. On a path that polls continuously,
+  that is the right side to err on."
+- **Explicit gesture** — a `--recheck` flag that clears the row. Worth having as
+  an escape hatch either way, but it cannot be the primary mechanism, because
+  nobody knows to run it.
+
+Two repo rules bear on the persisted form specifically. If the capability lives
+in a **DB column**, the flag rule in the root `CLAUDE.md` applies and is
+unusually apt: add it with **no SQL default**, so `NULL` means "never tested" and
+stays distinguishable from `0` ("the rich query was rejected") and `1` ("it
+worked") — exactly the three states a capability record needs, and exactly what
+`ADD COLUMN … DEFAULT` would destroy by backfilling. And a persisted row is
+durable derived state, so the PR-review gate will ask **who refreshes it**; the
+natural answer is the PR poll, which already runs on its own clock, but it wants
+naming rather than leaving implicit.
 
 **git-spice** supports GitHub, GitLab, Bitbucket, Gitea and Forgejo, and its
 GitLab mergeability logic
@@ -1211,3 +1273,21 @@ ceiling — so on the GitLab path the cap buys essentially nothing below the
 removing it: it still bounds the GitHub path, where cost genuinely is per-alias,
 and a cap that differs per forge is a worse thing to reason about than one that
 is merely redundant on one side.
+
+**12. If the schema capability is persisted per host, what re-arms it?**
+The full evidence is in
+[Part 9](#is-ce-or-ee-the-question-and-can-one-api-call-settle-it); the short
+form is that only one direction needs a trigger. A *lost* capability is
+rediscovered free on the next poll, so the question is solely how often a
+*gained* one is retried. *Evidence bearing on it:* GitLab sends no version
+header, so version-keying costs a deliberate extra call per host; consecutive
+requests to one hostname were measured landing on different backends including a
+canary, so a version key can thrash on large deployments; and a TTL re-arm costs
+no extra call at all, because the retry is the poll. TBD has already made the
+same trade once, in `headRefVerifiedIDs` (`PRStatusManager.swift:107-122`),
+scoping a remembered negative to a daemon run rather than to forever.
+
+Two constraints come from the repo rather than from GitLab: a capability column
+must be added with **no SQL default** so `NULL` ("never tested") stays distinct
+from `0` and `1`, and the persisted row needs a **named refresher** for the
+review gate — most plausibly the PR poll itself.

--- a/docs/research/2026-08-16-gitlab-pr-support/findings.md
+++ b/docs/research/2026-08-16-gitlab-pr-support/findings.md
@@ -72,7 +72,7 @@ where the design work actually is. Three assumptions do not survive the move:
   rejection.
 - **Mergeability is `mergeStateStatus` + `reviewDecision` + a per-check
   `isRequired` rollup.** GitLab collapses all three into one enum,
-  `detailed_merge_status`, with 22 values that do not partition the way TBD's
+  `detailed_merge_status`, with 24 values that do not partition the way TBD's
   eight states do. Some GitLab states have no TBD expression; some TBD states
   have no GitLab answer.
 - **Required checks are a per-PR list you must fetch separately.** GitLab has no
@@ -103,6 +103,20 @@ all; it takes the host from configuration or `GITLAB_HOST` and assumes
 But an unauthenticated `GET /api/v4/version` discriminates cleanly: **401 on
 GitLab, 404 on every non-GitLab host tested**, including another forge. Whether
 TBD should make that request at all is still a decision, not a lookup.
+
+**Prior art agrees with itself, which is the most useful thing about it.**
+Renovate, git-spice, Git Town and `git-pkgs/forge` have each solved parts of
+this, and they converge: forge type comes from the remote URL with an explicit
+override for private instances; GitLab mergeability is read from
+`detailed_merge_status` alone; unknown enum values map to *unknown*, never to
+blocked; and instance variation is handled by version-gating and field-presence
+sniffing rather than by modelling editions. That last point reframes the
+CE/EE risk — **presence-sniffing is a REST affordance, and GraphQL rejects a
+whole query for one unknown field**, so choosing GraphQL couples an entire
+batch to the instance's schema. Codex, asked about specifically, turns out not
+to support GitLab at all
+([openai/codex#26963](https://github.com/openai/codex/issues/26963)). Details in
+[Part 9](#part-9--prior-art-what-other-tools-actually-do).
 
 A note on scope, because it changes the shape of the work: **GitHub Enterprise
 is a much smaller, separable case.** `gh` already speaks to it, the GraphQL
@@ -293,7 +307,7 @@ Against each fact TBD needs:
   ([merge requests API](https://docs.gitlab.com/api/merge_requests/)). Note
   `opened`, not GitHub's `OPEN`, and the extra `locked`.
 - **Mergeability** — `detailed_merge_status` (REST) / `detailedMergeStatus`
-  (GraphQL), a 22-value enum; plus a coarse `mergeable` boolean and a
+  (GraphQL), a 24-value enum; plus a coarse `mergeable` boolean and a
   `conflicts` boolean. The older `merge_status` (`unchecked`, `checking`,
   `can_be_merged`, `cannot_be_merged`, `cannot_be_merged_recheck`) is deprecated
   in favour of `detailed_merge_status` as of GitLab 15.6.
@@ -359,15 +373,26 @@ toolbar icon, the sidebar dot and the `Worktree.prStatus` column all read it.
   that way (`:1172-1173`).
 - `detailedMergeStatus = CI_MUST_PASS` → `.checksFailed`. This is the one that
   most needs a decision, and it is discussed below.
-- `detailedMergeStatus = NOT_APPROVED` → `.blocked` or `.changesRequested`,
-  depending on the answer to the review-decision question below.
+- `detailedMergeStatus = REQUESTED_CHANGES` → `.changesRequested`. The enum
+  carries a dedicated value — "Indicates a reviewer has requested changes" — so
+  the state TBD ranks at severity 4 has a direct single-field source, with no
+  paid-tier field and no per-reviewer scan.
+- `detailedMergeStatus = NOT_APPROVED` → `.mergeable`, matching how TBD already
+  treats GitHub's `BLOCKED` + `REVIEW_REQUIRED` as "Ready to merge"
+  (`PRStatusManager.swift:1166-1167`). With `REQUESTED_CHANGES` available
+  separately, `NOT_APPROVED` genuinely means "nobody has approved yet" rather
+  than conflating that with an objection.
 
 ### Where it breaks
 
-**GitLab states TBD cannot express.** The 22-value enum
-([source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/merge_requests/detailed_merge_status_enum.rb),
-read 2026-08-16) includes several blockers that TBD can only flatten into
-`.blocked`, losing the reason:
+**GitLab states TBD cannot express.** The enum has **24 values**, read by live
+introspection of gitlab.com's schema on 2026-08-16. That count is worth stating
+precisely, because the
+[source file at `master`](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/merge_requests/detailed_merge_status_enum.rb)
+carried only 22 — `REQUESTED_CHANGES` and `SECURITY_POLICY_PIPELINE_CHECK` were
+absent from the tree read but present in the deployed schema. **The enum grows,
+and a design must assume it will grow again.** Several of its blockers are ones
+TBD can only flatten into `.blocked`, losing the reason:
 
 - `DISCUSSIONS_NOT_RESOLVED` — "Discussions must be resolved before merging."
   GitHub has no equivalent gate; TBD has no state for it.
@@ -375,8 +400,9 @@ read 2026-08-16) includes several blockers that TBD can only flatten into
   be merged." A cross-MR dependency; TBD models no such relation.
 - `EXTERNAL_STATUS_CHECKS` (`status_checks_must_pass`) — Ultimate-tier external
   checks ([status checks](https://docs.gitlab.com/user/project/merge_requests/status_checks/)).
-- `SECURITY_POLICIES_VIOLATIONS`, `JIRA_ASSOCIATION`, `TITLE_NOT_MATCHING`,
-  `LOCKED_PATHS`, `LOCKED_LFS_FILES`, `MERGE_TIME`, `COMMITS_STATUS`.
+- `SECURITY_POLICIES_VIOLATIONS`, `SECURITY_POLICY_PIPELINE_CHECK`,
+  `JIRA_ASSOCIATION`, `TITLE_NOT_MATCHING`, `LOCKED_PATHS`, `LOCKED_LFS_FILES`,
+  `MERGE_TIME`, `COMMITS_STATUS`.
 
 `.blocked` already carries a free-text `reason` string, so the *reason* survives
 in the tooltip. What does not survive is severity: all of these land at
@@ -385,6 +411,17 @@ merged until after the specified time") demands no action at all while ranking
 above a reviewer asking for changes. Whether the ordering needs a new tier — or
 whether some of these should map to a low-severity "waiting" rather than
 `.blocked` — is a design call, not a mechanical one.
+
+**And the unknown-value arm is a real defect, not a formality.** TBD's
+`mapStateAndReason` ends in `default: return (.blocked, "Blocked")`
+(`PRStatusManager.swift:1175`), so an enum value TBD has not heard of renders a
+merge blocker that may not exist — at severity 5, above changes-requested.
+Since two values appeared in the deployed schema that were not in the source
+tree, this is a state a shipped build will reach. git-spice returns *unknown*
+rather than blocked for precisely this case
+([Part 9](#part-9--prior-art-what-other-tools-actually-do)), and TBD has the
+vocabulary to do the same: `PRObservation.undetermined(cause:)` already means
+"we could not settle this", and is already rendered honestly.
 
 **TBD states GitLab cannot answer.**
 
@@ -404,17 +441,6 @@ whether some of these should map to a low-severity "waiting" rather than
   failed — which reports `SUCCESS`, so the state is simply invisible rather than
   mis-mapped. Acceptable, but it means the GitLab path can never show the amber
   "something failed but it doesn't block" signal.
-- **`.changesRequested` as a first-class decision.** GitHub's `reviewDecision`
-  is one field with three values. GitLab's nearest analogue is either
-  `detailedMergeStatus = NOT_APPROVED` (which conflates "nobody has approved
-  yet" with "someone objected") or the EE-only `changeRequesters` connection,
-  or a scan of every reviewer's `reviewState` for `REQUESTED_CHANGES`. The
-  first is available everywhere and is the wrong shape; the latter two are
-  either paid-tier or cost extra fields. Note that TBD's current rule treats
-  GitHub's `BLOCKED` + `REVIEW_REQUIRED` as `.mergeable`, deliberately
-  ("Ready to merge", `:1166-1167`) — the analogous GitLab call would be to treat
-  `NOT_APPROVED` with zero change-requesters as `.mergeable`, which needs the
-  paid-tier field to distinguish.
 - **`isTerminal`.** GitLab's `locked` state is a fourth value TBD's
   `PRMergeableState` has no case for. It is transient (the MR is mid-merge), so
   mapping it to `.pending` is probably right, but it must be mapped explicitly
@@ -816,6 +842,111 @@ Note that the internal vocabulary is already partly neutral —
 (`PRStatusManager.swift:13-34`) — so there is precedent for the neutral
 direction in the layer users do not see.
 
+## Part 9 — Prior art: what other tools actually do
+
+Five projects were examined because they have already solved some version of
+this. They agree with each other more than they disagree, and where they agree
+the convergence is worth more than any argument from first principles.
+
+**Renovate** has the widest real-world exposure to self-hosted GitLab of
+anything surveyed — it runs against thousands of instances of varying age and
+edition — and its GitLab platform module
+([`lib/modules/platform/gitlab/index.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/platform/gitlab/index.ts))
+answers the CE/EE question by not asking it. It does three things instead:
+
+- **Fetches the server version once** and semver-gates version-dependent
+  behaviour: `const useMergeTrain = config.mergeTrainsEnabled && !semver.lt(defaults.version, '17.11.0')`,
+  degrading to the plain `/merge` endpoint with a logged warning when the
+  instance is older. The docs list the same pattern for several features —
+  `Draft:` prefix since 13.2.0, configurable reviewers since 13.9.0, merge
+  trains since 17.11.0.
+- **Presence-sniffs fields rather than predicting availability**:
+  `const use_detailed_merge_status = !!body.detailed_merge_status;`, falling back
+  to the deprecated `merge_status` when the field simply is not there.
+- **Degrades on tier at runtime**, e.g. applying only the first assignee when
+  multiple assignees turn out to be Premium/Ultimate-only, rather than
+  pre-computing what the tier allows
+  ([platform docs](https://docs.renovatebot.com/modules/platform/gitlab/)).
+
+**This reframes the CE/EE worry, and the reframing matters.** Nobody models CE
+versus EE. They model *version* and *field presence*. But presence-sniffing is a
+**REST affordance**: REST omits a field and the client copes, whereas GraphQL
+**rejects the entire query** for an unknown field. So the risk I flagged as
+"CE/EE" is really "GraphQL couples the whole batch to the instance's schema" —
+and it applies to any field that might be absent, not only EE ones. On a
+100-node batch, one unknown field returns nothing for every merge request in it.
+That is an argument for either splitting the risky fields into a second query,
+running a capability probe once per host, or using REST for the fields that vary.
+
+**git-spice** supports GitHub, GitLab, Bitbucket, Gitea and Forgejo, and its
+GitLab mergeability logic
+([`internal/forge/gitlab/mergeability.go`](https://github.com/abhinav/git-spice/blob/main/internal/forge/gitlab/mergeability.go))
+is the closest existing analogue to `mapStateAndReason`. It is instructive on
+three points TBD has to decide:
+
+- It reads **`DetailedMergeStatus` and nothing else** — no pipeline field, no
+  approvals field — mapping 23 values through one table.
+- Unrecognised values return `ChangeMergeabilityUnknown`, **not** a blocked
+  state. TBD's `default:` arm returns `(.blocked, "Blocked")`
+  (`PRStatusManager.swift:1175`), so a GitLab value TBD has not heard of would
+  show a user a blocker that may not exist. Given GitLab added two enum values
+  between the source tree read here and the live schema, "a value we do not
+  know" is a live possibility, not a hypothetical.
+- `UNCHECKED` and `CHECKING` map to a distinct **Waiting** state rather than to
+  a pending-checks state — the "third thing" Part 3 argues TBD lacks, built as a
+  first-class case by someone who hit the same problem.
+- One special case worth stealing outright: `NEED_REBASE` **plus**
+  `HasConflicts` reports conflicts rather than "behind", because the two are
+  reported through the same status but mean different things to a user.
+
+**Git Town** and **git-pkgs/forge** independently converged on the same answer to
+host identification, and it is a hybrid rather than either pole:
+
+- Git Town "determines the forge type by looking at the URL of the development
+  remote" and, when that fails "for example when using a private forge", takes
+  an explicit `forge-type` setting — `git config git-town.forge-type <value>` or
+  `GIT_TOWN_FORGE_TYPE`, over seven known values
+  ([forge type](https://www.git-town.com/preferences/forge-type)).
+- [`git-pkgs/forge`](https://github.com/git-pkgs/forge), a Go library exposing
+  one interface across GitHub, GitLab, Gitea/Forgejo, Bitbucket, Gerrit and
+  Tangled, detects from the git remote, accepts a `--forge-type` flag, and adds
+  a third option TBD's Part 5 list did not have: **a committed `.forge` file** in
+  the repo root declaring `forge-type = gitlab`. Its stated rationale answers the
+  friction objection directly — "so contributors don't each need `--forge-type`".
+
+A repo-committed declaration is a genuinely different option from a per-user
+setting: it is set once by whoever knows, travels with the repository, and costs
+a 40-worktree fleet nothing because every worktree of a repo shares it.
+
+**Codex is prior art for the gap, not the solution.** The user asked
+specifically, and the answer is that Codex has no GitLab merge-request support:
+[openai/codex#26963](https://github.com/openai/codex/issues/26963), open since
+June 2026, requests exactly this — "For GitHub repositories, Codex App surfaces a
+convenient PR link in the floating/sidebar UI. For GitLab repositories or
+branches associated with an MR, the equivalent GitLab Merge Request link is
+missing." The requester independently proposes hostname detection plus
+"configuring one or more GitLab hosts and access tokens, similar to how other
+integrations handle enterprise/self-hosted instances" — the same two options
+reached here. This is consistent with the multi-PR design's own survey, which
+found the Codex CLI recomputes a single `Option<PullRequest>` per render and
+persists nothing.
+
+**One transport option the survey turned up that Part 6 did not list:** GitLab
+ships an official **MCP server** as part of the platform (experiment in 18.3,
+beta in 18.6), which exposes merge-request reads to any MCP client. It is not
+obviously right for a daemon poll — MCP is a per-session agent protocol, and TBD
+polls from the daemon, not from inside an agent — but it is a supported,
+first-party read path that needs no CLI on PATH, and it is worth a sentence in
+the design rather than silent omission.
+
+**What nobody surveyed does:** use GitLab's GraphQL API for merge-request status.
+Renovate and git-spice both use REST, and GitLab's own Go SDK
+(`gitlab-org/api/client-go`) is REST-shaped. The measurements in Part 4 still
+say GraphQL is the cheaper batch on GitLab — that finding stands on its own
+evidence — but it is worth knowing that choosing GraphQL means leaving the
+path the ecosystem has worn, and taking the schema-coupling risk described
+above with it.
+
 ## What could not be verified
 
 Stated plainly rather than asserted anywhere above:
@@ -847,11 +978,11 @@ Stated plainly rather than asserted anywhere above:
   text says it resolves from `git remote`, `GITLAB_HOST` or configuration, and
   `--all` proves several instances can be configured at once, but the resolution
   was not exercised against two authenticated hosts.
-- **The `detailed_merge_status` value count.** The enum source was read twice;
-  one read reported "24 values" and one "21", while both listings enumerated the
-  same 22 entries. The values themselves agreed exactly across both reads and are
-  what Part 3 rests on, but the count should be re-derived before anything
-  exhaustive is built on it.
+- **Whether `REQUESTED_CHANGES` is reported on a Free-tier project.** The value
+  exists in the schema (see Part 3), but the sampled open merge requests never
+  returned it, so it was observed in the type system and not in the wild. If it
+  turns out to require a paid tier — GitLab's "request changes" reviewer action
+  is tier-gated in some forms — the Part 3 mapping loses its cleanest arm.
 - **Nothing was written.** No merge request was created by any route, so
   `glab mr create`'s end-to-end output was inferred from its source rather than
   observed, and the push-option path was never exercised. A throwaway project on
@@ -869,7 +1000,11 @@ bearing on it:* there is exactly one forge subprocess call site
 (`PRStatusManager.swift:2196`) and one injected seam (`:129-131`), so the
 abstraction is unusually cheap to introduce; but `PRStatusManager` is a
 2,293-line actor whose heal logic is deeply entangled with GitHub's viewer-batch
-shape, and the abstraction boundary would have to cut through it.
+shape, and the abstraction boundary would have to cut through it. Prior art
+leans toward the abstraction: Git Town, git-spice and `git-pkgs/forge` all
+carry an explicit forge interface with per-forge backends, and git-spice's
+GitLab mergeability file shows what the GitLab conformance actually costs — one
+lookup table over one enum, roughly a screen of code.
 
 **2. Should GitHub Enterprise land first?**
 GHE needs the URL regex generalised, the `host` column threaded through, and
@@ -892,6 +1027,17 @@ measured and works cleanly (401 on GitLab, 404 on four non-GitLab hosts
 including another forge), so the question is no longer "would a probe work" but
 "should a background daemon make unsolicited requests to hosts it read out of a
 user's git config".
+
+*Prior art narrows this more than anything else in the survey.* Git Town and
+`git-pkgs/forge` independently ship the same hybrid — infer from the remote URL,
+accept an explicit override when inference fails — and neither probes. And
+`git-pkgs/forge` adds an option not in Part 5's list: a **committed `.forge`
+file** declaring the forge type, so the declaration is made once per repository
+rather than once per user, which removes the per-worktree friction objection
+entirely. Against adopting it wholesale: TBD already has two established homes
+for per-repo settings (a `repo` column, or a file under
+`~/tbd/repos/<repoID>/`), and a file committed into the *user's* repository is a
+third thing TBD has never done.
 
 **4. What is a repository's identity, now that it is not `(owner, repo)`?**
 GitLab projects nest up to 20 levels. The choices are: keep two columns and
@@ -927,24 +1073,31 @@ not). Treating only the first as red preserves today's meaning; treating the
 second as red is what most GitLab users would expect from their own UI. These
 diverge exactly on projects that do not require pipelines to pass.
 
-**7. What stands in for `reviewDecision`?**
-`NOT_APPROVED` conflates "nobody has approved yet" with "a reviewer objected",
-and TBD currently treats the former as `.mergeable`
-(`PRStatusManager.swift:1166-1167`) and the latter as `.changesRequested` at a
-higher severity. Distinguishing them on GitLab needs either the EE-only
-`changeRequesters` field or a per-reviewer `reviewState` scan. *The fork:* accept
-that GitLab Free cannot express `.changesRequested` at all, or query paid-tier
-fields and degrade when they are unavailable. *Evidence bearing on it:* the
-degradation is graceful on gitlab.com — a free-tier project answered
-`approvalsLeft`/`approvalsRequired` with real numbers and `mergeTrainCar` with
-null, no error — so the "query them and cope" branch is viable there. Whether it
-survives a CE-built self-managed instance is still open, and that is the shape
-that would fail the *whole* query rather than one field.
+**7. Is a single `detailedMergeStatus` switch enough, or does anything else get
+queried?**
+This started as "what stands in for `reviewDecision`", and live introspection
+mostly dissolved it: `DetailedMergeStatus` carries a dedicated
+`REQUESTED_CHANGES` value, so `.changesRequested` has a single-field source with
+no paid-tier field and no per-reviewer scan. git-spice reaches the same
+conclusion in shipped code — its GitLab mergeability reads
+`DetailedMergeStatus` and *nothing else* (see
+[Part 9](#part-9--prior-art-what-other-tools-actually-do)).
 
-Note also that `NOT_APPROVED` is not a rare corner: three of six open merge
-requests sampled on a live public project reported it, and two more reported
-`DISCUSSIONS_NOT_RESOLVED` — a state TBD has no case for at all. Whatever this
-question resolves to will be visible constantly, not occasionally.
+What remains is narrower and still a real fork. TBD's icon also wants to say
+"CI is failing" on a project that does **not** gate merges on pipelines, and
+`detailedMergeStatus` is silent there by construction — it reports merge
+blockers, and a non-blocking pipeline failure is not one. So the question is
+whether to query `headPipeline { status }` alongside, and let it colour the icon
+when the merge status is otherwise clean. *Evidence bearing on it:* it is free
+to ask for, arriving in the same batched response; but adding it means the icon
+no longer means "GitLab will not let this merge", which is the one thing
+`detailedMergeStatus` says precisely. This is the same fork as question 6, seen
+from the other side.
+
+Note the live sampling: three of six open merge requests reported
+`NOT_APPROVED` and two reported `DISCUSSIONS_NOT_RESOLVED` — a state TBD has no
+case for at all. Whatever these questions resolve to will be visible constantly,
+not occasionally.
 
 **8. `glab` subprocess, or direct HTTPS?**
 Laid out in [Part 6](#part-6--the-cli-and-auth-story). The fork is really about
@@ -955,6 +1108,23 @@ route is nearly free to build; but a missing or unauthenticated `glab` fails the
 same silent way a missing forge declaration does, and TBD has no surface today
 that tells a user "your PRs are not updating because a CLI is missing" —
 `PRUndeterminedCause.cliUnavailable` exists (`:15`) but only reaches a tooltip.
+A third option surfaced late: GitLab ships a first-party **MCP server** (beta in
+18.6) that exposes merge-request reads with no CLI on PATH — awkward for a
+daemon poll, since MCP is a per-session agent protocol, but it exists and should
+be dismissed explicitly rather than by omission.
+
+**8b. REST or GraphQL — and this is not the same question as 8.**
+Part 4 measures GraphQL as the cheaper batch on GitLab by a wide margin, and
+that finding rests on its own evidence. But Part 9 finds that **nobody in the
+surveyed ecosystem uses GitLab GraphQL for this** — Renovate and git-spice are
+both REST, and GitLab's own Go SDK is REST-shaped — and supplies the reason it
+might not be mere habit: REST omits an unavailable field and lets the client
+sniff for it, which is exactly how Renovate survives instance variation, while
+GraphQL rejects the entire query for one unknown field. On a 100-node batch that
+turns one schema mismatch into zero merge requests. *The fork:* take the cheaper
+batch and manage the schema coupling (split volatile fields into a second query,
+or probe capability once per host), or take the worn path and pay the per-MR
+pipeline call REST forces.
 
 **9. Does the hook gain a `glab mr create` arm, and what covers push-created
 MRs?**

--- a/docs/research/2026-08-16-gitlab-pr-support/findings.md
+++ b/docs/research/2026-08-16-gitlab-pr-support/findings.md
@@ -16,10 +16,25 @@ asserted.
 `--help` surfaces read directly. Its *source* was read at `main`, which may sit
 slightly ahead of 1.113.0.
 
-Nothing here was measured against a live GitLab instance: no merge request was
-created, fetched, or polled, and no authenticated call was made. Facts about
-`glab` come from the installed binary's help output and from its source; facts
-about GitLab's API come from documentation and from GitLab's own source.
+**Measured against gitlab.com:** 2026-08-16, **unauthenticated**, by cloning two
+public projects and querying the public API. Sections resting on a live
+measurement say so. No merge request was created, no write was made, and no
+account was used — so everything requiring authentication or write access
+remains open, and is listed in
+[What could not be verified](#what-could-not-be-verified).
+
+The probes were:
+
+- **A top-level clone** (`gitlab-org/cli`) and a **four-segment nested clone**
+  (`gitlab-org/ruby/gems/gitlab-styles`), to exercise both namespace shapes.
+- **Batched GraphQL reads** by `iids` and by `state: opened`, single-project and
+  multi-project-aliased.
+- **A REST `iids[]` batch** against the same project.
+- **A host-fingerprint sweep** of `/api/v4/version` across five hosts.
+
+Facts about `glab` come from the installed binary's help output and from its
+source; facts about GitLab's API come from documentation, from GitLab's own
+source, and — where marked — from these probes.
 
 ## Summary
 
@@ -72,17 +87,22 @@ so N merge requests in a project come back from one *field*, not N aliases —
 and `detailedMergeStatus` and `headPipeline { status }` ride in the same
 response, eliminating TBD's per-PR check query. Per-tick round trips on a
 40-worktree fleet go from roughly 11–51 down to roughly 5–6. REST batches too:
-`GET /projects/:id/merge_requests?iids[]=…`. The real cost question is not the
-number of calls but the server-side price of the fields, several of which are
-`calls_gitaly: true`, against a documented complexity ceiling of 250 for an
-authenticated GraphQL query.
+`GET /projects/:id/merge_requests?iids[]=…`. **Measured:** 88 merge requests
+across 5 aliased projects, 12 fields each, came back in one unauthenticated
+round trip in 7.8 s / 30 KB — and 100 merge requests with 11 fields, including
+every `calls_gitaly` field, returned HTTP 200 against the *unauthenticated*
+complexity ceiling of 200. Complexity is therefore scored per query field, not
+multiplied by page size, which was the one number that could have made this
+approach unaffordable.
 
-**Host identification is the genuinely unsolved part.** Self-hosted GitLab lives
-on arbitrary domains, and nothing in a git remote says which forge answers
-there. `glab` does not solve this — it does not probe at all; it takes the host
-from configuration or `GITLAB_HOST` and assumes
+**Host identification remains a decision, but a cheap probe is now measured.**
+Self-hosted GitLab lives on arbitrary domains, and nothing in a git remote says
+which forge answers there. `glab` does not solve this — it does not probe at
+all; it takes the host from configuration or `GITLAB_HOST` and assumes
 ([`internal/glinstance/host.go`](https://gitlab.com/gitlab-org/cli/-/raw/main/internal/glinstance/host.go)).
-Whatever TBD does here is a decision, not a lookup.
+But an unauthenticated `GET /api/v4/version` discriminates cleanly: **401 on
+GitLab, 404 on every non-GitLab host tested**, including another forge. Whether
+TBD should make that request at all is still a decision, not a lookup.
 
 A note on scope, because it changes the shape of the work: **GitHub Enterprise
 is a much smaller, separable case.** `gh` already speaks to it, the GraphQL
@@ -406,17 +426,41 @@ documented as 1-indexed with "front of queue == 1" (`Models.swift:1643`);
 reads that number directly, so the mapping must add one — or the field's
 contract must change, which touches the GitHub side too.
 
-**Mergeability may be stale on a list read.** GitLab's merge-request list
-endpoint documentation notes that listing "might not proactively update the
-`merge_status` field, as this represents an expensive operation", and offers
-`with_merge_status_recheck` to request (but not guarantee) an asynchronous
-recomputation. TBD's `PRObservation` vocabulary already has the right shape for
-this — an `.undetermined(cause:)` distinct from a value — but a
-`detailedMergeStatus` of `UNCHECKED` arriving from a batch read is a *third*
+**Mergeability is routinely stale, on GraphQL too — measured.** GitLab's
+merge-request list endpoint documentation notes that listing "might not
+proactively update the `merge_status` field, as this represents an expensive
+operation", and offers `with_merge_status_recheck` to request (but not
+guarantee) an asynchronous recomputation. The GraphQL path is **not** exempt: a
+live batch read of three open merge requests on a public project returned
+`detailedMergeStatus: "UNCHECKED"` for two of them and `"NOT_APPROVED"` for the
+third, in the same response. So a poll will see `UNCHECKED` regularly, not
+rarely.
+
+TBD's `PRObservation` vocabulary already has the right shape for this — an
+`.undetermined(cause:)` distinct from a value — but `UNCHECKED` is a *third*
 thing again: the forge answered, and the answer is "I have not computed it".
-Mapping that to `.pending` is plausible; mapping it to
-`.undetermined(cause: …)` may be more honest. Whether the GraphQL path has the
-same laziness is unverified.
+Mapping it to `.pending` is plausible; mapping it to `.undetermined(cause: …)`
+may be more honest, and would keep the previous value on screen rather than
+flipping a settled PR to amber every time GitLab's cache expires.
+
+**A merged or closed MR reports `NOT_OPEN`, not a merge verdict — measured.**
+Every merged merge request in the live batch came back with
+`detailedMergeStatus: "NOT_OPEN"`. So `state` must be read first and
+`detailedMergeStatus` consulted only when `state == "opened"` — which is
+structurally the same shape as `mapStateAndReason` switching on `ghState`
+before it looks at `mergeStateStatus` (`PRStatusManager.swift:1149-1153`).
+Note also that `mergeable` is `false` on a merged MR, so that field must not be
+read as "was mergeable".
+
+**Node order does not follow the `iids` argument — measured.** The response
+returned nodes newest-first regardless of the order requested, and **a requested
+`iid` that does not resolve is silently absent from `nodes`** rather than
+appearing as a null (a 20-iid request against one project returned 8 nodes).
+TBD's alias-keyed approach gets its binding correspondence from the alias table;
+a GitLab port must match on `iid` and treat absence as "did not resolve" — which
+is exactly what `refreshBindingGroup` already does when
+`nodesByBindingID[binding.id]` misses (`:872-877`), so the existing
+keep-previous-status behaviour carries over unchanged.
 
 ## Part 4 — Batching and fleet cost
 
@@ -481,10 +525,11 @@ strength here, not a risk.
 **REST batches too**, if a design prefers it:
 `GET /projects/:id/merge_requests?iids[]=1&iids[]=2`, and the list response
 carries `detailed_merge_status`, `draft`, `source_branch`, `target_branch`,
-`web_url`, `has_conflicts` and `blocking_discussions_resolved`. It does **not**
-appear to carry `head_pipeline` — that is documented on the single-MR response —
-so a REST design would reintroduce a per-MR call for pipeline status, or accept
-`detailed_merge_status` alone. This asymmetry is the strongest argument for
+`web_url`, `has_conflicts` and `blocking_discussions_resolved`. **Measured:** a
+two-iid REST batch returned in 0.5 s with `detailed_merge_status` present
+(`not_approved`, `mergeable`) and **`head_pipeline` absent entirely**. So a REST
+design reintroduces a per-MR call for pipeline status — the exact per-PR term
+the GraphQL path deletes. This measured asymmetry is the strongest argument for
 GraphQL on the GitLab side.
 
 ### The real cost ceilings
@@ -497,16 +542,29 @@ GraphQL on the GitLab side.
   [`gitlab_schema.rb`](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/gitlab_schema.rb)).
   Docs state "each field in a query adds `1` to the complexity score, although
   this can be higher or lower for particular fields", and do not document how
-  connections or `calls_gitaly` fields are scored. A batch of 20 merge requests
-  with 10 fields each is either 10 (if connections cost per-field) or 200+ (if
-  per-node) — a factor of twenty apart, and the answer decides whether the
-  20-binding cap is comfortable or already over budget. **This must be measured
-  against a real instance before a cadence is chosen.**
-- **Gitaly-backed fields.** `detailedMergeStatus`, `mergeable`, `approved`,
-  `approvalsLeft` and `approvalsRequired` are all declared `calls_gitaly: true`.
-  Each is a git-layer operation server-side. Asking for all of them across 20
-  merge requests every 30 seconds, per project, per fleet, is a load question
-  that no rate limit will surface until an administrator complains.
+  connections or `calls_gitaly` fields are scored. **Measured, and the answer is
+  the good one:** `mergeRequests(first: 100)` selecting 11 fields per node —
+  including every `calls_gitaly` field — returned HTTP 200 *unauthenticated*,
+  against the lower ceiling of 200. Per-node scoring would have put that query
+  above 1,000. So complexity counts query-AST fields and is **not** multiplied
+  by page size, and batch width is bounded by page size (100) and query text
+  (10,000 characters), not by the complexity budget. A 5-project × 20-iid ×
+  12-field query measured 1,561 characters — roughly 6× headroom on the text
+  limit.
+- **Gitaly-backed fields are affordable, but the first read is not.**
+  `detailedMergeStatus`, `mergeable`, `approved`, `approvalsLeft` and
+  `approvalsRequired` are all declared `calls_gitaly: true`. Measured warm, each
+  is cheap: 6 open merge requests with `detailedMergeStatus` took 0.42 s,
+  `mergeable` 0.36 s, `approved` 0.18 s. But the **first** query combining all of
+  them against a cold cache took over two minutes before returning, while every
+  repeat was sub-second. One observation is not a pattern, and this was
+  unauthenticated against gitlab.com's busiest namespace — but a first-poll
+  latency spike is worth expecting, and TBD's existing discipline already covers
+  it: a slow or failed fetch keeps the previous cached status rather than
+  guessing.
+- **Bulk timings, for cadence sizing.** 100 merge requests × 11 fields: 2.6 s.
+  88 merge requests across 5 aliased projects × 12 fields: 7.8 s, 30 KB. Both
+  unauthenticated and uncached.
 - **Rate limits are generous.** gitlab.com allows **2,000 authenticated API
   requests per minute per user** and 500 unauthenticated per IP
   ([gitlab.com limits](https://docs.gitlab.com/user/gitlab_com/)). At the 5-minute
@@ -536,15 +594,24 @@ user must first have run `glab auth login --hostname <host>`, which is itself
 the declaration. **`glab`'s answer to "how do you know it's GitLab" is "the user
 told us."**
 
-**A cheap probe does exist, if a design wants one.** `GET
-https://<host>/api/v4/version` returns **HTTP 401** unauthenticated — verified
-directly against gitlab.com on 2026-08-16, which returned 401 with no body
-readable. Authentication is required for that endpoint and for `/api/v4/metadata`
-([version/metadata API](https://docs.gitlab.com/api/version/)). A 401 from
-`/api/v4/version` is therefore a strong positive fingerprint: a non-GitLab host
-almost certainly 404s. But it is an unauthenticated outbound request to an
-arbitrary domain read from a user's git config, made by a background daemon, and
-that is a decision with a privacy dimension, not a lookup.
+**A cheap probe does exist, and it discriminates cleanly — measured.**
+`GET https://<host>/api/v4/version` requires authentication
+([version/metadata API](https://docs.gitlab.com/api/version/)), so on GitLab it
+answers 401 rather than 404. Swept across five hosts on 2026-08-16,
+unauthenticated:
+
+- `gitlab.com` → **401**, body `{"message":"401 Unauthorized"}`
+- `github.com` → 404, body `Not Found`
+- `codeberg.org` (Forgejo) → 404, body `Not found.`
+- `git.kernel.org` (cgit) → 404, an HTML page
+- `example.com` → 404, an HTML page
+
+The 401-versus-404 split is crisp, and notably does **not** false-positive on
+another forge. One request, no auth, no state. But it is still an outbound
+request to an arbitrary domain read from a user's git config, made by a
+background daemon on the user's behalf — a decision with a privacy dimension,
+not a lookup. It also cannot distinguish a GitLab instance the user can reach
+from one they cannot, since 401 is exactly what "no credentials" looks like.
 
 **The options, stated without choosing between them:**
 
@@ -757,17 +824,18 @@ Stated plainly rather than asserted anywhere above:
   whether it contains the created MR's URL or only the "new merge request" form
   URL. GitLab's docs page for push options redirected to an authentication gate
   and could not be read.
-- **How GitLab scores GraphQL complexity for connections and for
-  `calls_gitaly: true` fields.** The 250 ceiling is documented; the arithmetic
-  that consumes it is not. This decides whether a 20-MR batch fits.
-- **Whether the GraphQL `detailedMergeStatus` is computed on read or is as lazy
-  as REST's `merge_status`.** The REST laziness is documented; the GraphQL
-  behaviour is not.
-- **How EE-only fields behave on a Free instance.** `approvalsLeft`,
-  `approvalsRequired`, `approvalState`, `mergeTrainCar` and `changeRequesters`
-  are declared in `ee/`. Whether they are absent from the schema (query error) or
-  present-and-null (graceful) on a Free self-managed instance was not tested, and
-  a query that errors wholesale on one instance shape is a real failure mode.
+- **How EE-only fields behave on a self-managed instance built without the EE
+  code.** On gitlab.com they degrade gracefully: querying `approvalsLeft`,
+  `approvalsRequired` and `mergeTrainCar` against a free-tier public project
+  (`veloren/veloren`) returned `1`, `1` and `null` respectively with no error,
+  and the same fields on a licensed project returned real values. But gitlab.com
+  runs the EE codebase with tier gating, so this shows *tier* degradation, not
+  *codebase* degradation. A CE-built self-managed instance may not carry the
+  fields in its schema at all, which would fail the whole query rather than one
+  field. Only a CE instance can settle it.
+- **Whether authenticated behaviour differs from what was measured.** Every
+  probe was unauthenticated. Rate limits, complexity ceiling (250 vs 200),
+  private-project visibility and per-user throttling were all untested.
 - **Whether GitLab project paths are case-insensitive.** TBD lowercases owner and
   repo on write and on comparison specifically because GitHub is
   (`PRBindingStore.swift:29-31`, `PRBinding.swift:96-99`). GitLab has a
@@ -784,8 +852,11 @@ Stated plainly rather than asserted anywhere above:
   same 22 entries. The values themselves agreed exactly across both reads and are
   what Part 3 rests on, but the count should be re-derived before anything
   exhaustive is built on it.
-- **Nothing was run against a live GitLab instance.** No latency figure, no
-  measured complexity score, no observed response body for a merge request.
+- **Nothing was written.** No merge request was created by any route, so
+  `glab mr create`'s end-to-end output was inferred from its source rather than
+  observed, and the push-option path was never exercised. A throwaway project on
+  any instance would settle both, plus the CE question above if the instance is
+  self-managed.
 
 ## Open questions for the design session
 
@@ -816,7 +887,11 @@ bearing on it:* `glab` itself does not probe, and the repo's own doctrine
 edits rather than an inference the daemon computes. Against that: a fleet of 40
 worktrees across many repos makes a per-repo setup step real friction, and a
 wrong or absent declaration fails silently — no binding ever forms, which is
-exactly the symptom that prompted this research.
+exactly the symptom that prompted this research. The probe option is now
+measured and works cleanly (401 on GitLab, 404 on four non-GitLab hosts
+including another forge), so the question is no longer "would a probe work" but
+"should a background daemon make unsolicited requests to hosts it read out of a
+user's git config".
 
 **4. What is a repository's identity, now that it is not `(owner, repo)`?**
 GitLab projects nest up to 20 levels. The choices are: keep two columns and
@@ -859,8 +934,17 @@ and TBD currently treats the former as `.mergeable`
 higher severity. Distinguishing them on GitLab needs either the EE-only
 `changeRequesters` field or a per-reviewer `reviewState` scan. *The fork:* accept
 that GitLab Free cannot express `.changesRequested` at all, or query paid-tier
-fields and degrade when they are unavailable — which requires knowing how those
-fields behave on a Free instance, listed above as unverified.
+fields and degrade when they are unavailable. *Evidence bearing on it:* the
+degradation is graceful on gitlab.com — a free-tier project answered
+`approvalsLeft`/`approvalsRequired` with real numbers and `mergeTrainCar` with
+null, no error — so the "query them and cope" branch is viable there. Whether it
+survives a CE-built self-managed instance is still open, and that is the shape
+that would fail the *whole* query rather than one field.
+
+Note also that `NOT_APPROVED` is not a rare corner: three of six open merge
+requests sampled on a live public project reported it, and two more reported
+`DISCUSSIONS_NOT_RESOLVED` — a state TBD has no case for at all. Whatever this
+question resolves to will be visible constantly, not occasionally.
 
 **8. `glab` subprocess, or direct HTTPS?**
 Laid out in [Part 6](#part-6--the-cli-and-auth-story). The fork is really about
@@ -896,8 +980,11 @@ layer users do not read.
 
 **11. Does the 20-binding cap still make sense?**
 It exists to bound per-poll GraphQL cost (`PRBindingStore.swift:87-90`), and on
-GitLab that cost is a single `iids: [...]` argument rather than 20 aliases — so
-the justification weakens considerably. *Evidence bearing on it:* whether it
-weakens or vanishes depends on GitLab's connection complexity arithmetic, which
-is unverified. If a connection costs per-node, the cap matters more on GitLab,
-not less.
+GitLab that cost is a single `iids: [...]` argument rather than 20 aliases.
+*Evidence bearing on it:* the complexity arithmetic is now measured and does not
+scale with node count — 100 nodes × 11 fields passed the *lower* unauthenticated
+ceiling — so on the GitLab path the cap buys essentially nothing below the
+100-node page limit. That is an argument for leaving it alone rather than
+removing it: it still bounds the GitHub path, where cost genuinely is per-alias,
+and a cap that differs per forge is a worse thing to reason about than one that
+is merely redundant on one side.

--- a/docs/research/2026-08-16-gitlab-pr-support/findings.md
+++ b/docs/research/2026-08-16-gitlab-pr-support/findings.md
@@ -871,12 +871,56 @@ answers the CE/EE question by not asking it. It does three things instead:
 **This reframes the CE/EE worry, and the reframing matters.** Nobody models CE
 versus EE. They model *version* and *field presence*. But presence-sniffing is a
 **REST affordance**: REST omits a field and the client copes, whereas GraphQL
-**rejects the entire query** for an unknown field. So the risk I flagged as
-"CE/EE" is really "GraphQL couples the whole batch to the instance's schema" —
-and it applies to any field that might be absent, not only EE ones. On a
-100-node batch, one unknown field returns nothing for every merge request in it.
-That is an argument for either splitting the risky fields into a second query,
-running a capability probe once per host, or using REST for the fields that vary.
+**rejects the entire query** for an unknown field — measured: a query naming one
+non-existent field returned HTTP 200 with `"data": null` and no merge requests
+at all. So the risk is not "CE/EE", it is "GraphQL couples the whole batch to
+the instance's schema", and it applies to any field that might be absent, not
+only EE ones.
+
+### Is "CE or EE?" the question, and can one API call settle it?
+
+Both halves are worth answering directly, because the obvious answer is the
+wrong one.
+
+**Edition is a proxy, and a lossy one.** `GET /api/v4/metadata` does report it —
+the documented response carries `"version": "18.1.1-ee"` and `"enterprise":
+true` ([metadata API](https://docs.gitlab.com/api/version/)) — so one
+authenticated call genuinely answers "CE or EE". But edition does not determine
+field availability on its own. Measured on gitlab.com, which is an EE build: a
+free-tier project answered `approvalsLeft` and `approvalsRequired` with real
+numbers while `mergeTrainCar` came back null — so tier gates *values* on an EE
+build. And two enum values were present in the deployed schema but absent from
+the source tree at `master`, so *version* gates the schema independently of
+edition. An edition flag predicts neither.
+
+**Introspection is not a cheap probe here.** gitlab.com returns the **full 7.8 MB
+schema for any introspection query**, including a narrowly targeted
+`__type(name: "MergeRequest") { fields { name } }` — measured, byte-identical
+size to a bare `__schema` query. Asking "does this host have that field" costs a
+7.8 MB download per host.
+
+**The cheapest correct probe is no extra call at all.** An unknown field fails
+in a precisely machine-readable way — measured, 291 bytes total:
+
+```json
+{"data": null, "errors": [{
+  "message": "Field 'totallyNotAField' doesn't exist on type 'MergeRequest'",
+  "extensions": {"code": "undefinedField",
+                 "typeName": "MergeRequest",
+                 "fieldName": "totallyNotAField"}}]}
+```
+
+`extensions.code` is a stable discriminator and `fieldName` names exactly what to
+drop. So the shape available is: send the rich query; on `undefinedField`, drop
+the named field, retry lean, and remember the answer per host. Cost is zero
+round trips in the happy path and one wasted round trip, once, on a host that
+cannot serve the rich query. It needs no version table, no edition check and no
+introspection, and it degrades identically for a CE build, an old version, and a
+field GitLab removes in future — which is the property a version-keyed table
+does not have.
+
+The remaining judgement is what "remember" means — process lifetime, a TTL, or a
+persisted per-host capability row — and that is a design call, not a fact.
 
 **git-spice** supports GitHub, GitLab, Bitbucket, Gitea and Forgejo, and its
 GitLab mergeability logic
@@ -963,7 +1007,10 @@ Stated plainly rather than asserted anywhere above:
   runs the EE codebase with tier gating, so this shows *tier* degradation, not
   *codebase* degradation. A CE-built self-managed instance may not carry the
   fields in its schema at all, which would fail the whole query rather than one
-  field. Only a CE instance can settle it.
+  field. Only a CE instance can settle it — **but a design need not wait for
+  that answer.** The `undefinedField` fallback in Part 9 handles the CE case
+  without knowing in advance whether it will occur, which converts this from a
+  blocking unknown into a branch that wants a test.
 - **Whether authenticated behaviour differs from what was measured.** Every
   probe was unauthenticated. Rate limits, complexity ceiling (250 vs 200),
   private-project visibility and per-user throttling were all untested.
@@ -1121,10 +1168,16 @@ both REST, and GitLab's own Go SDK is REST-shaped — and supplies the reason it
 might not be mere habit: REST omits an unavailable field and lets the client
 sniff for it, which is exactly how Renovate survives instance variation, while
 GraphQL rejects the entire query for one unknown field. On a 100-node batch that
-turns one schema mismatch into zero merge requests. *The fork:* take the cheaper
-batch and manage the schema coupling (split volatile fields into a second query,
-or probe capability once per host), or take the worn path and pay the per-MR
-pipeline call REST forces.
+turns one schema mismatch into zero merge requests — measured, `"data": null`.
+*The fork:* take the cheaper batch and manage the schema coupling, or take the
+worn path and pay the per-MR pipeline call REST forces. *Evidence bearing on
+it:* managing the coupling turns out to be cheap. An unknown field returns a
+machine-readable `extensions.code: "undefinedField"` naming the offending field,
+so a retry-lean-and-remember fallback costs nothing in the happy path and needs
+no version or edition table — see
+[Part 9](#is-ce-or-ee-the-question-and-can-one-api-call-settle-it). That
+weakens the main argument against GraphQL considerably, though it does add a
+degraded path that must itself be tested on both branches.
 
 **9. Does the hook gain a `glab mr create` arm, and what covers push-created
 MRs?**

--- a/docs/research/2026-08-16-gitlab-pr-support/findings.md
+++ b/docs/research/2026-08-16-gitlab-pr-support/findings.md
@@ -1,0 +1,873 @@
+# Extending TBD's pull-request subsystem to GitLab
+
+**Status:** Research only. No design, no spec, no implementation. The open
+questions at the end are deliberately left open — a human answers them.
+
+**TBD code read:** 2026-08-16, against the tree at `bf0719f4`. Every claim about
+TBD cites `file:line` in that tree.
+
+**GitLab facts checked:** 2026-08-16, against `docs.gitlab.com` and against
+GitLab's own source at `gitlab-org/gitlab` `master`. Every claim about GitLab
+names the page or file it came from. Claims that could not be verified are
+listed in [What could not be verified](#what-could-not-be-verified) rather than
+asserted.
+
+Nothing here was measured against a live GitLab instance. `glab` is not
+installed on the probe machine (`which glab` → not found), so no command
+surface was exercised; the CLI section rests on documentation and on `glab`'s
+own source.
+
+## Summary
+
+TBD's PR subsystem is GitHub-only in three separable ways, and they cost
+different amounts.
+
+**A URL regex and a handful of string literals** pin the host to `github.com`.
+This is the cheap layer. `PRBindingExtractor.urlPattern`
+(`Sources/TBDShared/PRBindingExtractor.swift:32`) will not match any other host,
+and because every binding path — hook, branch match, manual attach, and the
+poll's own heal — funnels through `parsePRURLs`, no binding can form on any
+other host at all. The `host` column already exists and already defaults to
+`github.com` (`Sources/TBDDaemon/Database/Database.swift:1255`), so the storage
+groundwork is done.
+
+**A hard dependency on the `gh` binary** is the middle layer. Every forge call
+in the daemon is `gh` (`PRStatusManager.resolvedGHPath`,
+`Sources/TBDDaemon/PR/PRStatusManager.swift:2236`), and `gh` is the *only*
+forge subprocess in `Sources/` — there is exactly one call site to redirect.
+`glab` turns out to be a close counterpart: `glab api graphql -f query='…'`
+takes the same subcommand, the same flag spelling, and the same semantics as
+`gh api graphql -f query='…'`.
+
+**An assumption about GitHub's data model** is the expensive layer, and it is
+where the design work actually is. Three assumptions do not survive the move:
+
+- **A repository is `(owner, repo)`.** GitLab projects live at arbitrary
+  namespace depth — up to 20 levels of subgroup nesting
+  ([subgroups](https://docs.gitlab.com/user/group/subgroups/)) — so a project's
+  identity is a single `fullPath` string, not a pair. This reaches the DB unique
+  index, `PRBinding.identityKey`, the cross-repo heal, and the wrong-repo
+  rejection.
+- **Mergeability is `mergeStateStatus` + `reviewDecision` + a per-check
+  `isRequired` rollup.** GitLab collapses all three into one enum,
+  `detailed_merge_status`, with 22 values that do not partition the way TBD's
+  eight states do. Some GitLab states have no TBD expression; some TBD states
+  have no GitLab answer.
+- **Required checks are a per-PR list you must fetch separately.** GitLab has no
+  per-check required flag. That removes TBD's second round trip per PR entirely,
+  which is a *simplification* — and it removes the distinction TBD's icon colour
+  currently rests on.
+
+**Batching is not a risk; it is the strongest part of the story.** GitLab's
+GraphQL `mergeRequests` resolver takes `iids: [String]`
+([resolver source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/resolvers/merge_requests_resolver.rb)),
+so N merge requests in a project come back from one *field*, not N aliases —
+and `detailedMergeStatus` and `headPipeline { status }` ride in the same
+response, eliminating TBD's per-PR check query. Per-tick round trips on a
+40-worktree fleet go from roughly 11–51 down to roughly 5–6. REST batches too:
+`GET /projects/:id/merge_requests?iids[]=…`. The real cost question is not the
+number of calls but the server-side price of the fields, several of which are
+`calls_gitaly: true`, against a documented complexity ceiling of 250 for an
+authenticated GraphQL query.
+
+**Host identification is the genuinely unsolved part.** Self-hosted GitLab lives
+on arbitrary domains, and nothing in a git remote says which forge answers
+there. `glab` does not solve this — it does not probe at all; it takes the host
+from configuration or `GITLAB_HOST` and assumes
+([`internal/glinstance/host.go`](https://gitlab.com/gitlab-org/cli/-/raw/main/internal/glinstance/host.go)).
+Whatever TBD does here is a decision, not a lookup.
+
+A note on scope, because it changes the shape of the work: **GitHub Enterprise
+is a much smaller, separable case.** `gh` already speaks to it, the GraphQL
+schema is identical, and the state model is identical. Only the URL regex and
+the `host` plumbing block it. Whether to do that first — as a cheap validation
+of the host plumbing GitLab will also need — is one of the open questions.
+
+## Part 1 — Where TBD assumes GitHub
+
+### Hardcoded `github.com`
+
+- **The binding URL regex.** `PRBindingExtractor.urlPattern` is
+  `https://github\.com/…/pull/(\d+)`
+  (`Sources/TBDShared/PRBindingExtractor.swift:32-33`), and `parsePRURLs` stamps
+  `host: "github.com"` onto every result it returns (`:239`). Its own comment
+  states the lock is deliberate and additive support is later (`:29-31`).
+- **This regex is the single chokepoint for all three discovery sources.** The
+  hook path calls it through `PRBindingExtractor.extract(fromHookPayload:)`
+  (`:249-255`); manual attach calls it through
+  `RPCRouter.resolvePRRef` (`Sources/TBDDaemon/Server/RPCRouter.swift:1237`);
+  and the poll's branch matcher and both heals call it through
+  `PRStatusManager.bindablePRURLs`
+  (`Sources/TBDDaemon/PR/PRStatusManager.swift:714-725`), which routes through
+  `parsePRURLs` *on purpose* so the poll obeys the same host lock. On a
+  non-`github.com` host every one of these yields nothing, and the heals yield
+  nothing in the safe direction (no removal).
+- **Bare-number attach synthesises a GitHub URL.** `RPCRouter.prRef` builds
+  `https://github.com/\(owner)/\(name)/pull/\(number)` with `host: "github.com"`
+  (`RPCRouter.swift:1255-1260`). This is also what seeds provenance bindings
+  from `Worktree.prNumber`, so `tbd pr attach 412` on a GitLab worktree would
+  mint a URL pointing at the wrong forge.
+- **The model default.** `PRBinding.init` defaults `host` to `"github.com"`
+  (`Sources/TBDShared/PRBinding.swift:32`), as does the DB column
+  (`Database.swift:1255`).
+- **The display-only synthetic binding** the app lifts from a cached
+  `Worktree.prStatus` takes that same default
+  (`Sources/TBDApp/PRBindingPresentation.swift:71-81`), so a chip rendered from
+  a cached status is labelled `github.com` regardless of where the PR lives.
+- **The terminal's `PR #123` click target.** `TBDTerminalView.gitHubBrowserURL`
+  rewrites an `scp`-style remote only when it starts with `git@github.com:` and
+  then appends `/pull/<n>` (`Sources/TBDApp/Terminal/TBDTerminalView.swift:576`,
+  `:586-593`). On any other host it produces a link to a path that does not
+  exist.
+- **URL parsing assumes the GitHub path shape.**
+  `PRStatusManager.parseOwnerRepo(fromURL:)` requires `parts[2] == "pull"`
+  (`PRStatusManager.swift:1340-1346`). A GitLab MR URL is
+  `https://<host>/<namespace…>/<project>/-/merge_requests/<iid>`, whose third
+  segment is `-`, so this returns nil — which in turn silently disables the
+  cross-repo poisoned-cache heal (`:1691-1706`) and `fetchCheckSignals`
+  (`:2155`).
+
+### The `gh` CLI
+
+- **One resolver, one runner.** `resolvedGHPath` probes
+  `/usr/local/bin/gh`, `/opt/homebrew/bin/gh`, `/usr/bin/gh`, then `PATH`
+  (`PRStatusManager.swift:2236-2249`), and `runGHResult` is the only place a
+  forge subprocess is spawned (`:2196-2233`). A repo-wide grep for a forge
+  binary finds `gh` in exactly this file and in the seeded Nightwatch scripts;
+  no other `Sources/` target shells out to a forge.
+- **The seam already exists.** `PRStatusManager.GHRunner`
+  (`:129-131`) is an injected closure taking `(args, repoPath)`, used by tests.
+  Whatever a second forge needs, it does not need a new process-spawning
+  abstraction invented for it.
+- **Five distinct `gh` argument vectors** are in use:
+  - `repo view --json nameWithOwner --jq .nameWithOwner` (`:2017`) — resolve the
+    checkout's `owner/name`, TTL-cached 15 minutes (`:2028-2035`).
+  - `api graphql -f query=<viewer batch>` (`:2122-2133`) — the viewer's first
+    100 PRs across every repo.
+  - `api graphql -f query=<aliased by-number> -f owner= -f name=` (`:2098-2103`,
+    `:829-834`) — the numbered and per-binding paths.
+  - `api graphql -f query=<by branch> -f owner= -f name= -f branch=`
+    (`:1398-1406`) — single-worktree refresh.
+  - `api graphql -f query=<per-PR check detail>` (`:2159-2160`) — the required-
+    check rollup for one PR.
+- **Auth is assumed host-scoped and ambient.** The code notes that `gh` auth is
+  host-scoped so any checkout serves as the working directory (`:434-438`,
+  `:771-773`). `refreshBindingGroup` explicitly does *not* pass `group.host` to
+  `gh`, and says so, precisely because binding is host-locked today
+  (`:818-820`).
+
+### GitHub's data model
+
+- **`(owner, repo)` as the repository identity.** It is a tuple in every
+  signature that carries it — `resolveNameWithOwner` (`:2016`), `repoIdentity`
+  (`:2042`), `groupNumberedByRepo` (`:2055`), `groupBindingsByRepo` (`:792`),
+  `repoBranchKey` (`:1619`) — and two columns in the schema
+  (`Database.swift:1256-1257`) participating in the unique identity index
+  (`:1273-1277`). `PRBinding.identityKey` is
+  `host ⧉ owner ⧉ repo ⧉ number` (`PRBinding.swift:97-99`), and
+  `PRBindingStore.identity(from:)` splits it back on exactly four parts
+  (`Sources/TBDDaemon/Database/PRBindingStore.swift:257-264`).
+- **Case folding justified by GitHub's rules.** Owner and repo are lowercased on
+  write (`PRBindingStore.swift:29-31`) and on comparison
+  (`PRBinding.swift:96-99`, `PRStatusManager.swift:1615-1621`,
+  `PRBindingCoordinator.swift:81-82`), each citing that GitHub treats them
+  case-insensitively.
+- **The state derivation.** `mapStateAndReason`
+  (`PRStatusManager.swift:1141-1178`) reads GitHub's `state`,
+  `mergeStateStatus` (`CLEAN`, `HAS_HOOKS`, `UNSTABLE`, `BLOCKED`, `DIRTY`,
+  `BEHIND`, `UNKNOWN`, `DRAFT`), `reviewDecision` (`CHANGES_REQUESTED`,
+  `REVIEW_REQUIRED`, `APPROVED`), `isDraft`, and two booleans derived from the
+  per-check query.
+- **Required-check awareness.** `checkSignals` filters contexts to
+  `isRequired == true` (`:1250-1256`), where `isRequired` comes from GitHub's
+  `isRequired(pullRequestNumber:)` field on `CheckRun` and `StatusContext`
+  (`prCheckQuery`, `:1351-1363`). The comment at `:1244-1249` states the
+  consequence: a PR with no required checks gets no CI colouring at all, and
+  `mergeStateStatus` decides instead.
+- **The merge queue.** `PRStatus.mergeQueuePosition` is documented as
+  "1-indexed position in GitHub's merge queue"
+  (`Sources/TBDShared/Models.swift:1643-1650`), sourced from
+  `mergeQueueEntry.position` (`PRStatusManager.swift:1875-1876`) — with a note
+  that no `mergeStateStatus` value expresses it.
+- **The viewer-authored batch as the discovery substrate.**
+  `runGHGraphQL` fetches `viewer { pullRequests(first: 100, …) }`
+  (`:2122-2132`), and the whole unnumbered path — `matchUnnumbered` (`:1660`),
+  `bestNodeByRepoBranch` (`:1632`), `cachedNumberFallback` (`:1598`),
+  `headRefVerificationTargets` (`:1789`) — is built on it, including the
+  `batchSucceeded` predicate that gates both heals.
+- **`PRMergeableState`** is eight cases (`Models.swift:1607-1630`) with an
+  `attentionSeverity` ordering defined once in `PRBinding.swift:114-124`, read by
+  the toolbar icon, the sidebar dot and the `Worktree.prStatus` column.
+
+### The hook's `gh pr create` gate
+
+- **The prefilter grep** is `pr([^[:alnum:]]|\\[tr])+create`
+  (`Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift:182`), embedded in
+  `prBindCommand` (`:196-197`) and wired as a `PostToolUse` `Bash` matcher with a
+  3-second timeout (`:281-294`, `:209`). The pattern deliberately does not
+  require `gh` adjacency (`:144-148`), so it would also admit a `glab mr create`
+  payload only if the words `pr` and `create` appear — which they do not.
+- **The authoritative gate** is `PRBindingExtractor.isPRCreateCommand`, which
+  requires the command word to be `gh` or to end in `/gh`
+  (`PRBindingExtractor.swift:210-212`) and the subcommand path to be exactly
+  `["pr", "create"]` (`:224`), with `-R`, `--repo`, `--hostname` treated as
+  value-taking flags (`:41`).
+
+### UI copy and the CLI
+
+Surfaces that say "GitHub" or "PR" to a user:
+
+- **CLI help and errors.** `PRRefArgument.reference` help reads "PR number,
+  #number, or full GitHub PR URL"
+  (`Sources/TBDCLI/Commands/PRCommands.swift:99`), and the parse failure says
+  the same (`:105`). `PRCommand.parseReference`'s doc says GitHub PR URL
+  (`:17`).
+- **The RPC error string** "pr reference must be a github PR url or a number in
+  the worktree's own repo" (`RPCRouter.swift:1210`).
+- **`tbd pr list` output** renders `#412  <reason>  <branch>  (<source>)`
+  (`PRCommands.swift:86-90`) and "No PRs bound to this worktree." (`:76`).
+- **The `tbd` skill** documents `tbd pr list|attach|detach` as PRs
+  (`Sources/TBDShared/TBDSkillContent.swift:187-189`).
+- **App copy**: `"\(bindings.count) PRs"` and `"#412"`
+  (`Sources/TBDApp/PRBindingPresentation.swift:87-93`), `"Open PR #…"` and
+  `"PR #…"` (`Sources/TBDApp/ContentView.swift:487-488`, `:1065`),
+  `"Open PR \(chip.label)"` and the accessibility label
+  (`Sources/TBDApp/Helpers/StatusBarView.swift:291-292`, `:333`), the sidebar
+  tooltip (`Sources/TBDApp/Sidebar/WorktreeRowView.swift:213`, `:223`), the tab
+  label `"PR #\(number)"` (`Sources/TBDApp/AppState+Tabs.swift:531`), the
+  auto-archive and auto-hibernate toggles (`ContentView.swift:439`, `:455`;
+  `Sources/TBDApp/Settings/SettingsView.swift:148`, `:154`), the branch picker
+  placeholder "Filter branches & PRs"
+  (`Sources/TBDApp/Sidebar/BranchPickerView.swift:53`) and its rows (`:225-226`),
+  and the hibernation banner "Hibernated after the PR merged"
+  (`Sources/TBDApp/Terminal/TerminalContainerView.swift:408`).
+- **Deliberately forge-neutral already**: the `PRUndeterminedCause` vocabulary
+  says "the forge CLI was unavailable", "the forge query failed" and so on
+  (`PRStatusManager.swift:13-34`) — a closed vocabulary chosen so a tooltip never
+  carries a host or org name. That naming convention is the one piece of
+  user-facing copy that already generalises.
+
+## Part 2 — What GitLab offers, against what TBD needs
+
+GitLab exposes both a REST v4 API at `/api/v4`
+([REST docs](https://docs.gitlab.com/api/rest/), `PRIVATE-TOKEN` header,
+pagination default 20 / max 100) and a GraphQL API at `/api/graphql`
+([GraphQL docs](https://docs.gitlab.com/api/graphql/), `Authorization: Bearer`).
+
+Against each fact TBD needs:
+
+- **Merge-request number** — `iid`, the per-project internal ID. In GraphQL it
+  is typed `GraphQL::Types::String`, not `Int`
+  ([`merge_request_type.rb`](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/merge_request_type.rb)),
+  so a parse must accept a string. There is also a separate instance-global
+  `id`; the `iid` is what appears in the URL and in the UI.
+- **Title** — `title` (GraphQL and REST).
+- **State** — `state`, values `opened`, `closed`, `merged`, `locked`
+  ([merge requests API](https://docs.gitlab.com/api/merge_requests/)). Note
+  `opened`, not GitHub's `OPEN`, and the extra `locked`.
+- **Mergeability** — `detailed_merge_status` (REST) / `detailedMergeStatus`
+  (GraphQL), a 22-value enum; plus a coarse `mergeable` boolean and a
+  `conflicts` boolean. The older `merge_status` (`unchecked`, `checking`,
+  `can_be_merged`, `cannot_be_merged`, `cannot_be_merged_recheck`) is deprecated
+  in favour of `detailed_merge_status` as of GitLab 15.6.
+- **Review / approval decision** — there is no single field. GitLab exposes
+  `approved` (Boolean), `approvedBy`, and, in the EE code path,
+  `approvalsLeft`, `approvalsRequired`, `approvalState` and `changeRequesters`
+  ([`ee/…/merge_request_type.rb`](https://gitlab.com/gitlab-org/gitlab/-/raw/master/ee/app/graphql/ee/types/merge_request_type.rb)).
+  Per-reviewer state lives in `MergeRequestReviewState`, whose values are
+  `UNREVIEWED`, `REVIEWED`, `REQUESTED_CHANGES`, `APPROVED`, `UNAPPROVED`,
+  `REVIEW_STARTED`
+  ([enum source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/merge_request_review_state_enum.rb)).
+  Over REST, approvals are a *separate call*:
+  `GET /projects/:id/merge_requests/:iid/approvals` (Free; returns
+  `approvals_required`, `approvals_left`, `approved`, `approved_by`) and
+  `GET …/approval_state` (Premium/Ultimate; per-rule detail)
+  ([approvals API](https://docs.gitlab.com/api/merge_request_approvals/)).
+- **CI status** — `headPipeline { status }`, an enum with values `CREATED`,
+  `WAITING_FOR_RESOURCE`, `PREPARING`, `WAITING_FOR_CALLBACK`, `PENDING`,
+  `RUNNING`, `FAILED`, `SUCCESS`, `CANCELING`, `CANCELED`, `SKIPPED`, `MANUAL`,
+  `SCHEDULED`
+  ([enum source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/ci/pipeline_status_enum.rb)).
+  A merge request has **one** head pipeline, not a rollup of independent checks.
+- **Head and base branch** — `sourceBranch` and `targetBranch` (GraphQL),
+  `source_branch` / `target_branch` (REST).
+- **Draft status** — `draft` (Boolean) in both. GitLab's draft state is derived
+  from a `Draft:` title prefix but is exposed as a first-class field, and it also
+  appears in `detailed_merge_status` as `draft_status`.
+- **Merge-queue analogue** — merge *trains*
+  ([docs](https://docs.gitlab.com/ci/pipelines/merge_trains/)). Position is
+  available in GraphQL as `MergeTrainCar.index`, documented as "Zero-based
+  position of the car in the merge train. Returns `null` if the car is not
+  active in a merge train"
+  ([car type source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/ee/app/graphql/types/merge_trains/car_type.rb)),
+  reachable from the merge request as `mergeTrainCar { index }`. The REST merge
+  trains API explicitly does not return a position — "The REST API response does
+  not include an explicit queue position for each merge request" — and directs
+  callers to sort by `id` ascending, or to use `MergeTrainCar.index`
+  ([merge trains API](https://docs.gitlab.com/api/merge_trains/)). Merge trains
+  are a paid-tier feature; TBD's merge-queue field is already optional and nil
+  by default, so an instance without them simply reports nil.
+- **Web URL** — `webUrl` (GraphQL) / `web_url` (REST), giving the canonical
+  `https://<host>/<fullPath>/-/merge_requests/<iid>`.
+
+## Part 3 — The state-model mapping, and where it breaks
+
+TBD's `PRMergeableState` has eight cases with a strict attention ordering:
+`checksFailed` (6) > `blocked` (5) > `changesRequested` (4) > `pending` (3) >
+`mergeable` (2) > `draft` (1) > `merged`/`closed` (0)
+(`PRBinding.swift:114-124`). That ordering is what a red dot means, and the
+toolbar icon, the sidebar dot and the `Worktree.prStatus` column all read it.
+
+### Where the mapping is clean
+
+- `state = merged` → `.merged`; `state = closed` → `.closed`.
+- `draft = true`, or `detailedMergeStatus = DRAFT_STATUS` → `.draft`.
+- `detailedMergeStatus = MERGEABLE` → `.mergeable`.
+- `detailedMergeStatus = CONFLICT` → `.blocked`, matching TBD's handling of
+  GitHub's `DIRTY` ("Merge conflicts", `PRStatusManager.swift:1168-1169`).
+- `detailedMergeStatus = NEED_REBASE` → `.blocked`, matching GitHub's `BEHIND`
+  ("Behind base branch", `:1170-1171`).
+- `detailedMergeStatus = CI_STILL_RUNNING`, `UNCHECKED`, `CHECKING`,
+  `PREPARING`, `APPROVALS_SYNCING` → `.pending`. GitHub's `UNKNOWN` already maps
+  that way (`:1172-1173`).
+- `detailedMergeStatus = CI_MUST_PASS` → `.checksFailed`. This is the one that
+  most needs a decision, and it is discussed below.
+- `detailedMergeStatus = NOT_APPROVED` → `.blocked` or `.changesRequested`,
+  depending on the answer to the review-decision question below.
+
+### Where it breaks
+
+**GitLab states TBD cannot express.** The 22-value enum
+([source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/merge_requests/detailed_merge_status_enum.rb),
+read 2026-08-16) includes several blockers that TBD can only flatten into
+`.blocked`, losing the reason:
+
+- `DISCUSSIONS_NOT_RESOLVED` — "Discussions must be resolved before merging."
+  GitHub has no equivalent gate; TBD has no state for it.
+- `BLOCKED_STATUS` (`merge_request_blocked`) — "Merge request dependencies must
+  be merged." A cross-MR dependency; TBD models no such relation.
+- `EXTERNAL_STATUS_CHECKS` (`status_checks_must_pass`) — Ultimate-tier external
+  checks ([status checks](https://docs.gitlab.com/user/project/merge_requests/status_checks/)).
+- `SECURITY_POLICIES_VIOLATIONS`, `JIRA_ASSOCIATION`, `TITLE_NOT_MATCHING`,
+  `LOCKED_PATHS`, `LOCKED_LFS_FILES`, `MERGE_TIME`, `COMMITS_STATUS`.
+
+`.blocked` already carries a free-text `reason` string, so the *reason* survives
+in the tooltip. What does not survive is severity: all of these land at
+severity 5, above `changesRequested`, and a `MERGE_TIME` block ("may not be
+merged until after the specified time") demands no action at all while ranking
+above a reviewer asking for changes. Whether the ordering needs a new tier — or
+whether some of these should map to a low-severity "waiting" rather than
+`.blocked` — is a design call, not a mechanical one.
+
+**TBD states GitLab cannot answer.**
+
+- **`.checksFailed` as distinct from `.blocked`.** GitHub gives TBD a per-check
+  `isRequired` flag, and TBD colours the icon red *only* on a failing required
+  check (`checkSignals`, `PRStatusManager.swift:1250-1256`). GitLab has no
+  per-check required flag. Required-ness is expressed three other ways: the
+  project setting that pipelines must succeed, `allow_failure` on individual
+  jobs (which keeps the pipeline green), and Ultimate-tier external status
+  checks. So on GitLab, "a required check is failing" collapses to
+  `detailedMergeStatus = CI_MUST_PASS`, or to `headPipeline.status = FAILED` on a
+  project that does not require pipelines. Those are two different facts and only
+  one of them is a merge blocker.
+- **GitHub's `UNSTABLE`.** TBD maps it to `.mergeable` with the explicit note
+  "mergeable with only non-required checks failing → not red" (`:1162-1164`).
+  GitLab's nearest equivalent is a green pipeline with `allow_failure` jobs that
+  failed — which reports `SUCCESS`, so the state is simply invisible rather than
+  mis-mapped. Acceptable, but it means the GitLab path can never show the amber
+  "something failed but it doesn't block" signal.
+- **`.changesRequested` as a first-class decision.** GitHub's `reviewDecision`
+  is one field with three values. GitLab's nearest analogue is either
+  `detailedMergeStatus = NOT_APPROVED` (which conflates "nobody has approved
+  yet" with "someone objected") or the EE-only `changeRequesters` connection,
+  or a scan of every reviewer's `reviewState` for `REQUESTED_CHANGES`. The
+  first is available everywhere and is the wrong shape; the latter two are
+  either paid-tier or cost extra fields. Note that TBD's current rule treats
+  GitHub's `BLOCKED` + `REVIEW_REQUIRED` as `.mergeable`, deliberately
+  ("Ready to merge", `:1166-1167`) — the analogous GitLab call would be to treat
+  `NOT_APPROVED` with zero change-requesters as `.mergeable`, which needs the
+  paid-tier field to distinguish.
+- **`isTerminal`.** GitLab's `locked` state is a fourth value TBD's
+  `PRMergeableState` has no case for. It is transient (the MR is mid-merge), so
+  mapping it to `.pending` is probably right, but it must be mapped explicitly
+  or the `default:` arm sends it to `.blocked`.
+
+**The merge-queue index is off by one.** `PRStatus.mergeQueuePosition` is
+documented as 1-indexed with "front of queue == 1" (`Models.swift:1643`);
+`MergeTrainCar.index` is documented as zero-based. Whatever renders the bus icon
+reads that number directly, so the mapping must add one — or the field's
+contract must change, which touches the GitHub side too.
+
+**Mergeability may be stale on a list read.** GitLab's merge-request list
+endpoint documentation notes that listing "might not proactively update the
+`merge_status` field, as this represents an expensive operation", and offers
+`with_merge_status_recheck` to request (but not guarantee) an asynchronous
+recomputation. TBD's `PRObservation` vocabulary already has the right shape for
+this — an `.undetermined(cause:)` distinct from a value — but a
+`detailedMergeStatus` of `UNCHECKED` arriving from a batch read is a *third*
+thing again: the forge answered, and the answer is "I have not computed it".
+Mapping that to `.pending` is plausible; mapping it to
+`.undetermined(cause: …)` may be more honest. Whether the GraphQL path has the
+same laziness is unverified.
+
+## Part 4 — Batching and fleet cost
+
+### What TBD spends today
+
+Derived from the code, per poll pass (`RPCRouter.runPollPass`,
+`RPCRouter.swift:735-774`), at 30 s foregrounded and 300 s backgrounded
+(`GitPollCadence.prInterval`,
+`Sources/TBDDaemon/Server/GitPollingPolicy.swift:40-42`):
+
+- **1** viewer-batch GraphQL call covering every unnumbered worktree across
+  every repo (`PRStatusManager.swift:2122-2133`).
+- **1 per repo group** for the aliased by-number query
+  (`fetchNumberedMatches`, `:2081-2120`).
+- **≤1 per repo group** more for `cachedNumberFallback` (`:1598`), and **≤1 per
+  repo group** more for the once-per-daemon-run head-ref verification (`:1789`).
+- **1 per (host, owner, repo) group** for `refreshBindings` (`:774-785`,
+  `:821-834`).
+- **1 per PR** — the expensive term — for `fetchCheckSignals` (`:2154-2174`),
+  run for every matched OPEN PR whose aggregate rollup is not `SUCCESS`, on both
+  the worktree-keyed and the binding-keyed paths.
+- **1 `gh repo view` subprocess per distinct checkout path**, behind a 15-minute
+  TTL (`:2028-2035`).
+
+On a 40-worktree fleet across 5 repos with every worktree bound, that is roughly
+11 GraphQL round trips in the quiet case and up to ~51 when every PR is open and
+non-green — each one a separate `gh` subprocess.
+
+The 20-bindings-per-worktree cap exists explicitly to bound this: "Bounds the
+per-poll GraphQL cost of a long-lived worktree"
+(`PRBindingStore.swift:87-90`).
+
+### What GitLab would spend
+
+**GraphQL batches by argument, not by alias.** The `mergeRequests` resolver
+takes `iids: [GraphQL::Types::String]` — "Array of IIDs of merge requests, for
+example `[1, 2]`" — and also `sourceBranches: [String]`, `targetBranches`,
+`state`, `authorUsername`, `reviewState(s)`
+([resolver source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/resolvers/merge_requests_resolver.rb)).
+So one field under `project(fullPath:)` returns N merge requests, and several
+projects can be aliased in one document:
+
+```
+query {
+  p0: project(fullPath: "acme/backend")  { mergeRequests(iids: ["1","2","3"]) { nodes { … } } }
+  p1: project(fullPath: "acme/infra/db") { mergeRequests(iids: ["7"])         { nodes { … } } }
+}
+```
+
+**And the second round trip disappears.** `detailedMergeStatus`,
+`headPipeline { status }`, `approved`, `conflicts`, `draft`, `sourceBranch`,
+`targetBranch` and `webUrl` are all fields on `MergeRequest`
+([type source](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/merge_request_type.rb)),
+so the per-PR `fetchCheckSignals` call has no GitLab counterpart — the verdict
+arrives in the batch. That removes the one term in TBD's cost that scales with
+PR count rather than repo count.
+
+**Net:** the same 40-worktree, 5-repo fleet costs roughly **5–6 round trips per
+pass**, quiet case and busy case alike, versus 11–51 today. Batching is a
+strength here, not a risk.
+
+**REST batches too**, if a design prefers it:
+`GET /projects/:id/merge_requests?iids[]=1&iids[]=2`, and the list response
+carries `detailed_merge_status`, `draft`, `source_branch`, `target_branch`,
+`web_url`, `has_conflicts` and `blocking_discussions_resolved`. It does **not**
+appear to carry `head_pipeline` — that is documented on the single-MR response —
+so a REST design would reintroduce a per-MR call for pipeline status, or accept
+`detailed_merge_status` alone. This asymmetry is the strongest argument for
+GraphQL on the GitLab side.
+
+### The real cost ceilings
+
+- **Query complexity.** Authenticated GraphQL queries are capped at **250**
+  complexity, unauthenticated at 200, admin at 300; depth 15 authenticated-20;
+  max query size **10,000 characters**; request timeout **30 seconds**; max page
+  size **100 nodes**
+  ([GraphQL limits](https://docs.gitlab.com/api/graphql/),
+  [`gitlab_schema.rb`](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/gitlab_schema.rb)).
+  Docs state "each field in a query adds `1` to the complexity score, although
+  this can be higher or lower for particular fields", and do not document how
+  connections or `calls_gitaly` fields are scored. A batch of 20 merge requests
+  with 10 fields each is either 10 (if connections cost per-field) or 200+ (if
+  per-node) — a factor of twenty apart, and the answer decides whether the
+  20-binding cap is comfortable or already over budget. **This must be measured
+  against a real instance before a cadence is chosen.**
+- **Gitaly-backed fields.** `detailedMergeStatus`, `mergeable`, `approved`,
+  `approvalsLeft` and `approvalsRequired` are all declared `calls_gitaly: true`.
+  Each is a git-layer operation server-side. Asking for all of them across 20
+  merge requests every 30 seconds, per project, per fleet, is a load question
+  that no rate limit will surface until an administrator complains.
+- **Rate limits are generous.** gitlab.com allows **2,000 authenticated API
+  requests per minute per user** and 500 unauthenticated per IP
+  ([gitlab.com limits](https://docs.gitlab.com/user/gitlab_com/)). At the 5-minute
+  background cadence, a 5-project fleet spends about 60 requests per hour.
+  Self-hosted instances set their own limits.
+
+## Part 5 — Identifying the host
+
+**A git remote gives you a hostname and nothing else.** `git@gitlab.acme.com:…`
+and `git@git.acme.com:…` are equally plausible GitLab remotes, and
+`git@git.acme.com:…` is an equally plausible Gitea, Forgejo, Bitbucket Server or
+plain-SSH remote. TBD's existing `RemoteRepoMatching` deliberately *discards*
+the host when normalising remotes (`Sources/TBDShared/RemoteRepoMatching.swift:17-23`),
+and already documents the resulting collision — "a self-hosted GitLab mirror of
+a GitHub repo" — as accepted. Nothing in TBD currently records which forge a
+repo belongs to.
+
+**`glab` does not solve this.** Its `internal/glinstance` package resolves a
+hostname from configuration and environment only, and `IsSelfHosted()` is a
+string comparison against `gitlab.com`
+([`host.go`](https://gitlab.com/gitlab-org/cli/-/raw/main/internal/glinstance/host.go)).
+There is no network probe anywhere in that logic. `glab api` selects the host by
+taking "the authenticated GitLab host from that repo" if inside a git directory,
+else gitlab.com, overridable with `--hostname`
+([`glab-api(1)`](https://man.archlinux.org/man/glab-api.1.en)) — that is, the
+user must first have run `glab auth login --hostname <host>`, which is itself
+the declaration. **`glab`'s answer to "how do you know it's GitLab" is "the user
+told us."**
+
+**A cheap probe does exist, if a design wants one.** `GET
+https://<host>/api/v4/version` returns **HTTP 401** unauthenticated — verified
+directly against gitlab.com on 2026-08-16, which returned 401 with no body
+readable. Authentication is required for that endpoint and for `/api/v4/metadata`
+([version/metadata API](https://docs.gitlab.com/api/version/)). A 401 from
+`/api/v4/version` is therefore a strong positive fingerprint: a non-GitLab host
+almost certainly 404s. But it is an unauthenticated outbound request to an
+arbitrary domain read from a user's git config, made by a background daemon, and
+that is a decision with a privacy dimension, not a lookup.
+
+**The options, stated without choosing between them:**
+
+- **User declaration per repo** — a `forge` value the user sets, stored either as
+  a DB column on `repo` (the structured-settings pattern) or as a file under
+  `~/tbd/repos/<repoID>/` (the user-authored-blob pattern; see the two patterns
+  in the root `CLAUDE.md`). Zero network, zero guessing, and consistent with
+  "compile only what user-land cannot do well". Costs a setup step per repo.
+- **Infer from what the user already configured** — if `glab auth status` (or
+  `~/.config/glab-cli/config.yml`) already names the host, TBD can read that
+  rather than asking again. This is exactly what `glab` itself relies on, and it
+  degrades to "no GitLab support here" rather than to a wrong answer.
+- **Hostname heuristic** — treat a host containing `gitlab` as GitLab. Cheap,
+  wrong on `git.acme.com`, and wrong in the silent direction.
+- **Network probe** — `/api/v4/version` as above, cached per host.
+- **Try both CLIs** — run `gh` and, on the "not a GitHub host" failure, run
+  `glab`. No probe of TBD's own, but two subprocesses per resolution and an
+  error path used as control flow.
+
+## Part 6 — The CLI and auth story
+
+**`glab` is the counterpart to `gh`**, published by GitLab at
+`gitlab-org/cli`, and it is closer to a drop-in than the two projects'
+independence would suggest.
+
+- **The GraphQL invocation is character-for-character analogous.**
+  `glab api graphql -f query='…'` is documented with GraphQL examples, `-f,
+  --raw-field` is "Add a string parameter" and `-F, --field` is the
+  type-inferring one — the same split as `gh`, including which letter means
+  which ([`glab-api(1)`](https://man.archlinux.org/man/glab-api.1.en)). TBD's
+  existing comment explaining why it uses `-f` and not `-F`
+  (`PRStatusManager.swift:1392-1397`) transfers verbatim. `--paginate`,
+  `--method`, `--header` and `--hostname` all exist.
+- **Authentication.** Token resolution order is `GITLAB_TOKEN` environment
+  variable, then `$HOME/.config/glab-cli/config.yml`
+  ([README](https://gitlab.com/gitlab-org/cli/-/raw/main/README.md)); on macOS
+  the config may also live under `~/Library/Application Support/glab-cli/`.
+  `glab auth login` supports OAuth (web or device flow), a personal access token
+  via `--token` or `--stdin`, and CI job tokens; a PAT needs at least the `api`
+  and `write_repository` scopes
+  ([authentication docs](https://docs.gitlab.com/cli/authentication/)).
+- **Self-hosted is first-class.** `--hostname` targets an instance and
+  `GITLAB_HOST` sets the default; glab is documented as supporting GitLab.com,
+  Dedicated and Self-Managed. OAuth against a self-managed instance additionally
+  requires an OAuth application registered on that instance with redirect URI
+  `http://localhost:7171/auth/redirect` — a token is the simpler route for a
+  daemon.
+- **The multi-host question is where `gh` and `glab` differ in a way that
+  matters.** `gh` auth is host-scoped and ambient, which is why TBD can run any
+  `gh` call from any checkout and rely on the auth being right
+  (`PRStatusManager.swift:434-438`). Whether `glab` holds credentials for several
+  hosts simultaneously and picks per-repo, or whether `GITLAB_HOST` must be set
+  per invocation, is **not clearly documented** and would need testing. If it is
+  the latter, `refreshBindingGroup`'s existing per-`(host, owner, repo)` grouping
+  (`:792-809`) is already the right shape to carry a `--hostname` per group —
+  the code comment at `:818-820` anticipates exactly this.
+
+**Is shelling out still the right move?** Three considerations, none of them
+decided here:
+
+- **For.** It reuses the one existing subprocess seam (`GHRunner`,
+  `PRStatusManager.swift:129-131`); it inherits the user's existing auth without
+  TBD ever holding a token; and it keeps TBD out of the credential-storage
+  business entirely, which is a real ongoing cost avoided.
+- **Against.** `glab` is one more binary a user must install and authenticate
+  before anything works, and unlike `gh` its absence is invisible until a
+  binding silently never forms. GitLab's REST API is a plain HTTPS call with a
+  `PRIVATE-TOKEN` header — meaningfully simpler to speak directly than GitHub's,
+  and TBD already has a NIO stack.
+- **The token question is genuinely different.** GitLab PATs are per-instance
+  and scoped; a direct-HTTP design would have to store one per host somewhere,
+  which is a new class of secret in TBD (there is precedent in the ModelProfile
+  keychain path, but PR polling has never held a credential).
+
+## Part 7 — Discovery paths
+
+TBD binds a PR three ways
+(`docs/specs/2026-08-10-multi-pr-per-worktree-design.md`, "Discovery: three
+sources"). Each has a GitLab counterpart, and one has a gap with no counterpart
+at all.
+
+**Hook binding — has a counterpart, needs a second gate.** The `PostToolUse`
+`Bash` hook's authoritative gate demands the command word `gh` and the
+subcommand path `["pr", "create"]`
+(`PRBindingExtractor.swift:210-224`). The GitLab equivalent is `glab` with
+`["mr", "create"]`, and the value-taking global flags differ (`glab` uses
+`--hostname` and `-R/--repo` too, but the set should be re-derived from `glab`'s
+own flags rather than assumed identical). The prefilter grep
+(`ClaudeHookOverlay.swift:182`) matches `pr…create` and would drop every
+`glab mr create` payload before the tokenizer ever ran — the exact failure mode
+that comment warns about at `:144-148`. A second alternation is needed, and the
+same "prefilter is a cost optimisation, never a gate" discipline applies.
+
+Whether `glab mr create` prints the created MR's URL to stdout — which is what
+makes the GitHub hook work — is **unverified**; the manpage documents no output
+format and no JSON option.
+
+**A discovery path with no GitHub analogue, and no hook counterpart.** GitLab
+lets a plain `git push` create a merge request via push options:
+`git push -u origin -o merge_request.create`, plus `merge_request.target=` and
+related options. The tool call an agent makes is `git push` — so the hook's
+command gate rejects it, correctly, and no `glab` ever runs. The MR gets created
+and TBD never sees it. Branch matching would still find it on the next poll,
+which is the safety net, but the *headline* case the hook exists for — a
+subagent's MR on a branch the worktree never checked out — is not recoverable
+this way. The push output does carry a URL, but GitLab's own issue tracker
+records that the URL echoed by a push is the "create a merge request" form URL
+rather than the created MR
+([issue 441944](https://gitlab.com/gitlab-org/gitlab/-/issues/441944)); the
+exact string emitted after a successful `merge_request.create` push is
+**unverified**.
+
+**Branch matching — has a counterpart, and a better one.** TBD matches a
+worktree's branch candidates against the viewer's authored PRs
+(`matchUnnumbered`, `PRStatusManager.swift:1660-1676`), scoped to the worktree's
+own repo, from a single cross-repo `viewer { pullRequests(first: 100) }` batch
+(`:2122-2132`). GitLab offers two shapes:
+
+- **Repo-scoped, which is what TBD actually wants** —
+  `project(fullPath:) { mergeRequests(sourceBranches: [...]) }`. This asks the
+  question directly instead of fetching 100 PRs and filtering. It also removes
+  the 100-PR truncation that motivates `cachedNumberFallback` (`:1574-1597`),
+  though it costs one call per project rather than one call total.
+- **Viewer-scoped, cross-project** — REST
+  `GET /merge_requests?scope=created_by_me&state=all`, which returns merge
+  requests across all accessible projects. The GraphQL root equivalent,
+  `Query.mergeRequests`, exists but is marked `experiment: { milestone: '19.3' }`
+  with `max_page_size: 20` and "At least one filter must be provided"
+  ([`query_type.rb`](https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/graphql/types/query_type.rb))
+  — too new and too small a page to be the substrate a fleet poll rests on.
+
+The `batchSucceeded` predicate is load-bearing across both heals
+(`:1604`, `:1796`) and the observation vocabulary (`:670-673`): it distinguishes
+"the forge answered and there is no PR" from "we could not ask". A repo-scoped
+matcher changes what that predicate ranges over — per project rather than
+globally — which is a behaviour change in the heals, not just a query swap.
+
+**Manual attach — has a counterpart.** `tbd pr attach <number|url>` needs the URL
+regex generalised and `RPCRouter.prRef` (`RPCRouter.swift:1255-1260`) taught to
+synthesise the right URL shape for the worktree's forge. The bare-number form is
+where the forge must already be known, since the URL is constructed rather than
+parsed.
+
+**Provenance seeding — has a counterpart, with a caveat.**
+`seedProvenanceBindings` (`RPCRouter.swift:791-803`) turns `Worktree.prNumber`
+into a binding through the same `prRef`. `Worktree.prNumber` is documented as a
+GitHub PR number (`Models.swift:229`) and is fed by the branch picker's
+`repo.listOpenPRs` flow (`PRStatusManager.fetchOpenPRs`, `:1938-1967`), which is
+itself a GitHub-shaped GraphQL query including `isCrossRepository` and
+`headRepositoryOwner { login }`. Fork PRs are the case that makes the number
+load-bearing; GitLab's equivalent is a fork MR whose `sourceProject` differs
+from the target, so the concept survives but the field names do not.
+
+## Part 8 — Terminology
+
+GitLab calls them merge requests, and the acronym differs in every surface
+listed in [UI copy and the CLI](#ui-copy-and-the-cli) — roughly two dozen
+strings, plus the `tbd pr` command name itself, the `pr.*` RPC method names, the
+`worktree_pull_request` table, the `PRBinding`/`PRStatus` type names and the
+`tbd` skill entry.
+
+The options, without choosing:
+
+- **Keep "PR" everywhere** and treat it as TBD's own generic term. Zero churn,
+  zero migration, and wrong-sounding to a GitLab user reading their own toolbar.
+- **Per-forge copy** — the label follows the binding's host, so a GitLab
+  worktree shows `!412` (GitLab's own sigil for a merge request) and "2 MRs".
+  Correct-looking, but the toolbar and the sidebar summarise *several* bindings
+  under one label, and a worktree could in principle hold both — so the
+  summarising surfaces need a fallback term anyway.
+- **A neutral term** — "change", "review", "request". Correct on both, familiar
+  on neither, and it means renaming surfaces that GitHub users already read
+  fluently.
+
+The command name is the sharpest instance: `tbd pr attach` is documented in the
+`tbd` skill (`TBDSkillContent.swift:187-189`) and is therefore something agents
+have been told to type. An alias is cheap; a rename is not.
+
+Note that the internal vocabulary is already partly neutral —
+`PRUndeterminedCause` says "forge", not "GitHub"
+(`PRStatusManager.swift:13-34`) — so there is precedent for the neutral
+direction in the layer users do not see.
+
+## What could not be verified
+
+Stated plainly rather than asserted anywhere above:
+
+- **Whether `glab mr create` prints the created merge request's URL to stdout.**
+  `glab` is not installed here, and its manpage documents no output format. The
+  entire hook-binding path depends on this.
+- **The exact remote message after `git push -o merge_request.create`,** and
+  whether it contains the created MR's URL or only the "new merge request" form
+  URL. GitLab's docs page for push options redirected to an authentication gate
+  and could not be read.
+- **How GitLab scores GraphQL complexity for connections and for
+  `calls_gitaly: true` fields.** The 250 ceiling is documented; the arithmetic
+  that consumes it is not. This decides whether a 20-MR batch fits.
+- **Whether the GraphQL `detailedMergeStatus` is computed on read or is as lazy
+  as REST's `merge_status`.** The REST laziness is documented; the GraphQL
+  behaviour is not.
+- **How EE-only fields behave on a Free instance.** `approvalsLeft`,
+  `approvalsRequired`, `approvalState`, `mergeTrainCar` and `changeRequesters`
+  are declared in `ee/`. Whether they are absent from the schema (query error) or
+  present-and-null (graceful) on a Free self-managed instance was not tested, and
+  a query that errors wholesale on one instance shape is a real failure mode.
+- **Whether GitLab project paths are case-insensitive.** TBD lowercases owner and
+  repo on write and on comparison specifically because GitHub is
+  (`PRBindingStore.swift:29-31`, `PRBinding.swift:96-99`). GitLab has a
+  long-standing open issue titled "Make project paths case-insensitive on
+  database level", which suggests they are not — but the evidence found was
+  mostly about GitLab Pages, not project lookup, so this is unresolved.
+- **Whether `glab` can hold credentials for several hosts at once and select
+  per-repo,** or whether `GITLAB_HOST` must be set per invocation.
+- **The `detailed_merge_status` value count.** The enum source was read twice;
+  one read reported "24 values" and one "21", while both listings enumerated the
+  same 22 entries. The values themselves agreed exactly across both reads and are
+  what Part 3 rests on, but the count should be re-derived before anything
+  exhaustive is built on it.
+- **Nothing was run against a live GitLab instance.** No latency figure, no
+  measured complexity score, no observed response body for a merge request.
+
+## Open questions for the design session
+
+**1. Is the target GitLab, or is it "a second forge"?**
+The two produce different architectures. A GitLab-specific path can hardcode
+`glab` and GitLab's shapes throughout. A forge abstraction — a protocol behind
+which GitHub and GitLab are two conformances — costs more now and is the only
+thing that makes GitHub Enterprise, Gitea or Forgejo cheap later. *Evidence
+bearing on it:* there is exactly one forge subprocess call site
+(`PRStatusManager.swift:2196`) and one injected seam (`:129-131`), so the
+abstraction is unusually cheap to introduce; but `PRStatusManager` is a
+2,293-line actor whose heal logic is deeply entangled with GitHub's viewer-batch
+shape, and the abstraction boundary would have to cut through it.
+
+**2. Should GitHub Enterprise land first?**
+GHE needs the URL regex generalised, the `host` column threaded through, and
+`--hostname` passed to `gh` — and nothing else, because the schema and the state
+model are identical. It would validate the host plumbing GitLab also needs, on a
+change small enough to review in one sitting. *Against:* it is a detour if
+nobody needs GHE, and shipping host-awareness without a second data model may
+bake in assumptions that GitLab then has to unpick.
+
+**3. How does TBD learn a repo's forge?**
+The five options are laid out in [Part 5](#part-5--identifying-the-host). The
+fork is essentially *ask the user* versus *probe the network*. *Evidence
+bearing on it:* `glab` itself does not probe, and the repo's own doctrine
+("compile only what user-land cannot do well") points at a declaration the user
+edits rather than an inference the daemon computes. Against that: a fleet of 40
+worktrees across many repos makes a per-repo setup step real friction, and a
+wrong or absent declaration fails silently — no binding ever forms, which is
+exactly the symptom that prompted this research.
+
+**4. What is a repository's identity, now that it is not `(owner, repo)`?**
+GitLab projects nest up to 20 levels. The choices are: keep two columns and
+stuff the whole namespace into `owner` (works, but `owner` stops meaning owner,
+and every log line and error message that renders `owner/name` becomes
+misleading); add a `fullPath` column and treat `owner`/`repo` as a GitHub-only
+projection; or migrate to a single path column for both forges. *Evidence
+bearing on it:* the identity reaches a unique DB index
+(`Database.swift:1273-1277`), a `\u{1}`-delimited four-part key
+(`PRBinding.swift:97-99`) parsed back on exactly four parts
+(`PRBindingStore.swift:257-264`), the cross-repo heal
+(`PRStatusManager.swift:1691-1706`) and the wrong-repo rejection
+(`PRBindingCoordinator.swift:81-85`). A migration touching the unique index is
+the most invasive part of any GitLab work.
+
+**5. Does `PRMergeableState` grow, and does `attentionSeverity` change?**
+GitLab has blockers TBD flattens into `.blocked` at severity 5 — including
+`MERGE_TIME`, which demands nothing, and `DISCUSSIONS_NOT_RESOLVED`, which
+arguably demands more than a failing check. *Evidence bearing on it:* the
+ordering is defined once (`PRBinding.swift:114-124`) and read by the toolbar,
+the sidebar and the `Worktree.prStatus` column, which the design explicitly
+requires not to disagree; and `attentionSeverity` also drives `worst(of:)`
+(`:130-139`), so any new tier changes which PR a multi-PR worktree's single icon
+represents — on GitHub too, not only on GitLab.
+
+**6. What does a red dot mean on GitLab, given there are no required checks?**
+`.checksFailed` currently fires only on a failing *required* check
+(`PRStatusManager.swift:1250-1256`), and TBD deliberately does not colour on
+non-required failures (`:1162-1164`, `:1244-1249`). On GitLab the available
+facts are `detailedMergeStatus = CI_MUST_PASS` (the pipeline is a merge
+blocker) and `headPipeline.status = FAILED` (the pipeline failed, blocker or
+not). Treating only the first as red preserves today's meaning; treating the
+second as red is what most GitLab users would expect from their own UI. These
+diverge exactly on projects that do not require pipelines to pass.
+
+**7. What stands in for `reviewDecision`?**
+`NOT_APPROVED` conflates "nobody has approved yet" with "a reviewer objected",
+and TBD currently treats the former as `.mergeable`
+(`PRStatusManager.swift:1166-1167`) and the latter as `.changesRequested` at a
+higher severity. Distinguishing them on GitLab needs either the EE-only
+`changeRequesters` field or a per-reviewer `reviewState` scan. *The fork:* accept
+that GitLab Free cannot express `.changesRequested` at all, or query paid-tier
+fields and degrade when they are unavailable — which requires knowing how those
+fields behave on a Free instance, listed above as unverified.
+
+**8. `glab` subprocess, or direct HTTPS?**
+Laid out in [Part 6](#part-6--the-cli-and-auth-story). The fork is really about
+where the credential lives: `glab` means TBD never holds a token; direct HTTPS
+means TBD must store one per host. *Evidence bearing on it:* `glab api graphql
+-f query=` is close enough to `gh api graphql -f query=` that the subprocess
+route is nearly free to build; but a missing or unauthenticated `glab` fails the
+same silent way a missing forge declaration does, and TBD has no surface today
+that tells a user "your PRs are not updating because a CLI is missing" —
+`PRUndeterminedCause.cliUnavailable` exists (`:15`) but only reaches a tooltip.
+
+**9. Does the hook gain a `glab mr create` arm, and what covers push-created
+MRs?**
+Adding the arm is mechanical. The gap is `git push -o merge_request.create`,
+which no hook gate can admit without admitting every `git push`. *The fork:*
+accept that push-created MRs are found only by branch matching (which cannot see
+a subagent's branch — the case the hook exists for), or find a different signal.
+*Evidence bearing on it:* a false bind can auto-archive a worktree, which is why
+the gate fails closed (`PRBindingExtractor.swift:64-79`), so widening it to
+`git push` is not a small trade.
+
+**10. Terminology: "PR", "MR", per-forge, or neutral?**
+Laid out in [Part 8](#part-8--terminology). *Evidence bearing on it:* the
+`tbd pr` command name is documented in the `tbd` skill
+(`TBDSkillContent.swift:187-189`) so agents have been instructed to type it; the
+toolbar and sidebar summarise several bindings under one label and therefore
+need a term that works when a worktree spans forges; and the daemon's internal
+vocabulary already says "forge" rather than "GitHub"
+(`PRStatusManager.swift:13-34`), so the neutral direction has precedent in the
+layer users do not read.
+
+**11. Does the 20-binding cap still make sense?**
+It exists to bound per-poll GraphQL cost (`PRBindingStore.swift:87-90`), and on
+GitLab that cost is a single `iids: [...]` argument rather than 20 aliases — so
+the justification weakens considerably. *Evidence bearing on it:* whether it
+weakens or vanishes depends on GitLab's connection complexity arithmetic, which
+is unverified. If a connection costs per-node, the cap matters more on GitLab,
+not less.

--- a/docs/research/2026-08-16-gitlab-pr-support/findings.md
+++ b/docs/research/2026-08-16-gitlab-pr-support/findings.md
@@ -12,10 +12,14 @@ names the page or file it came from. Claims that could not be verified are
 listed in [What could not be verified](#what-could-not-be-verified) rather than
 asserted.
 
-Nothing here was measured against a live GitLab instance. `glab` is not
-installed on the probe machine (`which glab` → not found), so no command
-surface was exercised; the CLI section rests on documentation and on `glab`'s
-own source.
+**`glab` inspected:** 1.113.0 (`d62881304`), installed locally, with its
+`--help` surfaces read directly. Its *source* was read at `main`, which may sit
+slightly ahead of 1.113.0.
+
+Nothing here was measured against a live GitLab instance: no merge request was
+created, fetched, or polled, and no authenticated call was made. Facts about
+`glab` come from the installed binary's help output and from its source; facts
+about GitLab's API come from documentation and from GitLab's own source.
 
 ## Summary
 
@@ -37,7 +41,10 @@ in the daemon is `gh` (`PRStatusManager.resolvedGHPath`,
 forge subprocess in `Sources/` — there is exactly one call site to redirect.
 `glab` turns out to be a close counterpart: `glab api graphql -f query='…'`
 takes the same subcommand, the same flag spelling, and the same semantics as
-`gh api graphql -f query='…'`.
+`gh api graphql -f query='…'`; it authenticates several instances at once and
+resolves the right one per repository, as `gh` does; and `glab mr create` prints
+the bare merge-request URL when stdout is not a TTY, which is exactly the
+condition a hook payload is captured under.
 
 **An assumption about GitHub's data model** is the expensive layer, and it is
 where the design work actually is. Three assumptions do not survive the move:
@@ -585,15 +592,18 @@ independence would suggest.
   requires an OAuth application registered on that instance with redirect URI
   `http://localhost:7171/auth/redirect` — a token is the simpler route for a
   daemon.
-- **The multi-host question is where `gh` and `glab` differ in a way that
-  matters.** `gh` auth is host-scoped and ambient, which is why TBD can run any
-  `gh` call from any checkout and rely on the auth being right
-  (`PRStatusManager.swift:434-438`). Whether `glab` holds credentials for several
-  hosts simultaneously and picks per-repo, or whether `GITLAB_HOST` must be set
-  per invocation, is **not clearly documented** and would need testing. If it is
-  the latter, `refreshBindingGroup`'s existing per-`(host, owner, repo)` grouping
-  (`:792-809`) is already the right shape to carry a `--hostname` per group —
-  the code comment at `:818-820` anticipates exactly this.
+- **Multi-host works the same ambient way `gh` does.** This matters because TBD
+  runs every `gh` call from whatever checkout is handy and relies on the auth
+  being right (`PRStatusManager.swift:434-438`). `glab auth status --help`
+  (1.113.0) states it "checks the authentication state of the GitLab instance
+  determined by your current context (`git remote`, `GITLAB_HOST` environment
+  variable, or configuration)", offers `--all` to "check all configured
+  instances" and `--hostname` to name one. So several instances can be
+  authenticated at once and the right one is selected per repository — the same
+  model TBD already depends on. `refreshBindingGroup`'s existing
+  per-`(host, owner, repo)` grouping (`:792-809`) can still carry an explicit
+  `--hostname` per group if the ambient resolution proves unreliable; the code
+  comment at `:818-820` anticipates exactly that.
 
 **Is shelling out still the right move?** Three considerations, none of them
 decided here:
@@ -631,9 +641,27 @@ own flags rather than assumed identical). The prefilter grep
 that comment warns about at `:144-148`. A second alternation is needed, and the
 same "prefilter is a cost optimisation, never a gate" discipline applies.
 
-Whether `glab mr create` prints the created MR's URL to stdout — which is what
-makes the GitHub hook work — is **unverified**; the manpage documents no output
-format and no JSON option.
+**`glab mr create` does print the URL, and its non-TTY output is better shaped
+than `gh`'s.** On success it calls `mrutils.DisplayMR`, which is:
+
+```go
+func DisplayMR(c *iostreams.ColorPalette, mr *gitlab.BasicMergeRequest, isTTY bool) string {
+	mrID := MRState(c, mr)
+	if isTTY {
+		return fmt.Sprintf("%s %s (%s)\n %s\n", mrID, mr.Title, mr.SourceBranch, mr.WebURL)
+	} else {
+		return mr.WebURL
+	}
+}
+```
+
+([`internal/commands/mr/mrutils/mrutils.go`](https://gitlab.com/gitlab-org/cli/-/raw/main/internal/commands/mr/mrutils/mrutils.go)).
+Under a Claude Code `Bash` tool call stdout is not a TTY, so the branch that
+runs emits **the bare web URL and nothing else** — no title, no branch name, no
+decoration for a regex to survive. `mr_create.go` additionally prints a
+"Creating merge request for … into … in …" progress line and, with
+`--auto-merge`, an "Auto-merge enabled" line, so the payload is not URL-only,
+but the URL itself arrives clean.
 
 **A discovery path with no GitHub analogue, and no hook counterpart.** GitLab
 lets a plain `git push` create a merge request via push options:
@@ -725,9 +753,6 @@ direction in the layer users do not see.
 
 Stated plainly rather than asserted anywhere above:
 
-- **Whether `glab mr create` prints the created merge request's URL to stdout.**
-  `glab` is not installed here, and its manpage documents no output format. The
-  entire hook-binding path depends on this.
 - **The exact remote message after `git push -o merge_request.create`,** and
   whether it contains the created MR's URL or only the "new merge request" form
   URL. GitLab's docs page for push options redirected to an authentication gate
@@ -749,8 +774,11 @@ Stated plainly rather than asserted anywhere above:
   long-standing open issue titled "Make project paths case-insensitive on
   database level", which suggests they are not — but the evidence found was
   mostly about GitLab Pages, not project lookup, so this is unresolved.
-- **Whether `glab` can hold credentials for several hosts at once and select
-  per-repo,** or whether `GITLAB_HOST` must be set per invocation.
+- **Whether `glab`'s ambient host resolution actually picks the right instance**
+  for a checkout whose remote host is authenticated alongside others. The help
+  text says it resolves from `git remote`, `GITLAB_HOST` or configuration, and
+  `--all` proves several instances can be configured at once, but the resolution
+  was not exercised against two authenticated hosts.
 - **The `detailed_merge_status` value count.** The enum source was read twice;
   one read reported "24 values" and one "21", while both listings enumerated the
   same 22 entries. The values themselves agreed exactly across both reads and are
@@ -846,7 +874,9 @@ that tells a user "your PRs are not updating because a CLI is missing" —
 
 **9. Does the hook gain a `glab mr create` arm, and what covers push-created
 MRs?**
-Adding the arm is mechanical. The gap is `git push -o merge_request.create`,
+Adding the arm is mechanical, and cleaner than the GitHub side: under a
+non-TTY `Bash` call `glab mr create` emits the bare web URL, so the extractor
+has less to sift. The gap is `git push -o merge_request.create`,
 which no hook gate can admit without admitting every `git push`. *The fork:*
 accept that push-created MRs are found only by branch matching (which cannot see
 a subagent's branch — the case the hook exists for), or find a different signal.

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -235,22 +235,31 @@ open merge request in the project.
 This is not a fallback transport and does not reopen the transport decision. The
 poll remains GraphQL; the REST call carries no data TBD reads.
 
-**The recheck is detached, and single-flighted per project by
-`GitLabRecheckGate`.** Nothing in the pass reads the recheck's answer, so
-nothing in the pass may wait for it — and it is the call most likely to hang,
-since its whole purpose is to queue work on someone else's server. Left
-attached, one hung `glab` stalls PR polling for the entire fleet, because
-`refreshBindings` walks its groups one at a time and `fetchAll` skips the next
-poll while one is in flight. Detaching removes that stall and, unbounded, would
-replace it with a subprocess leak: `runCLI` imposes no timeout and a detached
-task inherits no cancellation, so a hung endpoint accumulates one `glab`, one
+**The recheck is detached, and bounded twice where it is created.** Nothing in
+the pass reads the recheck's answer, so nothing in the pass may wait for it —
+and it is the call most likely to hang, since its whole purpose is to queue work
+on someone else's server. Left attached, one hung `glab` stalls PR polling for
+the entire fleet, because `refreshBindings` walks its groups one at a time and
+`fetchAll` skips the next poll while one is in flight. Detaching removes that
+stall and, unbounded, would replace it with a subprocess leak: a detached task
+inherits no cancellation, so a hung endpoint accumulates one `glab`, one
 `Process` and its file descriptors per project per tick — around 288 of them
 overnight at a five-minute cadence, and no reconciler covers a forge CLI
-subprocess. `GitLabRecheckGate` is an actor holding the set of projects with a
-recheck outstanding; a project with one in flight issues no second call, and
-outstanding-forever is the intended reading of a hang — that project stops
-asking until the process ends. Only non-terminal merge requests are named: a
-merged or closed one has a mergeability nobody recomputes and nobody reads.
+subprocess.
+
+The two bounds answer different questions, and both are needed.
+
+- **How many.** `GitLabRecheckGate` is an actor holding the set of projects with
+  a recheck outstanding; a project with one in flight issues no second call, so
+  a stuck endpoint cannot multiply per tick.
+- **For how long.** The detached call is raced against a 60-second deadline on
+  an injected clock, and the child is terminated when it fires, so no recheck is
+  outstanding forever. The deadline is deliberately generous: a slow instance
+  should be allowed to finish rather than be killed and retried next tick. What
+  it rules out is the unbounded case.
+
+Only non-terminal merge requests are named: a merged or closed one has a
+mergeability nobody recomputes and nobody reads.
 
 **Branch matching queries the server, not the viewer.** GitHub forces TBD to
 fetch the authenticated user's own pull requests and match branches locally,
@@ -537,6 +546,8 @@ tested.
   `CHECKING` and `PREPARING` cases.
 - The recheck request names only bound merge requests, and a failure or an
   unparseable response from it does not disturb the poll's own result.
+- A hung recheck is terminated once its deadline elapses, driven by the injected
+  clock so the test proves the bound without waiting for it.
 - Forge derivation is not attempted for a GitHub remote, asserted by an injected
   `GLRunner` that fails the test if invoked.
 - GitLab node parsing, including an absent `headPipeline`.
@@ -562,12 +573,24 @@ GitHub arm is unchanged, and is covered by the existing suite.
 **No new reconciler.** No durable external resource is created. `glab`
 subprocesses are transient in exactly the way `gh`'s already are, no git ref,
 worktree, tmux entity, or file outlives the request that created it, and no new
-row is written that an existing sweep does not already cover. The single
-exception is the detached mergeability recheck, whose subprocess outlives the
-pass that spawned it; it is bounded at its creation site by `GitLabRecheckGate`
-— at most one live recheck per project — because a forge CLI subprocess is
-covered by no sweep and the count, not the lifetime, is what has to stay
-finite.
+row is written that an existing sweep does not already cover.
+
+The single exception is the detached mergeability recheck, whose subprocess
+outlives the pass that spawned it. It is bounded at its creation site instead of
+by a sweep, by the pair described under "GitLab I/O": the single-flight gate
+keeps at most one live recheck per project, and the deadline terminates the
+child when it fires, so neither the count nor the lifetime is open-ended. A
+forge CLI subprocess is covered by no existing sweep, and this design adds none.
+
+**A daemon that dies mid-recheck orphans that child, and nothing reclaims it.**
+The deadline lives in the daemon's own process, so it dies with it, and the
+gate's set is in memory and starts empty at the next launch. Stated plainly
+rather than left implied: at the instant of a crash the exposure is at most one
+`glab` per GitLab project, each one a request whose only effect is to queue a
+mergeability recomputation on the server, and each holding its own file
+descriptors until that request ends. A sweep for those would have to reap by
+command line — the only handle a restarted daemon has on a process it never
+spawned — which is a worse trade than the bounded exposure it would reclaim.
 
 **No migration.** No column is added or changed, so the migration-plus-record-
 plus-model rule has nothing to apply to.
@@ -626,15 +649,16 @@ substantial part of a GitLab fleet would permanently display a status that
 communicates nothing — and the state is reachable out of TBD's own poll, which
 makes leaving it a choice rather than a limitation.
 
-**Bounding the recheck with a timeout instead of single-flight.** A deadline on
-the detached call would also stop the subprocess pile-up, and it would end a hung
-`glab` rather than waiting on it. Rejected because single-flight is both cheaper
-and the stronger statement: it needs no timer and therefore no injected clock
-seam, and a second recheck for a project whose first is still outstanding is
-asking the server to redo work it has not finished — so skipping it loses
-nothing even when the endpoint is perfectly healthy. A timeout would still
-permit one live process per project per tick until it fired. `GitLabRecheckGate`
-is what ships.
+**Bounding the recheck with either mechanism alone.** Each half looks
+sufficient on its own and neither is. A deadline with no admission gate still
+admits a fresh process per project per tick until it fires, so a stuck endpoint
+multiplies inside the deadline. Single-flight with no deadline is cheaper — it
+needs no timer and therefore no clock seam — and it does cap the count, but it
+never ends a hung `glab`: the project stops asking and the process stays for the
+life of the daemon, which is precisely the unreclaimed resource that has to be
+answered for. Skipping a second recheck loses nothing even on a healthy endpoint,
+since it asks the server to redo work it has not finished, so the gate is worth
+keeping — alongside the deadline, not instead of it.
 
 **Growing `PRMergeableState`.** Dedicated cases for GitLab's distinct states
 would be more faithful to what GitLab reports. Rejected because every new tier

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -299,6 +299,30 @@ a GitLab branch that splits the path on the `/-/` separator: everything left of
 it is the project path, so no segment counting is needed and nesting depth is
 irrelevant.
 
+**Two forges can name one `owner/name`, so binding validation compares hosts as
+well.** `identityKey` and the unique index already key on the host; the
+wrong-repo guard is the one place that does not, and comparing namespace and
+project alone lets a merge request for `acme/proj` bind to a
+`github.com/acme/proj` worktree. A false bind is the expensive direction — the
+foreign request merging can auto-archive a worktree that never had anything to
+do with it, while a missed bind costs one `tbd pr attach` — so a request whose
+captured host is not the worktree's is refused.
+
+One exemption, bounded by the forge rather than by the hostname. The extractor's
+GitHub pattern is host-locked, so a parsed `github.com` is a constant that
+pattern supplies rather than a host it read; refusing on it would break a
+`github.com` URL attached to a GitHub Enterprise or mirror checkout of the same
+project — the collision `RemoteRepoMatching` documents as tolerated — so such a
+checkout keeps its binding. A worktree whose own host is one `glab` names does
+not. Its requests live on that host, so a github.com pull request sharing its
+namespace and project is a different project, and binding it would poll a
+stranger's PR through `gh` and let that stranger's merge archive the worktree.
+The forge is asked here — the same declaration the URL composer and the mapping
+arm read — never inferred from the hostname, and a forge nothing could establish
+defers rather than binding, exactly as an unresolvable repo does. A worktree
+already on the URL's own host settles on the host comparison alone, so a
+github.com fleet never puts the question at all.
+
 ## Attaching by bare number
 
 `tbd pr attach <number>` does not carry a URL, so the daemon builds one. That

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -353,9 +353,10 @@ essentially never on such an instance. Worse, combined with `NOT_APPROVED`
 mapping to `.mergeable`, a merge request with a failing pipeline would render as
 "Ready to merge".
 
-So the GitLab arm mirrors the structure GitHub's arm already has: a CI signal
-computed independently of the merge status, and evaluated in the same precedence
-position — after draft, before the merge-status switch.
+So the GitLab arm takes the structure GitHub's arm already has: a CI signal
+computed independently of the merge status, evaluated after draft and before the
+merge-status switch, with one signal ranked above it — see "What outranks the CI
+signal" below.
 
 - The signal is **gated on the project's `onlyAllowMergeIfPipelineSucceeds`**,
   which is the faithful analogue of GitHub's "required check". A failing pipeline
@@ -382,9 +383,9 @@ progress does not turn the fleet red.
 - `DISCUSSIONS_NOT_RESOLVED` maps to `.changesRequested`, "Unresolved
   discussions". A human is waiting on the author, which is what that state
   already means. Two of the same six merge requests reported it.
-- `REQUESTED_CHANGES` maps to `.changesRequested`. GitLab carries this as a
-  dedicated `detailedMergeStatus` value, so no per-reviewer scan and no
-  paid-tier field is needed to express it.
+- `REQUESTED_CHANGES` maps to `.changesRequested`, and is the one value ranked
+  above the CI signal. GitLab carries it as a dedicated `detailedMergeStatus`
+  value, so no per-reviewer scan and no paid-tier field is needed to express it.
 - `DRAFT_STATUS`, and the `draft` boolean, map to `.draft`.
 - `CHECKING` and `PREPARING` map to `.pending`, "Checks pending". These are
   genuinely transient.
@@ -405,6 +406,31 @@ progress does not turn the fleet red.
   attention. Unknown means unknown. This is the one place the GitLab arm
   deliberately differs from the GitHub arm's `default: return (.blocked,
   "Blocked")` (`:1175`).
+
+### What outranks the CI signal
+
+Exactly one merge-status value is evaluated ahead of the CI signal:
+`REQUESTED_CHANGES`. So the full order is terminal, draft, explicit change
+request, CI signal, merge-status switch — the GitHub arm's own order, where
+`CHANGES_REQUESTED` likewise sits ahead of the required-check signals. A merge
+request that a reviewer has explicitly rejected while its pipeline is also red
+reports the rejection; read off the merge status instead, it would report only
+the pipeline and the reviewer's decision would surface nowhere in the UI.
+
+`DISCUSSIONS_NOT_RESOLVED` does **not** share that slot, and the two are
+deliberately not lumped together. The rule is that an explicit change request
+outranks CI and an unresolved thread does not. GitHub's arm privileges only the
+explicit review decision, and an open discussion thread is not a rejection —
+the author may have answered every comment and simply not clicked resolve — so
+when a pipeline is failing too, the pipeline is the more actionable thing to
+show.
+
+Ranking a change request above a failing pipeline is a deliberate step *down* in
+attention severity: `.changesRequested` is 4 and `.checksFailed` is 6, so a
+merge request with both renders as the less severe of the two. That is already
+the GitHub arm's behaviour, and the stance behind it is that an explicit human
+rejection is the thing to tell the author about — the icon is a pointer to the
+next action, not a maximum over everything wrong.
 
 ### Observed distribution
 
@@ -501,6 +527,12 @@ tested.
   `FAILED` on a non-gating project does not; a draft with `FAILED` stays
   `.draft`; `MANUAL` gives `.pending` with its own reason; a null
   `headPipeline` leaves the merge status to decide.
+- The precedence around that signal, in both directions:
+  `REQUESTED_CHANGES` with a failing gated pipeline gives `.changesRequested`,
+  "Changes requested", while `DISCUSSIONS_NOT_RESOLVED` with the same pipeline
+  gives `.checksFailed`, "Pipeline failed" — so a later edit cannot promote the
+  unresolved-thread case to the change-request slot without going red. A draft
+  carrying both stays `.draft`.
 - `UNCHECKED` yields `.pending` with a reason distinct from the transient
   `CHECKING` and `PREPARING` cases.
 - The recheck request names only bound merge requests, and a failure or an

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -88,8 +88,47 @@ Four constraints on the derivation:
   on ambient repo context would send a self-managed instance's queries to the
   public one.
 
-The derived host set is cached in memory for the daemon run. Nothing is
-persisted, so nothing needs invalidating, and no clock seam is required.
+**The derivation remembers three outcomes for three different spans, because
+they are three different facts.** Nothing is persisted; all of it lives in
+memory for the daemon run.
+
+- **A non-empty derivation** — `glab` ran and named hosts — is kept for the
+  resolver's life. It is a derived truth about a declaration the user made, and
+  nothing invalidates a declaration.
+- **`glab` failing to launch** is never remembered. It is not an observation
+  that the fleet has no GitLab hosts, only a failure to ask: the binary is
+  absent, or one exec failed transiently. Remembering it would mean a user who
+  runs `glab auth login` after TBD started gets no GitLab support until the
+  next restart, with no message anywhere. Retrying costs nothing in the case
+  that dominates, because an absent `glab` resolves to a static nil path that
+  spawns no subprocess at all.
+- **`glab` running and naming no host** is remembered for a bounded window,
+  `emptyStatusLifetime`, of 300 seconds. That one *is* an observation, and it is
+  the steady state of every fleet with `glab` installed and no GitLab host
+  configured — so re-deriving it per call means one `glab auth status`
+  subprocess per worktree per poll tick, forever, for an answer that has not
+  changed. It cannot be kept for the run either, since the same user is one
+  `glab auth login --hostname …` away from making it wrong.
+
+The window is bounded on the side that matters: the empty answer is at worst
+300 seconds stale, never stale until restart. Its floor is the poll cadence —
+`GitPollCadence.prInterval` is 30 s in the foreground and every distinct
+worktree path on the tick asks — so even one interval collapses a fleet's worth
+of spawns into one; its ceiling is how long a user who has just authenticated
+waits. The wait is not merely cosmetic: for its duration the checkout is still
+classified non-GitLab, so a stored merge-request number can be offered to gh's
+by-number query, where a same-named GitHub repository may answer. Bounding it
+to 300 seconds makes that self-healing rather than durable.
+
+The window takes an injected **date** seam, `now: @Sendable () -> Date`, not a
+clock. The timestamp is compared and never slept on, and the resolver schedules
+nothing — `Duration` is behavior, `Date` is data. The comparison uses the
+magnitude of the interval, so a wall clock that steps backwards re-derives
+early rather than pinning the empty answer in place until the clock catches up.
+
+None of this sits on a pure `github.com` fleet's path, which short-circuits
+before any subprocess. It sits on a GitHub Enterprise, Bitbucket, Gitea or
+Codeberg fleet's path, which is why the empty answer has to be cheap.
 
 **Credential expiry is a reporting requirement, not a recovery one.** Tokens are
 personal access tokens with an expiry and no refresh, so a host that worked
@@ -180,6 +219,23 @@ open merge request in the project.
 
 This is not a fallback transport and does not reopen the transport decision. The
 poll remains GraphQL; the REST call carries no data TBD reads.
+
+**The recheck is detached, and single-flighted per project by
+`GitLabRecheckGate`.** Nothing in the pass reads the recheck's answer, so
+nothing in the pass may wait for it — and it is the call most likely to hang,
+since its whole purpose is to queue work on someone else's server. Left
+attached, one hung `glab` stalls PR polling for the entire fleet, because
+`refreshBindings` walks its groups one at a time and `fetchAll` skips the next
+poll while one is in flight. Detaching removes that stall and, unbounded, would
+replace it with a subprocess leak: `runCLI` imposes no timeout and a detached
+task inherits no cancellation, so a hung endpoint accumulates one `glab`, one
+`Process` and its file descriptors per project per tick — around 288 of them
+overnight at a five-minute cadence, and no reconciler covers a forge CLI
+subprocess. `GitLabRecheckGate` is an actor holding the set of projects with a
+recheck outstanding; a project with one in flight issues no second call, and
+outstanding-forever is the intended reading of a hang — that project stops
+asking until the process ends. Only non-terminal merge requests are named: a
+merged or closed one has a mergeability nobody recomputes and nobody reads.
 
 **Branch matching queries the server, not the viewer.** GitHub forces TBD to
 fetch the authenticated user's own pull requests and match branches locally,
@@ -444,7 +500,12 @@ GitHub arm is unchanged, and is covered by the existing suite.
 **No new reconciler.** No durable external resource is created. `glab`
 subprocesses are transient in exactly the way `gh`'s already are, no git ref,
 worktree, tmux entity, or file outlives the request that created it, and no new
-row is written that an existing sweep does not already cover.
+row is written that an existing sweep does not already cover. The single
+exception is the detached mergeability recheck, whose subprocess outlives the
+pass that spawned it; it is bounded at its creation site by `GitLabRecheckGate`
+— at most one live recheck per project — because a forge CLI subprocess is
+covered by no sweep and the count, not the lifetime, is what has to stay
+finite.
 
 **No migration.** No column is added or changed, so the migration-plus-record-
 plus-model rule has nothing to apply to.
@@ -503,11 +564,15 @@ substantial part of a GitLab fleet would permanently display a status that
 communicates nothing — and the state is reachable out of TBD's own poll, which
 makes leaving it a choice rather than a limitation.
 
-**Rate-limiting the recheck behind a staleness timer.** Politest to the server,
-and rejected for now only because it buys little over scoping the request to bound
-merge requests, while introducing a timer and therefore an injected clock seam. If
-field use shows the per-tick request is too much load, this is the change to
-make.
+**Bounding the recheck with a timeout instead of single-flight.** A deadline on
+the detached call would also stop the subprocess pile-up, and it would end a hung
+`glab` rather than waiting on it. Rejected because single-flight is both cheaper
+and the stronger statement: it needs no timer and therefore no injected clock
+seam, and a second recheck for a project whose first is still outstanding is
+asking the server to redo work it has not finished — so skipping it loses
+nothing even when the endpoint is perfectly healthy. A timeout would still
+permit one live process per project per tick until it fired. `GitLabRecheckGate`
+is what ships.
 
 **Growing `PRMergeableState`.** Dedicated cases for GitLab's distinct states
 would be more faithful to what GitLab reports. Rejected because every new tier

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -547,7 +547,13 @@ tested.
 - The recheck request names only bound merge requests, and a failure or an
   unparseable response from it does not disturb the poll's own result.
 - A hung recheck is terminated once its deadline elapses, driven by the injected
-  clock so the test proves the bound without waiting for it.
+  clock so the test proves the bound without waiting for it. Two of those tests
+  run a real child through the production subprocess path rather than a stubbed
+  runner, because the property is about a process and not about a Swift task: a
+  child that sets SIGTERM to `SIG_IGN` and then `exec`s survives the signal and
+  is nonetheless gone by the end of the grace, verified by `kill(pid, 0)` on the
+  pid it reported; a child that takes the signal exits on the deadline alone,
+  with the grace never spent.
 - Forge derivation is not attempted for a GitHub remote, asserted by an injected
   `GLRunner` that fails the test if invoked.
 - GitLab node parsing, including an absent `headPipeline`.
@@ -579,8 +585,13 @@ The single exception is the detached mergeability recheck, whose subprocess
 outlives the pass that spawned it. It is bounded at its creation site instead of
 by a sweep, by the pair described under "GitLab I/O": the single-flight gate
 keeps at most one live recheck per project, and the deadline terminates the
-child when it fires, so neither the count nor the lifetime is open-ended. A
-forge CLI subprocess is covered by no existing sweep, and this design adds none.
+child when it fires, so neither the count nor the lifetime is open-ended. The
+termination escalates: SIGTERM, then SIGKILL after `childKillGrace` if the
+child is still there. Without that second step the bound is on the signal and
+not on the process — SIGTERM is a request, the task group awaits the child
+before returning, and a child that ignores it holds both the recheck task and
+that project's single-flight gate open indefinitely. A forge CLI subprocess is
+covered by no existing sweep, and this design adds none.
 
 **A daemon that dies mid-recheck orphans that child, and nothing reclaims it.**
 The deadline lives in the daemon's own process, so it dies with it, and the

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -1,0 +1,374 @@
+# GitLab support for PR binding
+
+TBD's pull-request subsystem tracks GitHub only, and not by configuration —
+by construction. This design adds GitLab as a second forge without a database
+migration, a configuration column, or a feature flag, and without changing any
+behaviour on the GitHub path.
+
+Research backing every measured claim here:
+[`docs/research/2026-08-16-gitlab-pr-support/findings.md`](../research/2026-08-16-gitlab-pr-support/findings.md).
+
+## The problem
+
+`PRBindingExtractor`'s URL pattern is host-locked to `https://github.com/`
+(`Sources/TBDShared/PRBindingExtractor.swift:32-33`), and every discovered
+binding is stamped `host: "github.com"` (`:239`). All three discovery
+paths — the `PostToolUse:Bash` hook, branch matching, and manual attach — funnel
+through that pattern, so on a non-GitHub worktree no binding can ever form. The
+status-bar chip a user sees there is synthetic, and the URL that chip carries is
+rejected by the daemon if they try to act on it.
+
+The groundwork for fixing this was laid deliberately. The `host` column on
+`worktree_pull_request` already exists, and the extractor's own comment
+(`:29-31`) states the intent: "the binding's `host` column exists so enterprise
+support is a later additive change."
+
+## Scope
+
+In scope: GitLab merge requests appear as bindings, poll for status, colour the
+toolbar and sidebar, and participate in the merged-transition machinery exactly
+as GitHub pull requests do.
+
+Not in scope: GitHub Enterprise (the plumbing here makes it small, but it is a
+separate change), Gitea and Forgejo, GitLab write actions beyond what already
+exists, and merge-train position parity with GitHub's merge queue.
+
+## Forge identification
+
+**Two mechanisms, because the two discovery shapes need different things.**
+
+URL-shaped discovery needs no host knowledge at all. GitLab merge-request URLs
+contain the path segment `/-/merge_requests/<n>`, which no other forge uses, so
+the URL identifies its own forge. `PRBindingExtractor` gains a second pattern
+alongside the GitHub one:
+
+- The GitHub pattern is unchanged, byte for byte. Its fail-closed reasoning
+  (`:64-79`) — a false bind can auto-archive a worktree, so ambiguity must lose
+  binds rather than invent them — is preserved by not touching it.
+- The GitLab pattern anchors on the literal `/-/merge_requests/`, captures
+  everything before it as the project path, and applies the same
+  `(?!\.{1,2}/)` lookahead to every path segment that the GitHub pattern applies
+  to two.
+- The host is taken from the matched URL rather than stamped as a literal.
+
+Repo-shaped discovery — branch matching, which starts from a worktree and its
+remote rather than from a URL — does need to know the forge. It derives it from
+`glab auth status`, whose output enumerates the hosts `glab` is configured for
+and whether each authenticates.
+
+**Why derive from `glab` rather than declare or probe.** A host appears in that
+list only because someone ran `glab auth login --hostname <host>`, and that same
+act is what makes every subsequent API call succeed. Declaration and capability
+become one precondition, so TBD can never reach the state "I know this is GitLab
+but I cannot talk to it" — the state every other option permits, and the one
+whose symptom (no binding ever forms, silently) is the bug being fixed. It also
+needs no configuration column and therefore no migration.
+
+Three constraints on the derivation:
+
+- **Parse the output, never the exit status.** `glab auth status` exits `0` while
+  reporting that it could not authenticate to any configured instance.
+- **`gitlab.com` appears in the list even with no credentials**, so its presence
+  proves nothing. Only a non-default host is evidence.
+- **Attempt it only when the remote host is not `github.com`.** A GitHub-only
+  fleet then spawns no `glab` subprocess at all, so the common case pays
+  nothing.
+
+The derived host set is cached in memory for the daemon run. Nothing is
+persisted, so nothing needs invalidating, and no clock seam is required.
+
+`RemoteRepoMatching` deliberately discards the host when normalising remotes and
+documents the resulting collision — "a self-hosted GitLab mirror of a GitHub
+repo" — as accepted (`Sources/TBDShared/RemoteRepoMatching.swift:17-23`). That
+stays as it is; this design does not route forge identity through remote
+matching.
+
+## The typed seam
+
+GitHub's data model reaches only one file. All 51 uses of `mergeStateStatus`,
+`reviewDecision` and `statusCheckRollupState` live in
+`Sources/TBDDaemon/PR/PRStatusManager.swift`; every other hit in `Sources/` is a
+comment. Inside that file the two verdict fields are **carried, never
+interpreted**, except in one function: they flow from `prNode` (`:1862-1892`)
+through the `PRNode` struct to `mapStateAndReason` (`:1862-1886`, `:1141-1178`). The heal logic
+that matches, poisons cache entries and verifies head refs branches only on
+`state` and `statusCheckRollupState`.
+
+That makes `PRNode` the seam, and the change to it small:
+
+- `PRNode` gains `forge: Forge`, declared last and defaulted to `.github` so the
+  memberwise initialiser stays source-compatible. This is the same technique
+  `baseRefName` already uses and documents (`:1536-1540`).
+- Its two verdict fields are renamed `mergeVerdictRaw` and `reviewVerdictRaw`.
+  They hold whatever vocabulary their forge speaks, and the neutral names stop
+  a GitLab value from sitting in a field called `mergeStateStatus`. The rename is
+  confined to one file.
+- `mapStateAndReason` takes the forge and dispatches. The `.github` arm is
+  today's switch verbatim, so GitHub's mapping is unchanged because its code is
+  unchanged.
+- A `GLRunner` seam mirrors `GHRunner` (`:131`, `:145`) for test injection, and
+  the GitLab subprocess call site mirrors `runGHResult` (`:2196`).
+
+`Forge` is a two-case enum in `TBDShared`. It is derived at parse time and
+carried on the node; it is never stored.
+
+## GitLab I/O
+
+**GraphQL, with a field set chosen to be available everywhere.** One batched
+query per project replaces both of GitHub's calls, because GitLab's
+`mergeRequests(iids: [String])` is a single field carrying pipeline status
+inline — where GitHub needs a per-PR check query for the same fact. Measured
+cost is roughly five to six round trips per poll pass against eleven to
+fifty-one today, and GraphQL complexity is scored per query-AST field rather
+than multiplied by page size, so a hundred nodes of eleven fields passes even
+the lower unauthenticated ceiling.
+
+The tier-1 field set is `iid`, `state`, `draft`, `detailedMergeStatus`,
+`conflicts`, `sourceBranch`, `targetBranch`, `createdAt`, `webUrl`, and
+`headPipeline { status }`. Every one of these is Free-tier and predates any
+instance likely to be in service.
+
+**No paid-tier fields are requested.** GraphQL rejects an entire query for one
+unknown field, returning `"data": null` — on a hundred-node batch that turns a
+single schema mismatch into zero merge requests. Requesting only fields that
+exist everywhere makes that failure unreachable rather than recoverable, which
+is why there is no schema-capability cache in this design, and nothing for a
+reconciler to refresh. Adding a paid-tier field later is what would introduce
+that machinery, and the mechanism is already known: an unknown field returns a
+machine-readable `extensions.code: "undefinedField"` naming the offending field,
+supporting a retry-lean-and-remember fallback that costs nothing on the happy
+path.
+
+**Branch matching queries the server, not the viewer.** GitHub forces TBD to
+fetch the authenticated user's own pull requests and match branches locally,
+which is why a merge request opened by anyone else is invisible to branch
+matching. GitLab accepts `mergeRequests(sourceBranches: [...])` with no author
+filter, so TBD asks for exactly the branches its worktrees are on and gets back
+matching merge requests regardless of who opened them — including ones created
+through the web UI or by `git push -o merge_request.create`.
+
+## Project identity
+
+A GitLab namespace nests up to twenty levels, so a project path is
+`acme/platform/backend/api-gateway` rather than `owner/name`. The two existing
+columns hold it unchanged, reframed as namespace and project: the namespace path
+goes in `owner`, the project name in `repo`. GitHub's `owner` is simply a
+one-segment namespace, so the concept is already shared; only the column's name
+is narrower than what it holds, and that is documented at the declaration site.
+
+Nothing in the identity plumbing constrains the format. `identityKey` joins on
+`\u{1}` (`Sources/TBDShared/PRBinding.swift:98`), the parse back requires only
+four parts (`Sources/TBDDaemon/Database/PRBindingStore.swift:260-261`), and the
+unique index imposes no shape (`Sources/TBDDaemon/Database/Database.swift:1273-1277`).
+A namespace containing slashes survives all three.
+
+Identity comparison already lowercases, justified by GitHub treating owner and
+repo case-insensitively. GitLab does the same: `GitLab-Org/GitLab` and
+`gitlab-org/gitlab` both resolve to one project. The existing rule needs no
+change.
+
+`parseOwnerRepo` (`Sources/TBDDaemon/PR/PRStatusManager.swift:1340-1346`) is the
+only place that assumes a URL *shape*, requiring `parts[2] == "pull"`. It gains
+a GitLab branch that splits the path on the `/-/` separator: everything left of
+it is the project path, so no segment counting is needed and nesting depth is
+irrelevant.
+
+## Attaching by bare number
+
+`tbd pr attach <number>` does not carry a URL, so the daemon builds one. That
+path is GitHub-only in two ways at once: it stamps `host: "github.com"` and
+composes a `/pull/` URL from the worktree's owner and name
+(`Sources/TBDDaemon/Server/RPCRouter.swift:1255-1260`). On a GitLab worktree it
+would fabricate a GitHub URL for a merge request that does not exist there,
+which is worse than refusing, because the resulting binding looks valid.
+
+Composing the URL requires the forge, and this is the one user-facing path that
+depends on the repo-shaped derivation rather than on a URL that identifies
+itself. So the repo resolver returns the host alongside the owner and name, and
+the URL shape is chosen from the forge: `/pull/<n>` for GitHub,
+`/-/merge_requests/<n>` for GitLab. When the forge cannot be determined the call
+returns nil, which the existing contract already handles — the caller defers
+rather than guessing, exactly as it does today when the repo cannot be named.
+
+The related synthetic binding in
+`Sources/TBDApp/PRBindingPresentation.swift:71-81` constructs a placeholder with
+empty owner and repo, so it silently takes `PRBinding`'s `host` default of
+`github.com`. Its URL comes from the observed status and is therefore correct,
+but the host field is not; it is set from the status URL's own host so that no
+part of a rendered binding disagrees with the others.
+
+## State mapping
+
+GitLab's states map into the existing eight `PRMergeableState` cases.
+`PRMergeableState` does not grow and `attentionSeverity` is untouched, so
+`worst(of:)` — which decides which binding a multi-PR worktree's single icon
+represents — behaves identically for existing fleets. Precision that the eight
+cases cannot express is carried in `PRStatus.reason`, which the tooltip and
+sidebar already render, so a coarse icon can still be explained in words.
+
+The mapping is derived from a position TBD already holds rather than invented for
+GitLab. At `PRStatusManager.swift:1166`, a GitHub pull request that is `BLOCKED`
+solely by an ungiven review maps to `.mergeable`, "Ready to merge", commented as
+deliberate: checks are settled, and awaiting a review nobody has performed is not
+something demanding the author's attention.
+
+- `MERGEABLE` maps to `.mergeable`.
+- `NOT_APPROVED` maps to `.mergeable`, "Ready to merge". It is the precise
+  analogue of GitHub's `BLOCKED` plus `REVIEW_REQUIRED`. This matters in
+  practice: of six open merge requests sampled live, three reported
+  `NOT_APPROVED`, so mapping it to `.blocked` would paint most of a healthy
+  GitLab fleet as needing attention.
+- `DISCUSSIONS_NOT_RESOLVED` maps to `.changesRequested`, "Unresolved
+  discussions". A human is waiting on the author, which is what that state
+  already means. Two of the same six merge requests reported it.
+- `REQUESTED_CHANGES` maps to `.changesRequested`. GitLab carries this as a
+  dedicated `detailedMergeStatus` value, so no per-reviewer scan and no
+  paid-tier field is needed to express it.
+- `DRAFT_STATUS`, and the `draft` boolean, map to `.draft`.
+- `CHECKING`, `UNCHECKED` and `PREPARING` map to `.pending`.
+- `CONFLICT` maps to `.blocked`, "Merge conflicts"; `NEED_REBASE` to `.blocked`,
+  "Behind base branch"; `BLOCKED_STATUS` to `.blocked`, "Blocked by another
+  merge request".
+- `NOT_OPEN` defers to `state`, which distinguishes merged from closed.
+- **Any value not listed maps to `.pending`, not `.blocked`.** GitLab's
+  `DetailedMergeStatus` demonstrably grows — twenty-four values are live against
+  twenty-two in the source tree at `master` — so treating unknown as blocked
+  would make future GitLab releases silently paint merge requests as needing
+  attention. Unknown means unknown. This is the one place the GitLab arm
+  deliberately differs from the GitHub arm's `default: return (.blocked,
+  "Blocked")` (`:1175`).
+
+## Terminology
+
+The command name, the database tables, the daemon's internal vocabulary and any
+label summarising several bindings keep saying "PR". Only user-facing text
+describing one specific binding whose forge is known renders "MR".
+
+`tbd pr` is documented to agents in the `tbd` skill
+(`Sources/TBDShared/TBDSkillContent.swift:187-189`), so agents have been
+instructed to type it; renaming it would break instructions already in the field
+and the tests that pin those substrings. Aggregate labels need a word that works
+when a worktree spans forges, and "PR" is the one already in place. The daemon's
+own vocabulary is already forge-neutral where it matters — `PRUndeterminedCause`
+speaks of a forge rather than of GitHub (`PRStatusManager.swift:13-34`).
+
+## Decisions this design defers
+
+Two questions are answerable by a GitLab user's report rather than by reasoning,
+and the design records both branches with the fact that selects each. Neither
+blocks the rest of the work.
+
+**What makes a GitLab chip red.** `.checksFailed` currently fires only on a
+failing *required* check, and TBD deliberately does not colour on non-required
+failures (`PRStatusManager.swift:1244-1256`). GitLab has no "required check"
+concept; its analogue is `detailedMergeStatus == CI_MUST_PASS`, meaning the
+pipeline blocks the merge. The strict analogue therefore colours red only when
+the pipeline both blocks merge and failed, which preserves today's meaning
+exactly — a failed non-blocking pipeline on GitLab is the same situation as
+GitHub's `UNSTABLE`, which TBD already shows as not red. The alternative colours
+red on any `headPipeline.status == FAILED`, which is what a GitLab user's own web
+UI leads them to expect. *Selecting fact:* whether the instance in question gates
+merges on pipelines. If it does, the two branches never diverge.
+
+**Whether the hook gains a `glab mr create` arm.** Adding it is mechanical, and
+cleaner than the GitHub side because under a non-TTY `Bash` call `glab mr create`
+emits a bare web URL. Because GitLab branch matching is author-blind, merge
+requests created outside the hook's view are already discovered, so the arm is a
+latency improvement rather than the only route — which is the opposite of its
+role on GitHub. *Selecting fact:* how merge requests are actually created in
+practice. Widening the gate to bare `git push` is not on the table: the gate
+fails closed because a false bind can auto-archive a worktree.
+
+## Testing
+
+The forge switch is a conditional that gates behaviour, so each branch is
+tested.
+
+- Both `mapStateAndReason` arms: every listed GitLab value to its expected
+  state and reason, an unrecognised value to `.pending`, and the existing GitHub
+  cases still passing unchanged.
+- `PRBindingExtractor` accepting GitLab merge-request URLs, including a deeply
+  nested namespace, and rejecting near-misses — a `merge_requests` path without
+  the `/-/` separator, and `.`/`..` path segments — so the fail-closed property
+  holds on the new pattern too.
+- Identity round-trip: a binding whose namespace contains slashes survives
+  `identityKey`, the four-part parse, and the unique index without collapsing
+  into a different binding.
+- `glab auth status` parsing: a host list with one authenticated and one
+  unauthenticated host, a run that reports failure while exiting `0`, and absent
+  or unconfigured `glab`.
+- Forge derivation is not attempted for a GitHub remote, asserted by an injected
+  `GLRunner` that fails the test if invoked.
+- GitLab node parsing, including an absent `headPipeline`.
+- Attach by bare number composes a `/-/merge_requests/<n>` URL with the GitLab
+  host on a GitLab worktree, still composes `/pull/<n>` on a GitHub one, and
+  returns nil rather than guessing when the forge is undetermined.
+
+## Rules this design answers
+
+**No feature flag.** The relevant criteria are behaviour that acts without a user
+gesture, destroys or mutates persisted state, or wholesale-replaces a
+load-bearing path. This is additive and unreachable for any host that is not
+GitLab: a GitHub-only fleet spawns no new subprocess, takes the unchanged
+`.github` arm, and sees no new state. The one edit that touches shared code — the
+`PRNode` field rename and the `mapStateAndReason` signature — is a refactor whose
+GitHub arm is unchanged, and is covered by the existing suite.
+
+**No new reconciler.** No durable external resource is created. `glab`
+subprocesses are transient in exactly the way `gh`'s already are, no git ref,
+worktree, tmux entity, or file outlives the request that created it, and no new
+row is written that an existing sweep does not already cover.
+
+**No migration.** No column is added or changed, so the migration-plus-record-
+plus-model rule has nothing to apply to.
+
+## Rejected alternatives
+
+**Translating GitLab into GitHub's vocabulary.** The GitLab parser could
+synthesize `mergeStateStatus: "BLOCKED"` and similar, leaving everything
+downstream untouched for the smallest possible diff. Rejected because it is
+lossy exactly where GitLab is most informative: `DISCUSSIONS_NOT_RESOLVED` has no
+GitHub equivalent, so it either collapses to "Blocked" and discards the only
+useful part, or invents a string that falls into the GitHub arm's
+`default: .blocked`. Every diagnostic about a GitLab merge request would also
+speak GitHub.
+
+**A full `ForgeClient` protocol.** Extracting query construction, subprocess
+invocation, parsing and mapping into per-forge conformances is the right
+long-term shape and is where the surveyed prior art lands. Rejected for now
+because it cuts a new boundary through a 2,293-line actor to serve one known
+user, and puts the working GitHub path on the far side of that cut. The `forge`
+discriminator introduced here is the same seam such a protocol would need, so
+this remains a refactor later rather than a rewrite.
+
+**A `forge` configuration column.** An explicit per-repo declaration is
+inspectable and matches the project's preference for behaviour that lives in
+user-land. Rejected because it can be set correctly and still not work — a repo
+declared as GitLab with an unauthenticated `glab` produces no bindings, silently,
+which is the exact failure this work exists to remove — and because it costs a
+migration that deriving from `glab` does not.
+
+**Probing `/api/v4/version` per host.** Measured to discriminate cleanly: GitLab
+answers `401` where four non-GitLab hosts, including another forge, answer `404`,
+with no false positive. Rejected because it makes a background daemon send
+unsolicited requests to arbitrary domains read out of a user's git config, and
+because `401` cannot distinguish a GitLab instance the user can reach from one
+they cannot.
+
+**A hostname heuristic**, treating any host containing `gitlab` as GitLab.
+Rejected because it is wrong precisely in the self-hosted case that motivates
+this work, and wrong in the silent direction.
+
+**REST instead of GraphQL.** REST is the worn path — the surveyed tools and
+GitLab's own Go SDK all use it — and it tolerates instance variation by omitting
+unknown fields rather than failing the whole request. Rejected because its
+`iids[]` batch omits pipeline status, forcing one additional call per merge
+request per poll pass, and because confining the query to fields available on
+every edition removes the failure mode REST's tolerance protects against.
+
+**Growing `PRMergeableState`.** Dedicated cases for GitLab's distinct states
+would be more faithful to what GitLab reports. Rejected because every new tier
+reshuffles `attentionSeverity`, which the toolbar, the sidebar and the
+`Worktree.prStatus` column all read and must not disagree about, changing which
+binding a multi-PR worktree's icon represents on GitHub as well. Carrying the
+detail in `PRStatus.reason` gets the precision without touching the ordering.

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -85,7 +85,7 @@ that is the only fact being extracted. Whether credentials currently work is
 proven by an API call succeeding, never by status text — which is measurably
 unreliable: on a self-managed instance the block for a working host printed
 `✓ Logged in to <host>` and `! Invalid token provided in configuration file`
-together, while every REST and GraphQL call with that token succeeded (#673).
+together, while every REST and GraphQL call with that token succeeded.
 
 Four constraints on the derivation:
 
@@ -219,9 +219,9 @@ path.
 **A REST call accompanies the GraphQL read, for one narrow purpose.** GitLab
 computes mergeability asynchronously and does not recompute it on read, so a
 merge request can report `UNCHECKED` indefinitely — 21 of 71 open merge requests
-on a self-managed instance, including some open for months (#673). GraphQL offers
-no way to ask for a recomputation; both plausible argument spellings are rejected
-as `argumentNotAccepted`. REST's list endpoint does, via
+measured on a self-managed instance, including some open for months. GraphQL
+offers no way to ask for a recomputation; both plausible argument spellings are
+rejected as `argumentNotAccepted`. REST's list endpoint does, via
 `with_merge_status_recheck=true`, and accepts it alongside `iids[]`.
 
 So each poll pass issues one additional REST call per project, naming only the
@@ -266,9 +266,9 @@ A GitLab namespace nests up to twenty levels, so a project path is
 `acme/platform/backend/api-gateway` rather than `owner/name`. Nesting is the
 common case rather than an edge case: of 100 projects sampled on a self-managed
 instance, 72 had one intermediate subgroup and 7 had two, leaving 21 flat as the
-minority (#673). A design that treated `owner/name` as normal and nesting as an
-exception would be calibrated backwards. The two existing
-columns hold it unchanged, reframed as namespace and project: the namespace path
+minority. A design that treated `owner/name` as normal and nesting as an
+exception would be calibrated backwards. The two existing columns hold it
+unchanged, reframed as namespace and project: the namespace path
 goes in `owner`, the project name in `repo`. GitHub's `owner` is simply a
 one-segment namespace, so the concept is already shared; only the column's name
 is narrower than what it holds, and that is documented at the declaration site.
@@ -344,7 +344,7 @@ something demanding the author's attention.
 owns, and continuous-integration failure sits low in that order. Field
 measurement makes this unmissable: across 71 open merge requests on a project
 configured with `only_allow_merge_if_pipeline_succeeds`, 33 had a failing head
-pipeline and **not one** reported `CI_MUST_PASS` (#673). Approval, draft and
+pipeline and **not one** reported `CI_MUST_PASS`. Approval, draft and
 unchecked states masked every one of them.
 
 Two consequences follow, and together they rule out reading CI state off
@@ -392,8 +392,8 @@ progress does not turn the fleet red.
 - `UNCHECKED` maps to `.pending` with the distinct reason **"Mergeability not
   checked"**, because it is *not* transient: GitLab computes mergeability
   asynchronously and leaves a stale merge request unchecked until something
-  re-triggers it, so 21 of 71 sampled merge requests sat in it, some for months
-  (#673). The reason string must not imply the state is about to resolve. The
+  re-triggers it, so 21 of 71 sampled merge requests sat in it, some for
+  months. The reason string must not imply the state is about to resolve. The
   recheck request described under "GitLab I/O" is what actually moves it.
 - `CONFLICT` maps to `.blocked`, "Merge conflicts"; `NEED_REBASE` to `.blocked`,
   "Behind base branch"; `BLOCKED_STATUS` to `.blocked`, "Blocked by another
@@ -434,10 +434,10 @@ next action, not a maximum over everything wrong.
 
 ### Observed distribution
 
-Every mapping choice above is calibrated against one measurement rather than
+Every mapping choice above is calibrated against field measurement rather than
 against the enum's shape: 71 open merge requests on one active project of a
-self-managed 19.0.3-ee instance that requires both passing pipelines and resolved
-discussions (#673).
+self-managed GitLab instance that requires both passing pipelines and resolved
+discussions.
 
 | `detailedMergeStatus` | count |
 |---|---|
@@ -487,8 +487,8 @@ The arm earns its place on evidence rather than symmetry: merge requests in the
 field are created almost entirely through `glab mr create`, much of it
 agent-driven, which is exactly the case the hook exists to catch — an agent
 opening a merge request that the fleet would otherwise not notice until the next
-poll. The web UI accounts for the rest, and `git push -o merge_request.create`
-is not used at all (#673).
+poll. The web UI accounts for the rest, and the merge requests measured on a
+self-managed instance include none created by `git push -o merge_request.create`.
 
 Because GitLab branch matching is author-blind, every route is discovered
 eventually even without the hook, so the arm buys latency rather than coverage —

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -12,11 +12,15 @@ Research backing every measured claim here:
 
 `PRBindingExtractor`'s URL pattern is host-locked to `https://github.com/`
 (`Sources/TBDShared/PRBindingExtractor.swift:32-33`), and every discovered
-binding is stamped `host: "github.com"` (`:239`). All three discovery
-paths — the `PostToolUse:Bash` hook, branch matching, and manual attach — funnel
-through that pattern, so on a non-GitHub worktree no binding can ever form. The
-status-bar chip a user sees there is synthetic, and the URL that chip carries is
-rejected by the daemon if they try to act on it.
+binding is stamped `host: "github.com"` (`:239`). The three discovery
+paths that start from a URL — the `PostToolUse:Bash` hook, branch matching, and
+`tbd pr attach <url>` — funnel through that pattern, so on a non-GitHub worktree
+no binding forms from a URL at all. The status-bar chip a user sees there is
+synthetic, and the URL that chip carries is rejected by the daemon if they try to
+act on it. The fourth path, `tbd pr attach <number>`, does form a binding
+anywhere, because it composes its own URL — but it composes a github.com one for
+every host, so on a non-GitHub worktree it yields a binding that points at a
+repository which is not the user's.
 
 The groundwork for fixing this was laid deliberately. The `host` column on
 `worktree_pull_request` already exists, and the extractor's own comment
@@ -55,6 +59,17 @@ Repo-shaped discovery — branch matching, which starts from a worktree and its
 remote rather than from a URL — does need to know the forge. It derives it from
 `glab auth status`, whose output enumerates the hosts `glab` is configured for
 and whether each authenticates.
+
+**Neither mechanism reads the hostname's shape, and nothing else may either.**
+"Not github.com" describes GitHub Enterprise, Bitbucket, Gitea and Codeberg as
+readily as it describes a self-managed GitLab, and all of them serve `/pull/<n>`,
+so a host-keyed classifier is wrong for every non-GitLab fleet off github.com —
+it would label their pull requests "MR" and compose merge-request URLs that
+404. `Forge` therefore offers exactly one classifier, `Forge.forURL`, keyed on
+the `/-/merge_requests/` marker the extractor already anchors on, and every
+per-binding label reads the binding's own `url` through it. Where no URL exists
+yet the forge is established rather than classified — see "Attaching by bare
+number".
 
 **Why derive from `glab` rather than declare or probe.** A host appears in that
 list only because someone ran `glab auth login --hostname <host>`, and that same
@@ -284,13 +299,22 @@ composes a `/pull/` URL from the worktree's owner and name
 would fabricate a GitHub URL for a merge request that does not exist there,
 which is worse than refusing, because the resulting binding looks valid.
 
-Composing the URL requires the forge, and this is the one user-facing path that
-depends on the repo-shaped derivation rather than on a URL that identifies
-itself. So the repo resolver returns the host alongside the owner and name, and
-the URL shape is chosen from the forge: `/pull/<n>` for GitHub,
-`/-/merge_requests/<n>` for GitLab. When the forge cannot be determined the call
-returns nil, which the existing contract already handles — the caller defers
-rather than guessing, exactly as it does today when the repo cannot be named.
+Composing the URL requires the forge, and this is the one user-facing path with
+no URL to read it from. So the repo resolver returns the host alongside the
+owner and name, and the daemon asks the host-list derivation directly —
+`PRStatusManager.isGitLabHost`, answered by `GitLabHostResolver` in the
+worktree's own directory, where `glab` reads its configuration. Only a host
+named there gets `/-/merge_requests/<n>`; every other host gets `/pull/<n>`,
+which is the shape github.com has always been given and the shape a GitHub
+Enterprise, Bitbucket, Gitea or Codeberg checkout serves. github.com
+short-circuits inside the resolver, so a GitHub-only fleet spawns nothing.
+
+The answer is one declaration, so a fleet on which nobody has run
+`glab auth login --hostname …` composes GitHub's shape — the same URL it
+composed before GitLab existed here, on the worktree's own host rather than a
+hardcoded github.com. When the repo itself cannot be named the call returns nil
+and the caller defers rather than guessing, exactly as it does when a worktree
+has no resolvable identity.
 
 The related synthetic binding in
 `Sources/TBDApp/PRBindingPresentation.swift:71-81` constructs a placeholder with
@@ -416,7 +440,8 @@ CI signal to be computed independently.
 
 The command name, the database tables, the daemon's internal vocabulary and any
 label summarising several bindings keep saying "PR". Only user-facing text
-describing one specific binding whose forge is known renders "MR".
+describing one specific binding renders "MR", and only when that binding's own
+URL says it is a merge request.
 
 `tbd pr` is documented to agents in the `tbd` skill
 (`Sources/TBDShared/TBDSkillContent.swift:187-189`), so agents have been
@@ -484,8 +509,13 @@ tested.
   `GLRunner` that fails the test if invoked.
 - GitLab node parsing, including an absent `headPipeline`.
 - Attach by bare number composes a `/-/merge_requests/<n>` URL with the GitLab
-  host on a GitLab worktree, still composes `/pull/<n>` on a GitHub one, and
-  returns nil rather than guessing when the forge is undetermined.
+  host on a GitLab worktree, and `/pull/<n>` on every host the resolver does not
+  name — github.com and the self-hosted non-GitLab fleets alike, pinned by
+  driving one host both ways so the branch is asserted rather than the string.
+  It returns nil rather than guessing when the repo cannot be named.
+- A binding's own label follows its URL: a `/pull/` binding reads "PR" whatever
+  host it sits on, and a `/-/merge_requests/` one reads "MR" on gitlab.com and
+  on a self-managed instance alike.
 
 ## Rules this design answers
 

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -316,7 +316,9 @@ worktree's own directory, where `glab` reads its configuration. Only a host
 named there gets `/-/merge_requests/<n>`; every other host gets `/pull/<n>`,
 which is the shape github.com has always been given and the shape a GitHub
 Enterprise, Bitbucket, Gitea or Codeberg checkout serves. github.com
-short-circuits inside the resolver, so a GitHub-only fleet spawns nothing.
+short-circuits inside the resolver and spawns nothing; every other host reaches
+the same cached read-only derivation described above, and is answered
+`/pull/<n>` whenever `glab` does not name it.
 
 The answer is one declaration, so a fleet on which nobody has run
 `glab auth login --hostname …` composes GitHub's shape — the same URL it
@@ -371,6 +373,15 @@ signal" below.
   which is the faithful analogue of GitHub's "required check". A failing pipeline
   on a project that does not gate merges on pipelines is the same situation as
   GitHub's `UNSTABLE`, which TBD deliberately does not colour red.
+- That gating answer is a **third state**, not a Bool: null, absent, or
+  unreadable means the project did not say, and only an explicit `false`
+  switches the signal off. Reading an unknown answer as "does not gate" is the
+  fail-open the paragraph above describes — with `NOT_APPROVED` mapping to
+  `.mergeable`, a failing pipeline would render "Ready to merge" — while
+  reading it as gated at worst colours a merge request that was fine. The
+  unknown answer is carried as a missing scalar rather than as an unreadable
+  response: one field nobody could read must not discard the merge requests
+  that arrived with it.
 - `FAILED` on a gating project yields `.checksFailed`; `RUNNING` and `PENDING`
   yield `.pending`.
 - `MANUAL` yields `.pending`, "Pipeline awaiting manual action" — neither failing
@@ -532,6 +543,11 @@ tested.
   `GLRunner` that inspects the arguments.
 - A GitLab host whose calls fail on authentication reports that host, and does
   not degrade to "not a GitLab repo".
+- The gating answer's three states: an explicit `false` still silences the CI
+  signal, while a field that is null, absent entirely, or of the wrong type is
+  each paired with a `FAILED` pipeline and must not come out `.mergeable` — and
+  the merge requests that arrived alongside the unreadable field are still
+  parsed, so the tri-state cannot have re-introduced one null zeroing a batch.
 - The CI signal: `FAILED` on a pipeline-gating project gives `.checksFailed`;
   `FAILED` on a non-gating project does not; a draft with `FAILED` stays
   `.draft`; `MANUAL` gives `.pending` with its own reason; a null
@@ -570,11 +586,38 @@ tested.
 
 **No feature flag.** The relevant criteria are behaviour that acts without a user
 gesture, destroys or mutates persisted state, or wholesale-replaces a
-load-bearing path. This is additive and unreachable for any host that is not
-GitLab: a GitHub-only fleet spawns no new subprocess, takes the unchanged
-`.github` arm, and sees no new state. The one edit that touches shared code — the
-`PRNode` field rename and the `mapStateAndReason` signature — is a refactor whose
-GitHub arm is unchanged, and is covered by the existing suite.
+load-bearing path. What a fleet actually gets depends on its host, and the
+three classes get three different things:
+
+- **`github.com`** – nothing new. `isGitLabHost` short-circuits on the literal
+  host before any subprocess, so such a fleet takes the unchanged `.github` arm
+  over unchanged data and never reaches a line of this work.
+- **A host the user has authenticated `glab` against** – all of it: the
+  derivation, the queries, the `.gitlab` mapping arm, the recheck. Reaching it
+  takes `glab auth login --hostname …`, an explicit act, and the same one that
+  makes the queries work at all.
+- **Every other host** – GitHub Enterprise, Bitbucket, Gitea, Codeberg, any
+  self-hosted forge that is not GitLab – runs the host derivation and stops
+  there. `glab auth status` does not name the host, so the worktree is
+  classified non-GitLab and takes the unchanged `.github` arm; every query,
+  mapping and recheck above is unreachable for it.
+
+That third class is what the decision rests on, because it is the one paying
+for a feature it will never use, and the claim it needs is not "nothing runs"
+but "what runs is small, read-only, and bounded". `glab auth status` reads: it
+starts nothing, writes nothing, and touches no state of TBD's. Where `glab` is
+not installed — the common case on those hosts — the lookup resolves to a
+static nil path and no subprocess is spawned at all. Where it is installed, the
+empty answer is remembered for `emptyStatusLifetime`, so the steady state is
+one short-lived read-only subprocess per 300 seconds for the whole fleet, on a
+poll path that already spawns `gh` on every tick. A flag over that would trade a
+bounded read-only probe for a default in which a GitLab user's merge requests
+stay invisible with no message anywhere, which is the failure this work exists
+to remove.
+
+The one edit that touches shared code — the `PRNode` field rename and the
+`mapStateAndReason` signature — is a refactor whose GitHub arm is unchanged,
+and is covered by the existing suite.
 
 **No new reconciler.** No durable external resource is created. `glab`
 subprocesses are transient in exactly the way `gh`'s already are, no git ref,

--- a/docs/specs/2026-08-17-gitlab-forge-support-design.md
+++ b/docs/specs/2026-08-17-gitlab-forge-support-design.md
@@ -64,18 +64,39 @@ but I cannot talk to it" — the state every other option permits, and the one
 whose symptom (no binding ever forms, silently) is the bug being fixed. It also
 needs no configuration column and therefore no migration.
 
-Three constraints on the derivation:
+**TBD reads the host list only, never the authentication verdict.** This
+distinction carries the design. A host appears because someone declared it, and
+that is the only fact being extracted. Whether credentials currently work is
+proven by an API call succeeding, never by status text — which is measurably
+unreliable: on a self-managed instance the block for a working host printed
+`✓ Logged in to <host>` and `! Invalid token provided in configuration file`
+together, while every REST and GraphQL call with that token succeeded (#673).
 
-- **Parse the output, never the exit status.** `glab auth status` exits `0` while
-  reporting that it could not authenticate to any configured instance.
+Four constraints on the derivation:
+
+- **Ignore the exit status entirely; parse the per-host blocks.** `glab auth
+  status` exits `1` if *any* configured host fails to authenticate, so a
+  perfectly working setup reports failure whenever an unused `gitlab.com` entry
+  sits in the same config. The exit code is uninformative in both directions.
 - **`gitlab.com` appears in the list even with no credentials**, so its presence
   proves nothing. Only a non-default host is evidence.
 - **Attempt it only when the remote host is not `github.com`.** A GitHub-only
   fleet then spawns no `glab` subprocess at all, so the common case pays
   nothing.
+- **Pass `--hostname` explicitly on every `glab` invocation.** Outside a
+  repository directory `glab api` silently defaults to `gitlab.com`, so relying
+  on ambient repo context would send a self-managed instance's queries to the
+  public one.
 
 The derived host set is cached in memory for the daemon run. Nothing is
 persisted, so nothing needs invalidating, and no clock seam is required.
+
+**Credential expiry is a reporting requirement, not a recovery one.** Tokens are
+personal access tokens with an expiry and no refresh, so a host that worked
+yesterday can start refusing today. When calls against a known GitLab host begin
+failing on authentication, the failure names that host. It must not degrade into
+"this is not a GitLab repo", because that is indistinguishable from the bug this
+work exists to remove.
 
 `RemoteRepoMatching` deliberately discards the host when normalising remotes and
 documents the resulting collision — "a self-hosted GitLab mirror of a GitHub
@@ -125,8 +146,10 @@ the lower unauthenticated ceiling.
 
 The tier-1 field set is `iid`, `state`, `draft`, `detailedMergeStatus`,
 `conflicts`, `sourceBranch`, `targetBranch`, `createdAt`, `webUrl`, and
-`headPipeline { status }`. Every one of these is Free-tier and predates any
-instance likely to be in service.
+`headPipeline { status }`, plus one project-level field,
+`onlyAllowMergeIfPipelineSucceeds`. Every one of these is Free-tier and predates
+any instance likely to be in service. The project-level field is what makes a
+faithful CI signal possible — see "State mapping".
 
 **No paid-tier fields are requested.** GraphQL rejects an entire query for one
 unknown field, returning `"data": null` — on a hundred-node batch that turns a
@@ -139,6 +162,25 @@ machine-readable `extensions.code: "undefinedField"` naming the offending field,
 supporting a retry-lean-and-remember fallback that costs nothing on the happy
 path.
 
+**A REST call accompanies the GraphQL read, for one narrow purpose.** GitLab
+computes mergeability asynchronously and does not recompute it on read, so a
+merge request can report `UNCHECKED` indefinitely — 21 of 71 open merge requests
+on a self-managed instance, including some open for months (#673). GraphQL offers
+no way to ask for a recomputation; both plausible argument spellings are rejected
+as `argumentNotAccepted`. REST's list endpoint does, via
+`with_merge_status_recheck=true`, and accepts it alongside `iids[]`.
+
+So each poll pass issues one additional REST call per project, naming only the
+merge requests TBD actually has bindings for, whose sole purpose is to request a
+recomputation. Its response is discarded; the next GraphQL tick reads the
+refreshed value. The cost is one call per project rather than per merge request,
+and the scoping to bound merge requests matters — it queues background work on
+someone else's server, so TBD asks about the handful it tracks rather than every
+open merge request in the project.
+
+This is not a fallback transport and does not reopen the transport decision. The
+poll remains GraphQL; the REST call carries no data TBD reads.
+
 **Branch matching queries the server, not the viewer.** GitHub forces TBD to
 fetch the authenticated user's own pull requests and match branches locally,
 which is why a merge request opened by anyone else is invisible to branch
@@ -150,7 +192,11 @@ through the web UI or by `git push -o merge_request.create`.
 ## Project identity
 
 A GitLab namespace nests up to twenty levels, so a project path is
-`acme/platform/backend/api-gateway` rather than `owner/name`. The two existing
+`acme/platform/backend/api-gateway` rather than `owner/name`. Nesting is the
+common case rather than an edge case: of 100 projects sampled on a self-managed
+instance, 72 had one intermediate subgroup and 7 had two, leaving 21 flat as the
+minority (#673). A design that treated `owner/name` as normal and nesting as an
+exception would be calibrated backwards. The two existing
 columns hold it unchanged, reframed as namespace and project: the namespace path
 goes in `owner`, the project name in `repo`. GitHub's `owner` is simply a
 one-segment namespace, so the concept is already shared; only the column's name
@@ -212,12 +258,47 @@ solely by an ungiven review maps to `.mergeable`, "Ready to merge", commented as
 deliberate: checks are settled, and awaiting a review nobody has performed is not
 something demanding the author's attention.
 
+### The CI signal is separate from the merge status
+
+`detailedMergeStatus` reports **one** blocker, chosen by a precedence GitLab
+owns, and continuous-integration failure sits low in that order. Field
+measurement makes this unmissable: across 71 open merge requests on a project
+configured with `only_allow_merge_if_pipeline_succeeds`, 33 had a failing head
+pipeline and **not one** reported `CI_MUST_PASS` (#673). Approval, draft and
+unchecked states masked every one of them.
+
+Two consequences follow, and together they rule out reading CI state off
+`detailedMergeStatus` at all. Colouring red only on `CI_MUST_PASS` would show red
+essentially never on such an instance. Worse, combined with `NOT_APPROVED`
+mapping to `.mergeable`, a merge request with a failing pipeline would render as
+"Ready to merge".
+
+So the GitLab arm mirrors the structure GitHub's arm already has: a CI signal
+computed independently of the merge status, and evaluated in the same precedence
+position — after draft, before the merge-status switch.
+
+- The signal is **gated on the project's `onlyAllowMergeIfPipelineSucceeds`**,
+  which is the faithful analogue of GitHub's "required check". A failing pipeline
+  on a project that does not gate merges on pipelines is the same situation as
+  GitHub's `UNSTABLE`, which TBD deliberately does not colour red.
+- `FAILED` on a gating project yields `.checksFailed`; `RUNNING` and `PENDING`
+  yield `.pending`.
+- `MANUAL` yields `.pending`, "Pipeline awaiting manual action" — neither failing
+  nor passing, and common enough to need its own wording (5 of the 71).
+- A **null `headPipeline`** yields no CI signal at all, and the merge status
+  decides. Very old merge requests have none.
+
+Draft precedence is what makes this safe rather than noisy. Because `isDraft` is
+evaluated first (`:1153`), a draft with a failing pipeline stays `.draft` — which
+matters, since 15 of 17 drafts in the sample had failing pipelines. Work in
+progress does not turn the fleet red.
+
 - `MERGEABLE` maps to `.mergeable`.
 - `NOT_APPROVED` maps to `.mergeable`, "Ready to merge". It is the precise
   analogue of GitHub's `BLOCKED` plus `REVIEW_REQUIRED`. This matters in
-  practice: of six open merge requests sampled live, three reported
-  `NOT_APPROVED`, so mapping it to `.blocked` would paint most of a healthy
-  GitLab fleet as needing attention.
+  practice: it is the single most common state observed in the field, so mapping
+  it to `.blocked` would paint most of a healthy GitLab fleet as needing
+  attention.
 - `DISCUSSIONS_NOT_RESOLVED` maps to `.changesRequested`, "Unresolved
   discussions". A human is waiting on the author, which is what that state
   already means. Two of the same six merge requests reported it.
@@ -225,7 +306,14 @@ something demanding the author's attention.
   dedicated `detailedMergeStatus` value, so no per-reviewer scan and no
   paid-tier field is needed to express it.
 - `DRAFT_STATUS`, and the `draft` boolean, map to `.draft`.
-- `CHECKING`, `UNCHECKED` and `PREPARING` map to `.pending`.
+- `CHECKING` and `PREPARING` map to `.pending`, "Checks pending". These are
+  genuinely transient.
+- `UNCHECKED` maps to `.pending` with the distinct reason **"Mergeability not
+  checked"**, because it is *not* transient: GitLab computes mergeability
+  asynchronously and leaves a stale merge request unchecked until something
+  re-triggers it, so 21 of 71 sampled merge requests sat in it, some for months
+  (#673). The reason string must not imply the state is about to resolve. The
+  recheck request described under "GitLab I/O" is what actually moves it.
 - `CONFLICT` maps to `.blocked`, "Merge conflicts"; `NEED_REBASE` to `.blocked`,
   "Behind base branch"; `BLOCKED_STATUS` to `.blocked`, "Blocked by another
   merge request".
@@ -237,6 +325,36 @@ something demanding the author's attention.
   attention. Unknown means unknown. This is the one place the GitLab arm
   deliberately differs from the GitHub arm's `default: return (.blocked,
   "Blocked")` (`:1175`).
+
+### Observed distribution
+
+Every mapping choice above is calibrated against one measurement rather than
+against the enum's shape: 71 open merge requests on one active project of a
+self-managed 19.0.3-ee instance that requires both passing pipelines and resolved
+discussions (#673).
+
+| `detailedMergeStatus` | count |
+|---|---|
+| `NOT_APPROVED` | 26 |
+| `UNCHECKED` | 21 |
+| `DRAFT_STATUS` | 17 |
+| `DISCUSSIONS_NOT_RESOLVED` | 3 |
+| `NEED_REBASE` | 3 |
+| `MERGEABLE` | 1 |
+
+| `headPipeline.status` | count |
+|---|---|
+| `FAILED` | 33 |
+| `SUCCESS` | 32 |
+| `MANUAL` | 5 |
+| null | 1 |
+
+Three facts fall out of those two columns and none of them is visible from the
+schema alone. `MERGEABLE` is rare, so any design that treats it as the normal
+case is calibrated wrong. The states TBD renders most often are precisely the two
+with no GitHub equivalent, `NOT_APPROVED` and `UNCHECKED`. And 33 failing
+pipelines produced zero `CI_MUST_PASS`, which is the measurement that forced the
+CI signal to be computed independently.
 
 ## Terminology
 
@@ -252,32 +370,28 @@ when a worktree spans forges, and "PR" is the one already in place. The daemon's
 own vocabulary is already forge-neutral where it matters — `PRUndeterminedCause`
 speaks of a forge rather than of GitHub (`PRStatusManager.swift:13-34`).
 
-## Decisions this design defers
+## Discovery: the hook arm
 
-Two questions are answerable by a GitLab user's report rather than by reasoning,
-and the design records both branches with the fact that selects each. Neither
-blocks the rest of the work.
+The `PostToolUse:Bash` hook gains a `glab mr create` arm alongside the
+`gh pr create` one. Under a non-TTY `Bash` call `glab mr create` emits the bare
+web URL, so the extractor has less to sift than on the GitHub side.
 
-**What makes a GitLab chip red.** `.checksFailed` currently fires only on a
-failing *required* check, and TBD deliberately does not colour on non-required
-failures (`PRStatusManager.swift:1244-1256`). GitLab has no "required check"
-concept; its analogue is `detailedMergeStatus == CI_MUST_PASS`, meaning the
-pipeline blocks the merge. The strict analogue therefore colours red only when
-the pipeline both blocks merge and failed, which preserves today's meaning
-exactly — a failed non-blocking pipeline on GitLab is the same situation as
-GitHub's `UNSTABLE`, which TBD already shows as not red. The alternative colours
-red on any `headPipeline.status == FAILED`, which is what a GitLab user's own web
-UI leads them to expect. *Selecting fact:* whether the instance in question gates
-merges on pipelines. If it does, the two branches never diverge.
+The arm earns its place on evidence rather than symmetry: merge requests in the
+field are created almost entirely through `glab mr create`, much of it
+agent-driven, which is exactly the case the hook exists to catch — an agent
+opening a merge request that the fleet would otherwise not notice until the next
+poll. The web UI accounts for the rest, and `git push -o merge_request.create`
+is not used at all (#673).
 
-**Whether the hook gains a `glab mr create` arm.** Adding it is mechanical, and
-cleaner than the GitHub side because under a non-TTY `Bash` call `glab mr create`
-emits a bare web URL. Because GitLab branch matching is author-blind, merge
-requests created outside the hook's view are already discovered, so the arm is a
-latency improvement rather than the only route — which is the opposite of its
-role on GitHub. *Selecting fact:* how merge requests are actually created in
-practice. Widening the gate to bare `git push` is not on the table: the gate
-fails closed because a false bind can auto-archive a worktree.
+Because GitLab branch matching is author-blind, every route is discovered
+eventually even without the hook, so the arm buys latency rather than coverage —
+the opposite of its role on GitHub, where a pull request opened by anyone else is
+invisible to branch matching.
+
+Widening the gate to bare `git push` remains off the table. The gate fails closed
+because a false bind can auto-archive a worktree
+(`PRBindingExtractor.swift:64-79`), and no gate can admit the push option without
+admitting every push.
 
 ## Testing
 
@@ -295,8 +409,21 @@ tested.
   `identityKey`, the four-part parse, and the unique index without collapsing
   into a different binding.
 - `glab auth status` parsing: a host list with one authenticated and one
-  unauthenticated host, a run that reports failure while exiting `0`, and absent
-  or unconfigured `glab`.
+  unauthenticated host still yields both hosts despite the command exiting `1`, a
+  block that reports "Logged in" and "Invalid token" simultaneously still yields
+  the host, and absent or unconfigured `glab` yields none.
+- Every `glab` invocation carries `--hostname`, asserted by an injected
+  `GLRunner` that inspects the arguments.
+- A GitLab host whose calls fail on authentication reports that host, and does
+  not degrade to "not a GitLab repo".
+- The CI signal: `FAILED` on a pipeline-gating project gives `.checksFailed`;
+  `FAILED` on a non-gating project does not; a draft with `FAILED` stays
+  `.draft`; `MANUAL` gives `.pending` with its own reason; a null
+  `headPipeline` leaves the merge status to decide.
+- `UNCHECKED` yields `.pending` with a reason distinct from the transient
+  `CHECKING` and `PREPARING` cases.
+- The recheck request names only bound merge requests, and a failure or an
+  unparseable response from it does not disturb the poll's own result.
 - Forge derivation is not attempted for a GitHub remote, asserted by an injected
   `GLRunner` that fails the test if invoked.
 - GitLab node parsing, including an absent `headPipeline`.
@@ -359,12 +486,28 @@ they cannot.
 Rejected because it is wrong precisely in the self-hosted case that motivates
 this work, and wrong in the silent direction.
 
-**REST instead of GraphQL.** REST is the worn path — the surveyed tools and
-GitLab's own Go SDK all use it — and it tolerates instance variation by omitting
-unknown fields rather than failing the whole request. Rejected because its
-`iids[]` batch omits pipeline status, forcing one additional call per merge
-request per poll pass, and because confining the query to fields available on
-every edition removes the failure mode REST's tolerance protects against.
+**REST for the whole poll, not just the recheck.** REST is the worn path — the
+surveyed tools and GitLab's own Go SDK all use it — it tolerates instance
+variation by omitting unknown fields rather than failing the whole request, and
+it is the only transport that can request a mergeability recomputation. Rejected
+because its `iids[]` batch omits pipeline status, forcing one additional call per
+merge request per poll pass, where the recheck costs one call per *project*.
+Confining the GraphQL query to fields available on every edition also removes the
+failure mode REST's tolerance protects against. Using each transport for what it
+alone does well costs less than committing to either.
+
+**Rendering `UNCHECKED` as unknown and leaving it there.** Zero extra calls, and
+no background work queued on someone else's instance. Rejected because roughly a
+third of observed merge requests sit in that state, some for months, so a
+substantial part of a GitLab fleet would permanently display a status that
+communicates nothing — and the state is reachable out of TBD's own poll, which
+makes leaving it a choice rather than a limitation.
+
+**Rate-limiting the recheck behind a staleness timer.** Politest to the server,
+and rejected for now only because it buys little over scoping the request to bound
+merge requests, while introducing a timer and therefore an injected clock seam. If
+field use shows the per-tick request is too much load, this is the change to
+make.
 
 **Growing `PRMergeableState`.** Dedicated cases for GitLab's distinct states
 would be more faithful to what GitLab reports. Rejected because every new tier


### PR DESCRIPTION
## Summary

TBD tracks pull requests on GitHub only — and not by configuration, but by
construction. On a GitLab worktree no binding could ever form: the URL pattern
every discovery path funnels through was host-locked to `https://github.com/`,
so the status-bar chip was synthetic and the daemon rejected the URL that chip
carried if you tried to act on it.

This makes GitLab merge requests first-class. They bind from a pasted URL, from
`glab mr create` in an agent session, and from branch matching; they poll for
status, colour the toolbar and sidebar, and participate in the merged-transition
machinery exactly as pull requests do. A worktree can hold bindings on both
forges at once.

No database migration, no configuration column, and no feature flag — each of
those fell out of a design decision rather than being a goal, and together they
mean nothing about a GitHub-only fleet changes.

## Why this shape

Full rationale, measurements, and rejected alternatives:
[`docs/specs/2026-08-17-gitlab-forge-support-design.md`](docs/specs/2026-08-17-gitlab-forge-support-design.md).
Prior research: [`docs/research/2026-08-16-gitlab-pr-support/findings.md`](docs/research/2026-08-16-gitlab-pr-support/findings.md).

The four decisions that shaped the diff:

- **Forge identity is derived from `glab auth status`, not declared or probed.**
  A host appears in that list only because someone ran
  `glab auth login --hostname …`, and that same act is what makes every
  subsequent API call succeed. Declaration and capability become one
  precondition, so TBD can never reach the state "I know this is GitLab but I
  cannot talk to it" — the state a config column would permit, and whose
  symptom is silence. It also needs no column, and therefore no migration.
- **URL discovery identifies its own forge.** `/-/merge_requests/<n>` is a path
  segment no other forge uses, so the extractor needs no host knowledge and the
  GitHub pattern is untouched byte for byte.
- **Project identity reuses the existing two columns as namespace and project.**
  GitLab namespaces nest — measurement on a self-managed instance found 79 of
  100 projects nested, up to three levels, so nesting is the common case and
  flat is the minority. Slashes survive the `\u{1}`-delimited identity key, the
  four-part parse and the unique index unchanged, which is what keeps this
  migration-free.
- **The CI signal is computed independently of the merge status.** This is the
  least obvious decision and the one most load-bearing. `detailedMergeStatus`
  reports exactly one blocker, by a precedence GitLab owns, and CI ranks below
  approval, draft and unchecked: across 71 open merge requests on a
  pipeline-gated project, 33 had failing pipelines and **zero** reported
  `CI_MUST_PASS`. Reading CI off that field would show red essentially never —
  and because `NOT_APPROVED` maps to `.mergeable`, a merge request with a
  failing pipeline would have rendered "Ready to merge". So the signal comes
  from `headPipeline.status`, gated on the project's
  `onlyAllowMergeIfPipelineSucceeds`, and takes the GitHub arm's structure with
  one signal ranked above it: an explicit `REQUESTED_CHANGES` outranks a failing
  pipeline, mirroring GitHub putting `CHANGES_REQUESTED` ahead of a failing
  required check. An unresolved discussion thread is not an explicit rejection
  and stays below the CI signal.

GitLab's states map into the existing eight `PRMergeableState` cases rather than
growing the enum, because `attentionSeverity` is read by the toolbar, the
sidebar and the `prStatus` column and they must not disagree; precision that the
eight cannot carry goes in `PRStatus.reason`. An unrecognised
`detailedMergeStatus` maps to `.pending`, never `.blocked` — the enum grows
between GitLab releases, and unknown-means-blocked would let a future release
silently paint merge requests red.

## What this PR does

- **`Forge`** (`Sources/TBDShared/Forge.swift`) — a two-case discriminator,
  derived at parse time, carried on `PRNode`, never persisted.
- **`PRBindingExtractor`** — a second URL pattern for GitLab, host taken from
  the match instead of stamped; `glab mr create` accepted, with the verb checked
  against its own CLI so `gh mr create` and `glab pr create` are both rejected.
- **`GitLabHostResolver`** — reads the host *list* from `glab auth status`,
  never the authentication verdict.
- **`GitLabQueries`** — one batched `mergeRequests(iids:)` GraphQL query
  carrying pipeline status inline, branch matching via `sourceBranches`, and a
  REST recheck path.
- **`PRStatusManager`** — `PRNode` gains `forge` and forge-neutral verdict
  fields; `mapStateAndReason` dispatches with the GitHub arm moved verbatim;
  binding groups and branch matching route by host.
- **Attach-by-number** composes `/-/merge_requests/<n>` when the resolver
  confirms a GitLab host and `/pull/<n>` otherwise, and defers — returns nil —
  when the worktree's forge cannot be determined at all, rather than guessing a
  shape.
- **UI** renders `MR !412` for a GitLab binding. Anything summarising several
  bindings keeps neutral wording, because a worktree can span forges. The
  `tbd pr` command name, DB tables and daemon vocabulary are unchanged.

Two behaviours worth calling out because they are not symmetric with GitHub.
GitLab's `sourceBranches` filter has no author filter, so branch matching finds
a merge request opened by anyone — including through the web UI — which makes
the hook a latency improvement rather than the only route, the opposite of its
role on GitHub. And GitLab computes mergeability asynchronously and never
recomputes on read, so a merge request can report `UNCHECKED` indefinitely (21
of the 71 sampled, some open for months); GraphQL offers no way to ask for a
recomputation, so each pass also issues one REST call per project, scoped to
bound merge requests, whose only purpose is to request one.

## Flag & rollout

None. The criteria are behaviour that acts without a user gesture, destroys or
mutates persisted state, or wholesale-replaces a load-bearing path. This is
additive and unreachable for `github.com`, which short-circuits before any
subprocess: such a fleet takes the unchanged `.github` arm, spawns no `glab`,
and sees no new state. The one edit to shared code — the `PRNode` field rename
and the `mapStateAndReason` signature — is a refactor whose GitHub arm is
byte-identical.

**No new reconciler.** `glab` subprocesses are transient exactly as `gh`'s are.
The one subprocess that outlives its poll pass is the detached mergeability
recheck, and it is bounded at its creation site in both dimensions rather than
by a sweep: single-flight admission caps how many can exist per project, and a
60-second deadline caps how long one can live — SIGTERM, then SIGKILL after a
grace period, so the child actually dies rather than the wait merely being
abandoned. A test spawns a SIGTERM-immune child and asserts by pid that it is
gone. The residual is stated plainly in the spec — a daemon that dies
mid-recheck orphans that child, and nothing reclaims it.

## Assumptions

- **`glab` is on PATH and authenticated to the instance.** If it is not, no
  GitLab host is derived and no binding forms. This is deliberate — the
  derivation and the capability are the same precondition — but it means the
  failure mode for an unconfigured `glab` is the same silence this PR removes
  for a configured one.
- **The instance runs GitLab 15.6 or later**, where `detailedMergeStatus`
  exists, and has `/api/graphql` enabled. Both confirmed on the target instance
  (19.0.3-ee).
- **Only CE-tier GraphQL fields are requested.** GraphQL rejects an entire query
  for one unknown field and returns `data: null`, which on a batched read would
  mean zero merge requests. Adding a paid-tier field later reintroduces that
  risk and needs the `undefinedField` retry the spec describes.
- **A repo's forge does not change under a running daemon**, except that a host
  gaining GitLab credentials is picked up within 300 seconds.

## Evidence & verification

**Field-measured, not assumed.** The mapping is calibrated against 71 open merge
requests on a self-managed 19.0.3-ee instance (#673), which is where the
`CI_MUST_PASS` masking above was found. The shipped GraphQL query was also run
against live gitlab.com: it is valid, returns exactly the ten expected keys, and
the two merge requests it came back with exercise the central decision — one
reported `UNCHECKED` with a `FAILED` pipeline on a gated project, which this PR
renders `.checksFailed` and which the naive reading would have rendered
`.pending`, hiding the failure.

**Both branches of every new conditional are tested**, per the repo rule: each
mapping row, the extractor accepting GitLab URLs *and* rejecting near-misses
(no `/-/` separator, dot segments at every namespace depth), identity round-trip
with slashes, `glab auth status` parsing including its exit-1-while-working and
self-contradictory-verdict shapes, and `--hostname` asserted on every `glab`
invocation.

**Three review passes.** The first found nine defects, including a GitHub-only
regression where a transient `gh` failure cached a fork's identity for fifteen
minutes, and three paths that degraded a GitLab error into "no merge request".
The second found that three of those *fixes* introduced new problems — most
importantly that an unauthenticated `gh` made the entire GitLab path inert,
since `gh` checks auth before base-repo resolution and so never emits the
disownment message the fix keyed on. The third found no correctness defects and
verified the fixes by mutation: five deliberate breakages, each caught by a
failing test.

**Suite:** 7,053 tests in 709 suites passing, 0 failures, 70 pre-existing known
issues. `swiftlint --strict` clean. `Sources/TBDDaemon/Database/` untouched.

**Not live-verified in the running app.** No GitLab instance is reachable from
this machine, so the end-to-end path — a real binding appearing and polling —
has not been exercised against a server. That is the gap this PR cannot close
itself; the target user is an informant rather than a tester.

## Known residuals

- **GitHub Enterprise.** Forge classification no longer guesses from the host:
  a binding's label comes from its own URL shape, and `pr.attach <number>`
  composes `/pull/<n>` unless the resolver confirms the host is GitLab. A GHE checkout on a machine whose `gh` has never
  been logged in can resolve to a fork rather than its parent — unsolvable from
  that path, since with no credentials there is no gh host configuration to read
  the enterprise hostname from.
- A GitLab worktree carrying a provenance `prNumber` is no longer polled through
  the by-number path; its merge request is reached through its binding instead.
- `fetchGitLabBranchMatches` keeps one failure cause across project groups, so
  an unanswered worktree can be shown a sibling project's cause. The
  classification is correct; only the wording can be wrong.
- `lastUndeterminedCause(forHost:)` has no production reader. The user-visible
  half of credential-expiry reporting rides the `PRObservation` rail, which does.
- The open-PR picker returns empty on a GitLab repo rather than listing merge
  requests; giving `listOpenPRs` a GitLab arm is out of scope here.

[20260816-delicate-goldfish](https://cheapsteak.github.io/tbd/open/?worktree=DE02B6B8-D3D0-4862-B1F7-66C1873E7C68)
