### PR TITLE
DX: Let machine owners raise build parallelism past the 2-job cap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,12 @@ jobs:
     # steps already `tee` to /tmp on these runners.
     env:
       TBD_RETRY_METRICS_PATH: /tmp/retry-metrics.jsonl
+      # The ~7 GB runner's OOM cap, pinned HERE rather than inherited from
+      # `scripts/swift-safe`'s default — see the "Two parallel swift-frontend
+      # processes" block below. Job-level so all three `scripts/test.sh` steps
+      # get it; the bare `swift build -j 2` at the end of the job does not read
+      # this variable and names its own count.
+      TBD_SWIFT_JOBS: "2"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -214,12 +220,15 @@ jobs:
       # now — kept as safety margin; candidate for re-validation.
       #
       # The test steps below do NOT pass `-j` themselves: `scripts/swift-safe`,
-      # which `scripts/test.sh` runs SwiftPM through, supplies `--jobs 2` and
-      # refuses a command line above TBD_SWIFT_JOBS. Nothing sets that variable
-      # in this workflow, so the effective count here is the wrapper's 2 —
-      # unchanged — while a box whose owner lowered it is no longer failed by a
-      # hardcoded number. The bare `swift build` at the end of the job bypasses
-      # the wrapper, so it still names `-j 2` itself.
+      # which `scripts/test.sh` runs SwiftPM through, supplies `--jobs` from
+      # TBD_SWIFT_JOBS and refuses a command line above it. That variable is
+      # pinned to 2 in this job's `env:` block, so the cap above is stated
+      # explicitly here instead of riding on the wrapper's default — raising
+      # that default would otherwise lift CI past the runner's memory ceiling
+      # silently. A developer box, which sets its own TBD_SWIFT_JOBS, is no
+      # longer failed or throttled by a hardcoded number. The bare
+      # `swift build` at the end of the job bypasses the wrapper and does not
+      # read the variable, so it still names `-j 2` itself.
       #
       # Three sequential steps, one job (docs/specs/2026-07-24-test-hardening-design.md
       # §4): the tier-3 live suites live in their own target so they can run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,9 +127,9 @@ jobs:
       TBD_RETRY_METRICS_PATH: /tmp/retry-metrics.jsonl
       # The ~7 GB runner's OOM cap, pinned HERE rather than inherited from
       # `scripts/swift-safe`'s default — see the "Two parallel swift-frontend
-      # processes" block below. Job-level so all three `scripts/test.sh` steps
-      # get it; the bare `swift build -j 2` at the end of the job does not read
-      # this variable and names its own count.
+      # processes" block below. Job-level so every step gets it: the three
+      # `scripts/test.sh` steps through the wrapper, and the bare build at the
+      # end of the job by spelling `-j "$TBD_SWIFT_JOBS"`. One cap, one place.
       TBD_SWIFT_JOBS: "2"
     steps:
       - uses: actions/checkout@v4
@@ -226,9 +226,10 @@ jobs:
       # explicitly here instead of riding on the wrapper's default — raising
       # that default would otherwise lift CI past the runner's memory ceiling
       # silently. A developer box, which sets its own TBD_SWIFT_JOBS, is no
-      # longer failed or throttled by a hardcoded number. The bare
-      # `swift build` at the end of the job bypasses the wrapper and does not
-      # read the variable, so it still names `-j 2` itself.
+      # longer failed or throttled by a hardcoded number. The bare build at the
+      # end of the job bypasses the wrapper, so it spells the same variable on
+      # its own command line rather than repeating the number — one cap, one
+      # place to change it.
       #
       # Three sequential steps, one job (docs/specs/2026-07-24-test-hardening-design.md
       # §4): the tier-3 live suites live in their own target so they can run
@@ -452,4 +453,4 @@ jobs:
           if-no-files-found: warn
 
       - name: Build (verify TBDCLI and TBDDaemon executable targets compile)
-        run: swift build -j 2
+        run: swift build -j "$TBD_SWIFT_JOBS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,12 +206,20 @@ jobs:
             ls -la .build/*/debug/Modules/"$module".swiftmodule 2>/dev/null || echo "(absent)"
           done
 
-      # `-j 2` caps parallel swift-frontend processes on the ~7 GB runner.
+      # Two parallel swift-frontend processes is the cap on the ~7 GB runner.
       # Historically (Swift 6.2, all-per-file builds) default parallelism
       # OOMed late in the build with a bare `error: fatalError`. Under
       # Swift 6.3 the two big modules build WMO in debug (~1.35 GB peak
       # frontend RSS each, measured), so the cap is likely over-conservative
       # now — kept as safety margin; candidate for re-validation.
+      #
+      # The test steps below do NOT pass `-j` themselves: `scripts/swift-safe`,
+      # which `scripts/test.sh` runs SwiftPM through, supplies `--jobs 2` and
+      # refuses a command line above TBD_SWIFT_JOBS. Nothing sets that variable
+      # in this workflow, so the effective count here is the wrapper's 2 —
+      # unchanged — while a box whose owner lowered it is no longer failed by a
+      # hardcoded number. The bare `swift build` at the end of the job bypasses
+      # the wrapper, so it still names `-j 2` itself.
       #
       # Three sequential steps, one job (docs/specs/2026-07-24-test-hardening-design.md
       # §4): the tier-3 live suites live in their own target so they can run
@@ -347,7 +355,7 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
-          scripts/test.sh --fingerprint --parallel -j 2 --filter '^TBDDaemonTests\.' 2>&1 | tee /tmp/fast-pass-daemon.log
+          scripts/test.sh --fingerprint --parallel --filter '^TBDDaemonTests\.' 2>&1 | tee /tmp/fast-pass-daemon.log
           # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
           # with no summary line makes the first `grep` exit 1 and a failing
           # command substitution in an assignment kills the shell — so the
@@ -381,7 +389,7 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
-          scripts/test.sh --fingerprint --parallel -j 2 --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.' 2>&1 | tee /tmp/fast-pass-app.log
+          scripts/test.sh --fingerprint --parallel --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.' 2>&1 | tee /tmp/fast-pass-app.log
           # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
           # with no summary line makes the first `grep` exit 1 and a failing
           # command substitution in an assignment kills the shell — so the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,9 @@ The main chat session agent should not write code directly. Delegate all impleme
 - Run `scripts/test.sh` if you changed daemon or shared code. It fences the run
   against the developer's real `~/tbd` and `~/.claude` (see "Tests must not
   touch ~/tbd") and invokes SwiftPM through `scripts/swift-safe`, which
-  serializes builds across TBD worktrees and defaults to two compiler jobs;
+  serializes builds across TBD worktrees and defaults to two compiler jobs —
+  the machine's owner can raise that by exporting `TBD_SWIFT_JOBS` (builds are
+  serialized, so it is a machine-wide ceiling: e.g. 8 on a 12-core machine);
   raw `swift build/test/run` is blocked by the repo guardrail because
   concurrent default `-j12` builds can exhaust this development machine. The
   two wrappers are orthogonal — admission control and filesystem isolation —

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -126,15 +126,17 @@ Local SwiftPM `build`, `test`, and `run` compilation goes through
 `scripts/swift-safe`. It holds a
 kernel-managed, machine-global lock at `~/tbd/runtime/swift-build.lock`, so a
 fleet of TBD worktrees cannot compile simultaneously. Compile commands default
-to two jobs and rejects an explicit job count above that configured limit unless
-a developer opts out. Non-compiling `swift package` metadata and resolution
-commands do not enter the governor.
+to two jobs and reject an explicit job count above that configured limit.
+Non-compiling `swift package` metadata and resolution commands do not enter the
+governor.
 
-- `TBD_SWIFT_JOBS` sets the default and maximum job count (default `2`).
+- `TBD_SWIFT_JOBS` sets the job count (default `2`), honored at face value with
+  no ceiling. Because the lock already allows only one build at a time, this is
+  a bound on the whole machine's compiler parallelism, and exporting it is the
+  machine owner's consent — e.g. `8` on a 12-core laptop. A `-j`/`--jobs` on
+  the command line may lower it but not raise it; raise this instead.
 - `TBD_SWIFT_LOCK_TIMEOUT_SECONDS` sets the wait timeout (default `1800`).
 - `TBD_SWIFT_LOCK_PATH` overrides the shared lock path for isolated testing.
-- `TBD_SWIFT_ALLOW_HIGH_JOBS=1` permits an explicit higher job count on an
-  otherwise idle machine.
 - `TBD_SWIFT_ALLOW_ORPHAN=1` keeps a queued build waiting even after the
   process that requested it exits. A queued wrapper otherwise records its
   ancestor chain at startup and gives up as soon as any of those processes

--- a/docs/specs/2026-08-18-swift-safe-jobs-design.md
+++ b/docs/specs/2026-08-18-swift-safe-jobs-design.md
@@ -1,0 +1,138 @@
+# Compiler jobs under the machine-global build lock — design
+
+Status: **implemented**. Scope: `scripts/swift-safe` and its in-repo callers.
+
+## Problem
+
+Local SwiftPM `build`, `test`, and `run` compilation goes through
+`scripts/swift-safe`, which holds a kernel-managed, machine-global lock at
+`~/tbd/runtime/swift-build.lock`. That lock is the defense against the failure
+this wrapper exists for: a fleet of TBD worktrees, each running SwiftPM's
+default jobs-per-core build, saturating one development machine at once. While
+one worktree compiles, every other worktree queues.
+
+Bounding the sole lock holder's compiler jobs is a second defense against that
+same failure, and once the lock is in place it defends nothing the lock does
+not. Its cost is not local: throttling the one build allowed on a 12-core
+machine to two jobs makes that build several times longer, and because every
+other worktree is queued behind the lock, the extra minutes are paid by the
+whole fleet rather than by the worktree that is building. Test execution is not
+what makes a suite feel slow here — roughly 3,100 tests run in 15–20 seconds —
+so build time plus queue time is nearly all of the wall clock a contributor
+waits through.
+
+The bound therefore has to be something the machine's owner can set to fit the
+machine, rather than a number the repository picks for every machine.
+
+## Design
+
+### `TBD_SWIFT_JOBS` is honored at face value
+
+The wrapper reads `TBD_SWIFT_JOBS` and passes it to SwiftPM as `--jobs`. Any
+positive integer is accepted: there is no ceiling, and no second variable to
+export alongside it. Because the lock already guarantees at most one build on
+the machine, the variable is a bound on the whole machine's compiler
+parallelism, and setting it is the machine owner's decision to make.
+
+The default is **2**, deliberately unchanged by the freedom to raise it. A
+machine where nobody exports anything runs two-job builds, so a contributor who
+never opts in never meets a build that takes more of their machine than they
+asked for.
+
+### Persistence is the owner's shell profile
+
+There is no TBD-side store for the value. The owner exports it from their shell
+profile — `~/.zshenv` or equivalent — which reaches every worktree, every
+terminal, and every agent session on that machine. That single export is both
+the persistence mechanism and the consent gesture, and it lands at exactly the
+scope the value describes: one machine.
+
+### A command line may lower the bound, never raise it
+
+A `-j`/`--jobs` passed on the wrapper's own command line is accepted when it is
+at or below the configured bound and refused above it. A caller with a reason to
+be conservative — a script running alongside something memory-hungry, an agent
+that wants to leave headroom — can ask for less. A caller asking for more is
+asking to overrule the machine's owner, and is told to raise `TBD_SWIFT_JOBS`
+instead.
+
+### Typo protection is advisory
+
+Jobs beyond the core count buy memory pressure rather than throughput: each
+compiler frontend holds several hundred megabytes to about a gigabyte, so a
+stray digit costs a swapping machine and nothing else in the pipeline would
+report it. The wrapper emits one stderr line when the job count exceeds
+`os.cpu_count()`. It never refuses.
+
+Two rules keep that line honest:
+
+- It reports the count the build will **actually** use. When a command-line
+  `-j` lowers the effective count below the core count, nothing is said — the
+  warned-of build would not have happened.
+- It speaks only for a value somebody exported. The shipped default has nothing
+  to tell the owner of a one-core container, who set nothing and could not
+  silence it.
+
+A machine whose core count is unreadable has no ground to warn from, and says
+nothing.
+
+### Sizing guidance
+
+Match the machine. Past the core count there is no throughput to gain and real
+memory pressure to lose, and the machine is simultaneously running the app, the
+daemon, agent sessions, and SourceKit. On a 12-core machine, 8 is a sensible
+export: it uses most of the machine for the one build the lock permits while
+leaving headroom for everything that has to stay responsive during it.
+
+### Callers state no job count; CI pins its own
+
+No in-repo caller hardcodes a job count. `scripts/test.sh`, the pre-push hook,
+and the nightly flake-stress harness all reach SwiftPM through the wrapper and
+let it supply `--jobs`. A hardcoded number in any of them would both abort every
+run on a machine whose owner lowered the bound and pin the build at that number
+on a machine whose owner raised it.
+
+CI is the exception, and it is explicit rather than inherited. The runner has
+roughly 7 GB of memory and an OOM floor that two parallel compiler frontends
+sit under, so the workflow job sets `TBD_SWIFT_JOBS: "2"` in its own `env:`
+block; the one step that bypasses the wrapper spells `-j "$TBD_SWIFT_JOBS"`
+rather than repeating the number. CI's memory ceiling is a property of CI's
+hardware, so it belongs in CI's configuration — where it is visible next to the
+runner it constrains, and where a change to the wrapper's default constant
+cannot silently lift it.
+
+## Accepted limitation
+
+An environment variable can be set inline by any subprocess, so "the machine's
+owner consented" is a convention rather than an enforced property. The
+machine-global lock is what bounds the blast radius: whatever the value, at most
+one build on the machine is using it.
+
+## Rejected alternatives
+
+**A ceiling plus a second opt-out variable.** A hard ceiling on
+`TBD_SWIFT_JOBS`, with values above it refused unless a second variable is also
+exported, turns the documented knob into a refusal trap for the person it is
+documented for. The only protection it still offers past the lock is against a
+fat-fingered digit, which the advisory warning delivers without refusing
+anything. As a consent gesture it protects nothing further either: any process
+that can export one variable can export two.
+
+**A hard clamp at some multiple of the core count.** This refuses a value the
+owner deliberately chose, on the theory that they did not mean it. The failure
+it prevents is an oversubscribed single build — degradation, and self-inflicted
+— not the concurrent multi-build swarm the wrapper was built for, which the lock
+already prevents outright.
+
+**Owner state in a file under `~/tbd/`.** A file is not meaningfully more
+owner-only than an environment variable: any process running as the same user
+can write the file exactly as it can set the variable. It is heavier to
+implement, heavier to inspect, and it would split the wrapper's configuration
+across two surfaces when every other knob it has — the lock path, the wait
+timeout, the heartbeat interval, the orphan opt-out — is a `TBD_SWIFT_*`
+variable.
+
+**Raising the shipped default instead.** A higher default changes behavior on
+every contributor's machine, including small ones that cannot absorb it, and it
+interacts silently with CI's memory floor. Consent scales with the machine;
+a constant does not.

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -68,6 +68,14 @@ fi
 # collapsed target runs nothing and passes. The floors sit well below the real
 # counts (CI executes ~2194 + ~2342 fast, ~57 live) so ordinary test churn never
 # trips them; their job is to catch a collapse, not to track the population.
+#
+# Neither pass carries `-j`: the compile job count belongs to
+# `scripts/swift-safe`, which `scripts/test.sh` runs SwiftPM through. It
+# supplies the count itself (2 unless TBD_SWIFT_JOBS says otherwise) and
+# REFUSES a command line asking for more, so a hardcoded `-j 2` here would
+# abort every push on a box whose owner lowered that bound — and pin the build
+# at 2 on a box whose owner raised it. `--parallel` / `--no-parallel` and
+# `--filter` / `--skip` below are test-runner options, not build jobs, and stay.
 run_pass() {
   local label="$1" floor="$2" log; shift 2
   log="$(mktemp -t tbd-prepush-XXXXXXXX)"
@@ -97,7 +105,7 @@ run_pass() {
 }
 
 run_pass "fast parallel pass (scratch TBD_HOME fence)" 3700 \
-  --no-fingerprint --parallel -j 2 --skip '^TBDDaemonLiveTests\.'
+  --no-fingerprint --parallel --skip '^TBDDaemonLiveTests\.'
 
 run_pass "quiet pass (tier-3 live suites, serial)" 35 \
   --no-fingerprint --no-parallel --filter '^TBDDaemonLiveTests\.'

--- a/scripts/nightly-flake-stress.sh
+++ b/scripts/nightly-flake-stress.sh
@@ -54,11 +54,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # when a pass collapses to near-nothing, not to break every time somebody adds or
 # deletes a test. A floor pinned to the exact count would make ordinary test
 # churn look like a filter defect.
+#
+# No filter carries `-j`: the compile job count belongs to `scripts/swift-safe`,
+# which supplies it (2 by default) and refuses a command line asking for more
+# than TBD_SWIFT_JOBS allows. A hardcoded `-j 2` here would abort every
+# iteration on a box whose owner lowered that bound.
 TARGETS=(
-  "ControlModeInputHealth|--parallel -j 2 --filter ControlModeInputHealthTests|5|494|control-mode input health: two contention races"
+  "ControlModeInputHealth|--parallel --filter ControlModeInputHealthTests|5|494|control-mode input health: two contention races"
   "GitManagerTimeout|--no-parallel --filter ^TBDDaemonLiveTests\\.GitManagerTimeoutTests|3|503|60s hang at ~1/22 under heavy load, mechanism unknown"
-  "AppearanceDebounce|--parallel -j 2 --filter AppearanceDebounceTests|4|496|clock-driven wedge: megaYield at background QoS"
-  "FastPassWhole|--parallel -j 2 --skip ^TBDDaemonLiveTests\\.|3000|503|#503's actual reproduction shape: whole fast pass under load"
+  "AppearanceDebounce|--parallel --filter AppearanceDebounceTests|4|496|clock-driven wedge: megaYield at background QoS"
+  "FastPassWhole|--parallel --skip ^TBDDaemonLiveTests\\.|3000|503|#503's actual reproduction shape: whole fast pass under load"
 )
 
 DEFAULT_ITERATIONS=10
@@ -339,9 +344,13 @@ main() {
   # Build ONCE up front so the first iteration's timing is not dominated by the
   # compile. `swift build` alone does NOT build test targets — `--build-tests` does.
   echo
-  echo "building test targets (swift-safe build --build-tests -j 2)…"
+  echo "building test targets (swift-safe build --build-tests)…"
+  # No `-j`: `swift-safe` supplies the machine's job count itself (2 unless
+  # TBD_SWIFT_JOBS says otherwise) and REFUSES a command line above it, so a
+  # box whose owner lowered TBD_SWIFT_JOBS would fail this build for a reason
+  # that reads as a harness defect.
   if ! run_governed_swift "$BUILD_DEADLINE_S" "$work_dir/build.log" \
-    build --build-tests -j 2; then
+    build --build-tests; then
     echo "nightly-flake-stress: BUILD FAILED — see $work_dir/build.log" >&2
     tail -30 "$work_dir/build.log" >&2
     exit 2

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -12,9 +12,13 @@ guarantees at most one build on the machine, so the variable is a total-machine
 compiler bound and whoever owns the machine sets it.  A value above the
 machine's core count is honored too, with one stderr line saying so: jobs past
 the cores buy memory pressure rather than speed, and a typo would otherwise be
-invisible.  A ``-j``/``--jobs`` on the command line may lower it but not raise
-it — an agent that wants more parallelism is asking to overrule the machine
-owner, and should raise ``TBD_SWIFT_JOBS`` instead.
+invisible.  That line reports the count this build will actually use — never a
+configured bound a command-line ``-j`` then lowers, which would warn about a
+build that never happens — and only when ``TBD_SWIFT_JOBS`` was exported: the
+shipped default has nothing to say to the owner of a one-core container, who
+set nothing and could not silence it.  A ``-j``/``--jobs`` on the command line
+may lower it but not raise it — an agent that wants more parallelism is asking
+to overrule the machine owner, and should raise ``TBD_SWIFT_JOBS`` instead.
 
 Waiting is reported on stderr, never stdout, so a caller parsing SwiftPM's
 output sees nothing from this wrapper.  The holder writes ``pid``/``cwd``/
@@ -139,18 +143,31 @@ def _job_limit() -> int:
     # No ceiling on purpose: the machine-global lock means this is the whole
     # machine's compiler bound, and exporting the variable is its owner's
     # consent. A cap on top of serialization was doubly conservative.
-    limit = _positive_integer("TBD_SWIFT_JOBS", DEFAULT_JOBS)
-    # Say it, do not refuse it: past the core count the extra jobs only add
-    # memory pressure, so a stray digit costs a swapping machine and nothing
-    # else would report it. `os.cpu_count()` can answer None, and a machine
-    # that cannot count its own cores has no ground to warn from.
+    return _positive_integer("TBD_SWIFT_JOBS", DEFAULT_JOBS)
+
+
+def _report_jobs_past_the_core_count(effective: int) -> None:
+    """Say it, do not refuse it, once the effective job count is known.
+
+    Past the core count the extra jobs only add memory pressure, so a stray
+    digit costs a swapping machine and nothing else would report it.  Two
+    things keep the line honest.  It is given the count this build will really
+    run with, so a bound a command-line `-j` lowers is never warned about —
+    the warned-of build would not have happened.  And it speaks only for a
+    value somebody exported: the shipped default on a one-core machine would
+    otherwise name a variable its owner never set, with no way to silence it.
+    `os.cpu_count()` can answer None, and a machine that cannot count its own
+    cores has no ground to warn from.
+    """
+    if "TBD_SWIFT_JOBS" not in os.environ:
+        return
     cores = os.cpu_count()
-    if cores is not None and limit > cores:
+    if cores is not None and effective > cores:
         _report(
-            f"swift-safe: TBD_SWIFT_JOBS={limit} exceeds this machine's {cores} "
-            "CPU cores; jobs beyond core count add memory pressure without speedup"
+            f"swift-safe: this build will use {effective} jobs, past this "
+            f"machine's {cores} CPU cores; jobs beyond core count add memory "
+            "pressure without speedup"
         )
-    return limit
 
 
 def _requested_jobs(arguments: list[str]) -> int | None:
@@ -208,6 +225,7 @@ def _bounded_arguments(subcommand: str, arguments: list[str]) -> list[str]:
     )
     requested = _requested_jobs(job_arguments)
     if requested is None:
+        _report_jobs_past_the_core_count(limit)
         if subcommand == "run":
             return [subcommand, "--jobs", str(limit), *arguments]
         return [*result, "--jobs", str(limit)]
@@ -218,6 +236,7 @@ def _bounded_arguments(subcommand: str, arguments: list[str]) -> list[str]:
             f"requested SwiftPM --jobs {requested} exceeds TBD_SWIFT_JOBS={limit}; "
             "lower the command, or raise TBD_SWIFT_JOBS if you own this machine"
         )
+    _report_jobs_past_the_core_count(requested)
     return result
 
 

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -9,10 +9,12 @@ ownership is kernel-managed and is released when this process exits.
 Compile commands are given ``--jobs`` from ``TBD_SWIFT_JOBS`` (default 2).
 That value is honored at face value, with no ceiling: the lock already
 guarantees at most one build on the machine, so the variable is a total-machine
-compiler bound and whoever owns the machine sets it.  A ``-j``/``--jobs`` on
-the command line may lower it but not raise it — an agent that wants more
-parallelism is asking to overrule the machine owner, and should raise
-``TBD_SWIFT_JOBS`` instead.
+compiler bound and whoever owns the machine sets it.  A value above the
+machine's core count is honored too, with one stderr line saying so: jobs past
+the cores buy memory pressure rather than speed, and a typo would otherwise be
+invisible.  A ``-j``/``--jobs`` on the command line may lower it but not raise
+it — an agent that wants more parallelism is asking to overrule the machine
+owner, and should raise ``TBD_SWIFT_JOBS`` instead.
 
 Waiting is reported on stderr, never stdout, so a caller parsing SwiftPM's
 output sees nothing from this wrapper.  The holder writes ``pid``/``cwd``/
@@ -137,7 +139,18 @@ def _job_limit() -> int:
     # No ceiling on purpose: the machine-global lock means this is the whole
     # machine's compiler bound, and exporting the variable is its owner's
     # consent. A cap on top of serialization was doubly conservative.
-    return _positive_integer("TBD_SWIFT_JOBS", DEFAULT_JOBS)
+    limit = _positive_integer("TBD_SWIFT_JOBS", DEFAULT_JOBS)
+    # Say it, do not refuse it: past the core count the extra jobs only add
+    # memory pressure, so a stray digit costs a swapping machine and nothing
+    # else would report it. `os.cpu_count()` can answer None, and a machine
+    # that cannot count its own cores has no ground to warn from.
+    cores = os.cpu_count()
+    if cores is not None and limit > cores:
+        _report(
+            f"swift-safe: TBD_SWIFT_JOBS={limit} exceeds this machine's {cores} "
+            "CPU cores; jobs beyond core count add memory pressure without speedup"
+        )
+    return limit
 
 
 def _requested_jobs(arguments: list[str]) -> int | None:

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -6,6 +6,14 @@ prevents otherwise-independent Claude sessions from each starting a full
 Swift compiler swarm on the same laptop.  The file may remain on disk: flock
 ownership is kernel-managed and is released when this process exits.
 
+Compile commands are given ``--jobs`` from ``TBD_SWIFT_JOBS`` (default 2).
+That value is honored at face value, with no ceiling: the lock already
+guarantees at most one build on the machine, so the variable is a total-machine
+compiler bound and whoever owns the machine sets it.  A ``-j``/``--jobs`` on
+the command line may lower it but not raise it — an agent that wants more
+parallelism is asking to overrule the machine owner, and should raise
+``TBD_SWIFT_JOBS`` instead.
+
 Waiting is reported on stderr, never stdout, so a caller parsing SwiftPM's
 output sees nothing from this wrapper.  The holder writes ``pid``/``cwd``/
 ``command`` into the lock file after acquiring, and a waiter reads it back to
@@ -44,7 +52,6 @@ import time
 
 
 DEFAULT_JOBS = 2
-MAX_JOBS = 4
 DEFAULT_TIMEOUT_SECONDS = 1_800.0
 # Agent harnesses kill a session that emits nothing for 600s, and a queued
 # build used to be silent for the full 30-minute timeout.  One line a minute
@@ -127,13 +134,10 @@ def _positive_integer(name: str, default: int) -> int:
 
 
 def _job_limit() -> int:
-    value = _positive_integer("TBD_SWIFT_JOBS", DEFAULT_JOBS)
-    if value > MAX_JOBS and os.environ.get("TBD_SWIFT_ALLOW_HIGH_JOBS") != "1":
-        raise SystemExit(
-            f"TBD_SWIFT_JOBS={value} exceeds the safe local ceiling {MAX_JOBS}; "
-            "set TBD_SWIFT_ALLOW_HIGH_JOBS=1 only for an isolated machine"
-        )
-    return value
+    # No ceiling on purpose: the machine-global lock means this is the whole
+    # machine's compiler bound, and exporting the variable is its owner's
+    # consent. A cap on top of serialization was doubly conservative.
+    return _positive_integer("TBD_SWIFT_JOBS", DEFAULT_JOBS)
 
 
 def _requested_jobs(arguments: list[str]) -> int | None:
@@ -196,10 +200,10 @@ def _bounded_arguments(subcommand: str, arguments: list[str]) -> list[str]:
         return [*result, "--jobs", str(limit)]
     if requested <= 0:
         raise SystemExit("SwiftPM --jobs must be positive")
-    if requested > limit and os.environ.get("TBD_SWIFT_ALLOW_HIGH_JOBS") != "1":
+    if requested > limit:
         raise SystemExit(
             f"requested SwiftPM --jobs {requested} exceeds TBD_SWIFT_JOBS={limit}; "
-            "lower the command or explicitly set TBD_SWIFT_ALLOW_HIGH_JOBS=1"
+            "lower the command, or raise TBD_SWIFT_JOBS if you own this machine"
         )
     return result
 

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -108,8 +108,19 @@ class SwiftSafeTests(unittest.TestCase):
     def tearDown(self):
         self.temp.cleanup()
 
-    def run_runner(self, *arguments, **extra_env):
-        env = os.environ.copy()
+    def runner_env(self, **extra_env) -> dict[str, str]:
+        """The wrapper's environment with every knob it reads cleared first.
+
+        A developer who exported `TBD_SWIFT_JOBS` for their own machine — the
+        wrapper invites exactly that — must not decide what these cases
+        observe, or the default cases assert their job count instead of the
+        shipped one.  Each case states the settings it depends on itself.
+        """
+        env = {
+            name: value
+            for name, value in os.environ.items()
+            if not name.startswith("TBD_SWIFT_")
+        }
         env.update(
             {
                 "TBD_HOME": str(self.tbd_home),
@@ -117,11 +128,14 @@ class SwiftSafeTests(unittest.TestCase):
                 **extra_env,
             }
         )
+        return env
+
+    def run_runner(self, *arguments, **extra_env):
         return subprocess.run(
             [str(RUNNER), *arguments],
             text=True,
             capture_output=True,
-            env=env,
+            env=self.runner_env(**extra_env),
             check=False,
         )
 
@@ -145,10 +159,44 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "build -j 1")
 
+    def test_a_job_count_at_the_configured_limit_is_preserved(self):
+        result = self.run_runner("build", "-j", "8", TBD_SWIFT_JOBS="8")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build -j 8")
+
+    def test_an_exported_job_count_is_honored_at_face_value(self):
+        """The lock already caps the machine at one build, so no ceiling."""
+        result = self.run_runner("build", TBD_SWIFT_JOBS="8")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build --jobs 8")
+
+    def test_a_large_exported_job_count_is_honored_too(self):
+        """A big machine's owner sets the bound; the wrapper does not argue."""
+        result = self.run_runner("test", "--filter", "Foo", TBD_SWIFT_JOBS="34")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "test --filter Foo --jobs 34")
+
+    def test_zero_and_negative_exported_job_counts_are_rejected(self):
+        for value in ("0", "-1"):
+            with self.subTest(value=value):
+                result = self.run_runner("build", TBD_SWIFT_JOBS=value)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("must be positive", result.stderr)
+                self.assertEqual(result.stdout, "")
+
     def test_excessive_job_count_is_rejected(self):
+        """A command line may lower the machine owner's bound, never raise it."""
         result = self.run_runner("test", "-j12")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("exceeds TBD_SWIFT_JOBS=2", result.stderr)
+        self.assertIn("raise TBD_SWIFT_JOBS", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_a_raised_limit_admits_the_command_line_count_it_rejected(self):
+        """Same command, TBD_SWIFT_JOBS raised: the bound is the only gate."""
+        result = self.run_runner("test", "-j12", TBD_SWIFT_JOBS="12")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "test -j12")
 
     def test_fractional_default_job_count_is_rejected(self):
         result = self.run_runner("build", TBD_SWIFT_JOBS="2.5")
@@ -165,9 +213,7 @@ class SwiftSafeTests(unittest.TestCase):
             "#!/bin/sh\nprintf 'ready\\n'\nsleep 30\n",
             encoding="utf-8",
         )
-        env = os.environ.copy()
-        env.update({"TBD_HOME": str(self.tbd_home), "TBD_SWIFT_BIN": str(self.fake_swift)})
-        with _lock_holder(env):
+        with _lock_holder(self.runner_env()):
             result = self.run_runner(
                 "test", TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.05"
             )
@@ -224,14 +270,7 @@ class SwiftSafeTests(unittest.TestCase):
             "#!/bin/sh\nprintf 'ready\\n'\nsleep 30\n",
             encoding="utf-8",
         )
-        env = os.environ.copy()
-        env.update(
-            {
-                "TBD_HOME": str(self.tbd_home),
-                "TBD_SWIFT_BIN": str(self.fake_swift),
-            }
-        )
-        with _lock_holder(env, cwd=str(holder_directory)) as holder:
+        with _lock_holder(self.runner_env(), cwd=str(holder_directory)) as holder:
             result = self.run_runner(
                 "test",
                 TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.4",

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -186,7 +186,8 @@ class SwiftSafeTests(unittest.TestCase):
         result = self.run_runner("build", TBD_SWIFT_JOBS="9999")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "build --jobs 9999")
-        self.assertIn("TBD_SWIFT_JOBS=9999 exceeds this machine's", result.stderr)
+        self.assertIn("this build will use 9999 jobs", result.stderr)
+        self.assertIn("past this machine's", result.stderr)
         self.assertIn("CPU cores", result.stderr)
         self.assertIn("without speedup", result.stderr)
 
@@ -195,7 +196,41 @@ class SwiftSafeTests(unittest.TestCase):
         result = self.run_runner("build", TBD_SWIFT_JOBS="1")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "build --jobs 1")
-        self.assertNotIn("exceeds this machine's", result.stderr)
+        self.assertNotIn("past this machine's", result.stderr)
+
+    def test_a_command_line_lowering_the_count_silences_the_report(self):
+        """The line speaks for the build that runs, not for the bound it read.
+
+        `-j 2` is what SwiftPM is handed, so warning about the 9999 the
+        command line just lowered would name a build nobody asked for.
+        """
+        result = self.run_runner("build", "-j", "2", TBD_SWIFT_JOBS="9999")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build -j 2")
+        self.assertNotIn("past this machine's", result.stderr)
+        self.assertNotIn("9999", result.stderr)
+
+    def test_a_command_line_count_past_the_core_count_is_still_reported(self):
+        """Mutation guard: lowering the bound is not the same as being safe."""
+        result = self.run_runner("build", "-j", "9998", TBD_SWIFT_JOBS="9999")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build -j 9998")
+        self.assertIn("this build will use 9998 jobs", result.stderr)
+
+    def test_the_shipped_default_never_reports_on_any_machine(self):
+        """Nobody exported anything, so there is nobody to warn — and no knob.
+
+        This must hold on a one-core machine or container too, where the
+        shipped default of 2 is itself past the core count: a line naming
+        TBD_SWIFT_JOBS to someone who never set it is noise they cannot
+        silence.  Asserted with no `TBD_SWIFT_JOBS` in the environment at all,
+        which `runner_env` guarantees.
+        """
+        result = self.run_runner("build")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build --jobs 2")
+        self.assertNotIn("past this machine's", result.stderr)
+        self.assertNotIn("TBD_SWIFT_JOBS", result.stderr)
 
     def test_zero_and_negative_exported_job_counts_are_rejected(self):
         for value in ("0", "-1"):

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -176,6 +176,27 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "test --filter Foo --jobs 34")
 
+    def test_a_job_count_past_the_core_count_is_honored_but_reported(self):
+        """A typo'd digit is honored — and said out loud, on stderr only.
+
+        9999 is past any machine's cores, so what this asserts does not depend
+        on the machine running it; the core number itself is left unasserted
+        for the same reason.
+        """
+        result = self.run_runner("build", TBD_SWIFT_JOBS="9999")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build --jobs 9999")
+        self.assertIn("TBD_SWIFT_JOBS=9999 exceeds this machine's", result.stderr)
+        self.assertIn("CPU cores", result.stderr)
+        self.assertIn("without speedup", result.stderr)
+
+    def test_a_job_count_within_the_core_count_is_not_reported(self):
+        """Mutation guard: 1 is at or below every machine's core count."""
+        result = self.run_runner("build", TBD_SWIFT_JOBS="1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build --jobs 1")
+        self.assertNotIn("exceeds this machine's", result.stderr)
+
     def test_zero_and_negative_exported_job_counts_are_rejected(self):
         for value in ("0", "-1"):
             with self.subTest(value=value):
@@ -746,11 +767,21 @@ class OrphanedWrapperTests(unittest.TestCase):
         return condition()
 
     def wrapper_env(self, **extra_env) -> dict[str, str]:
-        env = os.environ.copy()
-        # A developer who exported the escape hatch — docs/reclaim-build.md
-        # invites it — must not silently disarm the check under test. The
-        # hatch case below sets it back explicitly.
-        env.pop("TBD_SWIFT_ALLOW_ORPHAN", None)
+        """The wrapper's environment with every knob it reads cleared first.
+
+        Same reason as `SwiftSafeTests.runner_env`, plus one specific to these
+        cases: an exported `TBD_SWIFT_JOBS` that is empty or not an integer
+        makes the wrapper exit during argument parsing, before it ever reaches
+        the wait loop — so the orphan check under test would never run and the
+        failure would read as a broken check rather than a stray variable. The
+        escape hatch goes with the rest; the hatch case below sets it back
+        explicitly, as does every setting this suite depends on.
+        """
+        env = {
+            name: value
+            for name, value in os.environ.items()
+            if not name.startswith("TBD_SWIFT_")
+        }
         env.update(
             {
                 "TBD_HOME": str(Path(self.temp.name) / "tbd"),

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -143,8 +143,8 @@
 # collision is impossible — `swift test` has no flag of either name — so
 # filtering them out everywhere is strictly safer at no cost. Last one wins.
 #   scripts/test.sh
-#   scripts/test.sh --parallel -j 2 --filter '^TBDDaemonTests\.'
-#   scripts/test.sh --no-fingerprint --parallel -j 2
+#   scripts/test.sh --parallel --filter '^TBDDaemonTests\.'
+#   scripts/test.sh --no-fingerprint --parallel
 #   scripts/test.sh --fingerprint            # deliberate local leak hunt
 #
 # TESTED BY `scripts/test.test.sh`, which drives the guards below against

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -587,7 +587,10 @@ test_detection_is_off_by_default_off_ci() {
 # Position-independent, last one wins, and neither flag reaches `swift test`.
 test_fingerprint_flags_are_consumed_and_last_wins() {
   local fix; fix="$(mkfix)"
-  RUN_ENV=(FAKE_SWIFT_LEAK="$fix/home/tbd/profiles")
+  # TBD_SWIFT_JOBS is pinned because the forwarded `-j 2` must clear
+  # swift-safe's bound: left unset it rides on that wrapper's DEFAULT_JOBS, and
+  # lowering that constant would red this case as if forwarding had broken.
+  RUN_ENV=(FAKE_SWIFT_LEAK="$fix/home/tbd/profiles" TBD_SWIFT_JOBS=2)
   run_wrapper "$fix" --parallel --fingerprint -j 2 --no-fingerprint
   assert_ok "a trailing --no-fingerprint wins" "$RUN_RC"
   assert_missing "flags are not forwarded to swift" "$(dump_of "$fix")" "fingerprint"

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -137,7 +137,12 @@ STUB
 #
 # The `-u` list matters: this harness may itself be running under a fenced
 # session, and an inherited TBD_HOME or TBD_SWIFT_LOCK_PATH would silently
-# change which branch of the lock resolution is under test.
+# change which branch of the lock resolution is under test. Every OTHER knob
+# `scripts/swift-safe` reads is cleared for the same reason — the cases below
+# run the REAL wrapper, so a developer's exported TBD_SWIFT_JOBS decides
+# whether a forwarded `-j 2` is admitted at all, and an exported timeout,
+# heartbeat or orphan hatch decides how the admission-lock cases wait.
+# TBD_SWIFT_BIN is the deliberate exception: this harness sets it itself, below.
 #
 # `TMUX_TMPDIR` is pinned rather than unset, and it stands in for the
 # DEVELOPER'S REAL socket directory: the wrapper overwrites it for the run, so
@@ -151,6 +156,8 @@ run_script() {
   local script="$1" fix="$2"; shift 2
   RUN_OUT="$(env -u CI -u TBD_HOME -u TBD_SOCKET_PATH -u TBD_CLAUDE_HOST_HOME \
                  -u TBD_TEST_CODEX_HOME -u TBD_SWIFT_LOCK_PATH -u CFFIXED_USER_HOME \
+                 -u TBD_SWIFT_JOBS -u TBD_SWIFT_LOCK_TIMEOUT_SECONDS \
+                 -u TBD_SWIFT_HEARTBEAT_SECONDS -u TBD_SWIFT_ALLOW_ORPHAN \
                  -u FAKE_SWIFT_DISARM -u FAKE_SWIFT_LEAK -u FAKE_SWIFT_RC \
                  -u FAKE_SWIFT_TMUX_SOCKETS \
                  ${RUN_ENV[@]+"${RUN_ENV[@]}"} \


### PR DESCRIPTION
## Summary

`scripts/swift-safe` serializes every local SwiftPM build behind a machine-global lock, and until now also capped the one running build at 2 compiler jobs — with values above 4 refused unless a second variable (`TBD_SWIFT_ALLOW_HIGH_JOBS=1`) was also exported. On a 12-core machine that left the single permitted build using 2 cores while every other worktree queued behind it.

`TBD_SWIFT_JOBS` is now honored at face value: any positive integer, default still 2, so contributors who set nothing see no change. Exporting it is the machine owner's consent — and because the admission lock already allows at most one build at a time, the value bounds the whole machine's compiler parallelism, not one worktree's. A command-line `-j`/`--jobs` may still lower the effective count but not raise it past the bound, and a one-line stderr note reports an exported value that pushes the effective count past the machine's cores.

## Why this shape

- The old ceiling and the lock were two defenses against the same incident (several worktrees each running concurrent default `-j12` builds), and they were redundant with each other: once builds are serialized, throttling the sole lock holder just slows every queued worktree behind it. Serialization stays; the per-build throttle becomes the owner's choice.
- The consent signal is a persistent shell export rather than a config file or per-invocation flag: it survives across worktrees and sessions, and the shipped default still protects any machine whose owner never opted in. Rejected: keeping a hard cap with an override variable — the handshake mainly guarded against a fat-fingered export, which the over-core-count warning now covers without refusing a deliberate value.
- Known and accepted: an env var can be set inline by any process, so "owner-only" is convention, not enforcement. The lock still bounds concurrency to one build, so the worst case of an inline raise is one hot build, not a swarm.
- Design: `docs/specs/2026-08-18-swift-safe-jobs-design.md`, transcribing the decisions made with the maintainer. Not flag-gated for the same reason (nothing autonomous or destructive; the default is unchanged). No new durable resources, so no reconciler question arises.

## What this PR does

- `scripts/swift-safe`: `_job_limit()` returns `TBD_SWIFT_JOBS` at face value (default 2); `MAX_JOBS` and `TBD_SWIFT_ALLOW_HIGH_JOBS` are deleted; the may-lower-not-raise rejection for a command-line `-j` remains, its message now pointing at `TBD_SWIFT_JOBS`; a stderr note reports an effective job count past `os.cpu_count()`, only when the value came from an explicit export.
- Every in-repo caller that hardcoded `-j 2` now lets the wrapper supply the count, since a hardcoded value both breaks under a lowered bound and pins the count under a raised one: the pre-push hook's fast pass, `scripts/nightly-flake-stress.sh` (up-front compile plus three target specs), and the CI workflow's two fast-pass steps. CI instead pins `TBD_SWIFT_JOBS: "2"` at job level — the ~7 GB runner's OOM cap expressed in one place — and the workflow's final bare compile step reads the same variable.
- Test hygiene: both harnesses (`scripts/test-swift-safe.py`, `scripts/test.test.sh`) scrub ambient `TBD_SWIFT_*` from their environments, so a developer's persistent export can't decide what default-expecting cases observe; the one case that genuinely forwards `-j 2` pins `TBD_SWIFT_JOBS=2` so it can't silently couple to the shipped default.
- Docs: the CLAUDE.md test-wrapper bullet and `docs/reclaim-build.md`'s admission section describe the single-variable model.

## Evidence & verification

- `python3 scripts/test-swift-safe.py`: 60 cases green, including discriminating new ones — an exported 8 (previously refused) composes `--jobs 8`; a command-line `-j` above the bound is still refused with the new message; the warning fires for an exported over-core value, stays silent for the shipped default on any machine including one core, and is silenced by a command line that lowers the count. Warning coverage was mutation-checked in both directions.
- `bash scripts/test.test.sh` green; `actionlint` on the edited workflow reports no new findings; `bash -n` clean on the touched shell scripts.
- Hardened through three rounds of fresh-context `/code-review high`: round 1 caught an env-hygiene leak the new persistent export would have caused in the harness itself; round 2 caught the pre-push hook aborting every `git push` on a lowered bound; round 3 caught the warning misfiring on command-line-lowered runs and one-core machines.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9FBDD42F-623F-4362-B281-2B4DB6D17344)

