### PR TITLE
DX: Let a starved build lane verify on CI instead of waiting out the shared slot

### DIFF
--- a/.github/workflows/preflight-cleanup.yml
+++ b/.github/workflows/preflight-cleanup.yml
@@ -15,9 +15,14 @@ name: Preflight ref cleanup
 #
 # Two legs, and the second is the one that carries the guarantee:
 #
-#   - CLOSE PATH — a PR closing deletes its own preflight ref immediately, so
-#     the common case is reclaimed within seconds and the weekly pass usually
-#     finds nothing.
+#   - CLOSE PATH — a PR closing reclaims its own preflight ref immediately, so
+#     the common case needs no weekly wait. It runs the SAME sweep, narrowed to
+#     that one ref, rather than deleting it itself: the sweep's age guard spares
+#     anything under an hour old precisely so a reclaim cannot take a ref out
+#     from under a run that is about to check it out, and in a forty-worktree
+#     fleet "another agent merges this PR while a lane verifies against it" is
+#     ordinary. A ref young enough to be spared here is inert an hour later and
+#     the weekly pass takes it.
 #   - SWEEP — a weekly pass over every `preflight/*` ref on the remote, keeping
 #     only those whose branch still has an open PR. This is what makes the
 #     close path best-effort rather than load-bearing: a cancelled run, a
@@ -70,20 +75,23 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         env:
+          # `gh pr list` decides what is still in use, so this leg needs a token
+          # as much as the sweep leg does.
+          GH_TOKEN: ${{ github.token }}
           # Via the environment, never interpolated into the script body: a
           # branch name is attacker-controlled text that may legally contain
           # `$`, backticks and `;`, so `${{ … }}` inside `run:` would be a
           # shell injection.
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        # ONE REF, THROUGH THE SWEEP, so the two guards that decide whether a
+        # preflight ref may be deleted — an open PR still naming it, and an age
+        # under the grace period — are written once and apply to both legs. A
+        # bare `git push --delete` here would honour neither, and the age one is
+        # load-bearing: it is what stops this leg deleting a ref seconds after a
+        # lane pushed it and before the run it dispatched has checked it out.
         run: |
           set -euo pipefail
-          ref="refs/heads/preflight/$HEAD_REF"
-          if git ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
-            git push origin --delete "$ref"
-            echo "deleted $ref"
-          else
-            echo "no preflight ref for $HEAD_REF; nothing to reclaim"
-          fi
+          bash scripts/sweep-preflight-refs.sh --apply --branch "$HEAD_REF"
 
       - name: Sweep preflight refs with no open PR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/preflight-cleanup.yml
+++ b/.github/workflows/preflight-cleanup.yml
@@ -1,0 +1,100 @@
+name: Preflight ref cleanup
+
+# THE NAMED RECONCILER FOR INERT `preflight/*` REFS.
+#
+# The remote verification valve
+# (docs/specs/2026-08-16-remote-verification-valve-design.md) pushes
+# `preflight/<branch>` when a lane needs a CI verdict on a branch that already
+# has an open PR — pushing the PR branch itself would fire
+# `pull_request_target: synchronize` and spend Claude quota on a review nobody
+# asked for. Those refs are a genuine new durable resource, and CLAUDE.md's
+# reconciler doctrine says who reclaims them must be named rather than left to
+# a best-effort cleanup on the happy path: every unbounded leak this repo has
+# found in the wild sat on a resource no sweep covered, including 2,804 leaked
+# git branches.
+#
+# Two legs, and the second is the one that carries the guarantee:
+#
+#   - CLOSE PATH — a PR closing deletes its own preflight ref immediately, so
+#     the common case is reclaimed within seconds and the weekly pass usually
+#     finds nothing.
+#   - SWEEP — a weekly pass over every `preflight/*` ref on the remote, keeping
+#     only those whose branch still has an open PR. This is what makes the
+#     close path best-effort rather than load-bearing: a cancelled run, a
+#     force-pushed rename, or a ref pushed for a branch that never opened a PR
+#     all land here.
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    # 12:00 UTC Sunday. Nothing here is urgent — the refs cost only namespace —
+    # and a weekly cadence keeps the sweep's own noise near zero.
+    - cron: '0 12 * * 0'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually delete the refs (unchecked = dry run)'
+        type: boolean
+        required: false
+        default: false
+
+# Declaring this block sets every scope NOT listed to `none`, so both entries
+# are load-bearing: `contents: write` to delete refs, and `pull-requests: read`
+# for the `gh pr list` the sweep uses to decide what is still in use. Without
+# the latter every query fails — which the sweep treats as "unknown", keeping
+# every ref, rather than as "no PR", which would empty the namespace.
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: preflight-cleanup
+  # NOT cancel-in-progress: two legs deleting disjoint refs do not conflict,
+  # and a cancelled sweep is a week with no reconciliation.
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Reclaim preflight refs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Skipped for forks: the valve pushes preflight refs to this repo only, so
+      # a fork PR has none — and `pull_request` hands a fork a read-only token
+      # regardless of the `permissions` block above, so the attempt would fail
+      # rather than no-op.
+      - name: Delete this PR's preflight ref
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          # Via the environment, never interpolated into the script body: a
+          # branch name is attacker-controlled text that may legally contain
+          # `$`, backticks and `;`, so `${{ … }}` inside `run:` would be a
+          # shell injection.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          ref="refs/heads/preflight/$HEAD_REF"
+          if git ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
+            git push origin --delete "$ref"
+            echo "deleted $ref"
+          else
+            echo "no preflight ref for $HEAD_REF; nothing to reclaim"
+          fi
+
+      - name: Sweep preflight refs with no open PR
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # A scheduled pass reclaims; a manual dispatch previews unless asked.
+          APPLY: ${{ github.event_name == 'schedule' || inputs.apply }}
+        run: |
+          set -euo pipefail
+          if [ "$APPLY" = "true" ]; then
+            bash scripts/sweep-preflight-refs.sh --apply
+          else
+            bash scripts/sweep-preflight-refs.sh
+          fi

--- a/.github/workflows/preflight-cleanup.yml
+++ b/.github/workflows/preflight-cleanup.yml
@@ -17,20 +17,39 @@ name: Preflight ref cleanup
 #
 #   - CLOSE PATH — a PR closing reclaims its own preflight ref immediately, so
 #     the common case needs no weekly wait. It runs the SAME sweep, narrowed to
-#     that one ref, rather than deleting it itself: the sweep's age guard spares
-#     anything under an hour old precisely so a reclaim cannot take a ref out
-#     from under a run that is about to check it out, and in a forty-worktree
-#     fleet "another agent merges this PR while a lane verifies against it" is
-#     ordinary. A ref young enough to be spared here is inert an hour later and
-#     the weekly pass takes it.
+#     that one ref, rather than deleting it itself: the sweep asks whether a
+#     workflow run is still using the ref and spares anything under an hour old,
+#     precisely so a reclaim cannot take a ref out from under a run that is about
+#     to check it out, and in a forty-worktree fleet "another agent merges this PR
+#     while a lane verifies against it" is ordinary. A ref spared here is inert
+#     soon after and the weekly pass takes it.
 #   - SWEEP — a weekly pass over every `preflight/*` ref on the remote, keeping
 #     only those whose branch still has an open PR. This is what makes the
 #     close path best-effort rather than load-bearing: a cancelled run, a
 #     force-pushed rename, or a ref pushed for a branch that never opened a PR
 #     all land here.
 
+# `pull_request_target`, NOT `pull_request`, AND THE REASON IS THE TOKEN. This is
+# the repo's only close-triggered workflow that wants `contents: write`. Under
+# `pull_request` a same-repo PR runs the workflow file AND the scripts it invokes
+# as they exist on the PR's HEAD, so a branch author could edit the sweep or this
+# step body, open a PR, close it, and have unreviewed code execute with a
+# write-scoped token — outside the review gate entirely. `pull_request_target`
+# runs the BASE branch's copy of both, which is the principled trigger for a
+# write-scoped close handler and the pattern this repo already documents for
+# `claude-code-review.yml`.
+#
+# It grants no privilege the actor lacks — pushing a branch already needs push
+# access — so this is defence in depth rather than a closed hole. What it buys is
+# that the code holding the token is code that went through review.
+#
+# THE FORK GATE BELOW IS STILL LOAD-BEARING, AND MORE SO NOW. `pull_request_target`
+# hands a fork PR a token with the `permissions` block's full scope rather than a
+# read-only one, so the gate is what keeps a fork's close event from reaching a
+# write-scoped step at all. Nothing in the step body interpolates PR-controlled
+# text either — the head branch name arrives through `env:`.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   schedule:
     # 12:00 UTC Sunday. Nothing here is urgent — the refs cost only namespace —
@@ -44,14 +63,24 @@ on:
         required: false
         default: false
 
-# Declaring this block sets every scope NOT listed to `none`, so both entries
-# are load-bearing: `contents: write` to delete refs, and `pull-requests: read`
-# for the `gh pr list` the sweep uses to decide what is still in use. Without
-# the latter every query fails — which the sweep treats as "unknown", keeping
-# every ref, rather than as "no PR", which would empty the namespace.
+# Declaring this block sets every scope NOT listed to `none`, so all three
+# entries are load-bearing:
+#
+#   contents: write     to delete refs.
+#   pull-requests: read for the `gh pr list` that asks whether a PR still names a
+#                       ref.
+#   actions: read       for the `gh run list` that asks whether a workflow run is
+#                       still USING one. That question is what covers the window
+#                       the commit-date age guard cannot see, and without this
+#                       scope every query 403s.
+#
+# Each missing scope fails the same safe way: the sweep treats a failed query as
+# "unknown" and keeps the ref, rather than as "nothing is using it", which would
+# empty the namespace.
 permissions:
   contents: write
   pull-requests: read
+  actions: read
 
 concurrency:
   group: preflight-cleanup
@@ -64,15 +93,22 @@ jobs:
     name: Reclaim preflight refs
     runs-on: ubuntu-latest
     steps:
+      # NO `ref:`, DELIBERATELY. Under `pull_request_target` the default checkout
+      # is the BASE branch's commit, which is the whole point of the trigger: the
+      # sweep this job runs is the reviewed one on `main`, not whatever the PR's
+      # head has. Adding `ref: ${{ github.event.pull_request.head.sha }}` here
+      # would hand the head's code the write-scoped token again and undo it.
       - uses: actions/checkout@v4
 
       # Skipped for forks: the valve pushes preflight refs to this repo only, so
-      # a fork PR has none — and `pull_request` hands a fork a read-only token
-      # regardless of the `permissions` block above, so the attempt would fail
-      # rather than no-op.
+      # a fork PR has none — and under `pull_request_target` a fork's close event
+      # would otherwise reach this step with the full `permissions` scope above,
+      # not the read-only token `pull_request` hands a fork. So this gate carries
+      # more weight than it did, and it is what keeps the trigger change from
+      # widening anything.
       - name: Delete this PR's preflight ref
         if: >-
-          github.event_name == 'pull_request' &&
+          github.event_name == 'pull_request_target' &&
           github.event.pull_request.head.repo.full_name == github.repository
         env:
           # `gh pr list` decides what is still in use, so this leg needs a token
@@ -94,7 +130,7 @@ jobs:
           bash scripts/sweep-preflight-refs.sh --apply --branch "$HEAD_REF"
 
       - name: Sweep preflight refs with no open PR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         env:
           GH_TOKEN: ${{ github.token }}
           # A scheduled pass reclaims; a manual dispatch previews unless asked.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,30 @@ concurrency:
   group: test-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+# Every job below carries a job-level `timeout-minutes`. GitHub's default is 360
+# minutes, so an untimed job that wedges holds its runner for six hours. On the
+# two `macos-26` jobs that is expensive rather than merely untidy: GitHub allows
+# five concurrent macOS jobs account-wide, a normal run of this workflow spends
+# two of them, and the remote verification valve
+# (docs/specs/2026-08-16-remote-verification-valve-design.md) dispatches THIS
+# workflow so a lane that has queued too long for the machine-global build slot
+# can borrow one of those five. `remote_verify.py` bounds only the local dispatch
+# ticket (45 minutes) and cancels nothing, so releasing that ticket does not stop
+# the GitHub-side job — an abandoned run outlives the lane that asked for it.
+# Unbounded, it goes on consuming the scarce resource the valve exists to share:
+# the starvation the valve was built to fix, inflicted on every other lane.
+#
+# Each number below is sized to its own job and none of them is a performance
+# budget — a job that legitimately grows past its bound wants the bound raised,
+# not the work trimmed.
 jobs:
   lint:
     name: Lint
     runs-on: macos-26
+    # 20: brew, swiftlint, and harnesses that are pure Python/git/bash — no
+    # SwiftPM build at all. Recent runs sit at 0.6 min median, 0.9 min worst, so
+    # this is over an order of magnitude of headroom on a macOS slot.
+    timeout-minutes: 20
     steps:
       # `fetch-depth: 0` is load-bearing for the migration lint below: its
       # history-is-frozen check needs `git merge-base origin/main HEAD`, and
@@ -110,6 +130,11 @@ jobs:
   plans-guard:
     name: No committed implementation plans
     runs-on: ubuntu-latest
+    # 10: a shell guard plus harnesses that build fixture repos in temp dirs and
+    # touch no network — 0.2 min median, 0.6 min worst. Linux runners are not
+    # rationed against the macOS cap, but an unbounded wedge still occupies one
+    # for six hours and leaves this check unreported for the whole of it.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -138,6 +163,10 @@ jobs:
   review-scripts-tests:
     name: Review scripts tests
     runs-on: ubuntu-latest
+    # 10: a pip install and a pytest suite that finishes in seconds — 0.4 min
+    # median, 0.6 min worst. Nearly all of the bound is there to absorb a slow
+    # package index rather than the tests themselves.
+    timeout-minutes: 10
     # Unit tests for the claude-review-v2 bookend scripts (prepare.py /
     # validate.py / render_comment.py) plus the workflow's own post/enforce
     # shell, which a test extracts by step name and runs against a stub `gh`
@@ -163,6 +192,18 @@ jobs:
 
   test:
     runs-on: macos-26
+    # 90, deliberately NOT sized to this job's 15.3-minute observed worst case
+    # (10.7 median). The three test steps below carry `timeout-minutes` of 30, 30
+    # and 15 — a 75-minute step budget — and they exist so that a wedged suite
+    # dies on a step that names which pass hung, with the per-test limits given
+    # room to fire first and attribute the hang to a named test. A job bound at
+    # or below 75 would pre-empt all three and kill the run with the
+    # uninformative message those step bounds were written to avoid. 90 clears
+    # the step budget with room for checkout, `brew install tmux`, the cache
+    # restore and the final build — none of which is individually timed — while
+    # cutting worst-case occupancy of one of the five macOS slots from six hours
+    # to an hour and a half.
+    timeout-minutes: 90
     # All three test steps below append their `.flaky(issue:)` retry records
     # here (docs/specs/2026-07-24-test-hardening-design.md §7), so one run
     # produces one artifact covering both fast passes and the quiet pass

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,7 @@ jobs:
           python3 scripts/test-remote-verify.py
           bash scripts/remote-verify.test.sh
           bash scripts/sweep-preflight-refs.test.sh
+          bash scripts/nightly-flake-stress.test.sh
 
   review-scripts-tests:
     name: Review scripts tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,22 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # On-demand runs. The remote verification valve
+  # (docs/specs/2026-08-16-remote-verification-valve-design.md) asks for a run
+  # on a ref that fires nothing else, so a lane that has queued too long for
+  # the machine-global build slot can get its verdict from CI instead.
+  #
+  # `scope` has one option today and is kept anyway: it pins the input's name
+  # and type now, so adding a narrower scope later needs no change at the
+  # dispatch site.
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Which suites to run'
+        required: false
+        default: full
+        type: choice
+        options: [full]
 
 concurrency:
   group: test-${{ github.head_ref || github.ref_name }}
@@ -375,6 +391,23 @@ jobs:
       # A CI runner has no `~/tbd` to pollute, so the guard reads as a no-op
       # there. It is not: an empty `~/tbd` makes it MORE sensitive, because the
       # fingerprint goes from "absent" to a listing on the first stray write.
+      #
+      # ---------------------------------------------------------------------
+      # Why every pass also writes xUnit XML
+      #
+      # A remote run has to tell whoever asked for it WHAT failed, and the job
+      # log cannot carry that: a single failed run of this workflow produces
+      # 5.3 MB across 32,228 lines, in which every line is prefixed with
+      # job/step/timestamp and ANSI codes, several parallel passes interleave,
+      # and compiler diagnostics print source context that looks exactly like
+      # test output. Two extraction passes over a real failed log both produced
+      # wrong answers — one surfaced a deliberate known-issue self-test, the
+      # other matched 22 `#require is redundant` warnings displaying source
+      # context. An extractor that silently reports the wrong failure is worse
+      # than no extractor, so the structured file is the interface:
+      # `--xunit-output` writes it and `--experimental-xunit-message-failure`
+      # puts the failure messages inside it. `scripts/test.sh` forwards
+      # unrecognised arguments straight through to `swift test`.
       # ---------------------------------------------------------------------
       - name: Test (fast parallel pass 1/2 — TBDDaemonTests)
         # A tier-1 test can still hang indefinitely: an over-long TestClock
@@ -392,7 +425,9 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
-          scripts/test.sh --fingerprint --parallel --filter '^TBDDaemonTests\.' 2>&1 | tee /tmp/fast-pass-daemon.log
+          scripts/test.sh --fingerprint --parallel --filter '^TBDDaemonTests\.' \
+            --xunit-output /tmp/xunit-daemon.xml --experimental-xunit-message-failure \
+            2>&1 | tee /tmp/fast-pass-daemon.log
           # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
           # with no summary line makes the first `grep` exit 1 and a failing
           # command substitution in an assignment kills the shell — so the
@@ -426,7 +461,9 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
-          scripts/test.sh --fingerprint --parallel --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.' 2>&1 | tee /tmp/fast-pass-app.log
+          scripts/test.sh --fingerprint --parallel --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.' \
+            --xunit-output /tmp/xunit-app.xml --experimental-xunit-message-failure \
+            2>&1 | tee /tmp/fast-pass-app.log
           # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
           # with no summary line makes the first `grep` exit 1 and a failing
           # command substitution in an assignment kills the shell — so the
@@ -456,7 +493,9 @@ jobs:
         timeout-minutes: 15
         run: |
           set -o pipefail
-          scripts/test.sh --fingerprint --filter '^TBDDaemonLiveTests\.' --no-parallel 2>&1 | tee /tmp/quiet-pass.log
+          scripts/test.sh --fingerprint --filter '^TBDDaemonLiveTests\.' --no-parallel \
+            --xunit-output /tmp/xunit-quiet.xml --experimental-xunit-message-failure \
+            2>&1 | tee /tmp/quiet-pass.log
           # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
           # with no summary line makes the first `grep` exit 1 and a failing
           # command substitution in an assignment kills the shell — so the
@@ -478,6 +517,20 @@ jobs:
           name: retry-metrics
           path: /tmp/retry-metrics.jsonl
           if-no-files-found: warn
+
+      # `if: always()` is the whole point: a passing run's XML tells nobody
+      # anything, and a failing run's is the only machine-readable account of
+      # what failed. Without it the artifact would exist exactly when it is
+      # useless. `warn` on absence, matching the metrics upload above — a
+      # missing file means the wiring broke and that must be visible.
+      - name: Upload xUnit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xunit-results
+          path: /tmp/xunit-*.xml
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Build (verify TBDCLI and TBDDaemon executable targets compile)
         run: swift build -j "$TBD_SWIFT_JOBS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -531,11 +531,13 @@ jobs:
           path: /tmp/retry-metrics.jsonl
           if-no-files-found: warn
 
-      # `if: always()` is the whole point: a passing run's XML tells nobody
-      # anything, and a failing run's is the only machine-readable account of
-      # what failed. Without it the artifact would exist exactly when it is
-      # useless. `warn` on absence, matching the metrics upload above — a
-      # missing file means the wiring broke and that must be visible.
+      # `if: always()` is the whole point, and both outcomes need the XML. A
+      # failing run's is the only machine-readable account of what failed. A
+      # passing run's carries the test populations the valve sums to print
+      # `Test run with N tests`, which six floor checks require before they will
+      # believe a run happened at all — without it a green remote verdict reads
+      # as a truncated suite. `warn` on absence, matching the metrics upload
+      # above: a missing file means the wiring broke and that must be visible.
       - name: Upload xUnit results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,10 +116,23 @@ jobs:
       - name: Check for committed implementation plans
         run: scripts/check-no-committed-plans.sh
 
-      - name: Test agent guardrails and Swift admission wrapper
+      # Every script harness that needs nothing but bash, git and python lives
+      # here — a test file no workflow runs is worth nothing, and three of
+      # these shipped that way before this step collected them. They are on
+      # `ubuntu-latest` because none of them reads a BSD-only tool; the fence
+      # harness (`scripts/test.test.sh`) is the exception and stays in the
+      # macOS `lint` job because its guards read BSD `stat -f`.
+      #
+      # Nothing here touches the network, a real remote, `~/tbd`, or a real
+      # `gh`: each harness builds a fixture repo in a temp dir and puts a stub
+      # `gh` first on PATH.
+      - name: Test agent guardrails and the script harnesses
         run: |
           python3 .claude/hooks/guardrails/dispatch.py --self-test
           python3 scripts/test-swift-safe.py
+          python3 scripts/test-remote-verify.py
+          bash scripts/remote-verify.test.sh
+          bash scripts/sweep-preflight-refs.test.sh
 
   review-scripts-tests:
     name: Review scripts tests

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -284,13 +284,28 @@ forwarded. It acts without a user gesture and force-pushes refs, which is what
 the default-off rule exists for.
 
 **Enabling it for the soak** is `export TBD_REMOTE_VERIFY=1` in the shell whose
-`scripts/test.sh` runs should be eligible. Four knobs tune it, each with the
-shipped default: `TBD_REMOTE_VERIFY_YIELD_SECONDS` (300) is T;
-`TBD_REMOTE_VERIFY_SLOTS` (2) is the dispatch ticket count, sized to the macOS
-job cap; `TBD_REMOTE_VERIFY_COMMAND_SECONDS` (300) bounds each `git` or `gh`
-call; and `TBD_REMOTE_VERIFY_ALLOW_ORPHAN=1` disables the requester-liveness
-check for a run deliberately detached. A run may take at most 45 minutes end to
-end, and at most 50 failures are rendered.
+`scripts/test.sh` runs should be eligible. Seven knobs tune it, each with its
+shipped default:
+
+- `TBD_REMOTE_VERIFY_YIELD_SECONDS` (300) — T, the queue time after which a lane
+  stops waiting.
+- `TBD_REMOTE_VERIFY_SLOTS` (2) — the dispatch ticket count, sized to the macOS
+  job cap. Values above 5 are refused by name rather than clamped, because
+  silently sizing the pool differently from what an operator asked for is the
+  failure this bound exists to make visible.
+- `TBD_REMOTE_VERIFY_CORRELATE_SECONDS` (180) — how long to wait for a dispatched
+  run to become visible.
+- `TBD_REMOTE_VERIFY_RUN_SECONDS` (2700) — the ceiling on the run itself.
+- `TBD_REMOTE_VERIFY_POLL_SECONDS` (10) — the gap between polls.
+- `TBD_REMOTE_VERIFY_COMMAND_SECONDS` (300) — the bound on any single `git` or
+  `gh` call.
+- `TBD_REMOTE_VERIFY_ALLOW_ORPHAN=1` — disables the requester-liveness check, for
+  a run deliberately detached.
+
+Those bounds compose rather than cap each other, so the ticket-hold ceiling is
+the run ceiling plus correlation plus whatever a final bounded call spends —
+roughly 48 minutes at the shipped defaults, not 45. At most 50 failures are
+rendered.
 
 **Graduation** flips that default only once a soak shows three things, because
 each is a way the valve can be quietly worse than waiting: that a green remote
@@ -329,19 +344,34 @@ produce artifacts someone is waiting for, and their callers do not understand 76
   sweep required and no marker to leak. A hand-rolled occupancy file would
   reintroduce the stale-marker problem this repo has already paid for.
 - **Inert refs** — a genuine new durable resource, and the one thing here that
-  needs a named sweep. They are deleted when the PR closes, with a periodic pass
-  reclaiming any the close path missed. Because a ref now exists whether or not a
-  PR does, that pass spares anything under an hour old rather than reclaiming on
-  PR state alone, so a sweep cannot delete a ref a live run is about to check out.
-  The age it can observe is the commit's date, which bounds the ref's age from
-  below — a young commit implies a young ref, though an old commit re-pushed today
-  is not spared. The sweep reads the namespace into `FETCH_HEAD`, creating no
-  local ref of its own to reclaim, and keeps any ref it cannot date.
+  needs a named sweep. A ref is reclaimed when its PR closes and by a periodic
+  pass, and because a ref now exists whether or not a PR does, neither may decide
+  on PR state alone.
+
+  What protects a ref a run is still using is the run itself: a ref with a queued
+  or in-progress run against it is kept regardless of anything else. An age guard
+  keeps anything under an hour as a cheap second line, but it is a weak one and
+  should not be mistaken for the guarantee — the only age observable on a remote
+  ref is its commit's date, which bounds the ref's age from below rather than
+  above. A commit authored yesterday and pushed to a preflight ref a second ago
+  reads as a day old, and that is the ordinary case rather than an exotic one,
+  because a lane commits and then verifies some minutes or hours later.
+
+  The sweep reads the namespace into `FETCH_HEAD`, creating no local ref of its
+  own to reclaim, and keeps any ref whose PR state or age it cannot determine.
+
+  Losing this race costs a wasted macOS slot and one local fallback, not a wrong
+  answer: a run whose checkout fails produces no results, and a run with no
+  results is no verdict.
 - **A dispatched run whose requester dies** — deliberately not reclaimed. It is
-  free, self-terminating, and bounded at the observed 32-minute worst case, which
-  makes it categorically different from a lock holder that blocks others without
-  limit. Cancelling on abandonment is best-effort at exactly the moment the
-  requester is gone, and it buys back a slot that would have freed itself.
+  free and self-terminating: GitHub ends it at its own timeout, and the observed
+  worst case is 32 minutes, which makes it categorically different from a lock
+  holder that blocks others without limit. Cancelling on abandonment is
+  best-effort at exactly the moment the requester is gone, and it buys back a slot
+  that would have freed itself. The ticket the abandoned lane was holding is
+  reclaimed rather than waiting on the run: the driver notices its requester is
+  gone and exits, releasing the flock, so the pool recovers even while the run it
+  started plays out.
 
 ## What this does not do
 

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -142,6 +142,19 @@ Swift Testing writers, so the reader globs and merges whatever arrived. Fewer
 files than passes is normal rather than an error: a run that died early produces
 only what it reached.
 
+**A passing remote run must also state how many tests ran.** Six places decide
+whether a run is trustworthy by grepping its output for `Test run with N tests` —
+the pre-push hook, the nightly stress judge, and three floors in `test.yml` —
+because a suite that compiles and runs nothing otherwise reports success. A
+remote verdict that omits the line is read as a truncated run and rejected, so
+the driver sums the `tests=` populations across the merged results and prints it
+in that exact wording.
+
+The count is never invented. A pass whose results are missing, unreadable, or
+silent about their population refuses rather than emitting a number, because six
+floor checks would take that number as evidence. The cost of refusing is one
+local re-run.
+
 **Scraping the job log is rejected, on evidence.** A single failed `test.yml` run
 produces **5.3 MB across 32,228 lines** — far past what any agent can read — in
 which each line carries a job/step/timestamp prefix and ANSI codes, several
@@ -172,18 +185,36 @@ committing more often, so the constraint is cheap here.
 
 ## Which ref gets pushed
 
-`test.yml` triggers on `pull_request`, and on `push` only to `main`. Two cases
-follow:
+The valve pushes the commit to `preflight/<branch>` and never to the branch
+itself. That rule is unconditional, and the namespace is enforced at the one
+function that moves a ref, so no upstream choice can publish a branch.
 
-- **No PR open** — push the branch. Nothing fires, so the ref is inert already and
-  the dispatch is the only run.
-- **PR open** — push a separate inert ref instead. A push to the PR branch fires
-  `pull_request_target: synchronize`, which runs the claude-review fan-out on
-  every iteration. GitHub minutes are free; Claude quota is not, and it is the
-  only metered resource left in this loop.
+Three separate hazards make the branch unpushable, and the first two are why the
+rule takes no exceptions:
 
-`test.yml` gains a `workflow_dispatch` trigger. It has none today, so nothing can
-currently ask for a run on demand.
+- **A push to `main` is admitted.** `main` never has an open PR, so any rule of
+  the form "push the branch when no PR exists" resolves to `main` on `main` and
+  fast-forwards it. Branch protection does not stop this: `enforce_admins` is
+  false and there are no push restrictions, so the owner's push lands, firing the
+  `push: branches:[main]` CI and the Pages deploy with commits nobody reviewed.
+- **It bypasses the gate that called it.** `scripts/git-hooks/pre-push` runs the
+  suite to decide whether a push may proceed. A valve that publishes the branch
+  during that run has already shipped the commits, whatever verdict follows.
+- **A bare branch has no reconciler.** Refs under `preflight/` are swept; a
+  branch pushed to `origin` without a user gesture is not, which is the shape
+  behind this repo's largest measured leak.
+
+Pushing an inert ref also keeps the review gate quiet. A push to a branch with an
+open PR fires `pull_request_target: synchronize` and runs the claude-review
+fan-out on every iteration; GitHub minutes are free, but Claude quota is not, and
+it is the only metered resource in this loop.
+
+Because every pushable ref is a throwaway in a swept namespace, the push is
+always a force-push, and the driver additionally refuses outright when the
+current branch is the repository's default.
+
+`test.yml` gains a `workflow_dispatch` trigger. It has none otherwise, so nothing
+can ask for a run on demand.
 
 ## Placement and flag
 

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -228,8 +228,20 @@ when a compiler changes how it renders a warning.
 ## Preconditions, and no silent fallback
 
 The valve refuses and stays local, naming the condition, when the tree is dirty,
-`gh` is unauthenticated, or no ref can be pushed. It never falls back silently: a
-quiet fallback reintroduces the long stall at the moment it is least visible.
+`gh` is missing or unauthenticated, the current branch is the repository's
+default, or the preflight ref it would push belongs to somebody. It never falls
+back silently: a quiet fallback reintroduces the long stall at the moment it is
+least visible. The local checks run before any of the GitHub ones, so the most
+common refusal costs no network round trip.
+
+**A ref belongs to somebody if a pull request is open against it.** Nothing stops
+a person from working on a branch genuinely named `preflight/<something>`, and the
+valve force-pushes, so it asks before it writes and refuses when the answer is
+yes, or when the question cannot be answered. That signal is narrower than the
+hazard: a preflight ref merely existing proves nothing, because every previous
+valve run leaves one behind, so a human branch in that namespace with no pull
+request is not distinguishable from a throwaway and is still overwritten. The
+sweep makes the same judgment on the delete side, for the same reason.
 
 The dirty-tree stop is a semantic requirement, not a convenience.
 `scripts/test.sh` runs against the working tree, uncommitted edits included;
@@ -264,8 +276,9 @@ fan-out on every iteration; GitHub minutes are free, but Claude quota is not, an
 it is the only metered resource in this loop.
 
 Because every pushable ref is a throwaway in a swept namespace, the push is
-always a force-push. The default-branch refusal sits further out still, in the
-front-end that checks preconditions, so it answers before anything contacts
+always a force-push — which is why the ref is checked for an owner first, as the
+preconditions describe. The default-branch refusal sits further out still, in the
+front-end, and the local half of that front-end answers before anything contacts
 GitHub at all.
 
 `test.yml` gains a `workflow_dispatch` trigger. It has none otherwise, so nothing

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -184,14 +184,21 @@ is spent and then the local run happens anyway. On a tree whose whole suite is
 reliably green this is rare; on a tree where it is not, a narrowed lane degrades
 toward always running locally, which is where it started.
 
-**One existing guard is weakened, and it is the reason the follow-up matters.**
-A floor serves two purposes: catching a truncated run, and catching a filter that
-matched nothing — the failure where `--filter` names a renamed type, selects zero
-tests, and exits green. A whole-suite count satisfies a narrow pass's floor
-trivially, so it still proves a run happened but no longer proves the caller's
-filter selected anything. The pre-push hook's tier-3 pass, whose floor of 35
-exists precisely to catch a vacuous filter, therefore stops catching one whenever
-its verdict came from a remote run.
+**One existing guard is weakened on the green path, and it is the reason the
+follow-up matters.** A floor serves two purposes: catching a truncated run, and
+catching a filter that matched nothing — the failure where `--filter` names a
+renamed type, selects zero tests, and exits green. A whole-suite count satisfies a
+narrow pass's floor trivially, so it still proves a run happened but no longer
+proves the caller's filter selected anything. The pre-push hook's tier-3 pass,
+whose floor of 35 exists precisely to catch a vacuous filter, therefore stops
+catching one when it adopts a **green** remote verdict.
+
+A red one is different, because a floor consumer reads the *first* count in a
+log and the remote report is printed before the local re-run's. A narrowed caller
+therefore tells the driver so, and a failing report omits its count entirely: the
+only population in the log is the one the re-run actually selected, so the floor
+judges the run whose verdict is being reported. Without that, a vacuous filter
+would clear a floor of 35 with several thousand tests it never selected.
 
 The backstop is that CI never enables the valve, so its filtered passes run
 directly with their floors intact and a rename is still caught before a merge.

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -182,6 +182,19 @@ is spent and then the local run happens anyway. On a tree whose whole suite is
 reliably green this is rare; on a tree where it is not, a narrowed lane degrades
 toward always running locally, which is where it started.
 
+**One existing guard is weakened, and it is the reason the follow-up matters.**
+A floor serves two purposes: catching a truncated run, and catching a filter that
+matched nothing — the failure where `--filter` names a renamed type, selects zero
+tests, and exits green. A whole-suite count satisfies a narrow pass's floor
+trivially, so it still proves a run happened but no longer proves the caller's
+filter selected anything. The pre-push hook's tier-3 pass, whose floor of 35
+exists precisely to catch a vacuous filter, therefore stops catching one whenever
+its verdict came from a remote run.
+
+The backstop is that CI never enables the valve, so its filtered passes run
+directly with their floors intact and a rename is still caught before a merge.
+What is lost is the local, pre-push instance of that check.
+
 Passing the caller's narrowing arguments through to the dispatch would remove the
 mismatch and make a red verdict directly usable. That input must be allowlisted
 and delivered through the environment rather than interpolated into a workflow's

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -166,12 +166,18 @@ local re-run.
 ## A narrowed caller reads the verdict differently
 
 The remote run is always the whole suite, so a caller that narrowed its own run
-with `--filter` or `--skip` did not ask the question the remote answered. One
+with any of the arguments that select a subset did not ask the question the
+remote answered. One
 half of that mismatch is free and the other is not, and the asymmetry is what
 lets narrowed runs use the valve at all:
 
 - **A green whole-suite verdict is sound for a narrowed caller.** If every test
-  passes, every subset of them passes. The count reported is the whole suite's,
+  passes, every subset of them passes. A green conclusion is taken at its word
+  here rather than re-derived from the result files: every test step exited zero,
+  so a recorded failure in the artifact is a known-issue record rather than a real
+  one, and this repo records those routinely. That premise is asserted rather than
+  enforced — nothing reads a known-issue marker — so a toolchain that ever exited
+  zero while recording a genuine failure would be believed. The count reported is the whole suite's,
   which clears a narrowed caller's floor because that floor is a minimum and the
   whole suite is a superset of what the caller asked for.
 - **A red whole-suite verdict says nothing about the caller's subset.** The
@@ -203,6 +209,17 @@ would clear a floor of 35 with several thousand tests it never selected.
 The backstop is that CI never enables the valve, so its filtered passes run
 directly with their floors intact and a rename is still caught before a merge.
 What is lost is the local, pre-push instance of that check.
+
+**What counts as narrowing is deliberately over-broad**, because the two
+directions cost differently. A false positive costs one lane an optimisation. A
+false negative adopts a whole-suite failure as a narrowed run's result, naming
+tests the caller excluded — so anything that might select a subset is treated as
+if it does: `--filter` and `--skip`, the deprecated `--specifier` and its `-s`
+spelling, `--disable-xctest` and `--disable-swift-testing`, `--test-product`, and
+`--list-tests` and the bare `list` subcommand, which run no tests at all. Both the
+`--flag value` and `--flag=value` spellings are recognised. Options that widen or
+merely configure a run — `--enable-xctest`, `--num-workers`, `--xunit-output` —
+are deliberately absent.
 
 Passing the caller's narrowing arguments through to the dispatch would remove the
 mismatch and make a red verdict directly usable. That input must be allowlisted
@@ -315,10 +332,12 @@ shipped default:
 - `TBD_REMOTE_VERIFY_ALLOW_ORPHAN=1` — disables the requester-liveness check, for
   a run deliberately detached.
 
-Those bounds compose rather than cap each other, so the ticket-hold ceiling is
-the run ceiling plus correlation plus whatever a final bounded call spends —
-roughly 48 minutes at the shipped defaults, not 45. At most 50 failures are
-rendered.
+Those bounds compose rather than cap each other, and the ticket is held across
+all of them: a baseline query, a push, a dispatch, correlation, the run itself,
+and the download. At the shipped defaults that is a worst case near 78 minutes,
+not the run ceiling alone. The number matters because hold time against a
+two-ticket pool is the capacity model — understating it would size the pool
+against a wait that cannot happen. At most 50 failures are rendered.
 
 **Graduation** flips that default only once a soak shows three things, because
 each is a way the valve can be quietly worse than waiting: that a green remote

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -395,13 +395,17 @@ produce artifacts someone is waiting for, and their callers do not understand 76
   Losing this race costs a wasted macOS slot and one local fallback, not a wrong
   answer: a run whose checkout fails produces no results, and a run with no
   results is no verdict.
-- **A dispatched run whose requester dies** — deliberately not reclaimed. It is
-  free and self-terminating: GitHub ends it at its own timeout, and the observed
-  worst case is 32 minutes, which makes it categorically different from a lock
-  holder that blocks others without limit. Cancelling on abandonment is
+- **A dispatched run whose requester dies** — deliberately not reclaimed, because
+  it is self-terminating. Every job in `test.yml` carries a job-level
+  `timeout-minutes`, so the run ends on the workflow's own bound rather than
+  GitHub's six-hour default: the `test` job stops at 90 minutes at the latest,
+  against an observed worst case of 32. That bound is what makes an abandoned run
+  categorically different from a lock holder that blocks others without limit,
+  and it is load-bearing here rather than incidental — the slot it occupies is
+  one of the five this design is rationing. Cancelling on abandonment is
   best-effort at exactly the moment the requester is gone, and it buys back a slot
-  that would have freed itself. The ticket the abandoned lane was holding is
-  reclaimed rather than waiting on the run: the driver notices its requester is
+  that frees itself. The ticket the abandoned lane was holding is reclaimed
+  rather than waiting on the run: the driver notices its requester is
   gone and exits, releasing the flock, so the pool recovers even while the run it
   started plays out.
 

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -36,6 +36,12 @@ snapshot were `--filter`ed runs, which is the worst case for staying local:
 `--filter` selects which tests execute *after* the whole package compiles, so
 each was paying a full package build to run a handful of tests.
 
+Narrowed runs are the common case rather than an edge one, and the valve has to
+serve them. Four of the five queued test lanes across both snapshots narrowed the
+suite, `scripts/git-hooks/pre-push` runs with `--skip`, and the nightly stress
+harness passes a filter — a valve that declined a narrowed run would decline
+almost every real caller.
+
 ## Why fairness alone does not fix this
 
 Ordering the queue is worth doing and is not designed here. It does not
@@ -155,6 +161,32 @@ silent about their population refuses rather than emitting a number, because six
 floor checks would take that number as evidence. The cost of refusing is one
 local re-run.
 
+## A narrowed caller reads the verdict differently
+
+The remote run is always the whole suite, so a caller that narrowed its own run
+with `--filter` or `--skip` did not ask the question the remote answered. One
+half of that mismatch is free and the other is not, and the asymmetry is what
+lets narrowed runs use the valve at all:
+
+- **A green whole-suite verdict is sound for a narrowed caller.** If every test
+  passes, every subset of them passes. The count reported is the whole suite's,
+  which clears a narrowed caller's floor because that floor is a minimum and the
+  whole suite is a superset of what the caller asked for.
+- **A red whole-suite verdict says nothing about the caller's subset.** The
+  failures may lie entirely outside it. Adopting that verdict would report
+  failures the caller deliberately excluded as its own result, so a narrowed run
+  that comes back red is re-run locally to get its true answer.
+
+The cost lands only on red, and only for narrowed callers: the remote round trip
+is spent and then the local run happens anyway. On a tree whose whole suite is
+reliably green this is rare; on a tree where it is not, a narrowed lane degrades
+toward always running locally, which is where it started.
+
+Passing the caller's narrowing arguments through to the dispatch would remove the
+mismatch and make a red verdict directly usable. That input must be allowlisted
+and delivered through the environment rather than interpolated into a workflow's
+`run:` block, since a dispatch input is attacker-influenced text.
+
 **Scraping the job log is rejected, on evidence.** A single failed `test.yml` run
 produces **5.3 MB across 32,228 lines** — far past what any agent can read — in
 which each line carries a job/step/timestamp prefix and ANSI codes, several
@@ -236,7 +268,13 @@ the default once the soak shows the routing behaves.
   reintroduce the stale-marker problem this repo has already paid for.
 - **Inert refs** — a genuine new durable resource, and the one thing here that
   needs a named sweep. They are deleted when the PR closes, with a periodic pass
-  reclaiming any the close path missed.
+  reclaiming any the close path missed. Because a ref now exists whether or not a
+  PR does, that pass spares anything under an hour old rather than reclaiming on
+  PR state alone, so a sweep cannot delete a ref a live run is about to check out.
+  The age it can observe is the commit's date, which bounds the ref's age from
+  below — a young commit implies a young ref, though an old commit re-pushed today
+  is not spared. The sweep reads the namespace into `FETCH_HEAD`, creating no
+  local ref of its own to reclaim, and keeps any ref it cannot date.
 - **A dispatched run whose requester dies** — deliberately not reclaimed. It is
   free, self-terminating, and bounded at the observed 32-minute worst case, which
   makes it categorically different from a lock holder that blocks others without

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -1,0 +1,239 @@
+# Remote verification valve: sending queued test runs to CI instead of waiting
+
+Every build and test run on this machine passes through `scripts/swift-safe`, a
+machine-global admission lock that admits one run at a time so forty agent
+worktrees cannot start forty compiler swarms at once. The lock does its job. The
+cost is that everyone else waits, and on a busy machine the wait has no ceiling.
+
+This design adds an overflow path. A lane that has queued for the local slot
+longer than a threshold, and whose tree is clean, verifies its commit on GitHub
+instead — and leaves the local queue. The local slot is unchanged; nothing is
+killed; a lane that cannot go remote waits exactly as it does today.
+
+## What the queue actually holds
+
+Two snapshots of live contention, taken minutes apart on a working afternoon:
+
+- Holder running `swift test`, with three lanes queued behind it — one
+  `swift-safe build` and two `swift test --filter …` runs.
+- Holder running `swift test`, with two `swift test --filter …` lanes queued.
+
+Of the seven lanes across both snapshots, six were **verification**: their entire
+output is a pass/fail verdict, and nothing they produce needs to exist on this
+disk. The seventh was a build whose artifact someone would run.
+
+That distinction is the whole design. A build has two possible purposes, and only
+one of them is tied to this machine:
+
+- **An artifact you are going to run** — `scripts/restart.sh` builds `TBDApp` and
+  `TBDDaemon` and launches them. The binary is the point, it must land on this
+  disk, and it can never move.
+- **A verdict** — "do the tests pass?" The compile is a means. The only thing
+  that comes back is one bit, and it can be computed anywhere.
+
+The queue is dominated by the second kind. Both queued lanes in the second
+snapshot were `--filter`ed runs, which is the worst case for staying local:
+`--filter` selects which tests execute *after* the whole package compiles, so
+each was paying a full package build to run a handful of tests.
+
+## Why fairness alone does not fix this
+
+Ordering the queue is worth doing and is not designed here. It does not
+shorten the queue either. Four lanes needing five minutes each leave the fourth waiting
+fifteen minutes however scrupulously they are ordered.
+
+The valve removes lanes instead. In the first snapshot, three of the four would
+have left and the one real build would have started immediately.
+
+## Capacity, and why the valve is deliberately narrow
+
+GitHub bills nothing for standard runners on a public repository. A recent
+`test.yml` run reports `MACOS: total_ms: 0` across both of its macOS jobs, so
+minutes are not the constraint.
+
+Concurrency is. GitHub caps **five concurrent macOS jobs** per account on the
+Free, Pro and Team plans — only Enterprise raises it, and the cap is shared
+across every repository the account owns. `test.yml` spends two macOS jobs per
+run, so the account sustains roughly **two concurrent runs** before everything
+else queues on GitHub's side.
+
+That ceiling decides the shape of this design. The valve is a pressure release
+sized at about two lanes, not a new home for the fleet. Most verification stays
+local, and the local queue keeps mattering.
+
+Observed round-trip, measured across `test.yml` runs and their macOS jobs:
+
+| | p50 | p90 | max |
+|---|---|---|---|
+| Remote run, end to end (n=14) | 591s | 853s | 1910s |
+| Runner pickup delay (n=16 jobs) | 2s | 3s | 3s |
+
+Remote is slow in absolute terms — roughly ten minutes — and a warm incremental
+local run beats it easily. The trade is not speed but a ceiling: local is fast
+when uncontended and unbounded when it is not, with 30-minute lock timeouts and,
+in one measured session, a lane that waited over two hours across five attempts.
+Remote's worst observed run is 32 minutes.
+
+If the two macOS jobs per run are ever consolidated into one, the same account
+allowance sustains five concurrent runs instead of two. That is the cheapest
+capacity available and it is independent of everything else here.
+
+## The mechanism
+
+Two admission pools, both local, both `flock`-based. Every contender runs on the
+same laptop, so a local file arbitrates remote capacity authoritatively — this is
+not a distributed consensus problem.
+
+- **The local build slot** — one ticket, `~/tbd/runtime/swift-build.lock`,
+  unchanged from today.
+- **Remote dispatch slots** — N tickets (N=2), each held for the lifetime of the
+  remote run it authorizes.
+
+A lane queues for the local slot as it does now. Once it has waited **T seconds
+(T=60) without ever acquiring**, it attempts a remote ticket:
+
+- **Ticket acquired and preconditions met** — it stops waiting locally, pushes,
+  dispatches, waits for the verdict, and reports.
+- **Otherwise** — it keeps waiting locally, exactly as today.
+
+The threshold measures queue time, never run time. That choice matters more than
+its value:
+
+- **Nothing is wasted.** A lane that has never acquired the slot has compiled
+  nothing, so there is no build to kill and no work to discard.
+- **The threshold is meaningful.** Run time conflates waiting with compiling, and
+  a solo compile ranges from seconds when warm to many minutes when cold — there
+  is no defensible number. Queue time has no legitimate variance: every second
+  spent queued is a second of nothing.
+- **The exit path already exists.** `_acquire` abandons a wait and returns
+  without starting a build when its requester dies. Crossing T is a second reason
+  to take that same path.
+
+Because forty lanes run one uniform rule, the second pool is what prevents a
+stampede. Without it, every queued lane would dispatch at once into a queue two
+runs wide that TBD cannot observe, prioritize, or abandon.
+
+## Returning the verdict
+
+A red run must tell the lane what failed, or the valve makes agents worse at
+their job rather than faster.
+
+The remote job writes machine-readable results and uploads them as an artifact.
+`swift-test` supports `--xunit-output <path>`, which emits xUnit XML, and
+`--experimental-xunit-message-failure`, which puts failure messages in it. On a
+failure the local side downloads that artifact and renders it in the shape a
+local run would have printed.
+
+**Scraping the job log is rejected, on evidence.** A single failed `test.yml` run
+produces **5.3 MB across 32,228 lines** — far past what any agent can read — in
+which each line carries a job/step/timestamp prefix and ANSI codes, several
+parallel test passes interleave, and compiler diagnostics print source context
+that looks exactly like test output. Two extraction passes over a real failed log
+both produced wrong answers: one surfaced a deliberate known-issue self-test
+rather than the failure, and one matched 22 lines that were `#require is
+redundant` compiler warnings displaying source context, not failures at all. The
+repo's existing extractor, `failing_tests_from` in
+`scripts/nightly-flake-stress.sh`, greps for the same markers; it is correct
+against clean local `swift test` output and does not survive a CI log.
+
+An extractor that silently reports the wrong failure is worse than no extractor.
+Structured output costs kilobytes, needs no regex archaeology, and does not break
+when a compiler changes how it renders a warning.
+
+## Preconditions, and no silent fallback
+
+The valve refuses and stays local, naming the condition, when the tree is dirty,
+`gh` is unauthenticated, or no ref can be pushed. It never falls back silently: a
+quiet fallback reintroduces the long stall at the moment it is least visible.
+
+The dirty-tree stop is a semantic requirement, not a convenience.
+`scripts/test.sh` runs against the working tree, uncommitted edits included;
+GitHub can only test what was pushed. A green remote result on a dirty tree is a
+false statement about the code in hand. Squash merge absorbs the cost of
+committing more often, so the constraint is cheap here.
+
+## Which ref gets pushed
+
+`test.yml` triggers on `pull_request`, and on `push` only to `main`. Two cases
+follow:
+
+- **No PR open** — push the branch. Nothing fires, so the ref is inert already and
+  the dispatch is the only run.
+- **PR open** — push a separate inert ref instead. A push to the PR branch fires
+  `pull_request_target: synchronize`, which runs the claude-review fan-out on
+  every iteration. GitHub minutes are free; Claude quota is not, and it is the
+  only metered resource left in this loop.
+
+`test.yml` gains a `workflow_dispatch` trigger. It has none today, so nothing can
+currently ask for a run on demand.
+
+## Placement and flag
+
+Everything here lives in user-land — `scripts/`, plus the workflow file. No
+daemon change, no `config` column. Per the placement rule in `CLAUDE.md`, the
+daemon compiles only what user-land cannot do well, and a wrapper script deciding
+where to run a build is squarely user-land.
+
+The valve ships behind an environment flag that defaults to off, so an unset
+environment behaves exactly as today. It acts without a user gesture and pushes
+refs, which is what the default-off rule exists for. Graduation is a change to
+the default once the soak shows the routing behaves.
+
+## Who reclaims the orphans
+
+- **Remote dispatch tickets** — `flock`, released by the kernel when the process
+  exits by any means. Self-reclaiming, on the same footing as the build slot; no
+  sweep required and no marker to leak. A hand-rolled occupancy file would
+  reintroduce the stale-marker problem this repo has already paid for.
+- **Inert refs** — a genuine new durable resource, and the one thing here that
+  needs a named sweep. They are deleted when the PR closes, with a periodic pass
+  reclaiming any the close path missed.
+- **A dispatched run whose requester dies** — deliberately not reclaimed. It is
+  free, self-terminating, and bounded at the observed 32-minute worst case, which
+  makes it categorically different from a lock holder that blocks others without
+  limit. Cancelling on abandonment is best-effort at exactly the moment the
+  requester is gone, and it buys back a slot that would have freed itself.
+
+## What this does not do
+
+- **It does not order the local queue.** A lane that has waited longer still gets
+  no priority, so a lane can still be passed over repeatedly. Fairness needs its
+  own design, and the valve may lower the pressure enough to change what that
+  design should be — re-measure before building it.
+- **It does not move artifact builds.** `restart.sh` and anything else whose
+  output is a binary someone runs stays local permanently.
+- **It does not help a dirty tree**, which is a common state for the lane most
+  likely to be starving.
+
+## Testing
+
+`scripts/swift-safe` and `scripts/test.sh` carry mutation-checked harnesses that
+drive the real scripts against synthetic homes with a stub compiler, run in
+seconds, and touch no real store. New behavior joins them on the same terms:
+every guard gets a case, and every case is mutation-checked by weakening the
+guard and confirming the verdict flips.
+
+The routing decision is exercised without the network. Both admission pools are
+ordinary lock files, so a test takes the tickets itself and asserts what the lane
+does. Cases to cover: a lane that acquires locally before T never consults the
+valve; a lane past T with a free ticket routes remote; a lane past T with the
+tickets held keeps waiting; each precondition refuses and stays local, naming
+itself; and the flag off leaves every path identical to today.
+
+## Rejected alternatives
+
+- **Kill the local run past a threshold, then dispatch.** Pays both costs
+  serially — the threshold elapses, then the remote round-trip — and discards
+  real compile work. Thresholding queue time instead achieves the intent with
+  neither cost.
+- **Route on local occupancy alone.** "The slot is busy, so go remote" ignores
+  the two-run ceiling and stampedes. Remote congestion is real and independent:
+  at one measured moment the local queue held one waiter while GitHub held three
+  queued runs and one running.
+- **Priority classes for interactive work.** Which worktree is interactive
+  changes with whoever is looking at it. A uniform rule is both simpler and what
+  `CLAUDE.md` requires — features and defaults must generalize rather than encode
+  one workflow.
+- **A daemon-mediated queue.** The daemon is built by this very wrapper, so a
+  build path that depends on it cannot bootstrap, and builds must keep working
+  while it is down.

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -90,7 +90,7 @@ not a distributed consensus problem.
   remote run it authorizes.
 
 A lane queues for the local slot as it does now. Once it has waited **T seconds
-(T=60) without ever acquiring**, it attempts a remote ticket:
+(T=300) without ever acquiring**, it attempts a remote ticket:
 
 - **Ticket acquired and preconditions met** — it stops waiting locally, pushes,
   dispatches, waits for the verdict, and reports.
@@ -113,6 +113,18 @@ Because forty lanes run one uniform rule, the second pool is what prevents a
 stampede. Without it, every queued lane would dispatch at once into a queue two
 runs wide that TBD cannot observe, prioritize, or abandon.
 
+**T is sized against remote capacity, not against impatience.** Sampling the
+lock every two seconds for two hours of ordinary fleet activity recorded 110
+queueing episodes with a peak wait of 84s at the median, 268s at p90, and 1790s
+at the maximum — a lane riding the lock's own timeout out. Remote sustains
+roughly two concurrent runs of about ten minutes, so about twelve runs an hour.
+Trip rates follow from the episode distribution: T=60 trips 28 times an hour and
+oversubscribes the valve more than twofold, T=180 trips 14, and T=300 trips
+between four and five. A lane that trips, finds no ticket, and returns to the
+local queue has spent its trip for nothing, so a threshold below capacity buys
+churn rather than relief. T=300 also selects the right episodes: it ignores the
+median wait entirely and fires on the tail this valve exists for.
+
 ## Returning the verdict
 
 A red run must tell the lane what failed, or the valve makes agents worse at
@@ -123,6 +135,12 @@ The remote job writes machine-readable results and uploads them as an artifact.
 `--experimental-xunit-message-failure`, which puts failure messages in it. On a
 failure the local side downloads that artifact and renders it in the shape a
 local run would have printed.
+
+**The artifact holds several files, not one.** Each of the run's test passes
+writes its own, and SwiftPM may split a single pass again between its XCTest and
+Swift Testing writers, so the reader globs and merges whatever arrived. Fewer
+files than passes is normal rather than an error: a run that died early produces
+only what it reached.
 
 **Scraping the job log is rejected, on evidence.** A single failed `test.yml` run
 produces **5.3 MB across 32,228 lines** — far past what any agent can read — in
@@ -196,10 +214,15 @@ the default once the soak shows the routing behaves.
 
 ## What this does not do
 
-- **It does not order the local queue.** A lane that has waited longer still gets
-  no priority, so a lane can still be passed over repeatedly. Fairness needs its
-  own design, and the valve may lower the pressure enough to change what that
-  design should be — re-measure before building it.
+- **It does not order the local queue**, and that queue is measurably unfair.
+  Across two hours, 52 of 99 handoffs went to a lane while another that had
+  already waited at least 30 seconds was still queued; the worst passed over a
+  lane 24 minutes into its wait, and one worktree was jumped at 21, 22 and 24
+  minutes in the same stretch. The lock is memoryless, so seniority buys
+  nothing. Fairness needs its own design. This valve relieves only the tail it
+  fires on — at T=300, four or five episodes an hour out of roughly fifty-five —
+  so most of that unfairness survives it, and the two changes are complementary
+  rather than alternatives.
 - **It does not move artifact builds.** `restart.sh` and anything else whose
   output is a binary someone runs stays local permanently.
 - **It does not help a dirty tree**, which is a common state for the lane most

--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -111,9 +111,11 @@ its value:
   a solo compile ranges from seconds when warm to many minutes when cold — there
   is no defensible number. Queue time has no legitimate variance: every second
   spent queued is a second of nothing.
-- **The exit path already exists.** `_acquire` abandons a wait and returns
-  without starting a build when its requester dies. Crossing T is a second reason
-  to take that same path.
+- **The machinery already exists.** `_acquire` can already leave a wait without
+  starting a build, which is how it handles a requester that died. Crossing T
+  reuses that shape but reports it as its own status: an abandoned wait wants
+  nothing, while a yielded one wants a verdict from somewhere else, and a caller
+  that could not tell them apart would dispatch for a lane that has gone away.
 
 Because forty lanes run one uniform rule, the second pool is what prevents a
 stampede. Without it, every queued lane would dispatch at once into a queue two
@@ -255,8 +257,9 @@ fan-out on every iteration; GitHub minutes are free, but Claude quota is not, an
 it is the only metered resource in this loop.
 
 Because every pushable ref is a throwaway in a swept namespace, the push is
-always a force-push, and the driver additionally refuses outright when the
-current branch is the repository's default.
+always a force-push. The default-branch refusal sits further out still, in the
+front-end that checks preconditions, so it answers before anything contacts
+GitHub at all.
 
 `test.yml` gains a `workflow_dispatch` trigger. It has none otherwise, so nothing
 can ask for a run on demand.
@@ -268,10 +271,49 @@ daemon change, no `config` column. Per the placement rule in `CLAUDE.md`, the
 daemon compiles only what user-land cannot do well, and a wrapper script deciding
 where to run a build is squarely user-land.
 
-The valve ships behind an environment flag that defaults to off, so an unset
-environment behaves exactly as today. It acts without a user gesture and pushes
-refs, which is what the default-off rule exists for. Graduation is a change to
-the default once the soak shows the routing behaves.
+The valve ships behind `TBD_REMOTE_VERIFY`, which defaults to off: unset, every
+path behaves exactly as it did before the valve existed, and no bound is
+forwarded. It acts without a user gesture and force-pushes refs, which is what
+the default-off rule exists for.
+
+**Enabling it for the soak** is `export TBD_REMOTE_VERIFY=1` in the shell whose
+`scripts/test.sh` runs should be eligible. Four knobs tune it, each with the
+shipped default: `TBD_REMOTE_VERIFY_YIELD_SECONDS` (300) is T;
+`TBD_REMOTE_VERIFY_SLOTS` (2) is the dispatch ticket count, sized to the macOS
+job cap; `TBD_REMOTE_VERIFY_COMMAND_SECONDS` (300) bounds each `git` or `gh`
+call; and `TBD_REMOTE_VERIFY_ALLOW_ORPHAN=1` disables the requester-liveness
+check for a run deliberately detached. A run may take at most 45 minutes end to
+end, and at most 50 failures are rendered.
+
+**Graduation** flips that default only once a soak shows three things, because
+each is a way the valve can be quietly worse than waiting: that a green remote
+verdict never stood in for a suite that did not run, that a red one never named
+tests outside the caller's request, and that the ticket pool was the binding
+constraint rather than GitHub's queue. Until then it stays opt-in. The flag is
+deleted, rather than flipped, if the soak shows the valve fires too rarely to
+matter — at T=300 it is expected to fire four or five times an hour against
+roughly fifty-five queueing episodes.
+
+### The exit contract
+
+Three statuses carry the whole design, and conflating any two of them produces a
+wrong answer rather than a degraded one:
+
+- **75** — the wait timed out, or its requester died. Not a reason to go remote:
+  nobody is waiting for the result in the second case, and the first has already
+  spent its whole budget.
+- **76** — the wait yielded at T, having compiled nothing. This is the only status
+  that routes, and it is deliberately distinct from 75 so that a timeout can never
+  be mistaken for an invitation to dispatch.
+- **78** — the remote path refused, or returned no verdict at all. Always a
+  fallback to a local run, never a failure: the valve is an optimisation, and a
+  refusal that failed the run would make it a gate.
+
+Anything outside that contract — a missing driver's 127, an interrupt's 130 — is
+treated as a refusal rather than adopted, because the alternative is reporting an
+unrelated status as a test result. `TBD_SWIFT_QUEUE_YIELD_SECONDS` carries T to
+the wrapper and is honoured only for the `test` subcommand: `build` and `run`
+produce artifacts someone is waiting for, and their callers do not understand 76.
 
 ## Who reclaims the orphans
 

--- a/scripts/nightly-flake-stress.sh
+++ b/scripts/nightly-flake-stress.sh
@@ -75,6 +75,47 @@ BUILD_DEADLINE_S=1800
 SWIFT_LOCK_TIMEOUT_S=1800
 SWIFT_DEADLINE_GRACE_S=30
 
+# THE REMOTE VERIFICATION VALVE IS TURNED OFF FOR EVERY RUN THIS HARNESS
+# GOVERNS, AND THE RIGHT FIX WAS "DON'T", NOT "WIDEN THE DEADLINE".
+# (docs/specs/2026-08-16-remote-verification-valve-design.md.)
+#
+# `scripts/test.sh` opts into the valve when `TBD_REMOTE_VERIFY=1` is in its
+# environment, and this harness invokes `test.sh`. So a night started from a shell
+# that had the valve exported would route iterations to GitHub — and that is wrong
+# on the merits before it is wrong on any deadline:
+#
+#   THIS HARNESS MEASURES LOCAL FLAKINESS UNDER CONTENTION. That is its entire
+#   purpose: reproduce #503's regime — spinners pinning the cores, several agents'
+#   compiles queueing on the machine-global lock — and see which suites come apart
+#   under it. An iteration that leaves the local queue and gets its verdict from a
+#   quiet CI runner measures NOTHING this program was built to measure, and it
+#   scores a green for a regime nobody was testing.
+#
+# Two concrete ways the routed iteration also breaks the reporting, recorded so
+# nobody "fixes" them by widening a bound instead:
+#
+#   THE OUTER DEADLINE CANNOT COVER A ROUND TRIP. `governed_outer_deadline` is
+#   sized for lock wait + local execution — 1800 + 600 + 30 = 2430s. A valve round
+#   trip is the yield (up to 300s), then correlating the dispatched run (up to
+#   180s), then the run itself (ceiling ~2700s): past 3100s. The iteration is
+#   killed at 2430, scored rc=124, and reported as "FAIL wedged" — a false red
+#   attributed to a wedged test, which is exactly the diagnosis this harness exists
+#   to produce truthfully.
+#
+#   THE SIGNATURES WOULD NAME THE WRONG TESTS. `failing_tests_from` greps the
+#   iteration log for failure markers, and on the narrowed-red path the valve
+#   prints the WHOLE suite's failures into that same log before the local re-run
+#   happens. A failing iteration's "Signatures" block would then name tests outside
+#   the target's filter and attach them to that target's GitHub issue.
+#
+# `TBD_REMOTE_VERIFY=0` because `test.sh` tests it against the literal `1`;
+# clearing `TBD_SWIFT_QUEUE_YIELD_SECONDS` because it is a documented `swift-safe`
+# knob in its own right, and an inherited one would make the test leg yield 76
+# with the valve off — a status `test.sh` then propagates, and `judge_iteration`
+# reads as a truncated log. Both are ASSIGNED rather than left alone: an inherited
+# value must not decide what this harness measures.
+NO_VALVE_ENV=(TBD_REMOTE_VERIFY=0 TBD_SWIFT_QUEUE_YIELD_SECONDS=)
+
 SPINNER_PIDS=()
 REPORT_DIR=""
 FAILED_TARGETS=0
@@ -182,6 +223,7 @@ run_governed_swift() {
   local command_deadline_s="$1" log="$2"; shift 2
   local outer_deadline_s; outer_deadline_s="$(governed_outer_deadline "$command_deadline_s")"
   run_with_deadline "$outer_deadline_s" "$log" env \
+    "${NO_VALVE_ENV[@]}" \
     TBD_SWIFT_LOCK_TIMEOUT_SECONDS="$SWIFT_LOCK_TIMEOUT_S" \
     "$SCRIPT_DIR/swift-safe" "$@"
 }
@@ -197,10 +239,15 @@ run_governed_swift() {
 # sibling worktree's, which is the load this harness is trying to CONTROL rather
 # than add to. This harness is documented for local use, where an unfenced run
 # would write into the real config dirs.
+#
+# `NO_VALVE_ENV` matters most on THIS leg, because `test.sh` is the only caller
+# that opts into the remote verification valve. See its definition above for why
+# an iteration must never route.
 run_governed_fenced() {
   local command_deadline_s="$1" log="$2"; shift 2
   local outer_deadline_s; outer_deadline_s="$(governed_outer_deadline "$command_deadline_s")"
   run_with_deadline "$outer_deadline_s" "$log" env \
+    "${NO_VALVE_ENV[@]}" \
     TBD_SWIFT_LOCK_TIMEOUT_SECONDS="$SWIFT_LOCK_TIMEOUT_S" \
     "$SCRIPT_DIR/test.sh" "$@"
 }

--- a/scripts/nightly-flake-stress.test.sh
+++ b/scripts/nightly-flake-stress.test.sh
@@ -25,13 +25,23 @@ mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/stress-test.XXXXXX"; }
 
 mk_log() { local f="$1"; shift; printf '%s\n' "$@" > "$f"; }
 
+# A copy of the script with one guard deliberately weakened. Echoes its path.
+MUTANT_DIR="$(mktmpd)"
+MUTANT_SEQ=0
+trap 'rm -rf "$MUTANT_DIR"' EXIT
+mutant_of() {
+  local sed_expr="$1" out
+  MUTANT_SEQ=$((MUTANT_SEQ + 1))
+  out="$MUTANT_DIR/mutant.$MUTANT_SEQ.sh"
+  sed -E "$sed_expr" "$SCRIPT" > "$out"
+  echo "$out"
+}
+
 # Run judge_iteration inside a MUTATED copy of the script, to prove a given
 # verdict is actually produced by the guard it is attributed to.
 judge_mutated() {
   local sed_expr="$1" rc="$2" log="$3" floor="$4"
-  local mutant; mutant="$(mktmpd)/mutant.sh"
-  sed -E "$sed_expr" "$SCRIPT" > "$mutant"
-  bash -c "source '$mutant'; judge_iteration '$rc' '$log' '$floor'"
+  bash -c "source '$(mutant_of "$sed_expr")'; judge_iteration '$rc' '$log' '$floor'"
 }
 
 # ---------------------------------------------------------------------------
@@ -79,7 +89,13 @@ test_a_deadline_kill_is_reported_as_wedged() {
   mk_log "$d/wedged.log" "Test run started."
   local verdict; verdict="$(judge_iteration 124 "$d/wedged.log" 10)"
   assert_contains "rc=124 -> wedged" "$verdict" "FAIL wedged"
-  assert_contains "and says it was the harness deadline" "$verdict" "killed by the harness deadline"
+  # It has to say WHICH deadline, because the answer decides where a reader
+  # goes next: the governed outer bound covers the lock wait as well as the
+  # execution budget, so "it wedged" and "it never got admitted" are different
+  # diagnoses wearing the same rc.
+  assert_contains "and says it was the governed outer deadline" "$verdict" \
+    "no completion within the governed outer deadline"
+  assert_contains "and names both phases it covers" "$verdict" "lock wait"
   rm -rf "$d"
 }
 
@@ -190,30 +206,152 @@ test_run_with_deadline_passes_through_a_fast_commands_status() {
   rm -rf "$d"
 }
 
+# STUB WRAPPERS, AND `SCRIPT_DIR` IS THE ONLY SEAM THAT REACHES THEM. The script
+# resolves both wrappers as `$SCRIPT_DIR/<name>`, so a case that overrode anything
+# else — `REPO_ROOT`, a `cd`, a PATH entry — would leave `run_governed_swift` and
+# `run_governed_fenced` invoking the REAL `scripts/swift-safe` and `scripts/test.sh`
+# from this worktree. That is not a stub that quietly did nothing: it starts a real
+# compile, takes the machine-global build slot, and contradicts this file's own
+# "ZERO BUILDS" claim while every assertion reads an args file nothing wrote.
+#
+# Each stub records the environment it was handed. `${VAR-<unset>}` rather than
+# `${VAR:-<unset>}` on purpose: the valve cases below turn on the difference
+# between a variable that was CLEARED and one that was never set.
+mk_stub_wrapper() {
+  local dir="$1" name="$2"
+  mkdir -p "$dir"
+  cat > "$dir/$name" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf 'lock_timeout=%s\n' "${TBD_SWIFT_LOCK_TIMEOUT_SECONDS-<unset>}"
+  printf 'TBD_REMOTE_VERIFY=%s\n' "${TBD_REMOTE_VERIFY-<unset>}"
+  printf 'TBD_SWIFT_QUEUE_YIELD_SECONDS=%s\n' "${TBD_SWIFT_QUEUE_YIELD_SECONDS-<unset>}"
+  printf 'argv=%s\n' "$*"
+} > "$STUB_RECORD"
+EOF
+  chmod +x "$dir/$name"
+}
+
+# One recorded line's value, so an assertion can distinguish `VAR=` from `VAR=5`
+# — which `assert_contains` on the name alone cannot.
+recorded() { sed -n "s/^$2=//p" "$1"; }
+
 test_governed_swift_deadline_covers_lock_wait_and_command() {
   local d; d="$(mktmpd)"
-  local fake_repo="$d/repo" args_file="$d/args"
-  mkdir -p "$fake_repo/scripts"
-  cat > "$fake_repo/scripts/swift-safe" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$TBD_SWIFT_LOCK_TIMEOUT_SECONDS|$*" > "$ARGS_FILE"
-EOF
-  chmod +x "$fake_repo/scripts/swift-safe"
+  local record="$d/record"
+  mk_stub_wrapper "$d/scripts" swift-safe
 
-  local old_repo_root="${REPO_ROOT:-}" old_lock="$SWIFT_LOCK_TIMEOUT_S"
-  REPO_ROOT="$fake_repo"
+  local old_script_dir="$SCRIPT_DIR" old_lock="$SWIFT_LOCK_TIMEOUT_S"
+  SCRIPT_DIR="$d/scripts"
   SWIFT_LOCK_TIMEOUT_S=7
   assert_eq "outer deadline includes lock wait, command budget, and grace" \
     "48" "$(governed_outer_deadline 11)"
-  ARGS_FILE="$args_file" run_governed_swift 11 "$d/out.log" test --filter Foo
+  STUB_RECORD="$record" run_governed_swift 11 "$d/out.log" test --filter Foo
 
   assert_eq "governed command receives the explicit lock timeout" \
-    "7|test --filter Foo" "$(cat "$args_file")"
+    "7" "$(recorded "$record" lock_timeout)"
+  assert_eq "and the arguments it was given" \
+    "test --filter Foo" "$(recorded "$record" argv)"
   assert_eq "governed command completes without consuming its outer deadline" \
     "" "$(cat "$d/out.log")"
-  REPO_ROOT="$old_repo_root"
+  SCRIPT_DIR="$old_script_dir"
   SWIFT_LOCK_TIMEOUT_S="$old_lock"
   rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# The remote verification valve is OFF for everything this harness governs
+#
+# `scripts/test.sh` opts into the valve on `TBD_REMOTE_VERIFY=1`, and this harness
+# invokes `test.sh`. Routing an iteration to CI would not merely stretch a
+# deadline — it would measure the wrong thing entirely: this program exists to
+# reproduce LOCAL flakiness under induced contention, and a verdict computed on a
+# quiet runner answers a question nobody asked. So the harness turns the valve off
+# itself rather than trusting the shell it was started from.
+# ---------------------------------------------------------------------------
+
+test_an_iteration_never_routes_even_when_the_caller_enabled_the_valve() {
+  local d; d="$(mktmpd)"
+  local record="$d/record"
+  mk_stub_wrapper "$d/scripts" test.sh
+
+  local old_script_dir="$SCRIPT_DIR"
+  SCRIPT_DIR="$d/scripts"
+  # The caller's environment has the valve on and a bound of its own — the shape
+  # of a night started from a shell that exported them for the soak.
+  export TBD_REMOTE_VERIFY=1 TBD_SWIFT_QUEUE_YIELD_SECONDS=5
+  STUB_RECORD="$record" run_governed_fenced 5 "$d/out.log" --no-fingerprint --filter Foo
+  unset TBD_REMOTE_VERIFY TBD_SWIFT_QUEUE_YIELD_SECONDS
+  SCRIPT_DIR="$old_script_dir"
+
+  assert_eq "the iteration runs with the valve explicitly off" "0" \
+    "$(recorded "$record" TBD_REMOTE_VERIFY)"
+  # CLEARED, not merely unassigned: `env VAR=` wins over an inherited value, and
+  # an inherited bound would make the test leg yield 76 with the valve off — a
+  # status `test.sh` propagates and `judge_iteration` reads as a truncated log.
+  assert_eq "and the inherited yield bound cleared rather than passed through" "" \
+    "$(recorded "$record" TBD_SWIFT_QUEUE_YIELD_SECONDS)"
+  assert_eq "the iteration's own arguments are untouched" \
+    "--no-fingerprint --filter Foo" "$(recorded "$record" argv)"
+  rm -rf "$d"
+}
+
+# The build leg goes straight to `swift-safe`, which ignores a yield bound for any
+# subcommand but `test` — but it warns about one, into `build.log`, and the
+# harness should not depend on that leniency to stay correct.
+test_the_build_leg_also_runs_with_the_valve_off() {
+  local d; d="$(mktmpd)"
+  local record="$d/record"
+  mk_stub_wrapper "$d/scripts" swift-safe
+
+  local old_script_dir="$SCRIPT_DIR"
+  SCRIPT_DIR="$d/scripts"
+  export TBD_REMOTE_VERIFY=1 TBD_SWIFT_QUEUE_YIELD_SECONDS=5
+  STUB_RECORD="$record" run_governed_swift 5 "$d/out.log" build --build-tests -j 2
+  unset TBD_REMOTE_VERIFY TBD_SWIFT_QUEUE_YIELD_SECONDS
+  SCRIPT_DIR="$old_script_dir"
+
+  assert_eq "the build runs with the valve off too" "0" \
+    "$(recorded "$record" TBD_REMOTE_VERIFY)"
+  assert_eq "and with no inherited bound to warn about" "" \
+    "$(recorded "$record" TBD_SWIFT_QUEUE_YIELD_SECONDS)"
+  rm -rf "$d"
+}
+
+# MUTATION. Empty the clearing out of `NO_VALVE_ENV` — leaving a harmless
+# placeholder so the array stays non-empty, since bash 3.2 errors on an empty
+# `"${a[@]}"` under `set -u` and would fail for the wrong reason — and the caller's
+# `TBD_REMOTE_VERIFY=1` rides into the iteration. That iteration then routes to
+# GitHub, and this harness reports a verdict from a quiet runner as a measurement
+# of local contention.
+test_disabling_the_valve_is_load_bearing() {
+  local d; d="$(mktmpd)"
+  local record="$d/record" mutant
+  mk_stub_wrapper "$d/scripts" test.sh
+  mutant="$(mutant_of 's/^NO_VALVE_ENV=\(TBD_REMOTE_VERIFY=0 TBD_SWIFT_QUEUE_YIELD_SECONDS=\)$/NO_VALVE_ENV=(TBD_STRESS_MUTANT=1)/')"
+
+  STUB_RECORD="$record" TBD_REMOTE_VERIFY=1 TBD_SWIFT_QUEUE_YIELD_SECONDS=5 \
+    bash -c "source '$mutant'; SCRIPT_DIR='$d/scripts'; \
+             run_governed_fenced 5 '$d/out.log' --no-fingerprint --filter Foo"
+
+  assert_eq "without the clearing the caller's valve flag reaches the iteration" \
+    "1" "$(recorded "$record" TBD_REMOTE_VERIFY)"
+  assert_eq "and so does the caller's yield bound" "5" \
+    "$(recorded "$record" TBD_SWIFT_QUEUE_YIELD_SECONDS)"
+  rm -rf "$d"
+}
+
+# The harness's own account of WHY it disables the valve, pinned so a future edit
+# cannot quietly turn "measure local flakiness" into "widen the deadline". The
+# rejected fix is named because it is the one a reader reaches for first.
+test_the_no_valve_decision_is_documented_in_the_script() {
+  local body; body="$(cat "$SCRIPT")"
+  assert_contains "the script says the valve is off for its runs" "$body" \
+    "TBD_REMOTE_VERIFY=0"
+  assert_contains "and says this harness measures LOCAL flakiness" "$body" \
+    "MEASURES LOCAL FLAKINESS UNDER CONTENTION"
+  assert_contains "and records that widening the deadline was the wrong fix" "$body" \
+    'NOT "WIDEN THE DEADLINE"'
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/remote-verify.sh
+++ b/scripts/remote-verify.sh
@@ -37,7 +37,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # The remote itself is named once, in the driver: this front-end never pushes.
 REMOTE="origin"
 INERT_NAMESPACE="preflight/"
-# Used only when the remote's own HEAD cannot be read; see `default_branch`.
+# Used only when the remote's own HEAD cannot be read, and it names one trunk
+# rather than recognising any; see `default_branch` for what that does not cover.
 FALLBACK_DEFAULT_BRANCH="main"
 EXIT_REFUSED=78
 
@@ -142,10 +143,18 @@ ref_is_unowned() {
 
 # default_branch -> the branch this repository treats as its trunk.
 #
-# Read from the remote's own HEAD, which is what `git remote set-head` records,
-# and falling back to a name rather than to "no protected branch": a repository
-# whose `origin/HEAD` was never fetched is the common case on a fresh clone, and
-# the fallback must fail towards refusing rather than towards verifying trunk.
+# Read from the remote's own HEAD, which is what `git remote set-head` records.
+# A repository whose `origin/HEAD` was never fetched — the common case on a
+# fresh clone — falls back to the literal name `main`, and that fallback covers
+# exactly one trunk: a repository whose trunk is called anything else gets a
+# comparison that never matches, so a lane standing on trunk is not stopped
+# here. The honest fix would be `git ls-remote --symref origin HEAD`, and it is
+# not worth a network round trip on every invocation for a stop that is already
+# redundant: `dispatch_ref_for` answers `preflight/<branch>` for every branch
+# and `push_ref` refuses any ref outside that namespace, so trunk is protected
+# by construction whatever this function returns. What this guard buys is a
+# second, independent stop if that construction ever regresses — on this
+# repository, whose trunk is `main`. It does not buy a general one.
 default_branch() {
   local head=""
   head="$(git symbolic-ref --quiet --short "refs/remotes/$REMOTE/HEAD" 2>/dev/null)" || head=""

--- a/scripts/remote-verify.sh
+++ b/scripts/remote-verify.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# scripts/remote-verify.sh — get this commit's test verdict from CI instead of
+# waiting any longer for the machine-global build slot.
+#
+# THE OVERFLOW PATH OF THE REMOTE VERIFICATION VALVE
+# (docs/specs/2026-08-16-remote-verification-valve-design.md). A lane that has
+# queued for `scripts/swift-safe`'s single build slot past a threshold has
+# compiled nothing, so nothing is wasted by leaving that queue and asking
+# GitHub for the same verdict. `scripts/test.sh` calls this; nothing else does.
+#
+# THE EXIT CONTRACT, which the caller depends on:
+#   0   the remote run passed
+#   1   the remote run failed, and its failing tests are already printed
+#   78   refused — the caller must return to the local queue
+#
+# 78 is what keeps this an optimisation rather than a gate. Every refusal names
+# its condition on stderr: NO SILENT FALLBACK. A quiet fall-back to a local run
+# reintroduces the long stall at exactly the moment it is least visible.
+#
+# THE SPLIT WITH `remote_verify.py`. This front-end answers "should we, and
+# against which ref"; the python driver does the run, because the dispatch
+# ticket is an flock that must be held by the process that waits out the whole
+# remote round trip, and macOS ships no `flock(1)` for a bash 3.2 shell to use.
+# It is `exec`ed for the same reason — a subshell would return early and drop
+# the ticket while its run was still burning GitHub's two-run allowance.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The remote itself is named once, in the driver: this front-end never pushes.
+INERT_NAMESPACE="preflight/"
+EXIT_REFUSED=78
+
+log() { printf '%s\n' "$*" >&2; }
+
+# THE DIRTY-TREE STOP IS SEMANTIC, NOT COSMETIC. `scripts/test.sh` runs against
+# the working tree, uncommitted edits and untracked files included; GitHub can
+# only test what was pushed. A green remote result on a dirty tree is a false
+# statement about the code in hand — and an untracked file is the worst case,
+# because a brand-new test that never left this disk would be reported as
+# passing. Squash merge absorbs the cost of committing more often.
+check_preconditions() {
+  if ! command -v gh >/dev/null 2>&1; then
+    log "remote-verify: gh is not installed, so no run can be dispatched"
+    return $EXIT_REFUSED
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    log "remote-verify: gh is not authenticated, so no run can be dispatched"
+    return $EXIT_REFUSED
+  fi
+  if [ -n "$(git status --porcelain)" ]; then
+    log "remote-verify: the tree has uncommitted changes; a remote run would test a different commit"
+    return $EXIT_REFUSED
+  fi
+  return 0
+}
+
+# dispatch_ref_for BRANCH -> the ref to push and dispatch.
+# Status 2 means the question could not be answered and the lane must refuse.
+#
+# `test.yml` fires on `pull_request`, and on `push` only to main — so a branch
+# with no PR is already inert and needs no separate ref. Once a PR is open a
+# push to that branch fires `pull_request_target: synchronize`, which runs the
+# claude-review fan-out on every iteration; GitHub minutes are free but Claude
+# quota is not, and it is the only metered resource left in this loop. So that
+# case gets a throwaway `preflight/<branch>` ref instead, reclaimed by
+# `scripts/sweep-preflight-refs.sh`.
+#
+# A FAILED QUERY IS NOT "NO PR". Treating it as one would push the PR branch
+# and spend the quota this branch exists to protect, which is the expensive
+# direction to be wrong in.
+dispatch_ref_for() {
+  local branch="$1" open status=0
+  open="$(gh pr list --head "$branch" --state open --json number --jq '.[].number' 2>&1)" || status=$?
+  if [ $status -ne 0 ]; then
+    log "remote-verify: gh pr list failed for $branch (exit $status): $open"
+    return 2
+  fi
+  if [ -z "${open//[[:space:]]/}" ]; then
+    printf '%s\n' "$branch"
+  else
+    printf '%s%s\n' "$INERT_NAMESPACE" "$branch"
+  fi
+}
+
+main() {
+  local repo_dir branch sha ref status=0
+
+  repo_dir="$(git rev-parse --show-toplevel 2>/dev/null)" || status=$?
+  if [ $status -ne 0 ] || [ -z "$repo_dir" ]; then
+    log "remote-verify: not inside a git repository"
+    return $EXIT_REFUSED
+  fi
+
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || branch=""
+  if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+    log "remote-verify: HEAD is detached, so there is no branch to push"
+    return $EXIT_REFUSED
+  fi
+
+  check_preconditions || return $?
+
+  status=0
+  ref="$(dispatch_ref_for "$branch")" || status=$?
+  if [ $status -ne 0 ] || [ -z "$ref" ]; then
+    return $EXIT_REFUSED
+  fi
+
+  sha="$(git rev-parse HEAD)"
+
+  local inert=()
+  if [ "$ref" != "$branch" ]; then
+    inert=(--inert)
+  fi
+
+  # `exec`: the driver holds the dispatch ticket for the whole remote run, and
+  # its exit status is this script's contract verbatim.
+  exec python3 "$HERE/remote_verify.py" drive \
+    --repo-dir "$repo_dir" --ref "$ref" --sha "$sha" ${inert[@]+"${inert[@]}"}
+}
+
+# --- entrypoint (strict mode only when executed, not when sourced) -----------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  main "$@"
+fi

--- a/scripts/remote-verify.sh
+++ b/scripts/remote-verify.sh
@@ -26,7 +26,10 @@
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # The remote itself is named once, in the driver: this front-end never pushes.
+REMOTE="origin"
 INERT_NAMESPACE="preflight/"
+# Used only when the remote's own HEAD cannot be read; see `default_branch`.
+FALLBACK_DEFAULT_BRANCH="main"
 EXIT_REFUSED=78
 
 log() { printf '%s\n' "$*" >&2; }
@@ -53,32 +56,48 @@ check_preconditions() {
   return 0
 }
 
-# dispatch_ref_for BRANCH -> the ref to push and dispatch.
-# Status 2 means the question could not be answered and the lane must refuse.
+# dispatch_ref_for BRANCH -> the ref to push and dispatch. Always inert, never
+# the branch, and deliberately answerable without asking GitHub anything.
 #
-# `test.yml` fires on `pull_request`, and on `push` only to main — so a branch
-# with no PR is already inert and needs no separate ref. Once a PR is open a
-# push to that branch fires `pull_request_target: synchronize`, which runs the
-# claude-review fan-out on every iteration; GitHub minutes are free but Claude
-# quota is not, and it is the only metered resource left in this loop. So that
-# case gets a throwaway `preflight/<branch>` ref instead, reclaimed by
-# `scripts/sweep-preflight-refs.sh`.
+# THE BRANCH ITSELF IS NEVER PUSHED, for three independent reasons:
 #
-# A FAILED QUERY IS NOT "NO PR". Treating it as one would push the PR branch
-# and spend the quota this branch exists to protect, which is the expensive
-# direction to be wrong in.
+#   - A PUSH IS WHAT THE PRE-PUSH HOOK IS GATING. `scripts/git-hooks/pre-push`
+#     runs the suite before the commits are published; a verification path that
+#     publishes them to the branch to get its verdict has bypassed the gate it
+#     was running inside.
+#   - THE DEFAULT BRANCH NEVER HAS AN OPEN PR. A ref choice keyed on "is there a
+#     PR?" therefore fast-forwards `origin/main`, and nothing refuses it: the
+#     protection on `main` was read at the time of writing and enforces against
+#     neither admins nor pushers. The result is main's CI and the Pages deploy
+#     firing on unreviewed commits.
+#   - AN INERT REF HAS A NAMED RECONCILER AND A BRANCH DOES NOT.
+#     `scripts/sweep-preflight-refs.sh` matches `refs/heads/preflight/` and
+#     nothing else, so a branch pushed from here would be a durable resource
+#     nobody reclaims.
+#
+# A push to a branch with an open PR would also fire `pull_request_target:
+# synchronize` and run the claude-review fan-out on every iteration; GitHub
+# minutes are free but Claude quota is not, and it is the only metered resource
+# left in this loop. One namespace covers every one of those cases, so this
+# needs no `gh pr list` and cannot be wrong about the answer.
 dispatch_ref_for() {
-  local branch="$1" open status=0
-  open="$(gh pr list --head "$branch" --state open --json number --jq '.[].number' 2>&1)" || status=$?
-  if [ $status -ne 0 ]; then
-    log "remote-verify: gh pr list failed for $branch (exit $status): $open"
-    return 2
+  printf '%s%s\n' "$INERT_NAMESPACE" "$1"
+}
+
+# default_branch -> the branch this repository treats as its trunk.
+#
+# Read from the remote's own HEAD, which is what `git remote set-head` records,
+# and falling back to a name rather than to "no protected branch": a repository
+# whose `origin/HEAD` was never fetched is the common case on a fresh clone, and
+# the fallback must fail towards refusing rather than towards verifying trunk.
+default_branch() {
+  local head=""
+  head="$(git symbolic-ref --quiet --short "refs/remotes/$REMOTE/HEAD" 2>/dev/null)" || head=""
+  if [ -n "$head" ]; then
+    printf '%s\n' "${head#"$REMOTE/"}"
+    return 0
   fi
-  if [ -z "${open//[[:space:]]/}" ]; then
-    printf '%s\n' "$branch"
-  else
-    printf '%s%s\n' "$INERT_NAMESPACE" "$branch"
-  fi
+  printf '%s\n' "$FALLBACK_DEFAULT_BRANCH"
 }
 
 main() {
@@ -96,6 +115,17 @@ main() {
     return $EXIT_REFUSED
   fi
 
+  # DEFENCE IN DEPTH, and the only guard here that is deliberately redundant.
+  # `dispatch_ref_for` already answers `preflight/<branch>` for every branch, so
+  # trunk is safe by construction — but the cost of that construction ever
+  # regressing is a push to `origin/main` that fires main's CI and the Pages
+  # deploy, which is worth a second, independent stop.
+  local trunk; trunk="$(default_branch)"
+  if [ "$branch" = "$trunk" ]; then
+    log "remote-verify: refusing to verify $branch, the default branch; commit to a lane branch instead"
+    return $EXIT_REFUSED
+  fi
+
   check_preconditions || return $?
 
   status=0
@@ -106,15 +136,10 @@ main() {
 
   sha="$(git rev-parse HEAD)"
 
-  local inert=()
-  if [ "$ref" != "$branch" ]; then
-    inert=(--inert)
-  fi
-
   # `exec`: the driver holds the dispatch ticket for the whole remote run, and
   # its exit status is this script's contract verbatim.
   exec python3 "$HERE/remote_verify.py" drive \
-    --repo-dir "$repo_dir" --ref "$ref" --sha "$sha" ${inert[@]+"${inert[@]}"}
+    --repo-dir "$repo_dir" --ref "$ref" --sha "$sha"
 }
 
 # --- entrypoint (strict mode only when executed, not when sourced) -----------

--- a/scripts/remote-verify.sh
+++ b/scripts/remote-verify.sh
@@ -49,17 +49,24 @@ log() { printf '%s\n' "$*" >&2; }
 # statement about the code in hand — and an untracked file is the worst case,
 # because a brand-new test that never left this disk would be reported as
 # passing. Squash merge absorbs the cost of committing more often.
+#
+# THE FREE LOCAL CHECKS COME FIRST, and the dirty tree is checked before `gh` is
+# even looked for. `gh auth status` is a network round-trip, and a dirty tree is
+# the most common refusal by far — the lane most likely to be starving is the one
+# with uncommitted work — so answering it locally spends nothing and keeps the
+# refusal instant. The order is a property of the whole function rather than any
+# one line, which is why a case asserts that a dirty tree asks GitHub nothing.
 check_preconditions() {
+  if [ -n "$(git status --porcelain)" ]; then
+    log "remote-verify: the tree has uncommitted changes; a remote run would test a different commit"
+    return $EXIT_REFUSED
+  fi
   if ! command -v gh >/dev/null 2>&1; then
     log "remote-verify: gh is not installed, so no run can be dispatched"
     return $EXIT_REFUSED
   fi
   if ! gh auth status >/dev/null 2>&1; then
     log "remote-verify: gh is not authenticated, so no run can be dispatched"
-    return $EXIT_REFUSED
-  fi
-  if [ -n "$(git status --porcelain)" ]; then
-    log "remote-verify: the tree has uncommitted changes; a remote run would test a different commit"
     return $EXIT_REFUSED
   fi
   return 0
@@ -87,10 +94,50 @@ check_preconditions() {
 # A push to a branch with an open PR would also fire `pull_request_target:
 # synchronize` and run the claude-review fan-out on every iteration; GitHub
 # minutes are free but Claude quota is not, and it is the only metered resource
-# left in this loop. One namespace covers every one of those cases, so this
-# needs no `gh pr list` and cannot be wrong about the answer.
+# left in this loop. One namespace covers every one of those cases, so the CHOICE
+# of ref asks GitHub nothing and cannot be wrong about it. Whether the ref that
+# choice lands on is already somebody's branch is a different question, asked
+# separately in `ref_is_unowned`.
 dispatch_ref_for() {
   printf '%s%s\n' "$INERT_NAMESPACE" "$1"
+}
+
+# ref_is_unowned REF -> 0 when REF is free to force-push, $EXIT_REFUSED otherwise.
+#
+# THE NAMESPACE IS A CONVENTION, NOT A RESERVATION. Every ref the valve moves is
+# force-pushed, because a `preflight/*` ref is a throwaway that any lane may
+# repoint after an amend — but nothing stops a human from working on a branch
+# actually named `preflight/flaky-repro`, and a lane on `flaky-repro` computes
+# exactly that ref. Force-pushing it destroys their commits, and if it carries an
+# open PR the push also fires `pull_request_target: synchronize` and spends the
+# claude-review fan-out, the one metered resource the inert-ref design exists to
+# protect. `scripts/sweep-preflight-refs.sh` already refuses this same collision
+# on the delete side, in the same words; this is that defence on the push side.
+#
+# AN OPEN PR IS THE SIGNAL, because it is the one that can be read without
+# guessing. A `preflight/*` ref existing on the remote proves nothing — every
+# previous run of this valve left one — so ref existence cannot separate a
+# throwaway from somebody's work, while a pull request is a human gesture that
+# only a branch somebody is using ever receives.
+#
+# A QUERY THAT FAILED IS NOT A "NO". Reading a rate limit or a token that lost
+# its scope as "nobody owns this ref" would turn the guard off exactly when
+# GitHub is unhealthy, so an unanswerable question refuses. Same reasoning, and
+# the same fail-closed direction, as the sweep's `has_open_pr`. Only stdout
+# decides: `gh`'s own stderr flows to ours, where an operator reads it verbatim,
+# and folding it into the value would make any deprecation notice read as a PR.
+ref_is_unowned() {
+  local ref="$1" numbers status=0
+  numbers="$(gh pr list --head "$ref" --state open --json number --jq '.[].number')" || status=$?
+  if [ $status -ne 0 ]; then
+    log "remote-verify: could not ask whether a pull request is open for $ref (gh exit $status); refusing rather than force-pushing a ref somebody may own"
+    return $EXIT_REFUSED
+  fi
+  if [ -n "${numbers//[[:space:]]/}" ]; then
+    log "remote-verify: $ref has an open pull request (#${numbers//[[:space:]]/ }), so it is somebody's branch rather than an inert ref; refusing rather than force-pushing over it"
+    return $EXIT_REFUSED
+  fi
+  return 0
 }
 
 # default_branch -> the branch this repository treats as its trunk.
@@ -157,6 +204,11 @@ main() {
   if [ $status -ne 0 ] || [ -z "$ref" ]; then
     return $EXIT_REFUSED
   fi
+
+  # Asked before anything is pushed, and it is the only `gh` call this front-end
+  # makes about the ref: the driver force-pushes whatever it is handed, so the
+  # question of whether the ref is somebody's branch has to be answered here.
+  ref_is_unowned "$ref" || return $?
 
   sha="$(git rev-parse HEAD)"
 

--- a/scripts/remote-verify.sh
+++ b/scripts/remote-verify.sh
@@ -13,6 +13,15 @@
 #   1   the remote run failed, and its failing tests are already printed
 #   78   refused — the caller must return to the local queue
 #
+# USAGE: scripts/remote-verify.sh [--narrowed]
+#
+# `--narrowed` says the caller selected a subset of the suite with `--filter` or
+# `--skip`, so it will re-run locally rather than adopt a failing whole-suite
+# verdict. It changes nothing about routing; it suppresses the `Test run with N
+# tests` line on a failure, because six consumers grep that line and take the
+# first match — a whole-suite count printed ahead of the local re-run's own would
+# clear the very floor that exists to catch a filter matching nothing.
+#
 # 78 is what keeps this an optimisation rather than a gate. Every refusal names
 # its condition on stderr: NO SILENT FALLBACK. A quiet fall-back to a local run
 # reintroduces the long stall at exactly the moment it is least visible.
@@ -102,6 +111,21 @@ default_branch() {
 
 main() {
   local repo_dir branch sha ref status=0
+  # AN UNRECOGNISED ARGUMENT REFUSES RATHER THAN BEING IGNORED. The caller passes
+  # `--narrowed` to change how its verdict may be read, so a flag this front-end
+  # silently dropped — a rename, a typo — would hand back a verdict the caller
+  # then reads under the wrong rule. 78 is free; a misread verdict is not.
+  local -a narrowing=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --narrowed) narrowing=(--narrowed) ;;
+      *)
+        log "remote-verify: unknown argument '$1'; refusing rather than guessing"
+        return $EXIT_REFUSED
+        ;;
+    esac
+    shift
+  done
 
   repo_dir="$(git rev-parse --show-toplevel 2>/dev/null)" || status=$?
   if [ $status -ne 0 ] || [ -z "$repo_dir" ]; then
@@ -139,7 +163,8 @@ main() {
   # `exec`: the driver holds the dispatch ticket for the whole remote run, and
   # its exit status is this script's contract verbatim.
   exec python3 "$HERE/remote_verify.py" drive \
-    --repo-dir "$repo_dir" --ref "$ref" --sha "$sha"
+    --repo-dir "$repo_dir" --ref "$ref" --sha "$sha" \
+    ${narrowing[@]+"${narrowing[@]}"}
 }
 
 # --- entrypoint (strict mode only when executed, not when sourced) -----------

--- a/scripts/remote-verify.test.sh
+++ b/scripts/remote-verify.test.sh
@@ -105,7 +105,19 @@ case "$1 ${2:-}" in
     exit "${STUB_GH_AUTH_STATUS:-0}" ;;
   "pr list")
     if [ -n "${STUB_GH_PR_FAIL:-}" ]; then echo "API rate limit exceeded" >&2; exit 1; fi
-    if [ -n "${STUB_GH_PR_OPEN:-}" ]; then echo 7; fi
+    # HEAD-AWARE ON PURPOSE. The valve asks about one specific ref, and a stub
+    # that answered "a PR is open" whatever it was asked could not tell a lane
+    # branch with a PR — which changes nothing — from a human working on the very
+    # `preflight/` ref the valve is about to force-push. `STUB_GH_PR_OPEN_HEADS`
+    # is the space-separated list of head refs that have one.
+    head=""
+    while [ $# -gt 0 ]; do
+      if [ "$1" = "--head" ]; then head="${2:-}"; fi
+      shift
+    done
+    for owned in ${STUB_GH_PR_OPEN_HEADS:-}; do
+      if [ "$owned" = "$head" ]; then echo 7; fi
+    done
     exit 0 ;;
   "workflow run")
     status="${STUB_GH_DISPATCH_STATUS:-0}"
@@ -190,7 +202,7 @@ test_dispatch_ref_for_always_answers_an_inert_ref() {
   local root; root="$(setup)"
   local ref; ref="$(cd "$root/work" && PATH="$root/bin:$PATH" dispatch_ref_for "$BRANCH")"
   assert_eq "a branch with no PR still dispatches a preflight ref" "preflight/$BRANCH" "$ref"
-  ref="$(cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_PR_OPEN=1 dispatch_ref_for "$BRANCH")"
+  ref="$(cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_PR_OPEN_HEADS="$BRANCH" dispatch_ref_for "$BRANCH")"
   assert_eq "and so does one with a PR open" "preflight/$BRANCH" "$ref"
   rm -rf "$root"
 }
@@ -225,6 +237,10 @@ test_a_dirty_tree_refuses_and_stays_local() {
   assert_eq "dirty tree exits 78" "78" "$RC"
   assert_contains "and names the condition" "$OUT" "uncommitted"
   assert_missing "and dispatches nothing" "$(gh_calls "$root")" "workflow run"
+  # THE FREE CHECK COMES FIRST. `gh auth status` is a network round-trip and the
+  # dirty tree is the most common refusal there is, so this one must be answered
+  # without asking GitHub anything at all — not even whether we are logged in.
+  assert_eq "and asks GitHub nothing whatsoever" "" "$(gh_calls "$root")"
   rm -rf "$root"
 }
 
@@ -300,7 +316,7 @@ test_an_open_pr_changes_nothing_about_the_ref() {
   local head before
   head="$(git -C "$root/work" rev-parse HEAD)"
   before="$(remote_sha "$root" "$BRANCH")"
-  run_verify "$root" STUB_GH_PR_OPEN=1
+  run_verify "$root" STUB_GH_PR_OPEN_HEADS="$BRANCH"
   assert_eq "a passing remote run exits 0" "0" "$RC"
   assert_eq "the inert ref carries the commit" "$head" "$(remote_sha "$root" "preflight/$BRANCH")"
   assert_eq "the PR branch never moved" "$before" "$(remote_sha "$root" "$BRANCH")"
@@ -337,6 +353,63 @@ test_a_stale_run_for_this_commit_is_not_adopted() {
   assert_eq "the run exits 0" "0" "$RC"
   assert_contains "the dispatched run is the one watched" "$(gh_calls "$root")" "run view 4243"
   assert_missing "and the stale run is not" "$(gh_calls "$root")" "run view 4000"
+  rm -rf "$root"
+}
+
+test_a_preflight_ref_somebody_else_owns_is_never_force_pushed() {
+  # THE NAMESPACE IS A CONVENTION, NOT A RESERVATION. A lane on `flaky-repro`
+  # computes `preflight/flaky-repro`, and nothing stops a human from working on a
+  # branch by exactly that name: the push is unconditionally forced, so it would
+  # destroy their commits — and firing `pull_request_target: synchronize` on their
+  # PR would spend the claude-review fan-out, the one metered resource the
+  # inert-ref design exists to protect. `scripts/sweep-preflight-refs.sh` already
+  # refuses this collision on the delete side; this is the push side of it.
+  local root; root="$(setup)"
+  git -C "$root/work" checkout -q -b "flaky-repro"
+  local human; human="$(remote_sha "$root" "preflight/flaky-repro")"
+  run_verify "$root" STUB_GH_PR_OPEN_HEADS="preflight/flaky-repro"
+  assert_eq "a ref with an open PR exits 78" "78" "$RC"
+  assert_contains "and names the collision" "$OUT" "open pull request"
+  assert_eq "the ref is exactly as it was" "$human" "$(remote_sha "$root" "preflight/flaky-repro")"
+  assert_missing "and nothing was dispatched" "$(gh_calls "$root")" "workflow run"
+  rm -rf "$root"
+}
+
+test_a_pr_on_the_lane_branch_itself_still_verifies() {
+  # The other side of the same guard: the open PR that matters is the one on the
+  # ref about to be force-pushed, not the one on the branch being verified. A
+  # check that could not tell them apart would refuse every lane with a PR — which
+  # is nearly all of them — and turn the valve off in practice.
+  local root; root="$(setup)"
+  local head; head="$(git -C "$root/work" rev-parse HEAD)"
+  run_verify "$root" STUB_GH_PR_OPEN_HEADS="$BRANCH"
+  assert_eq "a PR on the lane branch still exits 0" "0" "$RC"
+  assert_eq "and the inert ref carries the commit" "$head" "$(remote_sha "$root" "preflight/$BRANCH")"
+  rm -rf "$root"
+}
+
+test_the_owner_check_happens_before_anything_is_pushed() {
+  # The ordering, from the call log: the question is asked before the dispatch,
+  # which the driver only reaches after its push.
+  local root; root="$(setup)"
+  run_verify "$root"
+  assert_contains "the computed ref is the one asked about" \
+    "$(gh_calls "$root")" "pr list --head preflight/$BRANCH"
+  assert_contains "and it is asked before the dispatch" \
+    "$(gh_calls "$root" | grep -E '^(pr list|workflow run)' | head -1)" "pr list"
+  rm -rf "$root"
+}
+
+test_an_unanswerable_pr_query_refuses_rather_than_assuming_nobody_owns_the_ref() {
+  # FAIL CLOSED. Reading a rate limit or an expired token as "no PR here" would
+  # disarm the guard exactly when GitHub is unhealthy, and the cost of being wrong
+  # is somebody's branch.
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_PR_FAIL=1
+  assert_eq "an unanswerable query exits 78" "78" "$RC"
+  assert_contains "and says the question could not be answered" "$OUT" "could not ask"
+  assert_eq "no inert ref was created" "" "$(remote_sha "$root" "preflight/$BRANCH")"
+  assert_missing "and nothing was dispatched" "$(gh_calls "$root")" "workflow run"
   rm -rf "$root"
 }
 
@@ -401,12 +474,22 @@ test_a_truncated_result_file_is_named_rather_than_read_as_green() {
   rm -rf "$root"
 }
 
-test_a_failing_run_with_no_results_artifact_still_fails_loudly() {
+test_a_failing_run_with_no_results_artifact_falls_back_to_a_local_run() {
+  # A RED RUN THAT PUBLISHED NOTHING IS NOT A RED SUITE. `test.yml`'s test job
+  # runs eight fallible setup steps — checkout, mtime restore, `brew install
+  # tmux`, `xcode-select`, toolchain capture, cache restore, workspace repair,
+  # force rebuild — before it reaches the first `scripts/test.sh`, so a `brew`
+  # flake or a swept ref failing `actions/checkout` means zero tests ran and no
+  # artifact exists. 78 sends this lane back to the local queue, where it gets a
+  # real answer; 1 would tell it its suite is red with nothing to show and no
+  # fallback left.
   local root; root="$(setup)"
   run_verify "$root" STUB_GH_CONCLUSION=failure STUB_GH_NO_ARTIFACT=1
-  assert_eq "a failing run with no artifact still exits 1" "1" "$RC"
+  assert_eq "a failing run with no artifact exits 78, not 1" "78" "$RC"
   assert_contains "says the results could not be had" "$OUT" "could not download"
+  assert_contains "and that nothing says the tests ran" "$OUT" "published no results"
   assert_contains "and points at the run" "$OUT" "https://example.invalid/runs/4242"
+  assert_missing "and never claims a failure it cannot describe" "$OUT" "run FAILED"
   rm -rf "$root"
 }
 

--- a/scripts/remote-verify.test.sh
+++ b/scripts/remote-verify.test.sh
@@ -87,12 +87,19 @@ XML
 
 # A `gh` that answers from the environment and records every call it was given,
 # so a case can assert that a dispatch did NOT happen as easily as that it did.
+#
+# RUNS EXIST ONLY ONCE THEY HAVE BEEN DISPATCHED, recorded in `$STUB_GH_RUNS`
+# with a fresh id each time. A stub that answered `run list` with a constant run
+# could not tell the run a lane just asked for from one that was already there,
+# which is exactly the confusion the driver's baseline exists to prevent — and a
+# case can seed that file to put a stale run in front of a lane.
 stub_gh() {
   local root="$1"
   cat > "$root/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 [ -n "${STUB_GH_LOG:-}" ] && printf '%s\n' "$*" >> "$STUB_GH_LOG"
 conclusion="${STUB_GH_CONCLUSION:-success}"
+runs="${STUB_GH_RUNS:-}"
 case "$1 ${2:-}" in
   "auth status")
     exit "${STUB_GH_AUTH_STATUS:-0}" ;;
@@ -101,14 +108,29 @@ case "$1 ${2:-}" in
     if [ -n "${STUB_GH_PR_OPEN:-}" ]; then echo 7; fi
     exit 0 ;;
   "workflow run")
-    exit "${STUB_GH_DISPATCH_STATUS:-0}" ;;
+    status="${STUB_GH_DISPATCH_STATUS:-0}"
+    if [ "$status" -ne 0 ]; then exit "$status"; fi
+    next=4242
+    if [ -f "$runs" ]; then next=$(( $(wc -l < "$runs") + 4242 )); fi
+    printf '%s %s\n' "$next" "$(git rev-parse HEAD)" >> "$runs"
+    exit 0 ;;
   "run list")
-    printf '[{"databaseId":4242,"headSha":"%s","status":"completed","conclusion":"%s","event":"workflow_dispatch","url":"https://example.invalid/runs/4242"}]\n' \
-      "$(git rev-parse HEAD)" "$conclusion"
+    ids=(); shas=()
+    if [ -f "$runs" ]; then
+      while read -r id sha; do ids+=("$id"); shas+=("$sha"); done < "$runs"
+    fi
+    out=""; i=$(( ${#ids[@]} - 1 ))
+    while [ $i -ge 0 ]; do
+      entry="$(printf '{"databaseId":%s,"headSha":"%s","status":"completed","conclusion":"%s","event":"workflow_dispatch","url":"https://example.invalid/runs/%s"}' \
+        "${ids[$i]}" "${shas[$i]}" "$conclusion" "${ids[$i]}")"
+      if [ -n "$out" ]; then out="$out,$entry"; else out="$entry"; fi
+      i=$((i - 1))
+    done
+    printf '[%s]\n' "$out"
     exit 0 ;;
   "run view")
-    printf '{"status":"completed","conclusion":"%s","url":"https://example.invalid/runs/4242","jobs":[{"name":"Test","conclusion":"%s"}]}\n' \
-      "$conclusion" "$conclusion"
+    printf '{"status":"completed","conclusion":"%s","url":"https://example.invalid/runs/%s","jobs":[{"name":"Test","conclusion":"%s"}]}\n' \
+      "$conclusion" "${3:-0}" "$conclusion"
     exit 0 ;;
   "run download")
     if [ -n "${STUB_GH_NO_ARTIFACT:-}" ]; then echo "no artifact matches xunit-results" >&2; exit 1; fi
@@ -138,6 +160,7 @@ run_verify() {
     PATH="$root/bin:$PATH" \
     TBD_HOME="$root/home" \
     STUB_GH_LOG="$root/gh.log" \
+    STUB_GH_RUNS="$root/runs" \
     STUB_GH_XML_DIR="$root/xml" \
     TBD_REMOTE_VERIFY_POLL_SECONDS=0.01 \
     TBD_REMOTE_VERIFY_CORRELATE_SECONDS=2 \
@@ -160,25 +183,36 @@ setup() {
 
 # --- ref choice, at the unit level -------------------------------------------
 
-test_dispatch_ref_for_uses_the_branch_when_no_pr_is_open() {
+test_dispatch_ref_for_always_answers_an_inert_ref() {
+  # THE BRANCH IS NEVER THE ANSWER, whether or not a PR is open. Pushing it
+  # would publish the commits a pre-push hook is gating, and it would leave a
+  # ref that `scripts/sweep-preflight-refs.sh` does not match.
   local root; root="$(setup)"
   local ref; ref="$(cd "$root/work" && PATH="$root/bin:$PATH" dispatch_ref_for "$BRANCH")"
-  assert_eq "no open PR dispatches the branch itself" "$BRANCH" "$ref"
+  assert_eq "a branch with no PR still dispatches a preflight ref" "preflight/$BRANCH" "$ref"
+  ref="$(cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_PR_OPEN=1 dispatch_ref_for "$BRANCH")"
+  assert_eq "and so does one with a PR open" "preflight/$BRANCH" "$ref"
   rm -rf "$root"
 }
 
-test_dispatch_ref_for_uses_an_inert_ref_when_a_pr_is_open() {
+test_dispatch_ref_for_asks_github_nothing() {
+  # The answer is the same in every case, so it needs no query — and a call
+  # that cannot happen cannot be answered wrongly, rate-limited, or read as
+  # "no PR" when it merely failed.
   local root; root="$(setup)"
-  local ref; ref="$(cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_PR_OPEN=1 dispatch_ref_for "$BRANCH")"
-  assert_eq "an open PR dispatches a preflight ref" "preflight/$BRANCH" "$ref"
+  (cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_LOG="$root/gh.log" dispatch_ref_for "$BRANCH") >/dev/null
+  assert_eq "the ref choice consults no gh call" "" "$(gh_calls "$root")"
   rm -rf "$root"
 }
 
-test_dispatch_ref_for_refuses_when_the_query_fails() {
+test_the_default_branch_is_read_from_the_remote_head() {
   local root; root="$(setup)"
-  local status=0
-  (cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_PR_FAIL=1 dispatch_ref_for "$BRANCH") >/dev/null 2>&1 || status=$?
-  assert_eq "a failed PR query is not read as 'no PR'" "2" "$status"
+  local trunk; trunk="$(cd "$root/work" && default_branch)"
+  assert_eq "an unfetched origin/HEAD falls back to main" "main" "$trunk"
+  git -C "$root/work" fetch -q origin
+  git -C "$root/work" symbolic-ref "refs/remotes/origin/HEAD" "refs/remotes/origin/$BRANCH"
+  trunk="$(cd "$root/work" && default_branch)"
+  assert_eq "and a recorded one is believed" "$BRANCH" "$trunk"
   rm -rf "$root"
 }
 
@@ -229,30 +263,39 @@ test_a_detached_head_refuses() {
   rm -rf "$root"
 }
 
-test_a_failed_pr_query_refuses_without_pushing() {
+test_the_default_branch_refuses_before_anything_is_pushed() {
+  # DEFENCE IN DEPTH. `dispatch_ref_for` already answers `preflight/main`, so
+  # this stop is redundant by construction — and worth having anyway, because
+  # what a regression there would cost is a fast-forward of `origin/main`
+  # firing main's CI and the Pages deploy on unreviewed commits.
   local root; root="$(setup)"
-  local before; before="$(remote_sha "$root" "$BRANCH")"
-  run_verify "$root" STUB_GH_PR_FAIL=1
-  assert_eq "an unanswerable PR query exits 78" "78" "$RC"
-  assert_eq "and the PR branch is untouched" "$before" "$(remote_sha "$root" "$BRANCH")"
+  git -C "$root/work" checkout -q main
+  local before; before="$(remote_sha "$root" main)"
+  run_verify "$root"
+  assert_eq "verifying the default branch exits 78" "78" "$RC"
+  assert_contains "and names it" "$OUT" "default branch"
+  assert_eq "main on the remote is untouched" "$before" "$(remote_sha "$root" main)"
+  assert_eq "and no preflight ref was created either" "" "$(remote_sha "$root" "preflight/main")"
   assert_missing "and nothing was dispatched" "$(gh_calls "$root")" "workflow run"
   rm -rf "$root"
 }
 
 # --- which ref gets pushed ---------------------------------------------------
 
-test_a_branch_with_no_pr_is_pushed_and_dispatched() {
+test_the_inert_ref_is_pushed_and_the_branch_is_left_alone() {
   local root; root="$(setup)"
-  local head; head="$(git -C "$root/work" rev-parse HEAD)"
+  local head before
+  head="$(git -C "$root/work" rev-parse HEAD)"
+  before="$(remote_sha "$root" "$BRANCH")"
   run_verify "$root"
   assert_eq "a passing remote run exits 0" "0" "$RC"
-  assert_eq "the branch itself was pushed" "$head" "$(remote_sha "$root" "$BRANCH")"
-  assert_eq "no inert ref was created" "" "$(remote_sha "$root" "preflight/$BRANCH")"
-  assert_contains "and the dispatch named the branch" "$(gh_calls "$root")" "workflow run test.yml --ref $BRANCH"
+  assert_eq "the inert ref carries the commit" "$head" "$(remote_sha "$root" "preflight/$BRANCH")"
+  assert_eq "the branch itself never moved" "$before" "$(remote_sha "$root" "$BRANCH")"
+  assert_contains "and the dispatch named the inert ref" "$(gh_calls "$root")" "--ref preflight/$BRANCH"
   rm -rf "$root"
 }
 
-test_an_open_pr_pushes_an_inert_ref_and_leaves_the_pr_branch_alone() {
+test_an_open_pr_changes_nothing_about_the_ref() {
   local root; root="$(setup)"
   local head before
   head="$(git -C "$root/work" rev-parse HEAD)"
@@ -261,7 +304,6 @@ test_an_open_pr_pushes_an_inert_ref_and_leaves_the_pr_branch_alone() {
   assert_eq "a passing remote run exits 0" "0" "$RC"
   assert_eq "the inert ref carries the commit" "$head" "$(remote_sha "$root" "preflight/$BRANCH")"
   assert_eq "the PR branch never moved" "$before" "$(remote_sha "$root" "$BRANCH")"
-  assert_contains "and the dispatch named the inert ref" "$(gh_calls "$root")" "--ref preflight/$BRANCH"
   rm -rf "$root"
 }
 
@@ -269,37 +311,61 @@ test_an_inert_ref_survives_a_rewritten_commit() {
   # Amending or rebasing between two verifications leaves the throwaway ref on
   # a commit the new HEAD does not descend from. The ref is inert and belongs
   # to nobody, so it is forced; without that this lane could never verify
-  # again after a rebase.
+  # again after a rebase — and the branch it shadows still never moves.
   local root; root="$(setup)"
-  run_verify "$root" STUB_GH_PR_OPEN=1
+  run_verify "$root"
+  local before; before="$(remote_sha "$root" "$BRANCH")"
   git -C "$root/work" reset -q --hard HEAD~1
   echo "a rewritten commit" > "$root/work/seed"
   "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -am "rewritten"
   local head; head="$(git -C "$root/work" rev-parse HEAD)"
-  run_verify "$root" STUB_GH_PR_OPEN=1
+  run_verify "$root"
   assert_eq "the second run exits 0" "0" "$RC"
   assert_eq "and the inert ref moved to the rewritten commit" "$head" "$(remote_sha "$root" "preflight/$BRANCH")"
+  assert_eq "the branch itself still never moved" "$before" "$(remote_sha "$root" "$BRANCH")"
   rm -rf "$root"
 }
 
-test_a_real_branch_is_never_force_pushed() {
-  # The other half of the same rule. A branch somebody else may be reading is
-  # not this lane's to rewrite: a non-fast-forward push refuses and the lane
-  # goes back to the local queue rather than discarding work to run a test.
+test_a_stale_run_for_this_commit_is_not_adopted() {
+  # A run already registered for this sha — an earlier lane on the same commit,
+  # or this lane's own previous attempt — answers `gh run list` instantly while
+  # the run just dispatched takes seconds to register. Adopting it would report
+  # its verdict while the run this lane paid for burns a macOS slot unwatched.
   local root; root="$(setup)"
+  printf '4000 %s\n' "$(git -C "$root/work" rev-parse HEAD)" > "$root/runs"
   run_verify "$root"
-  local pushed; pushed="$(remote_sha "$root" "$BRANCH")"
-  git -C "$root/work" reset -q --hard HEAD~1
-  echo "a rewritten commit" > "$root/work/seed"
-  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -am "rewritten"
-  run_verify "$root"
-  assert_eq "a non-fast-forward branch push refuses" "78" "$RC"
-  assert_contains "and names it" "$OUT" "could not push"
-  assert_eq "the branch on the remote is untouched" "$pushed" "$(remote_sha "$root" "$BRANCH")"
+  assert_eq "the run exits 0" "0" "$RC"
+  assert_contains "the dispatched run is the one watched" "$(gh_calls "$root")" "run view 4243"
+  assert_missing "and the stale run is not" "$(gh_calls "$root")" "run view 4000"
   rm -rf "$root"
 }
 
 # --- the verdict -------------------------------------------------------------
+
+test_a_passing_remote_run_states_the_population_it_executed() {
+  # SIX CALL SITES GREP FOR THIS EXACT LINE — `scripts/git-hooks/pre-push`,
+  # `scripts/nightly-flake-stress.sh` and three steps of `.github/workflows/
+  # test.yml` — and read its absence as a truncated or collapsed suite. A GREEN
+  # remote verdict without it blocks the push naming the wrong cause.
+  local root; root="$(setup)"
+  run_verify "$root"
+  assert_eq "a passing remote run exits 0" "0" "$RC"
+  # 3 + 3 + 1, summed across the three passes exactly as the files declare them.
+  assert_contains "and states the population it ran" "$OUT" "Test run with 7 tests passed"
+  assert_contains "in the wording the callers grep for" \
+    "$(printf '%s' "$OUT" | grep -oE 'Test run with [0-9]+ tests?' | head -1)" "Test run with 7 tests"
+  rm -rf "$root"
+}
+
+test_a_passing_run_whose_results_are_missing_refuses_rather_than_inventing() {
+  # A count no result file supports is worse than no verdict: every floor check
+  # downstream would read it as the run's real population.
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_NO_ARTIFACT=1
+  assert_eq "an uncountable pass exits 78" "78" "$RC"
+  assert_missing "and states no population" "$OUT" "Test run with"
+  rm -rf "$root"
+}
 
 test_a_failing_remote_run_renders_the_failing_tests() {
   local root; root="$(setup)"

--- a/scripts/remote-verify.test.sh
+++ b/scripts/remote-verify.test.sh
@@ -280,11 +280,32 @@ test_an_untracked_file_refuses_too() {
 }
 
 test_a_missing_gh_refuses_rather_than_falling_back_silently() {
+  # A CONSTRUCTED PATH, NOT A SYSTEM ONE. "gh lives somewhere else" is a fact
+  # about one machine, not about any machine: on a developer's mac `gh` is
+  # under `/opt/homebrew/bin`, so naming `/usr/bin:/bin` made it absent by
+  # accident, while a GitHub runner ships `/usr/bin/gh` and the same PATH finds
+  # it — the case then exercised the auth branch and could never pass on CI.
+  #
+  # The fixture bin below holds exactly the tools the script reaches for BEFORE
+  # it looks for `gh` — `dirname` to locate itself, `git` for the repository and
+  # dirty-tree checks that deliberately come first — and nothing else. An empty
+  # bin would refuse for a missing `git` instead, and the case would be testing
+  # nothing it names. `/bin/bash` is absolute because PATH is where bash would
+  # otherwise be found.
   local root; root="$(setup)"
-  OUT="$(cd "$root/work" && env PATH="/usr/bin:/bin" TBD_HOME="$root/home" bash "$SCRIPT" 2>&1)"
+  local nogh="$root/nogh-bin" tool
+  mkdir -p "$nogh"
+  for tool in git dirname; do ln -s "$(command -v "$tool")" "$nogh/$tool"; done
+  # Asserted, not assumed: a future runner image that put `gh` somewhere this
+  # bin reaches must redden here rather than quietly move the case to another
+  # branch of `check_preconditions`.
+  assert_eq "the fixture PATH really has no gh" "" "$(PATH="$nogh" command -v gh)"
+  OUT="$(cd "$root/work" && env PATH="$nogh" TBD_HOME="$root/home" /bin/bash "$SCRIPT" 2>&1)"
   RC=$?
   assert_eq "no gh exits 78" "78" "$RC"
   assert_contains "and says so" "$OUT" "gh is not installed"
+  # And it refused for the missing `gh` rather than for a hole in the fixture.
+  assert_missing "with nothing else missing from the bin" "$OUT" "command not found"
   rm -rf "$root"
 }
 

--- a/scripts/remote-verify.test.sh
+++ b/scripts/remote-verify.test.sh
@@ -152,6 +152,9 @@ case "$1 ${2:-}" in
       shift
     done
     mkdir -p "$dir"
+    # THE DOWNLOAD SUCCEEDING AND HOLDING NOTHING is a third shape, not the one
+    # above: `gh` exits 0 and the artifact has no xUnit file in it.
+    if [ -n "${STUB_GH_EMPTY_ARTIFACT:-}" ]; then printf 'no results\n' > "$dir/README.txt"; exit 0; fi
     cp "$STUB_GH_XML_DIR"/*.xml "$dir"/
     exit 0 ;;
 esac
@@ -225,6 +228,29 @@ test_the_default_branch_is_read_from_the_remote_head() {
   git -C "$root/work" symbolic-ref "refs/remotes/origin/HEAD" "refs/remotes/origin/$BRANCH"
   trunk="$(cd "$root/work" && default_branch)"
   assert_eq "and a recorded one is believed" "$BRANCH" "$trunk"
+  rm -rf "$root"
+}
+
+test_a_differently_named_trunk_is_confined_rather_than_refused() {
+  # THE LIMIT OF THE DEFAULT-BRANCH STOP, PINNED SO THE COMMENT CANNOT DRIFT.
+  # The fallback is the literal name `main`, so on a repository whose trunk is
+  # `master` and whose `origin/HEAD` was never fetched, a lane standing on trunk
+  # is NOT stopped by that comparison. Nothing is lost, because it was never the
+  # containment: `dispatch_ref_for` answers `preflight/<branch>` for every branch
+  # and `push_ref` refuses every ref outside that namespace, so trunk stays
+  # untouched anyway. This case asserts both halves — the stop does not fire, and
+  # trunk does not move.
+  local root; root="$(setup)"
+  git -C "$root/work" branch -m main master
+  git -C "$root/work" checkout -q master
+  local trunk; trunk="$(cd "$root/work" && default_branch)"
+  assert_eq "the fallback still answers main, not this repo's trunk" "main" "$trunk"
+  local head; head="$(git -C "$root/work" rev-parse HEAD)"
+  run_verify "$root"
+  assert_eq "so standing on master is verified rather than refused" "0" "$RC"
+  assert_missing "and the refusal never fired" "$OUT" "default branch"
+  assert_eq "yet the trunk itself was never pushed" "" "$(remote_sha "$root" master)"
+  assert_eq "the commit went to the inert ref instead" "$head" "$(remote_sha "$root" "preflight/master")"
   rm -rf "$root"
 }
 
@@ -490,6 +516,29 @@ test_a_failing_run_with_no_results_artifact_falls_back_to_a_local_run() {
   assert_contains "and that nothing says the tests ran" "$OUT" "published no results"
   assert_contains "and points at the run" "$OUT" "https://example.invalid/runs/4242"
   assert_missing "and never claims a failure it cannot describe" "$OUT" "run FAILED"
+  rm -rf "$root"
+}
+
+test_a_failing_run_whose_artifact_holds_no_results_falls_back_too() {
+  # THE ARTIFACT ARRIVED AND SAID NOTHING, which is the same claim as no
+  # artifact at all: no failing test to report and no population to weigh
+  # against the run's own conclusion. The green run below refuses the identical
+  # artifact, and one artifact may not mean two things.
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_CONCLUSION=failure STUB_GH_EMPTY_ARTIFACT=1
+  assert_eq "an empty artifact on a red run exits 78, not 1" "78" "$RC"
+  assert_contains "and names what was missing" "$OUT" "held no result files"
+  assert_missing "and never claims a failure it cannot describe" "$OUT" "run FAILED"
+  assert_missing "and states no population" "$OUT" "Test run with"
+  rm -rf "$root"
+}
+
+test_a_passing_run_whose_artifact_holds_no_results_refuses() {
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_EMPTY_ARTIFACT=1
+  assert_eq "the same artifact on a green run exits 78" "78" "$RC"
+  assert_contains "and names what was missing" "$OUT" "held no result files"
+  assert_missing "and invents no count" "$OUT" "Test run with"
   rm -rf "$root"
 }
 

--- a/scripts/remote-verify.test.sh
+++ b/scripts/remote-verify.test.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# Tests for scripts/remote-verify.sh — run: bash scripts/remote-verify.test.sh
+#
+# NOTHING HERE REACHES THE NETWORK, DISPATCHES A RUN, OR TOUCHES ~/tbd. Each
+# case builds a throwaway bare repo in a temp dir and points a throwaway
+# clone's `origin` at it, so every `git push` the valve makes is real and
+# lands in a fixture. `gh` is a stub first on PATH; the real one is never
+# reached, authenticated or not. `TBD_HOME` points at the same temp dir, so
+# the dispatch tickets are taken in the fixture rather than in the runtime
+# directory the live daemon and forty agent lanes share.
+#
+# The whole path runs: the real front-end, the real python driver, real flocks,
+# real pushes. Only GitHub is fake — which is the only part that must be.
+#
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F`/"$t" below
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/remote-verify.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT"   # source-guard prevents main() from running
+
+FAIL=0
+assert_eq()       { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: [$2] lacks [$3]"; FAIL=1; fi; }
+assert_missing()  { if [[ "$2" != *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: [$2] unexpectedly contains [$3]"; FAIL=1; fi; }
+mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/remote-verify-test.XXXXXX"; }
+
+# Identity and signing are pinned per-command: a developer's global
+# `commit.gpgsign` would otherwise make the fixture commits fail here (and only
+# here) with no obvious cause.
+GIT_FIXTURE=(git -c user.email=valve-test@example.invalid -c user.name="Valve Test" -c commit.gpgsign=false)
+
+BRANCH="tbd/lane"
+
+# --- fixture -----------------------------------------------------------------
+
+# mkfixture ROOT -> a bare "origin" and a clone on $BRANCH whose HEAD commit is
+# NOT yet on the remote, so a case can see exactly which ref the valve moved.
+mkfixture() {
+  local root="$1"
+  git init -q --bare "$root/origin.git"
+  git init -q -b main "$root/work"
+  git -C "$root/work" remote add origin "$root/origin.git"
+  : > "$root/work/seed"
+  "${GIT_FIXTURE[@]}" -C "$root/work" add seed
+  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -m "seed"
+  git -C "$root/work" checkout -q -b "$BRANCH"
+  git -C "$root/work" push -q origin "HEAD:refs/heads/$BRANCH"   # remote is at the seed
+  echo "later" > "$root/work/seed"
+  "${GIT_FIXTURE[@]}" -C "$root/work" add seed
+  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -m "the commit under test"
+  mkdir -p "$root/home/runtime" "$root/bin" "$root/xml"
+}
+
+# Three result files, as `test.yml` uploads them: the two fast passes and the
+# quiet pass. The element shapes are the two writers SwiftPM actually uses —
+# its own XCTest generator (flat) and Swift Testing's (indented, `<skipped />`).
+write_xml() {
+  local dir="$1"
+  cat > "$dir/xunit-daemon.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+<testsuite name="TestResults" errors="0" tests="3" failures="1" time="12.5">
+<testcase classname="TBDDaemonTests.OrphanGCTests" name="reclaimsStaleWorktrees" time="0.031"/>
+<testcase classname="TBDDaemonTests.OrphanGCTests" name="quarantinesProfileDirs" time="0.044"><failure message="expected 1 got 2"></failure></testcase>
+</testsuite>
+</testsuites>
+XML
+  cat > "$dir/xunit-app.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="TestResults" errors="0" tests="3" failures="1" time="8.25">
+    <testcase classname="TBDAppTests" name="testExample()" time="0.100"><failure message="Expectation failed: the valve stayed local" /></testcase>
+    <testcase classname="TBDAppTests" name="skippedForNow()" time="0.000"><skipped /></testcase>
+  </testsuite>
+</testsuites>
+XML
+  cat > "$dir/xunit-quiet.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="TestResults" errors="0" tests="1" failures="0" time="1.5">
+    <testcase classname="TBDDaemonLiveTests" name="attachesToTmux()" time="1.400" />
+  </testsuite>
+</testsuites>
+XML
+}
+
+# A `gh` that answers from the environment and records every call it was given,
+# so a case can assert that a dispatch did NOT happen as easily as that it did.
+stub_gh() {
+  local root="$1"
+  cat > "$root/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+[ -n "${STUB_GH_LOG:-}" ] && printf '%s\n' "$*" >> "$STUB_GH_LOG"
+conclusion="${STUB_GH_CONCLUSION:-success}"
+case "$1 ${2:-}" in
+  "auth status")
+    exit "${STUB_GH_AUTH_STATUS:-0}" ;;
+  "pr list")
+    if [ -n "${STUB_GH_PR_FAIL:-}" ]; then echo "API rate limit exceeded" >&2; exit 1; fi
+    if [ -n "${STUB_GH_PR_OPEN:-}" ]; then echo 7; fi
+    exit 0 ;;
+  "workflow run")
+    exit "${STUB_GH_DISPATCH_STATUS:-0}" ;;
+  "run list")
+    printf '[{"databaseId":4242,"headSha":"%s","status":"completed","conclusion":"%s","event":"workflow_dispatch","url":"https://example.invalid/runs/4242"}]\n' \
+      "$(git rev-parse HEAD)" "$conclusion"
+    exit 0 ;;
+  "run view")
+    printf '{"status":"completed","conclusion":"%s","url":"https://example.invalid/runs/4242","jobs":[{"name":"Test","conclusion":"%s"}]}\n' \
+      "$conclusion" "$conclusion"
+    exit 0 ;;
+  "run download")
+    if [ -n "${STUB_GH_NO_ARTIFACT:-}" ]; then echo "no artifact matches xunit-results" >&2; exit 1; fi
+    dir=""
+    while [ $# -gt 0 ]; do
+      if [ "$1" = "--dir" ]; then dir="$2"; fi
+      shift
+    done
+    mkdir -p "$dir"
+    cp "$STUB_GH_XML_DIR"/*.xml "$dir"/
+    exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$root/bin/gh"
+}
+
+# run_verify ROOT [ENV=VAL ...] — runs the real front-end in the fixture clone
+# with the stub `gh` first on PATH, leaving its combined output in OUT and its
+# status in RC. Deliberately NOT `out=$(run_verify …)`: command substitution
+# would run this in a subshell and the status would never come back.
+OUT=""
+RC=0
+run_verify() {
+  local root="$1"; shift
+  OUT="$(cd "$root/work" && env \
+    PATH="$root/bin:$PATH" \
+    TBD_HOME="$root/home" \
+    STUB_GH_LOG="$root/gh.log" \
+    STUB_GH_XML_DIR="$root/xml" \
+    TBD_REMOTE_VERIFY_POLL_SECONDS=0.01 \
+    TBD_REMOTE_VERIFY_CORRELATE_SECONDS=2 \
+    TBD_REMOTE_VERIFY_RUN_SECONDS=2 \
+    "$@" bash "$SCRIPT" 2>&1)"
+  RC=$?
+}
+
+# What the fixture remote holds for a ref, or nothing.
+remote_sha() { git -C "$1/work" ls-remote origin "refs/heads/$2" | awk '{print $1}'; }
+gh_calls()   { cat "$1/gh.log" 2>/dev/null; }
+
+setup() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root"
+  stub_gh "$root"
+  write_xml "$root/xml"
+  printf '%s\n' "$root"
+}
+
+# --- ref choice, at the unit level -------------------------------------------
+
+test_dispatch_ref_for_uses_the_branch_when_no_pr_is_open() {
+  local root; root="$(setup)"
+  local ref; ref="$(cd "$root/work" && PATH="$root/bin:$PATH" dispatch_ref_for "$BRANCH")"
+  assert_eq "no open PR dispatches the branch itself" "$BRANCH" "$ref"
+  rm -rf "$root"
+}
+
+test_dispatch_ref_for_uses_an_inert_ref_when_a_pr_is_open() {
+  local root; root="$(setup)"
+  local ref; ref="$(cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_PR_OPEN=1 dispatch_ref_for "$BRANCH")"
+  assert_eq "an open PR dispatches a preflight ref" "preflight/$BRANCH" "$ref"
+  rm -rf "$root"
+}
+
+test_dispatch_ref_for_refuses_when_the_query_fails() {
+  local root; root="$(setup)"
+  local status=0
+  (cd "$root/work" && PATH="$root/bin:$PATH" STUB_GH_PR_FAIL=1 dispatch_ref_for "$BRANCH") >/dev/null 2>&1 || status=$?
+  assert_eq "a failed PR query is not read as 'no PR'" "2" "$status"
+  rm -rf "$root"
+}
+
+# --- preconditions: every refusal names itself and exits 78 ------------------
+
+test_a_dirty_tree_refuses_and_stays_local() {
+  local root; root="$(setup)"
+  echo "uncommitted work" >> "$root/work/seed"
+  run_verify "$root"
+  assert_eq "dirty tree exits 78" "78" "$RC"
+  assert_contains "and names the condition" "$OUT" "uncommitted"
+  assert_missing "and dispatches nothing" "$(gh_calls "$root")" "workflow run"
+  rm -rf "$root"
+}
+
+test_an_untracked_file_refuses_too() {
+  local root; root="$(setup)"
+  : > "$root/work/NewTests.swift"
+  run_verify "$root"
+  assert_eq "untracked file exits 78" "78" "$RC"
+  assert_contains "and names the condition" "$OUT" "uncommitted"
+  rm -rf "$root"
+}
+
+test_a_missing_gh_refuses_rather_than_falling_back_silently() {
+  local root; root="$(setup)"
+  OUT="$(cd "$root/work" && env PATH="/usr/bin:/bin" TBD_HOME="$root/home" bash "$SCRIPT" 2>&1)"
+  RC=$?
+  assert_eq "no gh exits 78" "78" "$RC"
+  assert_contains "and says so" "$OUT" "gh is not installed"
+  rm -rf "$root"
+}
+
+test_an_unauthenticated_gh_refuses() {
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_AUTH_STATUS=1
+  assert_eq "unauthenticated gh exits 78" "78" "$RC"
+  assert_contains "and says so" "$OUT" "not authenticated"
+  rm -rf "$root"
+}
+
+test_a_detached_head_refuses() {
+  local root; root="$(setup)"
+  git -C "$root/work" checkout -q --detach
+  run_verify "$root"
+  assert_eq "detached HEAD exits 78" "78" "$RC"
+  assert_contains "and says so" "$OUT" "detached"
+  rm -rf "$root"
+}
+
+test_a_failed_pr_query_refuses_without_pushing() {
+  local root; root="$(setup)"
+  local before; before="$(remote_sha "$root" "$BRANCH")"
+  run_verify "$root" STUB_GH_PR_FAIL=1
+  assert_eq "an unanswerable PR query exits 78" "78" "$RC"
+  assert_eq "and the PR branch is untouched" "$before" "$(remote_sha "$root" "$BRANCH")"
+  assert_missing "and nothing was dispatched" "$(gh_calls "$root")" "workflow run"
+  rm -rf "$root"
+}
+
+# --- which ref gets pushed ---------------------------------------------------
+
+test_a_branch_with_no_pr_is_pushed_and_dispatched() {
+  local root; root="$(setup)"
+  local head; head="$(git -C "$root/work" rev-parse HEAD)"
+  run_verify "$root"
+  assert_eq "a passing remote run exits 0" "0" "$RC"
+  assert_eq "the branch itself was pushed" "$head" "$(remote_sha "$root" "$BRANCH")"
+  assert_eq "no inert ref was created" "" "$(remote_sha "$root" "preflight/$BRANCH")"
+  assert_contains "and the dispatch named the branch" "$(gh_calls "$root")" "workflow run test.yml --ref $BRANCH"
+  rm -rf "$root"
+}
+
+test_an_open_pr_pushes_an_inert_ref_and_leaves_the_pr_branch_alone() {
+  local root; root="$(setup)"
+  local head before
+  head="$(git -C "$root/work" rev-parse HEAD)"
+  before="$(remote_sha "$root" "$BRANCH")"
+  run_verify "$root" STUB_GH_PR_OPEN=1
+  assert_eq "a passing remote run exits 0" "0" "$RC"
+  assert_eq "the inert ref carries the commit" "$head" "$(remote_sha "$root" "preflight/$BRANCH")"
+  assert_eq "the PR branch never moved" "$before" "$(remote_sha "$root" "$BRANCH")"
+  assert_contains "and the dispatch named the inert ref" "$(gh_calls "$root")" "--ref preflight/$BRANCH"
+  rm -rf "$root"
+}
+
+test_an_inert_ref_survives_a_rewritten_commit() {
+  # Amending or rebasing between two verifications leaves the throwaway ref on
+  # a commit the new HEAD does not descend from. The ref is inert and belongs
+  # to nobody, so it is forced; without that this lane could never verify
+  # again after a rebase.
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_PR_OPEN=1
+  git -C "$root/work" reset -q --hard HEAD~1
+  echo "a rewritten commit" > "$root/work/seed"
+  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -am "rewritten"
+  local head; head="$(git -C "$root/work" rev-parse HEAD)"
+  run_verify "$root" STUB_GH_PR_OPEN=1
+  assert_eq "the second run exits 0" "0" "$RC"
+  assert_eq "and the inert ref moved to the rewritten commit" "$head" "$(remote_sha "$root" "preflight/$BRANCH")"
+  rm -rf "$root"
+}
+
+test_a_real_branch_is_never_force_pushed() {
+  # The other half of the same rule. A branch somebody else may be reading is
+  # not this lane's to rewrite: a non-fast-forward push refuses and the lane
+  # goes back to the local queue rather than discarding work to run a test.
+  local root; root="$(setup)"
+  run_verify "$root"
+  local pushed; pushed="$(remote_sha "$root" "$BRANCH")"
+  git -C "$root/work" reset -q --hard HEAD~1
+  echo "a rewritten commit" > "$root/work/seed"
+  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -am "rewritten"
+  run_verify "$root"
+  assert_eq "a non-fast-forward branch push refuses" "78" "$RC"
+  assert_contains "and names it" "$OUT" "could not push"
+  assert_eq "the branch on the remote is untouched" "$pushed" "$(remote_sha "$root" "$BRANCH")"
+  rm -rf "$root"
+}
+
+# --- the verdict -------------------------------------------------------------
+
+test_a_failing_remote_run_renders_the_failing_tests() {
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_CONCLUSION=failure
+  assert_eq "a failing remote run exits 1" "1" "$RC"
+  assert_contains "names the failing job" "$OUT" "failing jobs: Test"
+  assert_contains "names a test from the first pass" "$OUT" "TBDDaemonTests.OrphanGCTests.quarantinesProfileDirs"
+  assert_contains "and its message" "$OUT" "expected 1 got 2"
+  assert_contains "names a test from the second pass" "$OUT" "TBDAppTests.testExample()"
+  assert_contains "and its message" "$OUT" "the valve stayed local"
+  assert_contains "counts both" "$OUT" "2 failing tests"
+  rm -rf "$root"
+}
+
+test_a_run_that_published_fewer_files_still_renders_what_it_has() {
+  local root; root="$(setup)"
+  rm "$root/xml/xunit-app.xml" "$root/xml/xunit-quiet.xml"
+  run_verify "$root" STUB_GH_CONCLUSION=failure
+  assert_eq "still exits 1" "1" "$RC"
+  assert_contains "renders the one file it got" "$OUT" "quarantinesProfileDirs"
+  assert_contains "and says how many files it read" "$OUT" "1 result file(s)"
+  rm -rf "$root"
+}
+
+test_a_truncated_result_file_is_named_rather_than_read_as_green() {
+  local root; root="$(setup)"
+  rm "$root/xml/xunit-app.xml"
+  printf '<?xml version="1.0"?>\n<testsuites>\n  <testsuite name="TestResults"><testcase classname="A" name="di' \
+    > "$root/xml/xunit-daemon.xml"
+  run_verify "$root" STUB_GH_CONCLUSION=failure
+  assert_eq "still exits 1" "1" "$RC"
+  assert_contains "the half-written file is named" "$OUT" "xunit-daemon.xml — unreadable"
+  rm -rf "$root"
+}
+
+test_a_failing_run_with_no_results_artifact_still_fails_loudly() {
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_CONCLUSION=failure STUB_GH_NO_ARTIFACT=1
+  assert_eq "a failing run with no artifact still exits 1" "1" "$RC"
+  assert_contains "says the results could not be had" "$OUT" "could not download"
+  assert_contains "and points at the run" "$OUT" "https://example.invalid/runs/4242"
+  rm -rf "$root"
+}
+
+test_a_run_with_no_verdict_returns_the_lane_to_the_local_queue() {
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_CONCLUSION=cancelled
+  assert_eq "a cancelled run exits 78, not 1" "78" "$RC"
+  assert_contains "and says why" "$OUT" "no verdict"
+  rm -rf "$root"
+}
+
+test_a_dispatch_that_fails_refuses() {
+  local root; root="$(setup)"
+  run_verify "$root" STUB_GH_DISPATCH_STATUS=1
+  assert_eq "a failed dispatch exits 78" "78" "$RC"
+  assert_contains "and names it" "$OUT" "could not dispatch"
+  rm -rf "$root"
+}
+
+# --- the ticket pool, from the front-end -------------------------------------
+
+test_no_ticket_refuses_without_pushing_or_dispatching() {
+  # The ordering guarantee, end to end: a lane that never got a ticket leaves
+  # no ref behind on the remote and spends no dispatch.
+  local root; root="$(setup)"
+  local before; before="$(remote_sha "$root" "$BRANCH")"
+  run_verify "$root" TBD_REMOTE_VERIFY_SLOTS=0
+  assert_eq "no ticket exits 78" "78" "$RC"
+  assert_contains "and says the slots are in flight" "$OUT" "dispatch slots are in flight"
+  assert_eq "the branch was not pushed" "$before" "$(remote_sha "$root" "$BRANCH")"
+  assert_missing "and nothing was dispatched" "$(gh_calls "$root")" "workflow run"
+  rm -rf "$root"
+}
+
+test_the_ticket_is_released_when_the_run_is_over() {
+  local root; root="$(setup)"
+  run_verify "$root"
+  assert_eq "the first run passed" "0" "$RC"
+  run_verify "$root" TBD_REMOTE_VERIFY_SLOTS=1
+  assert_eq "a later lane still gets the only ticket" "0" "$RC"
+  rm -rf "$root"
+}
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done
+exit $FAIL

--- a/scripts/remote_verify.py
+++ b/scripts/remote_verify.py
@@ -758,16 +758,24 @@ def failures_in(path: Path) -> list[Failure]:
 class Report:
     """What the result files said, and how to print it.
 
+    `files` is how many result files this report describes, readable ones and
+    unreadable ones alike. Zero is a report about nothing — an artifact that
+    arrived holding no xUnit file at all — and is a different claim from a
+    report over files that recorded no failures. It is carried rather than
+    inferred because every other field of an empty report is indistinguishable
+    from a clean one: no total, no unreadable names, no population.
+
     `tests` is the population the run actually executed, summed across the
-    files, and is None when no file said — an artifact that never arrived, or
-    one whose every file was unreadable.  None is not zero: a caller that needs
-    to state how many tests ran must refuse rather than publish a number no
-    file supports.
+    files, and is None when no file said — an artifact that never arrived, one
+    that held no result file, or one whose every file was unreadable.  None is
+    not zero: a caller that needs to state how many tests ran must refuse
+    rather than publish a number no file supports.
     """
 
     total: int
     unreadable: tuple[str, ...]
     lines: tuple[str, ...]
+    files: int
     tests: int | None = None
 
 
@@ -797,7 +805,15 @@ def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES)
             sections.append((path, failures))
 
     lines: list[str] = []
-    if total:
+    if not paths:
+        # SAID SEPARATELY FROM "no failing tests", because it is not a statement
+        # about the tests at all: no file arrived to make one. The line below
+        # would otherwise read as "the passes ran and came back clean".
+        lines.append(
+            "remote-verify: no result files were published, so nothing here says "
+            "whether a single test ran"
+        )
+    elif total:
         plural = "" if total == 1 else "s"
         lines.append(
             f"remote-verify: {total} failing test{plural} "
@@ -830,6 +846,7 @@ def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES)
         total=total,
         unreadable=tuple(path.name for path, _ in unreadable),
         lines=tuple(lines),
+        files=len(paths),
         tests=tests,
     )
 
@@ -863,10 +880,23 @@ def verdict_from_results(results: Report | None) -> int:
     - **Readable results that state no population** — `EXIT_FAILED`. Files
       arrived, they record nothing failing, and they will not say how many tests
       ran; that is too little to set against the run's own conclusion, so the
-      conclusion stands.
+      conclusion stands. The distinction from the case below is the file: a pass
+      wrote something here, and a writer that emitted a result element without a
+      `tests=` attribute is a shape neither of SwiftPM's writers produces, so
+      what arrived is not the artifact of a run that never started.
     - **No results at all** — `EXIT_REFUSED`, and this is the case that must not
-      be a failure. `test.yml`'s test job runs eight fallible setup steps before
-      it reaches the first `scripts/test.sh` — checkout, mtime restore, `brew
+      be a failure. It covers both an artifact that never arrived and one that
+      arrived holding no result file (`files == 0`): a report describing no file
+      is a report about nothing, and it must not fall through to the branch above
+      on the strength of a population no file was ever asked for. That the two
+      are one case here is the point — the green path's `_write_pass_report`
+      already refuses both on `tests is None`, and the same downloaded artifact
+      must not be "no verdict" for a run that passed and "your suite is red" for
+      one that failed. Only `actions/upload-artifact`'s `if-no-files-found: warn`
+      keeps the second shape off the wire today, by publishing no artifact when
+      nothing matches; that is a third party's behavior, not a guard of ours.
+      `test.yml`'s test job runs eight fallible setup steps before it reaches
+      the first `scripts/test.sh` — checkout, mtime restore, `brew
       install tmux`, `xcode-select`, toolchain capture, cache restore, workspace
       repair, force rebuild — and any one of them failing means zero tests ran,
       no xUnit file was written and no artifact was uploaded. `brew install`
@@ -892,7 +922,7 @@ def verdict_from_results(results: Report | None) -> int:
     themselves instead. Failing job names are still reported to the operator —
     they just do not get to decide what the tests did.
     """
-    if results is None:
+    if results is None or not results.files:
         return EXIT_REFUSED
     if results.total or results.unreadable:
         return EXIT_FAILED
@@ -1054,10 +1084,17 @@ def drive(
             if verdict_from_results(results) == EXIT_REFUSED:
                 jobs = failed_job_names(completed)
                 attribution = f" (failing jobs: {', '.join(jobs)})" if jobs else ""
-                if results is None:
+                # An artifact holding no result file says exactly what a missing
+                # artifact says, so it is refused in the same words. Reaching the
+                # message below with it would print "every one of the None tests
+                # it ran passed".
+                if results is None or not results.files:
+                    cause = problem or (
+                        f"the {RESULTS_ARTIFACT} artifact held no result files"
+                    )
                     raise Refused(
                         f"run {run_id} finished failure and published no results "
-                        f"({problem}){attribution}, so nothing says its tests ran "
+                        f"({cause}){attribution}, so nothing says its tests ran "
                         "at all, let alone failed; re-running locally is the only "
                         f"honest answer {url}".rstrip()
                     )
@@ -1144,9 +1181,16 @@ def _write_pass_report(
     low.
     """
     if results is None or results.tests is None:
-        detail = problem or (
-            f"the {RESULTS_ARTIFACT} artifact named no test population"
-        )
+        # `problem` names a download that failed; the two branches under it are
+        # an artifact that arrived and still said nothing — grouped exactly as
+        # `verdict_from_results` groups them, so a caller reading a green refusal
+        # and a red one about the same artifact reads the same cause.
+        if problem:
+            detail = problem
+        elif results is None or not results.files:
+            detail = f"the {RESULTS_ARTIFACT} artifact held no result files"
+        else:
+            detail = f"the {RESULTS_ARTIFACT} artifact named no test population"
         raise Refused(
             f"run {run_id} passed but its results could not be counted "
             f"({detail}), so the test population cannot be stated {url}".rstrip()
@@ -1236,8 +1280,9 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         description=(
             "Exits 1 when the results record failures or cannot be believed, and "
             f"{EXIT_REFUSED} when they record a complete, empty set of failures "
-            "over a stated population — no test verdict. Same mapping the driver "
-            "uses; see verdict_from_results."
+            "over a stated population, or when there is no result file to read "
+            "at all — no test verdict either way. Same mapping the driver uses; "
+            "see verdict_from_results."
         ),
     )
     renderer.add_argument("paths", nargs="+")

--- a/scripts/remote_verify.py
+++ b/scripts/remote_verify.py
@@ -46,9 +46,10 @@ somewhere that cannot make it up.
 A FAILED RUN IS NOT THE SAME CLAIM AS A FAILED SUITE. `test.yml` holds four jobs
 with no `needs:` between them — lint, the committed-plans guard, the review-script
 tests and the test job — plus a `swift build` step after the results are uploaded,
-and `scripts/test.sh` runs none of that locally. So the results decide what the
-tests did, not the run's conclusion: `verdict_from_results` is the one authority
-on that, and both subcommands read it.
+and eight fallible setup steps before the first `scripts/test.sh`; and
+`scripts/test.sh` runs none of that locally. So a red run only becomes a red
+suite if its results say so: `verdict_from_results` decides that, on the red
+path, for both subcommands.
 """
 
 from __future__ import annotations
@@ -834,13 +835,17 @@ def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES)
 
 
 def verdict_from_results(results: Report | None) -> int:
-    """What a run's result files support as a verdict about the tests.
+    """Whether a run GitHub called red may be reported as a failing suite.
 
-    THE ONE AUTHORITY, AND BOTH SUBCOMMANDS READ IT. `drive` and `render` look
-    at the same files and must not disagree about what they mean; `drive` is the
-    consumer that matters, because `scripts/test.sh` adopts its status as the
-    run's own, and `render` exists to show a human what `drive` saw. So the
-    mapping lives here rather than at either call site.
+    WHAT THIS ACTUALLY GOVERNS IS THE RED PATH, and both subcommands consult it
+    there so the two cannot disagree about one artifact: `drive` reaches it only
+    after `verdict_for` said the run failed, and `render` — which has no run
+    conclusion of its own — reads every artifact through it. It deliberately
+    governs nothing on the green path. A run whose every test step exited 0 is
+    green even when a file records a `<failure>`, because a recorded failure
+    under a step that passed is a known-issue record rather than a real one; so
+    `_write_pass_report` reads `results.tests` straight off the report and asks
+    nothing here.
 
     - **Failures recorded, or a file that cannot be believed** — `EXIT_FAILED`.
       A truncated pass is unreadable rather than empty and must never be read as
@@ -855,10 +860,31 @@ def verdict_from_results(results: Report | None) -> int:
       gave. 78 sends the lane back to the local queue, where it gets an answer
       to its own question. Inventing red is precisely what `verdict_for` refuses
       to do for a cancelled run, on the same reasoning.
-    - **Nothing that states a population** — `EXIT_FAILED`. No artifact, or an
-      artifact silent about how many tests ran, is no evidence at all, so there
-      is nothing to set against the run's own conclusion and the conclusion
-      stands.
+    - **Readable results that state no population** — `EXIT_FAILED`. Files
+      arrived, they record nothing failing, and they will not say how many tests
+      ran; that is too little to set against the run's own conclusion, so the
+      conclusion stands.
+    - **No results at all** — `EXIT_REFUSED`, and this is the case that must not
+      be a failure. `test.yml`'s test job runs eight fallible setup steps before
+      it reaches the first `scripts/test.sh` — checkout, mtime restore, `brew
+      install tmux`, `xcode-select`, toolchain capture, cache restore, workspace
+      repair, force rebuild — and any one of them failing means zero tests ran,
+      no xUnit file was written and no artifact was uploaded. `brew install`
+      flaking on a hosted runner is ordinary weather, and reporting that as a red
+      suite tells a caller its tests failed when they never started, with no
+      local fallback to correct it. Every case that lands here is answered
+      correctly by 78: setup failed (nothing ran); the compile failed (the local
+      re-run reproduces the error properly); the tests really did fail but the
+      upload broke (the local re-run finds the real failures); cancelled (already
+      78, via `verdict_for`). The cost is one local re-run when a genuinely red
+      run loses its artifact, which is the trade every other refusal here makes,
+      and `unreadable` above still covers "a file exists and cannot be believed".
+
+      It also defuses a hazard that arrives from the other end of the valve: a
+      `preflight/*` ref swept out from under a run still queued on GitHub makes
+      that run fail at `actions/checkout`, before any test step and before any
+      artifact. That is now a benign fallback to the local queue rather than a
+      fabricated red suite.
 
     DELIBERATELY NOT KEYED ON WHICH JOBS WERE RED. Deciding this from job names
     would hardcode `test.yml`'s job list here, and a renamed or added job is the
@@ -867,7 +893,7 @@ def verdict_from_results(results: Report | None) -> int:
     they just do not get to decide what the tests did.
     """
     if results is None:
-        return EXIT_FAILED
+        return EXIT_REFUSED
     if results.total or results.unreadable:
         return EXIT_FAILED
     if results.tests is None:
@@ -1019,15 +1045,22 @@ def drive(
                     results, problem=problem, run_id=run_id, url=str(url), write=write
                 )
                 return EXIT_PASSED
-            # A RED RUN WHOSE TESTS ALL PASSED IS NOT A TEST FAILURE. The files,
-            # not the conclusion, are the authority here; `verdict_from_results`
-            # says why, and answering 78 rather than 1 is the difference between
+            # A RED RUN IS NOT THE SAME CLAIM AS A RED SUITE. The files, not the
+            # conclusion, decide that; `verdict_from_results` says why for each
+            # shape, and answering 78 rather than 1 is the difference between
             # sending this lane back to the local queue and telling the operator
             # a suite is red that `scripts/test.sh` never even runs the failing
-            # part of.
+            # part of — or never ran at all.
             if verdict_from_results(results) == EXIT_REFUSED:
                 jobs = failed_job_names(completed)
                 attribution = f" (failing jobs: {', '.join(jobs)})" if jobs else ""
+                if results is None:
+                    raise Refused(
+                        f"run {run_id} finished failure and published no results "
+                        f"({problem}){attribution}, so nothing says its tests ran "
+                        "at all, let alone failed; re-running locally is the only "
+                        f"honest answer {url}".rstrip()
+                    )
                 raise Refused(
                     f"run {run_id} finished failure, but every one of the "
                     f"{results.tests} tests it ran passed{attribution}, so the "
@@ -1035,7 +1068,7 @@ def drive(
                     f"this suite {url}".rstrip()
                 )
             _write_failure_report(
-                results, problem=problem, url=str(url), completed=completed,
+                results, url=str(url), completed=completed,
                 narrowed=narrowed, write=write,
             )
             return EXIT_FAILED
@@ -1099,6 +1132,16 @@ def _write_pass_report(
     exists to prevent, and claiming green with no line at all reaches the
     caller as a truncated run. Both cost a local re-run; inventing a count
     costs a wrong answer.
+
+    AN UNREADABLE FILE ALONGSIDE READABLE ONES SHORT-COUNTS THE LINE, AND IS
+    SAID OUT LOUD RATHER THAN REFUSED. `render_results` sums only the files it
+    could parse, so a green run that published one half-written file states a
+    population smaller than the one it ran. The direction is the safe one — a
+    number too small can only fail a floor, never falsely clear one — so
+    refusing here would spend a local re-run to correct an error that cannot
+    mislead anybody. It is still named, because a caller whose floor fails on a
+    green remote run would otherwise have no way to see why the number was
+    low.
     """
     if results is None or results.tests is None:
         detail = problem or (
@@ -1109,19 +1152,28 @@ def _write_pass_report(
             f"({detail}), so the test population cannot be stated {url}".rstrip()
         )
     write(_test_run_summary(results.tests, "passed"))
+    if results.unreadable:
+        write(
+            f"remote-verify: {len(results.unreadable)} result file(s) could not "
+            f"be read ({', '.join(results.unreadable)}), so the population above "
+            "counts only the passes that reported and is a floor, not the whole run"
+        )
     write(f"remote-verify: the remote run passed {url}".rstrip())
 
 
 def _write_failure_report(
-    results: Report | None,
+    results: Report,
     *,
-    problem: str | None,
     url: str,
     completed: Mapping[str, object],
     narrowed: bool,
     write: Callable[[str], None],
 ) -> None:
     """Print a red run's failures, and its population only if anybody may read it.
+
+    `results` is a real report rather than an optional one: a run that published
+    nothing is no evidence about the tests, so `drive` refuses it before reaching
+    here instead of announcing a failure it cannot describe.
 
     THE COUNT LINE IS SUPPRESSED FOR A NARROWED CALLER, and that is a guard
     rather than tidiness. Six consumers grep `Test run with [0-9]+ tests?` and
@@ -1141,10 +1193,6 @@ def _write_failure_report(
     jobs = failed_job_names(completed)
     if jobs:
         write(f"remote-verify: failing jobs: {', '.join(jobs)}")
-    if results is None:
-        write(f"remote-verify: {problem}")
-        write("remote-verify: open the run above for the failure")
-        return
     # Stated when it is known, this run is the one being reported, and it is not
     # a narrowed caller's; omitted otherwise. See the docstring.
     if results.tests is not None and not narrowed:
@@ -1204,8 +1252,10 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         report = render_results(paths)
         for line in report.lines:
             print(line)
-        # THE SAME AUTHORITY THE DRIVER USES, so the two cannot disagree about
-        # one artifact. This used to answer 0 for "no failures", which read as
+        # THE SAME MAPPING THE DRIVER READS ON THE RED PATH, so the two cannot
+        # disagree about one artifact. `render` has no conclusion to weigh, so it
+        # applies that mapping to every artifact it is given. This used to answer
+        # 0 for "no failures", which read as
         # "the tests passed" for the state the driver calls no verdict at all —
         # a red run whose passes all reported clean. `render` never answers 0
         # now: it has no run conclusion to weigh, so the strongest thing a set of

--- a/scripts/remote_verify.py
+++ b/scripts/remote_verify.py
@@ -2,11 +2,18 @@
 the machine-global build slot.
 
 THE TICKET POOL IS LOCAL ON PURPOSE. Every contender runs on this one laptop,
-so a local lock file arbitrates GitHub's capacity authoritatively — there is no
-distributed consensus problem here. GitHub caps five concurrent macOS jobs per
+so a local lock file can bound how many remote runs exist at once with no
+distributed consensus anywhere. GitHub caps five concurrent macOS jobs per
 account and `test.yml` spends two per run, so roughly two runs fit; without this
 bound every queued lane would dispatch at once into a queue TBD cannot observe,
 prioritise, or abandon.
+
+That bound is only as strong as the slot count every lane reads, and it is worth
+stating honestly rather than claiming the pool arbitrates capacity outright: a
+lane probes tickets 1..N for its own N, so a lane configured higher than its
+siblings takes tickets they never look at and the effective pool is the largest
+N any lane configures. `configured_slots` is where that constraint is bounded,
+and why the setting has a ceiling.
 
 The ticket is an flock rather than a hand-rolled occupancy file: the kernel
 releases it when this process exits by any means, so a ticket cannot outlive its
@@ -35,6 +42,13 @@ failure. So the workflow uploads xUnit XML and this module parses it. The same
 files carry the run's population, which is why a green run downloads them too:
 the verdict a caller reads is `Test run with N tests`, and N has to come from
 somewhere that cannot make it up.
+
+A FAILED RUN IS NOT THE SAME CLAIM AS A FAILED SUITE. `test.yml` holds four jobs
+with no `needs:` between them — lint, the committed-plans guard, the review-script
+tests and the test job — plus a `swift build` step after the results are uploaded,
+and `scripts/test.sh` runs none of that locally. So the results decide what the
+tests did, not the run's conclusion: `verdict_from_results` is the one authority
+on that, and both subcommands read it.
 """
 
 from __future__ import annotations
@@ -56,6 +70,9 @@ import time
 
 SLOTS_SETTING = "TBD_REMOTE_VERIFY_SLOTS"
 DEFAULT_SLOTS = 2
+# The ceiling on that setting: GitHub's own per-account macOS job concurrency.
+# See `configured_slots` for why a per-lane setting needs one at all.
+MAX_SLOTS = 5
 
 WORKFLOW_FILE = "test.yml"
 RESULTS_ARTIFACT = "xunit-results"
@@ -119,6 +136,19 @@ def configured_slots(environ: Mapping[str, str] | None = None) -> int:
     the sizing the spec measured. An unreadable value is refused by name rather
     than quietly falling back: silently sizing the pool differently from what
     somebody asked for is how a stampede gets shipped.
+
+    THE POOL IS ONLY AS AUTHORITATIVE AS THE VALUE EVERY LANE READS, and this
+    setting is per-lane. A lane probes tickets 1..N for its own N, so a lane set
+    to 4 takes tickets 3 and 4 that default lanes never look at: the effective
+    pool across the fleet is the *largest* N anybody configures, not the
+    smallest and not an average. Nothing here can fix that — a lane cannot know
+    what its siblings chose — so the exposure is bounded instead. `MAX_SLOTS`
+    caps how far one lane's private pool can reach, and a value above it is
+    refused by name rather than clamped, because a clamp is exactly the "sizing
+    the pool differently from what somebody asked for" this function refuses to
+    do elsewhere. 5 is GitHub's own per-account macOS concurrency, so past it a
+    ticket bounds nothing anyway: the run it authorises simply queues on
+    GitHub's side, where TBD can neither see it nor abandon it.
     """
     environ = os.environ if environ is None else environ
     raw = environ.get(SLOTS_SETTING, "")
@@ -130,6 +160,12 @@ def configured_slots(environ: Mapping[str, str] | None = None) -> int:
         raise ValueError(f"{SLOTS_SETTING} must be a whole number, not {raw!r}") from None
     if slots < 0:
         raise ValueError(f"{SLOTS_SETTING} must not be negative, but is {slots}")
+    if slots > MAX_SLOTS:
+        raise ValueError(
+            f"{SLOTS_SETTING}={slots} exceeds {MAX_SLOTS}, GitHub's per-account "
+            "macOS job concurrency; a larger pool would dispatch runs that only "
+            "queue where TBD cannot see them"
+        )
     return slots
 
 
@@ -606,7 +642,9 @@ class _ResultParser(HTMLParser):
         self.fallback_classname = fallback_classname
         self.failures: list[Failure] = []
         self.root_opened = False
-        self.root_closed = False
+        # How many result elements are currently open: a `<testsuites>` wrapper
+        # and each `<testsuite>` inside it. See `root_closed`.
+        self._depth = 0
         # None until a `<testsuite tests=…>` says otherwise: a file that
         # declared no population must not be read as one declaring zero.
         self.tests: int | None = None
@@ -615,10 +653,28 @@ class _ResultParser(HTMLParser):
         self._message: str | None = None
         self._text: list[str] = []
 
+    @property
+    def root_closed(self) -> bool:
+        """True only when every result element that opened has closed again.
+
+        A DEPTH COUNTER, NOT A LATCH ON THE FIRST CLOSING TAG. A file holding
+        several `<testsuite>`s and truncated after the first one closes would
+        otherwise read as complete — and worse than merely complete, because the
+        second suite's `tests=` attribute is already summed into the population
+        by then, so the number reported would describe cases that never arrived.
+        Today's SwiftPM writes one `<testsuite>` per file, so no live artifact
+        reaches that shape and this is not a bug anybody has been bitten by; it
+        is fixed because `results_in` promises to detect truncation
+        unconditionally, and a promise that holds only for the current writer's
+        output holds by luck.
+        """
+        return self.root_opened and self._depth == 0
+
     def handle_starttag(self, tag, attrs):
         values = {name: value or "" for name, value in attrs}
         if tag in ("testsuites", "testsuite"):
             self.root_opened = True
+            self._depth += 1
             # Counted from `<testsuite>` alone. Both writers put the population
             # there, and a `<testsuites>` wrapper that repeats it would double
             # every number if it were added in too.
@@ -645,7 +701,9 @@ class _ResultParser(HTMLParser):
         elif tag == "testcase":
             self._case = {}
         elif tag in ("testsuites", "testsuite"):
-            self.root_closed = True
+            # Floored at zero so a stray closing tag cannot cancel out a later
+            # element that never closed, which would read as complete again.
+            self._depth = max(0, self._depth - 1)
 
     def _record(self, message: str) -> None:
         failure = Failure(
@@ -675,9 +733,10 @@ def results_in(path: Path) -> Results:
     Testing's own generator emits the same elements indented with `<skipped />`
     for a disabled test. A passing case carries no failure child and is ignored.
 
-    Raises `MalformedResults` for a file that opened no result element or never
-    closed one — an empty or half-written file, which a run that was killed
-    mid-pass leaves behind.
+    Raises `MalformedResults` for a file that opened no result element or left
+    one open — an empty or half-written file, which a run that was killed
+    mid-pass leaves behind. "Left one open" is counted rather than latched; see
+    `_ResultParser.root_closed`.
     """
     parser = _ResultParser(fallback_classname=path.stem)
     parser.feed(path.read_text(encoding="utf-8", errors="replace"))
@@ -774,6 +833,48 @@ def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES)
     )
 
 
+def verdict_from_results(results: Report | None) -> int:
+    """What a run's result files support as a verdict about the tests.
+
+    THE ONE AUTHORITY, AND BOTH SUBCOMMANDS READ IT. `drive` and `render` look
+    at the same files and must not disagree about what they mean; `drive` is the
+    consumer that matters, because `scripts/test.sh` adopts its status as the
+    run's own, and `render` exists to show a human what `drive` saw. So the
+    mapping lives here rather than at either call site.
+
+    - **Failures recorded, or a file that cannot be believed** — `EXIT_FAILED`.
+      A truncated pass is unreadable rather than empty and must never be read as
+      a claim that nothing failed.
+    - **A stated population and nothing failing** — `EXIT_REFUSED`: no verdict.
+      Every pass that reported ran tests and none of them failed, so whatever
+      made the run red is not a test. `test.yml` holds four jobs with no
+      `needs:` between them and a `swift build` step after the results upload,
+      and `scripts/test.sh` runs none of that locally — so reporting red here
+      would fail a lane for a SwiftLint violation or a committed plan file it
+      cannot even see, and reporting green would adopt a pass the run never
+      gave. 78 sends the lane back to the local queue, where it gets an answer
+      to its own question. Inventing red is precisely what `verdict_for` refuses
+      to do for a cancelled run, on the same reasoning.
+    - **Nothing that states a population** — `EXIT_FAILED`. No artifact, or an
+      artifact silent about how many tests ran, is no evidence at all, so there
+      is nothing to set against the run's own conclusion and the conclusion
+      stands.
+
+    DELIBERATELY NOT KEYED ON WHICH JOBS WERE RED. Deciding this from job names
+    would hardcode `test.yml`'s job list here, and a renamed or added job is the
+    exact drift that made this function necessary; result files describe
+    themselves instead. Failing job names are still reported to the operator —
+    they just do not get to decide what the tests did.
+    """
+    if results is None:
+        return EXIT_FAILED
+    if results.total or results.unreadable:
+        return EXIT_FAILED
+    if results.tests is None:
+        return EXIT_FAILED
+    return EXIT_REFUSED
+
+
 def download_results(
     run_command: RunCommand, run_id: str, destination: Path
 ) -> tuple[list[Path], str | None]:
@@ -847,6 +948,7 @@ def drive(
     *,
     ref: str,
     sha: str,
+    narrowed: bool,
     runtime_dir: Path,
     slots: int,
     run_command: RunCommand,
@@ -864,6 +966,11 @@ def drive(
     Order is the point: ticket, then baseline, then push, then dispatch.
     Nothing durable and nothing metered happens until this lane is one of the
     two the pool allows.
+
+    `narrowed` says the caller selected a subset of the suite, so it will not
+    adopt a failing whole-suite verdict. It is required and keyword-only rather
+    than defaulted: a call site that forgot it would silently publish a test
+    count the caller's floor checks then misread — see `_write_failure_report`.
 
     NO ESCAPING EXCEPTION MAY BECOME EXIT 1. `scripts/test.sh` adopts this
     status as the run's own, so a `1` from an unhandled OSError, a killed
@@ -912,8 +1019,24 @@ def drive(
                     results, problem=problem, run_id=run_id, url=str(url), write=write
                 )
                 return EXIT_PASSED
+            # A RED RUN WHOSE TESTS ALL PASSED IS NOT A TEST FAILURE. The files,
+            # not the conclusion, are the authority here; `verdict_from_results`
+            # says why, and answering 78 rather than 1 is the difference between
+            # sending this lane back to the local queue and telling the operator
+            # a suite is red that `scripts/test.sh` never even runs the failing
+            # part of.
+            if verdict_from_results(results) == EXIT_REFUSED:
+                jobs = failed_job_names(completed)
+                attribution = f" (failing jobs: {', '.join(jobs)})" if jobs else ""
+                raise Refused(
+                    f"run {run_id} finished failure, but every one of the "
+                    f"{results.tests} tests it ran passed{attribution}, so the "
+                    "failure is outside the test passes and says nothing about "
+                    f"this suite {url}".rstrip()
+                )
             _write_failure_report(
-                results, problem=problem, url=str(url), completed=completed, write=write
+                results, problem=problem, url=str(url), completed=completed,
+                narrowed=narrowed, write=write,
             )
             return EXIT_FAILED
     except NoTicket:
@@ -995,8 +1118,25 @@ def _write_failure_report(
     problem: str | None,
     url: str,
     completed: Mapping[str, object],
+    narrowed: bool,
     write: Callable[[str], None],
 ) -> None:
+    """Print a red run's failures, and its population only if anybody may read it.
+
+    THE COUNT LINE IS SUPPRESSED FOR A NARROWED CALLER, and that is a guard
+    rather than tidiness. Six consumers grep `Test run with [0-9]+ tests?` and
+    take `head -1`, and `scripts/git-hooks/pre-push` captures both streams — so
+    this line would arrive *before*, and win over, the count printed by the local
+    re-run that a narrowed caller does next. A `--filter` naming a renamed type
+    selects zero tests, prints `Test run with 0 tests` locally, and would still
+    clear its floor on the remote whole-suite number: the exact vacuous-filter
+    failure the floor exists to catch. A narrowed caller is not adopting this
+    verdict, so the population here describes a run nobody is reporting.
+
+    The green path keeps the line on purpose. There the count is adopted, and a
+    whole-suite number legitimately clears a narrowed caller's floor — a floor is
+    a minimum and the whole suite is a superset of any subset of it.
+    """
     write(f"remote-verify: the remote run FAILED {url}".rstrip())
     jobs = failed_job_names(completed)
     if jobs:
@@ -1005,9 +1145,9 @@ def _write_failure_report(
         write(f"remote-verify: {problem}")
         write("remote-verify: open the run above for the failure")
         return
-    # Stated when it is known and silently omitted when it is not: a red run is
-    # already a verdict, and no caller reads the population off a failing run.
-    if results.tests is not None:
+    # Stated when it is known, this run is the one being reported, and it is not
+    # a narrowed caller's; omitted otherwise. See the docstring.
+    if results.tests is not None and not narrowed:
         write(_test_run_summary(results.tests, "failed"))
     for line in results.lines:
         write(line)
@@ -1032,9 +1172,25 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         help=f"the inert {INERT_NAMESPACE}* ref to push and dispatch",
     )
     driver.add_argument("--sha", required=True)
+    driver.add_argument(
+        "--narrowed",
+        action="store_true",
+        help=(
+            "the caller selected a subset of the suite (--filter/--skip), so it "
+            "will not adopt a failing whole-suite verdict; suppresses the test "
+            "count on a failure, which would otherwise be read as that subset's"
+        ),
+    )
 
     renderer = subcommands.add_parser(
-        "render", help="render already-downloaded xUnit results"
+        "render",
+        help="render already-downloaded xUnit results",
+        description=(
+            "Exits 1 when the results record failures or cannot be believed, and "
+            f"{EXIT_REFUSED} when they record a complete, empty set of failures "
+            "over a stated population — no test verdict. Same mapping the driver "
+            "uses; see verdict_from_results."
+        ),
     )
     renderer.add_argument("paths", nargs="+")
 
@@ -1048,7 +1204,13 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         report = render_results(paths)
         for line in report.lines:
             print(line)
-        return EXIT_FAILED if report.total or report.unreadable else EXIT_PASSED
+        # THE SAME AUTHORITY THE DRIVER USES, so the two cannot disagree about
+        # one artifact. This used to answer 0 for "no failures", which read as
+        # "the tests passed" for the state the driver calls no verdict at all —
+        # a red run whose passes all reported clean. `render` never answers 0
+        # now: it has no run conclusion to weigh, so the strongest thing a set of
+        # files can say on its own is "no failing test here".
+        return verdict_from_results(report)
 
     repo_dir = Path(options.repo_dir)
     try:
@@ -1069,6 +1231,7 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
     return drive(
         ref=options.ref,
         sha=options.sha,
+        narrowed=options.narrowed,
         runtime_dir=runtime_dir,
         slots=slots,
         run_command=system_runner(repo_dir, timeout=command_timeout),

--- a/scripts/remote_verify.py
+++ b/scripts/remote_verify.py
@@ -1,0 +1,77 @@
+"""Remote verification valve: verify this commit on GitHub instead of holding
+the machine-global build slot.
+
+THE TICKET POOL IS LOCAL ON PURPOSE. Every contender runs on this one laptop,
+so a local lock file arbitrates GitHub's capacity authoritatively — there is no
+distributed consensus problem here. GitHub caps five concurrent macOS jobs per
+account and `test.yml` spends two per run, so roughly two runs fit; without this
+bound every queued lane would dispatch at once into a queue TBD cannot observe,
+prioritise, or abandon.
+
+The ticket is an flock rather than a hand-rolled occupancy file: the kernel
+releases it when this process exits by any means, so a ticket cannot outlive its
+run and needs no sweep. It is held in python rather than the shell because macOS
+ships no `flock(1)` and `/bin/bash` here is 3.2, which cannot allocate the file
+descriptor such a lock would need.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+import contextlib
+import fcntl
+import os
+from pathlib import Path
+
+
+SLOTS_SETTING = "TBD_REMOTE_VERIFY_SLOTS"
+DEFAULT_SLOTS = 2
+
+
+class NoTicket(Exception):
+    """Every dispatch slot is taken, so this lane must keep waiting locally."""
+
+
+def configured_slots(environ: Mapping[str, str] | None = None) -> int:
+    """How many remote runs may be in flight at once.
+
+    Unset or empty means the shipped default, so an untouched environment gets
+    the sizing the spec measured. An unreadable value is refused by name rather
+    than quietly falling back: silently sizing the pool differently from what
+    somebody asked for is how a stampede gets shipped.
+    """
+    environ = os.environ if environ is None else environ
+    raw = environ.get(SLOTS_SETTING, "")
+    if not raw:
+        return DEFAULT_SLOTS
+    try:
+        slots = int(raw)
+    except ValueError:
+        raise ValueError(f"{SLOTS_SETTING} must be a whole number, not {raw!r}") from None
+    if slots < 0:
+        raise ValueError(f"{SLOTS_SETTING} must not be negative, but is {slots}")
+    return slots
+
+
+@contextlib.contextmanager
+def take_dispatch_ticket(runtime_dir: Path, slots: int) -> Iterator[int]:
+    """Hold one dispatch ticket for the duration of the block.
+
+    Yields the index of the ticket taken, and raises `NoTicket` at once when
+    every slot is held — this never queues, because a lane that cannot go
+    remote has a local queue to return to.
+    """
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(1, int(slots) + 1):
+        handle = (runtime_dir / f"remote-verify-{index}.lock").open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            handle.close()
+            continue
+        try:
+            yield index
+        finally:
+            handle.close()  # closing releases the flock
+        return
+    raise NoTicket

--- a/scripts/remote_verify.py
+++ b/scripts/remote_verify.py
@@ -24,13 +24,17 @@ GitHub's two-run allowance.
 PUSHING HAPPENS HERE, AFTER THE TICKET, and not in the front-end. A ref pushed
 before a ticket was granted is a durable resource created for a run that never
 happened; taking the ticket first means the only refs that exist are ones a
-dispatch was authorised for.
+dispatch was authorised for. The only ref this module will move is an inert
+`preflight/*` one — `push_ref` refuses anything else, and says why there.
 
 THE VERDICT IS READ FROM STRUCTURED RESULTS, NEVER FROM THE JOB LOG. One failed
 run of `test.yml` produces 5.3 MB across 32,228 lines in which parallel passes
 interleave and compiler diagnostics print source context that reads exactly like
 test output; two extraction attempts over a real failed log both named the wrong
-failure. So the workflow uploads xUnit XML and this module parses it.
+failure. So the workflow uploads xUnit XML and this module parses it. The same
+files carry the run's population, which is why a green run downloads them too:
+the verdict a caller reads is `Test run with N tests`, and N has to come from
+somewhere that cannot make it up.
 """
 
 from __future__ import annotations
@@ -56,6 +60,10 @@ DEFAULT_SLOTS = 2
 WORKFLOW_FILE = "test.yml"
 RESULTS_ARTIFACT = "xunit-results"
 DEFAULT_REMOTE = "origin"
+# The one namespace this driver may move. `scripts/remote-verify.sh` builds the
+# ref and `push_ref` enforces the namespace; see its docstring for why nothing
+# else is pushable.
+INERT_NAMESPACE = "preflight/"
 
 # Exit codes, and the contract every caller reads.  78 is the one that matters:
 # it means "no verdict, go back to the local queue", which is what keeps the
@@ -74,6 +82,26 @@ RUN_SETTING = "TBD_REMOTE_VERIFY_RUN_SECONDS"
 # The observed worst-case remote run is 32 minutes; 45 leaves room without
 # letting a wedged run hold a dispatch ticket indefinitely.
 DEFAULT_RUN_SECONDS = 2700.0
+# EVERY SUBPROCESS IS BOUNDED, because the bounded waits above only check their
+# deadline *between* calls: a `gh` that never returns would hold a dispatch
+# ticket past every timeout here, and with two tickets, two of them wedge the
+# valve for the whole fleet.  The bound is per call and generous — a push of a
+# cold repository and an artifact download both live under it.
+COMMAND_SETTING = "TBD_REMOTE_VERIFY_COMMAND_SECONDS"
+DEFAULT_COMMAND_SECONDS = 300.0
+
+# A command that timed out or could not be started reports a status rather than
+# an exception, so the ordinary "this call failed" refusals name it.  124 is the
+# shell's convention for a timeout and 127 for a missing program.
+STATUS_TIMED_OUT = 124
+STATUS_NOT_RUNNABLE = 127
+
+# THE REQUESTER IS WATCHED FOR THE WHOLE ROUND TRIP, on the same reasoning as
+# `scripts/swift-safe`: the chain here is test.sh -> remote-verify.sh -> exec
+# python3, so a killed agent session leaves this driver holding a ticket for up
+# to `DEFAULT_RUN_SECONDS` with nobody left to read the verdict.  Set to "1" for
+# a deliberately detached run.
+ALLOW_ORPHAN_SETTING = "TBD_REMOTE_VERIFY_ALLOW_ORPHAN"
 
 # A red run naming three thousand tests is the 5.3 MB problem again in a
 # smaller font, so the render is bounded and says how much it withheld.
@@ -138,7 +166,15 @@ class Refused(Exception):
 
 
 def _positive_seconds(environ: Mapping[str, str], name: str, default: float) -> float:
-    """A duration setting, refused by name rather than quietly defaulted."""
+    """A duration setting, refused by name rather than quietly defaulted.
+
+    Strictly positive, and `not seconds > 0` rather than `seconds <= 0` so a
+    NaN is refused too.  Zero is not a smaller bound, it is a different
+    behaviour: a zero poll turns every wait into a tight loop hammering `gh`
+    until the API rate-limits the whole account, and a zero timeout refuses
+    before the first answer could arrive.  Neither is what anybody setting a
+    duration to 0 is asking for, so it is named rather than obeyed.
+    """
     raw = environ.get(name, "")
     if not raw:
         return default
@@ -146,8 +182,8 @@ def _positive_seconds(environ: Mapping[str, str], name: str, default: float) -> 
         seconds = float(raw)
     except ValueError:
         raise ValueError(f"{name} must be a number of seconds, not {raw!r}") from None
-    if seconds < 0:
-        raise ValueError(f"{name} must not be negative, but is {seconds}")
+    if not seconds > 0:
+        raise ValueError(f"{name} must be greater than zero, but is {raw!r}")
     return seconds
 
 
@@ -166,25 +202,152 @@ class Completed:
 RunCommand = Callable[[Sequence[str]], Completed]
 
 
-def system_runner(directory: Path) -> RunCommand:
-    """Run commands inside the repository, capturing both streams.
+def system_runner(directory: Path, *, timeout: float = DEFAULT_COMMAND_SECONDS) -> RunCommand:
+    """Run commands inside the repository, capturing both streams, bounded.
 
     `gh` resolves which repository it is talking to from the working directory,
     so binding that here rather than at each call site keeps every subprocess on
     the same repo the preconditions were checked against.
+
+    EVERY CALL IS BOUNDED AND NONE OF THEM RAISE. A hung `gh` is the failure
+    that matters — it holds a dispatch ticket that the waits above cannot
+    reclaim, because they only test their deadline between calls — so the
+    timeout is mandatory rather than a parameter a call site may omit. A
+    timeout and a program that will not start are both reported as an ordinary
+    non-zero status, so the refusal that already exists for "this call failed"
+    names them instead of a traceback escaping the driver.
     """
 
     def run(argv: Sequence[str]) -> Completed:
-        finished = subprocess.run(  # noqa: S603 - argv is built here, never a shell string
-            list(argv),
-            cwd=str(directory),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            finished = subprocess.run(  # noqa: S603 - argv is built here, never a shell string
+                list(argv),
+                cwd=str(directory),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as expired:
+            said = _as_text(expired.stderr).strip()
+            return Completed(
+                STATUS_TIMED_OUT,
+                _as_text(expired.stdout),
+                f"{argv[0]} did not answer within {timeout:g}s"
+                + (f": {said}" if said else ""),
+            )
+        except OSError as error:
+            return Completed(STATUS_NOT_RUNNABLE, "", f"could not run {argv[0]}: {error}")
         return Completed(finished.returncode, finished.stdout, finished.stderr)
 
     return run
+
+
+def _as_text(captured: object) -> str:
+    """Whatever a killed subprocess had written so far, as text."""
+    if captured is None:
+        return ""
+    if isinstance(captured, bytes):
+        return captured.decode("utf-8", errors="replace")
+    return str(captured)
+
+
+# --- is anybody still waiting for this verdict? ------------------------------
+
+
+def _process_is_alive(pid: int) -> bool:
+    """Liveness of a single positive pid; callers screen out 0 and negatives."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    # A number too large for the platform's pid_t raises OverflowError, which is
+    # not an OSError; left uncaught it would end a healthy run.
+    except (OSError, OverflowError):
+        return False
+    return True
+
+
+def _process_table() -> dict[int, int]:
+    """child pid -> parent pid for every visible process, from one `ps`.
+
+    macOS has no `/proc`, so an ancestor walk needs the process table, and one
+    `ps` answers every step of it. Best effort: a table we could not read leaves
+    the caller watching the direct parent alone.
+    """
+    try:
+        completed = subprocess.run(
+            ["ps", "-Ao", "pid=,ppid="],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    table: dict[int, int] = {}
+    for line in completed.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            child, parent = int(fields[0]), int(fields[1])
+        except ValueError:
+            continue
+        table[child] = parent
+    return table
+
+
+def _ancestor_pids(*, getppid=os.getppid, process_table=_process_table) -> tuple[int, ...]:
+    """This process's ancestors, nearest first, ending at pid 1 if reachable.
+
+    Walked once, at startup: afterwards liveness is `kill(pid, 0)` per poll,
+    with no further subprocesses. The chain matters because `remote-verify.sh`
+    `exec`s this module — killing the agent's session kills a shell several
+    steps up, which never moves this process's own ppid.
+    """
+    parent = getppid()
+    if parent <= 0:
+        return ()
+    chain = [parent]
+    seen = {parent}
+    table = process_table()
+    current = parent
+    while current > 1:
+        nextpid = table.get(current)
+        if nextpid is None or nextpid <= 0 or nextpid in seen:
+            break
+        chain.append(nextpid)
+        seen.add(nextpid)
+        current = nextpid
+    return tuple(chain)
+
+
+def requester_watch(
+    environ: Mapping[str, str], *, getppid=os.getppid, ancestors=None
+) -> Callable[[], bool]:
+    """Is anybody still waiting for this verdict?
+
+    Recorded once, here, and asked on every poll. Two readings of the same fact,
+    because neither covers the other: a reparent is visible even while the old
+    parent lingers as an unreaped zombie, and an ancestor further up dying never
+    moves this process's own ppid at all. A dead pid that has been reused reads
+    as alive and the run continues — the pre-valve behaviour, so the failure is
+    the safe one.
+    """
+    if environ.get(ALLOW_ORPHAN_SETTING) == "1":
+        return lambda: True
+    requester = getppid()
+    if requester <= 0:
+        return lambda: True
+    chain = _ancestor_pids(getppid=getppid) if ancestors is None else tuple(ancestors)
+
+    def alive() -> bool:
+        return getppid() == requester and all(_process_is_alive(pid) for pid in chain)
+
+    return alive
 
 
 def _report(message: str) -> None:
@@ -195,11 +358,16 @@ def _report(message: str) -> None:
 # --- correlating a dispatch to its run ---------------------------------------
 
 
-def select_run(runs: Sequence[Mapping[str, object]], sha: str) -> dict[str, object] | None:
-    """The newest dispatched run for `sha`, or None.
+def select_run(
+    runs: Sequence[Mapping[str, object]],
+    sha: str,
+    *,
+    exclude: Sequence[int] | frozenset[int] = (),
+) -> dict[str, object] | None:
+    """The newest dispatched run for `sha` that this lane has not already seen.
 
     `gh workflow run` returns no run id, so the run has to be found by what it
-    is running.  Two guards earn their place:
+    is running.  Three guards earn their place:
 
     - **`event == "workflow_dispatch"`.** The same commit may also have a
       `pull_request` run; watching that one would report a verdict the valve
@@ -208,11 +376,16 @@ def select_run(runs: Sequence[Mapping[str, object]], sha: str) -> dict[str, obje
       `true` satisfies `isinstance(x, int)` in python and would coerce to run
       id 1 — a real, unrelated run whose verdict would be reported as this
       lane's.
-
-    A completed older dispatch of the same sha is a legitimate answer: the
-    verdict is a statement about the commit, and two lanes on one commit
-    deliberately share it.
+    - **`exclude` holds every run that already existed when this lane
+      dispatched.** Without it a lane verifying a commit that was dispatched
+      before — an earlier lane on the same sha, or this lane's own previous
+      attempt — adopts that older run on the very first poll, because it is
+      already registered and the new one is not. It would then report a stale
+      verdict while the run it paid for burned a macOS slot with nobody
+      watching. The baseline is taken before the dispatch, so anything left is
+      necessarily newer.
     """
+    seen = frozenset(exclude)
     for run in runs:
         if run.get("headSha") != sha:
             continue
@@ -220,6 +393,8 @@ def select_run(runs: Sequence[Mapping[str, object]], sha: str) -> dict[str, obje
             continue
         identifier = run.get("databaseId")
         if isinstance(identifier, bool) or not isinstance(identifier, int):
+            continue
+        if identifier in seen:
             continue
         return dict(run)
     return None
@@ -250,12 +425,45 @@ def list_runs(run_command: RunCommand, *, limit: int = 40) -> list[Mapping[str, 
     return [entry for entry in parsed if isinstance(entry, Mapping)]
 
 
+def baseline_run_ids(run_command: RunCommand, sha: str) -> frozenset[int]:
+    """Every dispatched run for `sha` that exists *before* this lane dispatches.
+
+    Taken as a set of ids rather than a `createdAt` floor on purpose: the clock
+    that stamps a run is GitHub's and the clock that would compare it is this
+    laptop's, and a laptop minutes ahead would exclude the very run it just
+    asked for.  Identity needs no clocks.
+    """
+    ids = set()
+    for run in list_runs(run_command):
+        if run.get("headSha") != sha or run.get("event") != "workflow_dispatch":
+            continue
+        identifier = run.get("databaseId")
+        if isinstance(identifier, bool) or not isinstance(identifier, int):
+            continue
+        ids.add(identifier)
+    return frozenset(ids)
+
+
+class Abandoned(Refused):
+    """Nobody is waiting for this verdict any more, so stop holding a ticket."""
+
+
+def _still_wanted(requester_alive: Callable[[], bool]) -> None:
+    if not requester_alive():
+        raise Abandoned(
+            "the process that asked for this verification has exited; "
+            "releasing the dispatch ticket rather than waiting out the run"
+        )
+
+
 def await_dispatched_run(
     run_command: RunCommand,
     sha: str,
     *,
     timeout: float,
     poll: float,
+    requester_alive: Callable[[], bool],
+    exclude: frozenset[int] = frozenset(),
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
     report: Callable[[str], None] = _report,
@@ -265,11 +473,15 @@ def await_dispatched_run(
     GitHub creates the run asynchronously, so it is normal for the first look
     to find nothing.  The bound exists so a dispatch that never registers ends
     as a named refusal rather than a process that waits forever holding a
-    ticket.
+    ticket, and `requester_alive` ends the wait early when the lane that asked
+    for the verdict is gone — up to 45 minutes of ticket, otherwise, held for
+    nobody.  Both are keyword-only and `requester_alive` is required, so a
+    future call site cannot drop the check silently.
     """
     deadline = monotonic() + timeout
     while True:
-        run = select_run(list_runs(run_command), sha)
+        _still_wanted(requester_alive)
+        run = select_run(list_runs(run_command), sha, exclude=exclude)
         if run is not None:
             return run
         if monotonic() >= deadline:
@@ -286,13 +498,15 @@ def await_completion(
     *,
     timeout: float,
     poll: float,
+    requester_alive: Callable[[], bool],
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
     report: Callable[[str], None] = _report,
 ) -> dict[str, object]:
-    """Wait for a run to reach `completed`, bounded."""
+    """Wait for a run to reach `completed`, bounded, and only while wanted."""
     deadline = monotonic() + timeout
     while True:
+        _still_wanted(requester_alive)
         result = run_command(
             ["gh", "run", "view", run_id, "--json", "status,conclusion,url,jobs"]
         )
@@ -393,6 +607,9 @@ class _ResultParser(HTMLParser):
         self.failures: list[Failure] = []
         self.root_opened = False
         self.root_closed = False
+        # None until a `<testsuite tests=…>` says otherwise: a file that
+        # declared no population must not be read as one declaring zero.
+        self.tests: int | None = None
         self._seen: set[Failure] = set()
         self._case: dict[str, str] = {}
         self._message: str | None = None
@@ -402,6 +619,12 @@ class _ResultParser(HTMLParser):
         values = {name: value or "" for name, value in attrs}
         if tag in ("testsuites", "testsuite"):
             self.root_opened = True
+            # Counted from `<testsuite>` alone. Both writers put the population
+            # there, and a `<testsuites>` wrapper that repeats it would double
+            # every number if it were added in too.
+            if tag == "testsuite":
+                with contextlib.suppress(ValueError):
+                    self.tests = (self.tests or 0) + int(values.get("tests", ""))
         elif tag == "testcase":
             self._case = values
         elif tag in ("failure", "error"):
@@ -436,8 +659,16 @@ class _ResultParser(HTMLParser):
         self.failures.append(failure)
 
 
-def failures_in(path: Path) -> list[Failure]:
-    """Failing tests in one xUnit file, in document order, without duplicates.
+@dataclass(frozen=True)
+class Results:
+    """One xUnit file, read: how many tests it ran and which of them failed."""
+
+    tests: int | None
+    failures: tuple[Failure, ...]
+
+
+def results_in(path: Path) -> Results:
+    """One xUnit file's population and failures.
 
     Both writers this repo meets are handled: SwiftPM's XCTest generator emits
     `<testcase classname=… name=…><failure message=…>` unindented, and Swift
@@ -455,16 +686,29 @@ def failures_in(path: Path) -> list[Failure]:
         raise MalformedResults("no test results in the file")
     if not parser.root_closed:
         raise MalformedResults("truncated: the result element never closed")
-    return parser.failures
+    return Results(tests=parser.tests, failures=tuple(parser.failures))
+
+
+def failures_in(path: Path) -> list[Failure]:
+    """Failing tests in one xUnit file, in document order, without duplicates."""
+    return list(results_in(path).failures)
 
 
 @dataclass(frozen=True)
 class Report:
-    """What the result files said, and how to print it."""
+    """What the result files said, and how to print it.
+
+    `tests` is the population the run actually executed, summed across the
+    files, and is None when no file said — an artifact that never arrived, or
+    one whose every file was unreadable.  None is not zero: a caller that needs
+    to state how many tests ran must refuse rather than publish a number no
+    file supports.
+    """
 
     total: int
     unreadable: tuple[str, ...]
     lines: tuple[str, ...]
+    tests: int | None = None
 
 
 def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES) -> Report:
@@ -478,12 +722,16 @@ def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES)
     sections: list[tuple[Path, list[Failure]]] = []
     unreadable: list[tuple[Path, str]] = []
     total = 0
+    tests: int | None = None
     for path in paths:
         try:
-            failures = failures_in(path)
+            results = results_in(path)
         except (MalformedResults, OSError) as error:
             unreadable.append((path, str(error)))
             continue
+        failures = list(results.failures)
+        if results.tests is not None:
+            tests = (tests or 0) + results.tests
         total += len(failures)
         if failures:
             sections.append((path, failures))
@@ -522,6 +770,7 @@ def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES)
         total=total,
         unreadable=tuple(path.name for path, _ in unreadable),
         lines=tuple(lines),
+        tests=tests,
     )
 
 
@@ -546,19 +795,34 @@ def download_results(
 
 
 def push_ref(
-    run_command: RunCommand, *, sha: str, ref: str, inert: bool, remote: str = DEFAULT_REMOTE
+    run_command: RunCommand, *, sha: str, ref: str, remote: str = DEFAULT_REMOTE
 ) -> None:
     """Put `sha` on `<remote>/<ref>`, or refuse by name.
 
-    An inert `preflight/*` ref is a throwaway that any lane may move to any
-    commit, so it is forced.  A real branch is not: a non-fast-forward push
-    there would discard somebody's work to run a test, so it is allowed to fail
-    and the lane goes back to the local queue.
+    ONLY THE INERT NAMESPACE IS PUSHABLE, and this is the guard that makes that
+    true — it sits at the one place that actually moves a ref, so no ref choice
+    upstream of it can publish a branch by accident. Three things follow from
+    pushing `preflight/<branch>` and never `<branch>`:
+
+    - A pre-push hook gates the commits on the branch; publishing them to the
+      branch first is a bypass of the very check that was running.
+    - The default branch never has an open PR, so a ref choice keyed on "is
+      there a PR?" fast-forwards it — firing main's CI and the Pages deploy on
+      unreviewed commits.
+    - `scripts/sweep-preflight-refs.sh` reclaims `refs/heads/preflight/` and
+      nothing else, so a branch pushed from here would be a durable resource
+      with no named reconciler.
+
+    The push is forced because a `preflight/*` ref is a throwaway that any lane
+    may move to any commit: without that, a lane could never verify again after
+    an amend or a rebase.
     """
-    argv = ["git", "push"]
-    if inert:
-        argv.append("--force")
-    argv += [remote, f"{sha}:refs/heads/{ref}"]
+    if not ref.startswith(INERT_NAMESPACE) or ref == INERT_NAMESPACE:
+        raise Refused(
+            f"refusing to push {ref!r}: this driver only ever moves "
+            f"{INERT_NAMESPACE}* refs"
+        )
+    argv = ["git", "push", "--force", remote, f"{sha}:refs/heads/{ref}"]
     result = run_command(argv)
     if result.status != 0:
         raise Refused(
@@ -583,13 +847,13 @@ def drive(
     *,
     ref: str,
     sha: str,
-    inert: bool,
     runtime_dir: Path,
     slots: int,
     run_command: RunCommand,
     poll: float,
     correlate_timeout: float,
     run_timeout: float,
+    requester_alive: Callable[[], bool],
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
     report: Callable[[str], None] = _report,
@@ -597,18 +861,33 @@ def drive(
 ) -> int:
     """Hold a ticket for one whole remote verification, and return its verdict.
 
-    Order is the point: ticket, then push, then dispatch.  Nothing durable and
-    nothing metered happens until this lane is one of the two the pool allows.
+    Order is the point: ticket, then baseline, then push, then dispatch.
+    Nothing durable and nothing metered happens until this lane is one of the
+    two the pool allows.
+
+    NO ESCAPING EXCEPTION MAY BECOME EXIT 1. `scripts/test.sh` adopts this
+    status as the run's own, so a `1` from an unhandled OSError, a killed
+    subprocess or a full disk would tell the operator that the suite is red
+    when zero tests ran. Everything unforeseen lands on 78 — no verdict, back
+    to the local queue — which is the only honest answer this function can give
+    about code it never managed to test.
     """
     try:
         with take_dispatch_ticket(runtime_dir, slots) as ticket:
             report(f"remote-verify: took dispatch ticket {ticket} of {slots}")
-            push_ref(run_command, sha=sha, ref=ref, inert=inert)
+            # Asked before anything durable happens: a lane whose requester has
+            # already gone wants no ref pushed and no dispatch spent.
+            _still_wanted(requester_alive)
+            # Taken before the dispatch, so every run it names is one this lane
+            # did not ask for; see `select_run`.
+            already_ran = baseline_run_ids(run_command, sha)
+            push_ref(run_command, sha=sha, ref=ref)
             dispatch_run(run_command, ref=ref)
             report(f"remote-verify: dispatched {WORKFLOW_FILE} on {ref} at {sha}")
             found = await_dispatched_run(
                 run_command, sha,
                 timeout=correlate_timeout, poll=poll,
+                requester_alive=requester_alive, exclude=already_ran,
                 sleep=sleep, monotonic=monotonic, report=report,
             )
             run_id = str(found["databaseId"])
@@ -617,6 +896,7 @@ def drive(
             completed = await_completion(
                 run_command, run_id,
                 timeout=run_timeout, poll=poll,
+                requester_alive=requester_alive,
                 sleep=sleep, monotonic=monotonic, report=report,
             )
             url = completed.get("url") or url or ""
@@ -626,12 +906,14 @@ def drive(
                     f"run {run_id} finished {completed.get('conclusion')}, "
                     f"which is no verdict {url}".rstrip()
                 )
+            results, problem = read_run_results(run_command, run_id)
             if verdict == EXIT_PASSED:
-                write(f"remote-verify: the remote run passed {url}".rstrip())
+                _write_pass_report(
+                    results, problem=problem, run_id=run_id, url=str(url), write=write
+                )
                 return EXIT_PASSED
             _write_failure_report(
-                run_command, run_id=run_id, url=str(url),
-                completed=completed, write=write,
+                results, problem=problem, url=str(url), completed=completed, write=write
             )
             return EXIT_FAILED
     except NoTicket:
@@ -643,12 +925,74 @@ def drive(
     except Refused as refusal:
         report(f"remote-verify: {refusal}")
         return EXIT_REFUSED
+    except Exception as error:  # noqa: BLE001 - see the docstring: 78, never 1
+        report(f"remote-verify: {type(error).__name__}: {error}")
+        report("remote-verify: no verdict could be had; staying in the local queue")
+        return EXIT_REFUSED
+
+
+def read_run_results(
+    run_command: RunCommand, run_id: str
+) -> tuple[Report | None, str | None]:
+    """Download and read a run's xUnit artifact, or say why it could not be had.
+
+    The download lives no longer than this call: `Report` holds counts, file
+    names and rendered lines, so nothing it carries points into the scratch
+    directory that is deleted on the way out.
+    """
+    with tempfile.TemporaryDirectory(prefix="remote-verify-results.") as scratch:
+        paths, problem = download_results(run_command, run_id, Path(scratch))
+        if problem:
+            return None, problem
+        return render_results(paths), None
+
+
+def _test_run_summary(count: int, outcome: str) -> str:
+    """The line six call sites grep for, in the wording they grep for.
+
+    `scripts/git-hooks/pre-push`, `scripts/nightly-flake-stress.sh` and three
+    steps of `.github/workflows/test.yml` all read a run's population out of
+    `Test run with N tests` and treat its absence as a collapsed or truncated
+    suite. A remote verdict that omitted it would be read as a broken run and
+    block the push naming the wrong cause, so the remote path states the same
+    fact in the same words — derived from the xUnit files, never invented.
+    """
+    plural = "" if count == 1 else "s"
+    return f"remote-verify: Test run with {count} test{plural} {outcome} remotely."
+
+
+def _write_pass_report(
+    results: Report | None,
+    *,
+    problem: str | None,
+    run_id: str,
+    url: str,
+    write: Callable[[str], None],
+) -> None:
+    """Announce a green run, with the population it actually executed.
+
+    A pass whose count cannot be supported is refused rather than announced.
+    Emitting a number no result file backs would be the exact failure this line
+    exists to prevent, and claiming green with no line at all reaches the
+    caller as a truncated run. Both cost a local re-run; inventing a count
+    costs a wrong answer.
+    """
+    if results is None or results.tests is None:
+        detail = problem or (
+            f"the {RESULTS_ARTIFACT} artifact named no test population"
+        )
+        raise Refused(
+            f"run {run_id} passed but its results could not be counted "
+            f"({detail}), so the test population cannot be stated {url}".rstrip()
+        )
+    write(_test_run_summary(results.tests, "passed"))
+    write(f"remote-verify: the remote run passed {url}".rstrip())
 
 
 def _write_failure_report(
-    run_command: RunCommand,
+    results: Report | None,
     *,
-    run_id: str,
+    problem: str | None,
     url: str,
     completed: Mapping[str, object],
     write: Callable[[str], None],
@@ -657,14 +1001,16 @@ def _write_failure_report(
     jobs = failed_job_names(completed)
     if jobs:
         write(f"remote-verify: failing jobs: {', '.join(jobs)}")
-    with tempfile.TemporaryDirectory(prefix="remote-verify-results.") as scratch:
-        paths, problem = download_results(run_command, run_id, Path(scratch))
-        if problem:
-            write(f"remote-verify: {problem}")
-            write("remote-verify: open the run above for the failure")
-            return
-        for line in render_results(paths).lines:
-            write(line)
+    if results is None:
+        write(f"remote-verify: {problem}")
+        write("remote-verify: open the run above for the failure")
+        return
+    # Stated when it is known and silently omitted when it is not: a red run is
+    # already a verdict, and no caller reads the population off a failing run.
+    if results.tests is not None:
+        write(_test_run_summary(results.tests, "failed"))
+    for line in results.lines:
+        write(line)
 
 
 def _resolve_runtime_dir(environ: Mapping[str, str]) -> Path:
@@ -680,13 +1026,12 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
 
     driver = subcommands.add_parser("drive", help="run one remote verification")
     driver.add_argument("--repo-dir", required=True)
-    driver.add_argument("--ref", required=True)
-    driver.add_argument("--sha", required=True)
     driver.add_argument(
-        "--inert",
-        action="store_true",
-        help="the ref is a throwaway preflight ref and may be force-pushed",
+        "--ref",
+        required=True,
+        help=f"the inert {INERT_NAMESPACE}* ref to push and dispatch",
     )
+    driver.add_argument("--sha", required=True)
 
     renderer = subcommands.add_parser(
         "render", help="render already-downloaded xUnit results"
@@ -711,19 +1056,26 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         poll = _positive_seconds(environ, POLL_SETTING, DEFAULT_POLL_SECONDS)
         correlate = _positive_seconds(environ, CORRELATE_SETTING, DEFAULT_CORRELATE_SECONDS)
         run_timeout = _positive_seconds(environ, RUN_SETTING, DEFAULT_RUN_SECONDS)
+        command_timeout = _positive_seconds(
+            environ, COMMAND_SETTING, DEFAULT_COMMAND_SECONDS
+        )
+        runtime_dir = _resolve_runtime_dir(environ)
+        # Recorded before the ticket, so a requester that dies during startup is
+        # already visible on the first poll rather than after the run.
+        alive = requester_watch(environ)
     except ValueError as error:
         _report(f"remote-verify: {error}")
         return EXIT_REFUSED
     return drive(
         ref=options.ref,
         sha=options.sha,
-        inert=options.inert,
-        runtime_dir=_resolve_runtime_dir(environ),
+        runtime_dir=runtime_dir,
         slots=slots,
-        run_command=system_runner(repo_dir),
+        run_command=system_runner(repo_dir, timeout=command_timeout),
         poll=poll,
         correlate_timeout=correlate,
         run_timeout=run_timeout,
+        requester_alive=alive,
     )
 
 

--- a/scripts/remote_verify.py
+++ b/scripts/remote_verify.py
@@ -13,19 +13,71 @@ releases it when this process exits by any means, so a ticket cannot outlive its
 run and needs no sweep. It is held in python rather than the shell because macOS
 ships no `flock(1)` and `/bin/bash` here is 3.2, which cannot allocate the file
 descriptor such a lock would need.
+
+That last constraint decides the whole split with `scripts/remote-verify.sh`.
+The shell front-end answers "should we, and against which ref" — preconditions
+and ref choice — and then `exec`s this module, which holds one ticket for the
+entire remote round trip: push, dispatch, correlate, wait, render. A subshell
+that returned early would drop the ticket while its run was still burning
+GitHub's two-run allowance.
+
+PUSHING HAPPENS HERE, AFTER THE TICKET, and not in the front-end. A ref pushed
+before a ticket was granted is a durable resource created for a run that never
+happened; taking the ticket first means the only refs that exist are ones a
+dispatch was authorised for.
+
+THE VERDICT IS READ FROM STRUCTURED RESULTS, NEVER FROM THE JOB LOG. One failed
+run of `test.yml` produces 5.3 MB across 32,228 lines in which parallel passes
+interleave and compiler diagnostics print source context that reads exactly like
+test output; two extraction attempts over a real failed log both named the wrong
+failure. So the workflow uploads xUnit XML and this module parses it.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+import argparse
+from collections.abc import Callable, Iterator, Mapping, Sequence
 import contextlib
+from dataclasses import dataclass
 import fcntl
+from html.parser import HTMLParser
+import json
 import os
 from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
 
 
 SLOTS_SETTING = "TBD_REMOTE_VERIFY_SLOTS"
 DEFAULT_SLOTS = 2
+
+WORKFLOW_FILE = "test.yml"
+RESULTS_ARTIFACT = "xunit-results"
+DEFAULT_REMOTE = "origin"
+
+# Exit codes, and the contract every caller reads.  78 is the one that matters:
+# it means "no verdict, go back to the local queue", which is what keeps the
+# valve an optimisation rather than a gate.
+EXIT_PASSED = 0
+EXIT_FAILED = 1
+EXIT_REFUSED = 78
+
+# Poll cadence and bounds.  Every one is overridable so the harness can drive
+# the same code paths without waiting on a wall clock.
+POLL_SETTING = "TBD_REMOTE_VERIFY_POLL_SECONDS"
+DEFAULT_POLL_SECONDS = 10.0
+CORRELATE_SETTING = "TBD_REMOTE_VERIFY_CORRELATE_SECONDS"
+DEFAULT_CORRELATE_SECONDS = 180.0
+RUN_SETTING = "TBD_REMOTE_VERIFY_RUN_SECONDS"
+# The observed worst-case remote run is 32 minutes; 45 leaves room without
+# letting a wedged run hold a dispatch ticket indefinitely.
+DEFAULT_RUN_SECONDS = 2700.0
+
+# A red run naming three thousand tests is the 5.3 MB problem again in a
+# smaller font, so the render is bounded and says how much it withheld.
+MAX_RENDERED_FAILURES = 50
 
 
 class NoTicket(Exception):
@@ -75,3 +127,605 @@ def take_dispatch_ticket(runtime_dir: Path, slots: int) -> Iterator[int]:
             handle.close()  # closing releases the flock
         return
     raise NoTicket
+
+
+class Refused(Exception):
+    """No verdict could be had, so this lane must go back to the local queue.
+
+    Every refusal carries the condition that caused it, because a silent
+    fallback reintroduces the long stall at the moment it is least visible.
+    """
+
+
+def _positive_seconds(environ: Mapping[str, str], name: str, default: float) -> float:
+    """A duration setting, refused by name rather than quietly defaulted."""
+    raw = environ.get(name, "")
+    if not raw:
+        return default
+    try:
+        seconds = float(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be a number of seconds, not {raw!r}") from None
+    if seconds < 0:
+        raise ValueError(f"{name} must not be negative, but is {seconds}")
+    return seconds
+
+
+# --- running commands --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Completed:
+    """What a `git` or `gh` invocation returned."""
+
+    status: int
+    stdout: str
+    stderr: str
+
+
+RunCommand = Callable[[Sequence[str]], Completed]
+
+
+def system_runner(directory: Path) -> RunCommand:
+    """Run commands inside the repository, capturing both streams.
+
+    `gh` resolves which repository it is talking to from the working directory,
+    so binding that here rather than at each call site keeps every subprocess on
+    the same repo the preconditions were checked against.
+    """
+
+    def run(argv: Sequence[str]) -> Completed:
+        finished = subprocess.run(  # noqa: S603 - argv is built here, never a shell string
+            list(argv),
+            cwd=str(directory),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return Completed(finished.returncode, finished.stdout, finished.stderr)
+
+    return run
+
+
+def _report(message: str) -> None:
+    """Progress is diagnostics: stderr, so stdout carries only the verdict."""
+    print(message, file=sys.stderr, flush=True)
+
+
+# --- correlating a dispatch to its run ---------------------------------------
+
+
+def select_run(runs: Sequence[Mapping[str, object]], sha: str) -> dict[str, object] | None:
+    """The newest dispatched run for `sha`, or None.
+
+    `gh workflow run` returns no run id, so the run has to be found by what it
+    is running.  Two guards earn their place:
+
+    - **`event == "workflow_dispatch"`.** The same commit may also have a
+      `pull_request` run; watching that one would report a verdict the valve
+      never asked for and would race its own dispatch.
+    - **`databaseId` must be a real integer, and `bool` is not one.** A JSON
+      `true` satisfies `isinstance(x, int)` in python and would coerce to run
+      id 1 — a real, unrelated run whose verdict would be reported as this
+      lane's.
+
+    A completed older dispatch of the same sha is a legitimate answer: the
+    verdict is a statement about the commit, and two lanes on one commit
+    deliberately share it.
+    """
+    for run in runs:
+        if run.get("headSha") != sha:
+            continue
+        if run.get("event") != "workflow_dispatch":
+            continue
+        identifier = run.get("databaseId")
+        if isinstance(identifier, bool) or not isinstance(identifier, int):
+            continue
+        return dict(run)
+    return None
+
+
+def _decode_json(result: Completed, what: str) -> object:
+    if result.status != 0:
+        raise Refused(f"{what} failed ({result.status}): {result.stderr.strip() or 'no output'}")
+    try:
+        return json.loads(result.stdout or "null")
+    except ValueError:
+        raise Refused(f"{what} returned output that is not JSON") from None
+
+
+def list_runs(run_command: RunCommand, *, limit: int = 40) -> list[Mapping[str, object]]:
+    """Recent runs of the verification workflow, newest first."""
+    result = run_command(
+        [
+            "gh", "run", "list",
+            "--workflow", WORKFLOW_FILE,
+            "--limit", str(limit),
+            "--json", "databaseId,headSha,status,conclusion,event,url",
+        ]
+    )
+    parsed = _decode_json(result, "gh run list")
+    if not isinstance(parsed, list):
+        raise Refused("gh run list did not return a list of runs")
+    return [entry for entry in parsed if isinstance(entry, Mapping)]
+
+
+def await_dispatched_run(
+    run_command: RunCommand,
+    sha: str,
+    *,
+    timeout: float,
+    poll: float,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    report: Callable[[str], None] = _report,
+) -> dict[str, object]:
+    """Wait for the dispatched run to register, bounded.
+
+    GitHub creates the run asynchronously, so it is normal for the first look
+    to find nothing.  The bound exists so a dispatch that never registers ends
+    as a named refusal rather than a process that waits forever holding a
+    ticket.
+    """
+    deadline = monotonic() + timeout
+    while True:
+        run = select_run(list_runs(run_command), sha)
+        if run is not None:
+            return run
+        if monotonic() >= deadline:
+            raise Refused(
+                f"no dispatched run appeared for {sha} within {timeout:g}s"
+            )
+        report(f"remote-verify: waiting for the dispatched run for {sha} to register")
+        sleep(poll)
+
+
+def await_completion(
+    run_command: RunCommand,
+    run_id: str,
+    *,
+    timeout: float,
+    poll: float,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    report: Callable[[str], None] = _report,
+) -> dict[str, object]:
+    """Wait for a run to reach `completed`, bounded."""
+    deadline = monotonic() + timeout
+    while True:
+        result = run_command(
+            ["gh", "run", "view", run_id, "--json", "status,conclusion,url,jobs"]
+        )
+        parsed = _decode_json(result, f"gh run view {run_id}")
+        if not isinstance(parsed, Mapping):
+            raise Refused(f"gh run view {run_id} did not return a run")
+        if parsed.get("status") == "completed":
+            return dict(parsed)
+        if monotonic() >= deadline:
+            raise Refused(
+                f"run {run_id} was still {parsed.get('status')} after {timeout:g}s"
+            )
+        report(f"remote-verify: run {run_id} is {parsed.get('status')}")
+        sleep(poll)
+
+
+def verdict_for(conclusion: object) -> int | None:
+    """`EXIT_PASSED`, `EXIT_FAILED`, or None when the run said neither.
+
+    Only an unambiguous conclusion is a verdict.  A cancelled, skipped or
+    timed-out run says nothing about the code, and reporting it as a failure
+    would make the valve worse than no valve — it would invent red.  None sends
+    the lane back to the local queue, where it gets a real answer.
+    """
+    if conclusion == "success":
+        return EXIT_PASSED
+    if conclusion == "failure":
+        return EXIT_FAILED
+    return None
+
+
+def failed_job_names(run: Mapping[str, object]) -> list[str]:
+    """Which jobs of a red run were red, for the one-line attribution."""
+    jobs = run.get("jobs")
+    if not isinstance(jobs, list):
+        return []
+    names = []
+    for job in jobs:
+        if not isinstance(job, Mapping):
+            continue
+        if job.get("conclusion") in ("failure", "timed_out", "cancelled"):
+            name = job.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
+# --- rendering xUnit results -------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Failure:
+    """One failing test, in the shape a local run would have printed it."""
+
+    classname: str
+    name: str
+    message: str
+
+    def line(self) -> str:
+        return f"{self.classname}.{self.name}: {self.message}"
+
+
+def result_files(directory: Path) -> list[Path]:
+    """Every xUnit file in a downloaded artifact, in a stable order.
+
+    Globbed rather than named. `test.yml` writes one file per pass — three
+    today — and SwiftPM may split a pass again between its XCTest and Swift
+    Testing writers, so the count is a property of the run, not a constant.  A
+    run that died early simply publishes fewer, which is not an error here.
+    """
+    return sorted(path for path in directory.rglob("*.xml") if path.is_file())
+
+
+class MalformedResults(Exception):
+    """A result file that cannot be believed, rather than one with no failures.
+
+    The two are worlds apart here: "no failures in this file" is a claim about
+    the code, and a truncated or empty file must never be allowed to make it.
+    """
+
+
+class _ResultParser(HTMLParser):
+    """The xUnit reader, deliberately not `xml.etree`.
+
+    ElementTree needs `pyexpat`, a C extension that some perfectly ordinary
+    python installations cannot load: a package-manager build whose `pyexpat`
+    is linked against an older system `libexpat` raises ImportError on every
+    parse, which is exactly what the `python3` first on PATH did while this was
+    written. A renderer that works in CI and dies on the laptop it exists to
+    unblock is no renderer, and `html.parser` is pure python and always there.
+    The dialect these files use needs nothing more: flat elements, attribute
+    values, no namespaces, no DTD.
+    """
+
+    def __init__(self, fallback_classname: str):
+        super().__init__(convert_charrefs=True)
+        self.fallback_classname = fallback_classname
+        self.failures: list[Failure] = []
+        self.root_opened = False
+        self.root_closed = False
+        self._seen: set[Failure] = set()
+        self._case: dict[str, str] = {}
+        self._message: str | None = None
+        self._text: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        values = {name: value or "" for name, value in attrs}
+        if tag in ("testsuites", "testsuite"):
+            self.root_opened = True
+        elif tag == "testcase":
+            self._case = values
+        elif tag in ("failure", "error"):
+            self._message = values.get("message", "")
+            self._text = []
+
+    def handle_data(self, data):
+        if self._message is not None:
+            self._text.append(data)
+
+    def handle_endtag(self, tag):
+        if tag in ("failure", "error"):
+            if self._message is None:
+                return
+            self._record(self._message or "".join(self._text).strip())
+            self._message = None
+            self._text = []
+        elif tag == "testcase":
+            self._case = {}
+        elif tag in ("testsuites", "testsuite"):
+            self.root_closed = True
+
+    def _record(self, message: str) -> None:
+        failure = Failure(
+            classname=self._case.get("classname") or self.fallback_classname,
+            name=self._case.get("name") or "(unnamed test)",
+            message=message or "(no message)",
+        )
+        if failure in self._seen:
+            return
+        self._seen.add(failure)
+        self.failures.append(failure)
+
+
+def failures_in(path: Path) -> list[Failure]:
+    """Failing tests in one xUnit file, in document order, without duplicates.
+
+    Both writers this repo meets are handled: SwiftPM's XCTest generator emits
+    `<testcase classname=… name=…><failure message=…>` unindented, and Swift
+    Testing's own generator emits the same elements indented with `<skipped />`
+    for a disabled test. A passing case carries no failure child and is ignored.
+
+    Raises `MalformedResults` for a file that opened no result element or never
+    closed one — an empty or half-written file, which a run that was killed
+    mid-pass leaves behind.
+    """
+    parser = _ResultParser(fallback_classname=path.stem)
+    parser.feed(path.read_text(encoding="utf-8", errors="replace"))
+    parser.close()
+    if not parser.root_opened:
+        raise MalformedResults("no test results in the file")
+    if not parser.root_closed:
+        raise MalformedResults("truncated: the result element never closed")
+    return parser.failures
+
+
+@dataclass(frozen=True)
+class Report:
+    """What the result files said, and how to print it."""
+
+    total: int
+    unreadable: tuple[str, ...]
+    lines: tuple[str, ...]
+
+
+def render_results(paths: Sequence[Path], *, limit: int = MAX_RENDERED_FAILURES) -> Report:
+    """The failing tests across every result file, counted and printable.
+
+    Renders what it has.  A file that is missing, empty or half-written is
+    reported by name and the rest are still rendered — a run that died early
+    publishes exactly that, and losing the failures it did record would put us
+    back to reading the log.
+    """
+    sections: list[tuple[Path, list[Failure]]] = []
+    unreadable: list[tuple[Path, str]] = []
+    total = 0
+    for path in paths:
+        try:
+            failures = failures_in(path)
+        except (MalformedResults, OSError) as error:
+            unreadable.append((path, str(error)))
+            continue
+        total += len(failures)
+        if failures:
+            sections.append((path, failures))
+
+    lines: list[str] = []
+    if total:
+        plural = "" if total == 1 else "s"
+        lines.append(
+            f"remote-verify: {total} failing test{plural} "
+            f"in {len(paths)} result file(s)"
+        )
+    elif not unreadable:
+        lines.append(
+            "remote-verify: the remote run failed but published no failing tests — "
+            "the failure is outside the test passes (build, lint, or a run that "
+            "died before writing results)"
+        )
+    else:
+        lines.append("remote-verify: the remote run failed and its results are unreadable")
+
+    shown = 0
+    for path, failures in sections:
+        lines.append(f"  {path.name}")
+        for failure in failures:
+            if shown >= limit:
+                break
+            lines.append(f"    {failure.line()}")
+            shown += 1
+        if shown >= limit:
+            break
+    if total > shown:
+        lines.append(f"  … and {total - shown} more failing tests, withheld to stay readable")
+    for path, error in unreadable:
+        lines.append(f"  {path.name} — unreadable: {error}")
+    return Report(
+        total=total,
+        unreadable=tuple(path.name for path, _ in unreadable),
+        lines=tuple(lines),
+    )
+
+
+def download_results(
+    run_command: RunCommand, run_id: str, destination: Path
+) -> tuple[list[Path], str | None]:
+    """Unpack the run's xUnit artifact, or say why it could not be had.
+
+    A missing artifact is not a refusal: the run failed, and that verdict
+    stands whether or not it managed to publish results.
+    """
+    result = run_command(
+        ["gh", "run", "download", run_id, "--name", RESULTS_ARTIFACT, "--dir", str(destination)]
+    )
+    if result.status != 0:
+        detail = (result.stderr.strip() or result.stdout.strip() or "no output")
+        return [], f"could not download the {RESULTS_ARTIFACT} artifact: {detail}"
+    return result_files(destination), None
+
+
+# --- the driver --------------------------------------------------------------
+
+
+def push_ref(
+    run_command: RunCommand, *, sha: str, ref: str, inert: bool, remote: str = DEFAULT_REMOTE
+) -> None:
+    """Put `sha` on `<remote>/<ref>`, or refuse by name.
+
+    An inert `preflight/*` ref is a throwaway that any lane may move to any
+    commit, so it is forced.  A real branch is not: a non-fast-forward push
+    there would discard somebody's work to run a test, so it is allowed to fail
+    and the lane goes back to the local queue.
+    """
+    argv = ["git", "push"]
+    if inert:
+        argv.append("--force")
+    argv += [remote, f"{sha}:refs/heads/{ref}"]
+    result = run_command(argv)
+    if result.status != 0:
+        raise Refused(
+            f"could not push {sha} to {remote}/{ref}: "
+            f"{result.stderr.strip() or result.stdout.strip() or 'no output'}"
+        )
+
+
+def dispatch_run(run_command: RunCommand, *, ref: str) -> None:
+    """Ask GitHub for a run of the verification workflow on `ref`."""
+    result = run_command(
+        ["gh", "workflow", "run", WORKFLOW_FILE, "--ref", ref, "-f", "scope=full"]
+    )
+    if result.status != 0:
+        raise Refused(
+            f"could not dispatch {WORKFLOW_FILE} on {ref}: "
+            f"{result.stderr.strip() or result.stdout.strip() or 'no output'}"
+        )
+
+
+def drive(
+    *,
+    ref: str,
+    sha: str,
+    inert: bool,
+    runtime_dir: Path,
+    slots: int,
+    run_command: RunCommand,
+    poll: float,
+    correlate_timeout: float,
+    run_timeout: float,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    report: Callable[[str], None] = _report,
+    write: Callable[[str], None] = print,
+) -> int:
+    """Hold a ticket for one whole remote verification, and return its verdict.
+
+    Order is the point: ticket, then push, then dispatch.  Nothing durable and
+    nothing metered happens until this lane is one of the two the pool allows.
+    """
+    try:
+        with take_dispatch_ticket(runtime_dir, slots) as ticket:
+            report(f"remote-verify: took dispatch ticket {ticket} of {slots}")
+            push_ref(run_command, sha=sha, ref=ref, inert=inert)
+            dispatch_run(run_command, ref=ref)
+            report(f"remote-verify: dispatched {WORKFLOW_FILE} on {ref} at {sha}")
+            found = await_dispatched_run(
+                run_command, sha,
+                timeout=correlate_timeout, poll=poll,
+                sleep=sleep, monotonic=monotonic, report=report,
+            )
+            run_id = str(found["databaseId"])
+            url = found.get("url")
+            report(f"remote-verify: watching run {run_id} {url or ''}".rstrip())
+            completed = await_completion(
+                run_command, run_id,
+                timeout=run_timeout, poll=poll,
+                sleep=sleep, monotonic=monotonic, report=report,
+            )
+            url = completed.get("url") or url or ""
+            verdict = verdict_for(completed.get("conclusion"))
+            if verdict is None:
+                raise Refused(
+                    f"run {run_id} finished {completed.get('conclusion')}, "
+                    f"which is no verdict {url}".rstrip()
+                )
+            if verdict == EXIT_PASSED:
+                write(f"remote-verify: the remote run passed {url}".rstrip())
+                return EXIT_PASSED
+            _write_failure_report(
+                run_command, run_id=run_id, url=str(url),
+                completed=completed, write=write,
+            )
+            return EXIT_FAILED
+    except NoTicket:
+        report(
+            f"remote-verify: all {slots} dispatch slots are in flight; "
+            "staying in the local queue"
+        )
+        return EXIT_REFUSED
+    except Refused as refusal:
+        report(f"remote-verify: {refusal}")
+        return EXIT_REFUSED
+
+
+def _write_failure_report(
+    run_command: RunCommand,
+    *,
+    run_id: str,
+    url: str,
+    completed: Mapping[str, object],
+    write: Callable[[str], None],
+) -> None:
+    write(f"remote-verify: the remote run FAILED {url}".rstrip())
+    jobs = failed_job_names(completed)
+    if jobs:
+        write(f"remote-verify: failing jobs: {', '.join(jobs)}")
+    with tempfile.TemporaryDirectory(prefix="remote-verify-results.") as scratch:
+        paths, problem = download_results(run_command, run_id, Path(scratch))
+        if problem:
+            write(f"remote-verify: {problem}")
+            write("remote-verify: open the run above for the failure")
+            return
+        for line in render_results(paths).lines:
+            write(line)
+
+
+def _resolve_runtime_dir(environ: Mapping[str, str]) -> Path:
+    """Where the ticket files live, following `TBD_HOME` like everything else."""
+    home = environ.get("TBD_HOME") or str(Path.home() / "tbd")
+    return Path(home).expanduser() / "runtime"
+
+
+def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = None) -> int:
+    environ = os.environ if environ is None else environ
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    driver = subcommands.add_parser("drive", help="run one remote verification")
+    driver.add_argument("--repo-dir", required=True)
+    driver.add_argument("--ref", required=True)
+    driver.add_argument("--sha", required=True)
+    driver.add_argument(
+        "--inert",
+        action="store_true",
+        help="the ref is a throwaway preflight ref and may be force-pushed",
+    )
+
+    renderer = subcommands.add_parser(
+        "render", help="render already-downloaded xUnit results"
+    )
+    renderer.add_argument("paths", nargs="+")
+
+    options = parser.parse_args(list(argv) if argv is not None else None)
+
+    if options.command == "render":
+        paths: list[Path] = []
+        for raw in options.paths:
+            path = Path(raw)
+            paths.extend(result_files(path) if path.is_dir() else [path])
+        report = render_results(paths)
+        for line in report.lines:
+            print(line)
+        return EXIT_FAILED if report.total or report.unreadable else EXIT_PASSED
+
+    repo_dir = Path(options.repo_dir)
+    try:
+        slots = configured_slots(environ)
+        poll = _positive_seconds(environ, POLL_SETTING, DEFAULT_POLL_SECONDS)
+        correlate = _positive_seconds(environ, CORRELATE_SETTING, DEFAULT_CORRELATE_SECONDS)
+        run_timeout = _positive_seconds(environ, RUN_SETTING, DEFAULT_RUN_SECONDS)
+    except ValueError as error:
+        _report(f"remote-verify: {error}")
+        return EXIT_REFUSED
+    return drive(
+        ref=options.ref,
+        sha=options.sha,
+        inert=options.inert,
+        runtime_dir=_resolve_runtime_dir(environ),
+        slots=slots,
+        run_command=system_runner(repo_dir),
+        poll=poll,
+        correlate_timeout=correlate,
+        run_timeout=run_timeout,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sweep-preflight-refs.sh
+++ b/scripts/sweep-preflight-refs.sh
@@ -40,9 +40,25 @@
 # DRY RUN IS THE DEFAULT. This deletes refs on a shared remote, so it prints its
 # plan and does nothing until `--apply` says otherwise.
 #
+# `--branch <name>` NARROWS THE PASS TO ONE REF, AND IS WHY THE CLOSE PATH IS
+# NOT ITS OWN DELETE. A PR closing reclaims its own `preflight/<branch>` through
+# this script rather than with a `git push --delete` of its own, so both guards
+# above apply on both legs and live in exactly one place. The age guard is the
+# one that matters there: in a fleet of forty worktrees "another agent merges
+# this PR while a lane verifies against it" is ordinary, and an unguarded close
+# path deletes the ref between the dispatch and `actions/checkout`, failing a run
+# that was about to pass. A ref this leg spares for its age is inert by then and
+# the weekly pass takes it.
+#
+# The name only ever FILTERS. Every branch acted on is read back out of
+# `git ls-remote`, so an argument that names nothing deletes nothing — which
+# matters because the close path's value is a PR head branch, attacker-adjacent
+# text.
+#
 # Usage:
 #   scripts/sweep-preflight-refs.sh            # print the plan; delete nothing
 #   scripts/sweep-preflight-refs.sh --apply    # delete the refs planned above
+#   scripts/sweep-preflight-refs.sh --apply --branch tbd/foo   # that ref only
 #
 # Exit status: 0 clean, 1 something was kept or failed that should not have
 # been (a `gh` query failed, an age could not be read, a delete failed), 2 the
@@ -61,7 +77,7 @@ MIN_AGE_SECONDS=3600
 log() { printf '%s\n' "$*" >&2; }
 
 usage() {
-  log "usage: sweep-preflight-refs.sh [--apply | --dry-run]"
+  log "usage: sweep-preflight-refs.sh [--apply | --dry-run] [--branch <name>]"
 }
 
 # preflight_branch_of REF -> the branch this preflight ref shadows, or nothing.
@@ -174,11 +190,23 @@ fetch_namespace_objects() {
 }
 
 main() {
-  local apply=false
+  local apply=false only_branch=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --apply)   apply=true ;;
       --dry-run) apply=false ;;
+      # A `--branch` with nothing after it must not become a whole-namespace
+      # pass: the close path spells "this one ref" that way, and a caller whose
+      # variable came out empty would silently ask for every ref instead.
+      --branch)
+        shift
+        if [[ $# -eq 0 || -z "$1" ]]; then
+          log "--branch requires a branch name"
+          usage
+          return 2
+        fi
+        only_branch="$1"
+        ;;
       -h|--help) usage; return 0 ;;
       *) log "unknown argument: $1"; usage; return 2 ;;
     esac
@@ -208,13 +236,26 @@ main() {
       echo "SKIP outside-namespace $ref"
       continue
     fi
+    # The `--branch` filter, and the only thing that argument does. It cannot
+    # widen what is eligible — a name matching no ref on the remote leaves this
+    # loop with nothing to decide.
+    if [[ -n "$only_branch" && "$branch" != "$only_branch" ]]; then
+      echo "SKIP other-branch $ref"
+      continue
+    fi
     refs+=("$ref")
     shas+=("${line%%$'\t'*}")
   done <<< "$heads"
 
   # The objects the age check needs. A ref whose object never arrives has an
   # unknown age and is kept, not guessed at; see `fetch_namespace_objects`.
-  if [[ ${#refs[@]} -gt 0 ]]; then
+  if [[ ${#refs[@]} -eq 0 ]]; then
+    # Said only for a named branch, where "there is nothing here" is the answer
+    # to a question somebody asked. An empty namespace is not news.
+    if [[ -n "$only_branch" ]]; then
+      echo "no preflight ref for $only_branch; nothing to reclaim"
+    fi
+  else
     fetch_namespace_objects "${refs[@]}"
   fi
 

--- a/scripts/sweep-preflight-refs.sh
+++ b/scripts/sweep-preflight-refs.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# scripts/sweep-preflight-refs.sh — reclaim inert `preflight/*` refs on origin.
+#
+# THE NAMED RECONCILER FOR INERT REFS. The remote verification valve
+# (docs/specs/2026-08-16-remote-verification-valve-design.md) pushes
+# `preflight/<branch>` when a lane needs a CI verdict on a branch that already
+# has an open PR: pushing the PR branch itself would fire
+# `pull_request_target: synchronize` and spend Claude quota on a review nobody
+# asked for. That inert ref is a durable external resource created outside any
+# transaction, so per CLAUDE.md it needs a sweep that compares ground truth
+# against intent rather than a best-effort cleanup on the happy path. The close
+# path in `.github/workflows/preflight-cleanup.yml` deletes a PR's ref when the
+# PR closes; this sweep reclaims every ref that path missed.
+#
+# A `preflight/<branch>` ref is KEPT when `<branch>` still has an open PR — the
+# lane may dispatch against it again at any moment. Everything else in the
+# namespace is inert and gets deleted.
+#
+# DRY RUN IS THE DEFAULT. This deletes refs on a shared remote, so it prints its
+# plan and does nothing until `--apply` says otherwise.
+#
+# Usage:
+#   scripts/sweep-preflight-refs.sh            # print the plan; delete nothing
+#   scripts/sweep-preflight-refs.sh --apply    # delete the refs planned above
+#
+# Exit status: 0 clean, 1 something was kept or failed that should not have
+# been (a `gh` query failed, a delete failed), 2 the sweep could not run at all.
+
+REMOTE="origin"
+NAMESPACE="preflight/"
+
+log() { printf '%s\n' "$*" >&2; }
+
+usage() {
+  log "usage: sweep-preflight-refs.sh [--apply | --dry-run]"
+}
+
+# preflight_branch_of REF -> the branch this preflight ref shadows, or nothing.
+#
+# THE NAMESPACE GUARD, and deliberately the only one. A ref becomes eligible for
+# deletion here and nowhere else, so there is a single place to read when asking
+# "can this sweep reach `main`?" — it cannot, because a ref that does not start
+# with `refs/heads/preflight/` yields an empty branch and is skipped. Defence in
+# depth would be worse here: a second redundant check makes each copy untestable
+# in isolation, since weakening either one leaves the other still refusing.
+preflight_branch_of() {
+  case "$1" in
+    refs/heads/"$NAMESPACE"?*) printf '%s\n' "${1#refs/heads/"$NAMESPACE"}" ;;
+    *) return 0 ;;
+  esac
+}
+
+# has_open_pr BRANCH -> 0 open PR exists, 1 none, 2 the query itself failed.
+#
+# The failure case is distinct on purpose. Treating a failed `gh` call as "no
+# open PR" would delete every ref in the namespace the first time the API rate
+# limits or the token loses its scope — a silent failure whose blast radius is
+# the whole sweep.
+has_open_pr() {
+  local out status=0
+  out="$(gh pr list --head "$1" --state open --json number --jq '.[].number' 2>&1)" || status=$?
+  if [[ $status -ne 0 ]]; then
+    log "gh pr list failed for $1 (exit $status): $out"
+    return 2
+  fi
+  [[ -n "${out//[[:space:]]/}" ]]
+}
+
+main() {
+  local apply=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply)   apply=true ;;
+      --dry-run) apply=false ;;
+      -h|--help) usage; return 0 ;;
+      *) log "unknown argument: $1"; usage; return 2 ;;
+    esac
+    shift
+  done
+
+  if ! command -v gh >/dev/null 2>&1; then
+    log "gh is not installed; refusing to sweep (every ref would look PR-less)"
+    return 2
+  fi
+
+  local heads
+  if ! heads="$(git ls-remote --heads "$REMOTE")"; then
+    log "could not list refs on $REMOTE"
+    return 2
+  fi
+
+  local line ref branch pr problems=0
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    ref="${line#*$'\t'}"                       # "<sha>\trefs/heads/<name>"
+    branch="$(preflight_branch_of "$ref")"
+    if [[ -z "$branch" ]]; then
+      echo "SKIP outside-namespace $ref"
+      continue
+    fi
+    pr=0
+    has_open_pr "$branch" || pr=$?
+    if [[ $pr -eq 0 ]]; then
+      echo "KEEP open-pr $NAMESPACE$branch"
+      continue
+    fi
+    if [[ $pr -eq 2 ]]; then
+      echo "KEEP unknown-pr-state $NAMESPACE$branch"
+      problems=1
+      continue
+    fi
+    echo "PLAN delete $NAMESPACE$branch"
+    if [[ "$apply" == "true" ]]; then
+      if git push "$REMOTE" --delete "refs/heads/$NAMESPACE$branch" >/dev/null 2>&1; then
+        log "deleted $NAMESPACE$branch"
+      else
+        log "delete failed: $NAMESPACE$branch"
+        problems=1
+      fi
+    fi
+  done <<< "$heads"
+
+  if [[ "$apply" != "true" ]]; then
+    log "dry run: nothing deleted. Pass --apply to delete the refs planned above."
+  fi
+  return $problems
+}
+
+# --- entrypoint (strict mode only when executed, not when sourced) -----------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  main "$@"
+fi

--- a/scripts/sweep-preflight-refs.sh
+++ b/scripts/sweep-preflight-refs.sh
@@ -12,9 +12,30 @@
 # path in `.github/workflows/preflight-cleanup.yml` deletes a PR's ref when the
 # PR closes; this sweep reclaims every ref that path missed.
 #
-# A `preflight/<branch>` ref is KEPT when `<branch>` still has an open PR — the
-# lane may dispatch against it again at any moment. Everything else in the
-# namespace is inert and gets deleted.
+# A `preflight/<branch>` ref is KEPT when it is still plausibly in use, which is
+# two conditions rather than one:
+#
+#   - **An open PR names it.** Either `<branch>` or the ref's own full name has
+#     one; see `has_open_pr_for_any` for why both are asked about. The lane may
+#     dispatch against it again at any moment.
+#   - **It is younger than `MIN_AGE_SECONDS`.** The driver pushes
+#     `preflight/<branch>` for every lane, including one whose branch has no PR
+#     at all, so a brand-new ref is otherwise eligible for deletion the instant
+#     it exists — and this sweep could land between the push and the dispatch
+#     that consumes it.
+#
+# Everything else in the namespace is inert and gets deleted.
+#
+# WHAT THE AGE GUARD MEASURES, AND WHAT IT THEREFORE CANNOT SEE. There is no
+# push timestamp on a remote ref, so the age used here is the COMMIT's committer
+# date. That is a sound one-way implication: a ref cannot have been pushed before
+# its commit existed, so a commit younger than the grace period guarantees a ref
+# younger than it. The converse does not hold — a lane re-verifying a branch it
+# has not touched today pushes an old commit, and that ref is not spared. The
+# residual is small and its cost is bounded: the window is push → dispatch →
+# checkout (runner pickup is 3s at p90, and a ref deleted after checkout cannot
+# disturb a run that already has the code), and a lane whose dispatch fails
+# falls back to the local queue rather than reporting a wrong verdict.
 #
 # DRY RUN IS THE DEFAULT. This deletes refs on a shared remote, so it prints its
 # plan and does nothing until `--apply` says otherwise.
@@ -24,10 +45,18 @@
 #   scripts/sweep-preflight-refs.sh --apply    # delete the refs planned above
 #
 # Exit status: 0 clean, 1 something was kept or failed that should not have
-# been (a `gh` query failed, a delete failed), 2 the sweep could not run at all.
+# been (a `gh` query failed, an age could not be read, a delete failed), 2 the
+# sweep could not run at all.
 
 REMOTE="origin"
 NAMESPACE="preflight/"
+
+# THE GRACE PERIOD, SIZED AGAINST A RUN RATHER THAN AGAINST TIDINESS. The
+# valve's worst observed end-to-end remote run is 1910s and its ceiling is
+# ~2700s, so an hour clears a whole run with room to spare. Nothing is lost by
+# being generous: a ref that outlives its usefulness by an hour costs one line
+# in a namespace, and this sweep runs again.
+MIN_AGE_SECONDS=3600
 
 log() { printf '%s\n' "$*" >&2; }
 
@@ -56,14 +85,92 @@ preflight_branch_of() {
 # open PR" would delete every ref in the namespace the first time the API rate
 # limits or the token loses its scope — a silent failure whose blast radius is
 # the whole sweep.
+#
+# STDOUT ONLY DECIDES THE ANSWER. Folding stderr in with `2>&1` would let any
+# benign `gh` message — a deprecation notice, an upgrade nag, a hint about a
+# missing default remote — land in the value whose emptiness means "a PR exists".
+# The verdict would still be KEEP, so nothing would break loudly; the check would
+# simply be reading the wrong stream, and the first `gh` release that started
+# printing a notice would quietly stop this sweep deleting anything. `gh`'s
+# stderr is left to flow to ours, where an operator reads it verbatim.
 has_open_pr() {
-  local out status=0
-  out="$(gh pr list --head "$1" --state open --json number --jq '.[].number' 2>&1)" || status=$?
+  local numbers status=0
+  numbers="$(gh pr list --head "$1" --state open --json number --jq '.[].number')" || status=$?
   if [[ $status -ne 0 ]]; then
-    log "gh pr list failed for $1 (exit $status): $out"
+    log "gh pr list failed for $1 (exit $status); gh's own message is above"
     return 2
   fi
-  [[ -n "${out//[[:space:]]/}" ]]
+  [[ -n "${numbers//[[:space:]]/}" ]]
+}
+
+# has_open_pr_for_any HEAD... -> 0 any has an open PR, 1 none does, 2 a query
+# failed (and no other query answered yes).
+#
+# BOTH THE STRIPPED NAME AND THE REF'S OWN NAME GET ASKED ABOUT, because the
+# namespace is a convention rather than a reservation. Nothing stops a human from
+# working on a branch actually named `preflight/flaky-repro` and opening a PR for
+# it: `preflight_branch_of` hands back `flaky-repro`, `gh` finds no PR for a
+# branch by that name, and the sweep deletes the branch the PR is built on —
+# breaking the PR rather than reclaiming an orphan. Either name answering yes is
+# enough to keep the ref, which is the safe direction: the cost of a false KEEP
+# is one surviving ref, and the cost of a false delete is somebody's work.
+#
+# A failed query never becomes a "no" — same reasoning as `has_open_pr` — but it
+# does not override a yes either, so an open PR found on the first name is
+# reported even if the second query cannot be answered.
+has_open_pr_for_any() {
+  local head status failed=0
+  for head in "$@"; do
+    status=0
+    has_open_pr "$head" || status=$?
+    case "$status" in
+      0) return 0 ;;
+      2) failed=1 ;;
+    esac
+  done
+  if [[ $failed -eq 1 ]]; then
+    return 2
+  fi
+  return 1
+}
+
+# commit_time_of SHA -> the commit's committer time as a unix timestamp, or
+# nothing at all when this clone cannot see the object. Empty is a distinct
+# outcome from "old", and the caller keeps the ref rather than guessing.
+# `|| true` IS LOAD-BEARING UNDER `set -e`. Without it a `git log` that cannot
+# find the object exits 128, and `var="$(commit_time_of …)"` takes that as the
+# assignment's own status — killing the whole sweep at the first undatable ref
+# instead of keeping it and moving on.
+commit_time_of() {
+  git log -1 --format=%ct "$1" 2>/dev/null || true
+}
+
+# fetch_namespace_objects REF... -> best effort; the objects are what the age
+# check needs, and `git log` cannot date a commit this clone has never seen.
+#
+# ONE FETCH, THEN ONE PER REF IF THAT FAILED, AND THE RETRY IS NOT BELT AND
+# BRACES. git aborts an entire fetch on the first ref it cannot serve — one
+# deleted between the listing and now, or a dangling ref written by something
+# that bypassed git — so a single bad ref would leave EVERY age unknown. That is
+# the safe direction for one run, but it is not safe standing: unknown age means
+# KEEP, so the bad ref survives to poison the next run too, and the sweep would
+# never reclaim anything again. Retrying one at a time confines the damage to the
+# ref that caused it.
+#
+# Explicit refspecs with no destination — no wildcard, which git rejects without
+# one — land in `FETCH_HEAD`, which the next fetch overwrites. No local ref is
+# created, so there is nothing here for anything to reclaim.
+fetch_namespace_objects() {
+  local ref
+  if git fetch --quiet "$REMOTE" "$@"; then
+    return 0
+  fi
+  log "batch fetch of $NAMESPACE objects failed; retrying one ref at a time"
+  for ref in "$@"; do
+    if ! git fetch --quiet "$REMOTE" "$ref" 2>/dev/null; then
+      log "could not fetch $ref; its age will be unknown"
+    fi
+  done
 }
 
 main() {
@@ -89,7 +196,10 @@ main() {
     return 2
   fi
 
-  local line ref branch pr problems=0
+  # PASS ONE — partition the remote's heads. The namespace guard runs here and
+  # nowhere else, so `main` is reported skipped and never reaches the rest.
+  local line ref branch problems=0
+  local refs=() shas=()
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
     ref="${line#*$'\t'}"                       # "<sha>\trefs/heads/<name>"
@@ -98,8 +208,26 @@ main() {
       echo "SKIP outside-namespace $ref"
       continue
     fi
+    refs+=("$ref")
+    shas+=("${line%%$'\t'*}")
+  done <<< "$heads"
+
+  # The objects the age check needs. A ref whose object never arrives has an
+  # unknown age and is kept, not guessed at; see `fetch_namespace_objects`.
+  if [[ ${#refs[@]} -gt 0 ]]; then
+    fetch_namespace_objects "${refs[@]}"
+  fi
+
+  # PASS TWO — decide each ref. The PR question is asked before the age one so
+  # that an in-use ref is reported as such rather than as merely young.
+  local i sha pr committed now age
+  now="$(date +%s)"
+  for (( i = 0; i < ${#refs[@]}; i++ )); do
+    ref="${refs[$i]}"
+    sha="${shas[$i]}"
+    branch="$(preflight_branch_of "$ref")"
     pr=0
-    has_open_pr "$branch" || pr=$?
+    has_open_pr_for_any "$branch" "$NAMESPACE$branch" || pr=$?
     if [[ $pr -eq 0 ]]; then
       echo "KEEP open-pr $NAMESPACE$branch"
       continue
@@ -109,16 +237,27 @@ main() {
       problems=1
       continue
     fi
+    committed="$(commit_time_of "$sha")"
+    if [[ -z "$committed" ]]; then
+      echo "KEEP unknown-age $NAMESPACE$branch"
+      problems=1
+      continue
+    fi
+    age=$(( now - committed ))
+    if [[ $age -lt $MIN_AGE_SECONDS ]]; then
+      echo "KEEP too-young $NAMESPACE$branch (${age}s < ${MIN_AGE_SECONDS}s)"
+      continue
+    fi
     echo "PLAN delete $NAMESPACE$branch"
     if [[ "$apply" == "true" ]]; then
-      if git push "$REMOTE" --delete "refs/heads/$NAMESPACE$branch" >/dev/null 2>&1; then
+      if git push "$REMOTE" --delete "$ref" >/dev/null 2>&1; then
         log "deleted $NAMESPACE$branch"
       else
         log "delete failed: $NAMESPACE$branch"
         problems=1
       fi
     fi
-  done <<< "$heads"
+  done
 
   if [[ "$apply" != "true" ]]; then
     log "dry run: nothing deleted. Pass --apply to delete the refs planned above."

--- a/scripts/sweep-preflight-refs.sh
+++ b/scripts/sweep-preflight-refs.sh
@@ -13,42 +13,61 @@
 # PR closes; this sweep reclaims every ref that path missed.
 #
 # A `preflight/<branch>` ref is KEPT when it is still plausibly in use, which is
-# two conditions rather than one:
+# three conditions rather than one:
 #
 #   - **An open PR names it.** Either `<branch>` or the ref's own full name has
 #     one; see `has_open_pr_for_any` for why both are asked about. The lane may
 #     dispatch against it again at any moment.
+#   - **A workflow run is using it.** A run against `preflight/<branch>` that has
+#     not reached `completed` may not have checked out the code yet, so deleting
+#     the ref under it fails the run. This is asked directly rather than inferred;
+#     see `has_live_run`.
 #   - **It is younger than `MIN_AGE_SECONDS`.** The driver pushes
 #     `preflight/<branch>` for every lane, including one whose branch has no PR
 #     at all, so a brand-new ref is otherwise eligible for deletion the instant
-#     it exists — and this sweep could land between the push and the dispatch
-#     that consumes it.
+#     it exists.
 #
 # Everything else in the namespace is inert and gets deleted.
 #
-# WHAT THE AGE GUARD MEASURES, AND WHAT IT THEREFORE CANNOT SEE. There is no
-# push timestamp on a remote ref, so the age used here is the COMMIT's committer
-# date. That is a sound one-way implication: a ref cannot have been pushed before
-# its commit existed, so a commit younger than the grace period guarantees a ref
-# younger than it. The converse does not hold — a lane re-verifying a branch it
-# has not touched today pushes an old commit, and that ref is not spared. The
-# residual is small and its cost is bounded: the window is push → dispatch →
-# checkout (runner pickup is 3s at p90, and a ref deleted after checkout cannot
-# disturb a run that already has the code), and a lane whose dispatch fails
-# falls back to the local queue rather than reporting a wrong verdict.
+# THE TWO GUARDS COVER DISJOINT HALVES OF ONE WINDOW, WHICH IS WHY BOTH ARE HERE.
+# The exposure runs push → dispatch → checkout:
+#
+#   - Between the PUSH and the DISPATCH there is no run to ask about yet, so the
+#     live-run query answers "none" for a ref that is about to be used. Only the
+#     age guard spares it.
+#   - After the DISPATCH the run exists, and the age guard is the weaker half:
+#     the age it can observe is the COMMIT's committer date, since a remote ref
+#     carries no push timestamp. A commit younger than the grace period does
+#     imply a ref younger than it, but the converse fails, and it fails in the
+#     COMMON case rather than an exotic one — an agent commits, and the run
+#     needing verification happens minutes or hours later, so a ref pushed
+#     seconds ago reports an age well past the grace period. The live-run query
+#     is what spares that ref.
+#
+# HOW WIDE THAT WINDOW REALLY IS. Not seconds. Runner pickup measured at 3s at
+# p90 on an idle account, but the valve fires precisely when the local machine is
+# at capacity, and past roughly two concurrent runs everything queues on GitHub's
+# side — five concurrent macOS jobs per account, two per `test.yml` run. The
+# realistic dispatch → checkout window is minutes, which is why "the age guard
+# plus a short grace period" was not a sufficient bound on its own.
+#
+# WHAT A DELETED-TOO-EARLY REF ACTUALLY COSTS. The run fails at
+# `actions/checkout`, produces no results artifact, and the driver treats a
+# missing artifact as a refusal — so the lane falls back to a local run rather
+# than reporting a wrong verdict. The verdict is safe; what is wasted is a scarce
+# macOS slot and a lane's whole round trip, and that is worth a query to avoid.
 #
 # DRY RUN IS THE DEFAULT. This deletes refs on a shared remote, so it prints its
 # plan and does nothing until `--apply` says otherwise.
 #
 # `--branch <name>` NARROWS THE PASS TO ONE REF, AND IS WHY THE CLOSE PATH IS
 # NOT ITS OWN DELETE. A PR closing reclaims its own `preflight/<branch>` through
-# this script rather than with a `git push --delete` of its own, so both guards
-# above apply on both legs and live in exactly one place. The age guard is the
-# one that matters there: in a fleet of forty worktrees "another agent merges
-# this PR while a lane verifies against it" is ordinary, and an unguarded close
-# path deletes the ref between the dispatch and `actions/checkout`, failing a run
-# that was about to pass. A ref this leg spares for its age is inert by then and
-# the weekly pass takes it.
+# this script rather than with a `git push --delete` of its own, so all three
+# guards above apply on both legs and live in exactly one place. They matter most
+# there: in a fleet of forty worktrees "another agent merges this PR while a lane
+# verifies against it" is ordinary, and an unguarded close path deletes the ref
+# between the dispatch and `actions/checkout`, wasting a run that was about to
+# pass. A ref this leg spares is inert soon after and the weekly pass takes it.
 #
 # The name only ever FILTERS. Every branch acted on is read back out of
 # `git ls-remote`, so an argument that names nothing deletes nothing — which
@@ -67,11 +86,13 @@
 REMOTE="origin"
 NAMESPACE="preflight/"
 
-# THE GRACE PERIOD, SIZED AGAINST A RUN RATHER THAN AGAINST TIDINESS. The
-# valve's worst observed end-to-end remote run is 1910s and its ceiling is
-# ~2700s, so an hour clears a whole run with room to spare. Nothing is lost by
-# being generous: a ref that outlives its usefulness by an hour costs one line
-# in a namespace, and this sweep runs again.
+# THE GRACE PERIOD — THE SECOND LINE, AND THE ONLY ONE THAT COVERS PUSH →
+# DISPATCH. `has_live_run` answers the in-use question directly once a run exists;
+# before one does, this is what spares a ref. Sized against a run rather than
+# against tidiness: the valve's worst observed end-to-end remote run is 1910s and
+# its ceiling is ~2700s, so an hour clears a whole one with room to spare. Nothing
+# is lost by being generous — a ref that outlives its usefulness by an hour costs
+# one line in a namespace, and this sweep runs again.
 MIN_AGE_SECONDS=3600
 
 log() { printf '%s\n' "$*" >&2; }
@@ -148,6 +169,38 @@ has_open_pr_for_any() {
     return 2
   fi
   return 1
+}
+
+# has_live_run REF_BRANCH -> 0 a workflow run is using this ref, 1 none is, 2 the
+# query itself failed.
+#
+# THE QUESTION THE AGE GUARD CANNOT ANSWER, ASKED DIRECTLY. `gh run list --branch`
+# reports the runs GitHub has for a ref, so "is anything using it?" needs no
+# inference from a commit date at all. A ref with a live run is KEPT regardless of
+# how old its commit is, which is the case the age guard gets wrong every time an
+# agent verifies a commit it made an hour ago.
+#
+# THE FILTER IS `!= "completed"`, NOT A LIST OF THE LIVE STATUSES. The API's `status`
+# is one of `queued`, `in_progress`, `waiting`, `requested`, `pending` or
+# `completed`, and new spellings have been added before. Naming the live ones would
+# make a status nobody here has heard of read as "not in use" — a DELETE. Negating
+# the one terminal value makes every unknown read as "in use", which is a KEEP, and
+# the cost of a false keep is one surviving ref for a week.
+#
+# STDOUT ONLY DECIDES, and a failed query is its own outcome — the same two rules
+# `has_open_pr` is built on, and for the same reasons: a benign `gh` notice on
+# stderr must not read as a live run, and a rate limit must not read as an idle
+# ref. This one also needs `actions: read` in any workflow that calls it; without
+# it every query 403s, which lands here as "unknown" and keeps every ref.
+has_live_run() {
+  local live status=0
+  live="$(gh run list --branch "$1" --limit 50 --json status \
+            --jq '.[] | select(.status != "completed") | .status')" || status=$?
+  if [[ $status -ne 0 ]]; then
+    log "gh run list failed for $1 (exit $status); gh's own message is above"
+    return 2
+  fi
+  [[ -n "${live//[[:space:]]/}" ]]
 }
 
 # commit_time_of SHA -> the commit's committer time as a unix timestamp, or
@@ -259,9 +312,11 @@ main() {
     fetch_namespace_objects "${refs[@]}"
   fi
 
-  # PASS TWO — decide each ref. The PR question is asked before the age one so
-  # that an in-use ref is reported as such rather than as merely young.
-  local i sha pr committed now age
+  # PASS TWO — decide each ref. The questions are asked in order of how directly
+  # they answer "is this in use?", so a ref that is kept is reported with the
+  # strongest reason that applies rather than with whichever guard fired first: an
+  # open PR, then a live run, then merely being young.
+  local i sha pr run committed now age
   now="$(date +%s)"
   for (( i = 0; i < ${#refs[@]}; i++ )); do
     ref="${refs[$i]}"
@@ -275,6 +330,21 @@ main() {
     fi
     if [[ $pr -eq 2 ]]; then
       echo "KEEP unknown-pr-state $NAMESPACE$branch"
+      problems=1
+      continue
+    fi
+    # THE REF'S OWN NAME IS THE ONE A RUN IS ATTACHED TO. The valve dispatches
+    # against `preflight/<branch>`, never against `<branch>`, so this asks about
+    # the full ref name rather than the stripped one `has_open_pr_for_any` also
+    # tries.
+    run=0
+    has_live_run "$NAMESPACE$branch" || run=$?
+    if [[ $run -eq 0 ]]; then
+      echo "KEEP live-run $NAMESPACE$branch"
+      continue
+    fi
+    if [[ $run -eq 2 ]]; then
+      echo "KEEP unknown-run-state $NAMESPACE$branch"
       problems=1
       continue
     fi

--- a/scripts/sweep-preflight-refs.test.sh
+++ b/scripts/sweep-preflight-refs.test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Tests for scripts/sweep-preflight-refs.sh — run: bash scripts/sweep-preflight-refs.test.sh
+#
+# NOTHING HERE TOUCHES A REAL REMOTE. Each case builds a throwaway bare repo in
+# a temp dir and points a throwaway clone's `origin` at it, so the sweep runs
+# its real `git ls-remote` / `git push --delete` against a fixture. `gh` is a
+# stub on PATH; the real one is never reached, authenticated or not.
+#
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F`/"$t" below
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SWEEP="$HERE/sweep-preflight-refs.sh"
+# shellcheck source=/dev/null
+source "$SWEEP"   # source-guard prevents main() from running
+
+FAIL=0
+assert_eq()       { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: [$2] lacks [$3]"; FAIL=1; fi; }
+assert_missing()  { if [[ "$2" != *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: [$2] unexpectedly contains [$3]"; FAIL=1; fi; }
+mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/preflight-sweep-test.XXXXXX"; }
+
+# --- fixture -----------------------------------------------------------------
+
+# mkfixture ROOT BRANCH... -> a bare "origin" carrying one commit on each named
+# branch, plus a clone whose `origin` points at it. Identity and signing are
+# pinned per-command: a developer's global `commit.gpgsign` would otherwise make
+# the fixture commit fail here (and only here) with no obvious cause.
+GIT_FIXTURE=(git -c user.email=sweep-test@example.invalid -c user.name="Sweep Test" -c commit.gpgsign=false)
+
+mkfixture() {
+  local root="$1"; shift
+  git init -q --bare "$root/origin.git"
+  git init -q "$root/work"
+  : > "$root/work/seed"
+  "${GIT_FIXTURE[@]}" -C "$root/work" add seed
+  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -m "seed"
+  git -C "$root/work" remote add origin "$root/origin.git"
+  local branch
+  for branch in "$@"; do
+    git -C "$root/work" push -q origin "HEAD:refs/heads/$branch"
+  done
+}
+
+# stub_gh ROOT [OPEN_PR_BRANCHES] — a `gh` on PATH that reports an open PR for
+# each space-separated branch named, and none for anything else. With
+# STUB_GH_FAIL=1 in the environment it fails instead, standing in for a rate
+# limit or a token that lost its scope.
+stub_gh() {
+  local root="$1" open="${2:-}"
+  mkdir -p "$root/bin"
+  cat > "$root/bin/gh" <<STUB
+#!/usr/bin/env bash
+if [[ -n "\${STUB_GH_FAIL:-}" ]]; then echo "API rate limit exceeded" >&2; exit 1; fi
+head=""
+while [[ \$# -gt 0 ]]; do
+  if [[ "\$1" == "--head" ]]; then head="\$2"; shift; fi
+  shift
+done
+for open_branch in $open; do
+  if [[ "\$head" == "\$open_branch" ]]; then echo 7; exit 0; fi
+done
+exit 0
+STUB
+  chmod +x "$root/bin/gh"
+}
+
+# refs_on_origin ROOT -> the fixture remote's branch names, sorted, space-joined.
+refs_on_origin() {
+  git -C "$1/work" ls-remote --heads origin | awk '{sub(/^refs\/heads\//, "", $2); print $2}' | sort | tr '\n' ' '
+}
+
+# run_sweep ROOT ARGS... -> runs the sweep in ROOT's clone with the stub `gh`
+# first on PATH, leaving its combined output in OUT and its status in RC.
+# Deliberately NOT `out=$(run_sweep …)`: command substitution would run this in
+# a subshell and the status would never come back.
+OUT=""
+RC=0
+run_sweep() {
+  local root="$1"; shift
+  OUT="$(cd "$root/work" && PATH="$root/bin:$PATH" bash "$SWEEP" "$@" 2>&1)"
+  RC=$?
+}
+
+# --- the namespace guard, at the unit level ----------------------------------
+
+test_preflight_branch_of_only_matches_the_namespace() {
+  assert_eq "a preflight ref yields its branch" "feature-a" "$(preflight_branch_of refs/heads/preflight/feature-a)"
+  assert_eq "a nested branch keeps its slashes" "tbd/x/y" "$(preflight_branch_of refs/heads/preflight/tbd/x/y)"
+  assert_eq "main yields nothing" "" "$(preflight_branch_of refs/heads/main)"
+  assert_eq "a lookalike prefix yields nothing" "" "$(preflight_branch_of refs/heads/preflighty/x)"
+  assert_eq "a bare namespace with no branch yields nothing" "" "$(preflight_branch_of refs/heads/preflight/)"
+  assert_eq "a tag in the namespace yields nothing" "" "$(preflight_branch_of refs/tags/preflight/x)"
+}
+
+# --- the sweep ---------------------------------------------------------------
+
+test_dry_run_is_the_default() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  run_sweep "$root"
+  assert_contains "orphan planned for deletion" "$OUT" "PLAN delete preflight/orphan"
+  assert_contains "the plan says it did nothing" "$OUT" "dry run: nothing deleted"
+  assert_eq "the ref survives a default run" "main preflight/orphan " "$(refs_on_origin "$root")"
+  assert_eq "dry run exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+test_apply_deletes_an_orphaned_preflight_ref() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  run_sweep "$root" --apply
+  assert_contains "orphan planned for deletion" "$OUT" "PLAN delete preflight/orphan"
+  assert_eq "only main is left" "main " "$(refs_on_origin "$root")"
+  assert_eq "apply exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# THE OPEN-PR GUARD. The lane can dispatch against this ref again at any moment.
+test_a_ref_whose_branch_has_an_open_pr_survives_apply() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main feature-a preflight/feature-a
+  stub_gh "$root" "feature-a"
+  run_sweep "$root" --apply
+  assert_contains "kept for its open PR" "$OUT" "KEEP open-pr preflight/feature-a"
+  assert_missing "and never planned for deletion" "$OUT" "PLAN delete preflight/feature-a"
+  assert_eq "the ref survives" "feature-a main preflight/feature-a " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# THE NAMESPACE GUARD. Everything outside `preflight/` is untouchable, including
+# refs whose names merely start with the word.
+test_refs_outside_the_namespace_are_never_touched() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main feature-c preflighty/decoy preflight/orphan
+  stub_gh "$root"
+  run_sweep "$root" --apply
+  assert_contains "main skipped by name" "$OUT" "SKIP outside-namespace refs/heads/main"
+  assert_contains "a lookalike prefix skipped" "$OUT" "SKIP outside-namespace refs/heads/preflighty/decoy"
+  assert_missing "main never planned" "$OUT" "PLAN delete main"
+  assert_eq "only the preflight ref went" "feature-c main preflighty/decoy " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# A failed query is not evidence of a missing PR. Treating it as one would empty
+# the whole namespace the first time the API rate limits.
+test_a_failed_pr_query_keeps_the_ref_and_reports() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  export STUB_GH_FAIL=1
+  run_sweep "$root" --apply
+  unset STUB_GH_FAIL
+  assert_contains "kept, state unknown" "$OUT" "KEEP unknown-pr-state preflight/orphan"
+  assert_contains "the failure is reported" "$OUT" "gh pr list failed for orphan"
+  assert_eq "the ref survives" "main preflight/orphan " "$(refs_on_origin "$root")"
+  assert_eq "and the sweep exits non-zero" "1" "$RC"
+  rm -rf "$root"
+}
+
+test_a_missing_gh_refuses_to_sweep() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  # An empty PATH, so a `gh` installed on this machine cannot be found. `bash`
+  # is named absolutely for the same reason — PATH is where it would come from.
+  mkdir -p "$root/bin"
+  local out
+  out="$(cd "$root/work" && PATH="$root/bin" /bin/bash "$SWEEP" --apply 2>&1)"
+  local rc=$?
+  assert_contains "names the missing tool" "$out" "gh is not installed"
+  assert_eq "refuses with 2" "2" "$rc"
+  assert_eq "the ref survives" "main preflight/orphan " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+test_an_unknown_argument_refuses() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  run_sweep "$root" --force
+  assert_contains "names the argument" "$OUT" "unknown argument: --force"
+  assert_eq "refuses with 2" "2" "$RC"
+  assert_eq "the ref survives" "main preflight/orphan " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done
+exit $FAIL

--- a/scripts/sweep-preflight-refs.test.sh
+++ b/scripts/sweep-preflight-refs.test.sh
@@ -97,22 +97,66 @@ clone_without_namespace() {
   git clone -q --single-branch --branch main "file://$root/origin.git" "$root/clone"
 }
 
-# stub_gh ROOT [OPEN_PR_BRANCHES] — a `gh` on PATH that reports an open PR for
-# each space-separated branch named, and none for anything else. Two knobs stand
-# in for the two ways a real `gh` misbehaves:
+# stub_gh ROOT [OPEN_PR_BRANCHES] [LIVE_RUN_REFS] — a `gh` on PATH answering both
+# questions the sweep asks. `gh pr list --head X` reports an open PR for each
+# space-separated branch in OPEN_PR_BRANCHES; `gh run list --branch X` reports a
+# run for each ref in LIVE_RUN_REFS. Anything else gets no answer.
 #
-#   STUB_GH_FAIL=1  it fails outright — a rate limit, or a token that lost its
-#                   scope.
-#   STUB_GH_WARN=…  it succeeds, prints nothing on stdout, and writes the given
-#                   text to STDERR. That is the shape of every benign `gh`
-#                   message: a deprecation notice, an upgrade nag, a hint about
-#                   a missing default remote.
+# THE RUN LEG RUNS THE REAL `--jq` EXPRESSION. `gh` applies `--jq` internally, so a
+# stub that printed pre-filtered lines would leave the sweep's actual filter —
+# `select(.status != "completed")`, chosen so an unrecognised status reads as
+# in-use — never executed by anything. Instead the stub emits the JSON shape `gh
+# run list --json status` really produces and pipes it through `jq` with whatever
+# expression it was handed. `jq` ships with macOS; a machine without it skips
+# those cases rather than passing them vacuously.
+#
+# Four knobs stand in for the ways a real `gh` misbehaves:
+#
+#   STUB_GH_FAIL=1      every subcommand fails outright — a rate limit, or a
+#                       token that lost its scope.
+#   STUB_GH_WARN=…      `pr list` succeeds, prints nothing on stdout, and writes
+#                       the given text to STDERR. That is the shape of every
+#                       benign `gh` message: a deprecation notice, an upgrade
+#                       nag, a hint about a missing default remote.
+#   STUB_GH_RUN_FAIL=1  only `run list` fails — the `actions: read` scope missing
+#                       from a workflow while `pull-requests: read` is present.
+#   STUB_GH_RUN_WARN=…  only `run list` writes a benign notice to stderr.
+#
+# STUB_GH_RUN_STATUS picks which live status a matching ref reports; the default is
+# `in_progress`.
 stub_gh() {
-  local root="$1" open="${2:-}"
+  local root="$1" open="${2:-}" live="${3:-}"
   mkdir -p "$root/bin"
   cat > "$root/bin/gh" <<STUB
 #!/usr/bin/env bash
 if [[ -n "\${STUB_GH_FAIL:-}" ]]; then echo "API rate limit exceeded" >&2; exit 1; fi
+
+if [[ "\${1:-}" == "run" ]]; then
+  if [[ -n "\${STUB_GH_RUN_FAIL:-}" ]]; then
+    echo "gh: Resource not accessible by integration (HTTP 403)" >&2; exit 1
+  fi
+  if [[ -n "\${STUB_GH_RUN_WARN:-}" ]]; then echo "\$STUB_GH_RUN_WARN" >&2; exit 0; fi
+  branch=""; jq_expr=""
+  while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+      --branch) branch="\$2"; shift ;;
+      --jq)     jq_expr="\$2"; shift ;;
+    esac
+    shift
+  done
+  # The runs this ref has. A matching ref gets one live run plus one completed
+  # one, so the filter has to do real work; a non-matching ref gets the completed
+  # one only.
+  json='[{"status":"completed"}]'
+  for live_ref in $live; do
+    if [[ "\$branch" == "\$live_ref" ]]; then
+      json='[{"status":"'"\${STUB_GH_RUN_STATUS:-in_progress}"'"},{"status":"completed"}]'
+    fi
+  done
+  printf '%s' "\$json" | jq -r "\$jq_expr"
+  exit 0
+fi
+
 if [[ -n "\${STUB_GH_WARN:-}" ]]; then echo "\$STUB_GH_WARN" >&2; exit 0; fi
 head=""
 while [[ \$# -gt 0 ]]; do
@@ -126,6 +170,10 @@ exit 0
 STUB
   chmod +x "$root/bin/gh"
 }
+
+# The run-leg cases need a real `jq`, since the stub applies the sweep's own `--jq`
+# expression rather than faking its output. Echoes "yes" or "no".
+have_jq() { if command -v jq >/dev/null 2>&1; then echo yes; else echo no; fi; }
 
 # refs_on_origin ROOT -> the fixture remote's branch names, sorted, space-joined.
 refs_on_origin() {
@@ -384,6 +432,187 @@ test_an_aged_ref_with_no_pr_is_still_reclaimed() {
   rm -rf "$root"
 }
 
+# --- the live-run guard ------------------------------------------------------
+#
+# THE GUARD THE AGE ONE CANNOT BE. The age a remote ref exposes is its COMMIT's
+# committer date, and the common case is a commit made well before the run that
+# verifies it: an agent commits, and the lane needing a verdict queues for the
+# local slot for minutes or hours first. Such a ref reports an age far past the
+# grace period while a run is checking it out right now. Asking `gh run list`
+# whether anything is using the ref answers that directly, and a ref with a live
+# run is kept however old its commit is.
+
+test_an_aged_ref_with_a_live_run_is_kept() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/verifying
+  stub_gh "$root" "" "preflight/verifying"
+  run_sweep "$root" --apply
+  assert_contains "kept because a run is using it" "$OUT" "KEEP live-run preflight/verifying"
+  assert_missing "and never planned for deletion" "$OUT" "PLAN delete preflight/verifying"
+  assert_missing "its age was not the reason" "$OUT" "KEEP too-young preflight/verifying"
+  assert_eq "the ref survives its own aged commit" "main preflight/verifying " \
+    "$(refs_on_origin "$root")"
+  assert_eq "and an in-use ref is not a problem" "0" "$RC"
+  rm -rf "$root"
+}
+
+# MUTATION. Drop the live-run check — the shape this sweep shipped with, where the
+# age guard was the only second line — and a ref an in-flight run is about to check
+# out is deleted out from under it.
+test_the_live_run_guard_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/verifying
+  stub_gh "$root" "" "preflight/verifying"
+  run_mutant_sweep "$root" 's/if \[\[ \$run -eq 0 \]\]; then/if false; then/' --apply
+  assert_contains "without it the ref is planned despite the live run" "$OUT" \
+    "PLAN delete preflight/verifying"
+  assert_eq "and taken out from under the run" "main " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# The guard must not become a blanket KEEP. A ref whose runs have all COMPLETED is
+# inert, and a sweep that kept every ref that ever had a run would never reclaim
+# anything.
+test_a_ref_whose_runs_have_all_completed_is_reclaimed() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/finished
+  # No live refs, so the stub answers with a completed run only.
+  stub_gh "$root"
+  run_sweep "$root" --apply
+  assert_contains "a finished run does not keep the ref" "$OUT" "PLAN delete preflight/finished"
+  assert_missing "and it is not reported as in use" "$OUT" "KEEP live-run"
+  assert_eq "only main is left" "main " "$(refs_on_origin "$root")"
+  assert_eq "and the sweep exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# A STATUS NOBODY HERE HAS HEARD OF READS AS IN USE. The filter negates the one
+# terminal value rather than listing the live ones, so a spelling GitHub adds later
+# fails towards KEEP — one surviving ref for a week — instead of towards a delete
+# under a live run.
+test_an_unrecognised_run_status_is_read_as_in_use() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/verifying
+  stub_gh "$root" "" "preflight/verifying"
+  export STUB_GH_RUN_STATUS="some_status_invented_in_2027"
+  run_sweep "$root" --apply
+  unset STUB_GH_RUN_STATUS
+  assert_contains "an unknown status keeps the ref" "$OUT" "KEEP live-run preflight/verifying"
+  assert_eq "the ref survives" "main preflight/verifying " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# MUTATION. Name the live statuses instead of negating the terminal one and the
+# same ref is deleted, because its status is not on the list.
+test_negating_the_terminal_status_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/verifying
+  stub_gh "$root" "" "preflight/verifying"
+  export STUB_GH_RUN_STATUS="some_status_invented_in_2027"
+  run_mutant_sweep "$root" \
+    's/select\(\.status != "completed"\)/select(.status == "queued" or .status == "in_progress")/' \
+    --apply
+  unset STUB_GH_RUN_STATUS
+  assert_contains "an allowlist deletes a ref whose status it does not know" "$OUT" \
+    "PLAN delete preflight/verifying"
+  assert_eq "and the run loses its ref" "main " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# A FAILED RUN QUERY IS NOT AN IDLE REF — the same rule `has_open_pr` follows, and
+# the concrete way to hit it is a workflow with `pull-requests: read` but no
+# `actions: read`, where the PR question answers and the run question 403s.
+test_a_failed_run_query_keeps_the_ref_and_reports() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  export STUB_GH_RUN_FAIL=1
+  run_sweep "$root" --apply
+  unset STUB_GH_RUN_FAIL
+  assert_contains "kept, run state unknown" "$OUT" "KEEP unknown-run-state preflight/orphan"
+  assert_contains "the failure is reported" "$OUT" "gh run list failed for preflight/orphan"
+  assert_eq "the ref survives" "main preflight/orphan " "$(refs_on_origin "$root")"
+  assert_eq "and the sweep exits non-zero" "1" "$RC"
+  rm -rf "$root"
+}
+
+# MUTATION. Fold the failure into "nothing is using it" and a missing `actions:
+# read` scope empties the namespace on the first scheduled pass.
+test_treating_a_failed_run_query_as_unknown_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  export STUB_GH_RUN_FAIL=1
+  run_mutant_sweep "$root" \
+    '/^has_live_run\(\)/,/^\}/ s/if \[\[ \$status -ne 0 \]\]; then/if false; then/' --apply
+  unset STUB_GH_RUN_FAIL
+  assert_contains "a 403 read as 'no run' plans the deletion" "$OUT" \
+    "PLAN delete preflight/orphan"
+  assert_eq "and the namespace is emptied by a permissions mistake" "main " \
+    "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# STDOUT ONLY DECIDES HERE TOO. A benign `gh` notice on stderr must not read as a
+# live run — it would still fail safe (KEEP), but the first `gh` release printing
+# one would quietly stop the sweep reclaiming anything.
+test_a_gh_run_stderr_notice_is_not_read_as_a_live_run() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  export STUB_GH_RUN_WARN="gh: A new release of gh is available"
+  run_sweep "$root" --apply
+  unset STUB_GH_RUN_WARN
+  assert_contains "the orphan is still planned" "$OUT" "PLAN delete preflight/orphan"
+  assert_missing "and not mistaken for a live run" "$OUT" "KEEP live-run"
+  assert_eq "only main is left" "main " "$(refs_on_origin "$root")"
+  assert_eq "the sweep exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# THE CLOSE PATH GETS THE GUARD TOO, and this is the race the finding is about: a
+# lane pushed a preflight ref for a commit made hours ago, dispatched a run, and
+# another agent merges the PR while it is in flight. The commit-date age guard
+# cannot see that; the run query can.
+test_the_close_path_keeps_a_ref_with_a_live_run() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/verifying
+  stub_gh "$root" "" "preflight/verifying"
+  run_sweep "$root" --apply --branch verifying
+  assert_contains "the close path spares a ref a run is using" "$OUT" \
+    "KEEP live-run preflight/verifying"
+  assert_missing "and never plans it" "$OUT" "PLAN delete preflight/verifying"
+  assert_eq "so the in-flight run keeps its code" "main preflight/verifying " \
+    "$(refs_on_origin "$root")"
+  assert_eq "and sparing it is not a problem" "0" "$RC"
+  rm -rf "$root"
+}
+
+# THE RUN IS ASKED ABOUT UNDER THE REF'S OWN NAME. The valve dispatches against
+# `preflight/<branch>`, never `<branch>`, so a query on the stripped name would
+# find nothing for every ref in the namespace and the guard would be decorative.
+test_the_run_query_uses_the_full_ref_name() {
+  local root; root="$(mktmpd)"
+  [[ "$(have_jq)" == yes ]] || { echo "ok   - (skipped: no jq)"; return 0; }
+  mkfixture "$root" main preflight/verifying
+  # A live run recorded against the STRIPPED name only — which is not where the
+  # valve's run lives, so nothing should match.
+  stub_gh "$root" "" "verifying"
+  run_sweep "$root" --apply
+  assert_contains "a run on the stripped name does not keep the ref" "$OUT" \
+    "PLAN delete preflight/verifying"
+  rm -rf "$root"
+}
+
 # AN AGE THAT CANNOT BE READ IS NOT AN OLD AGE, at the unit level.
 test_commit_time_of_distinguishes_unreadable_from_old() {
   local root; root="$(mktmpd)"
@@ -597,8 +826,23 @@ test_the_empty_branch_name_refusal_is_load_bearing() {
 # The guards above are only reached if the workflow actually delegates. Pinned
 # here because the failure is invisible in this file otherwise: a close path that
 # went back to deleting the ref itself would leave every case above passing.
+WORKFLOW="$HERE/../.github/workflows/preflight-cleanup.yml"
+
+# The trigger the close leg runs on, as a verdict rather than a grep: "base-code"
+# when it is `pull_request_target` and the head-code trigger is absent, "head-code"
+# when `pull_request:` appears as a trigger key, "none" when neither does. Taking a
+# file argument is what lets the mutation case below run it against a copy.
+close_leg_trigger_of() {
+  local body; body="$(cat "$1" 2>/dev/null)"
+  case "$body" in
+    *$'\n  pull_request:'*)        echo "head-code" ;;
+    *$'\n  pull_request_target:'*) echo "base-code" ;;
+    *)                             echo "none" ;;
+  esac
+}
+
 test_the_workflow_close_path_delegates_to_this_sweep() {
-  local body; body="$(cat "$HERE/../.github/workflows/preflight-cleanup.yml" 2>/dev/null)"
+  local body; body="$(cat "$WORKFLOW" 2>/dev/null)"
   assert_contains "the close leg narrows this sweep to the PR's ref" "$body" \
     'bash scripts/sweep-preflight-refs.sh --apply --branch "$HEAD_REF"'
   assert_missing "and deletes nothing itself" "$body" "git push origin --delete"
@@ -607,11 +851,61 @@ test_the_workflow_close_path_delegates_to_this_sweep() {
   assert_contains "the branch name comes from the environment" "$body" \
     'HEAD_REF: ${{ github.event.pull_request.head.ref }}'
   assert_missing "never interpolated into the script" "$body" 'preflight/${{'
-  assert_eq "both legs carry a token" "2" "$(grep -c 'GH_TOKEN:' \
-    "$HERE/../.github/workflows/preflight-cleanup.yml")"
-  # Forks have no preflight ref here and a read-only token, so the leg is skipped.
+  assert_eq "both legs carry a token" "2" "$(grep -c 'GH_TOKEN:' "$WORKFLOW")"
+  # Forks have no preflight ref here, and under `pull_request_target` a fork's
+  # close event would otherwise reach a write-scoped step, so the gate carries
+  # more weight than it did under `pull_request`.
   assert_contains "the fork gate is intact" "$body" \
     "github.event.pull_request.head.repo.full_name == github.repository"
+}
+
+# THE CLOSE LEG MUST RUN THE BASE BRANCH'S CODE. It is the repo's only close-
+# triggered job wanting `contents: write`, and under `pull_request` a same-repo PR
+# would run the workflow AND this sweep as they exist on the PR's HEAD — unreviewed
+# code holding a write-scoped token, outside the review gate. `pull_request_target`
+# runs `main`'s copy of both.
+test_the_close_leg_runs_the_base_branchs_code() {
+  assert_eq "the close leg triggers on pull_request_target" "base-code" \
+    "$(close_leg_trigger_of "$WORKFLOW")"
+  local body; body="$(cat "$WORKFLOW" 2>/dev/null)"
+  # Both `if:` gates have to move with the trigger, or one leg runs never and the
+  # other runs twice.
+  assert_contains "the close leg gates on the new event name" "$body" \
+    "github.event_name == 'pull_request_target'"
+  assert_contains "and the sweep leg excludes the same one" "$body" \
+    "github.event_name != 'pull_request_target'"
+  assert_missing "with no gate left on the old event name" "$body" \
+    "event_name == 'pull_request'"
+  # And no `ref:` on the checkout, which would put the head's code back in the
+  # job that holds the token. Comment lines are stripped first: the workflow names
+  # that mistake in prose in order to warn about it, and a substring search over
+  # the whole file would find its own warning.
+  assert_eq "the checkout takes no explicit head ref" "0" \
+    "$(grep -v '^[[:space:]]*#' "$WORKFLOW" | grep -c 'pull_request\.head\.sha')"
+}
+
+# MUTATION. Put the head-code trigger back and the verdict flips, so the pin above
+# is reading the trigger rather than merely finding the word somewhere in a comment.
+test_the_base_code_trigger_check_discriminates() {
+  local copy; copy="$MUTANT_DIR/workflow.yml"
+  sed -e 's/^  pull_request_target:$/  pull_request:/' "$WORKFLOW" > "$copy"
+  assert_eq "a workflow triggered on pull_request reads as head-code" "head-code" \
+    "$(close_leg_trigger_of "$copy")"
+  assert_eq "and the real one does not" "base-code" "$(close_leg_trigger_of "$WORKFLOW")"
+}
+
+# THE SWEEP'S QUESTIONS NEED SCOPES, AND A DECLARED `permissions:` BLOCK SETS
+# EVERY UNLISTED ONE TO `none`. `gh run list` is the guard that covers the window
+# a commit date cannot see, and without `actions: read` every one of its queries
+# 403s — which lands as "unknown", keeping every ref, so the sweep silently stops
+# reclaiming rather than failing loudly.
+test_the_workflow_grants_the_scopes_both_queries_need() {
+  local body; body="$(cat "$WORKFLOW" 2>/dev/null)"
+  assert_contains "contents: write, to delete refs" "$body" "contents: write"
+  assert_contains "pull-requests: read, for gh pr list" "$body" "pull-requests: read"
+  assert_contains "actions: read, for gh run list" "$body" "actions: read"
+  # And the sweep really does ask that question, so the scope is not decorative.
+  assert_contains "the sweep asks about runs" "$(cat "$SWEEP")" "gh run list --branch"
 }
 
 test_an_unknown_argument_refuses() {

--- a/scripts/sweep-preflight-refs.test.sh
+++ b/scripts/sweep-preflight-refs.test.sh
@@ -53,6 +53,19 @@ mkfixture() {
   done
 }
 
+# "backdated" / the age itself — whether a dated commit is the fixture's seed,
+# allowing the one-second slack three separate `date +%s` reads can introduce.
+# A verdict rather than a comparison so a failure prints the age that missed.
+seed_age_verdict() {
+  local age="$1"
+  if [ "$age" -ge "$FIXTURE_SEED_AGE_SECONDS" ] \
+     && [ "$age" -le $(( FIXTURE_SEED_AGE_SECONDS + 2 )) ]; then
+    echo "backdated"
+  else
+    echo "$age"
+  fi
+}
+
 # push_fresh_ref ROOT REF -> a ref pointing at a commit made just now, which is
 # what a lane that has this second pushed a preflight ref looks like.
 push_fresh_ref() {
@@ -378,8 +391,14 @@ test_commit_time_of_distinguishes_unreadable_from_old() {
   local sha; sha="$(git -C "$root/work" rev-parse HEAD)"
   local dated; dated="$(cd "$root/work" && commit_time_of "$sha")"
   assert_eq "a real commit dates to digits only" "" "${dated//[0-9]/}"
-  assert_eq "and it is the backdated seed" "$FIXTURE_SEED_AGE_SECONDS" \
-    "$(( $(date +%s) - dated ))"
+  # A WINDOW, NOT AN EQUALITY, and the slack is not laziness. `mkfixture` reads
+  # `date +%s` once for the author date and again for the committer date, and this
+  # line reads it a third time — a second ticking over between any two of them
+  # shifts the age by one, which is a red suite for nothing. What the case pins is
+  # that the seed is backdated by the fixture's constant, not the instant three
+  # clock reads happened to agree.
+  assert_eq "and it is the backdated seed" "backdated" \
+    "$(seed_age_verdict "$(( $(date +%s) - dated ))")"
   assert_eq "an object this clone cannot see dates to nothing" "" \
     "$(cd "$root/work" && commit_time_of 0000000000000000000000000000000000000001)"
   rm -rf "$root"
@@ -440,6 +459,159 @@ test_the_per_ref_fetch_retry_is_load_bearing() {
   assert_eq "and the namespace is never reclaimed" "main preflight/ghost preflight/stale " \
     "$(refs_on_origin "$root")"
   rm -rf "$root"
+}
+
+# --- the close path: one ref, through the same two guards ---------------------
+#
+# A PR closing reclaims its own `preflight/<branch>`, and it does so by narrowing
+# THIS sweep to that ref rather than deleting it itself. The age guard is the
+# reason: a lane that pushed a preflight ref seconds ago and dispatched a run
+# against it is racing whoever merges the PR next, and in a forty-worktree fleet
+# that race is ordinary rather than exotic. A close path with its own
+# `git push --delete` honours neither guard.
+
+test_a_named_branch_is_still_subject_to_the_age_guard() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  push_fresh_ref "$root" preflight/just-pushed
+  stub_gh "$root"
+  run_sweep "$root" --apply --branch just-pushed
+  assert_contains "the close path keeps a ref a live run may still check out" "$OUT" \
+    "KEEP too-young preflight/just-pushed"
+  assert_missing "and never plans it" "$OUT" "PLAN delete preflight/just-pushed"
+  assert_eq "so the ref survives the merge that closed the PR" "main preflight/just-pushed " \
+    "$(refs_on_origin "$root")"
+  assert_eq "and sparing it is not a problem" "0" "$RC"
+  rm -rf "$root"
+}
+
+# MUTATION. Drop the grace period and the close path deletes the ref a lane
+# pushed seconds ago — the run it dispatched then fails at `actions/checkout`.
+test_the_age_guard_is_load_bearing_for_a_named_branch() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  push_fresh_ref "$root" preflight/just-pushed
+  stub_gh "$root"
+  run_mutant_sweep "$root" 's/^MIN_AGE_SECONDS=3600$/MIN_AGE_SECONDS=0/' \
+    --apply --branch just-pushed
+  assert_contains "without the grace period the close path plans it" "$OUT" \
+    "PLAN delete preflight/just-pushed"
+  assert_eq "and takes it out from under the lane" "main " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# The filter must not become a blanket KEEP either: the ordinary close, where the
+# ref has outlived any run, still reclaims.
+test_a_named_branch_that_is_inert_is_reclaimed() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/closed-pr preflight/other
+  stub_gh "$root"
+  run_sweep "$root" --apply --branch closed-pr
+  assert_contains "the named ref goes" "$OUT" "PLAN delete preflight/closed-pr"
+  assert_contains "and every other ref is left to the weekly pass" "$OUT" \
+    "SKIP other-branch refs/heads/preflight/other"
+  assert_missing "with no verdict reached on it" "$OUT" "preflight/other ("
+  assert_eq "only the named ref was reclaimed" "main preflight/other " \
+    "$(refs_on_origin "$root")"
+  assert_eq "the close path exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# THE OTHER GUARD IS REUSED TOO. A branch can carry a second open PR — the one
+# that closed is not necessarily the only one — and the ref stays while any of
+# them could dispatch against it again.
+test_a_named_branch_with_another_open_pr_survives() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main feature-a preflight/feature-a
+  stub_gh "$root" "feature-a"
+  run_sweep "$root" --apply --branch feature-a
+  assert_contains "kept for the open PR" "$OUT" "KEEP open-pr preflight/feature-a"
+  assert_eq "the ref survives" "feature-a main preflight/feature-a " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# A CLOSE WITH NOTHING TO RECLAIM IS THE COMMON CASE — most PRs never had a
+# preflight ref pushed for them at all.
+test_a_named_branch_with_no_ref_says_so_and_exits_clean() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/somebody-else
+  stub_gh "$root"
+  run_sweep "$root" --apply --branch never-verified
+  assert_contains "it says there was nothing to do" "$OUT" \
+    "no preflight ref for never-verified; nothing to reclaim"
+  assert_eq "nothing else is touched" "main preflight/somebody-else " "$(refs_on_origin "$root")"
+  assert_eq "and it exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# THE FILTER CANNOT WIDEN WHAT IS ELIGIBLE. Naming the default branch — which is
+# what a close event on a PR merged into `main` would hand a naive filter — reaches
+# the namespace guard exactly as it always did.
+test_a_named_branch_cannot_reach_outside_the_namespace() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  stub_gh "$root"
+  run_sweep "$root" --apply --branch main
+  assert_contains "main is skipped by the namespace guard" "$OUT" \
+    "SKIP outside-namespace refs/heads/main"
+  assert_contains "and the named branch has no preflight ref" "$OUT" \
+    "no preflight ref for main; nothing to reclaim"
+  assert_eq "main survives" "main " "$(refs_on_origin "$root")"
+  assert_eq "and the sweep exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# AN EMPTY NAME IS NOT "EVERY REF". The close path spells one ref as
+# `--branch "$HEAD_REF"`, so a variable that came out empty must refuse rather
+# than quietly widening into a whole-namespace apply.
+test_a_branch_filter_requires_a_name() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  run_sweep "$root" --apply --branch ""
+  assert_contains "an empty name is refused" "$OUT" "--branch requires a branch name"
+  assert_eq "refuses with 2" "2" "$RC"
+  assert_eq "and nothing is swept" "main preflight/orphan " "$(refs_on_origin "$root")"
+  run_sweep "$root" --apply --branch
+  assert_contains "a missing name is refused too" "$OUT" "--branch requires a branch name"
+  assert_eq "also with 2" "2" "$RC"
+  assert_eq "and still nothing is swept" "main preflight/orphan " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# MUTATION. Accept the empty name and `--branch "$HEAD_REF"` with an unset
+# variable sweeps the whole namespace under a close event.
+test_the_empty_branch_name_refusal_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  run_mutant_sweep "$root" 's/if \[\[ \$# -eq 0 \|\| -z "\$1" \]\]; then/if false; then/' \
+    --apply --branch ""
+  assert_contains "an accepted empty name reaches every ref" "$OUT" "PLAN delete preflight/orphan"
+  assert_eq "and empties the namespace" "main " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# --- the close path's wiring --------------------------------------------------
+#
+# The guards above are only reached if the workflow actually delegates. Pinned
+# here because the failure is invisible in this file otherwise: a close path that
+# went back to deleting the ref itself would leave every case above passing.
+test_the_workflow_close_path_delegates_to_this_sweep() {
+  local body; body="$(cat "$HERE/../.github/workflows/preflight-cleanup.yml" 2>/dev/null)"
+  assert_contains "the close leg narrows this sweep to the PR's ref" "$body" \
+    'bash scripts/sweep-preflight-refs.sh --apply --branch "$HEAD_REF"'
+  assert_missing "and deletes nothing itself" "$body" "git push origin --delete"
+  # The branch name arrives through `env:`, never interpolated into a `run:`
+  # body, and both legs need a token for `gh pr list`.
+  assert_contains "the branch name comes from the environment" "$body" \
+    'HEAD_REF: ${{ github.event.pull_request.head.ref }}'
+  assert_missing "never interpolated into the script" "$body" 'preflight/${{'
+  assert_eq "both legs carry a token" "2" "$(grep -c 'GH_TOKEN:' \
+    "$HERE/../.github/workflows/preflight-cleanup.yml")"
+  # Forks have no preflight ref here and a read-only token, so the leg is skipped.
+  assert_contains "the fork gate is intact" "$body" \
+    "github.event.pull_request.head.repo.full_name == github.repository"
 }
 
 test_an_unknown_argument_refuses() {

--- a/scripts/sweep-preflight-refs.test.sh
+++ b/scripts/sweep-preflight-refs.test.sh
@@ -7,6 +7,7 @@
 # stub on PATH; the real one is never reached, authenticated or not.
 #
 # shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F`/"$t" below
+# shellcheck disable=SC2016 # the sed mutation expressions must NOT expand here
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SWEEP="$HERE/sweep-preflight-refs.sh"
@@ -27,13 +28,24 @@ mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/preflight-sweep-test.XXXXXX"; }
 # the fixture commit fail here (and only here) with no obvious cause.
 GIT_FIXTURE=(git -c user.email=sweep-test@example.invalid -c user.name="Sweep Test" -c commit.gpgsign=false)
 
+# THE SEED COMMIT IS BACKDATED, AND EVERY DELETION CASE DEPENDS ON IT. The sweep
+# spares refs whose commit is younger than an hour, so a fixture committed
+# "now" would be kept by the AGE guard in every case that means to be exercising
+# the PR guard — each of them would pass while proving nothing. Backdating puts
+# the age question out of the way, and `push_fresh_ref` is how a case opts back
+# into it. `date +%s`-relative rather than a fixed year so the arithmetic reads
+# the same however far in the future this runs.
+FIXTURE_SEED_AGE_SECONDS=$(( 30 * 24 * 3600 ))
+
 mkfixture() {
   local root="$1"; shift
   git init -q --bare "$root/origin.git"
   git init -q "$root/work"
   : > "$root/work/seed"
   "${GIT_FIXTURE[@]}" -C "$root/work" add seed
-  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -m "seed"
+  GIT_AUTHOR_DATE="@$(( $(date +%s) - FIXTURE_SEED_AGE_SECONDS ))" \
+  GIT_COMMITTER_DATE="@$(( $(date +%s) - FIXTURE_SEED_AGE_SECONDS ))" \
+    "${GIT_FIXTURE[@]}" -C "$root/work" commit -q -m "seed"
   git -C "$root/work" remote add origin "$root/origin.git"
   local branch
   for branch in "$@"; do
@@ -41,16 +53,54 @@ mkfixture() {
   done
 }
 
+# push_fresh_ref ROOT REF -> a ref pointing at a commit made just now, which is
+# what a lane that has this second pushed a preflight ref looks like.
+push_fresh_ref() {
+  local root="$1" ref="$2"
+  "${GIT_FIXTURE[@]}" -C "$root/work" commit -q --allow-empty -m "fresh"
+  git -C "$root/work" push -q origin "HEAD:refs/heads/$ref"
+}
+
+# push_aged_ref ROOT REF -> the same, backdated, and on a commit that is NOT
+# reachable from `main`. The unreachability is what lets a `--single-branch`
+# clone of `main` be genuinely missing the object; see `clone_without_namespace`.
+push_aged_ref() {
+  local root="$1" ref="$2" when
+  when="@$(( $(date +%s) - FIXTURE_SEED_AGE_SECONDS ))"
+  GIT_AUTHOR_DATE="$when" GIT_COMMITTER_DATE="$when" \
+    "${GIT_FIXTURE[@]}" -C "$root/work" commit -q --allow-empty -m "aged $ref"
+  git -C "$root/work" push -q origin "HEAD:refs/heads/$ref"
+}
+
+# clone_without_namespace ROOT -> a second clone at `$ROOT/clone` holding only
+# `main`'s history, so the sweep run from it has to FETCH before it can date
+# anything. That is the production situation — a sweep run from any worktree has
+# never seen most of the namespace — and the fixture's own `work` repo cannot
+# stand in for it, because it authored those commits and has the objects already.
+# `file://` rather than a plain path: a local-path clone hardlinks the whole
+# object store and the clone would arrive holding everything.
+clone_without_namespace() {
+  local root="$1"
+  git clone -q --single-branch --branch main "file://$root/origin.git" "$root/clone"
+}
+
 # stub_gh ROOT [OPEN_PR_BRANCHES] — a `gh` on PATH that reports an open PR for
-# each space-separated branch named, and none for anything else. With
-# STUB_GH_FAIL=1 in the environment it fails instead, standing in for a rate
-# limit or a token that lost its scope.
+# each space-separated branch named, and none for anything else. Two knobs stand
+# in for the two ways a real `gh` misbehaves:
+#
+#   STUB_GH_FAIL=1  it fails outright — a rate limit, or a token that lost its
+#                   scope.
+#   STUB_GH_WARN=…  it succeeds, prints nothing on stdout, and writes the given
+#                   text to STDERR. That is the shape of every benign `gh`
+#                   message: a deprecation notice, an upgrade nag, a hint about
+#                   a missing default remote.
 stub_gh() {
   local root="$1" open="${2:-}"
   mkdir -p "$root/bin"
   cat > "$root/bin/gh" <<STUB
 #!/usr/bin/env bash
 if [[ -n "\${STUB_GH_FAIL:-}" ]]; then echo "API rate limit exceeded" >&2; exit 1; fi
+if [[ -n "\${STUB_GH_WARN:-}" ]]; then echo "\$STUB_GH_WARN" >&2; exit 0; fi
 head=""
 while [[ \$# -gt 0 ]]; do
   if [[ "\$1" == "--head" ]]; then head="\$2"; shift; fi
@@ -73,12 +123,45 @@ refs_on_origin() {
 # first on PATH, leaving its combined output in OUT and its status in RC.
 # Deliberately NOT `out=$(run_sweep …)`: command substitution would run this in
 # a subshell and the status would never come back.
+#
+# SWEEP_UNDER_TEST names a mutant to run in place of the real script; empty means
+# the real one.
+# SWEEP_CWD names which repo under ROOT the sweep runs in; empty means `work`.
 OUT=""
 RC=0
+SWEEP_UNDER_TEST=""
+SWEEP_CWD=""
 run_sweep() {
   local root="$1"; shift
-  OUT="$(cd "$root/work" && PATH="$root/bin:$PATH" bash "$SWEEP" "$@" 2>&1)"
+  OUT="$(cd "$root/${SWEEP_CWD:-work}" && PATH="$root/bin:$PATH" \
+         bash "${SWEEP_UNDER_TEST:-$SWEEP}" "$@" 2>&1)"
   RC=$?
+}
+
+# --- mutants ------------------------------------------------------------------
+#
+# EVERY GUARD IS MUTATION-CHECKED. `mutant_of` writes a copy of the sweep with
+# one guard deliberately weakened; the case re-runs against it and the verdict
+# has to flip. A guard whose test passes for reasons unrelated to the guard is
+# the failure mode this exists to prevent — and on a script that deletes refs on
+# a shared remote, the guard rotting silently is the expensive outcome.
+MUTANT_DIR="$(mktmpd)"
+MUTANT_SEQ=0
+trap 'rm -rf "$MUTANT_DIR"' EXIT
+mutant_of() {
+  local sed_expr="$1" out
+  MUTANT_SEQ=$((MUTANT_SEQ + 1))
+  out="$MUTANT_DIR/mutant.$MUTANT_SEQ.sh"
+  sed -E "$sed_expr" "$SWEEP" > "$out"
+  echo "$out"
+}
+
+# Run a case against a mutant and restore the real script afterwards.
+run_mutant_sweep() {
+  local root="$1" sed_expr="$2"; shift 2
+  SWEEP_UNDER_TEST="$(mutant_of "$sed_expr")"
+  run_sweep "$root" "$@"
+  SWEEP_UNDER_TEST=""
 }
 
 # --- the namespace guard, at the unit level ----------------------------------
@@ -171,6 +254,191 @@ test_a_missing_gh_refuses_to_sweep() {
   assert_contains "names the missing tool" "$out" "gh is not installed"
   assert_eq "refuses with 2" "2" "$rc"
   assert_eq "the ref survives" "main preflight/orphan " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# THE IN-NAMESPACE REAL BRANCH. `preflight/` is a convention, not a reservation:
+# a human can name a branch `preflight/flaky-repro` and open a PR for it. The
+# stripped name (`flaky-repro`) has no PR, so asking only about that deletes the
+# branch the PR is built on — breaking the PR rather than reclaiming an orphan.
+# The lookalike-prefix case above does NOT cover this: `preflighty/decoy` never
+# enters the namespace at all, while this ref does and is then misidentified.
+test_an_in_namespace_branch_with_its_own_pr_survives() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/flaky-repro
+  stub_gh "$root" "preflight/flaky-repro"
+  run_sweep "$root" --apply
+  assert_contains "kept for its own open PR" "$OUT" "KEEP open-pr preflight/flaky-repro"
+  assert_missing "and never planned for deletion" "$OUT" "PLAN delete preflight/flaky-repro"
+  assert_eq "the branch the PR is built on survives" "main preflight/flaky-repro " \
+    "$(refs_on_origin "$root")"
+  assert_eq "the sweep exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# MUTATION. Ask about the stripped name alone — the shape this sweep shipped with
+# — and the same fixture deletes a branch with an open PR.
+test_querying_the_refs_own_name_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/flaky-repro
+  stub_gh "$root" "preflight/flaky-repro"
+  run_mutant_sweep "$root" \
+    's/has_open_pr_for_any "\$branch" "\$NAMESPACE\$branch"/has_open_pr "$branch"/' --apply
+  assert_contains "asking only the stripped name plans the deletion" "$OUT" \
+    "PLAN delete preflight/flaky-repro"
+  assert_eq "and the branch with the open PR is gone" "main " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# A BENIGN `gh` NOTICE IS NOT A PR. `gh` writes deprecation notices, upgrade nags
+# and remote hints to stderr while exiting 0 with an empty stdout. Folding the
+# two streams together makes any of them read as "a PR exists" — KEEP, so it
+# fails safe, but the first `gh` release that starts printing a notice would
+# quietly stop this sweep reclaiming anything.
+test_a_gh_stderr_notice_is_not_read_as_an_open_pr() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  export STUB_GH_WARN="gh: A new release of gh is available"
+  run_sweep "$root" --apply
+  unset STUB_GH_WARN
+  assert_contains "the orphan is still planned for deletion" "$OUT" "PLAN delete preflight/orphan"
+  assert_missing "and is not mistaken for an open PR" "$OUT" "KEEP open-pr"
+  assert_eq "only main is left" "main " "$(refs_on_origin "$root")"
+  assert_eq "the sweep exits clean" "0" "$RC"
+  rm -rf "$root"
+}
+
+# MUTATION. Fold stderr back into the captured value and the notice becomes a PR.
+test_reading_stdout_only_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/orphan
+  stub_gh "$root"
+  export STUB_GH_WARN="gh: A new release of gh is available"
+  run_mutant_sweep "$root" \
+    "s/--jq '\.\[\]\.number'\)\"/--jq '.[].number' 2>\&1)\"/" --apply
+  unset STUB_GH_WARN
+  assert_contains "with the streams merged a notice reads as an open PR" "$OUT" \
+    "KEEP open-pr preflight/orphan"
+  assert_eq "and the orphan is never reclaimed" "main preflight/orphan " \
+    "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# THE AGE GUARD. The driver pushes `preflight/<branch>` for every lane, including
+# one whose branch has no PR, so a brand-new ref is eligible for deletion the
+# instant it exists — and a sweep landing between the push and the dispatch that
+# consumes it would take the ref out from under a lane that is mid-flight.
+test_a_fresh_ref_is_spared_even_with_no_open_pr() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  push_fresh_ref "$root" preflight/just-pushed
+  stub_gh "$root"
+  run_sweep "$root" --apply
+  assert_contains "kept for its age" "$OUT" "KEEP too-young preflight/just-pushed"
+  assert_missing "and never planned for deletion" "$OUT" "PLAN delete preflight/just-pushed"
+  assert_eq "the ref survives" "main preflight/just-pushed " "$(refs_on_origin "$root")"
+  assert_eq "a spared young ref is not a problem" "0" "$RC"
+  rm -rf "$root"
+}
+
+# MUTATION. Drop the grace period to zero and the same ref is reclaimed while
+# its lane is still waiting on the verdict.
+test_the_age_guard_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  push_fresh_ref "$root" preflight/just-pushed
+  stub_gh "$root"
+  run_mutant_sweep "$root" 's/^MIN_AGE_SECONDS=3600$/MIN_AGE_SECONDS=0/' --apply
+  assert_contains "without the grace period a fresh ref is planned" "$OUT" \
+    "PLAN delete preflight/just-pushed"
+  assert_eq "and deleted under the lane that pushed it" "main " "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# The guard must not become a blanket KEEP: a ref old enough to be inert still
+# goes. Without this, a mutant that spared everything would pass the case above.
+test_an_aged_ref_with_no_pr_is_still_reclaimed() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main preflight/stale
+  push_fresh_ref "$root" preflight/just-pushed
+  stub_gh "$root"
+  run_sweep "$root" --apply
+  assert_contains "the aged ref goes" "$OUT" "PLAN delete preflight/stale"
+  assert_contains "the fresh one stays" "$OUT" "KEEP too-young preflight/just-pushed"
+  assert_eq "only the aged ref was reclaimed" "main preflight/just-pushed " \
+    "$(refs_on_origin "$root")"
+  rm -rf "$root"
+}
+
+# AN AGE THAT CANNOT BE READ IS NOT AN OLD AGE, at the unit level.
+test_commit_time_of_distinguishes_unreadable_from_old() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  local sha; sha="$(git -C "$root/work" rev-parse HEAD)"
+  local dated; dated="$(cd "$root/work" && commit_time_of "$sha")"
+  assert_eq "a real commit dates to digits only" "" "${dated//[0-9]/}"
+  assert_eq "and it is the backdated seed" "$FIXTURE_SEED_AGE_SECONDS" \
+    "$(( $(date +%s) - dated ))"
+  assert_eq "an object this clone cannot see dates to nothing" "" \
+    "$(cd "$root/work" && commit_time_of 0000000000000000000000000000000000000001)"
+  rm -rf "$root"
+}
+
+# `plant_dangling_ref ROOT NAME` — a ref on origin pointing at an object that
+# does not exist there. `git ls-remote` lists it happily; any fetch of it dies
+# with `upload-pack: not our ref`. Written with `printf` because git itself
+# refuses to create one, which is the same reason it can exist in the wild only
+# by way of something that bypassed git.
+plant_dangling_ref() {
+  local root="$1" name="$2"
+  mkdir -p "$root/origin.git/refs/heads/$(dirname "$name")"
+  printf '%s\n' "0000000000000000000000000000000000000001" \
+    > "$root/origin.git/refs/heads/$name"
+}
+
+# END TO END. An unreadable age keeps the ref and reports, and — the part that
+# matters more — it does not take the rest of the namespace with it. git aborts a
+# whole fetch on the first ref it cannot serve, so without the per-ref retry a
+# single dangling ref leaves every age unknown, and since unknown means KEEP, the
+# dangling ref survives to do it again on every run from then on.
+test_a_dangling_ref_is_kept_without_blocking_the_rest() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  push_aged_ref "$root" preflight/stale
+  plant_dangling_ref "$root" preflight/ghost
+  clone_without_namespace "$root"
+  stub_gh "$root"
+  SWEEP_CWD="clone"
+  run_sweep "$root" --apply
+  SWEEP_CWD=""
+  assert_contains "the dangling ref is kept" "$OUT" "KEEP unknown-age preflight/ghost"
+  assert_contains "and the failure is named" "$OUT" "its age will be unknown"
+  assert_contains "the aged orphan is still reclaimed" "$OUT" "PLAN delete preflight/stale"
+  assert_eq "so only the unreadable one is left behind" "main preflight/ghost " \
+    "$(refs_on_origin "$root")"
+  assert_eq "and the sweep exits non-zero" "1" "$RC"
+  rm -rf "$root"
+}
+
+# MUTATION. Drop the per-ref retry and the dangling ref takes the whole namespace
+# hostage: nothing can be dated, so nothing is ever reclaimed.
+test_the_per_ref_fetch_retry_is_load_bearing() {
+  local root; root="$(mktmpd)"
+  mkfixture "$root" main
+  push_aged_ref "$root" preflight/stale
+  plant_dangling_ref "$root" preflight/ghost
+  clone_without_namespace "$root"
+  stub_gh "$root"
+  SWEEP_CWD="clone"
+  run_mutant_sweep "$root" \
+    's/if ! git fetch --quiet "\$REMOTE" "\$ref" 2>\/dev\/null; then/if false; then/' --apply
+  SWEEP_CWD=""
+  assert_contains "without the retry the healthy ref is undatable too" "$OUT" \
+    "KEEP unknown-age preflight/stale"
+  assert_missing "so nothing is planned" "$OUT" "PLAN delete"
+  assert_eq "and the namespace is never reclaimed" "main preflight/ghost preflight/stale " \
+    "$(refs_on_origin "$root")"
   rm -rf "$root"
 }
 

--- a/scripts/sweep-preflight-refs.test.sh
+++ b/scripts/sweep-preflight-refs.test.sh
@@ -175,6 +175,17 @@ STUB
 # expression rather than faking its output. Echoes "yes" or "no".
 have_jq() { if command -v jq >/dev/null 2>&1; then echo yes; else echo no; fi; }
 
+# A SKIP IS PRINTED AS AN `ok` LINE, so ten dropped cases and ten passing ones
+# look alike to anything counting output. On a developer's machine that is the
+# right trade — the harness still runs everything it can. On CI it is not: `jq`
+# is part of the runner image, so its absence means the image changed under us,
+# and a run that quietly stopped exercising the `--jq` expression would report
+# the same green as one that did.
+if [ -n "${CI:-}" ] && [ "$(have_jq)" != yes ]; then
+  echo "FAIL - jq is missing on CI, where the runner image provides it; the run-leg cases would be skipped silently"
+  FAIL=1
+fi
+
 # refs_on_origin ROOT -> the fixture remote's branch names, sorted, space-joined.
 refs_on_origin() {
   git -C "$1/work" ls-remote --heads origin | awk '{sub(/^refs\/heads\//, "", $2); print $2}' | sort | tr '\n' ' '

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -44,7 +44,7 @@ the stderr line distinguishes them.  Nothing branches on the code today, and
 the shared value says the same thing to a caller that does: the slot was not
 obtained, nothing was compiled, retrying later is reasonable.
 
-A caller that has somewhere else to run can bound its queueing with
+A ``test`` run that has somewhere else to go can bound its queueing with
 ``TBD_SWIFT_QUEUE_YIELD_SECONDS``: once that many seconds have passed without
 ever acquiring, the wait gives up its place in the queue and exits 76.  That
 is a separate code from 75 precisely because the caller must be able to tell
@@ -53,6 +53,18 @@ this somewhere else".  The bound measures queue time, never run time, so a
 yield discards nothing: a wait that never acquired has compiled nothing.
 Unset or empty leaves the wait unbounded except by the timeout, which is the
 behavior every caller gets today.
+
+**Only ``test`` honours it, and the restriction is the point.**  76 means "I
+gave up my place, verify this elsewhere", and only a verdict can be verified
+elsewhere: ``scripts/test.sh`` is the one caller that understands the code and
+has a remote path to take.  A ``build`` or ``run`` produces a binary that must
+land on this disk, and its callers do not check this wrapper's status at all —
+``scripts/restart.sh`` would carry on and assemble a bundle around whatever
+stale binaries were already there, which is this repo's documented
+"stale daemon reverts the fleet" failure.  So an exported knob meant for the
+test lane cannot silently stop a developer's rebuild.  A build that finds the
+variable set says so once on stderr and queues as usual, because a knob that is
+ignored in silence is indistinguishable from one that does not work.
 """
 
 from __future__ import annotations
@@ -520,9 +532,22 @@ def main(arguments: list[str]) -> int:
         "TBD_SWIFT_HEARTBEAT_SECONDS", DEFAULT_HEARTBEAT_SECONDS
     )
     # Unset or empty means never yield, which is what every caller gets today.
+    # GATED TO `test`: 76 means "verify this elsewhere", only a verdict can be
+    # verified elsewhere, and only `scripts/test.sh` reads the code. A `build`
+    # that yielded would return 76 to `scripts/restart.sh`, which never checks —
+    # it would bundle stale binaries and revert the fleet. See the module
+    # docstring. Validation is gated with it: a typo in a knob this subcommand
+    # ignores must not fail an unrelated rebuild.
     yield_after = None
-    if os.environ.get("TBD_SWIFT_QUEUE_YIELD_SECONDS"):
+    requested_yield = os.environ.get("TBD_SWIFT_QUEUE_YIELD_SECONDS")
+    if requested_yield and subcommand == "test":
         yield_after = _positive_number("TBD_SWIFT_QUEUE_YIELD_SECONDS", 0.0)
+    elif requested_yield:
+        _report(
+            "swift-safe: TBD_SWIFT_QUEUE_YIELD_SECONDS is set, but only `test` "
+            f"yields its place in the queue; this `{subcommand}` will wait for "
+            "the shared build slot as usual"
+        )
 
     if subcommand == "run":
         # `run` execs SwiftPM, which stays alive for as long as the program

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -43,6 +43,16 @@ An abandoned wait and a timed-out wait both exit 75 (``EX_TEMPFAIL``); only
 the stderr line distinguishes them.  Nothing branches on the code today, and
 the shared value says the same thing to a caller that does: the slot was not
 obtained, nothing was compiled, retrying later is reasonable.
+
+A caller that has somewhere else to run can bound its queueing with
+``TBD_SWIFT_QUEUE_YIELD_SECONDS``: once that many seconds have passed without
+ever acquiring, the wait gives up its place in the queue and exits 76.  That
+is a separate code from 75 precisely because the caller must be able to tell
+"nobody wants this any more" from "you asked to be released, now go and verify
+this somewhere else".  The bound measures queue time, never run time, so a
+yield discards nothing: a wait that never acquired has compiled nothing.
+Unset or empty leaves the wait unbounded except by the timeout, which is the
+behavior every caller gets today.
 """
 
 from __future__ import annotations
@@ -105,6 +115,15 @@ RUN_OPTIONS_WITH_VALUES = {
 
 class Abandoned(Exception):
     """The requester exited while we were queued, so the wait has no reader."""
+
+
+class Yielded(Exception):
+    """The caller asked us to stop queueing after a bound, and it elapsed.
+
+    Distinct from `Abandoned`, which means nobody is left to read the result.
+    Here the requester is alive and wants its place in the queue back so it can
+    verify somewhere else, so the caller must be able to tell the two apart.
+    """
 
 
 def _positive_number(name: str, default: float) -> float:
@@ -388,6 +407,7 @@ def _acquire(
     *,
     requester: int,
     ancestors: tuple[int, ...],
+    yield_after_seconds: float | None = None,
     monotonic=time.monotonic,
     sleep=time.sleep,
     report=_report,
@@ -441,6 +461,13 @@ def _acquire(
                     f"({_holder_description(lock_path)})"
                 )
                 next_heartbeat = now + heartbeat_seconds
+            # Checked after the abandonment clause on purpose: a requester that
+            # has died wants nothing, including a remote run. Checked before the
+            # deadline so the shorter of the two bounds is the one that fires,
+            # and after the reporting block so a yield still names the holder it
+            # was queued behind.
+            if yield_after_seconds is not None and now - start >= yield_after_seconds:
+                raise Yielded
             if now >= deadline:
                 raise TimeoutError
             sleep(min(0.25, max(0.01, deadline - now)))
@@ -492,6 +519,10 @@ def main(arguments: list[str]) -> int:
     heartbeat = _positive_number(
         "TBD_SWIFT_HEARTBEAT_SECONDS", DEFAULT_HEARTBEAT_SECONDS
     )
+    # Unset or empty means never yield, which is what every caller gets today.
+    yield_after = None
+    if os.environ.get("TBD_SWIFT_QUEUE_YIELD_SECONDS"):
+        yield_after = _positive_number("TBD_SWIFT_QUEUE_YIELD_SECONDS", 0.0)
 
     if subcommand == "run":
         # `run` execs SwiftPM, which stays alive for as long as the program
@@ -513,7 +544,16 @@ def main(arguments: list[str]) -> int:
                 heartbeat,
                 requester=requester,
                 ancestors=ancestors,
+                yield_after_seconds=yield_after,
             )
+        except Yielded:
+            print(
+                f"swift-safe: still queued for {path} after {yield_after:g}s; "
+                "yielding the local build slot so this run can be verified "
+                "elsewhere",
+                file=sys.stderr,
+            )
+            return 76
         except Abandoned:
             print(
                 "swift-safe: the process that requested this build exited while "

--- a/scripts/test-remote-verify.py
+++ b/scripts/test-remote-verify.py
@@ -159,6 +159,42 @@ class SlotCountTests(unittest.TestCase):
             remote_verify.configured_slots({"TBD_REMOTE_VERIFY_SLOTS": "-1"})
         self.assertIn("TBD_REMOTE_VERIFY_SLOTS", str(caught.exception))
 
+    def test_the_ceiling_itself_is_allowed(self):
+        self.assertEqual(
+            remote_verify.configured_slots(
+                {"TBD_REMOTE_VERIFY_SLOTS": str(remote_verify.MAX_SLOTS)}
+            ),
+            remote_verify.MAX_SLOTS,
+        )
+
+    def test_a_setting_above_the_ceiling_is_rejected_by_name(self):
+        # THE SETTING IS PER-LANE, so a lane that sizes its own pool larger takes
+        # tickets its siblings never probe and the effective pool is whatever the
+        # greediest lane chose. Nothing local can see the other lanes, so the
+        # exposure is bounded: past GitHub's own five-macOS-job concurrency a
+        # ticket authorises a run that only queues where TBD cannot see it.
+        # Refused by name rather than clamped — a silent clamp is the same sin as
+        # a silent default.
+        with self.assertRaises(ValueError) as caught:
+            remote_verify.configured_slots(
+                {"TBD_REMOTE_VERIFY_SLOTS": str(remote_verify.MAX_SLOTS + 1)}
+            )
+        self.assertIn("TBD_REMOTE_VERIFY_SLOTS", str(caught.exception))
+        self.assertIn(str(remote_verify.MAX_SLOTS), str(caught.exception))
+
+    def test_a_lane_above_the_ceiling_refuses_before_taking_any_ticket(self):
+        # End to end through `main`: the refusal reaches 78 rather than sizing a
+        # 40-ticket pool and dispatching into it.
+        with tempfile.TemporaryDirectory() as scratch:
+            status = remote_verify.main(
+                ["drive", "--repo-dir", scratch, "--ref", "preflight/tbd/lane", "--sha", "c0ffee"],
+                {"TBD_REMOTE_VERIFY_SLOTS": "40", "TBD_HOME": scratch},
+            )
+            # Asserted while the directory still exists: a glob under a deleted
+            # temp dir is empty whatever happened.
+            self.assertEqual(status, 78)
+            self.assertEqual(list(Path(scratch).glob("runtime/*.lock")), [])
+
 
 class BoundedCommandTests(unittest.TestCase):
     """Every subprocess is bounded, and none of them raise.
@@ -326,6 +362,28 @@ TRUNCATED = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="TestResults" errors="0" tests="9" failures="1" time="3.0">
     <testcase classname="TBDDaemonTests" name="died"""
+
+# The same thing one suite later: the file holds two `<testsuite>` elements and
+# dies inside the second. The first one closed, so a guard that latched on the
+# first closing tag reads the whole file as complete — while already having summed
+# the second suite's `tests=` into the population it reports.
+TRUNCATED_AFTER_THE_FIRST_SUITE = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="first" errors="0" tests="5" failures="2" time="3.0">
+    <testcase classname="A" name="one"><failure message="x"/></testcase>
+    <testcase classname="A" name="two"><failure message="y"/></testcase>
+  </testsuite>
+  <testsuite name="second" errors="0" tests="4" failures="1" time="2.0">
+    <testcase classname="B" name="three"><fail"""
+
+# A bare `<testsuite>` with no `<testsuites>` wrapper, closed properly. The depth
+# counter must still call this complete: the guard has to distinguish nesting
+# from truncation, not merely count closing tags.
+BARE_SUITE = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestResults" errors="0" tests="2" failures="0" time="1.0">
+  <testcase classname="A" name="one" time="0.1"/>
+</testsuite>
+"""
 
 
 def write_results(directory: Path, **files: str) -> Path:
@@ -532,6 +590,38 @@ class RenderingTests(unittest.TestCase):
         self.assertEqual(rendered.count("A.test"), 50, "the render was not bounded")
         self.assertIn("and 10 more failing tests", rendered)
 
+    def test_a_file_truncated_after_its_first_suite_closed_is_not_believed(self):
+        # THE TRUNCATION GUARD COUNTS DEPTH RATHER THAN LATCHING. Latching on the
+        # first `</testsuite>` read this file as complete and reported tests=9 —
+        # the population of both suites — while every case in the second one was
+        # missing. No SwiftPM writer emits two suites per file today, so nothing
+        # in the wild reaches this shape; the guard promises truncation detection
+        # unconditionally, and this is the case that makes the promise true.
+        path = write_results(self.dir, x=TRUNCATED_AFTER_THE_FIRST_SUITE) / "x.xml"
+        with self.assertRaises(remote_verify.MalformedResults) as caught:
+            remote_verify.results_in(path)
+        self.assertIn("truncated", str(caught.exception))
+
+    def test_a_bare_suite_with_no_wrapper_is_still_complete(self):
+        # The other half of the depth counter: it must not read ordinary nesting,
+        # or its absence, as a half-written file.
+        path = write_results(self.dir, x=BARE_SUITE) / "x.xml"
+        results = remote_verify.results_in(path)
+        self.assertEqual(results.tests, 2)
+        self.assertEqual(results.failures, ())
+
+    def test_a_stray_closing_tag_cannot_cancel_out_a_truncation(self):
+        # Depth floored at zero: without the floor the stray `</testsuite>` takes
+        # the count to -1, the real suite's open takes it back to 0, and a file
+        # that ends mid-case reads as complete.
+        body = (
+            '</testsuite><testsuite name="TestResults" tests="3">'
+            '<testcase classname="A" name="one"><fail'
+        )
+        path = write_results(self.dir, x=body) / "x.xml"
+        with self.assertRaises(remote_verify.MalformedResults):
+            remote_verify.results_in(path)
+
     def test_result_files_finds_nested_xml_and_nothing_else(self):
         write_results(self.dir / "xunit-results", **{"xunit-app": SWIFT_TESTING_STYLE})
         (self.dir / "notes.txt").write_text("not results", encoding="utf-8")
@@ -590,6 +680,51 @@ class VerdictTests(unittest.TestCase):
                 remote_verify.verdict_for(conclusion),
                 f"{conclusion!r} was read as a verdict",
             )
+
+
+class ResultsVerdictTests(unittest.TestCase):
+    """What the RESULT FILES say a red run means, which is not the conclusion.
+
+    `test.yml` holds four jobs with no `needs:` between them and a `swift build`
+    step after the results upload, so the run goes red for a SwiftLint violation
+    or a committed plan file while every test passed — none of which
+    `scripts/test.sh` runs locally.
+    """
+
+    def report(self, *, total=0, unreadable=(), tests=None):
+        return remote_verify.Report(
+            total=total, unreadable=tuple(unreadable), lines=(), tests=tests
+        )
+
+    def test_recorded_failures_are_a_test_failure(self):
+        self.assertEqual(
+            remote_verify.verdict_from_results(self.report(total=2, tests=9)), 1
+        )
+
+    def test_a_stated_population_with_nothing_failing_is_no_verdict(self):
+        # 78, NOT 1 and NOT 0: the passes ran and none failed, so the run's red
+        # came from something this suite does not run — there is no test verdict
+        # to adopt in either direction.
+        self.assertEqual(
+            remote_verify.verdict_from_results(self.report(total=0, tests=4593)), 78
+        )
+
+    def test_an_unreadable_file_keeps_the_conclusion(self):
+        # A truncated pass is not a claim that nothing failed.
+        self.assertEqual(
+            remote_verify.verdict_from_results(
+                self.report(total=0, unreadable=("xunit-quiet.xml",), tests=4593)
+            ),
+            1,
+        )
+
+    def test_results_that_state_no_population_keep_the_conclusion(self):
+        self.assertEqual(
+            remote_verify.verdict_from_results(self.report(total=0, tests=None)), 1
+        )
+
+    def test_no_results_at_all_keeps_the_conclusion(self):
+        self.assertEqual(remote_verify.verdict_from_results(None), 1)
 
 
 class CorrelationTests(unittest.TestCase):
@@ -726,9 +861,12 @@ class DriverTests(unittest.TestCase):
     def tearDown(self):
         self.temp.cleanup()
 
-    def drive(self, runner, *, slots=2, ref="preflight/tbd/lane", sha="c0ffee", alive=None):
+    def drive(
+        self, runner, *, slots=2, ref="preflight/tbd/lane", sha="c0ffee",
+        alive=None, narrowed=False,
+    ):
         return remote_verify.drive(
-            ref=ref, sha=sha,
+            ref=ref, sha=sha, narrowed=narrowed,
             runtime_dir=self.runtime, slots=slots,
             run_command=runner,
             poll=5.0, correlate_timeout=60.0, run_timeout=600.0,
@@ -864,6 +1002,69 @@ class DriverTests(unittest.TestCase):
         self.assertIn("TBDAppTests.valveRoutesRemote()", rendered)
         self.assertIn("Test run with 9 tests failed", rendered)
 
+    def test_a_red_run_whose_tests_all_passed_is_no_verdict(self):
+        # THE FOUR JOBS OF `test.yml` HAVE NO `needs:` BETWEEN THEM, and a `swift
+        # build` step follows the results upload — so a SwiftLint violation or a
+        # committed plan file turns the run red while every test passed.
+        # `scripts/test.sh` runs none of that locally, so adopting 1 here would
+        # report a red suite for something the local suite cannot even see.
+        runner = self.failing_runner(**{"xunit-quiet": CLEAN_STYLE})
+        self.assertEqual(self.drive(runner), 78)
+        self.assertNotIn("Test run with", self.output())
+        self.assertNotIn("FAILED", self.output())
+        self.assertIn("outside the test passes", self.diagnostics())
+        # The attribution still reaches the operator, it just does not decide.
+        self.assertIn("failing jobs: Test", self.diagnostics())
+
+    def test_a_red_run_with_an_unreadable_pass_stays_red(self):
+        # The limit of the exoneration: one pass reported clean and another died
+        # mid-write, so nothing here says the tests passed.
+        runner = self.failing_runner(
+            **{"xunit-quiet": CLEAN_STYLE, "xunit-daemon": TRUNCATED}
+        )
+        self.assertEqual(self.drive(runner), 1)
+        self.assertIn("unreadable", self.output())
+
+    def test_a_red_run_whose_results_state_no_population_stays_red(self):
+        # Readable, no failures, and silent about how many tests ran: no evidence
+        # at all, so the run's own conclusion stands.
+        body = (
+            '<testsuites><testsuite name="TestResults">'
+            '<testcase classname="A" name="b"/></testsuite></testsuites>'
+        )
+        self.assertEqual(self.drive(self.failing_runner(**{"xunit-daemon": body})), 1)
+
+    def test_a_narrowed_caller_gets_no_test_count_on_a_failure(self):
+        # SIX CONSUMERS GREP `Test run with N tests` AND TAKE `head -1`, and
+        # `pre-push` captures both streams — so a whole-suite count printed here
+        # arrives before the local re-run's own and wins. A `--filter` naming a
+        # renamed type prints `Test run with 0 tests` locally and would still
+        # clear its floor on this number, which is the vacuous filter the floor
+        # exists to catch.
+        runner = self.failing_runner(
+            **{
+                "xunit-daemon": XCTEST_STYLE,
+                "xunit-app": SWIFT_TESTING_STYLE,
+                "xunit-quiet": CLEAN_STYLE,
+            }
+        )
+        self.assertEqual(self.drive(runner, narrowed=True), 1)
+        rendered = self.output()
+        self.assertNotIn("Test run with", rendered)
+        # The failures themselves are still printed: the caller re-runs locally,
+        # and knowing what the whole suite broke on is diagnostics either way.
+        self.assertIn("TBDDaemonTests.OrphanGCTests.quarantinesProfileDirs", rendered)
+
+    def test_a_narrowed_caller_still_gets_the_count_on_a_pass(self):
+        # The green path is adopted, and a whole-suite count clears a narrowed
+        # caller's floor legitimately — a floor is a minimum and the whole suite
+        # is a superset of any subset of it.
+        runner = self.passing_runner(
+            **{"xunit-daemon": XCTEST_STYLE, "xunit-quiet": CLEAN_STYLE}
+        )
+        self.assertEqual(self.drive(runner, narrowed=True), 0)
+        self.assertIn("Test run with 5 tests passed", self.output())
+
     def test_a_failing_run_with_no_artifact_still_fails_loudly(self):
         # An uncountable red run is still red: the verdict came from the run's
         # conclusion, and only the pass path needs a population it can state.
@@ -986,7 +1187,7 @@ class DriverTests(unittest.TestCase):
         blocked = self.root / "not-a-directory"
         blocked.write_text("", encoding="utf-8")
         status = remote_verify.drive(
-            ref="preflight/tbd/lane", sha="c0ffee",
+            ref="preflight/tbd/lane", sha="c0ffee", narrowed=False,
             runtime_dir=blocked / "runtime", slots=2,
             run_command=self.passing_runner(),
             poll=5.0, correlate_timeout=60.0, run_timeout=600.0,
@@ -1015,6 +1216,17 @@ class DriverTests(unittest.TestCase):
             dispatched,
             ["gh", "workflow", "run", "test.yml", "--ref", "preflight/tbd/lane", "-f", "scope=full"],
         )
+
+    def test_the_driver_and_render_answer_the_same_status_for_one_artifact(self):
+        # The reconciliation, pinned across the two subcommands rather than
+        # inside either: the same result files must not mean "red" to one and
+        # "green" to the other.
+        driven = self.drive(self.failing_runner(**{"xunit-quiet": CLEAN_STYLE}))
+        artifact = write_results(self.root / "artifact", **{"xunit-quiet": CLEAN_STYLE})
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            rendered = remote_verify.main(["render", str(artifact)], {})
+        self.assertEqual(driven, rendered, "drive and render disagree about one artifact")
 
     def test_the_ticket_is_released_once_the_run_is_over(self):
         self.drive(self.passing_runner())
@@ -1088,6 +1300,25 @@ class SettingsTests(unittest.TestCase):
             )
         self.assertEqual(status, 78)
 
+    def test_the_narrowing_flag_reaches_the_driver(self):
+        """`--narrowed` is plumbing, and plumbing that silently drops is the bug.
+
+        The flag decides whether a failing run publishes a test count that six
+        floor checks would misread, so it is asserted at the boundary rather than
+        only through its effect.
+        """
+        recorded: list[bool] = []
+        original = remote_verify.drive
+        remote_verify.drive = lambda **kwargs: recorded.append(kwargs["narrowed"]) or 78
+        try:
+            with tempfile.TemporaryDirectory() as scratch:
+                base = ["drive", "--repo-dir", scratch, "--ref", "preflight/x", "--sha", "c0ffee"]
+                remote_verify.main(base, {"TBD_HOME": scratch})
+                remote_verify.main([*base, "--narrowed"], {"TBD_HOME": scratch})
+        finally:
+            remote_verify.drive = original
+        self.assertEqual(recorded, [False, True])
+
     def test_the_runtime_dir_follows_tbd_home(self):
         self.assertEqual(
             remote_verify._resolve_runtime_dir({"TBD_HOME": "/tmp/fixture-home"}),
@@ -1117,11 +1348,25 @@ class RenderCommandTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn("quarantinesProfileDirs", output)
 
-    def test_results_with_no_failures_exit_zero(self):
+    def test_results_with_no_failures_are_no_verdict_rather_than_a_pass(self):
+        # THE TWO SUBCOMMANDS READ THE SAME FILES AND MUST NOT DISAGREE. This
+        # used to exit 0 — read as "the tests passed" — for the very state the
+        # driver calls no verdict at all: a red run whose passes all reported
+        # clean. `render` has no run conclusion to weigh, so the strongest thing
+        # a set of files says on its own is "no failing test here", and 78 is how
+        # that is spelled everywhere else in the valve.
         write_results(self.dir, **{"xunit-quiet": CLEAN_STYLE})
         status, output = self.render(str(self.dir))
-        self.assertEqual(status, 0)
+        self.assertEqual(status, 78)
         self.assertIn("outside the test passes", output)
+
+    def test_render_and_the_driver_agree_about_one_artifact(self):
+        # Asserted against the driver's own answer rather than a literal, so the
+        # two cannot drift apart without this failing.
+        write_results(self.dir, **{"xunit-quiet": CLEAN_STYLE})
+        rendered, _ = self.render(str(self.dir))
+        report = remote_verify.render_results(remote_verify.result_files(self.dir))
+        self.assertEqual(rendered, remote_verify.verdict_from_results(report))
 
     def test_a_named_file_can_be_rendered_on_its_own(self):
         write_results(self.dir, **{"xunit-app": SWIFT_TESTING_STYLE})

--- a/scripts/test-remote-verify.py
+++ b/scripts/test-remote-verify.py
@@ -24,6 +24,7 @@ import io
 import json
 import os
 from pathlib import Path
+import re
 import signal
 import subprocess
 import sys
@@ -157,6 +158,133 @@ class SlotCountTests(unittest.TestCase):
         with self.assertRaises(ValueError) as caught:
             remote_verify.configured_slots({"TBD_REMOTE_VERIFY_SLOTS": "-1"})
         self.assertIn("TBD_REMOTE_VERIFY_SLOTS", str(caught.exception))
+
+
+class BoundedCommandTests(unittest.TestCase):
+    """Every subprocess is bounded, and none of them raise.
+
+    A `gh` that never returns is the failure that matters: the bounded waits
+    only test their deadline between calls, so one hung call would hold a
+    dispatch ticket past every timeout in the module — and with two tickets,
+    two of them wedge the valve for the whole fleet.
+    """
+
+    def test_a_command_that_overruns_is_reported_rather_than_awaited(self):
+        run = remote_verify.system_runner(Path.cwd(), timeout=0.05)
+        result = run([sys.executable, "-c", "import time; time.sleep(30)"])
+        self.assertNotEqual(result.status, 0, "a hung command was reported as success")
+        self.assertEqual(result.status, remote_verify.STATUS_TIMED_OUT)
+        self.assertIn("did not answer within", result.stderr)
+
+    def test_a_command_that_cannot_start_is_a_status_not_an_exception(self):
+        run = remote_verify.system_runner(Path.cwd(), timeout=5.0)
+        result = run(["./definitely-not-a-program-remote-verify"])
+        self.assertEqual(result.status, remote_verify.STATUS_NOT_RUNNABLE)
+        self.assertIn("could not run", result.stderr)
+
+    def test_an_ordinary_command_still_returns_its_output(self):
+        run = remote_verify.system_runner(Path.cwd(), timeout=30.0)
+        result = run([sys.executable, "-c", "print('hello')"])
+        self.assertEqual(result.status, 0)
+        self.assertEqual(result.stdout.strip(), "hello")
+
+    def test_a_hung_gh_ends_the_wait_instead_of_holding_the_ticket(self):
+        # The bound composes with the deadline: a call that answers "timed out"
+        # is a failed call, and a failed `gh run list` is already a refusal.
+        runner = RecordingRunner().reply(
+            "gh", "run", "list",
+            status=remote_verify.STATUS_TIMED_OUT,
+            stderr="gh did not answer within 300s",
+        )
+        with self.assertRaises(remote_verify.Refused) as caught:
+            remote_verify.await_dispatched_run(
+                runner, "c0ffee", timeout=30.0, poll=5.0,
+                requester_alive=lambda: True,
+                sleep=lambda _: None, monotonic=lambda: 0.0,
+                report=lambda *_: None,
+            )
+        self.assertIn("did not answer", str(caught.exception))
+
+
+class RequesterLivenessTests(unittest.TestCase):
+    """A verdict nobody is waiting for is not worth a dispatch ticket.
+
+    The chain is test.sh -> remote-verify.sh -> `exec python3`, so a killed
+    agent session kills a shell several steps up and never moves this process's
+    own ppid. Both readings are needed, and neither covers the other.
+    """
+
+    def test_a_live_requester_keeps_the_run_going(self):
+        alive = remote_verify.requester_watch({})
+        self.assertTrue(alive(), "this test's own parent is running")
+
+    def test_a_dead_ancestor_ends_the_watch(self):
+        holder = subprocess.Popen(
+            [sys.executable, "-c", "import sys; sys.stdin.readline()"],
+            text=True,
+            stdin=subprocess.PIPE,
+        )
+        holder_pid = holder.pid
+        try:
+            alive = remote_verify.requester_watch({}, ancestors=(holder_pid,))
+            self.assertTrue(alive())
+            # Killed by the exact pid recorded at spawn; a pattern kill would
+            # match unrelated sessions on this machine.
+            os.kill(holder_pid, signal.SIGKILL)
+            holder.wait(timeout=10)
+            self.assertFalse(alive(), "a dead ancestor was read as alive")
+        finally:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(holder_pid, signal.SIGKILL)
+            holder.wait(timeout=10)
+            if holder.stdin is not None:
+                holder.stdin.close()
+
+    def test_a_reparented_process_ends_the_watch(self):
+        parent = os.getppid()
+        alive = remote_verify.requester_watch({}, getppid=lambda: parent, ancestors=())
+        self.assertTrue(alive())
+        moved = remote_verify.requester_watch(
+            {}, getppid=iter([parent, parent + 1]).__next__, ancestors=()
+        )
+        self.assertFalse(moved(), "a reparent was not noticed")
+
+    def test_the_escape_hatch_disarms_the_watch(self):
+        alive = remote_verify.requester_watch(
+            {remote_verify.ALLOW_ORPHAN_SETTING: "1"},
+            getppid=lambda: 999999,
+            ancestors=(999999,),
+        )
+        self.assertTrue(alive(), "a deliberately detached run was abandoned")
+
+    # The clock advances so that a wait which stopped watching the requester
+    # ends on its own deadline instead of spinning: the assertion has to be
+    # `Abandoned` specifically, not merely "something was raised eventually".
+    def test_a_dead_requester_ends_the_correlation_wait(self):
+        clock = FakeClock()
+        runner = RecordingRunner().reply("gh", "run", "list", stdout="[]")
+        with self.assertRaises(remote_verify.Abandoned) as caught:
+            remote_verify.await_dispatched_run(
+                runner, "c0ffee", timeout=30.0, poll=5.0,
+                requester_alive=lambda: False,
+                sleep=clock.sleep, monotonic=clock.monotonic,
+                report=lambda *_: None,
+            )
+        self.assertIn("exited", str(caught.exception))
+        self.assertEqual(runner.ran("gh", "run", "list"), [], "GitHub was asked anyway")
+
+    def test_a_dead_requester_ends_the_completion_wait(self):
+        clock = FakeClock()
+        runner = RecordingRunner().reply(
+            "gh", "run", "view", stdout=json.dumps({"status": "in_progress"})
+        )
+        with self.assertRaises(remote_verify.Abandoned):
+            remote_verify.await_completion(
+                runner, "4242", timeout=30.0, poll=5.0,
+                requester_alive=lambda: False,
+                sleep=clock.sleep, monotonic=clock.monotonic,
+                report=lambda *_: None,
+            )
 
 
 # --- fixtures ----------------------------------------------------------------
@@ -437,6 +565,17 @@ class RunSelectionTests(unittest.TestCase):
     def test_nothing_matching_yields_nothing(self):
         self.assertIsNone(remote_verify.select_run([], "c0ffee"))
 
+    def test_a_run_that_predates_the_dispatch_is_skipped(self):
+        runs = [run_json(databaseId=1000), run_json(databaseId=1001)]
+        chosen = remote_verify.select_run(runs, "c0ffee", exclude=frozenset({1000}))
+        self.assertEqual(chosen["databaseId"], 1001)
+
+    def test_every_run_being_stale_yields_nothing_rather_than_the_newest(self):
+        runs = [run_json(databaseId=1000), run_json(databaseId=999)]
+        self.assertIsNone(
+            remote_verify.select_run(runs, "c0ffee", exclude=frozenset({999, 1000}))
+        )
+
 
 class VerdictTests(unittest.TestCase):
     def test_success_is_a_pass(self):
@@ -457,10 +596,11 @@ class CorrelationTests(unittest.TestCase):
     def setUp(self):
         self.clock = FakeClock()
 
-    def wait(self, runner, *, timeout=30.0):
+    def wait(self, runner, *, timeout=30.0, exclude=frozenset()):
         return remote_verify.await_dispatched_run(
             runner, "c0ffee",
             timeout=timeout, poll=5.0,
+            requester_alive=lambda: True, exclude=exclude,
             sleep=self.clock.sleep, monotonic=self.clock.monotonic,
             report=lambda *_: None,
         )
@@ -502,6 +642,7 @@ class CorrelationTests(unittest.TestCase):
         )
         finished = remote_verify.await_completion(
             runner, "4242", timeout=600.0, poll=10.0,
+            requester_alive=lambda: True,
             sleep=self.clock.sleep, monotonic=self.clock.monotonic,
             report=lambda *_: None,
         )
@@ -514,10 +655,46 @@ class CorrelationTests(unittest.TestCase):
         with self.assertRaises(remote_verify.Refused) as caught:
             remote_verify.await_completion(
                 runner, "4242", timeout=60.0, poll=10.0,
+                requester_alive=lambda: True,
                 sleep=self.clock.sleep, monotonic=self.clock.monotonic,
                 report=lambda *_: None,
             )
         self.assertIn("4242", str(caught.exception))
+
+    def test_a_run_dispatched_before_this_lane_is_not_adopted(self):
+        # THE STALE-RUN TRAP. `gh run list` answers instantly with the older
+        # dispatch of the same commit and only registers the new one seconds
+        # later, so an unfiltered first poll adopts the wrong run every time —
+        # reporting its verdict while the run this lane paid for burns a macOS
+        # slot unwatched.
+        stale = run_json(databaseId=1000, conclusion="failure")
+        fresh = run_json(databaseId=1001, conclusion="success")
+        answers = [
+            json.dumps([stale]),
+            json.dumps([stale]),
+            json.dumps([fresh, stale]),
+        ]
+        runner = RecordingRunner().reply(
+            "gh", "run", "list", handler=lambda argv: completed(stdout=answers.pop(0))
+        )
+        chosen = self.wait(runner, exclude=frozenset({1000}))
+        self.assertEqual(chosen["databaseId"], 1001, "a stale run was adopted")
+
+    def test_the_baseline_names_only_dispatched_runs_for_this_sha(self):
+        runner = RecordingRunner().reply(
+            "gh", "run", "list",
+            stdout=json.dumps(
+                [
+                    run_json(databaseId=1),
+                    run_json(databaseId=2, headSha="other"),
+                    run_json(databaseId=3, event="pull_request"),
+                    run_json(databaseId=True),
+                ]
+            ),
+        )
+        self.assertEqual(
+            remote_verify.baseline_run_ids(runner, "c0ffee"), frozenset({1})
+        )
 
 
 class FailedJobTests(unittest.TestCase):
@@ -544,63 +721,132 @@ class DriverTests(unittest.TestCase):
         self.runtime = self.root / "runtime"
         self.clock = FakeClock()
         self.printed: list[str] = []
+        self.reported: list[str] = []
 
     def tearDown(self):
         self.temp.cleanup()
 
-    def drive(self, runner, *, slots=2, inert=False, ref="tbd/lane", sha="c0ffee"):
+    def drive(self, runner, *, slots=2, ref="preflight/tbd/lane", sha="c0ffee", alive=None):
         return remote_verify.drive(
-            ref=ref, sha=sha, inert=inert,
+            ref=ref, sha=sha,
             runtime_dir=self.runtime, slots=slots,
             run_command=runner,
             poll=5.0, correlate_timeout=60.0, run_timeout=600.0,
+            requester_alive=alive or (lambda: True),
             sleep=self.clock.sleep, monotonic=self.clock.monotonic,
-            report=lambda *_: None, write=self.printed.append,
+            report=self.reported.append, write=self.printed.append,
         )
 
     def output(self) -> str:
         return "\n".join(self.printed)
 
-    def passing_runner(self):
-        return (
-            RecordingRunner()
-            .reply("gh", "run", "list", stdout=json.dumps([run_json()]))
-            .reply(
-                "gh", "run", "view",
-                stdout=json.dumps(
-                    {"status": "completed", "conclusion": "success", "url": "https://example.invalid/runs/4242"}
-                ),
-            )
-        )
+    def diagnostics(self) -> str:
+        return "\n".join(self.reported)
 
-    def failing_runner(self, **files):
+    def results_runner(self, conclusion, **files):
+        """A `gh` whose run reaches `conclusion` and publishes `files`.
+
+        Both verdicts download the artifact: a red run needs the failures, and
+        a green one needs the population, because a caller reading `Test run
+        with N tests` cannot be handed a number no result file supports.
+        """
+
         def download(argv):
+            if not files:
+                return completed(1, stderr="no artifact matches xunit-results")
             destination = Path(argv[argv.index("--dir") + 1])
             write_results(destination, **files)
             return completed()
 
+        # The first listing is the baseline, taken before the dispatch, and a
+        # commit nobody has dispatched yet has no run — which is what makes the
+        # run that appears afterwards identifiable as this lane's.
+        listed = json.dumps([run_json(conclusion=conclusion)])
+        answers = ["[]"]
+
+        def run_list(argv):
+            return completed(stdout=answers.pop(0) if answers else listed)
+
         return (
             RecordingRunner()
-            .reply("gh", "run", "list", stdout=json.dumps([run_json(conclusion="failure")]))
+            .reply("gh", "run", "list", handler=run_list)
             .reply(
                 "gh", "run", "view",
                 stdout=json.dumps(
                     {
                         "status": "completed",
-                        "conclusion": "failure",
+                        "conclusion": conclusion,
                         "url": "https://example.invalid/runs/4242",
-                        "jobs": [{"name": "Test", "conclusion": "failure"}],
+                        "jobs": [{"name": "Test", "conclusion": conclusion}],
                     }
                 ),
             )
             .reply("gh", "run", "download", handler=download)
         )
 
-    def test_a_passing_run_exits_zero_and_downloads_nothing(self):
+    def passing_runner(self, **files):
+        return self.results_runner("success", **(files or {"xunit-quiet": CLEAN_STYLE}))
+
+    def passing_runner_without_results(self):
+        """A green run whose artifact never arrived — nothing to count."""
+        return self.results_runner("success")
+
+    def failing_runner(self, **files):
+        return self.results_runner("failure", **files)
+
+    def test_a_passing_run_exits_zero(self):
         runner = self.passing_runner()
         self.assertEqual(self.drive(runner), 0)
         self.assertIn("passed", self.output())
-        self.assertEqual(runner.ran("gh", "run", "download"), [])
+
+    def test_a_passing_run_states_the_population_it_executed(self):
+        # SIX CALL SITES GREP FOR THIS EXACT LINE — `scripts/git-hooks/pre-push`,
+        # `scripts/nightly-flake-stress.sh` and three steps of `test.yml` — and
+        # read its absence as a collapsed or truncated suite. Without it a GREEN
+        # remote verdict blocks the push naming the wrong cause.
+        runner = self.passing_runner(
+            **{"xunit-daemon": XCTEST_STYLE, "xunit-app": SWIFT_TESTING_STYLE, "xunit-quiet": CLEAN_STYLE}
+        )
+        self.assertEqual(self.drive(runner), 0)
+        matched = re.search(r"Test run with (\d+) tests?", self.output())
+        self.assertIsNotNone(matched, f"no summary line in {self.output()!r}")
+        # 3 + 4 + 2, summed across the passes exactly as the files declare them.
+        self.assertEqual(matched.group(1), "9")
+
+    def test_a_single_test_is_named_in_the_singular(self):
+        one = (
+            '<testsuites><testsuite name="TestResults" tests="1">'
+            '<testcase classname="A" name="b"/></testsuite></testsuites>'
+        )
+        self.assertEqual(self.drive(self.passing_runner(**{"xunit-one": one})), 0)
+        self.assertIn("Test run with 1 test passed", self.output())
+
+    def test_a_pass_whose_results_are_missing_refuses_rather_than_inventing(self):
+        # A count nobody can support is worse than no verdict: it would be read
+        # as the run's real population by every floor check downstream.
+        runner = self.passing_runner_without_results()
+        self.assertEqual(self.drive(runner), 78)
+        self.assertNotIn("Test run with", self.output())
+        # Named, not merely refused: a refusal that says something else is a
+        # refusal for a different reason, and this one has to be readable.
+        self.assertIn("could not be counted", self.diagnostics())
+
+    def test_a_pass_whose_results_are_unreadable_refuses(self):
+        runner = self.passing_runner(**{"xunit-daemon": TRUNCATED})
+        self.assertEqual(self.drive(runner), 78)
+        self.assertNotIn("Test run with", self.output())
+        self.assertIn("could not be counted", self.diagnostics())
+
+    def test_a_pass_whose_results_declare_no_population_refuses(self):
+        # Readable, well-formed, and silent about how many tests ran: there is
+        # no number to state, so there is no verdict to report.
+        body = (
+            '<testsuites><testsuite name="TestResults">'
+            '<testcase classname="A" name="b"/></testsuite></testsuites>'
+        )
+        self.assertEqual(self.drive(self.passing_runner(**{"xunit-daemon": body})), 78)
+        self.assertNotIn("Test run with", self.output())
+        self.assertIn("could not be counted", self.diagnostics())
 
     def test_a_failing_run_renders_the_failing_tests(self):
         runner = self.failing_runner(
@@ -616,19 +862,16 @@ class DriverTests(unittest.TestCase):
         self.assertIn("failing jobs: Test", rendered)
         self.assertIn("TBDDaemonTests.OrphanGCTests.quarantinesProfileDirs", rendered)
         self.assertIn("TBDAppTests.valveRoutesRemote()", rendered)
+        self.assertIn("Test run with 9 tests failed", rendered)
 
     def test_a_failing_run_with_no_artifact_still_fails_loudly(self):
+        # An uncountable red run is still red: the verdict came from the run's
+        # conclusion, and only the pass path needs a population it can state.
         runner = self.failing_runner()
-        runner.replies.insert(
-            0,
-            (
-                ("gh", "run", "download"),
-                lambda argv: completed(1, stderr="no artifact matches xunit-results"),
-            ),
-        )
         self.assertEqual(self.drive(runner), 1)
         self.assertIn("could not download", self.output())
         self.assertIn("https://example.invalid/runs/4242", self.output())
+        self.assertNotIn("Test run with", self.output())
 
     def test_no_ticket_refuses_without_pushing_or_dispatching(self):
         # The ordering guarantee: a lane that never got a ticket must leave no
@@ -662,15 +905,96 @@ class DriverTests(unittest.TestCase):
         )
         self.assertEqual(self.drive(runner), 78)
 
-    def test_an_inert_ref_is_forced_and_a_branch_is_not(self):
+    def test_an_inert_ref_is_pushed_and_forced(self):
         runner = self.passing_runner()
-        self.drive(runner, inert=True, ref="preflight/tbd/lane")
+        self.drive(runner, ref="preflight/tbd/lane")
         self.assertIn("--force", runner.ran("git", "push")[0])
         self.assertIn("c0ffee:refs/heads/preflight/tbd/lane", runner.ran("git", "push")[0])
 
-        branch_runner = self.passing_runner()
-        self.drive(branch_runner, ref="tbd/lane")
-        self.assertNotIn("--force", branch_runner.ran("git", "push")[0])
+    def test_a_branch_is_refused_before_it_can_be_pushed(self):
+        # THE GUARD THAT MAKES "NEVER THE BRANCH" TRUE, at the one place that
+        # moves a ref. Pushing the branch would publish the very commits a
+        # pre-push hook is gating, and on the default branch it would
+        # fast-forward `origin/main` and fire main's CI and the Pages deploy.
+        for ref in ("tbd/lane", "main", "refs/heads/preflight/x", "preflight/"):
+            with self.subTest(ref=ref):
+                self.printed = []
+                runner = self.passing_runner()
+                self.assertEqual(self.drive(runner, ref=ref), 78)
+                self.assertEqual(runner.ran("git", "push"), [], f"{ref} was pushed")
+                self.assertEqual(runner.ran("gh", "workflow", "run"), [])
+
+    def test_the_baseline_is_taken_before_the_dispatch(self):
+        # Order is the guarantee: a baseline read after the dispatch could
+        # already contain this lane's own run and would exclude it forever.
+        phases = {
+            ("gh", "run", "list"): "baseline",
+            ("git", "push"): "push",
+            ("gh", "workflow", "run"): "dispatch",
+        }
+        runner = self.passing_runner()
+        self.drive(runner)
+        order = [
+            name
+            for call in runner.calls
+            for prefix, name in phases.items()
+            if tuple(call[: len(prefix)]) == prefix
+        ]
+        self.assertEqual(order[:3], ["baseline", "push", "dispatch"], order)
+
+    def test_a_stale_run_for_the_same_sha_is_not_adopted(self):
+        # End to end: the run that exists before the dispatch is red, the one
+        # this lane asked for is green. Adopting the stale one reports a
+        # failure the lane never caused.
+        stale = run_json(databaseId=1000, conclusion="failure")
+        fresh = run_json(databaseId=1001, conclusion="success")
+        listings = [json.dumps([stale]), json.dumps([fresh, stale])]
+
+        def listed(argv):
+            return completed(stdout=listings.pop(0) if listings else json.dumps([fresh, stale]))
+
+        runner = self.passing_runner().reply("gh", "run", "list", handler=listed)
+        # Replies match in order, so the scripted listing must win over the
+        # helper's default.
+        runner.replies.insert(0, runner.replies.pop())
+        self.assertEqual(self.drive(runner), 0)
+        viewed = runner.ran("gh", "run", "view")
+        self.assertTrue(viewed, "no run was watched")
+        self.assertIn("1001", viewed[0], f"the stale run was adopted: {viewed[0]}")
+
+    def test_a_dead_requester_releases_the_ticket_without_a_verdict(self):
+        runner = self.passing_runner()
+        self.assertEqual(self.drive(runner, alive=lambda: False), 78)
+        self.assertEqual(runner.ran("git", "push"), [], "a ref was pushed for nobody")
+        self.assertEqual(runner.ran("gh", "workflow", "run"), [])
+        with remote_verify.take_dispatch_ticket(self.runtime, 1) as index:
+            self.assertEqual(index, 1, "the ticket outlived the requester")
+
+    def test_an_unexpected_exception_is_a_refusal_and_never_a_failure(self):
+        # 78, NOT 1. `scripts/test.sh` adopts this status as the run's own, so
+        # a 1 from an unhandled OSError tells the operator the suite is red
+        # when zero tests ran.
+        def explode(argv):
+            raise OSError("the disk filled up mid-push")
+
+        runner = self.passing_runner().reply("git", "push", handler=explode)
+        self.assertEqual(self.drive(runner), 78)
+
+    def test_an_unusable_runtime_directory_refuses_rather_than_failing(self):
+        # The ticket pool cannot be created, which is an OSError out of `mkdir`
+        # from inside the context manager — the path that used to exit 1.
+        blocked = self.root / "not-a-directory"
+        blocked.write_text("", encoding="utf-8")
+        status = remote_verify.drive(
+            ref="preflight/tbd/lane", sha="c0ffee",
+            runtime_dir=blocked / "runtime", slots=2,
+            run_command=self.passing_runner(),
+            poll=5.0, correlate_timeout=60.0, run_timeout=600.0,
+            requester_alive=lambda: True,
+            sleep=self.clock.sleep, monotonic=self.clock.monotonic,
+            report=lambda *_: None, write=self.printed.append,
+        )
+        self.assertEqual(status, 78)
 
     def test_a_run_with_no_verdict_returns_the_lane_to_the_local_queue(self):
         runner = (
@@ -685,7 +1009,7 @@ class DriverTests(unittest.TestCase):
 
     def test_the_dispatch_names_the_ref_and_the_scope(self):
         runner = self.passing_runner()
-        self.drive(runner, ref="preflight/tbd/lane", inert=True)
+        self.drive(runner, ref="preflight/tbd/lane")
         dispatched = runner.ran("gh", "workflow", "run")[0]
         self.assertEqual(
             dispatched,
@@ -718,6 +1042,40 @@ class SettingsTests(unittest.TestCase):
                 {remote_verify.POLL_SETTING: "soon"}, remote_verify.POLL_SETTING, 10.0
             )
         self.assertIn(remote_verify.POLL_SETTING, str(caught.exception))
+
+    def test_a_zero_duration_is_rejected_rather_than_obeyed(self):
+        # A zero poll is not a smaller bound, it is a tight loop hammering `gh`
+        # until the API rate-limits the whole account; a zero timeout refuses
+        # before the first answer could arrive.
+        for raw in ("0", "0.0", "-0", "nan"):
+            with self.subTest(raw=raw):
+                with self.assertRaises(ValueError) as caught:
+                    remote_verify._positive_seconds(
+                        {remote_verify.POLL_SETTING: raw}, remote_verify.POLL_SETTING, 10.0
+                    )
+                self.assertIn(remote_verify.POLL_SETTING, str(caught.exception))
+
+    def test_a_zero_duration_refuses_before_anything_happens(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            status = remote_verify.main(
+                ["drive", "--repo-dir", scratch, "--ref", "preflight/tbd/lane", "--sha", "c0ffee"],
+                {remote_verify.POLL_SETTING: "0", "TBD_HOME": scratch},
+            )
+        self.assertEqual(status, 78)
+
+    def test_the_command_timeout_is_configurable_and_positive(self):
+        self.assertEqual(
+            remote_verify._positive_seconds(
+                {}, remote_verify.COMMAND_SETTING, remote_verify.DEFAULT_COMMAND_SECONDS
+            ),
+            remote_verify.DEFAULT_COMMAND_SECONDS,
+        )
+        with self.assertRaises(ValueError):
+            remote_verify._positive_seconds(
+                {remote_verify.COMMAND_SETTING: "0"},
+                remote_verify.COMMAND_SETTING,
+                remote_verify.DEFAULT_COMMAND_SECONDS,
+            )
 
     def test_an_unreadable_setting_refuses_before_anything_happens(self):
         # 78, and nothing pushed or dispatched: the repo directory here is not

--- a/scripts/test-remote-verify.py
+++ b/scripts/test-remote-verify.py
@@ -719,12 +719,24 @@ class ResultsVerdictTests(unittest.TestCase):
         )
 
     def test_results_that_state_no_population_keep_the_conclusion(self):
+        # Files DID arrive, they record nothing failing, and they will not say how
+        # many tests ran. Too little to overturn the conclusion — and distinct
+        # from no files at all, which is the case below.
         self.assertEqual(
             remote_verify.verdict_from_results(self.report(total=0, tests=None)), 1
         )
 
-    def test_no_results_at_all_keeps_the_conclusion(self):
-        self.assertEqual(remote_verify.verdict_from_results(None), 1)
+    def test_no_results_at_all_is_no_verdict_rather_than_a_failing_suite(self):
+        # 78, NOT 1. The test job runs eight fallible setup steps before the first
+        # `scripts/test.sh` — checkout, mtime restore, `brew install tmux`,
+        # `xcode-select`, toolchain capture, cache restore, workspace repair,
+        # force rebuild — so a `brew` flake means zero tests ran, no xUnit file
+        # exists and no artifact was uploaded. Adopting 1 there tells a caller its
+        # suite is red when nothing ever compiled, and `scripts/test.sh` has no
+        # local fallback for a 1. Every case that reaches here is answered by 78:
+        # setup died, the compile died, or the upload broke on a genuinely red run
+        # whose failures the local re-run finds properly.
+        self.assertEqual(remote_verify.verdict_from_results(None), 78)
 
 
 class CorrelationTests(unittest.TestCase):
@@ -975,6 +987,28 @@ class DriverTests(unittest.TestCase):
         self.assertNotIn("Test run with", self.output())
         self.assertIn("could not be counted", self.diagnostics())
 
+    def test_a_pass_that_lost_one_file_says_its_count_is_a_floor(self):
+        # THE COUNT IS SHORT HERE AND THE OUTPUT HAS TO SAY SO. `render_results`
+        # sums only the files it could parse, so a green run that published one
+        # half-written pass states fewer tests than it ran. Refusing would spend a
+        # local re-run to correct a number that can only fail a floor and never
+        # falsely clear one — so it is stated and qualified instead, because a
+        # caller whose floor trips on a green remote run needs to see why.
+        runner = self.passing_runner(
+            **{"xunit-quiet": CLEAN_STYLE, "xunit-daemon": TRUNCATED}
+        )
+        self.assertEqual(self.drive(runner), 0)
+        rendered = self.output()
+        self.assertIn("Test run with 2 tests passed", rendered)
+        self.assertIn("xunit-daemon.xml", rendered)
+        self.assertIn("floor", rendered)
+
+    def test_a_pass_whose_every_file_arrived_claims_no_floor(self):
+        # The other branch: nothing was lost, so the count is the whole run and
+        # qualifying it would teach a reader to distrust a sound number.
+        self.assertEqual(self.drive(self.passing_runner()), 0)
+        self.assertNotIn("floor", self.output())
+
     def test_a_pass_whose_results_declare_no_population_refuses(self):
         # Readable, well-formed, and silent about how many tests ran: there is
         # no number to state, so there is no verdict to report.
@@ -1065,14 +1099,22 @@ class DriverTests(unittest.TestCase):
         self.assertEqual(self.drive(runner, narrowed=True), 0)
         self.assertIn("Test run with 5 tests passed", self.output())
 
-    def test_a_failing_run_with_no_artifact_still_fails_loudly(self):
-        # An uncountable red run is still red: the verdict came from the run's
-        # conclusion, and only the pass path needs a population it can state.
+    def test_a_failing_run_with_no_artifact_falls_back_to_the_local_queue(self):
+        # A RED RUN THAT PUBLISHED NOTHING IS NOT A RED SUITE. This is the shape a
+        # setup failure takes — `brew install tmux` flaking before the first
+        # `scripts/test.sh`, so zero tests ran and no xUnit file exists — and it is
+        # indistinguishable here from a red run whose upload broke. 78 fits both:
+        # the local re-run either compiles nothing new or finds the real failures,
+        # where a 1 would report a suite as red that never ran.
         runner = self.failing_runner()
-        self.assertEqual(self.drive(runner), 1)
-        self.assertIn("could not download", self.output())
-        self.assertIn("https://example.invalid/runs/4242", self.output())
+        self.assertEqual(self.drive(runner), 78)
         self.assertNotIn("Test run with", self.output())
+        self.assertNotIn("FAILED", self.output())
+        # Named on the way out, because a silent fallback is what this valve is
+        # not allowed to do.
+        self.assertIn("could not download", self.diagnostics())
+        self.assertIn("published no results", self.diagnostics())
+        self.assertIn("https://example.invalid/runs/4242", self.diagnostics())
 
     def test_no_ticket_refuses_without_pushing_or_dispatching(self):
         # The ordering guarantee: a lane that never got a ticket must leave no

--- a/scripts/test-remote-verify.py
+++ b/scripts/test-remote-verify.py
@@ -1,0 +1,150 @@
+"""Tests for scripts/remote_verify.py (stdlib only).
+
+The ticket pool is exercised against real `flock`s in a temp directory, never
+the real `~/tbd/runtime`: the pool's whole job is to bound how many remote
+runs exist at once, and a mocked lock would prove nothing about that.
+
+One case takes a ticket in a separate process, because a lock that only holds
+within one interpreter would bound nothing — forty agent lanes are forty
+processes.  That child is killed by the exact pid recorded at spawn; a
+pattern kill would match unrelated sessions on this machine.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = REPO_ROOT / "scripts" / "remote_verify.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("remote_verify", str(MODULE_PATH))
+    assert spec is not None and spec.loader is not None, f"no import spec for {MODULE_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+remote_verify = _load_module()
+
+
+# Takes a ticket, announces its index on stdout, and holds it until stdin
+# closes.  Run as a separate process so the flock is contended across
+# processes rather than within one interpreter.
+TICKET_HOLDER = """
+import sys
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("remote_verify", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+with module.take_dispatch_ticket(Path(sys.argv[2]), int(sys.argv[3])) as index:
+    print(index, flush=True)
+    sys.stdin.readline()
+"""
+
+
+class DispatchTicketTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.runtime = Path(self.temp.name) / "runtime"
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_tickets_are_bounded_by_the_slot_count(self):
+        with remote_verify.take_dispatch_ticket(self.runtime, 2):
+            with remote_verify.take_dispatch_ticket(self.runtime, 2):
+                with self.assertRaises(remote_verify.NoTicket):
+                    with remote_verify.take_dispatch_ticket(self.runtime, 2):
+                        pass
+
+    def test_a_released_ticket_is_reusable(self):
+        with remote_verify.take_dispatch_ticket(self.runtime, 1):
+            pass
+        with remote_verify.take_dispatch_ticket(self.runtime, 1) as index:
+            self.assertEqual(index, 1)
+
+    def test_a_ticket_is_released_when_the_body_raises(self):
+        with contextlib.suppress(RuntimeError):
+            with remote_verify.take_dispatch_ticket(self.runtime, 1):
+                raise RuntimeError("the remote run blew up")
+        with remote_verify.take_dispatch_ticket(self.runtime, 1) as index:
+            self.assertEqual(index, 1)
+
+    def test_zero_slots_refuses_immediately(self):
+        with self.assertRaises(remote_verify.NoTicket):
+            with remote_verify.take_dispatch_ticket(self.runtime, 0):
+                pass
+
+    def test_the_ticket_files_are_named_for_their_index(self):
+        with remote_verify.take_dispatch_ticket(self.runtime, 2):
+            with remote_verify.take_dispatch_ticket(self.runtime, 2):
+                pass
+        self.assertTrue((self.runtime / "remote-verify-1.lock").exists())
+        self.assertTrue((self.runtime / "remote-verify-2.lock").exists())
+
+    def test_a_ticket_held_by_another_process_is_not_reissued(self):
+        holder = subprocess.Popen(
+            [sys.executable, "-c", TICKET_HOLDER, str(MODULE_PATH), str(self.runtime), "2"],
+            text=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        holder_pid = holder.pid
+        try:
+            assert holder.stdout is not None
+            self.assertEqual(holder.stdout.readline().strip(), "1")
+            with remote_verify.take_dispatch_ticket(self.runtime, 2) as index:
+                self.assertEqual(index, 2, "the other process's ticket was reissued")
+            with self.assertRaises(remote_verify.NoTicket):
+                with remote_verify.take_dispatch_ticket(self.runtime, 1):
+                    self.fail("ticket 1 was issued while another process held it")
+        finally:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(holder_pid, signal.SIGKILL)
+            holder.wait(timeout=10)
+            for stream in (holder.stdin, holder.stdout):
+                if stream is not None:
+                    stream.close()
+
+
+class SlotCountTests(unittest.TestCase):
+    def test_the_default_is_two_slots(self):
+        self.assertEqual(remote_verify.configured_slots({}), 2)
+
+    def test_an_empty_setting_takes_the_default(self):
+        self.assertEqual(
+            remote_verify.configured_slots({"TBD_REMOTE_VERIFY_SLOTS": ""}), 2
+        )
+
+    def test_the_setting_overrides_the_default(self):
+        self.assertEqual(
+            remote_verify.configured_slots({"TBD_REMOTE_VERIFY_SLOTS": "3"}), 3
+        )
+
+    def test_an_unreadable_setting_is_rejected_by_name(self):
+        with self.assertRaises(ValueError) as caught:
+            remote_verify.configured_slots({"TBD_REMOTE_VERIFY_SLOTS": "two"})
+        self.assertIn("TBD_REMOTE_VERIFY_SLOTS", str(caught.exception))
+
+    def test_a_negative_setting_is_rejected_by_name(self):
+        with self.assertRaises(ValueError) as caught:
+            remote_verify.configured_slots({"TBD_REMOTE_VERIFY_SLOTS": "-1"})
+        self.assertIn("TBD_REMOTE_VERIFY_SLOTS", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-remote-verify.py
+++ b/scripts/test-remote-verify.py
@@ -8,12 +8,20 @@ One case takes a ticket in a separate process, because a lock that only holds
 within one interpreter would bound nothing — forty agent lanes are forty
 processes.  That child is killed by the exact pid recorded at spawn; a
 pattern kill would match unrelated sessions on this machine.
+
+NOTHING HERE REACHES THE NETWORK. `git` and `gh` are a recorded fake, so the
+driver's real ordering — ticket, then push, then dispatch — is asserted from
+what it tried to run.  The xUnit fixtures are copied from the two generators
+this repo actually meets: SwiftPM's XCTest writer and Swift Testing's own,
+whose exact element shapes were read out of the shipped toolchain binaries.
 """
 
 from __future__ import annotations
 
 import contextlib
 import importlib.util
+import io
+import json
 import os
 from pathlib import Path
 import signal
@@ -31,6 +39,10 @@ def _load_module():
     spec = importlib.util.spec_from_file_location("remote_verify", str(MODULE_PATH))
     assert spec is not None and spec.loader is not None, f"no import spec for {MODULE_PATH}"
     module = importlib.util.module_from_spec(spec)
+    # Registered before execution, not after: `@dataclass` resolves the
+    # annotations of the class it decorates through `sys.modules`, so a module
+    # that is not there yet fails to define its own dataclasses.
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -48,6 +60,7 @@ from pathlib import Path
 
 spec = importlib.util.spec_from_file_location("remote_verify", sys.argv[1])
 module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module   # `@dataclass` resolves annotations through it
 spec.loader.exec_module(module)
 
 with module.take_dispatch_ticket(Path(sys.argv[2]), int(sys.argv[3])) as index:
@@ -144,6 +157,619 @@ class SlotCountTests(unittest.TestCase):
         with self.assertRaises(ValueError) as caught:
             remote_verify.configured_slots({"TBD_REMOTE_VERIFY_SLOTS": "-1"})
         self.assertIn("TBD_REMOTE_VERIFY_SLOTS", str(caught.exception))
+
+
+# --- fixtures ----------------------------------------------------------------
+
+# SwiftPM's XCTest xUnit writer: one flat `<testsuites>`, unindented, with the
+# failure message on the attribute `--experimental-xunit-message-failure` fills.
+XCTEST_STYLE = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+<testsuite name="TestResults" errors="0" tests="3" failures="1" time="12.5">
+<testcase classname="TBDDaemonTests.OrphanGCTests" name="reclaimsStaleWorktrees" time="0.031"/>
+<testcase classname="TBDDaemonTests.OrphanGCTests" name="quarantinesProfileDirs" time="0.044"><failure message="XCTAssertEqual failed: (&quot;1&quot;) is not equal to (&quot;2&quot;)"></failure></testcase>
+</testsuite>
+</testsuites>
+"""
+
+# Swift Testing's own writer: the same elements, indented, and with `<skipped />`
+# for a disabled test.
+SWIFT_TESTING_STYLE = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="TestResults" errors="0" tests="4" failures="2" time="8.250">
+    <testcase classname="TBDAppTests" name="valveRoutesRemote()" time="0.100"><failure message="Expectation failed: (actual → 1) == (expected → 2)" /></testcase>
+    <testcase classname="TBDAppTests" name="skippedForNow()" time="0.000"><skipped /></testcase>
+    <testcase classname="TBDAppTests" name="rendersFailures()" time="0.010" />
+    <testcase classname="TBDAppTests" name="pushesAfterTheTicket()" time="0.200"><failure message="Expectation failed: ticket was not held" /></testcase>
+  </testsuite>
+</testsuites>
+"""
+
+CLEAN_STYLE = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="TestResults" errors="0" tests="2" failures="0" time="1.5">
+    <testcase classname="TBDDaemonLiveTests" name="attachesToTmux()" time="1.400" />
+  </testsuite>
+</testsuites>
+"""
+
+# A run killed mid-write leaves exactly this: a prefix with no closing tag.
+TRUNCATED = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="TestResults" errors="0" tests="9" failures="1" time="3.0">
+    <testcase classname="TBDDaemonTests" name="died"""
+
+
+def write_results(directory: Path, **files: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (directory / f"{name}.xml").write_text(body, encoding="utf-8")
+    return directory
+
+
+def completed(status: int = 0, stdout: str = "", stderr: str = ""):
+    return remote_verify.Completed(status, stdout, stderr)
+
+
+class RecordingRunner:
+    """A `git`/`gh` stand-in that records every argv and replies from a script.
+
+    Replies match on an argv prefix, so each case scripts only the calls it
+    cares about and everything else succeeds silently.  The recording is the
+    point: the driver's ordering guarantee — no push before a ticket, no
+    dispatch before a push — is only observable from what it tried to run.
+    """
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+        self.replies: list[tuple[tuple[str, ...], object]] = []
+
+    def reply(self, *prefix: str, handler=None, status: int = 0, stdout: str = "", stderr: str = ""):
+        self.replies.append(
+            (tuple(prefix), handler or (lambda argv: completed(status, stdout, stderr)))
+        )
+        return self
+
+    def __call__(self, argv):
+        argv = list(argv)
+        self.calls.append(argv)
+        for prefix, handler in self.replies:
+            if tuple(argv[: len(prefix)]) == prefix:
+                return handler(argv)
+        return completed()
+
+    def ran(self, *prefix: str) -> list[list[str]]:
+        return [call for call in self.calls if tuple(call[: len(prefix)]) == prefix]
+
+
+class FakeClock:
+    """Monotonic time the test advances, so no case waits on a wall clock."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds if seconds > 0 else 1.0
+
+
+def run_json(**overrides):
+    run = {
+        "databaseId": 4242,
+        "headSha": "c0ffee",
+        "status": "completed",
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "url": "https://example.invalid/runs/4242",
+    }
+    run.update(overrides)
+    return run
+
+
+class RenderingTests(unittest.TestCase):
+    """The artifact holds one file per pass, and a red run may publish fewer."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def render(self, **files):
+        write_results(self.dir, **files)
+        return remote_verify.render_results(remote_verify.result_files(self.dir))
+
+    def test_failures_from_every_result_file_are_merged(self):
+        report = self.render(
+            **{
+                "xunit-daemon": XCTEST_STYLE,
+                "xunit-app": SWIFT_TESTING_STYLE,
+                "xunit-quiet": CLEAN_STYLE,
+            }
+        )
+        self.assertEqual(report.total, 3, report.lines)
+        rendered = "\n".join(report.lines)
+        self.assertIn("3 result file(s)", rendered)
+        self.assertIn(
+            "TBDDaemonTests.OrphanGCTests.quarantinesProfileDirs: "
+            'XCTAssertEqual failed: ("1") is not equal to ("2")',
+            rendered,
+        )
+        self.assertIn(
+            "TBDAppTests.valveRoutesRemote(): "
+            "Expectation failed: (actual → 1) == (expected → 2)",
+            rendered,
+        )
+        self.assertIn("TBDAppTests.pushesAfterTheTicket()", rendered)
+        self.assertIn("xunit-daemon.xml", rendered)
+        self.assertIn("xunit-app.xml", rendered)
+        # The clean pass contributes nothing to read past.
+        self.assertNotIn("xunit-quiet.xml", rendered)
+
+    def test_a_result_file_that_never_arrived_is_not_an_error(self):
+        report = self.render(**{"xunit-daemon": XCTEST_STYLE})
+        self.assertEqual(report.total, 1)
+        self.assertEqual(report.unreadable, ())
+        self.assertIn("1 result file(s)", "\n".join(report.lines))
+
+    def test_an_unreadable_file_does_not_hide_the_others(self):
+        report = self.render(
+            **{"xunit-app": SWIFT_TESTING_STYLE, "xunit-quiet": TRUNCATED}
+        )
+        self.assertEqual(report.total, 2, report.lines)
+        self.assertEqual(report.unreadable, ("xunit-quiet.xml",))
+        rendered = "\n".join(report.lines)
+        self.assertIn("xunit-quiet.xml — unreadable", rendered)
+        self.assertIn("TBDAppTests.valveRoutesRemote()", rendered)
+
+    def test_an_empty_file_is_reported_rather_than_swallowed(self):
+        report = self.render(**{"xunit-daemon": ""})
+        self.assertEqual(report.total, 0)
+        self.assertEqual(report.unreadable, ("xunit-daemon.xml",))
+
+    def test_a_red_run_with_no_failures_says_where_to_look(self):
+        report = self.render(**{"xunit-quiet": CLEAN_STYLE})
+        self.assertEqual(report.total, 0)
+        self.assertIn("outside the test passes", "\n".join(report.lines))
+
+    def test_no_results_at_all_still_produces_a_line(self):
+        report = remote_verify.render_results([])
+        self.assertEqual(report.total, 0)
+        self.assertTrue(report.lines)
+
+    def test_skipped_and_passing_cases_are_not_failures(self):
+        failures = remote_verify.failures_in(
+            write_results(self.dir, only=SWIFT_TESTING_STYLE) / "only.xml"
+        )
+        names = [failure.name for failure in failures]
+        self.assertNotIn("skippedForNow()", names)
+        self.assertNotIn("rendersFailures()", names)
+
+    def test_a_missing_message_is_named_rather_than_blank(self):
+        body = (
+            '<testsuites><testsuite name="TestResults">'
+            '<testcase classname="A" name="b"><failure/></testcase>'
+            "</testsuite></testsuites>"
+        )
+        report = self.render(**{"xunit-daemon": body})
+        self.assertIn("A.b: (no message)", "\n".join(report.lines))
+
+    def test_a_message_carried_as_element_text_is_used(self):
+        body = (
+            '<testsuites><testsuite name="TestResults">'
+            '<testcase classname="A" name="b"><failure>died in the fixture</failure></testcase>'
+            "</testsuite></testsuites>"
+        )
+        report = self.render(**{"xunit-daemon": body})
+        self.assertIn("A.b: died in the fixture", "\n".join(report.lines))
+
+    def test_an_error_element_counts_as_a_failure(self):
+        body = (
+            '<testsuites><testsuite name="TestResults">'
+            '<testcase classname="A" name="b"><error message="crashed"/></testcase>'
+            "</testsuite></testsuites>"
+        )
+        report = self.render(**{"xunit-daemon": body})
+        self.assertEqual(report.total, 1)
+        self.assertIn("A.b: crashed", "\n".join(report.lines))
+
+    def test_a_missing_classname_falls_back_to_the_file(self):
+        body = (
+            '<testsuites><testsuite name="TestResults">'
+            '<testcase name="b"><failure message="x"/></testcase>'
+            "</testsuite></testsuites>"
+        )
+        report = self.render(**{"xunit-daemon": body})
+        self.assertIn("xunit-daemon.b: x", "\n".join(report.lines))
+
+    def test_duplicate_failures_within_a_file_collapse(self):
+        case = '<testcase classname="A" name="b"><failure message="x"/></testcase>'
+        body = f'<testsuites><testsuite name="TestResults">{case}{case}</testsuite></testsuites>'
+        report = self.render(**{"xunit-daemon": body})
+        self.assertEqual(report.total, 1)
+
+    def test_the_render_is_bounded_and_says_what_it_withheld(self):
+        cases = "".join(
+            f'<testcase classname="A" name="test{index}"><failure message="x"/></testcase>'
+            for index in range(60)
+        )
+        report = self.render(
+            **{"xunit-daemon": f'<testsuites><testsuite name="TestResults">{cases}</testsuite></testsuites>'}
+        )
+        self.assertEqual(report.total, 60)
+        rendered = "\n".join(report.lines)
+        self.assertEqual(rendered.count("A.test"), 50, "the render was not bounded")
+        self.assertIn("and 10 more failing tests", rendered)
+
+    def test_result_files_finds_nested_xml_and_nothing_else(self):
+        write_results(self.dir / "xunit-results", **{"xunit-app": SWIFT_TESTING_STYLE})
+        (self.dir / "notes.txt").write_text("not results", encoding="utf-8")
+        found = remote_verify.result_files(self.dir)
+        self.assertEqual([path.name for path in found], ["xunit-app.xml"])
+
+
+class RunSelectionTests(unittest.TestCase):
+    def test_the_dispatched_run_for_this_sha_is_chosen(self):
+        runs = [
+            run_json(databaseId=1, headSha="other"),
+            run_json(databaseId=2, headSha="c0ffee"),
+        ]
+        chosen = remote_verify.select_run(runs, "c0ffee")
+        self.assertEqual(chosen["databaseId"], 2)
+
+    def test_the_newest_matching_run_wins(self):
+        runs = [run_json(databaseId=9), run_json(databaseId=8)]
+        self.assertEqual(remote_verify.select_run(runs, "c0ffee")["databaseId"], 9)
+
+    def test_a_pull_request_run_for_the_same_sha_is_ignored(self):
+        runs = [run_json(databaseId=3, event="pull_request")]
+        self.assertIsNone(remote_verify.select_run(runs, "c0ffee"))
+
+    def test_a_boolean_run_id_is_refused_rather_than_coerced(self):
+        # `isinstance(True, int)` is True in python, so an unguarded read would
+        # address run 1 — a real, unrelated run.
+        runs = [run_json(databaseId=True)]
+        self.assertIsNone(remote_verify.select_run(runs, "c0ffee"))
+
+    def test_nothing_matching_yields_nothing(self):
+        self.assertIsNone(remote_verify.select_run([], "c0ffee"))
+
+
+class VerdictTests(unittest.TestCase):
+    def test_success_is_a_pass(self):
+        self.assertEqual(remote_verify.verdict_for("success"), 0)
+
+    def test_failure_is_a_fail(self):
+        self.assertEqual(remote_verify.verdict_for("failure"), 1)
+
+    def test_anything_else_is_no_verdict(self):
+        for conclusion in ("cancelled", "skipped", "timed_out", "startup_failure", None):
+            self.assertIsNone(
+                remote_verify.verdict_for(conclusion),
+                f"{conclusion!r} was read as a verdict",
+            )
+
+
+class CorrelationTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+
+    def wait(self, runner, *, timeout=30.0):
+        return remote_verify.await_dispatched_run(
+            runner, "c0ffee",
+            timeout=timeout, poll=5.0,
+            sleep=self.clock.sleep, monotonic=self.clock.monotonic,
+            report=lambda *_: None,
+        )
+
+    def test_a_run_that_registers_late_is_still_found(self):
+        answers = ["[]", "[]", json.dumps([run_json()])]
+        runner = RecordingRunner().reply(
+            "gh", "run", "list", handler=lambda argv: completed(stdout=answers.pop(0))
+        )
+        self.assertEqual(self.wait(runner)["databaseId"], 4242)
+
+    def test_a_run_that_never_registers_refuses_by_name(self):
+        runner = RecordingRunner().reply("gh", "run", "list", stdout="[]")
+        with self.assertRaises(remote_verify.Refused) as caught:
+            self.wait(runner, timeout=10.0)
+        self.assertIn("c0ffee", str(caught.exception))
+
+    def test_a_failed_query_refuses_rather_than_reading_nothing(self):
+        runner = RecordingRunner().reply(
+            "gh", "run", "list", status=1, stderr="API rate limit exceeded"
+        )
+        with self.assertRaises(remote_verify.Refused) as caught:
+            self.wait(runner)
+        self.assertIn("rate limit", str(caught.exception))
+
+    def test_unreadable_json_refuses(self):
+        runner = RecordingRunner().reply("gh", "run", "list", stdout="not json at all")
+        with self.assertRaises(remote_verify.Refused):
+            self.wait(runner)
+
+    def test_completion_is_waited_for(self):
+        answers = [
+            json.dumps({"status": "queued"}),
+            json.dumps({"status": "in_progress"}),
+            json.dumps({"status": "completed", "conclusion": "failure"}),
+        ]
+        runner = RecordingRunner().reply(
+            "gh", "run", "view", handler=lambda argv: completed(stdout=answers.pop(0))
+        )
+        finished = remote_verify.await_completion(
+            runner, "4242", timeout=600.0, poll=10.0,
+            sleep=self.clock.sleep, monotonic=self.clock.monotonic,
+            report=lambda *_: None,
+        )
+        self.assertEqual(finished["conclusion"], "failure")
+
+    def test_a_run_that_never_completes_refuses_by_name(self):
+        runner = RecordingRunner().reply(
+            "gh", "run", "view", stdout=json.dumps({"status": "in_progress"})
+        )
+        with self.assertRaises(remote_verify.Refused) as caught:
+            remote_verify.await_completion(
+                runner, "4242", timeout=60.0, poll=10.0,
+                sleep=self.clock.sleep, monotonic=self.clock.monotonic,
+                report=lambda *_: None,
+            )
+        self.assertIn("4242", str(caught.exception))
+
+
+class FailedJobTests(unittest.TestCase):
+    def test_the_red_jobs_are_named(self):
+        run = {
+            "jobs": [
+                {"name": "Lint", "conclusion": "failure"},
+                {"name": "Test", "conclusion": "success"},
+                {"name": "Live", "conclusion": "cancelled"},
+            ]
+        }
+        self.assertEqual(remote_verify.failed_job_names(run), ["Lint", "Live"])
+
+    def test_a_run_without_jobs_names_none(self):
+        self.assertEqual(remote_verify.failed_job_names({}), [])
+
+
+class DriverTests(unittest.TestCase):
+    """The ordering guarantee, and the verdict, end to end without a network."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.runtime = self.root / "runtime"
+        self.clock = FakeClock()
+        self.printed: list[str] = []
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def drive(self, runner, *, slots=2, inert=False, ref="tbd/lane", sha="c0ffee"):
+        return remote_verify.drive(
+            ref=ref, sha=sha, inert=inert,
+            runtime_dir=self.runtime, slots=slots,
+            run_command=runner,
+            poll=5.0, correlate_timeout=60.0, run_timeout=600.0,
+            sleep=self.clock.sleep, monotonic=self.clock.monotonic,
+            report=lambda *_: None, write=self.printed.append,
+        )
+
+    def output(self) -> str:
+        return "\n".join(self.printed)
+
+    def passing_runner(self):
+        return (
+            RecordingRunner()
+            .reply("gh", "run", "list", stdout=json.dumps([run_json()]))
+            .reply(
+                "gh", "run", "view",
+                stdout=json.dumps(
+                    {"status": "completed", "conclusion": "success", "url": "https://example.invalid/runs/4242"}
+                ),
+            )
+        )
+
+    def failing_runner(self, **files):
+        def download(argv):
+            destination = Path(argv[argv.index("--dir") + 1])
+            write_results(destination, **files)
+            return completed()
+
+        return (
+            RecordingRunner()
+            .reply("gh", "run", "list", stdout=json.dumps([run_json(conclusion="failure")]))
+            .reply(
+                "gh", "run", "view",
+                stdout=json.dumps(
+                    {
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "url": "https://example.invalid/runs/4242",
+                        "jobs": [{"name": "Test", "conclusion": "failure"}],
+                    }
+                ),
+            )
+            .reply("gh", "run", "download", handler=download)
+        )
+
+    def test_a_passing_run_exits_zero_and_downloads_nothing(self):
+        runner = self.passing_runner()
+        self.assertEqual(self.drive(runner), 0)
+        self.assertIn("passed", self.output())
+        self.assertEqual(runner.ran("gh", "run", "download"), [])
+
+    def test_a_failing_run_renders_the_failing_tests(self):
+        runner = self.failing_runner(
+            **{
+                "xunit-daemon": XCTEST_STYLE,
+                "xunit-app": SWIFT_TESTING_STYLE,
+                "xunit-quiet": CLEAN_STYLE,
+            }
+        )
+        self.assertEqual(self.drive(runner), 1)
+        rendered = self.output()
+        self.assertIn("FAILED", rendered)
+        self.assertIn("failing jobs: Test", rendered)
+        self.assertIn("TBDDaemonTests.OrphanGCTests.quarantinesProfileDirs", rendered)
+        self.assertIn("TBDAppTests.valveRoutesRemote()", rendered)
+
+    def test_a_failing_run_with_no_artifact_still_fails_loudly(self):
+        runner = self.failing_runner()
+        runner.replies.insert(
+            0,
+            (
+                ("gh", "run", "download"),
+                lambda argv: completed(1, stderr="no artifact matches xunit-results"),
+            ),
+        )
+        self.assertEqual(self.drive(runner), 1)
+        self.assertIn("could not download", self.output())
+        self.assertIn("https://example.invalid/runs/4242", self.output())
+
+    def test_no_ticket_refuses_without_pushing_or_dispatching(self):
+        # The ordering guarantee: a lane that never got a ticket must leave no
+        # ref behind and must not have spent a dispatch.
+        runner = self.passing_runner()
+        self.assertEqual(self.drive(runner, slots=0), 78)
+        self.assertEqual(runner.ran("git", "push"), [])
+        self.assertEqual(runner.ran("gh", "workflow", "run"), [])
+
+    def test_the_ticket_is_taken_before_the_push(self):
+        held = []
+
+        def push(argv):
+            held.append(sorted(path.name for path in self.runtime.glob("*.lock")))
+            return completed()
+
+        runner = self.passing_runner().reply("git", "push", handler=push)
+        self.assertEqual(self.drive(runner), 0)
+        self.assertEqual(held, [["remote-verify-1.lock"]])
+
+    def test_a_failed_push_refuses_without_dispatching(self):
+        runner = self.passing_runner().reply(
+            "git", "push", status=1, stderr="rejected: non-fast-forward"
+        )
+        self.assertEqual(self.drive(runner), 78)
+        self.assertEqual(runner.ran("gh", "workflow", "run"), [])
+
+    def test_a_failed_dispatch_refuses(self):
+        runner = self.passing_runner().reply(
+            "gh", "workflow", "run", status=1, stderr="workflow not found"
+        )
+        self.assertEqual(self.drive(runner), 78)
+
+    def test_an_inert_ref_is_forced_and_a_branch_is_not(self):
+        runner = self.passing_runner()
+        self.drive(runner, inert=True, ref="preflight/tbd/lane")
+        self.assertIn("--force", runner.ran("git", "push")[0])
+        self.assertIn("c0ffee:refs/heads/preflight/tbd/lane", runner.ran("git", "push")[0])
+
+        branch_runner = self.passing_runner()
+        self.drive(branch_runner, ref="tbd/lane")
+        self.assertNotIn("--force", branch_runner.ran("git", "push")[0])
+
+    def test_a_run_with_no_verdict_returns_the_lane_to_the_local_queue(self):
+        runner = (
+            RecordingRunner()
+            .reply("gh", "run", "list", stdout=json.dumps([run_json()]))
+            .reply(
+                "gh", "run", "view",
+                stdout=json.dumps({"status": "completed", "conclusion": "cancelled"}),
+            )
+        )
+        self.assertEqual(self.drive(runner), 78)
+
+    def test_the_dispatch_names_the_ref_and_the_scope(self):
+        runner = self.passing_runner()
+        self.drive(runner, ref="preflight/tbd/lane", inert=True)
+        dispatched = runner.ran("gh", "workflow", "run")[0]
+        self.assertEqual(
+            dispatched,
+            ["gh", "workflow", "run", "test.yml", "--ref", "preflight/tbd/lane", "-f", "scope=full"],
+        )
+
+    def test_the_ticket_is_released_once_the_run_is_over(self):
+        self.drive(self.passing_runner())
+        with remote_verify.take_dispatch_ticket(self.runtime, 1) as index:
+            self.assertEqual(index, 1)
+
+
+class SettingsTests(unittest.TestCase):
+    def test_the_poll_settings_default_when_unset(self):
+        self.assertEqual(
+            remote_verify._positive_seconds({}, remote_verify.POLL_SETTING, 10.0), 10.0
+        )
+
+    def test_a_poll_setting_overrides_the_default(self):
+        self.assertEqual(
+            remote_verify._positive_seconds(
+                {remote_verify.POLL_SETTING: "0.5"}, remote_verify.POLL_SETTING, 10.0
+            ),
+            0.5,
+        )
+
+    def test_an_unreadable_duration_is_rejected_by_name(self):
+        with self.assertRaises(ValueError) as caught:
+            remote_verify._positive_seconds(
+                {remote_verify.POLL_SETTING: "soon"}, remote_verify.POLL_SETTING, 10.0
+            )
+        self.assertIn(remote_verify.POLL_SETTING, str(caught.exception))
+
+    def test_an_unreadable_setting_refuses_before_anything_happens(self):
+        # 78, and nothing pushed or dispatched: the repo directory here is not
+        # a git repository, so even a driver that ignored the refusal could
+        # only fail locally.
+        with tempfile.TemporaryDirectory() as scratch:
+            status = remote_verify.main(
+                ["drive", "--repo-dir", scratch, "--ref", "tbd/lane", "--sha", "c0ffee"],
+                {"TBD_REMOTE_VERIFY_SLOTS": "two", "TBD_HOME": scratch},
+            )
+        self.assertEqual(status, 78)
+
+    def test_the_runtime_dir_follows_tbd_home(self):
+        self.assertEqual(
+            remote_verify._resolve_runtime_dir({"TBD_HOME": "/tmp/fixture-home"}),
+            Path("/tmp/fixture-home/runtime"),
+        )
+
+
+class RenderCommandTests(unittest.TestCase):
+    """The `render` subcommand, for reading an artifact somebody downloaded."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def render(self, *args):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            status = remote_verify.main(["render", *args], {})
+        return status, buffer.getvalue()
+
+    def test_a_directory_of_results_renders_and_exits_one(self):
+        write_results(self.dir, **{"xunit-daemon": XCTEST_STYLE, "xunit-quiet": CLEAN_STYLE})
+        status, output = self.render(str(self.dir))
+        self.assertEqual(status, 1)
+        self.assertIn("quarantinesProfileDirs", output)
+
+    def test_results_with_no_failures_exit_zero(self):
+        write_results(self.dir, **{"xunit-quiet": CLEAN_STYLE})
+        status, output = self.render(str(self.dir))
+        self.assertEqual(status, 0)
+        self.assertIn("outside the test passes", output)
+
+    def test_a_named_file_can_be_rendered_on_its_own(self):
+        write_results(self.dir, **{"xunit-app": SWIFT_TESTING_STYLE})
+        status, output = self.render(str(self.dir / "xunit-app.xml"))
+        self.assertEqual(status, 1)
+        self.assertIn("TBDAppTests.valveRoutesRemote()", output)
 
 
 if __name__ == "__main__":

--- a/scripts/test-remote-verify.py
+++ b/scripts/test-remote-verify.py
@@ -524,7 +524,14 @@ class RenderingTests(unittest.TestCase):
     def test_no_results_at_all_still_produces_a_line(self):
         report = remote_verify.render_results([])
         self.assertEqual(report.total, 0)
+        self.assertEqual(report.files, 0)
         self.assertTrue(report.lines)
+        rendered = "\n".join(report.lines)
+        # NOT the "outside the test passes" line the case above gets. That one
+        # says the passes ran and came back clean, which is a claim about the
+        # tests; nothing ran here that could make one.
+        self.assertIn("no result files were published", rendered)
+        self.assertNotIn("outside the test passes", rendered)
 
     def test_skipped_and_passing_cases_are_not_failures(self):
         failures = remote_verify.failures_in(
@@ -691,9 +698,15 @@ class ResultsVerdictTests(unittest.TestCase):
     `scripts/test.sh` runs locally.
     """
 
-    def report(self, *, total=0, unreadable=(), tests=None):
+    def report(self, *, total=0, unreadable=(), tests=None, files=1):
+        # `files` defaults to a report that describes something, because that is
+        # what every case below but one is about. The one that is not passes 0.
         return remote_verify.Report(
-            total=total, unreadable=tuple(unreadable), lines=(), tests=tests
+            total=total,
+            unreadable=tuple(unreadable),
+            lines=(),
+            files=files,
+            tests=tests,
         )
 
     def test_recorded_failures_are_a_test_failure(self):
@@ -737,6 +750,27 @@ class ResultsVerdictTests(unittest.TestCase):
         # setup died, the compile died, or the upload broke on a genuinely red run
         # whose failures the local re-run finds properly.
         self.assertEqual(remote_verify.verdict_from_results(None), 78)
+
+    def test_an_artifact_holding_no_result_file_is_no_verdict_either(self):
+        # THE SAME CASE AS THE ONE ABOVE, arriving by a different route: the
+        # download succeeded and there was no xUnit file inside it. Every other
+        # field of that report is indistinguishable from a clean one — no total,
+        # no unreadable names, no population — so without `files` it falls
+        # through to "readable results that state no population" and reports a
+        # red suite for a run that said nothing about any test. The green path
+        # already refuses this shape, and the two paths must not read one
+        # artifact two ways.
+        self.assertEqual(
+            remote_verify.verdict_from_results(self.report(files=0, tests=None)), 78
+        )
+
+    def test_a_rendered_report_over_no_files_at_all_is_no_verdict(self):
+        # The same claim through the production path rather than a hand-built
+        # report, because `files` is only worth anything if `render_results` sets
+        # it: an artifact with nothing in it to read renders to exactly this.
+        self.assertEqual(
+            remote_verify.verdict_from_results(remote_verify.render_results([])), 78
+        )
 
 
 class CorrelationTests(unittest.TestCase):
@@ -893,18 +927,29 @@ class DriverTests(unittest.TestCase):
     def diagnostics(self) -> str:
         return "\n".join(self.reported)
 
-    def results_runner(self, conclusion, **files):
+    def results_runner(self, conclusion, *, empty=False, **files):
         """A `gh` whose run reaches `conclusion` and publishes `files`.
 
         Both verdicts download the artifact: a red run needs the failures, and
         a green one needs the population, because a caller reading `Test run
         with N tests` cannot be handed a number no result file supports.
+
+        `empty` publishes an artifact holding no xUnit file at all — the third
+        shape, between an artifact that arrived with results and one that never
+        arrived.
         """
 
         def download(argv):
+            destination = Path(argv[argv.index("--dir") + 1])
+            if empty:
+                # THE DOWNLOAD SUCCEEDS AND THERE IS NOTHING TO READ. Distinct
+                # from the missing artifact below, which fails the download and
+                # reaches the driver as `results is None`.
+                destination.mkdir(parents=True, exist_ok=True)
+                (destination / "README.txt").write_text("no results\n", encoding="utf-8")
+                return completed()
             if not files:
                 return completed(1, stderr="no artifact matches xunit-results")
-            destination = Path(argv[argv.index("--dir") + 1])
             write_results(destination, **files)
             return completed()
 
@@ -940,6 +985,10 @@ class DriverTests(unittest.TestCase):
     def passing_runner_without_results(self):
         """A green run whose artifact never arrived — nothing to count."""
         return self.results_runner("success")
+
+    def empty_artifact_runner(self, conclusion):
+        """A run whose artifact downloads and holds no result file."""
+        return self.results_runner(conclusion, empty=True)
 
     def failing_runner(self, **files):
         return self.results_runner("failure", **files)
@@ -1058,6 +1107,29 @@ class DriverTests(unittest.TestCase):
         )
         self.assertEqual(self.drive(runner), 1)
         self.assertIn("unreadable", self.output())
+
+    def test_a_red_run_whose_artifact_holds_no_result_file_is_no_verdict(self):
+        # AN ARTIFACT THAT ARRIVED AND HELD NOTHING SAYS WHAT A MISSING ONE
+        # SAYS. Nothing here describes any test population, so there is no
+        # evidence to set against the conclusion and no failing test to report —
+        # 78 sends the lane back to the local queue, where it gets a real answer.
+        # What keeps this shape off the wire today is `actions/upload-artifact`'s
+        # `if-no-files-found: warn`, which publishes nothing when the glob misses
+        # — a third party's behavior, not a guard of ours.
+        self.assertEqual(self.drive(self.empty_artifact_runner("failure")), 78)
+        self.assertNotIn("FAILED", self.output())
+        self.assertNotIn("Test run with", self.output())
+        self.assertIn("published no results", self.diagnostics())
+        self.assertIn("held no result files", self.diagnostics())
+
+    def test_the_same_empty_artifact_refuses_on_a_green_run_too(self):
+        # THE SYMMETRY IS THE POINT: one artifact, one meaning. The green path
+        # has always refused an uncountable pass; the red path used to call the
+        # identical report a failing suite.
+        self.assertEqual(self.drive(self.empty_artifact_runner("success")), 78)
+        self.assertNotIn("Test run with", self.output())
+        self.assertIn("could not be counted", self.diagnostics())
+        self.assertIn("held no result files", self.diagnostics())
 
     def test_a_red_run_whose_results_state_no_population_stays_red(self):
         # Readable, no failures, and silent about how many tests ran: no evidence
@@ -1409,6 +1481,16 @@ class RenderCommandTests(unittest.TestCase):
         rendered, _ = self.render(str(self.dir))
         report = remote_verify.render_results(remote_verify.result_files(self.dir))
         self.assertEqual(rendered, remote_verify.verdict_from_results(report))
+
+    def test_a_directory_with_nothing_to_read_is_no_verdict(self):
+        # The same artifact the driver refuses, handed to the other subcommand:
+        # a directory that holds no xUnit file at all. Exiting 1 here would call
+        # an empty download a red suite, and the two subcommands would disagree
+        # about one artifact.
+        (self.dir / "README.txt").write_text("no results\n", encoding="utf-8")
+        status, output = self.render(str(self.dir))
+        self.assertEqual(status, 78)
+        self.assertIn("no result files were published", output)
 
     def test_a_named_file_can_be_rendered_on_its_own(self):
         write_results(self.dir, **{"xunit-app": SWIFT_TESTING_STYLE})

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -352,6 +352,21 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("until the program exits", result.stderr)
 
+    def test_yielding_exits_with_its_own_code(self):
+        """76 is distinct from 75 so a caller can route the run elsewhere."""
+        lock_path = self.tbd_home / "runtime" / "swift-build.lock"
+        lock_path.parent.mkdir(parents=True)
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            result = self.run_runner(
+                "build",
+                TBD_SWIFT_QUEUE_YIELD_SECONDS="0.05",
+                TBD_SWIFT_LOCK_TIMEOUT_SECONDS="30",
+            )
+        self.assertEqual(result.returncode, 76)
+        self.assertIn("yield", result.stderr.lower())
+        self.assertEqual(result.stdout, "")
+
 
 class WaitReportingTests(unittest.TestCase):
     """Drive `_acquire` against a real contended flock with a fake clock."""
@@ -673,6 +688,56 @@ class AbandonedWaitTests(unittest.TestCase):
             )
         self.assertIs(outcome, TimeoutError)
         self.assertGreaterEqual(elapsed, 125.0)
+
+
+class QueueYieldTests(unittest.TestCase):
+    """Yielding is a caller-requested giveup, distinct from abandonment."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.lock_path = Path(self.temp.name) / "swift-build.lock"
+        self.holder = self.lock_path.open("a+", encoding="utf-8")
+        fcntl.flock(self.holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        os.environ.pop("TBD_SWIFT_ALLOW_ORPHAN", None)
+
+    def tearDown(self):
+        self.env.stop()
+        self.holder.close()
+        self.temp.cleanup()
+
+    def wait(self, yield_seconds, timeout=600.0):
+        clock = FakeClock()
+        start = clock.monotonic()
+        with self.lock_path.open("a+", encoding="utf-8") as waiter:
+            outcome = None
+            try:
+                swift_safe._acquire(
+                    waiter, self.lock_path, timeout, 60.0,
+                    requester=os.getppid(), ancestors=(),
+                    yield_after_seconds=yield_seconds,
+                    monotonic=clock.monotonic, sleep=clock.sleep,
+                    report=lambda *_: None, getppid=lambda: os.getppid(),
+                )
+            except BaseException as error:      # noqa: BLE001 - asserting the type
+                outcome = error
+            self.assertIsNotNone(outcome, "the wait acquired the build slot")
+        return type(outcome), clock.monotonic() - start
+
+    def test_the_wait_yields_once_the_threshold_passes(self):
+        outcome, elapsed = self.wait(60.0)
+        self.assertIs(outcome, swift_safe.Yielded)
+        self.assertGreaterEqual(elapsed, 60.0)
+        self.assertLess(elapsed, 61.0)
+
+    def test_an_unset_threshold_never_yields(self):
+        outcome, _ = self.wait(None, timeout=120.0)
+        self.assertIs(outcome, TimeoutError)
+
+    def test_a_threshold_beyond_the_timeout_never_yields(self):
+        outcome, _ = self.wait(500.0, timeout=120.0)
+        self.assertIs(outcome, TimeoutError)
 
 
 class AncestorChainTests(unittest.TestCase):

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -352,19 +352,60 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("until the program exits", result.stderr)
 
-    def test_yielding_exits_with_its_own_code(self):
-        """76 is distinct from 75 so a caller can route the run elsewhere."""
+    def _contended(self, *arguments, **extra_env):
+        """Run the wrapper with the shared slot already held by this process."""
         lock_path = self.tbd_home / "runtime" / "swift-build.lock"
-        lock_path.parent.mkdir(parents=True)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
         with lock_path.open("a+", encoding="utf-8") as lock_file:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            result = self.run_runner(
-                "build",
-                TBD_SWIFT_QUEUE_YIELD_SECONDS="0.05",
-                TBD_SWIFT_LOCK_TIMEOUT_SECONDS="30",
-            )
+            return self.run_runner(*arguments, **extra_env)
+
+    def test_yielding_exits_with_its_own_code(self):
+        """76 is distinct from 75 so a caller can route the run elsewhere."""
+        result = self._contended(
+            "test",
+            TBD_SWIFT_QUEUE_YIELD_SECONDS="0.05",
+            TBD_SWIFT_LOCK_TIMEOUT_SECONDS="30",
+        )
         self.assertEqual(result.returncode, 76)
         self.assertIn("yield", result.stderr.lower())
+        self.assertEqual(result.stdout, "")
+
+    def test_a_build_ignores_the_queue_yield_knob(self):
+        """ONLY `test` MAY YIELD, because only its caller understands 76.
+
+        `scripts/restart.sh` never checks this wrapper's status, so a developer
+        who exported this knob in a shell profile would get a build that stops
+        after the bound and a bundle assembled around whatever stale binaries
+        were already on disk — the documented "a stale daemon reverts the fleet"
+        failure. A build queues as usual and says once that the knob is not for
+        it, because a knob ignored in silence looks like a knob that is broken.
+        """
+        result = self._contended(
+            "build",
+            TBD_SWIFT_QUEUE_YIELD_SECONDS="0.05",
+            TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.5",
+        )
+        self.assertNotEqual(result.returncode, 76, "a build yielded its place")
+        self.assertEqual(result.returncode, 75)
+        self.assertIn("timed out", result.stderr)
+        self.assertIn("only `test`", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_a_bad_yield_value_does_not_fail_a_build(self):
+        # The validation is gated with the behaviour: a typo in a knob this
+        # subcommand ignores must not turn an unrelated rebuild into a hard exit.
+        result = self.run_runner("build", TBD_SWIFT_QUEUE_YIELD_SECONDS="soon")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build --jobs 2")
+        self.assertIn("only `test`", result.stderr)
+
+    def test_a_bad_yield_value_still_fails_a_test_run(self):
+        # Where the knob IS honoured, an unreadable value is refused by name
+        # rather than silently meaning "never yield".
+        result = self.run_runner("test", TBD_SWIFT_QUEUE_YIELD_SECONDS="soon")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("TBD_SWIFT_QUEUE_YIELD_SECONDS", result.stderr)
         self.assertEqual(result.stdout, "")
 
 

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -53,6 +53,41 @@ class FakeClock:
         self.now += seconds
 
 
+# A stub `swift` that holds the build slot until it is signalled.
+#
+# `exec`, AND THE WHOLE POINT OF THIS CONSTANT. `swift-safe` execs the tool, so
+# the process the fixture signals is this shell — and a plain `sleep 30` on the
+# last line makes the sleep a CHILD of it, which no signal to the shell reaches.
+# The shell died, the sleep was reparented, and two of them outlived the run on
+# a CI runner, which reaped them itself and said so. `exec` collapses the two
+# into one process, so the pid the fixture recorded at spawn IS the long-lived
+# one and killing it leaves nothing behind.
+HOLDING_SWIFT = "#!/bin/sh\nprintf 'ready\\n'\nexec sleep 30\n"
+
+
+def _descendants_of(pid: int) -> list[int]:
+    """Every live process below `pid`, from `ps` — BSD and GNU alike.
+
+    Both accept `ps -eo pid=,ppid=`; neither `--ppid` (GNU) nor `-o ppid= -p`
+    (which answers about one pid, not its children) is portable enough here.
+    """
+    listing = subprocess.run(
+        ["ps", "-eo", "pid=,ppid="], capture_output=True, text=True, check=False
+    ).stdout
+    children: dict[int, list[int]] = {}
+    for line in listing.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[0].isdigit() and fields[1].isdigit():
+            children.setdefault(int(fields[1]), []).append(int(fields[0]))
+    found: list[int] = []
+    pending = [pid]
+    while pending:
+        for child in children.get(pending.pop(), ()):
+            found.append(child)
+            pending.append(child)
+    return found
+
+
 @contextlib.contextmanager
 def _lock_holder(env: dict[str, str], cwd: str | None = None):
     """Run a real swift-safe that takes the lock and keeps it until exit.
@@ -60,6 +95,8 @@ def _lock_holder(env: dict[str, str], cwd: str | None = None):
     Yields once the stub `swift` has printed, which happens only after the
     lock was taken and the holder record written — so a waiter started inside
     the block genuinely contends with a genuinely identified holder.
+
+    Teardown is unconditional and signals only the pid recorded at spawn.
     """
     process = subprocess.Popen(
         [str(RUNNER), "build"],
@@ -75,10 +112,16 @@ def _lock_holder(env: dict[str, str], cwd: str | None = None):
         assert stdout.readline().strip() == "ready"
         yield process
     finally:
-        process.terminate()
-        process.wait(timeout=5)
-        stdout.close()
-        stderr.close()
+        try:
+            process.terminate()
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            # A holder that ignored SIGTERM still may not outlive its test.
+            process.kill()
+            process.wait(timeout=5)
+        finally:
+            stdout.close()
+            stderr.close()
 
 
 def _dead_pid() -> int:
@@ -265,16 +308,43 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertIn("usage:", result.stderr)
 
     def test_execed_swift_keeps_the_lock(self):
-        self.fake_swift.write_text(
-            "#!/bin/sh\nprintf 'ready\\n'\nsleep 30\n",
-            encoding="utf-8",
-        )
+        self.fake_swift.write_text(HOLDING_SWIFT, encoding="utf-8")
         with _lock_holder(self.runner_env()):
             result = self.run_runner(
                 "test", TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.05"
             )
             self.assertEqual(result.returncode, 75)
             self.assertIn("timed out", result.stderr)
+
+    def test_the_lock_holder_fixture_strands_no_process(self):
+        """Nothing this fixture starts may outlive its block.
+
+        Two `sleep`s from it outlived a CI run and the runner reaped them and
+        said so: the stub `swift` forked its sleeper, so the SIGTERM that ended
+        the shell never reached the child, which was reparented and kept
+        running.  Recording every descendant while the block is open and
+        asserting each is gone once it closes states that invariant whatever
+        shape the stub takes.  Only pids observed here are ever looked at, and
+        none of them is signalled.
+        """
+        self.fake_swift.write_text(HOLDING_SWIFT, encoding="utf-8")
+        with _lock_holder(self.runner_env()) as holder:
+            started = [holder.pid]
+            # A forked sleeper appears a moment after "ready", so poll for one
+            # rather than racing it.  The whole window is spent only when the
+            # stub is well-behaved and there is nothing to find.
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
+                descendants = _descendants_of(holder.pid)
+                if descendants:
+                    started.extend(descendants)
+                    break
+                time.sleep(0.02)
+        for pid in started:
+            self.assertFalse(
+                swift_safe._process_is_alive(pid),
+                f"pid {pid} outlived the lock-holder fixture",
+            )
 
     def test_contended_lock_times_out_without_spawning_swift(self):
         lock_path = self.tbd_home / "runtime" / "swift-build.lock"
@@ -322,10 +392,7 @@ class SwiftSafeTests(unittest.TestCase):
         """End to end: a real waiter behind a real holder, compressed cadence."""
         holder_directory = Path(self.temp.name) / "acme-worktree"
         holder_directory.mkdir()
-        self.fake_swift.write_text(
-            "#!/bin/sh\nprintf 'ready\\n'\nsleep 30\n",
-            encoding="utf-8",
-        )
+        self.fake_swift.write_text(HOLDING_SWIFT, encoding="utf-8")
         with _lock_holder(self.runner_env(), cwd=str(holder_directory)) as holder:
             result = self.run_runner(
                 "test",
@@ -864,12 +931,15 @@ class OrphanedWrapperTests(unittest.TestCase):
         self.wrapper_pid_file = root / "wrapper.pid"
         self.intermediate_pid_file = root / "intermediate.pid"
         self.fake_swift = root / "swift"
+        # No case here expects this to run — each asserts the marker stays
+        # absent — but if one ever regresses, `exec` keeps the long-lived
+        # process the same pid this test recorded, so teardown can end it.
         self.fake_swift.write_text(
             textwrap.dedent(
                 f"""\
                 #!/bin/sh
                 printf '%s\\n' "$*" > {shlex.quote(str(self.compiled_marker))}
-                sleep 30
+                exec sleep 30
                 """
             ),
             encoding="utf-8",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -175,8 +175,21 @@
 #      no pushable ref). The run falls back to the local queue. THE VALVE IS AN
 #      OPTIMISATION, NEVER A GATE: a refusal must never fail a run.
 #
-# Any other status from `remote-verify.sh` is the run's verdict — 0 for a green
-# remote run, 1 for a red one whose failing tests it has already printed.
+# `remote-verify.sh` answers 0 for a green remote run and 1 for a red one whose
+# failing tests it has already printed. THOSE TWO, AND ONLY THOSE TWO, ARE
+# VERDICTS. Everything else it can produce — 127 for a mangled interpreter line,
+# 130 for a Ctrl-C, 2 for a syntax error in it — says nothing about the tests,
+# and adopting one would report a suite that never ran as a failing suite. Any
+# status outside `{0, 1, 78}` is therefore treated exactly as 78 is, with the
+# status named on the way past.
+#
+# THE VALVE ALSO REFUSES A NARROWED RUN, and that is about soundness rather than
+# capacity. This wrapper forwards `--filter` and friends to `swift test` but the
+# dispatch has no way to carry them, so the remote run is always the whole
+# suite. Green whole-suite would still be sound for a filtered caller — it
+# implies the subset passed — but RED is not: it would report failures from
+# tests the caller deliberately excluded as if they were this run's result. A
+# narrowed run therefore waits for the local slot, and says so once.
 #
 # TESTED BY `scripts/test.test.sh`, which drives the guards below against
 # fixture directories with a stub `swift` — no build, no real `~/tbd`. Every
@@ -291,6 +304,39 @@ valid_yield_bound() {
   return 0
 }
 
+# THE ARGUMENTS THAT REDUCE THE SUITE, AND WHY THE VALVE WILL NOT ROUTE PAST
+# THEM. Nothing on the dispatch carries a filter, so a routed run is always the
+# whole suite. For a filtered caller that makes a GREEN remote result sound — the
+# whole suite passing implies their subset did — and a RED one a false statement
+# about their run, naming failures in tests they deliberately excluded. Measured
+# contention says filtered runs are the common case rather than an exotic one:
+# of the seven queued lanes in the two snapshots behind the design, three were
+# `swift test --filter …`. So this is refused rather than tolerated.
+#
+# FOLLOW-UP, AND THE REASON THIS RESTRICTION IS TEMPORARY: give the dispatch a
+# filter input, have the workflow forward it to `swift test`, and route a
+# narrowed run against the same narrowing. Then the verdict describes the
+# caller's run again and this refusal can go away.
+#
+# The list is deliberately allowed to be over-broad. A false positive costs one
+# lane a trip through the valve — the optimisation not firing — while a false
+# negative reports failures the caller excluded, so anything that plausibly
+# reduces what runs belongs here.
+SUITE_NARROWING_ARGS=(--filter --skip --disable-xctest --disable-swift-testing)
+
+narrows_the_suite() {
+  local arg known
+  for arg in "$@"; do
+    for known in "${SUITE_NARROWING_ARGS[@]}"; do
+      # Both spellings: `--filter X` and `--filter=X`.
+      case "$arg" in
+        "$known"|"$known"=*) return 0 ;;
+      esac
+    done
+  done
+  return 1
+}
+
 # Sourced rather than executed: `scripts/test.test.sh` wants the helpers above
 # without the run below. The siblings in this directory express the same thing
 # as `main "$@"` under the inverse condition; this script stays straight-line
@@ -343,7 +389,21 @@ if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
     echo "         indistinguishable from a failing test suite." >&2
     exit 64
   fi
-  fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$yield_seconds")
+  # DECIDED BEFORE THE BOUND IS FORWARDED, NOT AFTER THE RUN. Refusing later
+  # would be too late in the only way that matters: the bound would already have
+  # gone to `swift-safe`, which would answer 76 for a yield this run has now
+  # decided it cannot use — and 76 is not a test result. Turning the valve off
+  # here means no bound is forwarded, so there is no yield to strand.
+  if narrows_the_suite ${swift_test_args[@]+"${swift_test_args[@]}"}; then
+    echo "test.sh: narrowing arguments present, so this run stays in the local" >&2
+    echo "         queue instead of verifying remotely. The dispatch cannot" >&2
+    echo "         carry a filter, so a remote run is always the whole suite —" >&2
+    echo "         and a red whole-suite verdict would report failures in tests" >&2
+    echo "         this run excluded. See TBD_REMOTE_VERIFY in scripts/test.sh." >&2
+    remote_verify_enabled=0
+  else
+    fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$yield_seconds")
+  fi
 fi
 
 # Resolved HERE, while `$HOME` and `$TBD_HOME` still hold the caller's real
@@ -556,6 +616,28 @@ run_fenced_suite() {
     scripts/swift-safe test ${swift_test_args[@]+"${swift_test_args[@]}"}
 }
 
+# RETURNING TO THE LOCAL QUEUE, WHICH IS WHAT EVERY NON-VERDICT ENDS IN. The
+# re-run must queue without limit: yielding a second time would strand the run
+# at 76 with nothing tested and nothing said, because the valve block has
+# already been passed.
+#
+# THE BOUND IS CLEARED, NOT DROPPED, AND THE DIFFERENCE IS THE WHOLE BUG.
+# `fenced_env=()` stops this script from *adding* the assignment; it does not
+# unset the variable, and `env` passes an inherited one straight through.
+# `scripts/swift-safe` documents `TBD_SWIFT_QUEUE_YIELD_SECONDS` as a supported
+# knob, so a caller exporting it alongside `TBD_REMOTE_VERIFY=1` is expected
+# rather than perverse — and that caller's value would survive into this re-run,
+# yield 76 again, and exit the wrapper at 76 having tested nothing. An explicit
+# empty value wins in `env` and is falsy in `swift-safe` ("never yield"), which
+# is exactly the pre-valve behavior this fallback is supposed to restore.
+fall_back_to_the_local_queue() {
+  fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS=)
+  set +e
+  run_fenced_suite
+  test_status=$?
+  set -e
+}
+
 set +e
 run_fenced_suite
 test_status=$?
@@ -590,23 +672,39 @@ if [ "$remote_verify_enabled" -eq 1 ] && [ "$test_status" -eq "$YIELDED_THE_QUEU
     set -e
   fi
 
-  if [ "$remote_status" -eq "$REMOTE_VERIFY_REFUSED" ]; then
-    # A REFUSAL IS NOT A FAILURE. The remote path named its condition on stderr
-    # and declined; this lane returns to the local queue and waits it out, as it
-    # would have done before the valve existed. Anything else would make the
-    # valve a gate — a run that cannot go remote must still be able to test.
-    #
-    # The re-run drops the bound, so it queues without limit rather than
-    # yielding again and asking a precondition that just refused a second time.
-    fenced_env=()
-    set +e
-    run_fenced_suite
-    test_status=$?
-    set -e
-  else
-    # 0 or 1 — the remote verdict, with its failing tests already printed.
-    test_status=$remote_status
-  fi
+  # ONLY THE CONTRACT'S OWN STATUSES DECIDE ANYTHING; THE REST FALL BACK. The
+  # branches are listed as a whitelist rather than "78 means refuse, everything
+  # else is the answer", because the set of things that can come out of running
+  # a script is open-ended and every one of them outside the contract is a
+  # non-answer: 127 for an interpreter that is not there, 126 for a lost
+  # executable bit, 130 for a Ctrl-C, 2 for a syntax error. Adopting any of them
+  # reports a suite that never ran as a suite that failed.
+  case "$remote_status" in
+    0|1)
+      # THE REMOTE VERDICT, and the only thing here that is one. A red run has
+      # already printed its failing tests.
+      test_status=$remote_status
+      ;;
+    "$REMOTE_VERIFY_REFUSED")
+      # A REFUSAL IS NOT A FAILURE. The remote path named its condition on
+      # stderr and declined; this lane returns to the local queue and waits it
+      # out, as it would have done before the valve existed. Anything else would
+      # make the valve a gate — a run that cannot go remote must still be able
+      # to test.
+      fall_back_to_the_local_queue
+      ;;
+    *)
+      # OUTSIDE THE CONTRACT ENTIRELY, so it is treated as a refusal and named.
+      # A refusal explains itself on stderr; this one cannot, so the wrapper
+      # says what it saw. Silence here would leave a broken remote path looking
+      # like an ordinary local run forever.
+      echo "test.sh: scripts/remote-verify.sh exited $remote_status, which is" >&2
+      echo "         outside its {0, 1, 78} contract and says nothing about the" >&2
+      echo "         tests; treating it as a refusal and staying in the local" >&2
+      echo "         queue." >&2
+      fall_back_to_the_local_queue
+      ;;
+  esac
 fi
 
 # THE TRIPWIRE HAS TO BE RE-CHECKED, not just armed. The code inside the run

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -147,6 +147,37 @@
 #   scripts/test.sh --no-fingerprint --parallel
 #   scripts/test.sh --fingerprint            # deliberate local leak hunt
 #
+# THE REMOTE VERIFICATION VALVE — OFF UNLESS `TBD_REMOTE_VERIFY=1`.
+# (docs/specs/2026-08-16-remote-verification-valve-design.md.) This wrapper is
+# the only caller that opts in, because it is the one whose entire output is a
+# verdict: nothing it produces has to exist on this disk, so the same bit can be
+# computed on GitHub. `scripts/restart.sh` and every other artifact build stay
+# local permanently and are untouched by any of this.
+#
+# Enabled, the run bounds its queueing: `TBD_SWIFT_QUEUE_YIELD_SECONDS` tells
+# `scripts/swift-safe` to give up its place in the queue after
+# `TBD_REMOTE_VERIFY_YIELD_SECONDS` (default 300) and answer 76. The threshold
+# measures QUEUE time, never run time, so a yield discards nothing — a wait that
+# never acquired the slot has compiled nothing. 300 is sized against remote
+# capacity rather than impatience: two hours of sampled contention put T=60 at
+# ~28 trips an hour against a remote that sustains ~12 runs an hour, while T=300
+# fires four or five times, on the tail this valve exists for.
+#
+# THREE EXIT CODES DECIDE WHAT HAPPENS NEXT, AND CONFLATING ANY TWO IS A SILENT
+# WRONG ANSWER:
+#
+#   76 from `swift-safe` — it yielded the queue at our request. Verify remotely.
+#   75 from `swift-safe` — the wait TIMED OUT, or was ABANDONED because nobody
+#      is left to read the result. Neither is a request to verify elsewhere, so
+#      75 is propagated untouched; dispatching one spends a scarce remote slot
+#      on a verdict nobody wants.
+#   78 from `remote-verify.sh` — a precondition refused (dirty tree, no `gh`,
+#      no pushable ref). The run falls back to the local queue. THE VALVE IS AN
+#      OPTIMISATION, NEVER A GATE: a refusal must never fail a run.
+#
+# Any other status from `remote-verify.sh` is the run's verdict — 0 for a green
+# remote run, 1 for a red one whose failing tests it has already printed.
+#
 # TESTED BY `scripts/test.test.sh`, which drives the guards below against
 # fixture directories with a stub `swift` — no build, no real `~/tbd`. Every
 # guard there is mutation-checked: the assertion is shown going red against a
@@ -231,6 +262,35 @@ resolve_swift_lock_path() {
   fi
 }
 
+# THE YIELD BOUND IS VALIDATED HERE BECAUSE A BAD ONE IS INVISIBLE DOWNSTREAM.
+# `scripts/swift-safe` refuses a non-positive, `nan`, `inf` or non-numeric
+# `TBD_SWIFT_QUEUE_YIELD_SECONDS` with a `SystemExit`, and a `SystemExit` carrying
+# a message exits **1** — which is exactly what a failing test suite returns. So
+# a forwarded typo does not look like a misconfiguration, it looks like a red
+# run, and the fix people would reach for is to go hunting through tests that
+# never ran. `TBD_REMOTE_VERIFY_YIELD_SECONDS=0` is the plausible way somebody
+# spells "always go remote", and it lands precisely there.
+#
+# The accepted grammar is deliberately narrower than `float()`: decimal digits
+# with at most one point, and not zero in any spelling. That refuses `1e3` and
+# `+1`, which `swift-safe` would have taken — loudly, at the call site, with the
+# variable named — rather than widening a validator whose whole job is to be
+# obviously right.
+valid_yield_bound() {
+  local value="$1"
+  case "$value" in
+    ''|*[!0-9.]*) return 1 ;;   # empty, or anything but digits and points
+    *.*.*)        return 1 ;;   # more than one point
+    .)            return 1 ;;   # a lone point
+  esac
+  # Zero in every spelling — `0`, `00`, `0.0`, `.0` — is what is left once the
+  # zeros and the point come out.
+  case "${value//0/}" in
+    ''|.) return 1 ;;
+  esac
+  return 0
+}
+
 # Sourced rather than executed: `scripts/test.test.sh` wants the helpers above
 # without the run below. The siblings in this directory express the same thing
 # as `main "$@"` under the inverse condition; this script stays straight-line
@@ -257,6 +317,34 @@ for arg in "$@"; do
     *) swift_test_args+=("$arg") ;;
   esac
 done
+
+# THE VALVE, CONFIGURED BEFORE ANYTHING ELSE HAPPENS. See "THE REMOTE
+# VERIFICATION VALVE" above. Deciding it here means a bad bound is refused
+# before a scratch home is minted, a lock file is touched or a fingerprint is
+# taken — there is nothing to unwind, and the caller finds out immediately
+# rather than half an hour into a wait.
+#
+# `TBD_REMOTE_VERIFY` unset leaves `remote_verify_enabled` at 0 and
+# `fenced_env` empty, so every path below is what it was before the valve
+# existed: no bound is forwarded, and 76 is just an exit status.
+DEFAULT_REMOTE_VERIFY_YIELD_SECONDS=300
+YIELDED_THE_QUEUE=76
+REMOTE_VERIFY_REFUSED=78
+
+remote_verify_enabled=0
+fenced_env=()
+if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
+  remote_verify_enabled=1
+  yield_seconds="${TBD_REMOTE_VERIFY_YIELD_SECONDS-$DEFAULT_REMOTE_VERIFY_YIELD_SECONDS}"
+  if ! valid_yield_bound "$yield_seconds"; then
+    echo "test.sh: TBD_REMOTE_VERIFY_YIELD_SECONDS must be a positive number" >&2
+    echo "         (decimal digits, at most one point), got: '$yield_seconds'" >&2
+    echo "         Forwarding it would make swift-safe exit 1, which is" >&2
+    echo "         indistinguishable from a failing test suite." >&2
+    exit 64
+  fi
+  fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$yield_seconds")
+fi
 
 # Resolved HERE, while `$HOME` and `$TBD_HOME` still hold the caller's real
 # values — the `env` prefix at the bottom rewrites both, and `swift-safe`
@@ -441,21 +529,85 @@ for decoy in "${decoys[@]}"; do
   chmod 000 "$fake_home/$decoy"
 done
 
+# THE FENCED INVOCATION LIVES IN ONE PLACE, AND THAT IS THE POINT. The valve's
+# fallback below runs it a second time, and a second copy of this `env` prefix
+# is a fence that can drift: the two copies would have to be kept in step by
+# hand forever, and the failure mode of missing one is a run that silently
+# writes into the developer's real `~/tbd`. There is exactly one prefix, so
+# there is nothing to keep in step.
+#
+# `fenced_env` carries per-call environment and comes FIRST, so a fence
+# variable can never be overridden by it — `env` takes the last assignment of a
+# name, and the fence must always be the last word.
+#
 # `${a[@]+"${a[@]}"}` — macOS ships bash 3.2, where a bare `"${a[@]}"` on an
 # EMPTY array is an unbound-variable error under `set -u`.
+run_fenced_suite() {
+  env \
+    ${fenced_env[@]+"${fenced_env[@]}"} \
+    TBD_HOME="$sanctioned_home" \
+    TBD_SOCKET_PATH="$sanctioned_home/sock" \
+    TBD_CLAUDE_HOST_HOME="$sanctioned_home/claude-host" \
+    TBD_TEST_CODEX_HOME="$sanctioned_home/codex-host" \
+    TMUX_TMPDIR="$tmux_tmpdir" \
+    TBD_SWIFT_LOCK_PATH="$swift_lock_path" \
+    HOME="$fake_home" \
+    CFFIXED_USER_HOME="$fake_home" \
+    scripts/swift-safe test ${swift_test_args[@]+"${swift_test_args[@]}"}
+}
+
 set +e
-env \
-  TBD_HOME="$sanctioned_home" \
-  TBD_SOCKET_PATH="$sanctioned_home/sock" \
-  TBD_CLAUDE_HOST_HOME="$sanctioned_home/claude-host" \
-  TBD_TEST_CODEX_HOME="$sanctioned_home/codex-host" \
-  TMUX_TMPDIR="$tmux_tmpdir" \
-  TBD_SWIFT_LOCK_PATH="$swift_lock_path" \
-  HOME="$fake_home" \
-  CFFIXED_USER_HOME="$fake_home" \
-  scripts/swift-safe test ${swift_test_args[@]+"${swift_test_args[@]}"}
+run_fenced_suite
 test_status=$?
 set -e
+
+# THE OVERFLOW PATH. 76 is `swift-safe` reporting that it gave up its place in
+# the queue at our request, having compiled nothing — so there is no work to
+# discard and no build to kill, and the same verdict can be fetched from CI.
+#
+# The flag is re-checked rather than inferred from the status. A bound is only
+# ever forwarded when the valve is on, so 76 cannot arise here otherwise — but
+# inferring it would mean a suite that exits 76 for reasons of its own silently
+# changed what this wrapper does, and "the flag is off" must mean the pre-valve
+# behavior exactly.
+if [ "$remote_verify_enabled" -eq 1 ] && [ "$test_status" -eq "$YIELDED_THE_QUEUE" ]; then
+  # A MISSING REMOTE PATH IS A REFUSAL, NOT A VERDICT. Without this the shell
+  # answers 127 for "command not found", which would be adopted below as the
+  # run's exit status — a broken checkout reported as a failing test suite, with
+  # nothing said about why. Everything else here exists to keep a misrouted exit
+  # code from masquerading as a test result; so does this.
+  if [ ! -x scripts/remote-verify.sh ]; then
+    echo "test.sh: scripts/remote-verify.sh is missing or not executable;" >&2
+    echo "         staying in the local queue instead of verifying remotely." >&2
+    remote_status=$REMOTE_VERIFY_REFUSED
+  else
+    # Deliberately NOT fenced: the remote path needs the caller's real `$HOME`
+    # to find `gh`'s credentials and the real repository to push from. It
+    # touches no TBD-owned path.
+    set +e
+    scripts/remote-verify.sh
+    remote_status=$?
+    set -e
+  fi
+
+  if [ "$remote_status" -eq "$REMOTE_VERIFY_REFUSED" ]; then
+    # A REFUSAL IS NOT A FAILURE. The remote path named its condition on stderr
+    # and declined; this lane returns to the local queue and waits it out, as it
+    # would have done before the valve existed. Anything else would make the
+    # valve a gate — a run that cannot go remote must still be able to test.
+    #
+    # The re-run drops the bound, so it queues without limit rather than
+    # yielding again and asking a precondition that just refused a second time.
+    fenced_env=()
+    set +e
+    run_fenced_suite
+    test_status=$?
+    set -e
+  else
+    # 0 or 1 — the remote verdict, with its failing tests already printed.
+    test_status=$remote_status
+  fi
+fi
 
 # THE TRIPWIRE HAS TO BE RE-CHECKED, not just armed. The code inside the run
 # owns these directories, so it can chmod them back — and a decoy that comes

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -352,7 +352,38 @@ valid_yield_bound() {
 # false negative adopts a whole-suite failure as a narrowed run's result, naming
 # tests the caller excluded. So anything that plausibly reduces what runs belongs
 # here.
-SUITE_NARROWING_ARGS=(--filter --skip --disable-xctest --disable-swift-testing)
+#
+# THE ENTRIES, AND WHY EACH ONE IS ON THE LIST. Read out of this toolchain's own
+# `swift-test` binary rather than remembered, because a name that does not exist
+# costs nothing and a name that does and is missing is the expensive direction:
+#
+#   --filter / --skip           select and deselect test cases by regex.
+#   --specifier / -s            the deprecated spelling of `--filter` (the
+#                               binary still carries `'--specifier' option is
+#                               deprecated; use '--filter' instead`), so a
+#                               caller using it narrows exactly as much.
+#   --disable-xctest            drops a whole testing library's cases.
+#   --disable-swift-testing
+#   --test-product              restricts the run to ONE test product, which on
+#                               a multi-product package is the largest reduction
+#                               available. The binary names it itself: "found
+#                               multiple test products: …; use --test-product to
+#                               select one".
+#   --list-tests                the extreme case — it runs NOTHING and only
+#                               prints method names. A whole-suite verdict is not
+#                               an answer to that question in either direction.
+#   list                        `swift test list` is the same thing as a
+#                               subcommand. It is a bare word rather than a
+#                               flag, so it matches a `--filter list` value too;
+#                               that is a false positive, and false positives
+#                               are the cheap direction.
+SUITE_NARROWING_ARGS=(
+  --filter --skip
+  --specifier -s
+  --disable-xctest --disable-swift-testing
+  --test-product
+  --list-tests list
+)
 
 narrows_the_suite() {
   local arg known
@@ -412,7 +443,29 @@ caller_narrowed=0
 fenced_env=()
 if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
   remote_verify_enabled=1
-  yield_seconds="${TBD_REMOTE_VERIFY_YIELD_SECONDS-$DEFAULT_REMOTE_VERIFY_YIELD_SECONDS}"
+  # `:-`, SO AN EMPTY VALUE MEANS "NOT SET" RATHER THAN FAILING THE RUN. The
+  # alternative — a bare `-`, which substitutes only for an UNSET variable — sends
+  # the empty string to the validator, which refuses it and exits 64. That is the
+  # wrong trade in three directions:
+  #
+  #   - Empty conventionally means unset in shell. `TBD_REMOTE_VERIFY_YIELD_SECONDS=`
+  #     is how a script clears an inherited value, and how `env VAR=` and an
+  #     unquoted `"$maybe_unset"` both arrive. Refusing it makes clearing a knob
+  #     an error.
+  #   - Nothing needs empty to be an error, because empty is not how the valve is
+  #     turned off — that is `TBD_REMOTE_VERIFY` unset, which never reaches this
+  #     block at all. So a refusal here cannot be protecting a caller who meant
+  #     "do not go remote"; it can only be answering a caller who meant "use the
+  #     default".
+  #   - The cost of refusing is not confined to this script. `scripts/git-hooks/
+  #     pre-push` runs the suite to decide whether a push may proceed, and an exit
+  #     of 64 there BLOCKS THE PUSH — over an empty knob that asked for nothing.
+  #
+  # The validator still refuses empty, and that is deliberate: it is the guard for
+  # a value somebody actually typed. `0`, `nan` and `later` are typos with an
+  # intent behind them and must be named; empty is the absence of a value, and the
+  # two do not want the same answer.
+  yield_seconds="${TBD_REMOTE_VERIFY_YIELD_SECONDS:-$DEFAULT_REMOTE_VERIFY_YIELD_SECONDS}"
   if ! valid_yield_bound "$yield_seconds"; then
     echo "test.sh: TBD_REMOTE_VERIFY_YIELD_SECONDS must be a positive number" >&2
     echo "         (decimal digits, at most one point), got: '$yield_seconds'" >&2

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -163,6 +163,13 @@
 # ~28 trips an hour against a remote that sustains ~12 runs an hour, while T=300
 # fires four or five times, on the tail this valve exists for.
 #
+# OFF, THE BOUND IS CLEARED RATHER THAN LEFT ALONE, and that is what makes
+# "off" mean the pre-valve behavior exactly. `TBD_SWIFT_QUEUE_YIELD_SECONDS` is
+# a knob `swift-safe` documents and honours on any `test` run, whether or not
+# this valve is enabled — so a caller who exported it would otherwise yield 76
+# with the valve off, down a path that does not route, and this wrapper would
+# exit 76 having tested nothing.
+#
 # THREE EXIT CODES DECIDE WHAT HAPPENS NEXT, AND CONFLATING ANY TWO IS A SILENT
 # WRONG ANSWER:
 #
@@ -431,16 +438,28 @@ done
 # taken — there is nothing to unwind, and the caller finds out immediately
 # rather than half an hour into a wait.
 #
-# `TBD_REMOTE_VERIFY` unset leaves `remote_verify_enabled` at 0 and
-# `fenced_env` empty, so every path below is what it was before the valve
-# existed: no bound is forwarded, and 76 is just an exit status.
+# `TBD_REMOTE_VERIFY` unset leaves `remote_verify_enabled` at 0 and the bound
+# CLEARED, so every path below is what it was before the valve existed: the
+# run queues without limit, and 76 can only be the suite's own exit status.
 DEFAULT_REMOTE_VERIFY_YIELD_SECONDS=300
 YIELDED_THE_QUEUE=76
 REMOTE_VERIFY_REFUSED=78
 
 remote_verify_enabled=0
 caller_narrowed=0
-fenced_env=()
+# THE BOUND IS CLEARED, NOT LEFT ALONE — the same distinction the fallback
+# below turns on, and the valve-off path needs it just as badly. An empty
+# array only stops this script from ADDING the assignment; an inherited
+# `TBD_SWIFT_QUEUE_YIELD_SECONDS` passes straight through `env`, and
+# `swift-safe` gates the yield on the subcommand alone and knows nothing about
+# `TBD_REMOTE_VERIFY` — so the run would yield 76 with the valve off, the
+# routing below would not fire, and the wrapper would exit 76 having tested
+# nothing. `scripts/git-hooks/pre-push` runs this script with no scrubbing and
+# BLOCKS THE PUSH on that status, and `swift-safe`'s own docstring presents the
+# knob as supported, so the developer who exported it is doing nothing odd.
+# An explicit empty value wins in `env` and is falsy in `swift-safe` ("never
+# yield"), which is the pre-valve behavior "unset" is supposed to mean.
+fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS=)
 if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
   remote_verify_enabled=1
   # `:-`, SO AN EMPTY VALUE MEANS "NOT SET" RATHER THAN FAILING THE RUN. The

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -183,13 +183,34 @@
 # status outside `{0, 1, 78}` is therefore treated exactly as 78 is, with the
 # status named on the way past.
 #
-# THE VALVE ALSO REFUSES A NARROWED RUN, and that is about soundness rather than
-# capacity. This wrapper forwards `--filter` and friends to `swift test` but the
-# dispatch has no way to carry them, so the remote run is always the whole
-# suite. Green whole-suite would still be sound for a filtered caller — it
-# implies the subset passed — but RED is not: it would report failures from
-# tests the caller deliberately excluded as if they were this run's result. A
-# narrowed run therefore waits for the local slot, and says so once.
+# A NARROWED RUN ROUTES, BUT ITS VERDICT IS READ DIFFERENTLY — AND THE
+# ASYMMETRY IS THE WHOLE MECHANISM. This wrapper forwards `--filter` and friends
+# to `swift test`, and the dispatch has no way to carry them, so a remote run is
+# always the WHOLE suite. The two outcomes are not equally transferable:
+#
+#   GREEN whole-suite IS sound for a narrowed caller. If every test passed, then
+#      every subset of them passed, whatever the caller selected. It is adopted,
+#      with one line saying the run was the whole suite so nobody reads its test
+#      count as their subset's.
+#   RED whole-suite IS NOT. The failures may lie entirely outside what the
+#      caller selected, and reporting them as this run's result would name tests
+#      it deliberately excluded. The narrowed suite is re-run locally instead and
+#      the LOCAL verdict is reported.
+#
+# WHY NOT JUST REFUSE TO ROUTE A NARROWED RUN, which would need no interpretation
+# at all: because it turns the valve off for every real caller. `pre-push`
+# narrows both of its passes, the nightly stress harness forwards a filter, and
+# four of five live queued test lanes were `--filter` runs. Interpreting the
+# verdict keeps all of them eligible, and costs a local re-run only on red — the
+# case that was going to run locally anyway.
+#
+# ONE CONSEQUENCE WORTH KNOWING, because it is a real loss and not a wash.
+# `pre-push` gives each pass a test-count floor, and a floor is a minimum, so a
+# whole-suite count clears a narrowed pass's floor for free — including the
+# tier-3 pass whose floor of 35 exists to catch `--filter` matching nothing. A
+# renamed live-suite type would slip past that pass when its verdict came from a
+# whole-suite remote run. The floors still catch a collapse; they stop catching a
+# vacuous filter. The follow-up below is what fixes it properly.
 #
 # TESTED BY `scripts/test.test.sh`, which drives the guards below against
 # fixture directories with a stub `swift` — no build, no real `~/tbd`. Every
@@ -304,24 +325,27 @@ valid_yield_bound() {
   return 0
 }
 
-# THE ARGUMENTS THAT REDUCE THE SUITE, AND WHY THE VALVE WILL NOT ROUTE PAST
-# THEM. Nothing on the dispatch carries a filter, so a routed run is always the
-# whole suite. For a filtered caller that makes a GREEN remote result sound — the
-# whole suite passing implies their subset did — and a RED one a false statement
-# about their run, naming failures in tests they deliberately excluded. Measured
-# contention says filtered runs are the common case rather than an exotic one:
-# of the seven queued lanes in the two snapshots behind the design, three were
-# `swift test --filter …`. So this is refused rather than tolerated.
+# THE ARGUMENTS THAT REDUCE THE SUITE. This does not decide WHETHER to route —
+# a narrowed run routes like any other — it decides how the answer is read. A
+# routed run is always the whole suite, and only its GREEN answer transfers to a
+# caller who asked for less (whole suite passed ⟹ every subset passed). Its red
+# answer does not, so a narrowed caller re-runs locally to attribute it. See
+# "A NARROWED RUN ROUTES" above.
 #
-# FOLLOW-UP, AND THE REASON THIS RESTRICTION IS TEMPORARY: give the dispatch a
-# filter input, have the workflow forward it to `swift test`, and route a
-# narrowed run against the same narrowing. Then the verdict describes the
-# caller's run again and this refusal can go away.
+# FOLLOW-UP: pass the caller's narrowing arguments to the dispatch, so a narrowed
+# run gets a narrowed remote verdict and there is nothing left to interpret. That
+# input is attacker-adjacent text — a filter is a regex that may legally contain
+# `$`, backticks and `;` — so it must be ALLOWLISTED against these same names and
+# handed to the workflow through `env:`, never interpolated into a `run:` body.
+# `.github/workflows/preflight-cleanup.yml` already does exactly that with a
+# branch name, and the comment there says why.
 #
-# The list is deliberately allowed to be over-broad. A false positive costs one
-# lane a trip through the valve — the optimisation not firing — while a false
-# negative reports failures the caller excluded, so anything that plausibly
-# reduces what runs belongs here.
+# The list is deliberately allowed to be over-broad, and the new reading makes
+# that cheaper than it was. A false positive now costs one local re-run, and only
+# on a red remote verdict — the case that was going to run locally anyway. A
+# false negative adopts a whole-suite failure as a narrowed run's result, naming
+# tests the caller excluded. So anything that plausibly reduces what runs belongs
+# here.
 SUITE_NARROWING_ARGS=(--filter --skip --disable-xctest --disable-swift-testing)
 
 narrows_the_suite() {
@@ -378,6 +402,7 @@ YIELDED_THE_QUEUE=76
 REMOTE_VERIFY_REFUSED=78
 
 remote_verify_enabled=0
+caller_narrowed=0
 fenced_env=()
 if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
   remote_verify_enabled=1
@@ -389,21 +414,15 @@ if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
     echo "         indistinguishable from a failing test suite." >&2
     exit 64
   fi
-  # DECIDED BEFORE THE BOUND IS FORWARDED, NOT AFTER THE RUN. Refusing later
-  # would be too late in the only way that matters: the bound would already have
-  # gone to `swift-safe`, which would answer 76 for a yield this run has now
-  # decided it cannot use — and 76 is not a test result. Turning the valve off
-  # here means no bound is forwarded, so there is no yield to strand.
+  # ASKED ONCE, HERE, WHILE THE ARGUMENTS ARE IN FRONT OF US, and consulted
+  # later when the remote answer arrives. It gates nothing: a narrowed run
+  # forwards the bound and routes exactly like any other, because a green
+  # whole-suite verdict is sound for it. What this decides is how a RED answer is
+  # read — see the `case` on `$remote_status` below.
   if narrows_the_suite ${swift_test_args[@]+"${swift_test_args[@]}"}; then
-    echo "test.sh: narrowing arguments present, so this run stays in the local" >&2
-    echo "         queue instead of verifying remotely. The dispatch cannot" >&2
-    echo "         carry a filter, so a remote run is always the whole suite —" >&2
-    echo "         and a red whole-suite verdict would report failures in tests" >&2
-    echo "         this run excluded. See TBD_REMOTE_VERIFY in scripts/test.sh." >&2
-    remote_verify_enabled=0
-  else
-    fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$yield_seconds")
+    caller_narrowed=1
   fi
+  fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$yield_seconds")
 fi
 
 # Resolved HERE, while `$HOME` and `$TBD_HOME` still hold the caller's real
@@ -680,10 +699,33 @@ if [ "$remote_verify_enabled" -eq 1 ] && [ "$test_status" -eq "$YIELDED_THE_QUEU
   # executable bit, 130 for a Ctrl-C, 2 for a syntax error. Adopting any of them
   # reports a suite that never ran as a suite that failed.
   case "$remote_status" in
-    0|1)
-      # THE REMOTE VERDICT, and the only thing here that is one. A red run has
-      # already printed its failing tests.
-      test_status=$remote_status
+    0)
+      # GREEN TRANSFERS TO EVERY SUBSET. The whole suite passed, so whatever the
+      # caller selected passed with it — the one direction the asymmetry runs in.
+      # The count is the only thing that does not transfer, hence the note.
+      if [ "$caller_narrowed" -eq 1 ]; then
+        echo "test.sh: verified remotely, and the remote run was the WHOLE suite." >&2
+        echo "         Its test count is not this run's narrowed subset — a green" >&2
+        echo "         whole suite implies the subset passed, which is why the" >&2
+        echo "         result is adopted." >&2
+      fi
+      test_status=0
+      ;;
+    1)
+      # RED DOES NOT TRANSFER. For an unnarrowed caller this is simply the
+      # verdict, with its failing tests already printed. For a narrowed one the
+      # failures may lie entirely outside what was selected, so adopting them
+      # would name tests this run excluded; the narrowed suite is re-run locally
+      # to get a verdict that describes what was asked for.
+      if [ "$caller_narrowed" -eq 1 ]; then
+        echo "test.sh: the remote WHOLE-SUITE run failed, and its failures cannot" >&2
+        echo "         be attributed to this narrowed run — they may lie entirely" >&2
+        echo "         outside it. Re-running the narrowed suite locally, and" >&2
+        echo "         reporting THAT verdict." >&2
+        fall_back_to_the_local_queue
+      else
+        test_status=1
+      fi
       ;;
     "$REMOTE_VERIFY_REFUSED")
       # A REFUSAL IS NOT A FAILURE. The remote path named its condition on

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -208,9 +208,15 @@
 # `pre-push` gives each pass a test-count floor, and a floor is a minimum, so a
 # whole-suite count clears a narrowed pass's floor for free — including the
 # tier-3 pass whose floor of 35 exists to catch `--filter` matching nothing. A
-# renamed live-suite type would slip past that pass when its verdict came from a
-# whole-suite remote run. The floors still catch a collapse; they stop catching a
-# vacuous filter. The follow-up below is what fixes it properly.
+# renamed live-suite type slips past that pass whenever its verdict came from a
+# green whole-suite remote run. The floors still catch a collapse; they stop
+# catching a vacuous filter. The follow-up below is what fixes it properly.
+#
+# THE COUNT MUST DESCRIBE THE RUN BEING REPORTED, and on the narrowed-red path
+# that is the LOCAL re-run rather than the remote suite. Those consumers take
+# the FIRST count in the log, so a remote count printed on the way past would
+# answer for a verdict nobody adopted — see the `--narrowed` handoff at the
+# dispatch below, which is what keeps it out of the log.
 #
 # TESTED BY `scripts/test.test.sh`, which drives the guards below against
 # fixture directories with a stub `swift` — no build, no real `~/tbd`. Every
@@ -682,11 +688,31 @@ if [ "$remote_verify_enabled" -eq 1 ] && [ "$test_status" -eq "$YIELDED_THE_QUEU
     echo "         staying in the local queue instead of verifying remotely." >&2
     remote_status=$REMOTE_VERIFY_REFUSED
   else
+    # THE NARROWING IS DECLARED TO THE REMOTE PATH, AND IT IS THE COUNT LINE
+    # THAT MAKES IT NECESSARY. Six consumers read a run's population out of the
+    # first `Test run with N tests` in the log — `scripts/git-hooks/pre-push`
+    # pipes BOTH streams into its own — and a failing whole-suite report is
+    # printed BEFORE the local re-run below prints its own count. So without
+    # this the remote suite's number is the one `head -1` finds, standing in for
+    # a run whose verdict is not even being reported: a tier-3 pass whose
+    # `--filter` names a renamed type selects nothing, exits 0 saying `Test run
+    # with 0 tests`, and clears its floor of 35 on the remote's four thousand.
+    # The vacuous filter the floor exists to catch would go undetected.
+    #
+    # `--narrowed` tells the driver to omit the count from a FAILING report, so
+    # the only count in the log is the local re-run's. A PASSING report keeps
+    # its count: there the remote verdict is the one adopted and reported, and a
+    # whole-suite count clears a narrowed floor legitimately, a minimum against
+    # a superset. See "A NARROWED RUN ROUTES" above.
+    remote_verify_args=()
+    if [ "$caller_narrowed" -eq 1 ]; then
+      remote_verify_args=(--narrowed)
+    fi
     # Deliberately NOT fenced: the remote path needs the caller's real `$HOME`
     # to find `gh`'s credentials and the real repository to push from. It
     # touches no TBD-owned path.
     set +e
-    scripts/remote-verify.sh
+    scripts/remote-verify.sh ${remote_verify_args[@]+"${remote_verify_args[@]}"}
     remote_status=$?
     set -e
   fi

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -190,7 +190,15 @@ STUB
 # repository rather than asking the wrapper for an override it would never need
 # in production. Empty means "wherever the harness was invoked" — the real repo
 # — which is what every case outside section 7 wants.
+#
+# `RUN_TEE` names a file the run's output is STREAMED to while it happens.
+# `RUN_OUT` is a command substitution, so it exists only once the run is over —
+# which is no use to a case that must observe a run mid-flight and act on what
+# it sees (the lock-contention cases in section 7). `pipefail` is on for this
+# file, and `tee` never fails, so `RUN_RC` is still the wrapper's own status.
+# Empty means `/dev/null`, which is every other case.
 RUN_CWD=""
+RUN_TEE=""
 run_script() {
   local script="$1" fix="$2"; shift 2
   RUN_OUT="$(cd "${RUN_CWD:-.}" && env -u CI -u TBD_HOME -u TBD_SOCKET_PATH -u TBD_CLAUDE_HOST_HOME \
@@ -209,7 +217,7 @@ run_script() {
                  TMUX_TMPDIR="$(caller_tmux_tmpdir "$fix")" \
                  TBD_SWIFT_BIN="$fix/bin/fake-swift" \
                  FAKE_SWIFT_DUMP="$fix/swift-invocation" \
-                 bash "$script" "$@" 2>&1)"
+                 bash "$script" "$@" 2>&1 | tee "${RUN_TEE:-/dev/null}")"
   RUN_RC=$?
 }
 
@@ -1032,6 +1040,173 @@ test_the_valve_flag_is_load_bearing() {
   rmfix "$fix"
 }
 
+# THE BOUND THE CONTENTION CASES EXPORT, AND THE MARGIN THEY WAIT PAST IT.
+# `swift-safe` measures the bound from the moment it starts waiting — which is
+# the moment it prints the line the cases below poll for — so the margin is
+# relative to the bound and to nothing else. No case here waits on a wall-clock
+# guess about how long the wrapper's preamble takes, because on a loaded box
+# that guess is wrong and the case that made it passes vacuously.
+INHERITED_YIELD_SECONDS=0.4
+PAST_THE_BOUND_SECONDS=1.5
+# How long a case will wait for something it is certain must happen — the
+# holder taking the lock, the queued run announcing itself, the run giving up.
+# Generous, because it only bounds a WEDGE: reaching it is a failure with a
+# named cause, never a verdict. Expressed in 0.05s polls, which is also what
+# the holder is handed.
+WEDGE_DEADLINE_SECONDS=60
+WEDGE_DEADLINE_POLLS=1200
+
+# Poll until a file exists, or the deadline passes. Answers "waited" / "wedged"
+# so a failing assertion says which.
+await_file() {
+  local path="$1" waited=0
+  while [ ! -e "$path" ] && [ "$waited" -lt "$WEDGE_DEADLINE_POLLS" ]; do
+    sleep 0.05; waited=$((waited + 1))
+  done
+  if [ -e "$path" ]; then echo "waited"; else echo "wedged"; fi
+}
+
+# The same, for a string appearing in a file a live run is still writing to.
+await_text() {
+  local path="$1" needle="$2" waited=0
+  while ! grep -q -- "$needle" "$path" 2>/dev/null && [ "$waited" -lt "$WEDGE_DEADLINE_POLLS" ]; do
+    sleep 0.05; waited=$((waited + 1))
+  done
+  if grep -q -- "$needle" "$path" 2>/dev/null; then echo "waited"; else echo "wedged"; fi
+}
+
+# A REAL SECOND HOLDER ON THE REAL LOCK — the contention a yield needs, and
+# nothing else in this file simulates it. `swift-safe` takes an exclusive
+# `flock`, so the only way to make a run queue is to hold that lock from another
+# process; a stub could only assert that the bound was forwarded, which is the
+# half of the defect that was already visible.
+#
+# IT HOLDS UNTIL RELEASED, NOT FOR A FIXED TIME. A timed hold has to outlast the
+# wrapper's preamble — a scratch home, three decoys, a fingerprint, a python
+# interpreter — and on a loaded box that took longer than any hold worth
+# writing, at which point the run acquires an uncontended lock and the case
+# proves nothing. The holder's own deadline is a wedge guard, not a schedule.
+LOCK_HOLDER_PID=""
+hold_the_shared_lock() {
+  local lock="$1" ready="$2" release="$3"
+  mkdir -p "$(dirname "$lock")"
+  rm -f "$ready" "$release"
+  python3 - "$lock" "$ready" "$release" "$WEDGE_DEADLINE_SECONDS" <<'HOLDER' &
+import fcntl, os, sys, time
+lock_path, ready_path, release_path, deadline_seconds = sys.argv[1:5]
+with open(lock_path, "a+", encoding="utf-8") as handle:
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    open(ready_path, "w", encoding="utf-8").close()
+    deadline = time.monotonic() + float(deadline_seconds)
+    while not os.path.exists(release_path) and time.monotonic() < deadline:
+        time.sleep(0.05)
+HOLDER
+  LOCK_HOLDER_PID=$!
+  assert_eq "the holder took the shared lock" "waited" "$(await_file "$ready")"
+}
+
+release_the_shared_lock() {
+  local release="$1"
+  : > "$release"
+  wait "$LOCK_HOLDER_PID" 2>/dev/null
+  LOCK_HOLDER_PID=""
+}
+
+# The wrapper, running while the case watches it. `run_script` captures its
+# output with a command substitution, so it hands back nothing until the run is
+# over — and a run queued behind a held lock is not over. The subshell writes
+# the status to a file, whose EXISTENCE is what "has it exited yet?" is asked
+# through: no `kill -0`, no process-table matching, nothing that could touch a
+# process this harness does not own.
+BACKGROUND_RUN_PID=""
+start_run_in_background() {
+  local script="$1" fix="$2"
+  RUN_TEE="$fix/run-output"
+  : > "$RUN_TEE"
+  rm -f "$fix/run-status"
+  ( run_script "$script" "$fix"; printf '%s' "$RUN_RC" > "$fix/run-status" ) &
+  BACKGROUND_RUN_PID=$!
+}
+
+# Sets RUN_OUT and RUN_RC from the files, so the assertions below read exactly
+# as they do in every synchronous case.
+finish_background_run() {
+  local fix="$1"
+  wait "$BACKGROUND_RUN_PID" 2>/dev/null
+  BACKGROUND_RUN_PID=""
+  RUN_OUT="$(cat "$fix/run-output" 2>/dev/null)"
+  RUN_RC="$(cat "$fix/run-status" 2>/dev/null)"
+  RUN_TEE=""
+}
+
+# `swift-safe` announcing that it is queued. Waiting for THIS rather than for a
+# duration is what makes the two cases below independent of how slow the box is:
+# the bound is measured from here.
+QUEUED_ANNOUNCEMENT="waiting for the shared build slot"
+
+# THE DEFAULT-OFF GUARANTEE, TESTED THROUGH THE ONLY THING THAT CAN BREAK IT.
+# Every other off-path case here runs against an environment `run_script` has
+# already scrubbed, so none of them can see the one input that makes the off
+# path behave differently: an INHERITED `TBD_SWIFT_QUEUE_YIELD_SECONDS`. It is a
+# knob `scripts/swift-safe` documents, it is honoured on any `test` regardless
+# of `TBD_REMOTE_VERIFY`, and `env` ADDS assignments rather than clearing
+# inherited ones — so omitting the assignment is not the same as clearing it.
+# Left uncleared, a developer who exported that bound gets 76 out of a wrapper
+# that ran no tests at all, and `scripts/git-hooks/pre-push` runs this script
+# with no scrubbing and turns that into a blocked push.
+#
+# The run must REACH THE COMPILER, not merely exit non-76: the whole complaint
+# is a run that tested nothing.
+test_an_inherited_yield_bound_does_not_bound_a_valve_off_run() {
+  local fix; fix="$(mkfix)"
+  hold_the_shared_lock "$fix/home/tbd/runtime/swift-build.lock" \
+    "$fix/lock-held" "$fix/lock-release"
+  RUN_ENV=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$INHERITED_YIELD_SECONDS")
+  start_run_in_background "$SCRIPT" "$fix"
+  RUN_ENV=()
+  assert_eq "the run really was queued behind the holder" "waited" \
+    "$(await_text "$fix/run-output" "$QUEUED_ANNOUNCEMENT")"
+  sleep "$PAST_THE_BOUND_SECONDS"
+  assert_eq "and it is still queued well past the inherited bound" "false" \
+    "$([ -e "$fix/run-status" ] && echo true || echo false)"
+  release_the_shared_lock "$fix/lock-release"
+  finish_background_run "$fix"
+  assert_ok "a valve-off run under contention is green" "$RUN_RC"
+  assert_eq "and it reached the compiler" "1" "$(swift_invocations "$fix")"
+  assert_missing "having never yielded its place" "$RUN_OUT" \
+    "yielding the local build slot"
+  assert_contains "with the inherited bound cleared" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  rmfix "$fix"
+}
+
+# MUTATION. Put the bare `fenced_env=()` back — anchored at column 0, so this
+# weakens the valve-off initialisation and not the identically spelled clearing
+# inside `fall_back_to_the_local_queue` — and the caller's bound rides into a
+# run that never asked to be verified anywhere: 76, no tests, blocked push.
+# Nothing here is timed: the lock is held until the run gives up on its own.
+test_the_valve_off_bound_clearing_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"
+  mutant="$(mutant_of "$SCRIPT" \
+    's/^fenced_env=\(TBD_SWIFT_QUEUE_YIELD_SECONDS=\)$/fenced_env=()/')"
+  hold_the_shared_lock "$fix/home/tbd/runtime/swift-build.lock" \
+    "$fix/lock-held" "$fix/lock-release"
+  RUN_ENV=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$INHERITED_YIELD_SECONDS")
+  start_run_in_background "$mutant" "$fix"
+  RUN_ENV=()
+  assert_eq "the mutant queued behind the holder too" "waited" \
+    "$(await_text "$fix/run-output" "$QUEUED_ANNOUNCEMENT")"
+  assert_eq "and gave up on its own, without the lock ever being released" \
+    "waited" "$(await_file "$fix/run-status")"
+  release_the_shared_lock "$fix/lock-release"
+  finish_background_run "$fix"
+  assert_eq "without the clearing a valve-off run exits 76" "76" "$RUN_RC"
+  assert_eq "having compiled and tested nothing" "0" "$(swift_invocations "$fix")"
+  assert_contains "on a yield nobody asked for" "$RUN_OUT" \
+    "yielding the local build slot"
+  rmfix "$fix"
+}
+
 test_the_valve_forwards_its_default_bound_when_enabled() {
   local fix; fix="$(mkfix)"
   RUN_ENV=(TBD_REMOTE_VERIFY=1)
@@ -1322,11 +1497,14 @@ test_an_inherited_yield_bound_does_not_survive_the_fallback() {
 }
 
 # MUTATION. Put the bare `fenced_env=()` back and the caller's 10 rides straight
-# into the re-run.
+# into the re-run. Anchored to the indented occurrence, so it weakens the
+# clearing inside `fall_back_to_the_local_queue` and leaves the identically
+# spelled valve-off initialisation at column 0 intact — the two are separate
+# guards and a mutation that tripped both would prove neither.
 test_the_fallback_bound_clearing_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
   mutant="$(mutant_of "$SCRIPT" \
-    's/fenced_env=\(TBD_SWIFT_QUEUE_YIELD_SECONDS=\)/fenced_env=()/')"
+    's/^  fenced_env=\(TBD_SWIFT_QUEUE_YIELD_SECONDS=\)$/  fenced_env=()/')"
   RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_SWIFT_QUEUE_YIELD_SECONDS=10
            FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
            FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
@@ -1777,8 +1955,15 @@ test_a_timed_out_wait_is_not_routed_remotely() {
   rmfix "$fix"
 }
 
-# With the flag off the routing must not fire even on a 76 the suite produced
-# for its own reasons — the off path is the pre-valve path, byte for byte.
+# WITH THE FLAG OFF, A 76 CAN ONLY COME FROM THE SUITE ITSELF, and it is still
+# just an exit status. The yield can no longer produce one: the off path clears
+# `TBD_SWIFT_QUEUE_YIELD_SECONDS` rather than merely declining to set it, so
+# `swift-safe` never yields there however the caller's environment was primed
+# (see `test_an_inherited_yield_bound_does_not_bound_a_valve_off_run`). What is
+# left is a test process that exits 76 for reasons of its own — which the stub
+# is, standing in for `swift` — and the routing must not fire on it. Hence the
+# invocation count: the 76 asserted here is a suite's verdict, from a run that
+# reached the compiler, not a queue given up before one.
 test_a_76_with_the_valve_off_is_propagated_untouched() {
   local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
   RUN_ENV=(FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
@@ -1786,6 +1971,7 @@ test_a_76_with_the_valve_off_is_propagated_untouched() {
   run_with_valve "$fix"
   RUN_ENV=()
   assert_eq "76 is just an exit status when the valve is off" "76" "$RUN_RC"
+  assert_eq "and it came from a run that reached the compiler" "1" "$(swift_invocations "$fix")"
   assert_eq "and nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
   rmfix "$fix"
 }

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Tests for scripts/test.sh — run: bash scripts/test.test.sh
 #
+# MACOS ONLY, AND LOUDLY SO. `mode_of` reads the file mode with BSD `stat -f`,
+# which GNU `stat` spells differently, so on Linux the mode comes back empty and
+# the decoy cases fail rather than passing vacuously. That is why this file runs
+# in the macOS `lint` job while the other script harnesses run on `ubuntu-latest`
+# (.github/workflows/test.yml).
+#
 # ZERO BUILDS, ZERO CPU LOAD, AND IT NEVER TOUCHES THE REAL ~/tbd, ~/.claude,
 # ~/.codex OR THE REAL TMUX SOCKET DIRECTORY. Every case here drives the wrapper
 # against a synthetic home under a throwaway fixture directory, with a stub

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -98,6 +98,19 @@ mkfix() {
   cat > "$d/bin/fake-swift" <<'STUB'
 #!/usr/bin/env bash
 # Stands in for `swift`, exec'd by scripts/swift-safe from inside the fence.
+#
+# IT COUNTS ITS INVOCATIONS AND CAN VERDICT EACH ONE DIFFERENTLY. The remote
+# verification valve's fallback runs the fenced invocation a SECOND time, so a
+# stub with one fixed exit code cannot express "yielded the queue, then passed
+# locally". FAKE_SWIFT_RC is a space-separated list indexed by invocation, with
+# the last value repeating for any run beyond its length — so an unset or
+# single value behaves exactly as it always has.
+#
+# The dump is still OVERWRITTEN each time, so it describes the LAST invocation.
+# That is what the fallback cases assert against: the re-run must be fenced
+# identically and must NOT carry the yield bound.
+printf 'invocation\n' >> "$FAKE_SWIFT_DUMP.count"
+fake_swift_invocation="$(wc -l < "$FAKE_SWIFT_DUMP.count" | tr -d ' ')"
 {
   echo "argv: $*"
   echo "HOME=${HOME:-<unset>}"
@@ -109,6 +122,7 @@ mkfix() {
   echo "TMUX_TMPDIR=${TMUX_TMPDIR:-<unset>}"
   echo "tmux-tmpdir-mode=$(stat -f '%Lp' "${TMUX_TMPDIR:-/nonexistent}" 2>/dev/null)"
   echo "TBD_SWIFT_LOCK_PATH=${TBD_SWIFT_LOCK_PATH:-<unset>}"
+  echo "TBD_SWIFT_QUEUE_YIELD_SECONDS=${TBD_SWIFT_QUEUE_YIELD_SECONDS:-<unset>}"
   for decoy in tbd .claude .codex; do
     echo "decoy-mode $decoy=$(stat -f '%Lp' "$HOME/$decoy" 2>/dev/null)"
   done
@@ -126,7 +140,13 @@ if [ -n "${FAKE_SWIFT_TMUX_SOCKETS:-}" ]; then
   mkdir -p "$socket_dir"
   for socket_name in $FAKE_SWIFT_TMUX_SOCKETS; do : > "$socket_dir/$socket_name"; done
 fi
-exit "${FAKE_SWIFT_RC:-0}"
+# Unquoted on purpose: FAKE_SWIFT_RC is a space-separated list.
+fake_swift_codes=(${FAKE_SWIFT_RC:-0})
+fake_swift_index=$((fake_swift_invocation - 1))
+if [ "$fake_swift_index" -ge "${#fake_swift_codes[@]}" ]; then
+  fake_swift_index=$(( ${#fake_swift_codes[@]} - 1 ))
+fi
+exit "${fake_swift_codes[$fake_swift_index]}"
 STUB
   chmod +x "$d/bin/fake-swift"
   echo "$d"
@@ -152,14 +172,26 @@ STUB
 # sockets throughout — the fingerprint cases would flake, and they would be
 # reporting the machine rather than the wrapper. It doubles as the bogus
 # inherited value the overwrite case asserts against.
+#
+# `RUN_CWD` names the directory to run from, and it is a seam of the same kind:
+# `scripts/test.sh` resolves `scripts/swift-safe`, `scripts/remote-verify.sh`
+# and the fingerprint script relative to `git rev-parse --show-toplevel`, so a
+# case that wants a stub in place of one of them puts the wrapper in a fixture
+# repository rather than asking the wrapper for an override it would never need
+# in production. Empty means "wherever the harness was invoked" — the real repo
+# — which is what every case outside section 7 wants.
+RUN_CWD=""
 run_script() {
   local script="$1" fix="$2"; shift 2
-  RUN_OUT="$(env -u CI -u TBD_HOME -u TBD_SOCKET_PATH -u TBD_CLAUDE_HOST_HOME \
+  RUN_OUT="$(cd "${RUN_CWD:-.}" && env -u CI -u TBD_HOME -u TBD_SOCKET_PATH -u TBD_CLAUDE_HOST_HOME \
                  -u TBD_TEST_CODEX_HOME -u TBD_SWIFT_LOCK_PATH -u CFFIXED_USER_HOME \
                  -u TBD_SWIFT_JOBS -u TBD_SWIFT_LOCK_TIMEOUT_SECONDS \
                  -u TBD_SWIFT_HEARTBEAT_SECONDS -u TBD_SWIFT_ALLOW_ORPHAN \
                  -u FAKE_SWIFT_DISARM -u FAKE_SWIFT_LEAK -u FAKE_SWIFT_RC \
                  -u FAKE_SWIFT_TMUX_SOCKETS \
+                 -u TBD_REMOTE_VERIFY -u TBD_REMOTE_VERIFY_YIELD_SECONDS \
+                 -u TBD_SWIFT_QUEUE_YIELD_SECONDS \
+                 -u FAKE_REMOTE_VERIFY_RC -u FAKE_REMOTE_VERIFY_LOG \
                  ${RUN_ENV[@]+"${RUN_ENV[@]}"} \
                  HOME="$fix/home" \
                  TMPDIR="$fix/tmp" \
@@ -192,6 +224,15 @@ mutant_of() {
 
 dump_of()      { cat "$1/swift-invocation" 2>/dev/null; }
 fake_home_of() { echo "$1/tmp/tbd-test-fakehome.$(id -u)"; }
+
+# How many times the fenced invocation actually ran. The valve's fallback is
+# the only thing that makes this exceed 1, and asserting the COUNT is what
+# distinguishes "fell back and re-ran locally" from "reported the remote
+# verdict" — both of which can end in the same exit status.
+swift_invocations() {
+  local counted="$1/swift-invocation.count"
+  if [ -f "$counted" ]; then wc -l < "$counted" | tr -d ' '; else echo 0; fi
+}
 
 # The fixture's stand-in for the developer's real `/tmp/tmux-<uid>` parent —
 # what the CALLER has in `TMUX_TMPDIR`, and therefore what the fingerprint
@@ -664,7 +705,7 @@ test_fenced_run_takes_the_shared_lock() {
 # taken, so it stays empty.
 test_shared_lock_pin_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"
-  mutant="$(mutant_of "$SCRIPT" '/^  TBD_SWIFT_LOCK_PATH="\$swift_lock_path" \\$/d')"
+  mutant="$(mutant_of "$SCRIPT" '/^ +TBD_SWIFT_LOCK_PATH="\$swift_lock_path" \\$/d')"
   run_script "$mutant" "$fix"
   assert_ok "mutant run is green (the lock is not a correctness gate)" "$RUN_RC"
   local shared="$fix/home/tbd/runtime/swift-build.lock"
@@ -714,7 +755,7 @@ test_tmux_tmpdir_is_fenced_under_the_scratch_root() {
 # socket directory — every server it starts lands in the real one, forever.
 test_tmux_tmpdir_pin_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"
-  mutant="$(mutant_of "$SCRIPT" '/^  TMUX_TMPDIR="\$tmux_tmpdir" \\$/d')"
+  mutant="$(mutant_of "$SCRIPT" '/^ +TMUX_TMPDIR="\$tmux_tmpdir" \\$/d')"
   run_script "$mutant" "$fix"
   local dump; dump="$(dump_of "$fix")"
   assert_contains "without the pin the caller's value survives" "$dump" \
@@ -841,6 +882,310 @@ test_fingerprint_detects_a_leaked_tmux_socket() {
     "THE TEST RUN WROTE INTO ~/tbd, ~/.claude, ~/.codex OR /tmp/tmux-<uid>"
   assert_contains "the entry is named" "$RUN_OUT" "+  <tmux-sockets>/tbd-leaked-socket"
   assert_contains "and the fix is named" "$RUN_OUT" "the fix is TMUX_TMPDIR"
+  rmfix "$fix"
+}
+
+# ---------------------------------------------------------------------------
+# 7. The remote verification valve
+#
+# `scripts/test.sh` is the only caller that opts in. When `TBD_REMOTE_VERIFY=1`
+# it bounds its queueing with `TBD_SWIFT_QUEUE_YIELD_SECONDS`, and `swift-safe`
+# answers 76 — "I gave up my place in the queue, having compiled nothing" — at
+# which point the verdict is fetched from CI instead.
+#
+# TWO EXIT CODES CARRY THE WHOLE DESIGN AND BOTH ARE EASY TO GET WRONG:
+#
+#   76 vs 75.  `swift-safe` exits 75 for a wait that TIMED OUT or was ABANDONED
+#              and 76 only for a yield it was ASKED for. Routing a 75 to CI
+#              would dispatch a run nobody is waiting for; treating a 76 as a
+#              test failure would report a red suite that never compiled.
+#   78 vs 1.   `remote-verify.sh` exits 78 for a REFUSED precondition, which
+#              must fall back to a local run — the valve is an optimisation,
+#              never a gate — and 1 for a remote run that genuinely FAILED,
+#              which is the verdict.
+#
+# AND ONE MISCONFIGURATION LOOKS EXACTLY LIKE A RED SUITE. `swift-safe` rejects
+# a non-positive, nan, inf or non-numeric yield bound with `SystemExit`, which
+# exits 1 — the same code a failing suite returns. `TBD_REMOTE_VERIFY_YIELD_SECONDS=0`
+# is the plausible way to spell "always go remote", so the bound is validated
+# here, before the run starts, and refused with its own code and its own name.
+# ---------------------------------------------------------------------------
+
+# The spec's threshold, sized against remote capacity rather than impatience:
+# two hours of sampled contention put T=60 at ~28 trips an hour against a
+# remote that sustains ~12 runs an hour, while T=300 trips four or five times
+# and fires only on the tail the valve exists for.
+DEFAULT_YIELD_SECONDS=300
+
+# A fixture repository, so the wrapper's own relative `scripts/remote-verify.sh`
+# resolves to a stub. `scripts/test.sh` cd's to `git rev-parse --show-toplevel`
+# before doing anything, so running it from here is all it takes — the real
+# `swift-safe` and fingerprint scripts are symlinked in so every other layer of
+# the wrapper behaves exactly as it does in the real tree. Echoes the repo path.
+mk_repo_fixture() {
+  local fix="$1" repo="$1/repo"
+  mkdir -p "$repo/scripts"
+  git init -q "$repo" >/dev/null 2>&1
+  ln -sf "$HERE/swift-safe" "$repo/scripts/swift-safe"
+  ln -sf "$FINGERPRINT" "$repo/scripts/tbd-home-fingerprint.sh"
+  cat > "$repo/scripts/remote-verify.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stands in for the remote path. It records that it was reached — the valve
+# must consult it exactly once, and only when the queue was yielded — and
+# returns whichever verdict the case is exercising.
+echo "dispatched" >> "${FAKE_REMOTE_VERIFY_LOG:-/dev/null}"
+echo "remote-verify: stub reached" >&2
+exit "${FAKE_REMOTE_VERIFY_RC:-0}"
+STUB
+  chmod +x "$repo/scripts/remote-verify.sh"
+  echo "$repo"
+}
+
+remote_verify_dispatches() {
+  local log="$1/remote-verify-log"
+  if [ -f "$log" ]; then wc -l < "$log" | tr -d ' '; else echo 0; fi
+}
+
+# Run the wrapper from a fixture repo, with the remote path stubbed.
+run_with_valve() {
+  local fix="$1" script="${2:-$SCRIPT}" repo
+  repo="$fix/repo"
+  RUN_CWD="$repo"
+  run_script "$script" "$fix"
+  RUN_CWD=""
+}
+
+test_the_valve_is_off_by_default() {
+  local fix; fix="$(mkfix)"
+  run_wrapper "$fix"
+  assert_ok "a run with the flag unset is green" "$RUN_RC"
+  assert_contains "no yield bound reaches swift-safe" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  rmfix "$fix"
+}
+
+# MUTATION. Force the flag on and the default-off case above is a lie: the same
+# unset environment starts bounding its queueing.
+test_the_valve_flag_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"
+  mutant="$(mutant_of "$SCRIPT" 's/\[ "\$\{TBD_REMOTE_VERIFY:-\}" = "1" \]/[ "1" = "1" ]/')"
+  run_script "$mutant" "$fix"
+  assert_contains "without the flag check an unset environment yields anyway" \
+    "$(dump_of "$fix")" "TBD_SWIFT_QUEUE_YIELD_SECONDS=$DEFAULT_YIELD_SECONDS"
+  rmfix "$fix"
+}
+
+test_the_valve_forwards_its_default_bound_when_enabled() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1)
+  run_wrapper "$fix"
+  RUN_ENV=()
+  assert_ok "an enabled run is green" "$RUN_RC"
+  assert_contains "the spec's threshold is forwarded" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=$DEFAULT_YIELD_SECONDS"
+  rmfix "$fix"
+}
+
+test_the_valve_forwards_an_explicit_bound() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_REMOTE_VERIFY_YIELD_SECONDS=45.5)
+  run_wrapper "$fix"
+  RUN_ENV=()
+  assert_ok "an explicitly bounded run is green" "$RUN_RC"
+  assert_contains "the explicit bound is forwarded verbatim" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=45.5"
+  rmfix "$fix"
+}
+
+# A bound the flag never uses must not fail a run that never consults it.
+test_a_bad_bound_is_ignored_while_the_valve_is_off() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(TBD_REMOTE_VERIFY_YIELD_SECONDS=0)
+  run_wrapper "$fix"
+  RUN_ENV=()
+  assert_ok "a bad bound with the valve off changes nothing" "$RUN_RC"
+  assert_contains "and no bound is forwarded" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  rmfix "$fix"
+}
+
+# THE MEASURED HAZARD. `swift-safe` rejects each of these with SystemExit, which
+# exits 1 — indistinguishable from a red suite. The wrapper must refuse first,
+# with its own code and its own name, and must not start a run at all.
+test_a_bad_bound_fails_loudly_rather_than_as_a_red_suite() {
+  local fix bound
+  for bound in 0 0.0 .0 00 -5 nan inf later ""; do
+    fix="$(mkfix)"
+    RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_REMOTE_VERIFY_YIELD_SECONDS="$bound")
+    run_wrapper "$fix"
+    RUN_ENV=()
+    assert_eq "a bound of [$bound] exits 64, not 1" "64" "$RUN_RC"
+    assert_contains "and names the variable" "$RUN_OUT" "TBD_REMOTE_VERIFY_YIELD_SECONDS"
+    assert_contains "and says what it must be" "$RUN_OUT" "must be a positive number"
+    assert_eq "and no suite is started" "0" "$(swift_invocations "$fix")"
+    rmfix "$fix"
+  done
+}
+
+# MUTATION. Without the check the same value reaches `swift-safe`, which exits
+# 1 with no mention of the variable the caller actually set — a typo wearing a
+# failing test suite's clothes.
+test_the_bound_validation_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"
+  mutant="$(mutant_of "$SCRIPT" 's/if ! valid_yield_bound "\$yield_seconds"; then/if false; then/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_REMOTE_VERIFY_YIELD_SECONDS=0)
+  run_script "$mutant" "$fix"
+  RUN_ENV=()
+  assert_eq "without the check a zero bound exits 1, like a red suite" "1" "$RUN_RC"
+  assert_missing "and nothing names the variable the caller set" "$RUN_OUT" \
+    "TBD_REMOTE_VERIFY_YIELD_SECONDS must"
+  rmfix "$fix"
+}
+
+# The helper on its own, sourced — the table the case above cannot show without
+# running the whole wrapper nine times over.
+test_valid_yield_bound_accepts_only_positive_numbers() {
+  local value
+  for value in 300 60 0.5 .5 1.25 007; do
+    valid_yield_bound "$value"
+    assert_ok "[$value] is a usable bound" "$?"
+  done
+  for value in "" 0 0.0 .0 00 000.000 -1 +1 1e3 nan inf later 1.2.3 . " " "1 2"; do
+    valid_yield_bound "$value"
+    assert_nonzero "[$value] is refused" "$?"
+  done
+}
+
+test_a_yielded_queue_is_verified_remotely() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix"
+  RUN_ENV=()
+  assert_ok "a passing remote run is a passing run" "$RUN_RC"
+  assert_eq "the remote path was consulted once" "1" "$(remote_verify_dispatches "$fix")"
+  assert_eq "and the local suite was not re-run" "1" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# 1 is a verdict, not a refusal: the failing tests are already printed by the
+# remote path, so the run reports them rather than starting over locally.
+test_a_failing_remote_run_is_the_runs_verdict() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix"
+  RUN_ENV=()
+  assert_eq "a red remote run fails the run" "1" "$RUN_RC"
+  assert_eq "and nothing is re-run locally" "1" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# 78 IS THE ONE THAT MUST NOT FAIL THE RUN. A precondition the remote path
+# cannot meet — a dirty tree, no `gh` — returns this lane to the local queue.
+test_a_refused_precondition_falls_back_to_a_local_run() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix"
+  RUN_ENV=()
+  assert_ok "a refusal falls back rather than failing" "$RUN_RC"
+  assert_eq "the remote path was consulted once" "1" "$(remote_verify_dispatches "$fix")"
+  assert_eq "and the suite ran locally afterwards" "2" "$(swift_invocations "$fix")"
+  local dump; dump="$(dump_of "$fix")"
+  assert_contains "the fallback carries no yield bound" "$dump" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  # THE FENCE MUST NOT DRIFT BETWEEN THE TWO CALLS. That is why the invocation
+  # is a function rather than two copies of the same `env` prefix.
+  assert_contains "the fallback is still fenced (TBD_HOME)" "$dump" "TBD_HOME=/tmp/tbd-test-home."
+  assert_contains "the fallback is still fenced (host claude)" "$dump" "/sanctioned/tbd/claude-host"
+  assert_contains "the fallback is still fenced (codex)" "$dump" "/sanctioned/tbd/codex-host"
+  assert_contains "the fallback is still fenced (tmux)" "$dump" "TMUX_TMPDIR=/tmp/tbd-test-home."
+  assert_contains "and still pinned to the shared lock" "$dump" \
+    "TBD_SWIFT_LOCK_PATH=$fix/home/tbd/runtime/swift-build.lock"
+  rmfix "$fix"
+}
+
+# A BROKEN CHECKOUT IS A REFUSAL TOO. Without the executability check the shell
+# answers 127, which would be adopted as the run's exit status — a missing file
+# reported as a failing test suite.
+test_a_missing_remote_path_falls_back_to_a_local_run() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  rm -f "$fix/repo/scripts/remote-verify.sh"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0")
+  run_with_valve "$fix"
+  RUN_ENV=()
+  assert_ok "a missing remote path falls back rather than failing" "$RUN_RC"
+  assert_contains "and says why" "$RUN_OUT" "remote-verify.sh is missing or not executable"
+  assert_eq "and the suite ran locally afterwards" "2" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# MUTATION. Without the check the shell's 127 becomes the run's verdict.
+test_the_missing_remote_path_check_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  rm -f "$fix/repo/scripts/remote-verify.sh"
+  mutant="$(mutant_of "$SCRIPT" 's/if \[ ! -x scripts\/remote-verify\.sh \]; then/if false; then/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0")
+  run_with_valve "$fix" "$mutant"
+  RUN_ENV=()
+  assert_eq "without the check a broken checkout exits 127" "127" "$RUN_RC"
+  assert_eq "and the suite never ran locally" "1" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# MUTATION. Stop recognising 78 and a refusal becomes the run's verdict: a lane
+# that could not go remote reports a failure instead of testing anything.
+test_the_refusal_fallback_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/-eq "\$REMOTE_VERIFY_REFUSED"/-eq 999/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant"
+  RUN_ENV=()
+  assert_eq "without the fallback a refusal fails the run" "78" "$RUN_RC"
+  assert_eq "and the suite never ran locally" "1" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# MUTATION. Stop recognising 76 and the yield is reported as the run's exit
+# status — a lane that compiled nothing looks like a suite that failed.
+test_the_yield_routing_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/-eq "\$YIELDED_THE_QUEUE"/-eq 999/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant"
+  RUN_ENV=()
+  assert_eq "without the routing a yield leaks out as the exit status" "76" "$RUN_RC"
+  assert_eq "and nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
+  rmfix "$fix"
+}
+
+# 75 IS NOT 76. A timed-out or abandoned wait means nobody is waiting for this
+# verdict, or the slot simply never came free — neither is a request to verify
+# elsewhere, and dispatching one would spend a remote slot on nothing.
+test_a_timed_out_wait_is_not_routed_remotely() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=75 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix"
+  RUN_ENV=()
+  assert_eq "75 is propagated untouched" "75" "$RUN_RC"
+  assert_eq "and nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
+  rmfix "$fix"
+}
+
+# With the flag off the routing must not fire even on a 76 the suite produced
+# for its own reasons — the off path is the pre-valve path, byte for byte.
+test_a_76_with_the_valve_off_is_propagated_untouched() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix"
+  RUN_ENV=()
+  assert_eq "76 is just an exit status when the valve is off" "76" "$RUN_RC"
+  assert_eq "and nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
   rmfix "$fix"
 }
 

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -947,11 +947,17 @@ remote_verify_dispatches() {
 }
 
 # Run the wrapper from a fixture repo, with the remote path stubbed.
+#
+#   run_with_valve FIX [SCRIPT [ARG...]]
+#
+# SCRIPT is spelled out rather than defaulted-around when arguments follow it,
+# because the narrowing cases need both at once: a mutant AND a `--filter`.
 run_with_valve() {
-  local fix="$1" script="${2:-$SCRIPT}" repo
-  repo="$fix/repo"
-  RUN_CWD="$repo"
-  run_script "$script" "$fix"
+  local fix="$1" script="$SCRIPT"
+  shift
+  if [ $# -gt 0 ]; then script="$1"; shift; fi
+  RUN_CWD="$fix/repo"
+  run_script "$script" "$fix" "$@"
   RUN_CWD=""
 }
 
@@ -1121,7 +1127,13 @@ test_a_missing_remote_path_falls_back_to_a_local_run() {
   rmfix "$fix"
 }
 
-# MUTATION. Without the check the shell's 127 becomes the run's verdict.
+# MUTATION. The two guards are LAYERED, and this is where that shows. Without
+# the executability check the shell answers 127 — but 127 is outside the
+# `{0, 1, 78}` contract, so the whitelist below catches it and the run still
+# falls back rather than reporting a broken checkout as a failing suite. What
+# the check buys on top is the DIAGNOSIS: it names the missing file instead of
+# leaving the reader an exit status to interpret, and it does so without
+# spending a dispatch attempt on a script that is not there.
 test_the_missing_remote_path_check_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
   rm -f "$fix/repo/scripts/remote-verify.sh"
@@ -1129,22 +1141,183 @@ test_the_missing_remote_path_check_is_load_bearing() {
   RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0")
   run_with_valve "$fix" "$mutant"
   RUN_ENV=()
-  assert_eq "without the check a broken checkout exits 127" "127" "$RUN_RC"
-  assert_eq "and the suite never ran locally" "1" "$(swift_invocations "$fix")"
+  assert_missing "without the check nothing names the missing file" "$RUN_OUT" \
+    "remote-verify.sh is missing or not executable"
+  assert_contains "the reader is left with a bare 127 instead" "$RUN_OUT" \
+    "exited 127, which is"
   rmfix "$fix"
 }
 
-# MUTATION. Stop recognising 78 and a refusal becomes the run's verdict: a lane
-# that could not go remote reports a failure instead of testing anything.
+# MUTATION. Widen the verdict branch to everything and the two fallbacks below
+# it become unreachable: a refusal is adopted as the run's exit status, so a
+# lane that could not go remote reports a failure instead of testing anything.
 test_the_refusal_fallback_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
-  mutant="$(mutant_of "$SCRIPT" 's/-eq "\$REMOTE_VERIFY_REFUSED"/-eq 999/')"
+  mutant="$(mutant_of "$SCRIPT" 's/^( *)0\|1\)$/\1*)/')"
   RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
            FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
   run_with_valve "$fix" "$mutant"
   RUN_ENV=()
   assert_eq "without the fallback a refusal fails the run" "78" "$RUN_RC"
   assert_eq "and the suite never ran locally" "1" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# THE CONTRACT IS A WHITELIST, AND EVERYTHING OUTSIDE IT IS A NON-ANSWER. The
+# set of statuses a script can produce is open-ended — 127 for an interpreter
+# that is not there, 126 for a lost executable bit, 130 for a Ctrl-C, 2 for a
+# syntax error — and not one of them says anything about the tests. Adopting one
+# reports a suite that never ran as a suite that failed.
+test_an_out_of_contract_status_is_a_refusal_not_a_verdict() {
+  local fix status
+  for status in 2 126 127 130; do
+    fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+    RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC="$status"
+             FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+    run_with_valve "$fix"
+    RUN_ENV=()
+    assert_ok "an exit of $status falls back rather than failing the run" "$RUN_RC"
+    assert_contains "and names the status it saw" "$RUN_OUT" "exited $status, which is"
+    assert_contains "and says it is outside the contract" "$RUN_OUT" \
+      "outside its {0, 1, 78} contract"
+    assert_eq "the suite ran locally afterwards" "2" "$(swift_invocations "$fix")"
+    rmfix "$fix"
+  done
+}
+
+# MUTATION. The same widening as above, seen from the other side: with every
+# status treated as a verdict, a 127 from a mangled interpreter line becomes the
+# test suite's exit code and nothing is ever run.
+test_the_contract_whitelist_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/^( *)0\|1\)$/\1*)/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=127
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant"
+  RUN_ENV=()
+  assert_eq "without the whitelist a 127 becomes the run's verdict" "127" "$RUN_RC"
+  assert_eq "and the suite never ran locally" "1" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# THE INHERITED-BOUND TRAP, AND THE ONE CASE HERE THAT DELIBERATELY DOES NOT
+# UNSET `TBD_SWIFT_QUEUE_YIELD_SECONDS`. `scripts/swift-safe` documents it as a
+# supported knob, so a caller exporting it next to `TBD_REMOTE_VERIFY=1` is
+# expected. `fenced_env=()` on the fallback path omits the assignment but does
+# not unset the variable, and `env` passes the caller's value straight through —
+# so the re-run would yield 76 a second time, and since the valve block has
+# already been passed, the wrapper would exit 76 with nothing tested and nothing
+# said. `run_script`'s `-u` list would have hidden this exactly as it hid it
+# from review; the assignment below reaches the run because `env` applies
+# assignments after its options.
+test_an_inherited_yield_bound_does_not_survive_the_fallback() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_SWIFT_QUEUE_YIELD_SECONDS=10
+           FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix"
+  RUN_ENV=()
+  assert_ok "the fallback run is green" "$RUN_RC"
+  assert_eq "and it really did re-run locally" "2" "$(swift_invocations "$fix")"
+  # The dump describes the LAST invocation — the fallback. An inherited 10 here
+  # is the yield that would strand the run at 76.
+  assert_contains "the fallback carries no yield bound at all" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  rmfix "$fix"
+}
+
+# MUTATION. Put the bare `fenced_env=()` back and the caller's 10 rides straight
+# into the re-run.
+test_the_fallback_bound_clearing_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" \
+    's/fenced_env=\(TBD_SWIFT_QUEUE_YIELD_SECONDS=\)/fenced_env=()/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_SWIFT_QUEUE_YIELD_SECONDS=10
+           FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant"
+  RUN_ENV=()
+  assert_contains "without the clearing the caller's bound survives the fallback" \
+    "$(dump_of "$fix")" "TBD_SWIFT_QUEUE_YIELD_SECONDS=10"
+  rmfix "$fix"
+}
+
+# ---------------------------------------------------------------------------
+# 7b. The valve refuses a narrowed run
+#
+# Nothing on the dispatch carries a filter, so a routed run is always the whole
+# suite. GREEN whole-suite is still sound for a filtered caller — the whole
+# suite passing implies their subset did — but RED is not: it would name
+# failures in tests the caller deliberately excluded as this run's result. The
+# refusal is therefore made BEFORE the bound is forwarded; deciding it after the
+# run would be too late, because `swift-safe` would already have answered 76 for
+# a yield the run has since decided it cannot use.
+# ---------------------------------------------------------------------------
+
+test_narrows_the_suite_recognises_both_spellings() {
+  local arg
+  for arg in --filter --skip --disable-xctest --disable-swift-testing; do
+    narrows_the_suite "$arg"
+    assert_ok "[$arg] narrows" "$?"
+    narrows_the_suite "$arg=Foo"
+    assert_ok "[$arg=Foo] narrows" "$?"
+    narrows_the_suite --parallel -j 2 "$arg" Foo
+    assert_ok "[$arg] narrows wherever it appears" "$?"
+  done
+  for arg in --parallel --no-parallel -j --enable-code-coverage --verbose; do
+    narrows_the_suite "$arg"
+    assert_nonzero "[$arg] does not narrow" "$?"
+  done
+  narrows_the_suite
+  assert_nonzero "no arguments at all does not narrow" "$?"
+  # A value that merely looks like one of the names is not one of them.
+  narrows_the_suite --parallel '^--filterTests\.'
+  assert_nonzero "a regex mentioning a flag name does not narrow" "$?"
+}
+
+test_a_narrowed_run_is_never_routed_remotely() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --filter '^FooTests\.'
+  RUN_ENV=()
+  assert_eq "nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
+  assert_contains "no bound is forwarded, so there is no yield to strand" \
+    "$(dump_of "$fix")" "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  assert_contains "the filter still reaches swift test" "$(dump_of "$fix")" \
+    "argv: test --filter"
+  assert_contains "and the decision is stated once" "$RUN_OUT" \
+    "narrowing arguments present"
+  rmfix "$fix"
+}
+
+# The other side of the branch: with no narrowing argument the same fixture
+# routes. Without this the case above would pass against a valve that never
+# routes at all.
+test_an_unnarrowed_run_still_routes() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --parallel -j 2
+  RUN_ENV=()
+  assert_ok "an unnarrowed run takes the remote verdict" "$RUN_RC"
+  assert_eq "and dispatches exactly once" "1" "$(remote_verify_dispatches "$fix")"
+  assert_missing "nothing is said about narrowing" "$RUN_OUT" "narrowing arguments present"
+  rmfix "$fix"
+}
+
+# MUTATION. Stop recognising narrowing arguments and a `--filter`ed lane routes
+# to a whole-suite remote run, whose red verdict would name tests it excluded.
+test_the_narrowing_refusal_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/if narrows_the_suite .*; then/if false; then/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant" --filter '^FooTests\.'
+  RUN_ENV=()
+  assert_eq "without the refusal a filtered lane is dispatched whole-suite" "1" \
+    "$(remote_verify_dispatches "$fix")"
+  assert_eq "and its red whole-suite verdict fails the filtered run" "1" "$RUN_RC"
   rmfix "$fix"
 }
 

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -146,7 +146,17 @@ fake_swift_index=$((fake_swift_invocation - 1))
 if [ "$fake_swift_index" -ge "${#fake_swift_codes[@]}" ]; then
   fake_swift_index=$(( ${#fake_swift_codes[@]} - 1 ))
 fi
-exit "${fake_swift_codes[$fake_swift_index]}"
+fake_swift_rc="${fake_swift_codes[$fake_swift_index]}"
+# THE POPULATION LINE SIX FLOOR CONSUMERS GREP FOR, in the wording they grep
+# for. FAKE_SWIFT_TEST_COUNT unset prints nothing, which is what every case
+# outside the count ones wants. A 76 prints nothing either, whatever the count
+# says: 76 stands in for a queue yielded before anything compiled, and a summary
+# from a run that never ran would put a count in the log the fence never
+# produced.
+if [ -n "${FAKE_SWIFT_TEST_COUNT:-}" ] && [ "$fake_swift_rc" != "76" ]; then
+  echo "Test run with ${FAKE_SWIFT_TEST_COUNT} tests passed after 0.1 seconds."
+fi
+exit "$fake_swift_rc"
 STUB
   chmod +x "$d/bin/fake-swift"
   echo "$d"
@@ -188,10 +198,11 @@ run_script() {
                  -u TBD_SWIFT_JOBS -u TBD_SWIFT_LOCK_TIMEOUT_SECONDS \
                  -u TBD_SWIFT_HEARTBEAT_SECONDS -u TBD_SWIFT_ALLOW_ORPHAN \
                  -u FAKE_SWIFT_DISARM -u FAKE_SWIFT_LEAK -u FAKE_SWIFT_RC \
-                 -u FAKE_SWIFT_TMUX_SOCKETS \
+                 -u FAKE_SWIFT_TMUX_SOCKETS -u FAKE_SWIFT_TEST_COUNT \
                  -u TBD_REMOTE_VERIFY -u TBD_REMOTE_VERIFY_YIELD_SECONDS \
                  -u TBD_SWIFT_QUEUE_YIELD_SECONDS \
                  -u FAKE_REMOTE_VERIFY_RC -u FAKE_REMOTE_VERIFY_LOG \
+                 -u FAKE_REMOTE_VERIFY_COUNT -u FAKE_REMOTE_VERIFY_ARGV \
                  ${RUN_ENV[@]+"${RUN_ENV[@]}"} \
                  HOME="$fix/home" \
                  TMPDIR="$fix/tmp" \
@@ -931,11 +942,38 @@ mk_repo_fixture() {
   cat > "$repo/scripts/remote-verify.sh" <<'STUB'
 #!/usr/bin/env bash
 # Stands in for the remote path. It records that it was reached — the valve
-# must consult it exactly once, and only when the queue was yielded — and
-# returns whichever verdict the case is exercising.
+# must consult it exactly once, and only when the queue was yielded — records
+# the argv it was handed, and returns whichever verdict the case is exercising.
+#
+# IT MODELS THE ONE PART OF THE DRIVER'S OUTPUT ANYTHING DOWNSTREAM READS: the
+# `Test run with N tests` line, which six floor consumers grep out of a log and
+# take the FIRST of. `FAKE_REMOTE_VERIFY_COUNT` is the whole-suite population it
+# claims; unset prints nothing, which is what every case outside the count ones
+# wants.
+#
+# `--narrowed` is the caller declaring it asked for less than the whole suite,
+# and the driver's contract on that flag is to omit the count from a FAILING
+# report only. That caller is about to re-run locally and print a count of its
+# own, and the first count in the log has to be the run whose verdict is
+# reported. A PASSING report always states its population — there the remote
+# verdict is the one adopted, and a whole-suite count clears a narrowed floor
+# legitimately, being a minimum measured against a superset.
 echo "dispatched" >> "${FAKE_REMOTE_VERIFY_LOG:-/dev/null}"
+printf '%s\n' "$*" >> "${FAKE_REMOTE_VERIFY_ARGV:-/dev/null}"
+fake_remote_narrowed=0
+for fake_remote_arg in "$@"; do
+  case "$fake_remote_arg" in --narrowed) fake_remote_narrowed=1 ;; esac
+done
+fake_remote_rc="${FAKE_REMOTE_VERIFY_RC:-0}"
+if [ -n "${FAKE_REMOTE_VERIFY_COUNT:-}" ]; then
+  if [ "$fake_remote_rc" = "0" ]; then
+    echo "remote-verify: Test run with $FAKE_REMOTE_VERIFY_COUNT tests passed remotely." >&2
+  elif [ "$fake_remote_rc" = "1" ] && [ "$fake_remote_narrowed" -eq 0 ]; then
+    echo "remote-verify: Test run with $FAKE_REMOTE_VERIFY_COUNT tests failed remotely." >&2
+  fi
+fi
 echo "remote-verify: stub reached" >&2
-exit "${FAKE_REMOTE_VERIFY_RC:-0}"
+exit "$fake_remote_rc"
 STUB
   chmod +x "$repo/scripts/remote-verify.sh"
   echo "$repo"
@@ -944,6 +982,19 @@ STUB
 remote_verify_dispatches() {
   local log="$1/remote-verify-log"
   if [ -f "$log" ]; then wc -l < "$log" | tr -d ' '; else echo 0; fi
+}
+
+# The argv the wrapper handed the remote path, one dispatch per line.
+remote_verify_argv() { cat "$1/remote-verify-argv" 2>/dev/null; }
+
+# WHAT A FLOOR CONSUMER WOULD READ OUT OF THIS RUN'S LOG — the first
+# `Test run with N tests`, extracted exactly as `scripts/git-hooks/pre-push`,
+# `scripts/nightly-flake-stress.sh` and the three `test.yml` steps extract it,
+# `head -1` included. Asserting through the consumer's own reading is the point:
+# a count that is merely PRESENT somewhere in the log proves nothing, since the
+# floor only ever sees the first one.
+first_reported_test_count() {
+  printf '%s\n' "$1" | grep -oE 'Test run with [0-9]+ tests?' | grep -oE '[0-9]+' | head -1
 }
 
 # Run the wrapper from a fixture repo, with the remote path stubbed.
@@ -1402,6 +1453,158 @@ test_a_narrowed_run_falls_back_on_a_refusal_like_any_other() {
   assert_eq "with one local re-run" "2" "$(swift_invocations "$fix")"
   assert_missing "and no attribution message" "$RUN_OUT" "WHOLE-SUITE run failed"
   rmfix "$fix"
+}
+
+# ---------------------------------------------------------------------------
+# 7c. The count in the log has to describe the run being reported
+#
+# Six consumers decide whether a run is trustworthy by grepping its log for
+# `Test run with N tests` and taking the FIRST match — `scripts/git-hooks/
+# pre-push` (which pipes both streams into its log), `scripts/nightly-flake-
+# stress.sh`, and three floors in `.github/workflows/test.yml`.
+#
+# On the narrowed-red path two runs speak into one log, and only the second's
+# verdict is reported: the remote whole-suite report prints first, then the local
+# re-run. A remote count left in there is read as the reported run's population.
+# THE CONCRETE FAILURE that closes is pre-push's tier-3 pass — `--filter
+# '^TBDDaemonLiveTests\.'`, floor 35, a floor that exists precisely to catch a
+# filter that matched nothing. Rename the type, and the local re-run selects
+# zero tests, exits 0, and says `Test run with 0 tests`; with a whole-suite
+# count ahead of it in the log the floor sees four thousand, is satisfied, and
+# the push is allowed.
+#
+# The wrapper therefore declares its narrowing with `--narrowed`, and the driver
+# omits the count from a FAILING report only. Green keeps its count: there the
+# remote verdict is the one adopted, and a floor is a minimum measured against a
+# superset.
+# ---------------------------------------------------------------------------
+
+# The whole-suite population the stubbed remote path claims — the real number
+# from a recent full run, so the arithmetic below is the arithmetic in the wild.
+REMOTE_WHOLE_SUITE_COUNT=4593
+# What a vacuous filter's local re-run reports: it selected nothing and exited 0.
+VACUOUS_FILTER_COUNT=0
+
+# The tier-3 pass's floor, read out of the hook so this section cannot drift
+# from the number actually enforced.
+pre_push_tier3_floor() {
+  sed -n 's/^run_pass "quiet pass[^"]*" \([0-9][0-9]*\).*/\1/p' "$HERE/git-hooks/pre-push"
+}
+
+# "caught" / "undetected" — what the floor makes of the count a consumer read
+# out of a log, in `pre-push`'s own condition. A verdict rather than a number, so
+# the assertion reads as the consequence rather than as arithmetic.
+floor_verdict() {
+  local count="$1" floor="$2"
+  if [ -z "$count" ] || [ "$count" -lt "$floor" ]; then echo "caught"; else echo "undetected"; fi
+}
+
+test_the_tier3_floor_is_readable_from_the_hook() {
+  local floor; floor="$(pre_push_tier3_floor)"
+  assert_eq "the floor is digits only" "" "${floor//[0-9]/}"
+  assert_eq "a vacuous filter's count is below it" "caught" \
+    "$(floor_verdict "$VACUOUS_FILTER_COUNT" "$floor")"
+  assert_eq "and a whole-suite count is not" "undetected" \
+    "$(floor_verdict "$REMOTE_WHOLE_SUITE_COUNT" "$floor")"
+}
+
+# THE CASE THE FINDING IS ABOUT. A narrowed lane goes remote, the whole suite
+# comes back red on something outside the subset, the narrowed suite is re-run
+# locally and selects NOTHING — and the count a floor reads must be that re-run's
+# zero, not the remote suite's four thousand.
+test_a_narrowed_red_run_leaves_only_the_local_count_in_the_log() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0"
+           FAKE_SWIFT_TEST_COUNT="$VACUOUS_FILTER_COUNT"
+           FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_COUNT="$REMOTE_WHOLE_SUITE_COUNT"
+           FAKE_REMOTE_VERIFY_ARGV="$fix/remote-verify-argv"
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --no-parallel --filter '^TBDDaemonLiveTests\.'
+  RUN_ENV=()
+  assert_ok "the local re-run's verdict is the run's" "$RUN_RC"
+  assert_eq "and it really did re-run locally" "2" "$(swift_invocations "$fix")"
+  assert_contains "the narrowing is declared to the remote path" \
+    "$(remote_verify_argv "$fix")" "--narrowed"
+  assert_eq "the count a floor reads is the local re-run's" "$VACUOUS_FILTER_COUNT" \
+    "$(first_reported_test_count "$RUN_OUT")"
+  assert_missing "the remote suite's count is nowhere in the log" "$RUN_OUT" \
+    "$REMOTE_WHOLE_SUITE_COUNT tests"
+  assert_eq "so the vacuous filter is caught" "caught" \
+    "$(floor_verdict "$(first_reported_test_count "$RUN_OUT")" "$(pre_push_tier3_floor)")"
+  rmfix "$fix"
+}
+
+# MUTATION. Stop declaring the narrowing and the remote report keeps its count.
+# It is printed BEFORE the local re-run's, so `head -1` finds four thousand
+# tests, a floor of 35 is satisfied by a run that executed nothing, and the push
+# the floor exists to stop goes through.
+test_declaring_the_narrowing_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/remote_verify_args=\(--narrowed\)/remote_verify_args=()/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0"
+           FAKE_SWIFT_TEST_COUNT="$VACUOUS_FILTER_COUNT"
+           FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_COUNT="$REMOTE_WHOLE_SUITE_COUNT"
+           FAKE_REMOTE_VERIFY_ARGV="$fix/remote-verify-argv"
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant" --no-parallel --filter '^TBDDaemonLiveTests\.'
+  RUN_ENV=()
+  assert_missing "nothing declares the narrowing" "$(remote_verify_argv "$fix")" "--narrowed"
+  assert_eq "so the remote whole-suite count is the one a floor reads" \
+    "$REMOTE_WHOLE_SUITE_COUNT" "$(first_reported_test_count "$RUN_OUT")"
+  assert_eq "and the vacuous filter goes undetected" "undetected" \
+    "$(floor_verdict "$(first_reported_test_count "$RUN_OUT")" "$(pre_push_tier3_floor)")"
+  rmfix "$fix"
+}
+
+# THE OTHER TWO STATES, so "suppress the count whenever the valve fires" cannot
+# pass as this fix. A narrowed GREEN verdict is the one being reported, so its
+# count belongs in the log — a floor is a minimum and the whole suite is a
+# superset of the subset asked for.
+test_a_narrowed_green_run_keeps_the_remote_count() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_COUNT="$REMOTE_WHOLE_SUITE_COUNT"
+           FAKE_REMOTE_VERIFY_ARGV="$fix/remote-verify-argv"
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --filter '^FooTests\.'
+  RUN_ENV=()
+  assert_ok "a green whole-suite verdict is adopted" "$RUN_RC"
+  assert_contains "the narrowing is still declared" "$(remote_verify_argv "$fix")" "--narrowed"
+  assert_eq "and the adopted run's count is in the log" "$REMOTE_WHOLE_SUITE_COUNT" \
+    "$(first_reported_test_count "$RUN_OUT")"
+  rmfix "$fix"
+}
+
+# AN UNNARROWED CALLER DECLARES NOTHING, and its red verdict — which IS the
+# reported one — keeps the population it executed.
+test_an_unnarrowed_run_declares_nothing_and_keeps_its_count() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_COUNT="$REMOTE_WHOLE_SUITE_COUNT"
+           FAKE_REMOTE_VERIFY_ARGV="$fix/remote-verify-argv"
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --parallel -j 2
+  RUN_ENV=()
+  assert_eq "the remote verdict is the run's" "1" "$RUN_RC"
+  assert_eq "nothing is declared" "" "$(remote_verify_argv "$fix")"
+  assert_eq "and the reported run's count is in the log" "$REMOTE_WHOLE_SUITE_COUNT" \
+    "$(first_reported_test_count "$RUN_OUT")"
+  rmfix "$fix"
+}
+
+# THE FLAG IS A CONTRACT BETWEEN TWO FILES, so it is pinned against the real one
+# rather than only against the stub. `scripts/remote-verify.sh` refuses an
+# argument it does not recognise — 78, which this wrapper reads as a refusal and
+# answers with a local run — so a rename on either side would leave every
+# narrowed lane paying the remote round trip and then running locally anyway,
+# quietly, because a refusal is not a failure.
+test_the_narrowed_flag_is_one_the_remote_path_accepts() {
+  local remote; remote="$(cat "$HERE/remote-verify.sh" 2>/dev/null)"
+  assert_contains "the remote path parses the flag this wrapper sends" "$remote" "--narrowed)"
+  assert_contains "and this wrapper sends that one" "$(cat "$SCRIPT")" \
+    "remote_verify_args=(--narrowed)"
 }
 
 # THE FLOORS ARE MINIMUMS, WHICH IS WHY ADOPTING A WHOLE-SUITE GREEN IS SAFE FOR

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -1071,7 +1071,9 @@ test_a_bad_bound_is_ignored_while_the_valve_is_off() {
 # with its own code and its own name, and must not start a run at all.
 test_a_bad_bound_fails_loudly_rather_than_as_a_red_suite() {
   local fix bound
-  for bound in 0 0.0 .0 00 -5 nan inf later ""; do
+  # The EMPTY value is deliberately not in this list; see
+  # `test_an_empty_bound_means_unset_rather_than_a_refusal`.
+  for bound in 0 0.0 .0 00 -5 nan inf later; do
     fix="$(mkfix)"
     RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_REMOTE_VERIFY_YIELD_SECONDS="$bound")
     run_wrapper "$fix"
@@ -1082,6 +1084,45 @@ test_a_bad_bound_fails_loudly_rather_than_as_a_red_suite() {
     assert_eq "and no suite is started" "0" "$(swift_invocations "$fix")"
     rmfix "$fix"
   done
+}
+
+# EMPTY IS THE ABSENCE OF A VALUE, NOT A TYPO, and it is the one spelling that
+# must NOT join the list above. `TBD_REMOTE_VERIFY_YIELD_SECONDS=` is how a shell
+# clears an inherited value, how `env VAR=` arrives, and what an unquoted
+# `"$maybe_unset"` expands to — and it is not how the valve gets turned off, which
+# is `TBD_REMOTE_VERIFY` unset and never reaches the bound at all. So a refusal
+# here could only be answering a caller who meant "use the default", and the price
+# would be paid somewhere else entirely: `scripts/git-hooks/pre-push` runs this
+# wrapper to decide whether a push may proceed, and an exit of 64 there BLOCKS THE
+# PUSH.
+test_an_empty_bound_means_unset_rather_than_a_refusal() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_REMOTE_VERIFY_YIELD_SECONDS=)
+  run_wrapper "$fix"
+  RUN_ENV=()
+  assert_ok "an empty bound runs rather than exiting 64" "$RUN_RC"
+  assert_missing "and nothing is said about the variable" "$RUN_OUT" \
+    "TBD_REMOTE_VERIFY_YIELD_SECONDS must"
+  assert_contains "the default is used" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=$DEFAULT_YIELD_SECONDS"
+  rmfix "$fix"
+}
+
+# MUTATION, IN THE DIRECTION THIS DECISION WAS MADE AGAINST. Spell the expansion
+# `-` instead of `:-` — substituting only for an UNSET variable — and the empty
+# string reaches the validator, which refuses it with the code that blocks a push.
+test_the_empty_bound_defaulting_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"
+  mutant="$(mutant_of "$SCRIPT" \
+    's/\$\{TBD_REMOTE_VERIFY_YIELD_SECONDS:-\$DEFAULT_REMOTE_VERIFY_YIELD_SECONDS\}/${TBD_REMOTE_VERIFY_YIELD_SECONDS-$DEFAULT_REMOTE_VERIFY_YIELD_SECONDS}/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_REMOTE_VERIFY_YIELD_SECONDS=)
+  run_script "$mutant" "$fix"
+  RUN_ENV=()
+  assert_eq "with a bare dash an empty bound exits 64" "64" "$RUN_RC"
+  assert_contains "and a pre-push would be blocked over it" "$RUN_OUT" \
+    "TBD_REMOTE_VERIFY_YIELD_SECONDS must"
+  assert_eq "with no suite started at all" "0" "$(swift_invocations "$fix")"
+  rmfix "$fix"
 }
 
 # MUTATION. Without the check the same value reaches `swift-safe`, which exits
@@ -1318,7 +1359,8 @@ test_the_fallback_bound_clearing_is_load_bearing() {
 
 test_narrows_the_suite_recognises_both_spellings() {
   local arg
-  for arg in --filter --skip --disable-xctest --disable-swift-testing; do
+  for arg in --filter --skip --specifier -s --disable-xctest --disable-swift-testing \
+             --test-product --list-tests list; do
     narrows_the_suite "$arg"
     assert_ok "[$arg] narrows" "$?"
     narrows_the_suite "$arg=Foo"
@@ -1326,7 +1368,8 @@ test_narrows_the_suite_recognises_both_spellings() {
     narrows_the_suite --parallel -j 2 "$arg" Foo
     assert_ok "[$arg] narrows wherever it appears" "$?"
   done
-  for arg in --parallel --no-parallel -j --enable-code-coverage --verbose; do
+  for arg in --parallel --no-parallel -j --enable-code-coverage --verbose \
+             --enable-xctest --enable-swift-testing --num-workers --xunit-output; do
     narrows_the_suite "$arg"
     assert_nonzero "[$arg] does not narrow" "$?"
   done
@@ -1335,6 +1378,84 @@ test_narrows_the_suite_recognises_both_spellings() {
   # A value that merely looks like one of the names is not one of them.
   narrows_the_suite --parallel '^--filterTests\.'
   assert_nonzero "a regex mentioning a flag name does not narrow" "$?"
+}
+
+# THE LIST IS CHECKED AGAINST THE TOOLCHAIN, NOT AGAINST MEMORY. Every name here
+# is one this `swift-test` binary actually accepts — read out of its own strings,
+# since invoking SwiftPM to ask would take the machine-global build slot. A name
+# that does not exist costs nothing; a name that exists and is MISSING is the
+# expensive direction, because the run it fails to recognise adopts a whole-suite
+# failure as its own and reports tests the caller excluded.
+#
+# `--test-product` was the omission this case was written for: it restricts the
+# run to one test product, which on a multi-product package is the largest
+# reduction on offer, and SwiftPM names the flag itself in its "found multiple
+# test products" diagnostic.
+test_the_narrowing_list_names_only_real_swift_test_options() {
+  local swift_test missing=""
+  swift_test="$(xcrun -f swift-test 2>/dev/null || command -v swift-test || true)"
+  if [ -z "$swift_test" ] || [ ! -e "$swift_test" ]; then
+    echo "ok   - (skipped: no swift-test binary to read)"
+    return 0
+  fi
+  # ArgumentParser derives a long name from a property name or a `customLong`, so
+  # the string in the binary is sometimes the camelCase property (`testProduct`)
+  # and sometimes the flag's own stem (`specifier`, `xctest`). Each entry is
+  # looked for in whichever shape that toolchain stores it.
+  #
+  # STRINGS GOES TO A FILE FIRST, and that is not tidiness. This harness runs
+  # under `pipefail`, and `strings … | grep -q` closes the pipe on the first match
+  # — `strings` then dies of SIGPIPE and the PIPELINE reports 141 even though grep
+  # matched, so every needle would look missing. That failure looked exactly like
+  # a toolchain with none of these options.
+  local dump; dump="$(mktmpd)/swift-test.strings"
+  strings -a "$swift_test" > "$dump"
+  local -a needles=(testProduct specifier --list-tests filter skip xctest swift-testing)
+  local needle
+  for needle in "${needles[@]}"; do
+    grep -xF -- "$needle" "$dump" >/dev/null || missing="$missing $needle"
+  done
+  assert_eq "every narrowing name has a counterpart in the toolchain" "" "$missing"
+  # And the list in the script really carries them, so the check above is not
+  # asserting against a list that has drifted away from the one in use.
+  local body; body="$(cat "$SCRIPT")"
+  assert_contains "the script's list carries --test-product" "$body" "--test-product"
+  assert_contains "and --list-tests" "$body" "--list-tests"
+  assert_contains "and the deprecated --specifier with its short form" "$body" \
+    "--specifier -s"
+}
+
+# END TO END, THROUGH THE VERDICT INTERPRETATION. `--test-product` has to reach
+# the same reading `--filter` gets: a red whole-suite verdict is unattributable, so
+# the narrowed suite is re-run locally and THAT verdict is the run's.
+test_a_test_product_narrowed_run_reads_a_red_verdict_as_unattributable() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 3" FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --test-product TBDPackageTests
+  RUN_ENV=()
+  assert_eq "the LOCAL verdict is reported, not the remote 1" "3" "$RUN_RC"
+  assert_eq "the narrowed suite was re-run locally" "2" "$(swift_invocations "$fix")"
+  assert_contains "and the reason names the mismatch" "$RUN_OUT" \
+    "remote WHOLE-SUITE run failed"
+  rmfix "$fix"
+}
+
+# MUTATION. Drop `--test-product` back out of the list — the state this case was
+# written against — and the same run adopts a whole-suite failure as one test
+# product's result, naming tests the caller never asked to run.
+test_including_test_product_in_the_narrowing_list_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/^  --test-product$//')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 3" FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant" --test-product TBDPackageTests
+  RUN_ENV=()
+  assert_eq "without the entry the remote 1 is adopted" "1" "$RUN_RC"
+  assert_eq "and the one product is never re-run" "1" "$(swift_invocations "$fix")"
+  assert_missing "with nothing said about attribution" "$RUN_OUT" \
+    "WHOLE-SUITE run failed"
+  rmfix "$fix"
 }
 
 # NARROWED + GREEN — the sound direction, adopted. The whole suite passing

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -1148,12 +1148,14 @@ test_the_missing_remote_path_check_is_load_bearing() {
   rmfix "$fix"
 }
 
-# MUTATION. Widen the verdict branch to everything and the two fallbacks below
-# it become unreachable: a refusal is adopted as the run's exit status, so a
-# lane that could not go remote reports a failure instead of testing anything.
+# MUTATION. Have the refusal branch adopt the status instead of falling back and
+# a lane that could not go remote reports a failure instead of testing anything.
+# Keyed to the branch's own comment so the mutation is unambiguous about WHICH of
+# the three fallbacks it weakens — they all call the same function.
 test_the_refusal_fallback_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
-  mutant="$(mutant_of "$SCRIPT" 's/^( *)0\|1\)$/\1*)/')"
+  mutant="$(mutant_of "$SCRIPT" \
+    '/A REFUSAL IS NOT A FAILURE/,/;;/ s/fall_back_to_the_local_queue/test_status=$remote_status/')"
   RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
            FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
   run_with_valve "$fix" "$mutant"
@@ -1185,12 +1187,13 @@ test_an_out_of_contract_status_is_a_refusal_not_a_verdict() {
   done
 }
 
-# MUTATION. The same widening as above, seen from the other side: with every
-# status treated as a verdict, a 127 from a mangled interpreter line becomes the
-# test suite's exit code and nothing is ever run.
+# MUTATION. The same weakening one branch over: have the catch-all adopt the
+# status and a 127 from a mangled interpreter line becomes the test suite's exit
+# code with nothing ever run.
 test_the_contract_whitelist_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
-  mutant="$(mutant_of "$SCRIPT" 's/^( *)0\|1\)$/\1*)/')"
+  mutant="$(mutant_of "$SCRIPT" \
+    '/OUTSIDE THE CONTRACT ENTIRELY/,/;;/ s/fall_back_to_the_local_queue/test_status=$remote_status/')"
   RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=127
            FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
   run_with_valve "$fix" "$mutant"
@@ -1243,15 +1246,23 @@ test_the_fallback_bound_clearing_is_load_bearing() {
 }
 
 # ---------------------------------------------------------------------------
-# 7b. The valve refuses a narrowed run
+# 7b. A narrowed run routes, and its verdict is read by the asymmetry
 #
-# Nothing on the dispatch carries a filter, so a routed run is always the whole
-# suite. GREEN whole-suite is still sound for a filtered caller — the whole
-# suite passing implies their subset did — but RED is not: it would name
-# failures in tests the caller deliberately excluded as this run's result. The
-# refusal is therefore made BEFORE the bound is forwarded; deciding it after the
-# run would be too late, because `swift-safe` would already have answered 76 for
-# a yield the run has since decided it cannot use.
+# Nothing on the dispatch carries a filter, so a routed run is always the WHOLE
+# suite — and the two outcomes do not transfer equally to a caller who asked for
+# less:
+#
+#   GREEN transfers. Every test passed, so every subset of them passed. Adopted,
+#      with one line so the whole-suite test count is not read as the subset's.
+#   RED does not. The failures may lie entirely outside what the caller selected,
+#      so the narrowed suite is re-run locally and the LOCAL verdict reported.
+#
+# WHY THE CASES BELOW ASSERT ROUTING RATHER THAN REFUSAL. Refusing a narrowed run
+# outright needs no interpretation, but it turns the valve off for every real
+# caller: `scripts/git-hooks/pre-push` narrows BOTH of its passes (`--skip
+# '^TBDDaemonLiveTests\.'` and `--filter '^TBDDaemonLiveTests\.'`), the nightly
+# stress harness forwards a filter, and four of five live queued test lanes were
+# `--filter` runs.
 # ---------------------------------------------------------------------------
 
 test_narrows_the_suite_recognises_both_spellings() {
@@ -1275,50 +1286,143 @@ test_narrows_the_suite_recognises_both_spellings() {
   assert_nonzero "a regex mentioning a flag name does not narrow" "$?"
 }
 
-test_a_narrowed_run_is_never_routed_remotely() {
+# NARROWED + GREEN — the sound direction, adopted. The whole suite passing
+# implies the caller's subset passed, so there is nothing to re-run; only the
+# test COUNT fails to transfer, which is what the note exists for.
+test_a_narrowed_run_adopts_a_green_whole_suite_verdict() {
   local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
   RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
            FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
   run_with_valve "$fix" "$SCRIPT" --filter '^FooTests\.'
   RUN_ENV=()
-  assert_eq "nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
-  assert_contains "no bound is forwarded, so there is no yield to strand" \
-    "$(dump_of "$fix")" "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  assert_ok "a green whole-suite run passes the narrowed run" "$RUN_RC"
+  assert_eq "it really was dispatched" "1" "$(remote_verify_dispatches "$fix")"
+  assert_eq "and nothing was re-run locally" "1" "$(swift_invocations "$fix")"
+  assert_contains "the bound is forwarded like any other run" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=$DEFAULT_YIELD_SECONDS"
   assert_contains "the filter still reaches swift test" "$(dump_of "$fix")" \
     "argv: test --filter"
-  assert_contains "and the decision is stated once" "$RUN_OUT" \
-    "narrowing arguments present"
+  assert_contains "and the count is flagged as whole-suite" "$RUN_OUT" \
+    "the remote run was the WHOLE suite"
   rmfix "$fix"
 }
 
-# The other side of the branch: with no narrowing argument the same fixture
-# routes. Without this the case above would pass against a valve that never
-# routes at all.
-test_an_unnarrowed_run_still_routes() {
+# NARROWED + RED — unattributable, so it is not adopted. The local re-run's
+# verdict is the one reported, and this fixture makes the two differ: remote says
+# 1, the local re-run says 3, and 3 is what comes out.
+test_a_narrowed_run_reports_the_local_verdict_after_a_red_whole_suite_run() {
   local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
-  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 3" FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --filter '^FooTests\.'
+  RUN_ENV=()
+  assert_eq "the LOCAL verdict is reported, not the remote 1" "3" "$RUN_RC"
+  assert_eq "the narrowed suite was re-run locally" "2" "$(swift_invocations "$fix")"
+  assert_contains "and the re-run is still narrowed" "$(dump_of "$fix")" \
+    "argv: test --filter"
+  assert_contains "the reason is stated" "$RUN_OUT" "cannot"
+  assert_contains "and names what happened" "$RUN_OUT" "remote WHOLE-SUITE run failed"
+  assert_contains "the re-run carries no yield bound" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  rmfix "$fix"
+}
+
+# The same shape when the local re-run PASSES: a red whole-suite verdict whose
+# failures were all outside the caller's subset must not fail the caller's run.
+test_a_narrowed_run_goes_green_when_the_local_rerun_passes() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=1
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --skip '^TBDDaemonLiveTests\.'
+  RUN_ENV=()
+  assert_ok "failures outside the subset do not fail the narrowed run" "$RUN_RC"
+  assert_eq "the narrowed suite was re-run locally" "2" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# UNNARROWED + RED — still the verdict, still adopted, still no re-run. This is
+# the branch the narrowed cases above must be distinguished FROM.
+test_an_unnarrowed_run_still_adopts_a_red_verdict() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=1
            FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
   run_with_valve "$fix" "$SCRIPT" --parallel -j 2
   RUN_ENV=()
-  assert_ok "an unnarrowed run takes the remote verdict" "$RUN_RC"
-  assert_eq "and dispatches exactly once" "1" "$(remote_verify_dispatches "$fix")"
-  assert_missing "nothing is said about narrowing" "$RUN_OUT" "narrowing arguments present"
+  assert_eq "a red remote run fails an unnarrowed run" "1" "$RUN_RC"
+  assert_eq "and nothing is re-run locally" "1" "$(swift_invocations "$fix")"
+  assert_missing "nothing is said about attribution" "$RUN_OUT" "WHOLE-SUITE run failed"
+  assert_missing "nor about a whole-suite count" "$RUN_OUT" "was the WHOLE suite"
   rmfix "$fix"
 }
 
-# MUTATION. Stop recognising narrowing arguments and a `--filter`ed lane routes
-# to a whole-suite remote run, whose red verdict would name tests it excluded.
-test_the_narrowing_refusal_is_load_bearing() {
+# MUTATION, AND THE ONE THAT MATTERS MOST HERE. With `narrows_the_suite` never
+# recognising anything, a `--filter`ed lane adopts a whole-suite failure as its
+# own verdict — naming tests it deliberately excluded, which is the exact wrong
+# answer this interpretation exists to prevent.
+test_the_narrowed_verdict_discrimination_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
   mutant="$(mutant_of "$SCRIPT" 's/if narrows_the_suite .*; then/if false; then/')"
-  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=1
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 3" FAKE_REMOTE_VERIFY_RC=1
            FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
   run_with_valve "$fix" "$mutant" --filter '^FooTests\.'
   RUN_ENV=()
-  assert_eq "without the refusal a filtered lane is dispatched whole-suite" "1" \
-    "$(remote_verify_dispatches "$fix")"
-  assert_eq "and its red whole-suite verdict fails the filtered run" "1" "$RUN_RC"
+  assert_eq "without the discrimination the remote 1 is adopted" "1" "$RUN_RC"
+  assert_eq "and the narrowed suite is never re-run" "1" "$(swift_invocations "$fix")"
+  assert_missing "with nothing said about attribution" "$RUN_OUT" "WHOLE-SUITE run failed"
   rmfix "$fix"
+}
+
+# The other half of the same mutation: a narrowed GREEN result must be labelled.
+# Without it the caller reads a whole-suite test count as their subset's — which
+# is precisely how a `pre-push` floor stops catching a filter that matched
+# nothing.
+test_the_whole_suite_label_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/if narrows_the_suite .*; then/if false; then/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant" --filter '^FooTests\.'
+  RUN_ENV=()
+  assert_ok "the mutant still passes (the label is not a correctness gate)" "$RUN_RC"
+  assert_missing "but the whole-suite count goes unlabelled" "$RUN_OUT" \
+    "the remote run was the WHOLE suite"
+  rmfix "$fix"
+}
+
+# A NARROWED RUN'S 78 IS STILL JUST A REFUSAL. The interpretation only touches 0
+# and 1; a precondition that refused falls back exactly as it does unnarrowed,
+# and must not pick up the attribution message.
+test_a_narrowed_run_falls_back_on_a_refusal_like_any_other() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC="76 0" FAKE_REMOTE_VERIFY_RC=78
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --filter '^FooTests\.'
+  RUN_ENV=()
+  assert_ok "a refusal still falls back" "$RUN_RC"
+  assert_eq "with one local re-run" "2" "$(swift_invocations "$fix")"
+  assert_missing "and no attribution message" "$RUN_OUT" "WHOLE-SUITE run failed"
+  rmfix "$fix"
+}
+
+# THE FLOORS ARE MINIMUMS, WHICH IS WHY ADOPTING A WHOLE-SUITE GREEN IS SAFE FOR
+# `pre-push`. Both of its passes narrow, and the whole suite is a superset of
+# each, so a whole-suite count cannot fall below a count the narrowed pass would
+# have produced. Pinned here because the reasoning is what licenses the adoption:
+# were the check a ceiling, or an equality, a whole-suite count would trip it.
+test_pre_push_floors_are_minimums_a_superset_cannot_trip() {
+  local hook="$HERE/git-hooks/pre-push"
+  local body; body="$(cat "$hook" 2>/dev/null)"
+  assert_contains "the count check is a less-than against the floor" "$body" \
+    '[ "$count" -lt "$floor" ]'
+  assert_missing "and never a greater-than" "$body" '"$count" -gt'
+  assert_missing "nor an equality" "$body" '"$count" -eq "$floor"'
+  # Both passes narrow, so both are subsets of the whole suite.
+  assert_contains "the fast pass narrows with --skip" "$body" "--skip '^TBDDaemonLiveTests"
+  assert_contains "the tier-3 pass narrows with --filter" "$body" "--filter '^TBDDaemonLiveTests"
+  narrows_the_suite --no-fingerprint --parallel -j 2 --skip '^TBDDaemonLiveTests\.'
+  assert_ok "the fast pass is recognised as narrowed" "$?"
+  narrows_the_suite --no-fingerprint --no-parallel --filter '^TBDDaemonLiveTests\.'
+  assert_ok "the tier-3 pass is recognised as narrowed" "$?"
 }
 
 # MUTATION. Stop recognising 76 and the yield is reported as the run's exit


### PR DESCRIPTION
## Summary

Every build and test run on this machine passes through `scripts/swift-safe`, a machine-global admission lock that admits one run at a time so ~40 agent worktrees cannot start ~40 compiler swarms at once. The lock does its job; the cost is that everyone else waits, and the wait has no ceiling.

Two hours of sampling the lock every two seconds, during ordinary fleet activity, measured what that costs:

- A queue existed in **83% of samples**, mean depth 2.11, max 6.
- **52 of 99 handoffs** went to a lane while another that had already waited ≥30s was still queued. The lock is memoryless, so seniority buys nothing.
- Individual lanes were jumped **21, 22 and 24 minutes** into their waits. Peak wait per queueing episode: p50 84s, p90 268s, max 1790s — a lane riding the lock's own 30-minute timeout.

This adds an overflow path. A lane that has queued past a threshold, with a clean tree, verifies its commit on GitHub instead and leaves the local queue. The local slot is unchanged, nothing is killed, and a lane that cannot go remote waits exactly as it does today.

**Default off.** With `TBD_REMOTE_VERIFY` unset, every path behaves as it did before this branch and no bound is forwarded.

The whole design turns on one distinction: a build has two possible purposes, and only one is tied to this machine. `scripts/restart.sh` builds binaries someone then runs — the artifact is the point and it can never move. A test run's entire output is a verdict, and that can be computed anywhere. Of seven lanes captured contending live, **six were verification**.

## Why this shape

Spec: [`docs/specs/2026-08-16-remote-verification-valve-design.md`](docs/specs/2026-08-16-remote-verification-valve-design.md), brainstormed with a human before implementation.

**The valve is deliberately narrow, and does not replace fairness.** GitHub caps five concurrent macOS jobs per account (Free/Pro/Team alike; only Enterprise raises it), and `test.yml` spends two per run — so the account sustains roughly two concurrent runs. Minutes are free on a public repo (a run reports `MACOS: total_ms: 0`), but capacity is not. At T=300 the valve is expected to fire four or five times an hour against ~55 queueing episodes. The local queue's unfairness survives it; ordering that queue needs its own design.

**The threshold measures queue time, not run time.** A lane that has never acquired the slot has compiled nothing, so there is nothing to kill and no work to discard. Run time would conflate waiting with compiling, and a solo compile ranges from seconds when warm to many minutes when cold — there is no defensible number. T=300 was chosen against the measured episode distribution: T=60 would trip ~28 times an hour into a valve that sustains ~12, so most trips would push a ref, fail to get a ticket, and rejoin the queue having achieved nothing.

**Both admission pools are local `flock`s.** Every contender runs on the same laptop, so a local file arbitrates GitHub's capacity authoritatively — this is not a distributed consensus problem. `flock` also means the kernel releases a ticket when the holder exits by any means, so a ticket cannot outlive its run.

**Result files, never the run's conclusion, decide the verdict.** `test.yml` holds four jobs with no `needs:` between them and a build step after the results upload. Keying on the conclusion meant a SwiftLint violation or a committed plan file was reported as failing tests, and a run that died in setup — `brew install tmux` flaking is ordinary weather — was reported the same way. A stated population with nothing failing, or no results at all, is now **no verdict**, and the lane goes back to the local queue for an answer to its own question.

**Only `preflight/<branch>` is ever pushed, enforced at the function that moves refs.** Pushing the branch itself would fast-forward `origin/main` when run on `main` (`enforce_admins` is false and there are no push restrictions, so that push is admitted), publish the very commits `pre-push` runs the suite to gate, and leave a ref no sweep reclaims.

**A narrowed caller reads a whole-suite verdict asymmetrically.** Green is sound for any subset; red says nothing about the caller's subset, so it re-runs locally. Narrowed runs are the common case — `pre-push` uses `--skip`, the nightly harness passes a filter, and four of five live queued test lanes narrowed — so refusing them outright would have refused nearly every real caller.

## What this PR does

- **`scripts/swift-safe`** — exit **76** when a wait yields at T, distinct from **75** (timed out or abandoned). Honoured only for the `test` subcommand: `build` and `run` produce artifacts someone is waiting for, and their callers do not understand 76.
- **`scripts/remote_verify.py`** (new) — the ticket pool and the driver: baseline run ids, push, dispatch, correlate, wait, download, render. Bounds every subprocess and abandons when its requester dies, mirroring what #666 did for the build slot.
- **`scripts/remote-verify.sh`** (new) — preconditions and ref choice; refuses on a dirty tree, missing or unauthenticated `gh`, the default branch, or a preflight ref with an open PR.
- **`scripts/test.sh`** — routes 76 behind the flag; treats 78 and anything out-of-contract as a refusal that falls back to a local re-run.
- **`.github/workflows/test.yml`** — `workflow_dispatch` trigger, xUnit output on all three passes, artifact upload, and the new harnesses wired into CI.
- **`.github/workflows/preflight-cleanup.yml`** + **`scripts/sweep-preflight-refs.sh`** (new) — the named reconciler for preflight refs.
- **`scripts/nightly-flake-stress.sh`** — explicitly disables the valve. It measures *local* flakiness under induced contention; routing an iteration to a quiet CI runner measures nothing it was built to measure.

**Failures come back as structured results, not scraped logs.** A single failed `test.yml` run produces **5.3 MB across 32,228 lines** in which parallel passes interleave and compiler diagnostics print source context that looks exactly like test output. Two extraction attempts over a real failed log both produced wrong answers — one surfaced a deliberate known-issue self-test, one matched 22 lines that were `#require is redundant` warnings. The driver sums xUnit populations instead, and refuses rather than inventing a count.

## Flag & rollout

**Flag:** `TBD_REMOTE_VERIFY`, default **off**. Unset leaves every path byte-identical to today, with a test pinning that.

**Enable for the soak:** `export TBD_REMOTE_VERIFY=1` in the shell whose `scripts/test.sh` runs should be eligible. Seven knobs tune it, all documented in the spec with their shipped defaults — T is `TBD_REMOTE_VERIFY_YIELD_SECONDS` (300) and the pool is `TBD_REMOTE_VERIFY_SLOTS` (2).

**Graduation** flips the default only once a soak shows three things, each a way the valve could be quietly worse than waiting: that a green remote verdict never stood in for a suite that did not run, that a red one never named tests outside the caller's request, and that the ticket pool rather than GitHub's queue was the binding constraint. The flag is **deleted rather than flipped** if the soak shows the valve fires too rarely to matter, which at T=300 is a live possibility.

## Who reclaims the orphans

- **Dispatch tickets** — `flock`, released by the kernel on exit by any means. Self-reclaiming, same footing as the build slot; a hand-rolled occupancy file would reintroduce the stale-marker problem this repo has already paid for.
- **Preflight refs** — `scripts/sweep-preflight-refs.sh`, on PR close and weekly. It keeps any ref with a queued or in-progress run, keeps anything under an hour by commit date, and keeps whatever it cannot determine.
- **A dispatched run whose requester dies** — deliberately not reclaimed: free, self-terminating, bounded. The *ticket* is reclaimed immediately, because the driver notices its requester is gone and exits.

## Assumptions

- **Reparenting signals an abandoned requester.** True on darwin; a subreaper would break the inference, and the ancestor-liveness half still covers it.
- **A whole-suite count clears a narrowed caller's floor.** Floors are minimums with no ceiling or equality anywhere in `pre-push`, and the whole suite is a superset. Pinned by a test, since a ceiling there would invalidate adoption.
- **The sweep's age guard is weak, and is not what protects a live run.** The only age observable on a remote ref is its commit's date, which bounds age from below, not above — a commit authored yesterday and pushed a second ago reads as a day old, and that is the ordinary case. The live-run query is the real guard; age covers only the push→dispatch window, where no run exists to ask about.
- **CI never enables the valve**, so its filtered passes keep their floors.

## Evidence & verification

**The measurement is in the repo's own terms.** A read-only sampler over two hours produced the contention figures above; remote round-trip was measured from `test.yml`'s own history at p50 591s, p90 853s, max 1910s, with runner pickup at 2–3s.

**Harnesses**, all green, all fixture-isolated with a stub compiler and stub `gh` — no network, no real push, no real dispatch, no real compile:

- `scripts/test.test.sh` — **361** assertions (126 before this branch)
- `scripts/sweep-preflight-refs.test.sh` — **137**
- `scripts/remote-verify.test.sh` — **91**
- `scripts/nightly-flake-stress.test.sh` — **41**
- `scripts/test-remote-verify.py` — **114** tests
- `scripts/test-swift-safe.py` — **57** tests (29 before)

**Every guard is mutation-checked** — weakened, watched go red, restored — and the mutation expressions themselves were audited to confirm each still changes exactly one line after re-indentation.

**Four high-effort review passes** found 11, 7, 8 and 10 findings. Four would have failed on the soak's first day, and the design changed materially each round — the always-`preflight` rule, results-over-conclusion, and the narrowed-caller interpretation all came out of review rather than the original design. The fourth pass found nothing that reports success without tests running, nothing that reports failure for tests that did not fail, and no path that pushes or dispatches when it should refuse; its one Medium was a default-off leak, since fixed and re-verified against the repro that found it.

### What is NOT verified, and cannot be from a branch

**No real remote run has ever executed.** A `workflow_dispatch` trigger is not dispatchable until it exists on the default branch, so the entire dispatch path — `gh workflow run`, run correlation, artifact download — is proven only against stubs. That is the reason for shipping default-off: the first real exercise happens during the soak, deliberately, on a flag someone chose to set.

## Incidental fix

`scripts/nightly-flake-stress.test.sh` on `main` overrode `REPO_ROOT`, a variable that script never reads — it resolves wrappers through `$SCRIPT_DIR/`. So its stub was never reached, the case ran a **real** `swift-safe test` and held the machine-global slot for its deadline, and every assertion read an args file nothing had written. Vacuous and harmful, in a file whose header promises "ZERO BUILDS, ZERO CPU LOAD". Fixed here since this branch is what surfaced it.

## Known follow-ups, deliberately not in this PR

- **Pass the caller's narrowing through to the dispatch**, so a narrowed run gets a narrowed remote verdict. Until then a red whole-suite result costs a local re-run, and `pre-push`'s tier-3 floor stops catching a *vacuous* filter on an adopted green verdict (CI still catches a rename before merge). Such an input must be allowlisted and passed via `env`, never interpolated into `run:`.
- **Dedupe before dispatching.** Two lanes on the same commit each spend a dispatch against a two-run allowance. Adopting an in-flight run for the same sha has its own failure mode (a run dispatched from a different tree state) and needs its own design.
- **Ordering the local queue.** Measured and unaddressed: 53% of handoffs pass over a waiting lane.

Four Low findings from the last pass are known and accepted rather than fixed, each named here so they are not rediscovered as surprises: the ref-ownership check runs in the front-end rather than adjacent to the push, leaving a window bounded by one command timeout; run correlation keys on commit and event, so two lanes tripping on the identical commit can have one adopt the other's run (a capacity slip, not a wrong verdict); the sweep's live-run query reads the 50 most recent runs for a ref; and the narrowing detector does not match a glued single-character option (`-sFoo`), whose only instance is a deprecated flag no caller in the repo uses.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=68C0F549-84E5-44B9-A1CF-6642C94CAC12)
