### PR TITLE
fix: stop a scratch lane growing a PR "?" badge it can never resolve

### DIFF
--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1440,6 +1440,27 @@ public final class TBDDatabase: Sendable {
                 table: "reap_records", column: "quarantinePath", type: .text)
         }
 
+        // Clear the PR attempt outcome recorded against scratch rows. A scratch
+        // row (`repoID IS NULL`) has no repo, no branch, and a path that is not a
+        // checkout, so the poll skips it. `pr.refresh` queried it anyway on
+        // select, failed in that directory, and wrote `.undetermined` to the row.
+        // Every PR surface renders that as "PR status unknown", so a scratch lane
+        // grew a `?` badge it can never resolve.
+        //
+        // `RPCRouter.isPollable` now gates both paths, so no row can acquire one
+        // again, but the recorded ones outlive the guard, and by two separate
+        // readers: the daemon re-hydrates them into `PRStatusManager` at every
+        // start, and the app seeds `prObservations` straight off the worktree row.
+        // Both read the column, so the column is where the fix has to land.
+        //
+        // Scoped to `prObservation`. A scratch row's `prStatus` is left alone
+        // because no path ever wrote one: the failing query kept the (absent)
+        // cached value rather than replacing it.
+        migrator.registerMigration("v80_clear_scratch_pr_observation") { db in
+            try db.execute(
+                sql: "UPDATE worktree SET prObservation = NULL WHERE repoID IS NULL")
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -959,7 +959,24 @@ public final class RPCRouter: Sendable {
     /// in comes from `pollWorkingDirectory` — the repo's own checkout for a
     /// remote row — so no caller ever sees the synthetic `remote://` path.
     static func pollableWorktrees(_ worktrees: [Worktree]) -> [Worktree] {
-        worktrees.filter { !$0.isScratch }
+        worktrees.filter(isPollable)
+    }
+
+    /// Whether one row is asked about at all. The single predicate behind BOTH
+    /// the sweep's enumeration and `pr.refresh`, because the two disagreeing is
+    /// itself the bug: a scratch row the sweep skips forever used to be queried
+    /// the moment it was selected, the query failed in a directory that is not a
+    /// checkout, and the failure was recorded as `.undetermined`, which every PR
+    /// surface renders as "PR status unknown" for a row that cannot have a pull
+    /// request. Then the next sweep's `prManager.retain(active:)` evicted the
+    /// observation again, so the indicator blinked on select and off ~30s later.
+    ///
+    /// A scratch row is repo-less and branch-less by construction, so "no pull
+    /// request applies here" is settled knowledge and the right answer is to make
+    /// no attempt at all: not `.none` (which claims the forge answered), and not
+    /// `.undetermined` (which claims someone tried and could not tell).
+    static func isPollable(_ worktree: Worktree) -> Bool {
+        !worktree.isScratch
     }
 
     /// The directory this row's poll runs `git` and `gh` in, or nil when there
@@ -1070,6 +1087,13 @@ public final class RPCRouter: Sendable {
         guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
             // No observation: no attempt was made, which is a third thing again
             // from `.none` and `.undetermined` and must not be dressed as either.
+            return try RPCResponse(result: PRRefreshResult(status: nil, observation: nil))
+        }
+        // The same predicate the sweep enumerates through. A scratch row is not
+        // polled, so it must not be refreshed either: no attempt is made, and
+        // "no attempt" is reported rather than a failure invented by asking a
+        // question that has no answer here.
+        guard Self.isPollable(wt) else {
             return try RPCResponse(result: PRRefreshResult(status: nil, observation: nil))
         }
         var repo: Repo?

--- a/Tests/TBDDaemonTests/MigrationV80Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV80Tests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `v80_clear_scratch_pr_observation` erases the PR attempt outcome recorded
+/// against scratch rows.
+///
+/// The guard in `RPCRouter.isPollable` stops new ones being written, but it
+/// cannot reach the ones already on disk: the daemon re-hydrates them into
+/// `PRStatusManager` at every start, and the app seeds `prObservations` straight
+/// off the worktree row, so a scratch lane kept its unresolvable "?" badge
+/// across the fix and across restarts. The column is the only place both readers
+/// look, so the column is where it gets cleared.
+@Suite struct MigrationV80Tests {
+
+    /// The value under test is written BEFORE v80 runs, which is the only way to
+    /// prove the migration does anything: a row inserted afterwards would be
+    /// clean for a reason that has nothing to do with this migration.
+    private static func migrateToV79() throws -> DatabaseQueue {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v79_reap_records_quarantine_path")
+        return queue
+    }
+
+    private static let observation = """
+        {"observedAt":808761353.9,"outcome":{"outcome":"undetermined","cause":"the forge query failed"}}
+        """
+
+    private static func insertWorktree(
+        _ queue: DatabaseQueue, id: String, repoID: String?, path: String
+    ) throws {
+        try queue.write { db in
+            try db.execute(
+                sql: """
+                INSERT INTO worktree
+                  (id, repoID, name, displayName, branch, path, status, createdAt,
+                   tmuxServer, prObservation)
+                VALUES (?, ?, 'w', 'w', '', ?, 'active', ?, 'tbd-x', ?)
+                """,
+                arguments: [id, repoID, path, Date(), observation])
+        }
+    }
+
+    private static func observation(_ queue: DatabaseQueue, id: String) throws -> String? {
+        try queue.read { db in
+            try String.fetchOne(db, sql: "SELECT prObservation FROM worktree WHERE id = ?",
+                                arguments: [id])
+        }
+    }
+
+    @Test func scratchRowLosesItsRecordedOutcome() throws {
+        let queue = try Self.migrateToV79()
+        let scratchID = "E3DB7381-0000-0000-0000-000000000000"
+        try Self.insertWorktree(queue, id: scratchID, repoID: nil, path: "/tmp/v80-scratch")
+        #expect(try Self.observation(queue, id: scratchID) != nil, "precondition: the lie is on the row")
+
+        try TBDDatabase.buildMigratorForTests().migrate(queue)
+
+        #expect(try Self.observation(queue, id: scratchID) == nil)
+    }
+
+    /// Guard the scope. A repo-scoped row's outcome is a real reading of a real
+    /// forge attempt, and an outage that spans a restart must still be visible after
+    /// this migration runs, which is the whole reason the column is persisted.
+    @Test func repoScopedRowKeepsItsRecordedOutcome() throws {
+        let queue = try Self.migrateToV79()
+        let repoID = "11111111-1111-1111-1111-111111111111"
+        let regularID = "22222222-0000-0000-0000-000000000000"
+        try queue.write { db in
+            try db.execute(
+                sql: """
+                INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                VALUES (?, '/tmp/v80-repo', 'V80', 'main', ?)
+                """,
+                arguments: [repoID, Date()])
+        }
+        try Self.insertWorktree(queue, id: regularID, repoID: repoID, path: "/tmp/v80-wt")
+
+        try TBDDatabase.buildMigratorForTests().migrate(queue)
+
+        #expect(try Self.observation(queue, id: regularID) != nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ScratchExclusionTests.swift
+++ b/Tests/TBDDaemonTests/ScratchExclusionTests.swift
@@ -63,6 +63,63 @@ struct ScratchExclusionTests {
         #expect(result.statuses[scratch.id] == nil)
     }
 
+    /// The other half of the same guard, and the one that was missing: the poll
+    /// skipped a scratch row while `pr.refresh` (which the app fires the moment
+    /// a row is selected) queried it anyway. The query ran in a directory that
+    /// is not a checkout, failed, and the failure was recorded as `.undetermined`,
+    /// which every PR surface renders as an unresolvable "?" badge. Asserting the
+    /// DB row too, because the recorded outcome is what outlived the attempt: it
+    /// is re-hydrated at every daemon start and read straight off the row by the
+    /// app.
+    @Test("pr.refresh makes no attempt for a scratch worktree")
+    func prRefreshMakesNoAttemptForScratch() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
+        let scratch = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/scr-\(UUID().uuidString)", tmuxServer: "tbd-scratch")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.prRefresh, params: PRRefreshParams(worktreeID: scratch.id)))
+        let result = try response.decodeResult(PRRefreshResult.self)
+
+        #expect(result.status == nil)
+        #expect(result.observation == nil,
+                "no attempt was made: neither `.none` nor `.undetermined`")
+        #expect(try await db.worktrees.get(id: scratch.id)?.prObservation == nil,
+                "a scratch row must not acquire a recorded outcome that outlives the attempt")
+    }
+
+    /// A repo-scoped row still gets asked. Without this the fix above could be
+    /// widened into "never refresh anything" and nothing would notice: the test
+    /// environment has no usable `gh`, so the attempt cannot resolve, but it
+    /// must still be *made* and reported as unresolved.
+    @Test("pr.refresh still attempts a repo-scoped worktree")
+    func prRefreshStillAttemptsRegularRows() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
+        let repo = try await db.repos.create(
+            path: "/tmp/repo-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let regular = try await db.worktrees.create(
+            repoID: repo.id, name: "w", displayName: "w", branch: "tbd/w",
+            path: "/tmp/wt-\(UUID().uuidString)", tmuxServer: "tbd-w")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.prRefresh, params: PRRefreshParams(worktreeID: regular.id)))
+        let result = try response.decodeResult(PRRefreshResult.self)
+
+        let outcome = try #require(result.observation?.outcome,
+                                   "a repo-scoped row is still asked about")
+        if case .undetermined = outcome {} else {
+            Issue.record("expected the unresolved attempt to be .undetermined, observed \(outcome)")
+        }
+    }
+
     @Test("reconcile only ever lists worktrees scoped to a repoID")
     func reconcileIsRepoScoped() async throws {
         let (tempDir, repoDir) = try await createTestRepo()


### PR DESCRIPTION
## What's broken

A scratch lane (a worktree created with no repo behind it, living under
`~/tbd/scratch/`) grows a grey `?` badge in the sidebar where a pull-request icon
would go, and the badge blinks: it appears when you click the row, disappears
roughly half a minute later, and comes back the next time you select the row.
Hovering it reads "PR status unknown, the forge query failed".

A scratch lane has no repo and no branch, so it can never have a pull request.
The correct rendering is nothing at all. Anyone who keeps a scratch lane around
hits this the first time they click it, and it never settles on its own: the
recorded outcome is persisted, so it survives daemon restarts too.

## Why it happens

Two paths ask GitHub about a worktree, and only one of them knew to skip scratch
rows.

The background sweep enumerates through `RPCRouter.pollableWorktrees`, which
drops scratch rows. `pr.refresh` did not, and the app fires that RPC the moment a
row is selected. For a scratch row the working directory it picks is the row's own
path, which is a plain directory and not a git checkout, so `gh` fails there. That
failure is faithfully recorded as `PRObservation.Outcome.undetermined`, meaning
"someone asked and could not find out", and every PR surface renders that state as
the unknown indicator. The observation is correct about the attempt; the attempt
should never have been made.

The blinking is the same disagreement seen from the other side. Each poll pass
ends with `prManager.retain(active:)`, whose `active` set is the pollable rows, so
it evicts the scratch row's observation from the in-memory map (in memory only,
leaving the DB row intact). `pr.list` then stops reporting it, the app mirrors
that response exactly, and the badge vanishes about 30 seconds after it appeared.
Selecting the row runs `pr.refresh` again and writes it back.

## What this PR does

- Adds `RPCRouter.isPollable`, one predicate now standing behind both the sweep's
  enumeration and `pr.refresh`, so the two cannot drift again. A scratch row
  reports no attempt at all, which is a third state distinct from `.none` ("the
  forge answered, there is no PR") and `.undetermined` ("we could not find out").
- Adds `v80_clear_scratch_pr_observation`, clearing `worktree.prObservation` where
  `repoID IS NULL`.

The migration is not redundant with the guard, because the recorded outcome
outlives the attempt by two independent readers: the daemon re-hydrates it into
`PRStatusManager` at every start, and the app seeds `prObservations` straight off
the worktree row during its ordinary worktree refresh. Both read the column, so
the column is where it has to be cleared. Scoped to `prObservation` only, because
no path ever wrote a `prStatus` for a scratch row: the failing query kept the
(absent) cached value rather than replacing it.

Two alternatives were considered and rejected. Suppressing the indicator in
`WorktreeRowView` for scratch rows treats the symptom and leaves the daemon
recording a forge failure that never happened. Filtering at hydration time instead
of clearing the column fixes only the daemon's reader and leaves the app's own
seeding path showing the stale `?` on cold start.

No spec: this restores the system to its existing theory (a scratch row is not
polled) rather than revising it.

## Evidence & verification

The repro is on disk in a live install. The scratch row carried
`{"outcome":"undetermined","cause":"the forge query failed"}` in
`worktree.prObservation`, stamped a couple of hours after the row was last
selected, with `prStatus` and `pr_number` both NULL, and `gh repo view` run by
hand in that directory fails with `fatal: not a git repository`.

Discriminating tests, all in `Tests/TBDDaemonTests`:

- `pr.refresh makes no attempt for a scratch worktree` asserts a nil observation
  in the response and a still-nil `prObservation` on the row. Confirmed failing
  with the guard removed, and the recorded failure is the same string seen in the
  live DB: `Expectation failed: (result.observation -> PRObservation(outcome:
  undetermined(cause: "the forge query failed"), ...)) == nil`.
- `pr.refresh still attempts a repo-scoped worktree` pins the scope, so the guard
  cannot be widened into "never refresh anything" unnoticed. The test environment
  has no usable `gh`, so the attempt cannot resolve, but it must still be made and
  reported as unresolved.
- `MigrationV80Tests` writes the observation before v80 runs (migrating to v79
  first, since a row inserted afterwards would be clean for reasons unrelated to
  the migration) and asserts both arms: the scratch row loses its outcome, and a
  repo-scoped row keeps one, because a real forge outage spanning a restart is
  exactly what persisting the column is for.

`scripts/test.sh` full run: 6988 tests, one unrelated red,
`ReplayLiveIntegrationMatrixTests` "firehose overflow heals via the repair cycle",
which fails under parallel load, passes in isolation, and self-reports as
"harness/load, not production". `scripts/swift-safe build` clean, `swiftlint
--strict` 0 violations.

Not yet verified in a running app: applying it live means restarting the daemon
from this worktree, which also claims the `tbd://` handler, so it is left to the
reviewer's own restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
