### PR TITLE
Feat: Reclaim dev servers that outlive the worktree they were started in

### DIFF
--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -6,7 +6,10 @@ struct GCCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "gc",
         abstract: "Orphan GC: list reaps, restore a reaped agent worktree, trigger a sweep",
-        subcommands: [GCList.self, GCRestore.self, GCSweep.self, GCProfileDirs.self]
+        subcommands: [
+            GCList.self, GCRestore.self, GCSweep.self, GCProfileDirs.self,
+            GCOrphanProcesses.self,
+        ]
     )
 }
 
@@ -31,6 +34,29 @@ struct GCProfileDirs: AsyncParsableCommand {
     }
 }
 
+/// The soak switch for the orphaned-process collector. It is the one GC phase
+/// that signals processes rather than moving bytes, and what it misjudges
+/// cannot be restored, so it ships off and is opted into by hand — here rather
+/// than by editing `state.db`, which the project's own rules put out of bounds.
+struct GCOrphanProcesses: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "orphan-processes",
+        abstract: "Enable or disable reclaiming processes that outlived their worktree (default off)")
+    @Argument(help: "on | off") var state: String
+    mutating func run() async throws {
+        let enabled: Bool
+        switch state.lowercased() {
+        case "on", "true", "enable": enabled = true
+        case "off", "false", "disable": enabled = false
+        default: throw ValidationError("Expected 'on' or 'off', got: \(state)")
+        }
+        try SocketClient().callVoid(
+            method: RPCMethod.configSetGCOrphanProcessesEnabled,
+            params: ConfigSetGCOrphanProcessesEnabledParams(enabled: enabled))
+        print("Orphan-process GC \(enabled ? "enabled" : "disabled").")
+    }
+}
+
 struct GCList: AsyncParsableCommand {
     static let configuration = CommandConfiguration(commandName: "list", abstract: "List reap records")
     @Option(name: .long, help: "Filter by repo root path") var repo: String?
@@ -49,7 +75,14 @@ struct GCList: AsyncParsableCommand {
             // A quarantined reap has no restore path, so this is the only
             // handle a user has on the data before retention expires — print it.
             let quarantine = r.quarantinePath.map { "  quarantined→ \($0)" } ?? ""
-            print("\(r.id)  \(r.kind.rawValue)  \(r.worktreePath)  \(size)  \(snap)\(restored)\(quarantine)")
+            // An orphan-process reap removed nothing from disk, so its
+            // worktreePath alone says only where the process lived. The whole
+            // point of the field is to say WHAT was killed.
+            let process = r.processDescription.map { "  killed→ \($0)" } ?? ""
+            print("""
+            \(r.id)  \(r.kind.rawValue)  \(r.worktreePath)  \(size)  \
+            \(snap)\(restored)\(quarantine)\(process)
+            """)
         }
     }
 }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -68,6 +68,13 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// means "never chose" rather than "off". Resolve it through
     /// `Config.claudeCloudEnabledDefault`, never through `?? false`.
     var claude_cloud_enabled: Bool?
+    /// Gate for the orphaned-process collector
+    /// (design 2026-08-18). **Genuinely tri-state**, same shape as
+    /// `gc_profile_dirs_enabled`: the `v83_config_gc_orphan_processes` column
+    /// carries no SQL default, so `nil` here means "never chose" rather than
+    /// "off". Resolve it through `Config.gcOrphanProcessesEnabledDefault`,
+    /// never through `?? false`.
+    var gc_orphan_processes_enabled: Bool?
 
     /// - Parameter queuedPromptDefault: the shipped default a NULL
     ///   `queued_prompt_enabled` resolves to. Defaulted to the real constant;
@@ -83,11 +90,15 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// - Parameter claudeCloudEnabledDefault: same shape again, for the Claude
     ///   cloud gate — the parameter exists so tests can prove NULL follows a
     ///   changed default while an explicit `false` does not.
+    /// - Parameter gcOrphanProcessesDefault: same shape once more, for
+    ///   `gc_orphan_processes_enabled` — the orphaned-process collector's soak
+    ///   gate.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
         supervisionEnabledDefault: Bool = Config.supervisionEnabledDefault,
         gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault,
-        claudeCloudEnabledDefault: Bool = Config.claudeCloudEnabledDefault
+        claudeCloudEnabledDefault: Bool = Config.claudeCloudEnabledDefault,
+        gcOrphanProcessesDefault: Bool = Config.gcOrphanProcessesEnabledDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -137,7 +148,10 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // NOT `?? false`.
             gcProfileDirsEnabled: gc_profile_dirs_enabled ?? gcProfileDirsDefault,
             // Same reasoning again, for the Claude cloud gate — NOT `?? false`.
-            claudeCloudEnabled: claude_cloud_enabled ?? claudeCloudEnabledDefault
+            claudeCloudEnabled: claude_cloud_enabled ?? claudeCloudEnabledDefault,
+            // And once more, for the orphaned-process collector's gate —
+            // NOT `?? false`.
+            gcOrphanProcessesEnabled: gc_orphan_processes_enabled ?? gcOrphanProcessesDefault
         )
     }
 }
@@ -482,6 +496,19 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET gc_profile_dirs_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the orphaned-process collector gate (default OFF, soaking) —
+    /// read on top of the GC master switch, so both must be on for the phase to
+    /// run. The column is written on every call, because writing either value
+    /// is the explicit gesture that lifts it out of NULL forever after.
+    public func setGCOrphanProcessesEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_orphan_processes_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1514,6 +1514,20 @@ public final class TBDDatabase: Sendable {
                 columns: ["sessionID"], where: "sessionID IS NOT NULL")
         }
 
+        // Gate for `OrphanProcessCollector` — the reconciler for processes that
+        // outlived the worktree they were rooted in
+        // (docs/specs/2026-08-18-orphan-process-gc-design.md). Ships OFF: it is
+        // the first GC phase that signals processes rather than moving bytes,
+        // so it soaks behind its own switch. Tri-state like v73/v77/v78 — no
+        // SQL default, so a pre-migration row reads NULL ("never chose") rather
+        // than 0, and NULL resolves through
+        // `Config.gcOrphanProcessesEnabledDefault` in `ConfigRecord.toModel()`,
+        // the single place graduation changes.
+        migrator.registerMigration("v83_config_gc_orphan_processes") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "gc_orphan_processes_enabled", type: .boolean)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1528,6 +1528,16 @@ public final class TBDDatabase: Sendable {
                 table: "config", column: "gc_orphan_processes_enabled", type: .boolean)
         }
 
+        // What an `orphanProcess` reap killed: the pid and a truncated argv.
+        // Nullable and left NULL by every other kind, all of which describe a
+        // directory rather than a process. camelCase for the same reason
+        // v79 chose it — to match the columns this table already has
+        // (`repoPath`, `worktreePath`, `snapshotRef`, `quarantinePath`).
+        migrator.registerMigration("v84_reap_records_process_description") { db in
+            try db.addColumnIfMissing(
+                table: "reap_records", column: "processDescription", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/ReapRecordStore.swift
+++ b/Sources/TBDDaemon/Database/ReapRecordStore.swift
@@ -20,6 +20,9 @@ struct ReapRecordRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// Set by quarantining reaps (`profileDir`) only; NULL for kinds that
     /// delete outright.
     var quarantinePath: String?
+    /// Set by `orphanProcess` reaps only — the pid and a truncated argv of
+    /// what was killed. NULL for every directory-shaped kind.
+    var processDescription: String?
     var reapedAt: Date
     var restoredAt: Date?
 
@@ -33,6 +36,7 @@ struct ReapRecordRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.snapshotRef = record.snapshotRef
         self.apparentBytes = record.apparentBytes
         self.quarantinePath = record.quarantinePath
+        self.processDescription = record.processDescription
         self.reapedAt = record.reapedAt
         self.restoredAt = record.restoredAt
     }
@@ -60,6 +64,7 @@ struct ReapRecordRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             snapshotRef: snapshotRef,
             apparentBytes: apparentBytes,
             quarantinePath: quarantinePath,
+            processDescription: processDescription,
             reapedAt: reapedAt,
             restoredAt: restoredAt
         )

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -10,7 +10,8 @@ public enum OrphanGCError: LocalizedError, CustomStringConvertible, Equatable {
     /// No `ReapRecord` exists with the given id.
     case recordNotFound(UUID)
     /// `restore(recordID:)` only supports `.agentWorktree` records — scratchpads
-    /// have no restore path (there's nothing to recreate a bare tmp dir from).
+    /// have no restore path (there's nothing to recreate a bare tmp dir from),
+    /// and an `.orphanProcess` record describes a kill, which nothing can undo.
     case unsupportedKind(ReapKind)
     /// The record was already restored once; restoring twice would attempt to
     /// recreate a worktree that (probably) already exists on disk.
@@ -713,7 +714,19 @@ public actor OrphanGC {
         guard let record = try await db.reapRecords.get(id: recordID) else {
             throw OrphanGCError.recordNotFound(recordID)
         }
-        guard record.kind == .agentWorktree else {
+        // Exhaustive and default-less on purpose: a new `ReapKind` must not
+        // silently inherit either answer — it has to be classified here.
+        switch record.kind {
+        case .agentWorktree:
+            break
+        case .scratchpad, .archivedWorktree, .profileDir:
+            // Directory-shaped kinds with no way back: a bare tmp dir has
+            // nothing to recreate it from, an archived worktree's directory was
+            // drained, and a quarantined profile dir's row is already gone.
+            throw OrphanGCError.unsupportedKind(record.kind)
+        case .orphanProcess:
+            // A killed process cannot be restored at all. The record is an
+            // audit trail, not an undo.
             throw OrphanGCError.unsupportedKind(record.kind)
         }
         guard record.restoredAt == nil else {

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -83,6 +83,16 @@ public actor OrphanGC {
     /// deterministically. `nil` in production (both public inits omit it), so
     /// the sweep is unchanged there.
     private let beforeProfileDirReap: (@Sendable () async -> Void)?
+    /// Test seam for the pid-to-cwd half of the sweep's `lsof` pass. `nil` in
+    /// production, where the map comes from the same single pass that produces
+    /// `liveCWDsProvider`'s path list — no second subprocess, no per-pid
+    /// syscall.
+    private let processCWDsProvider: (@Sendable () async -> [Int32: String]?)?
+    /// Test seam for the `ps` snapshot. Returning `nil` means "the process
+    /// graph could not be determined", which skips the orphan-process phase —
+    /// never "there are no orphans".
+    private let processSnapshotProvider: (@Sendable () async -> [ProcessSnapshotEntry]?)?
+    private let orphanProcessCollector: OrphanProcessCollector
 
     /// Production seam: an injected `lsofProvider` returns a non-optional
     /// `[String]` — by definition authoritative, it can't signal
@@ -95,7 +105,8 @@ public actor OrphanGC {
         scratchpadBase: URL? = nil,
         now: (@Sendable () -> Date)? = nil,
         profileDirBase: URL? = nil,
-        credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain()
+        credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
+        signaller: any ProcessSignaller = ProductionProcessSignaller()
     ) {
         var wrapped: (@Sendable () async -> [String]?)?
         if let lsofProvider {
@@ -104,7 +115,8 @@ public actor OrphanGC {
         self.init(
             db: db, git: git, broadcast: broadcast, liveCWDsProvider: wrapped,
             scratchpadBase: scratchpadBase, now: now,
-            profileDirBase: profileDirBase, credentialsKeychain: credentialsKeychain
+            profileDirBase: profileDirBase, credentialsKeychain: credentialsKeychain,
+            signaller: signaller
         )
     }
 
@@ -123,7 +135,13 @@ public actor OrphanGC {
         beforeInterruptedArchiveReap: (@Sendable () async -> Void)? = nil,
         profileDirBase: URL? = nil,
         credentialsKeychain: any ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
-        beforeProfileDirReap: (@Sendable () async -> Void)? = nil
+        beforeProfileDirReap: (@Sendable () async -> Void)? = nil,
+        processCWDsProvider: (@Sendable () async -> [Int32: String]?)? = nil,
+        processSnapshotProvider: (@Sendable () async -> [ProcessSnapshotEntry]?)? = nil,
+        signaller: any ProcessSignaller = ProductionProcessSignaller(),
+        orphanProcessGraceAttempts: Int = 30,
+        orphanProcessPollInterval: Duration = .milliseconds(100),
+        clock: any Clock<Duration> = ContinuousClock()
     ) {
         let resolvedNow = now ?? Date.init
         let resolvedScratchpadBase = scratchpadBase ?? TBDConstants.claudeScratchpadBase
@@ -149,6 +167,13 @@ public actor OrphanGC {
         self.deletionQueueCollector = DeletionQueueCollector(git: git, now: resolvedNow)
         self.profileDirCollector = ProfileDirCollector(
             base: resolvedProfileDirBase, now: resolvedNow)
+        self.processCWDsProvider = processCWDsProvider
+        self.processSnapshotProvider = processSnapshotProvider
+        self.orphanProcessCollector = OrphanProcessCollector(
+            signaller: signaller, now: resolvedNow,
+            graceAttempts: orphanProcessGraceAttempts,
+            pollInterval: orphanProcessPollInterval,
+            clock: clock)
     }
 
     // MARK: - Sweep
@@ -173,7 +198,8 @@ public actor OrphanGC {
         for repo in repos {
             let candidates = await agentCollector.candidates(repoPath: repo.path)
             for candidate in candidates {
-                switch await agentCollector.decide(candidate, liveCWDs: live, graceSeconds: config.gcGraceSeconds) {
+                switch await agentCollector.decide(
+                    candidate, liveCWDs: live.paths, graceSeconds: config.gcGraceSeconds) {
                 case .keep(let reason):
                     planned.append("KEEP \(reason) \(candidate.path)")
                     logger.debug("gc: keep \(reason, privacy: .public) \(candidate.path, privacy: .public)")
@@ -182,7 +208,8 @@ public actor OrphanGC {
                     // The outer `gcEnabled || dryRun` guard means a non-dry
                     // run here always has gcEnabled == true.
                     guard !dryRun else { continue }
-                    if let record = await agentCollector.reap(candidate, freshLiveCWDs: { await self.liveCWDs() }) {
+                    if let record = await agentCollector.reap(
+                        candidate, freshLiveCWDs: { await self.liveCWDs()?.paths }) {
                         await insertReapRecord(record)
                         reaped += 1
                         logger.info("""
@@ -212,7 +239,7 @@ public actor OrphanGC {
         let archived = (try? await db.worktrees.list(status: .archived)) ?? []
 
         await reclaimDeletionQueue(
-            repos: repos, archived: archived, live: live,
+            repos: repos, archived: archived, live: live.paths,
             graceSeconds: config.gcGraceSeconds, dryRun: dryRun,
             planned: &planned, reaped: &reaped
         )
@@ -224,6 +251,11 @@ public actor OrphanGC {
 
         await reclaimProfileDirs(
             config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
+        )
+
+        await reclaimOrphanProcesses(
+            config: config, repos: repos, archived: archived, live: live,
+            dryRun: dryRun, planned: &planned, reaped: &reaped
         )
 
         // Snapshot retention never runs in dryRun; the outer guard already
@@ -630,6 +662,138 @@ public actor OrphanGC {
         }
     }
 
+    // MARK: - Orphaned processes
+
+    /// Reclaims processes that outlived the worktree they were rooted in —
+    /// `disown`ed and `nohup`ed jobs reparented to launchd, which no pane,
+    /// tmux server or `AgentReaper` structure can reach
+    /// (`docs/specs/2026-08-18-orphan-process-gc-design.md`).
+    ///
+    /// Gated by `gcOrphanProcessesEnabled` on top of `gcEnabled`, the same
+    /// shape `reclaimProfileDirs` uses and for the same reason: this is the
+    /// only GC phase that signals processes rather than moving bytes, and what
+    /// it misjudges cannot be restored. `dryRun` bypasses the flag exactly as
+    /// `sweep` lets it bypass `gcEnabled` — someone deciding whether to enable
+    /// a default-off flag needs to see what enabling it would reclaim first —
+    /// and touches nothing either way.
+    ///
+    /// Both inputs skip the phase rather than proceeding on a partial picture:
+    /// a `ps` snapshot that could not be taken, and a database read that
+    /// failed. That is the keep-favoring direction every other gate in this
+    /// sweep takes.
+    private func reclaimOrphanProcesses(
+        config: Config, repos: [Repo], archived: [Worktree], live: LiveCWDs,
+        dryRun: Bool, planned: inout [String], reaped: inout Int
+    ) async {
+        guard config.gcOrphanProcessesEnabled || dryRun else { return }
+
+        guard let processes = await processSnapshot() else {
+            logger.error("gc: ps unavailable this sweep — skipping the orphan-process phase")
+            planned.append("KEEP ps-unavailable orphan-processes")
+            return
+        }
+        guard let liveRows = try? await db.worktrees.listLocal(excludeArchived: true) else {
+            logger.warning("gc: orphan-process phase skipped — DB read failed")
+            return
+        }
+
+        let (roots, repoPathByPool) = orphanProcessRoots(
+            repos: repos, archived: archived, liveRows: liveRows)
+        let candidates = orphanProcessCollector.candidates(
+            processes: processes,
+            cwdByPID: live.cwdByPID,
+            roots: roots,
+            ourUID: getuid(),
+            ourPID: getpid(),
+            graceSeconds: config.gcGraceSeconds
+        )
+        guard !candidates.isEmpty else { return }
+
+        let protected = orphanProcessCollector.protectedPIDs(
+            processes: processes, ourPID: getpid())
+        for candidate in candidates {
+            let tree = orphanProcessCollector.descendantClosure(
+                of: candidate.pid, processes: processes, protected: protected)
+            planned.append(
+                "REAP orphan-process pid=\(candidate.pid) tree=\(tree.count) \(candidate.rootPath)")
+            // This phase's guard is `gcOrphanProcessesEnabled || dryRun`, so
+            // every line below runs only with the flag actually on.
+            guard !dryRun else { continue }
+            guard let record = await orphanProcessCollector.reap(
+                candidate, tree: tree,
+                repoPath: Self.repoPath(forRoot: candidate.rootPath, in: repoPathByPool)
+            ) else {
+                planned.append("KEEP empty-subtree \(candidate.rootPath)")
+                continue
+            }
+            await insertReapRecord(record)
+            reaped += 1
+        }
+    }
+
+    /// The TBD-managed path universe this sweep classifies cwds against, plus
+    /// a pool-to-repo map so a reap record can still name the owning repo.
+    ///
+    /// Every path goes through `DeletionQueueCollector.resolvedPath`, which
+    /// walks up to the deepest ancestor that exists and canonicalizes that.
+    /// Both sides have to be resolved because `lsof` reports fully resolved
+    /// paths (`/private/var/...`), and a plain `realpath` would resolve nothing
+    /// for an archived row whose directory is already gone.
+    private func orphanProcessRoots(
+        repos: [Repo], archived: [Worktree], liveRows: [LocalWorktree]
+    ) -> (TBDProcessRoots, [String: String]) {
+        let layout = WorktreeLayout()
+        var pools: [String] = []
+        var repoPathByPool: [String: String] = [:]
+        for repo in repos {
+            for prefix in layout.legacyAndCanonicalPrefixes(for: repo) {
+                let resolved = deletionQueueCollector.resolvedPath(prefix)
+                pools.append(resolved)
+                repoPathByPool[resolved] = repo.path
+            }
+        }
+        // Scratch worktrees and Claude scratchpads are TBD-managed roots too,
+        // and belong to no repo — hence no `repoPathByPool` entry, which stamps
+        // the record with `""` the same way the scratchpad phase does.
+        pools.append(deletionQueueCollector.resolvedPath(TBDConstants.scratchDir.path))
+        pools.append(deletionQueueCollector.resolvedPath(scratchpadBase.path))
+
+        let livePaths = liveRows.map { deletionQueueCollector.resolvedPath($0.path) }
+        let deadRoots = archived
+            .compactMap(LocalWorktree.init)
+            .map {
+                DeadWorktreeRoot(
+                    path: deletionQueueCollector.resolvedPath($0.path),
+                    archivedAt: $0.archivedAt)
+            }
+        return (
+            TBDProcessRoots(pools: pools, live: livePaths, dead: deadRoots),
+            repoPathByPool
+        )
+    }
+
+    /// The repo whose pool owns `root`, or `""` when none does (a scratch
+    /// worktree, a scratchpad, or a repo row that has since been removed).
+    /// Longest matching pool wins, so nested pools resolve to the inner one.
+    private static func repoPath(forRoot root: String, in repoPathByPool: [String: String]) -> String {
+        var best: (pool: String, repo: String)?
+        for (pool, repo) in repoPathByPool where root == pool || root.hasPrefix(pool + "/") {
+            if best == nil || pool.count > best!.pool.count {
+                best = (pool, repo)
+            }
+        }
+        return best?.repo ?? ""
+    }
+
+    /// One `ps` snapshot per sweep, or `nil` when it could not be taken —
+    /// which skips the orphan-process phase, never "there are no orphans".
+    private func processSnapshot() async -> [ProcessSnapshotEntry]? {
+        if let processSnapshotProvider {
+            return await processSnapshotProvider()
+        }
+        return await OrphanProcessCollector.realProcessSnapshot()
+    }
+
     /// Entry point for `repo.remove` (review Medium 2): `db.worktrees.deleteForRepo`
     /// deletes EVERY worktree row for `repoID` — every status, including
     /// archived — with no further chance for the sweep's own reconciliation
@@ -801,9 +965,18 @@ public actor OrphanGC {
     /// `nil` when that can't be determined reliably (lsof timed out or failed
     /// to spawn) — callers MUST treat `nil` as "skip the sweep", never as
     /// "no live processes".
-    private func liveCWDs() async -> [String]? {
+    private func liveCWDs() async -> LiveCWDs? {
         if let liveCWDsProvider {
-            return await liveCWDsProvider()
+            guard let paths = await liveCWDsProvider() else { return nil }
+            // Two seams rather than one so every existing test keeps injecting
+            // a plain `[String]`. An injected path list with no injected map
+            // yields an EMPTY map, which makes the orphan-process phase find no
+            // candidates — the keep-favoring reading. It is never read as "this
+            // process is not in a worktree", because candidacy requires a cwd
+            // that IS under a dead root; a missing entry can only subtract.
+            guard let processCWDsProvider else { return LiveCWDs(paths: paths, cwdByPID: [:]) }
+            guard let map = await processCWDsProvider() else { return nil }
+            return LiveCWDs(paths: paths, cwdByPID: map)
         }
         return await Self.realLiveCWDs()
     }
@@ -811,7 +984,7 @@ public actor OrphanGC {
     /// Real `lsof`-backed live-cwd provider: runs `lsof -d cwd -Fn` under a
     /// 60s deadline and hands the outcome to `parseLiveCWDs`. A spawn failure
     /// is the same "unavailable" sentinel as a timeout: `nil`, skip the sweep.
-    private static func realLiveCWDs() async -> [String]? {
+    private static func realLiveCWDs() async -> LiveCWDs? {
         let outcome: BoundedProcessOutcome
         do {
             outcome = try await runBoundedProcess(
@@ -841,7 +1014,7 @@ public actor OrphanGC {
     /// - non-zero exit: lsof's output on failure is not a complete cwd
     ///   picture, so it gets the same keep-biased treatment as a timeout.
     /// - non-UTF-8 stdout: unparseable output is no picture at all.
-    static func parseLiveCWDs(_ outcome: BoundedProcessOutcome) -> [String]? {
+    static func parseLiveCWDs(_ outcome: BoundedProcessOutcome) -> LiveCWDs? {
         switch outcome {
         case .timedOut:
             logger.error("gc: lsof timed out after 60s")
@@ -857,16 +1030,44 @@ public actor OrphanGC {
             }
             var seen = Set<String>()
             var result: [String] = []
+            var cwdByPID: [Int32: String] = [:]
+            // The `p<pid>` header the old parser discarded. Retaining it yields
+            // a pid-to-cwd map for every process on the machine at no
+            // additional cost, which is what the orphan-process phase runs on.
+            var currentPID: Int32?
             for line in text.split(separator: "\n") {
+                if line.hasPrefix("p") {
+                    currentPID = Int32(line.dropFirst())
+                    continue
+                }
                 guard line.hasPrefix("n") else { continue }
                 let raw = String(line.dropFirst())
                 guard !raw.isEmpty else { continue }
                 let canonical = AgentWorktreeCollector.canon(raw)
+                if let pid = currentPID {
+                    cwdByPID[pid] = canonical
+                }
                 if seen.insert(canonical).inserted {
                     result.append(canonical)
                 }
             }
-            return result
+            return LiveCWDs(paths: result, cwdByPID: cwdByPID)
         }
     }
+}
+
+/// One sweep's reading of `lsof -d cwd -Fn`, in both shapes its consumers
+/// need: the deduped path list the directory collectors gate on, and the
+/// pid-to-cwd map the orphan-process collector classifies against. Both come
+/// from the SAME single pass — the pid header was always in the output and was
+/// simply discarded.
+///
+/// The whole value being `nil` is the "unavailable" sentinel that skips the
+/// sweep. It is never partially available: a timeout, a non-zero exit or
+/// unparseable output invalidate both halves together.
+struct LiveCWDs: Sendable, Equatable {
+    /// Canonicalized cwds, deduped, in first-seen order.
+    var paths: [String]
+    /// Canonicalized cwd per pid.
+    var cwdByPID: [Int32: String]
 }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -687,17 +687,16 @@ public actor OrphanGC {
     /// sweep takes.
     ///
     /// Both row reads happen HERE rather than being handed down from `sweep`,
-    /// and both are read back to back. The sweep's own `archived` list is taken
-    /// before the deletion-queue, scratchpad and profile-dir phases have run —
-    /// `du` shells and Keychain calls, so a wide window — and a worktree
-    /// archived inside that window would be missing from the old `archived`
-    /// list and already excluded from the fresh live list. It would then fall
-    /// through to the "absent from the database" arm and be graced from
-    /// process start instead of from `archivedAt`, which is the weaker gate,
-    /// on the exact row whose grace was just supposed to begin. Reading both
-    /// together closes that. A failure on either read skips the phase, where
-    /// `sweep`'s `try? … ?? []` would have read "no archived worktrees" — the
-    /// same silent weakening by another route.
+    /// and back to back, so the live list and the archived list are one view of
+    /// one instant. The sweep's own `archived` list is taken before the
+    /// deletion-queue, scratchpad and profile-dir phases have run — `du` shells
+    /// and Keychain calls, so a wide window — and a worktree archived inside
+    /// that window would be missing from the old `archived` list while already
+    /// excluded from the fresh live list, leaving the phase to judge it on two
+    /// readings that disagree. Reading both together closes that. A failure on
+    /// either read skips the phase and says so, where `sweep`'s `try? … ?? []`
+    /// would have read "no archived worktrees" and reported a clean sweep of a
+    /// phase that never ran.
     private func reclaimOrphanProcesses(
         config: Config, repos: [Repo], live: LiveCWDs,
         dryRun: Bool, planned: inout [String], reaped: inout Int
@@ -803,12 +802,14 @@ public actor OrphanGC {
         // one directory there per project it has ever run in, and TBD manages
         // almost none of them — a single census of one developer machine found
         // 86 entries, of which 9 named no worktree at all (plain checkouts, a
-        // home directory, and loose files). Listing it as a pool would put
-        // every one of those in the "absent from the database" arm and make a
-        // stranger's live session reclaimable. `ScratchpadCollector.reconcile`
-        // already takes the whitelist side here for a merely destructive
-        // operation ("Unrelated directories in the base are untouched"); this
-        // phase kills processes, so it takes the same side.
+        // home directory, and loose files). A pool is where TBD's own
+        // `.deleting/` queues live and the only place an entry carrying no row
+        // is reclaimable at all; TBD queues no deletions here, so listing this
+        // base as a pool would extend that claim over a tree that is mostly
+        // other software's. `ScratchpadCollector.reconcile` already takes the
+        // whitelist side here for a merely destructive operation ("Unrelated
+        // directories in the base are untouched"); this phase kills processes,
+        // so it takes the same side.
         var sharedRoots = [deletionQueueCollector.resolvedPath(scratchpadBase.path)]
 
         // `adoptWorktree` inserts a row at a path the user chose, so an adopted
@@ -819,17 +820,14 @@ public actor OrphanGC {
         // close, for that whole class of worktree.
         //
         // The row's own path goes in as a SHARED root, never as a pool, and
-        // never its parent directory. A pool means "TBD owns every child
-        // outright, so a stray here is TBD's", which is false of a directory
-        // the user picked: its neighbours are a home directory's, a projects
-        // folder's, someone else's checkouts. Admitting the parent as a pool —
-        // or the path as one, which for a nested layout amounts to the same
-        // widening — would put every one of those neighbours in the
-        // "absent from the database" arm and make a stranger's live session
-        // reclaimable, the same mistake the Claude scratchpad base is listed
-        // above to avoid. A shared root classifies only what an explicit
-        // `live`/`dead` entry names, which is precisely the adopted worktree
-        // itself and nothing beside it.
+        // never its parent directory. A pool means "TBD owns this tree
+        // outright" — it is where TBD's own `.deleting/` queues live, and the
+        // only place an entry carrying no row is reclaimable at all — and that
+        // is false of a directory the user picked: its neighbours are a home
+        // directory's, a projects folder's, someone else's checkouts. A shared
+        // root classifies only what an explicit `live`/`dead` entry names,
+        // which is precisely the adopted worktree itself and nothing beside
+        // it, the same line the Claude scratchpad base above is drawn on.
         //
         // `reclaimDeletionQueue` widens its own set from adopted rows for the
         // same reason; it can take the parent because draining a `.deleting/`
@@ -851,9 +849,9 @@ public actor OrphanGC {
         // A worktree's Claude scratchpad answers to the same owner as the
         // worktree itself — `ScratchpadCollector`'s slug is derived from the
         // worktree path, so the owner is always recoverable. Classifying the
-        // scratchpad alongside its worktree is what keeps a live worktree's
-        // scratchpad out of the "absent from the database" arm, where it would
-        // otherwise become reclaimable while the work is still going on.
+        // scratchpad alongside its worktree is what makes an archived
+        // worktree's scratchpad reclaimable and a live one's explicitly not,
+        // rather than leaving a directory the sweep can see go unjudged.
         func scratchpadPath(forWorktreePath path: String) -> String {
             deletionQueueCollector.resolvedPath(
                 scratchpadBase.appendingPathComponent(

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -761,7 +761,9 @@ public actor OrphanGC {
         let layout = WorktreeLayout()
         var pools: [String] = []
         var repoPathByPool: [String: String] = [:]
+        var repoPathByID: [UUID: String] = [:]
         for repo in repos {
+            repoPathByID[repo.id] = repo.path
             for prefix in layout.legacyAndCanonicalPrefixes(for: repo) {
                 let resolved = deletionQueueCollector.resolvedPath(prefix)
                 pools.append(resolved)
@@ -782,7 +784,44 @@ public actor OrphanGC {
         // already takes the whitelist side here for a merely destructive
         // operation ("Unrelated directories in the base are untouched"); this
         // phase kills processes, so it takes the same side.
-        let sharedRoots = [deletionQueueCollector.resolvedPath(scratchpadBase.path)]
+        var sharedRoots = [deletionQueueCollector.resolvedPath(scratchpadBase.path)]
+
+        // `adoptWorktree` inserts a row at a path the user chose, so an adopted
+        // worktree sits under no pool at all. `ownership(ofCWD:roots:)` gates on
+        // pool-or-shared-root membership BEFORE it consults `dead`, so without
+        // an entry here a process inside an archived adopted worktree would
+        // classify `.outside` forever — the exact leak this phase exists to
+        // close, for that whole class of worktree.
+        //
+        // The row's own path goes in as a SHARED root, never as a pool, and
+        // never its parent directory. A pool means "TBD owns every child
+        // outright, so a stray here is TBD's", which is false of a directory
+        // the user picked: its neighbours are a home directory's, a projects
+        // folder's, someone else's checkouts. Admitting the parent as a pool —
+        // or the path as one, which for a nested layout amounts to the same
+        // widening — would put every one of those neighbours in the
+        // "absent from the database" arm and make a stranger's live session
+        // reclaimable, the same mistake the Claude scratchpad base is listed
+        // above to avoid. A shared root classifies only what an explicit
+        // `live`/`dead` entry names, which is precisely the adopted worktree
+        // itself and nothing beside it.
+        //
+        // `reclaimDeletionQueue` widens its own set from adopted rows for the
+        // same reason; it can take the parent because draining a `.deleting/`
+        // entry TBD itself renamed needs no provenance gate, while killing a
+        // process does.
+        for row in liveRows + archived.compactMap(LocalWorktree.init) {
+            let resolved = deletionQueueCollector.resolvedPath(row.path)
+            guard !pools.contains(where: { Self.isUnder(resolved, prefix: $0) }) else { continue }
+            sharedRoots.append(resolved)
+            // No pool contains this path, so `repoPath(forRoot:in:)` would
+            // stamp the reap record with `""`. The row names its repo directly,
+            // so map the worktree path itself; longest-prefix lookup means the
+            // entry answers for exactly this worktree and nothing above it.
+            if let repoID = row.repoID, let repoPath = repoPathByID[repoID] {
+                repoPathByPool[resolved] = repoPath
+            }
+        }
 
         // A worktree's Claude scratchpad answers to the same owner as the
         // worktree itself — `ScratchpadCollector`'s slug is derived from the
@@ -828,6 +867,15 @@ public actor OrphanGC {
             }
         }
         return best?.repo ?? ""
+    }
+
+    /// `path` is `prefix` itself or strictly below it. Component-wise, so
+    /// `/a/pool-2` is never read as living under `/a/pool` — the same rule
+    /// `OrphanProcessCollector` classifies with, so a row this method judges
+    /// pool-covered is exactly one the collector would too.
+    private static func isUnder(_ path: String, prefix: String) -> Bool {
+        guard !prefix.isEmpty else { return false }
+        return path == prefix || path.hasPrefix(prefix.hasSuffix("/") ? prefix : prefix + "/")
     }
 
     /// One `ps` snapshot per sweep, or `nil` when it could not be taken —

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -88,10 +88,12 @@ public actor OrphanGC {
     /// `liveCWDsProvider`'s path list — no second subprocess, no per-pid
     /// syscall.
     private let processCWDsProvider: (@Sendable () async -> [Int32: String]?)?
-    /// Test seam for the `ps` snapshot. Returning `nil` means "the process
-    /// graph could not be determined", which skips the orphan-process phase —
-    /// never "there are no orphans".
-    private let processSnapshotProvider: (@Sendable () async -> [ProcessSnapshotEntry]?)?
+    /// The `ps` snapshot reader. Returning `nil` means "the process graph
+    /// could not be determined", which skips the orphan-process phase — never
+    /// "there are no orphans". Injected in tests; the real `/bin/ps` reader in
+    /// production. The same closure is handed to `OrphanProcessCollector`,
+    /// which re-reads through it immediately before each signal volley.
+    private let processSnapshotProvider: @Sendable () async -> [ProcessSnapshotEntry]?
     private let orphanProcessCollector: OrphanProcessCollector
 
     /// Production seam: an injected `lsofProvider` returns a non-optional
@@ -168,9 +170,11 @@ public actor OrphanGC {
         self.profileDirCollector = ProfileDirCollector(
             base: resolvedProfileDirBase, now: resolvedNow)
         self.processCWDsProvider = processCWDsProvider
-        self.processSnapshotProvider = processSnapshotProvider
+        let resolvedSnapshotProvider: @Sendable () async -> [ProcessSnapshotEntry]? =
+            processSnapshotProvider ?? { await OrphanProcessCollector.realProcessSnapshot() }
+        self.processSnapshotProvider = resolvedSnapshotProvider
         self.orphanProcessCollector = OrphanProcessCollector(
-            signaller: signaller, now: resolvedNow,
+            signaller: signaller, snapshotProvider: resolvedSnapshotProvider, now: resolvedNow,
             graceAttempts: orphanProcessGraceAttempts,
             pollInterval: orphanProcessPollInterval,
             clock: clock)
@@ -700,6 +704,10 @@ public actor OrphanGC {
     ) async {
         guard config.gcOrphanProcessesEnabled || dryRun else { return }
 
+        // Stamped BEFORE the reading, so the start instants derived from it
+        // sit no later than the truth — the direction that widens apparent
+        // drift at signal time rather than hiding it.
+        let processesCapturedAt = now()
         guard let processes = await processSnapshot() else {
             logger.error("gc: ps unavailable this sweep — skipping the orphan-process phase")
             planned.append("KEEP ps-unavailable orphan-processes")
@@ -727,19 +735,36 @@ public actor OrphanGC {
 
         let protected = orphanProcessCollector.protectedPIDs(
             processes: processes, ourPID: getpid(), ourUID: getuid())
-        for candidate in candidates {
-            let tree = orphanProcessCollector.descendantClosure(
-                of: candidate.pid, processes: processes, protected: protected)
+        // Every tree is planned from the ONE snapshot before anything is
+        // signalled, so the plan is a single consistent reading of the process
+        // graph rather than one that interleaves with its own destruction.
+        // It does not by itself bound how stale a pid can be by the time it is
+        // signalled — each reap below blocks for up to
+        // `graceAttempts × pollInterval` before the next one starts — which is
+        // why `reap` re-reads identities immediately before each volley.
+        let plan = candidates.map { candidate in
+            (candidate, orphanProcessCollector.descendantClosure(
+                of: candidate.pid, processes: processes, protected: protected))
+        }
+        // The start instant recorded for every pid in the plan. `reap` refuses
+        // to signal a pid whose live start instant no longer matches, which is
+        // what keeps a pid the kernel reissued mid-sweep — to a descendant slot
+        // or to a late candidate's root — out of the volley.
+        let plannedStarts = OrphanProcessCollector.startInstants(
+            processes, capturedAt: processesCapturedAt)
+        for (candidate, tree) in plan {
             planned.append(
                 "REAP orphan-process pid=\(candidate.pid) tree=\(tree.count) \(candidate.rootPath)")
-            // This phase's guard is `gcOrphanProcessesEnabled || dryRun`, so
-            // every line below runs only with the flag actually on.
-            guard !dryRun else { continue }
+        }
+        // This phase's guard is `gcOrphanProcessesEnabled || dryRun`, so every
+        // line below runs only with the flag actually on.
+        guard !dryRun else { return }
+        for (candidate, tree) in plan {
             guard let record = await orphanProcessCollector.reap(
-                candidate, tree: tree,
+                candidate, tree: tree, plannedStarts: plannedStarts,
                 repoPath: Self.repoPath(forRoot: candidate.rootPath, in: repoPathByPool)
             ) else {
-                planned.append("KEEP empty-subtree \(candidate.rootPath)")
+                planned.append("KEEP nothing-signalled \(candidate.rootPath)")
                 continue
             }
             await insertReapRecord(record)
@@ -878,13 +903,11 @@ public actor OrphanGC {
         return path == prefix || path.hasPrefix(prefix.hasSuffix("/") ? prefix : prefix + "/")
     }
 
-    /// One `ps` snapshot per sweep, or `nil` when it could not be taken —
-    /// which skips the orphan-process phase, never "there are no orphans".
+    /// The sweep's planning `ps` snapshot, or `nil` when it could not be
+    /// taken — which skips the orphan-process phase, never "there are no
+    /// orphans".
     private func processSnapshot() async -> [ProcessSnapshotEntry]? {
-        if let processSnapshotProvider {
-            return await processSnapshotProvider()
-        }
-        return await OrphanProcessCollector.realProcessSnapshot()
+        await processSnapshotProvider()
     }
 
     /// Entry point for `repo.remove` (review Medium 2): `db.worktrees.deleteForRepo`

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -758,13 +758,31 @@ public actor OrphanGC {
         pools.append(deletionQueueCollector.resolvedPath(TBDConstants.scratchDir.path))
         pools.append(deletionQueueCollector.resolvedPath(scratchpadBase.path))
 
-        let livePaths = liveRows.map { deletionQueueCollector.resolvedPath($0.path) }
+        // A worktree's Claude scratchpad answers to the same owner as the
+        // worktree itself — `ScratchpadCollector`'s slug is derived from the
+        // worktree path, so the owner is always recoverable. Classifying the
+        // scratchpad alongside its worktree is what keeps a live worktree's
+        // scratchpad out of the "absent from the database" arm, where it would
+        // otherwise become reclaimable while the work is still going on.
+        func scratchpadPath(forWorktreePath path: String) -> String {
+            deletionQueueCollector.resolvedPath(
+                scratchpadBase.appendingPathComponent(
+                    ScratchpadCollector.slug(forWorktreePath: path)).path)
+        }
+        let livePaths = liveRows.flatMap {
+            [deletionQueueCollector.resolvedPath($0.path), scratchpadPath(forWorktreePath: $0.path)]
+        }
         let deadRoots = archived
             .compactMap(LocalWorktree.init)
-            .map {
-                DeadWorktreeRoot(
-                    path: deletionQueueCollector.resolvedPath($0.path),
-                    archivedAt: $0.archivedAt)
+            .flatMap {
+                [
+                    DeadWorktreeRoot(
+                        path: deletionQueueCollector.resolvedPath($0.path),
+                        archivedAt: $0.archivedAt),
+                    DeadWorktreeRoot(
+                        path: scratchpadPath(forWorktreePath: $0.path),
+                        archivedAt: $0.archivedAt),
+                ]
             }
         return (
             TBDProcessRoots(pools: pools, live: livePaths, dead: deadRoots),

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -254,7 +254,7 @@ public actor OrphanGC {
         )
 
         await reclaimOrphanProcesses(
-            config: config, repos: repos, archived: archived, live: live,
+            config: config, repos: repos, live: live,
             dryRun: dryRun, planned: &planned, reaped: &reaped
         )
 
@@ -677,12 +677,25 @@ public actor OrphanGC {
     /// a default-off flag needs to see what enabling it would reclaim first —
     /// and touches nothing either way.
     ///
-    /// Both inputs skip the phase rather than proceeding on a partial picture:
-    /// a `ps` snapshot that could not be taken, and a database read that
-    /// failed. That is the keep-favoring direction every other gate in this
+    /// Every input skips the phase rather than proceeding on a partial
+    /// picture: a `ps` snapshot that could not be taken, and either of the two
+    /// row reads. That is the keep-favoring direction every other gate in this
     /// sweep takes.
+    ///
+    /// Both row reads happen HERE rather than being handed down from `sweep`,
+    /// and both are read back to back. The sweep's own `archived` list is taken
+    /// before the deletion-queue, scratchpad and profile-dir phases have run —
+    /// `du` shells and Keychain calls, so a wide window — and a worktree
+    /// archived inside that window would be missing from the old `archived`
+    /// list and already excluded from the fresh live list. It would then fall
+    /// through to the "absent from the database" arm and be graced from
+    /// process start instead of from `archivedAt`, which is the weaker gate,
+    /// on the exact row whose grace was just supposed to begin. Reading both
+    /// together closes that. A failure on either read skips the phase, where
+    /// `sweep`'s `try? … ?? []` would have read "no archived worktrees" — the
+    /// same silent weakening by another route.
     private func reclaimOrphanProcesses(
-        config: Config, repos: [Repo], archived: [Worktree], live: LiveCWDs,
+        config: Config, repos: [Repo], live: LiveCWDs,
         dryRun: Bool, planned: inout [String], reaped: inout Int
     ) async {
         guard config.gcOrphanProcessesEnabled || dryRun else { return }
@@ -692,8 +705,10 @@ public actor OrphanGC {
             planned.append("KEEP ps-unavailable orphan-processes")
             return
         }
-        guard let liveRows = try? await db.worktrees.listLocal(excludeArchived: true) else {
+        guard let liveRows = try? await db.worktrees.listLocal(excludeArchived: true),
+              let archived = try? await db.worktrees.list(status: .archived) else {
             logger.warning("gc: orphan-process phase skipped — DB read failed")
+            planned.append("KEEP db-unavailable orphan-processes")
             return
         }
 
@@ -702,6 +717,7 @@ public actor OrphanGC {
         let candidates = orphanProcessCollector.candidates(
             processes: processes,
             cwdByPID: live.cwdByPID,
+            cwdsCapturedAt: live.capturedAt,
             roots: roots,
             ourUID: getuid(),
             ourPID: getpid(),
@@ -752,11 +768,21 @@ public actor OrphanGC {
                 repoPathByPool[resolved] = repo.path
             }
         }
-        // Scratch worktrees and Claude scratchpads are TBD-managed roots too,
-        // and belong to no repo — hence no `repoPathByPool` entry, which stamps
-        // the record with `""` the same way the scratchpad phase does.
+        // The scratch-worktree pool is TBD's outright, and belongs to no repo —
+        // hence no `repoPathByPool` entry, which stamps the record with `""`
+        // the same way the scratchpad phase does.
         pools.append(deletionQueueCollector.resolvedPath(TBDConstants.scratchDir.path))
-        pools.append(deletionQueueCollector.resolvedPath(scratchpadBase.path))
+        // The Claude scratchpad base is SHARED, not owned. Claude Code creates
+        // one directory there per project it has ever run in, and TBD manages
+        // almost none of them — a single census of one developer machine found
+        // 86 entries, of which 9 named no worktree at all (plain checkouts, a
+        // home directory, and loose files). Listing it as a pool would put
+        // every one of those in the "absent from the database" arm and make a
+        // stranger's live session reclaimable. `ScratchpadCollector.reconcile`
+        // already takes the whitelist side here for a merely destructive
+        // operation ("Unrelated directories in the base are untouched"); this
+        // phase kills processes, so it takes the same side.
+        let sharedRoots = [deletionQueueCollector.resolvedPath(scratchpadBase.path)]
 
         // A worktree's Claude scratchpad answers to the same owner as the
         // worktree itself — `ScratchpadCollector`'s slug is derived from the
@@ -785,7 +811,8 @@ public actor OrphanGC {
                 ]
             }
         return (
-            TBDProcessRoots(pools: pools, live: livePaths, dead: deadRoots),
+            TBDProcessRoots(
+                pools: pools, sharedRoots: sharedRoots, live: livePaths, dead: deadRoots),
             repoPathByPool
         )
     }
@@ -992,17 +1019,19 @@ public actor OrphanGC {
             // candidates — the keep-favoring reading. It is never read as "this
             // process is not in a worktree", because candidacy requires a cwd
             // that IS under a dead root; a missing entry can only subtract.
-            guard let processCWDsProvider else { return LiveCWDs(paths: paths, cwdByPID: [:]) }
+            guard let processCWDsProvider else {
+                return LiveCWDs(paths: paths, cwdByPID: [:], capturedAt: now())
+            }
             guard let map = await processCWDsProvider() else { return nil }
-            return LiveCWDs(paths: paths, cwdByPID: map)
+            return LiveCWDs(paths: paths, cwdByPID: map, capturedAt: now())
         }
-        return await Self.realLiveCWDs()
+        return await Self.realLiveCWDs(capturedAt: now())
     }
 
     /// Real `lsof`-backed live-cwd provider: runs `lsof -d cwd -Fn` under a
     /// 60s deadline and hands the outcome to `parseLiveCWDs`. A spawn failure
     /// is the same "unavailable" sentinel as a timeout: `nil`, skip the sweep.
-    private static func realLiveCWDs() async -> LiveCWDs? {
+    private static func realLiveCWDs(capturedAt: Date) async -> LiveCWDs? {
         let outcome: BoundedProcessOutcome
         do {
             outcome = try await runBoundedProcess(
@@ -1015,7 +1044,7 @@ public actor OrphanGC {
             logger.error("gc: lsof spawn failed: \(String(describing: error), privacy: .public)")
             return nil
         }
-        return parseLiveCWDs(outcome)
+        return parseLiveCWDs(outcome, capturedAt: capturedAt)
     }
 
     /// Pure parser for the lsof outcome — extracted so the safety-relevant
@@ -1032,7 +1061,9 @@ public actor OrphanGC {
     /// - non-zero exit: lsof's output on failure is not a complete cwd
     ///   picture, so it gets the same keep-biased treatment as a timeout.
     /// - non-UTF-8 stdout: unparseable output is no picture at all.
-    static func parseLiveCWDs(_ outcome: BoundedProcessOutcome) -> LiveCWDs? {
+    static func parseLiveCWDs(
+        _ outcome: BoundedProcessOutcome, capturedAt: Date = Date()
+    ) -> LiveCWDs? {
         switch outcome {
         case .timedOut:
             logger.error("gc: lsof timed out after 60s")
@@ -1069,7 +1100,7 @@ public actor OrphanGC {
                     result.append(canonical)
                 }
             }
-            return LiveCWDs(paths: result, cwdByPID: cwdByPID)
+            return LiveCWDs(paths: result, cwdByPID: cwdByPID, capturedAt: capturedAt)
         }
     }
 }
@@ -1088,4 +1119,9 @@ struct LiveCWDs: Sendable, Equatable {
     var paths: [String]
     /// Canonicalized cwd per pid.
     var cwdByPID: [Int32: String]
+    /// When the pass was read. The orphan-process phase joins `cwdByPID` to a
+    /// `ps` snapshot taken later in the same sweep, by pid alone, and macOS
+    /// recycles pids — so it needs to know how stale this reading is before it
+    /// trusts a pid to still mean the same process.
+    var capturedAt: Date
 }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -726,7 +726,7 @@ public actor OrphanGC {
         guard !candidates.isEmpty else { return }
 
         let protected = orphanProcessCollector.protectedPIDs(
-            processes: processes, ourPID: getpid())
+            processes: processes, ourPID: getpid(), ourUID: getuid())
         for candidate in candidates {
             let tree = orphanProcessCollector.descendantClosure(
                 of: candidate.pid, processes: processes, protected: protected)

--- a/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
+++ b/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
@@ -180,7 +180,9 @@ public struct OrphanProcessCollector: Sendable {
     /// A process qualifies only when ALL of these hold, and each of them fails
     /// toward keeping:
     /// - `ppid == 1` — reparented to launchd, i.e. actually escaped.
-    /// - owned by `ourUID`.
+    /// - owned by `ourUID`. Enforced through the protected set, so the same
+    ///   exclusion holds for every process the reap volley reaches and not only
+    ///   for the root that entered it.
     /// - `pid > 1`, and neither `ourPID` nor one of its ancestors.
     /// - not a `TBDDaemon` or `TBDApp` process. **Not hypothetical:** the
     ///   daemon runs at `ppid == 1` with its cwd inside a TBD tree — when
@@ -202,14 +204,16 @@ public struct OrphanProcessCollector: Sendable {
         ourPID: Int32,
         graceSeconds: Int
     ) -> [OrphanProcessCandidate] {
-        let protected = protectedPIDs(processes: processes, ourPID: ourPID)
+        let protected = protectedPIDs(processes: processes, ourPID: ourPID, ourUID: ourUID)
         // How stale the cwd map is by the time this snapshot was read. Never
         // negative, so a clock that went backwards cannot weaken the gate.
         let cwdAge = max(0, now().timeIntervalSince(cwdsCapturedAt))
         var result: [OrphanProcessCandidate] = []
         for entry in processes.sorted(by: { $0.pid < $1.pid }) {
             guard entry.pid > 1, entry.ppid == 1 else { continue }
-            guard entry.uid == ourUID else { continue }
+            // Covers the uid exclusion too: `protectedPIDs` holds every process
+            // owned by someone else, so there is one enforcement point rather
+            // than a root-only gate here and nothing at all on descendants.
             guard !protected.contains(entry.pid) else { continue }
             // Absence of evidence is not evidence of an orphan. A process whose
             // cwd could not be read is skipped, never reclaimed — the direction
@@ -300,10 +304,27 @@ public struct OrphanProcessCollector: Sendable {
         return elapsed >= Double(graceSeconds)
     }
 
-    /// `ourPID`, its ancestors, and every `TBDDaemon`/`TBDApp` process in the
-    /// snapshot. Never signalled, and never descended into when computing a
-    /// descendant closure.
-    func protectedPIDs(processes: [ProcessSnapshotEntry], ourPID: Int32) -> Set<Int32> {
+    /// `ourPID`, its ancestors, every `TBDDaemon`/`TBDApp` process in the
+    /// snapshot, and every process owned by a uid other than `ourUID`. Never
+    /// signalled, and never descended into when computing a descendant closure.
+    ///
+    /// The uid exclusion lives here rather than only at the orphan root because
+    /// a root-only gate is not the exclusion the sweep claims: once a root
+    /// passed it, every descendant entered the kill volley whatever its own uid
+    /// was, and only `kill(2)` returning `EPERM` across uids kept the promise.
+    /// That is the kernel's guarantee, not this collector's, and it evaporates
+    /// wherever the daemon is not the unprivileged per-user process it is today.
+    ///
+    /// A foreign uid protects the process **entirely** — the walk stops there,
+    /// so an `ourUID` grandchild underneath one keeps running. Reclaiming it
+    /// would mean reaching across a privilege boundary on the strength of a
+    /// parent link, and every degraded-input path in this file is keep-favoring
+    /// instead. The grandchild is not lost to the reconciler either: when its
+    /// foreign parent exits, it reparents to launchd and the next sweep sees it
+    /// as an orphan root of its own.
+    func protectedPIDs(
+        processes: [ProcessSnapshotEntry], ourPID: Int32, ourUID: uid_t
+    ) -> Set<Int32> {
         var byPID: [Int32: ProcessSnapshotEntry] = [:]
         for entry in processes { byPID[entry.pid] = entry }
 
@@ -316,6 +337,9 @@ public struct OrphanProcessCollector: Sendable {
             cursor = entry.ppid
         }
         for entry in processes where Self.isTBDBinary(entry.command) {
+            protected.insert(entry.pid)
+        }
+        for entry in processes where entry.uid != ourUID {
             protected.insert(entry.pid)
         }
         return protected

--- a/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
+++ b/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
@@ -145,10 +145,15 @@ public struct OrphanProcessCandidate: Sendable, Equatable {
 /// every gate below stays a pure function of its arguments.
 ///
 /// Every failure direction is toward KEEPING: an unreadable cwd, an unparseable
-/// start time, a uid that is not ours, and any ambiguity between a live and a
-/// dead owner all leave the process running.
+/// start time, a uid that is not ours, an identity that cannot be re-read at
+/// signal time, and any ambiguity between a live and a dead owner all leave the
+/// process running.
 public struct OrphanProcessCollector: Sendable {
     let signaller: any ProcessSignaller
+    /// One fresh `/bin/ps` reading, taken immediately before each volley so a
+    /// pid the kernel reissued since the sweep planned its tree is recognized
+    /// and left alone. Injected so tests never spawn a subprocess.
+    let snapshotProvider: @Sendable () async -> [ProcessSnapshotEntry]?
     let now: @Sendable () -> Date
     /// Number of liveness polls between SIGTERM and SIGKILL.
     let graceAttempts: Int
@@ -161,12 +166,16 @@ public struct OrphanProcessCollector: Sendable {
 
     public init(
         signaller: any ProcessSignaller = ProductionProcessSignaller(),
+        snapshotProvider: @escaping @Sendable () async -> [ProcessSnapshotEntry]? = {
+            await OrphanProcessCollector.realProcessSnapshot()
+        },
         now: @escaping @Sendable () -> Date = Date.init,
         graceAttempts: Int = 30,
         pollInterval: Duration = .milliseconds(100),
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.signaller = signaller
+        self.snapshotProvider = snapshotProvider
         self.now = now
         self.graceAttempts = graceAttempts
         self.pollInterval = pollInterval
@@ -372,6 +381,99 @@ public struct OrphanProcessCollector: Sendable {
         return false
     }
 
+    // MARK: - Identity across time
+
+    /// How far a re-read start instant may sit from the one the plan recorded
+    /// and still be the same process.
+    ///
+    /// `ps etime` is whole seconds truncated, so two readings of one process
+    /// can disagree by just under a second, and the instant a snapshot is
+    /// stamped is not the instant the kernel filled it in. Two seconds absorbs
+    /// both. It does not weaken the substitution test it guards: a reissued
+    /// pid necessarily started AFTER the reading that recorded the pid it
+    /// replaced, so its start instant moves by the whole age of that reading's
+    /// subject — days, in every orphan measured here — and never by a second.
+    public static let identityDriftTolerance: TimeInterval = 2
+
+    /// Start instant per pid: the snapshot's capture time minus the row's
+    /// `etime`. This is the cheap identity of a process across time — the pid
+    /// alone is not one, because macOS reissues pids, and a reissued pid
+    /// necessarily carries a later start instant than the one a snapshot
+    /// recorded for it.
+    ///
+    /// A row whose `etime` did not parse is deliberately ABSENT from the map,
+    /// so it can never be verified and is therefore never signalled: the same
+    /// keep-favoring direction an unreadable cwd and an unparseable age take
+    /// on the identification side.
+    public static func startInstants(
+        _ processes: [ProcessSnapshotEntry], capturedAt: Date
+    ) -> [Int32: Date] {
+        var result: [Int32: Date] = [:]
+        for entry in processes {
+            guard let elapsed = entry.elapsedSeconds else { continue }
+            result[entry.pid] = capturedAt.addingTimeInterval(-elapsed)
+        }
+        return result
+    }
+
+    /// The members of `tree`, in the plan's leaf-first order, whose identity in
+    /// a FRESH `ps` reading still matches what the plan recorded for them.
+    ///
+    /// Called immediately before every volley — the SIGTERM one and the SIGKILL
+    /// escalation alike — and for descendants exactly as for the root. The
+    /// sweep's own snapshot is not enough on its own: `reclaimOrphanProcesses`
+    /// reaps candidates one after another and each reap blocks for up to
+    /// `graceAttempts × pollInterval`, so with the half-dozen simultaneous
+    /// orphans a field census found, the last candidate's tree would otherwise
+    /// be signalled many seconds after the reading that named its pids. The
+    /// root's `age >= cwdAge` gate in `candidates(…)` covers neither that
+    /// drift nor descendants, which enter a tree purely by the snapshot's ppid
+    /// chain.
+    ///
+    /// `nil` means the re-reading itself failed, and the caller must signal
+    /// nothing at all: an identity that cannot be re-read is a skip, never a
+    /// kill.
+    func verifiedTargets(
+        _ tree: [Int32], plannedStarts: [Int32: Date]
+    ) async -> [Int32]? {
+        // Stamped BEFORE the reading rather than after it, so any delay in
+        // taking the snapshot widens the apparent drift rather than hiding it.
+        let capturedAt = now()
+        guard let fresh = await snapshotProvider() else {
+            logger.warning("""
+            gc: orphan-process identity re-read failed — signalling nothing this volley
+            """)
+            return nil
+        }
+        let current = Self.startInstants(fresh, capturedAt: capturedAt)
+        return tree.filter { pid in
+            guard let planned = plannedStarts[pid] else {
+                logger.debug("""
+                gc: orphan-process skip pid \(pid, privacy: .public) — \
+                the plan recorded no start instant for it
+                """)
+                return false
+            }
+            guard let live = current[pid] else {
+                logger.debug("""
+                gc: orphan-process skip pid \(pid, privacy: .public) — \
+                gone or unreadable at signal time
+                """)
+                return false
+            }
+            let drift = abs(live.timeIntervalSince(planned))
+            guard drift <= Self.identityDriftTolerance else {
+                logger.warning("""
+                gc: orphan-process skip pid \(pid, privacy: .public) — start time moved \
+                \(Int(drift), privacy: .public)s since the sweep planned this tree, \
+                so the pid now names a different process
+                """)
+                return false
+            }
+            return true
+        }
+    }
+
     // MARK: - Reclamation
 
     /// The orphan root plus every descendant of it in the snapshot, ordered
@@ -389,6 +491,12 @@ public struct OrphanProcessCollector: Sendable {
     /// waiting between generations, so a process that forks during its own
     /// SIGTERM handling can still leave a child behind. That residue is
     /// keep-biased — the next hourly sweep sees it as an orphan of its own.
+    ///
+    /// Membership here is decided purely by the snapshot's ppid chain, which
+    /// says nothing about whether a pid still names the same process by the
+    /// time the volley reaches it. That is `verifiedTargets`' job, and it runs
+    /// on this list — root and descendants alike — immediately before each
+    /// signal.
     public func descendantClosure(
         of pid: Int32, processes: [ProcessSnapshotEntry], protected: Set<Int32>
     ) -> [Int32] {
@@ -417,6 +525,13 @@ public struct OrphanProcessCollector: Sendable {
     /// `graceAttempts × pollInterval`, then SIGKILL whatever is still alive —
     /// again leaf-first.
     ///
+    /// Every volley is filtered through `verifiedTargets` first, so a pid whose
+    /// start instant has moved since `plannedStarts` was taken is dropped
+    /// rather than signalled, and a re-reading that fails drops the whole
+    /// volley. This is what makes the pid-reuse protection hold for the LAST
+    /// candidate of a multi-orphan sweep and for descendants, neither of which
+    /// the root-only `age >= cwdAge` gate in `candidates(…)` reaches.
+    ///
     /// Signalling goes through `ProcessSignaller` rather than raw `kill(2)` so
     /// tests never send a real signal, and so the `pid <= 1` refusal lives in
     /// exactly one place. It uses the seam's **process-only** methods: the
@@ -431,27 +546,47 @@ public struct OrphanProcessCollector: Sendable {
     /// Returns `nil` for an empty subtree (nothing was signalled, so there is
     /// nothing to record).
     public func reap(
-        _ candidate: OrphanProcessCandidate, tree: [Int32], repoPath: String
+        _ candidate: OrphanProcessCandidate, tree: [Int32],
+        plannedStarts: [Int32: Date], repoPath: String
     ) async -> ReapRecord? {
         guard !tree.isEmpty else { return nil }
 
-        for pid in tree {
+        guard let targets = await verifiedTargets(tree, plannedStarts: plannedStarts),
+              !targets.isEmpty else {
+            logger.info("""
+            gc: orphan-process pid \(candidate.pid, privacy: .public) — nothing left to \
+            signal once identities were re-read; keeping the whole tree
+            """)
+            return nil
+        }
+
+        for pid in targets {
             signaller.terminateProcessOnly(pid)
         }
         for _ in 0..<graceAttempts {
-            if !tree.contains(where: { signaller.isAlive($0) }) { break }
+            if !targets.contains(where: { signaller.isAlive($0) }) { break }
             try? await clock.sleep(for: pollInterval)
         }
-        for pid in tree where signaller.isAlive(pid) {
-            logger.warning("""
-            gc: orphan-process pid \(pid, privacy: .public) survived SIGTERM — sending SIGKILL
-            """)
-            signaller.forceKillProcessOnly(pid)
+        let survivors = targets.filter { signaller.isAlive($0) }
+        if !survivors.isEmpty {
+            // Re-verified separately, because the grace window is itself wall
+            // time — `graceAttempts × pollInterval`, ≈3s by default — during
+            // which a member that honored SIGTERM can exit and have its pid
+            // reissued to a stranger. SIGKILL is the signal nothing survives,
+            // so it gets the same check the SIGTERM volley got, not the
+            // SIGTERM volley's now-stale conclusion.
+            let killable = await verifiedTargets(survivors, plannedStarts: plannedStarts) ?? []
+            for pid in killable {
+                logger.warning("""
+                gc: orphan-process pid \(pid, privacy: .public) survived SIGTERM — sending SIGKILL
+                """)
+                signaller.forceKillProcessOnly(pid)
+            }
         }
 
         logger.info("""
         gc: reclaimed orphan process pid \(candidate.pid, privacy: .public) \
-        (subtree of \(tree.count, privacy: .public)) rooted in \
+        (subtree of \(targets.count, privacy: .public)) rooted in \
         \(candidate.rootPath, privacy: .public)
         """)
         return ReapRecord(
@@ -461,7 +596,10 @@ public struct OrphanProcessCollector: Sendable {
             // the dead worktree the process was rooted in, which is the only
             // place-shaped fact an orphan-process record has.
             worktreePath: candidate.rootPath,
-            processDescription: Self.describe(candidate: candidate, tree: tree),
+            // The set actually signalled, not the set planned: a member dropped
+            // by the identity check was never touched, and the record is an
+            // audit trail of what this sweep did.
+            processDescription: Self.describe(candidate: candidate, tree: targets),
             reapedAt: now()
         )
     }
@@ -508,7 +646,7 @@ public struct OrphanProcessCollector: Sendable {
     ///
     /// `-ww` disables column-width truncation, without which macOS clips the
     /// command column even when stdout is a pipe.
-    static func realProcessSnapshot() async -> [ProcessSnapshotEntry]? {
+    public static func realProcessSnapshot() async -> [ProcessSnapshotEntry]? {
         let outcome: BoundedProcessOutcome
         do {
             outcome = try await runBoundedProcess(

--- a/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
+++ b/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
@@ -56,22 +56,39 @@ public struct DeadWorktreeRoot: Sendable, Equatable {
 
 /// The TBD-managed path universe one sweep classifies cwds against.
 public struct TBDProcessRoots: Sendable {
-    /// Canonical pool prefixes: each repo's worktree pool directory (canonical
-    /// and legacy), the scratch-worktree pool, and the Claude scratchpad base.
-    /// A cwd outside every one of these is never a candidate, whatever its
-    /// parentage.
+    /// Canonical prefixes of directories TBD owns **outright**: each repo's
+    /// worktree pool (canonical and legacy) and the scratch-worktree pool.
+    /// Every child of one of these is a TBD worktree by construction, so a
+    /// child matching no row is a leftover this sweep owns.
     public var pools: [String]
-    /// Canonical paths of worktrees that are still alive. A cwd under one of
-    /// these is never a candidate, even at `ppid == 1` — that narrowness is
-    /// what keeps a deliberately detached dev server safe until the developer
-    /// has archived the worktree it belonged to.
+    /// Canonical prefixes of directories TBD **shares** with other software —
+    /// today the Claude scratchpad base, which Claude Code fills with one
+    /// directory per project it has ever been run in, most of which TBD has
+    /// never managed. A cwd here is classified only by an explicit `live` or
+    /// `dead` entry; an unrecognized child is never a candidate.
+    ///
+    /// The distinction is the whole difference between a whitelist and a
+    /// blacklist, and `ScratchpadCollector.reconcile` already takes the
+    /// whitelist side ("Unrelated directories in the base are untouched") for
+    /// a merely destructive operation. This one kills processes.
+    public var sharedRoots: [String]
+    /// Canonical paths of worktrees that are still alive, and of their Claude
+    /// scratchpads. A cwd under one of these is never a candidate, even at
+    /// `ppid == 1` — that narrowness is what keeps a deliberately detached dev
+    /// server safe until the developer has archived the worktree it belonged
+    /// to.
     public var live: [String]
-    /// Canonical paths of worktrees that are dead, with the archive instant
-    /// where the row survives to carry one.
+    /// Canonical paths of worktrees that are dead, and of their Claude
+    /// scratchpads, with the archive instant where the row survives to carry
+    /// one.
     public var dead: [DeadWorktreeRoot]
 
-    public init(pools: [String], live: [String], dead: [DeadWorktreeRoot]) {
+    public init(
+        pools: [String], sharedRoots: [String] = [], live: [String],
+        dead: [DeadWorktreeRoot]
+    ) {
         self.pools = pools
+        self.sharedRoots = sharedRoots
         self.live = live
         self.dead = dead
     }
@@ -119,10 +136,13 @@ public struct OrphanProcessCandidate: Sendable, Equatable {
 /// already dead, and its `isTBDOwned` gate excludes non-agent binaries by
 /// design.
 ///
-/// This type never reads the database and never spawns anything: the caller
-/// supplies the `ps` snapshot, the pid-to-cwd map, and the root classification,
-/// the same division of labor `ProfileDirCollector` and `DeletionQueueCollector`
-/// keep with `OrphanGC`.
+/// Classification and reclamation never read the database and never spawn
+/// anything: the caller supplies the `ps` snapshot, the pid-to-cwd map and the
+/// root classification, the same division of labor `ProfileDirCollector` and
+/// `DeletionQueueCollector` keep with `OrphanGC`. The one exception is
+/// `realProcessSnapshot()`, the production `/bin/ps` reader — a static factory
+/// for that injected input, deliberately outside the classifying surface so
+/// every gate below stays a pure function of its arguments.
 ///
 /// Every failure direction is toward KEEPING: an unreadable cwd, an unparseable
 /// start time, a uid that is not ours, and any ambiguity between a live and a
@@ -168,17 +188,24 @@ public struct OrphanProcessCollector: Sendable {
     ///   archiving it would otherwise have the sweep SIGKILL the live daemon
     ///   running the sweep.
     /// - its cwd is readable, and resolves under a dead TBD-managed root.
+    /// - it is at least as old as the cwd reading it was joined to, so a pid
+    ///   the kernel reissued between the two readings cannot inherit a dead
+    ///   process's cwd. An unreadable age fails this, i.e. keeps.
     /// - the grace window has passed: from `archivedAt` where the row survives
     ///   to carry one, and from process start time where it does not.
     public func candidates(
         processes: [ProcessSnapshotEntry],
         cwdByPID: [Int32: String],
+        cwdsCapturedAt: Date,
         roots: TBDProcessRoots,
         ourUID: uid_t,
         ourPID: Int32,
         graceSeconds: Int
     ) -> [OrphanProcessCandidate] {
         let protected = protectedPIDs(processes: processes, ourPID: ourPID)
+        // How stale the cwd map is by the time this snapshot was read. Never
+        // negative, so a clock that went backwards cannot weaken the gate.
+        let cwdAge = max(0, now().timeIntervalSince(cwdsCapturedAt))
         var result: [OrphanProcessCandidate] = []
         for entry in processes.sorted(by: { $0.pid < $1.pid }) {
             guard entry.pid > 1, entry.ppid == 1 else { continue }
@@ -190,6 +217,21 @@ public struct OrphanProcessCollector: Sendable {
             guard let cwd = cwdByPID[entry.pid] else {
                 logger.debug("""
                 gc: orphan-process skip pid \(entry.pid, privacy: .public) — cwd unreadable
+                """)
+                continue
+            }
+            // The cwd map and this snapshot are two readings taken at different
+            // moments and joined by **pid alone**, and macOS recycles pids. A
+            // process younger than the gap cannot be the one lsof saw: its pid
+            // was reissued in between, and the cwd it matched is a dead
+            // process's. Skip it — evidence of the wrong process is worse than
+            // no evidence. An unreadable age is skipped for the same reason,
+            // which also makes "an unparseable etime keeps the process" true
+            // for BOTH grace arms rather than only the no-row one.
+            guard let age = entry.elapsedSeconds, age >= cwdAge else {
+                logger.debug("""
+                gc: orphan-process skip pid \(entry.pid, privacy: .public) — \
+                younger than the cwd reading, so the pid may have been reused
                 """)
                 continue
             }
@@ -208,13 +250,24 @@ public struct OrphanProcessCollector: Sendable {
     /// and a dead owner resolves to `live` — keep-biased, like every other gate
     /// in this sweep.
     ///
-    /// A cwd under a pool that matches no row at all is `dead` with no archive
-    /// instant: that is the "absent from the database" arm, which covers
-    /// `.deleting/` entries and directories whose row was hard-deleted. Its
-    /// root is the pool's own child (two components for a `.deleting/<uuid>`
-    /// entry) so the record names a worktree-shaped path rather than the pool.
+    /// A cwd under a **pool** that matches no row at all is `dead` with no
+    /// archive instant: that is the "absent from the database" arm, which
+    /// covers `.deleting/` entries and directories whose row was hard-deleted.
+    /// Its root is the pool's own child (two components for a
+    /// `.deleting/<uuid>` entry) so the record names a worktree-shaped path
+    /// rather than the pool.
+    ///
+    /// That arm deliberately does NOT extend to a `sharedRoot`. The Claude
+    /// scratchpad base holds one directory per project Claude Code has ever
+    /// run in — `-Users-me-projects-something`, and slugs that are not
+    /// projects at all — and TBD manages almost none of them. Treating an
+    /// unrecognized child of a shared root as a dead worktree would put a
+    /// stranger's live session on the kill list, so a shared root classifies
+    /// only what an explicit `live`/`dead` entry names.
     public func ownership(ofCWD cwd: String, roots: TBDProcessRoots) -> CWDOwnership {
-        guard let pool = longestPrefix(of: cwd, among: roots.pools) else { return .outside }
+        let poolMatch = longestPrefix(of: cwd, among: roots.pools)
+        let sharedMatch = longestPrefix(of: cwd, among: roots.sharedRoots)
+        guard poolMatch != nil || sharedMatch != nil else { return .outside }
 
         let liveMatch = longestPrefix(of: cwd, among: roots.live)
         let deadMatch = roots.dead
@@ -227,7 +280,11 @@ public struct OrphanProcessCollector: Sendable {
         if let deadMatch {
             return .dead(deadMatch)
         }
-        return .dead(DeadWorktreeRoot(path: Self.poolChild(of: cwd, pool: pool), archivedAt: nil))
+        // Unrecognized. Only a pool owns its strays, and only when no shared
+        // root sits deeper — a nested shared root wins, keeping the process.
+        guard let poolMatch, poolMatch.count > (sharedMatch?.count ?? -1) else { return .outside }
+        return .dead(
+            DeadWorktreeRoot(path: Self.poolChild(of: cwd, pool: poolMatch), archivedAt: nil))
     }
 
     /// `gcGraceSeconds` measured from `archivedAt` where a row survives, and
@@ -264,15 +321,31 @@ public struct OrphanProcessCollector: Sendable {
         return protected
     }
 
-    /// True when argv[0]'s basename is `TBDDaemon` or `TBDApp`. Matched on the
-    /// basename, so a path that merely *contains* the name (every TBD worktree
-    /// does) is not mistaken for the binary.
+    /// True when the executable this process is running is `TBDDaemon` or
+    /// `TBDApp`.
+    ///
+    /// `ps -o command=` prints argv space-joined and unquoted, so where argv[0]
+    /// ends is genuinely ambiguous: a home directory named `Jane Roe` yields
+    /// `~/tbd/.build/debug/TBDApp` as two tokens, `.../Jane` and
+    /// `Roe/tbd/.build/debug/TBDApp`. Taking only the first would read that
+    /// basename as `Jane` and leave the app unprotected — and `isTBDBinary` is
+    /// the ONLY thing protecting
+    /// `TBDApp` and any sibling worktree's daemon, neither of which is in this
+    /// process's ancestry.
+    ///
+    /// So every whitespace-delimited token is checked, and any one of them
+    /// having basename `TBDDaemon`/`TBDApp` protects the process.
+    /// That over-matches — a stray argument spelled `.../TBDApp` protects its
+    /// process too — and over-matching is the keep-favoring direction, which is
+    /// the one this whole sweep takes. Matching stays on the **basename**, so a
+    /// path that merely contains the name (every TBD worktree does) is still
+    /// not mistaken for the binary.
     static func isTBDBinary(_ command: String) -> Bool {
-        guard let arg0 = command.split(whereSeparator: { $0 == " " || $0 == "\t" }).first else {
-            return false
+        for token in command.split(whereSeparator: { $0 == " " || $0 == "\t" }) {
+            let basename = token.split(separator: "/").last.map(String.init) ?? String(token)
+            if basename == "TBDDaemon" || basename == "TBDApp" { return true }
         }
-        let basename = arg0.split(separator: "/").last.map(String.init) ?? String(arg0)
-        return basename == "TBDDaemon" || basename == "TBDApp"
+        return false
     }
 
     // MARK: - Reclamation
@@ -282,9 +355,16 @@ public struct OrphanProcessCollector: Sendable {
     ///
     /// Computed here rather than by calling
     /// `ProcessSignaller.children(ofServerPID:)` in a loop, because that helper
-    /// walks exactly one generation by construction. Leaf-first so a parent
-    /// cannot fork a replacement child while its own subtree is being torn
-    /// down. A protected pid is skipped and never descended into.
+    /// walks exactly one generation by construction. A protected pid is skipped
+    /// and never descended into.
+    ///
+    /// Leaf-first so that no descendant is still unsignalled at the moment its
+    /// ancestor gets SIGTERM — an ancestor signalled first could spend its own
+    /// shutdown respawning children that are not in this list. It is an
+    /// ordering, not a barrier: `reap` sends the whole ordered volley without
+    /// waiting between generations, so a process that forks during its own
+    /// SIGTERM handling can still leave a child behind. That residue is
+    /// keep-biased — the next hourly sweep sees it as an orphan of its own.
     public func descendantClosure(
         of pid: Int32, processes: [ProcessSnapshotEntry], protected: Set<Int32>
     ) -> [Int32] {
@@ -315,10 +395,14 @@ public struct OrphanProcessCollector: Sendable {
     ///
     /// Signalling goes through `ProcessSignaller` rather than raw `kill(2)` so
     /// tests never send a real signal, and so the `pid <= 1` refusal lives in
-    /// exactly one place. That seam group-kills when the pid happens to be its
-    /// own group leader; here that is a harmless superset, because every member
-    /// of the closure is already being signalled individually. What it is not
-    /// is *sufficient* — which is why the closure exists.
+    /// exactly one place. It uses the seam's **process-only** methods: the
+    /// ordinary `terminate`/`forceKill` escalate to a group kill whenever the
+    /// pid is its own group leader, and a process group is a superset of the
+    /// *group*, not of this closure. That superset can hold a pid this sweep
+    /// deliberately protected, and on a reused pid it resolves to a stranger's
+    /// group outright — so the promise that a protected process is never
+    /// signalled would not survive it. Group semantics are also not
+    /// *sufficient* here, which is why the closure exists at all.
     ///
     /// Returns `nil` for an empty subtree (nothing was signalled, so there is
     /// nothing to record).
@@ -328,7 +412,7 @@ public struct OrphanProcessCollector: Sendable {
         guard !tree.isEmpty else { return nil }
 
         for pid in tree {
-            signaller.terminate(pid)
+            signaller.terminateProcessOnly(pid)
         }
         for _ in 0..<graceAttempts {
             if !tree.contains(where: { signaller.isAlive($0) }) { break }
@@ -338,7 +422,7 @@ public struct OrphanProcessCollector: Sendable {
             logger.warning("""
             gc: orphan-process pid \(pid, privacy: .public) survived SIGTERM — sending SIGKILL
             """)
-            signaller.forceKill(pid)
+            signaller.forceKillProcessOnly(pid)
         }
 
         logger.info("""

--- a/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
+++ b/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
@@ -1,0 +1,497 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// One row of a `/bin/ps` snapshot — the process graph `lsof` does not carry.
+///
+/// `sid` is deliberately absent: it is not a valid `ps` keyword on macOS, so
+/// session membership cannot be read this way at all. Parentage plus the
+/// descendant closure computed from it is what stands in for it.
+public struct ProcessSnapshotEntry: Sendable, Equatable {
+    public var pid: Int32
+    public var ppid: Int32
+    /// Process group. Recorded because it is the field that explains why a
+    /// group kill is not dependable here: a real orphan is often not its own
+    /// group leader (measured: `pid=1450, pgid=1448`, its leader already dead),
+    /// so `killpg` on it would strand its children.
+    public var pgid: Int32
+    public var uid: uid_t
+    /// Seconds since the process started (`ps etime`), or `nil` when the field
+    /// could not be parsed — which the grace gate reads as "too young to
+    /// touch", the keep-favoring direction.
+    public var elapsedSeconds: TimeInterval?
+    /// Full argv (`ps -ww -o command=`).
+    public var command: String
+
+    public init(
+        pid: Int32, ppid: Int32, pgid: Int32, uid: uid_t,
+        elapsedSeconds: TimeInterval?, command: String
+    ) {
+        self.pid = pid
+        self.ppid = ppid
+        self.pgid = pgid
+        self.uid = uid
+        self.elapsedSeconds = elapsedSeconds
+        self.command = command
+    }
+}
+
+/// A TBD-managed directory tree whose owning worktree is dead, so processes
+/// rooted inside it are reclaimable.
+public struct DeadWorktreeRoot: Sendable, Equatable {
+    /// Canonical directory path.
+    public var path: String
+    /// When the owning row was archived. `nil` means no row survives at all,
+    /// in which case grace is measured from process start instead — there is
+    /// no archive instant to measure from.
+    public var archivedAt: Date?
+
+    public init(path: String, archivedAt: Date?) {
+        self.path = path
+        self.archivedAt = archivedAt
+    }
+}
+
+/// The TBD-managed path universe one sweep classifies cwds against.
+public struct TBDProcessRoots: Sendable {
+    /// Canonical pool prefixes: each repo's worktree pool directory (canonical
+    /// and legacy), the scratch-worktree pool, and the Claude scratchpad base.
+    /// A cwd outside every one of these is never a candidate, whatever its
+    /// parentage.
+    public var pools: [String]
+    /// Canonical paths of worktrees that are still alive. A cwd under one of
+    /// these is never a candidate, even at `ppid == 1` — that narrowness is
+    /// what keeps a deliberately detached dev server safe until the developer
+    /// has archived the worktree it belonged to.
+    public var live: [String]
+    /// Canonical paths of worktrees that are dead, with the archive instant
+    /// where the row survives to carry one.
+    public var dead: [DeadWorktreeRoot]
+
+    public init(pools: [String], live: [String], dead: [DeadWorktreeRoot]) {
+        self.pools = pools
+        self.live = live
+        self.dead = dead
+    }
+}
+
+/// How one process's cwd relates to the TBD-managed path universe.
+public enum CWDOwnership: Sendable, Equatable {
+    /// Not under any TBD-managed pool. Never a candidate.
+    case outside
+    /// Under a worktree that is still alive. Never a candidate.
+    case live(path: String)
+    /// Under a dead worktree, a `.deleting/` entry, or a scratchpad.
+    case dead(DeadWorktreeRoot)
+}
+
+/// One process that outlived the worktree it was rooted in.
+public struct OrphanProcessCandidate: Sendable, Equatable {
+    public var pid: Int32
+    /// Resolved cwd, from the sweep's single `lsof -d cwd -Fn` pass.
+    public var cwd: String
+    /// The dead TBD-managed root the cwd fell under — what the reap record's
+    /// `worktreePath` carries.
+    public var rootPath: String
+    /// Full argv, truncated into the reap record's `processDescription`.
+    public var command: String
+
+    public init(pid: Int32, cwd: String, rootPath: String, command: String) {
+        self.pid = pid
+        self.cwd = cwd
+        self.rootPath = rootPath
+        self.command = command
+    }
+}
+
+/// Reclaims processes that outlived the worktree they were rooted in — the
+/// named reconciler for that resource class
+/// (`docs/specs/2026-08-18-orphan-process-gc-design.md`).
+///
+/// Under an interactive shell every job runs in its own process group, so
+/// `killpg(pane_pid, …)` reaches the shell and nothing else; what normally
+/// kills a foreground job is the kernel hanging up the pty. A `disown`ed or
+/// `nohup`ed job escapes both, reparents to launchd, and no TBD structure can
+/// find it again. `AgentReaper` cannot see one: it walks a single generation
+/// from the tmux server, its per-teardown escalation runs after the pane pid is
+/// already dead, and its `isTBDOwned` gate excludes non-agent binaries by
+/// design.
+///
+/// This type never reads the database and never spawns anything: the caller
+/// supplies the `ps` snapshot, the pid-to-cwd map, and the root classification,
+/// the same division of labor `ProfileDirCollector` and `DeletionQueueCollector`
+/// keep with `OrphanGC`.
+///
+/// Every failure direction is toward KEEPING: an unreadable cwd, an unparseable
+/// start time, a uid that is not ours, and any ambiguity between a live and a
+/// dead owner all leave the process running.
+public struct OrphanProcessCollector: Sendable {
+    let signaller: any ProcessSignaller
+    let now: @Sendable () -> Date
+    /// Number of liveness polls between SIGTERM and SIGKILL.
+    let graceAttempts: Int
+    /// Delay between liveness polls.
+    let pollInterval: Duration
+    /// Injected so the SIGTERM-to-SIGKILL escalation is testable without real
+    /// waiting (`Duration` is behavior; the grace comparison uses `now`
+    /// instead, because `Date` is data).
+    let clock: any Clock<Duration>
+
+    public init(
+        signaller: any ProcessSignaller = ProductionProcessSignaller(),
+        now: @escaping @Sendable () -> Date = Date.init,
+        graceAttempts: Int = 30,
+        pollInterval: Duration = .milliseconds(100),
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.signaller = signaller
+        self.now = now
+        self.graceAttempts = graceAttempts
+        self.pollInterval = pollInterval
+        self.clock = clock
+    }
+
+    // MARK: - Identification
+
+    /// Every process the sweep may reclaim, in pid order.
+    ///
+    /// A process qualifies only when ALL of these hold, and each of them fails
+    /// toward keeping:
+    /// - `ppid == 1` — reparented to launchd, i.e. actually escaped.
+    /// - owned by `ourUID`.
+    /// - `pid > 1`, and neither `ourPID` nor one of its ancestors.
+    /// - not a `TBDDaemon` or `TBDApp` process. **Not hypothetical:** the
+    ///   daemon runs at `ppid == 1` with its cwd inside a TBD tree — when
+    ///   `scripts/restart.sh` is run from a worktree, that worktree — so
+    ///   archiving it would otherwise have the sweep SIGKILL the live daemon
+    ///   running the sweep.
+    /// - its cwd is readable, and resolves under a dead TBD-managed root.
+    /// - the grace window has passed: from `archivedAt` where the row survives
+    ///   to carry one, and from process start time where it does not.
+    public func candidates(
+        processes: [ProcessSnapshotEntry],
+        cwdByPID: [Int32: String],
+        roots: TBDProcessRoots,
+        ourUID: uid_t,
+        ourPID: Int32,
+        graceSeconds: Int
+    ) -> [OrphanProcessCandidate] {
+        let protected = protectedPIDs(processes: processes, ourPID: ourPID)
+        var result: [OrphanProcessCandidate] = []
+        for entry in processes.sorted(by: { $0.pid < $1.pid }) {
+            guard entry.pid > 1, entry.ppid == 1 else { continue }
+            guard entry.uid == ourUID else { continue }
+            guard !protected.contains(entry.pid) else { continue }
+            // Absence of evidence is not evidence of an orphan. A process whose
+            // cwd could not be read is skipped, never reclaimed — the direction
+            // that matters most here, because the whole rule is keyed on cwd.
+            guard let cwd = cwdByPID[entry.pid] else {
+                logger.debug("""
+                gc: orphan-process skip pid \(entry.pid, privacy: .public) — cwd unreadable
+                """)
+                continue
+            }
+            guard case .dead(let root) = ownership(ofCWD: cwd, roots: roots) else { continue }
+            guard graceElapsed(root: root, entry: entry, graceSeconds: graceSeconds) else { continue }
+            result.append(OrphanProcessCandidate(
+                pid: entry.pid, cwd: cwd, rootPath: root.path, command: entry.command))
+        }
+        return result
+    }
+
+    /// Classifies one resolved cwd against the TBD-managed path universe.
+    ///
+    /// The longest matching prefix wins, so a worktree nested inside a pool is
+    /// classified by the worktree rather than the pool. A tie between a live
+    /// and a dead owner resolves to `live` — keep-biased, like every other gate
+    /// in this sweep.
+    ///
+    /// A cwd under a pool that matches no row at all is `dead` with no archive
+    /// instant: that is the "absent from the database" arm, which covers
+    /// `.deleting/` entries and directories whose row was hard-deleted. Its
+    /// root is the pool's own child (two components for a `.deleting/<uuid>`
+    /// entry) so the record names a worktree-shaped path rather than the pool.
+    public func ownership(ofCWD cwd: String, roots: TBDProcessRoots) -> CWDOwnership {
+        guard let pool = longestPrefix(of: cwd, among: roots.pools) else { return .outside }
+
+        let liveMatch = longestPrefix(of: cwd, among: roots.live)
+        let deadMatch = roots.dead
+            .filter { isUnder(cwd, prefix: $0.path) }
+            .max(by: { $0.path.count < $1.path.count })
+
+        if let liveMatch, liveMatch.count >= (deadMatch?.path.count ?? 0) {
+            return .live(path: liveMatch)
+        }
+        if let deadMatch {
+            return .dead(deadMatch)
+        }
+        return .dead(DeadWorktreeRoot(path: Self.poolChild(of: cwd, pool: pool), archivedAt: nil))
+    }
+
+    /// `gcGraceSeconds` measured from `archivedAt` where a row survives, and
+    /// from process start time where it does not. An unparseable start time
+    /// keeps the process.
+    func graceElapsed(
+        root: DeadWorktreeRoot, entry: ProcessSnapshotEntry, graceSeconds: Int
+    ) -> Bool {
+        if let archivedAt = root.archivedAt {
+            return now().timeIntervalSince(archivedAt) >= Double(graceSeconds)
+        }
+        guard let elapsed = entry.elapsedSeconds else { return false }
+        return elapsed >= Double(graceSeconds)
+    }
+
+    /// `ourPID`, its ancestors, and every `TBDDaemon`/`TBDApp` process in the
+    /// snapshot. Never signalled, and never descended into when computing a
+    /// descendant closure.
+    func protectedPIDs(processes: [ProcessSnapshotEntry], ourPID: Int32) -> Set<Int32> {
+        var byPID: [Int32: ProcessSnapshotEntry] = [:]
+        for entry in processes { byPID[entry.pid] = entry }
+
+        var protected: Set<Int32> = [0, 1, ourPID]
+        // Walk our own ancestry. Bounded by `protected` growing on every step,
+        // so a cyclic (corrupt) snapshot terminates instead of hanging a sweep.
+        var cursor = ourPID
+        while let entry = byPID[cursor], !protected.contains(entry.ppid) {
+            protected.insert(entry.ppid)
+            cursor = entry.ppid
+        }
+        for entry in processes where Self.isTBDBinary(entry.command) {
+            protected.insert(entry.pid)
+        }
+        return protected
+    }
+
+    /// True when argv[0]'s basename is `TBDDaemon` or `TBDApp`. Matched on the
+    /// basename, so a path that merely *contains* the name (every TBD worktree
+    /// does) is not mistaken for the binary.
+    static func isTBDBinary(_ command: String) -> Bool {
+        guard let arg0 = command.split(whereSeparator: { $0 == " " || $0 == "\t" }).first else {
+            return false
+        }
+        let basename = arg0.split(separator: "/").last.map(String.init) ?? String(arg0)
+        return basename == "TBDDaemon" || basename == "TBDApp"
+    }
+
+    // MARK: - Reclamation
+
+    /// The orphan root plus every descendant of it in the snapshot, ordered
+    /// **leaf-first** (deepest generation first).
+    ///
+    /// Computed here rather than by calling
+    /// `ProcessSignaller.children(ofServerPID:)` in a loop, because that helper
+    /// walks exactly one generation by construction. Leaf-first so a parent
+    /// cannot fork a replacement child while its own subtree is being torn
+    /// down. A protected pid is skipped and never descended into.
+    public func descendantClosure(
+        of pid: Int32, processes: [ProcessSnapshotEntry], protected: Set<Int32>
+    ) -> [Int32] {
+        var childrenByPPID: [Int32: [Int32]] = [:]
+        for entry in processes where entry.pid != entry.ppid {
+            childrenByPPID[entry.ppid, default: []].append(entry.pid)
+        }
+        var byDepth: [[Int32]] = []
+        var frontier: [Int32] = protected.contains(pid) ? [] : [pid]
+        var seen: Set<Int32> = Set(frontier)
+        while !frontier.isEmpty {
+            byDepth.append(frontier)
+            var next: [Int32] = []
+            for parent in frontier {
+                for child in childrenByPPID[parent, default: []].sorted() {
+                    guard !protected.contains(child), seen.insert(child).inserted else { continue }
+                    next.append(child)
+                }
+            }
+            frontier = next
+        }
+        return byDepth.reversed().flatMap { $0 }
+    }
+
+    /// SIGTERM the whole subtree leaf-first, poll for
+    /// `graceAttempts × pollInterval`, then SIGKILL whatever is still alive —
+    /// again leaf-first.
+    ///
+    /// Signalling goes through `ProcessSignaller` rather than raw `kill(2)` so
+    /// tests never send a real signal, and so the `pid <= 1` refusal lives in
+    /// exactly one place. That seam group-kills when the pid happens to be its
+    /// own group leader; here that is a harmless superset, because every member
+    /// of the closure is already being signalled individually. What it is not
+    /// is *sufficient* — which is why the closure exists.
+    ///
+    /// Returns `nil` for an empty subtree (nothing was signalled, so there is
+    /// nothing to record).
+    public func reap(
+        _ candidate: OrphanProcessCandidate, tree: [Int32], repoPath: String
+    ) async -> ReapRecord? {
+        guard !tree.isEmpty else { return nil }
+
+        for pid in tree {
+            signaller.terminate(pid)
+        }
+        for _ in 0..<graceAttempts {
+            if !tree.contains(where: { signaller.isAlive($0) }) { break }
+            try? await clock.sleep(for: pollInterval)
+        }
+        for pid in tree where signaller.isAlive(pid) {
+            logger.warning("""
+            gc: orphan-process pid \(pid, privacy: .public) survived SIGTERM — sending SIGKILL
+            """)
+            signaller.forceKill(pid)
+        }
+
+        logger.info("""
+        gc: reclaimed orphan process pid \(candidate.pid, privacy: .public) \
+        (subtree of \(tree.count, privacy: .public)) rooted in \
+        \(candidate.rootPath, privacy: .public)
+        """)
+        return ReapRecord(
+            kind: .orphanProcess,
+            repoPath: repoPath,
+            // Not a path this reap removed — nothing on disk was touched. It is
+            // the dead worktree the process was rooted in, which is the only
+            // place-shaped fact an orphan-process record has.
+            worktreePath: candidate.rootPath,
+            processDescription: Self.describe(candidate: candidate, tree: tree),
+            reapedAt: now()
+        )
+    }
+
+    /// `pid=<pid> tree=<n> <argv truncated>` — what was killed, not merely
+    /// where it lived.
+    static func describe(candidate: OrphanProcessCandidate, tree: [Int32]) -> String {
+        let argv = candidate.command.prefix(200)
+        return "pid=\(candidate.pid) tree=\(tree.count) \(argv)"
+    }
+
+    // MARK: - Path helpers
+
+    private func longestPrefix(of path: String, among prefixes: [String]) -> String? {
+        prefixes.filter { isUnder(path, prefix: $0) }.max(by: { $0.count < $1.count })
+    }
+
+    /// `path` is `prefix` itself or strictly below it. Component-wise, so
+    /// `/a/pool-2` is never read as living under `/a/pool`.
+    private func isUnder(_ path: String, prefix: String) -> Bool {
+        guard !prefix.isEmpty else { return false }
+        return path == prefix || path.hasPrefix(prefix.hasSuffix("/") ? prefix : prefix + "/")
+    }
+
+    /// The worktree-shaped child of `pool` that `cwd` sits under: one component
+    /// normally, two for a `<pool>/.deleting/<uuid>` queue entry, since the
+    /// queue directory itself owns nothing.
+    static func poolChild(of cwd: String, pool: String) -> String {
+        let base = pool.hasSuffix("/") ? String(pool.dropLast()) : pool
+        guard cwd.count > base.count else { return base }
+        let rest = cwd.dropFirst(base.count + 1).split(separator: "/").map(String.init)
+        guard let first = rest.first else { return base }
+        if first == WorktreeDeletionQueue.dirName, rest.count > 1 {
+            return base + "/" + first + "/" + rest[1]
+        }
+        return base + "/" + first
+    }
+
+    // MARK: - Real `ps` snapshot
+
+    /// One `/bin/ps` snapshot of every process on the machine, or `nil` when it
+    /// could not be taken — which the caller MUST treat as "skip this phase",
+    /// never as "no orphans".
+    ///
+    /// `-ww` disables column-width truncation, without which macOS clips the
+    /// command column even when stdout is a pipe.
+    static func realProcessSnapshot() async -> [ProcessSnapshotEntry]? {
+        let outcome: BoundedProcessOutcome
+        do {
+            outcome = try await runBoundedProcess(
+                executable: "/bin/ps",
+                arguments: ["-axww", "-o", "pid=,ppid=,pgid=,uid=,etime=,command="],
+                currentDirectory: nil,
+                timeout: .seconds(60)
+            )
+        } catch {
+            logger.error("gc: ps spawn failed: \(String(describing: error), privacy: .public)")
+            return nil
+        }
+        return parseProcessSnapshot(outcome)
+    }
+
+    /// Pure parser, extracted so the "unavailable ⇒ skip the phase" direction
+    /// is directly unit-testable. Same failure vocabulary as
+    /// `OrphanGC.parseLiveCWDs`: a timeout, a non-zero exit and non-UTF-8
+    /// output all yield `nil` rather than a partial picture.
+    static func parseProcessSnapshot(_ outcome: BoundedProcessOutcome) -> [ProcessSnapshotEntry]? {
+        switch outcome {
+        case .timedOut:
+            logger.error("gc: ps timed out after 60s")
+            return nil
+        case .completed(let status, let stdout, _):
+            guard status == 0 else {
+                logger.error("""
+                gc: ps exited \(status, privacy: .public) — treating the process snapshot as unavailable
+                """)
+                return nil
+            }
+            guard let text = String(data: stdout, encoding: .utf8) else {
+                logger.error("gc: ps output was not valid UTF-8")
+                return nil
+            }
+            return parseProcessLines(text)
+        }
+    }
+
+    /// `pid ppid pgid uid etime command...` — five fixed fields, then the
+    /// command, which may contain spaces and is therefore taken whole.
+    static func parseProcessLines(_ text: String) -> [ProcessSnapshotEntry] {
+        var result: [ProcessSnapshotEntry] = []
+        for line in text.split(separator: "\n") {
+            // Hand-scanned rather than `split(maxSplits:)`: `ps` right-aligns
+            // its numeric columns, so the runs of padding between them would
+            // eat an unpredictable share of any split budget. Take exactly five
+            // whitespace-delimited tokens, then keep the rest verbatim — the
+            // command legitimately contains spaces.
+            var rest = line[...]
+            var fields: [Substring] = []
+            for _ in 0..<5 {
+                rest = rest.drop(while: { $0 == " " || $0 == "\t" })
+                guard let end = rest.firstIndex(where: { $0 == " " || $0 == "\t" }) else {
+                    if !rest.isEmpty { fields.append(rest) }
+                    rest = rest[rest.endIndex...]
+                    break
+                }
+                fields.append(rest[..<end])
+                rest = rest[end...]
+            }
+            guard fields.count == 5,
+                  let pid = Int32(fields[0]), let ppid = Int32(fields[1]),
+                  let pgid = Int32(fields[2]), let uid = UInt32(fields[3])
+            else { continue }
+            result.append(ProcessSnapshotEntry(
+                pid: pid, ppid: ppid, pgid: pgid, uid: uid_t(uid),
+                elapsedSeconds: parseETime(String(fields[4])),
+                command: String(rest.drop(while: { $0 == " " || $0 == "\t" }))
+            ))
+        }
+        return result
+    }
+
+    /// `ps etime`: `[[dd-]hh:]mm:ss`. Returns `nil` for anything that does not
+    /// parse, which the grace gate reads as "too young to touch".
+    static func parseETime(_ raw: String) -> TimeInterval? {
+        var days = 0.0
+        var rest = raw
+        if let dash = rest.firstIndex(of: "-") {
+            guard let parsed = Double(rest[rest.startIndex..<dash]) else { return nil }
+            days = parsed
+            rest = String(rest[rest.index(after: dash)...])
+        }
+        let parts = rest.split(separator: ":").map(String.init)
+        guard (2...3).contains(parts.count) else { return nil }
+        var seconds = 0.0
+        for part in parts {
+            guard let value = Double(part) else { return nil }
+            seconds = seconds * 60 + value
+        }
+        return days * 86_400 + seconds
+    }
+}

--- a/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
+++ b/Sources/TBDDaemon/GC/OrphanProcessCollector.swift
@@ -43,9 +43,11 @@ public struct ProcessSnapshotEntry: Sendable, Equatable {
 public struct DeadWorktreeRoot: Sendable, Equatable {
     /// Canonical directory path.
     public var path: String
-    /// When the owning row was archived. `nil` means no row survives at all,
-    /// in which case grace is measured from process start instead — there is
-    /// no archive instant to measure from.
+    /// When the owning row was archived, where an archived row is what
+    /// established the death. `nil` means the evidence was of the other kind —
+    /// a `<pool>/.deleting/<uuid>` queue entry, which TBD renamed there itself
+    /// and which carries no archive instant to measure from, so grace runs
+    /// from process start instead.
     public var archivedAt: Date?
 
     public init(path: String, archivedAt: Date?) {
@@ -58,19 +60,25 @@ public struct DeadWorktreeRoot: Sendable, Equatable {
 public struct TBDProcessRoots: Sendable {
     /// Canonical prefixes of directories TBD owns **outright**: each repo's
     /// worktree pool (canonical and legacy) and the scratch-worktree pool.
-    /// Every child of one of these is a TBD worktree by construction, so a
-    /// child matching no row is a leftover this sweep owns.
+    ///
+    /// A pool is where TBD's own `.deleting/<uuid>` queue entries live, and an
+    /// entry there is positive evidence of death — TBD renamed it there. Being
+    /// under a pool is NOT itself such evidence: a directory a person created
+    /// under one by hand, with `git worktree add` or a bare `mkdir`, gets no
+    /// row until something calls `WorktreeLifecycle.reconcile`, and no timer
+    /// ever does. So an unrecognized child of a pool is ambiguous, and
+    /// ambiguity keeps.
     public var pools: [String]
     /// Canonical prefixes of directories TBD **shares** with other software —
     /// today the Claude scratchpad base, which Claude Code fills with one
     /// directory per project it has ever been run in, most of which TBD has
     /// never managed. A cwd here is classified only by an explicit `live` or
-    /// `dead` entry; an unrecognized child is never a candidate.
+    /// `dead` entry, and a shared root holds no `.deleting/` queue TBD drains,
+    /// so an unrecognized child is never a candidate.
     ///
-    /// The distinction is the whole difference between a whitelist and a
-    /// blacklist, and `ScratchpadCollector.reconcile` already takes the
-    /// whitelist side ("Unrelated directories in the base are untouched") for
-    /// a merely destructive operation. This one kills processes.
+    /// `ScratchpadCollector.reconcile` already takes the same whitelist side
+    /// ("Unrelated directories in the base are untouched") for a merely
+    /// destructive operation. This one kills processes.
     public var sharedRoots: [String]
     /// Canonical paths of worktrees that are still alive, and of their Claude
     /// scratchpads. A cwd under one of these is never a candidate, even at
@@ -78,9 +86,9 @@ public struct TBDProcessRoots: Sendable {
     /// server safe until the developer has archived the worktree it belonged
     /// to.
     public var live: [String]
-    /// Canonical paths of worktrees that are dead, and of their Claude
-    /// scratchpads, with the archive instant where the row survives to carry
-    /// one.
+    /// Canonical paths of worktrees whose rows say they are dead — archived —
+    /// and of their Claude scratchpads, each carrying that row's archive
+    /// instant.
     public var dead: [DeadWorktreeRoot]
 
     public init(
@@ -100,7 +108,8 @@ public enum CWDOwnership: Sendable, Equatable {
     case outside
     /// Under a worktree that is still alive. Never a candidate.
     case live(path: String)
-    /// Under a dead worktree, a `.deleting/` entry, or a scratchpad.
+    /// Under something positively known to be dead: an archived worktree, an
+    /// archived worktree's scratchpad, or a `<pool>/.deleting/<uuid>` entry.
     case dead(DeadWorktreeRoot)
 }
 
@@ -146,8 +155,10 @@ public struct OrphanProcessCandidate: Sendable, Equatable {
 ///
 /// Every failure direction is toward KEEPING: an unreadable cwd, an unparseable
 /// start time, a uid that is not ours, an identity that cannot be re-read at
-/// signal time, and any ambiguity between a live and a dead owner all leave the
-/// process running.
+/// signal time, and any ambiguity about whether the owning directory is dead
+/// all leave the process running. Reclamation runs on positive evidence of
+/// death — an archived row, or a `.deleting/<uuid>` entry TBD renamed there
+/// itself — never on the mere absence of one.
 public struct OrphanProcessCollector: Sendable {
     let signaller: any ProcessSignaller
     /// One fresh `/bin/ps` reading, taken immediately before each volley so a
@@ -198,12 +209,16 @@ public struct OrphanProcessCollector: Sendable {
     ///   `scripts/restart.sh` is run from a worktree, that worktree — so
     ///   archiving it would otherwise have the sweep SIGKILL the live daemon
     ///   running the sweep.
-    /// - its cwd is readable, and resolves under a dead TBD-managed root.
+    /// - its cwd is readable, and resolves under a TBD-managed root positively
+    ///   known to be dead — an archived worktree (or its scratchpad), or a
+    ///   `.deleting/<uuid>` queue entry. A directory nobody can attest is dead,
+    ///   including an unrecognized child of a worktree pool, keeps.
     /// - it is at least as old as the cwd reading it was joined to, so a pid
     ///   the kernel reissued between the two readings cannot inherit a dead
     ///   process's cwd. An unreadable age fails this, i.e. keeps.
-    /// - the grace window has passed: from `archivedAt` where the row survives
-    ///   to carry one, and from process start time where it does not.
+    /// - the grace window has passed: from `archivedAt` where an archived row
+    ///   established the death, and from process start time for a `.deleting/`
+    ///   entry, which carries no such instant.
     public func candidates(
         processes: [ProcessSnapshotEntry],
         cwdByPID: [Int32: String],
@@ -263,20 +278,21 @@ public struct OrphanProcessCollector: Sendable {
     /// and a dead owner resolves to `live` — keep-biased, like every other gate
     /// in this sweep.
     ///
-    /// A cwd under a **pool** that matches no row at all is `dead` with no
-    /// archive instant: that is the "absent from the database" arm, which
-    /// covers `.deleting/` entries and directories whose row was hard-deleted.
-    /// Its root is the pool's own child (two components for a
-    /// `.deleting/<uuid>` entry) so the record names a worktree-shaped path
-    /// rather than the pool.
+    /// Reclamation needs **positive evidence of death**, and there are exactly
+    /// two kinds. An archived row is one, and arrives as a `dead` entry. A
+    /// `<pool>/.deleting/<uuid>` queue entry is the other: TBD renamed the
+    /// directory there itself, so it is garbage by construction, and it is
+    /// reported with no archive instant because there is no row left to carry
+    /// one. Its root is the two-component entry path rather than the pool, so
+    /// the reap record names a worktree-shaped path.
     ///
-    /// That arm deliberately does NOT extend to a `sharedRoot`. The Claude
-    /// scratchpad base holds one directory per project Claude Code has ever
-    /// run in — `-Users-me-projects-something`, and slugs that are not
-    /// projects at all — and TBD manages almost none of them. Treating an
-    /// unrecognized child of a shared root as a dead worktree would put a
-    /// stranger's live session on the kill list, so a shared root classifies
-    /// only what an explicit `live`/`dead` entry names.
+    /// Every other unrecognized cwd is `outside`, under a pool as much as
+    /// under a shared root. The absence of a row is not evidence of death: a
+    /// directory a person made under a pool by hand acquires a row only when
+    /// something calls `WorktreeLifecycle.reconcile`, which has no periodic
+    /// caller at all, so on a daemon up for days a live hand-made worktree and
+    /// a leftover are indistinguishable — and this file resolves every
+    /// ambiguity by keeping.
     public func ownership(ofCWD cwd: String, roots: TBDProcessRoots) -> CWDOwnership {
         let poolMatch = longestPrefix(of: cwd, among: roots.pools)
         let sharedMatch = longestPrefix(of: cwd, among: roots.sharedRoots)
@@ -293,15 +309,19 @@ public struct OrphanProcessCollector: Sendable {
         if let deadMatch {
             return .dead(deadMatch)
         }
-        // Unrecognized. Only a pool owns its strays, and only when no shared
-        // root sits deeper — a nested shared root wins, keeping the process.
-        guard let poolMatch, poolMatch.count > (sharedMatch?.count ?? -1) else { return .outside }
-        return .dead(
-            DeadWorktreeRoot(path: Self.poolChild(of: cwd, pool: poolMatch), archivedAt: nil))
+        // Unrecognized by any row. The one stray that is still positive
+        // evidence of death is a `.deleting/<uuid>` entry TBD renamed there
+        // itself; everything else under a pool is ambiguous and keeps. Claimed
+        // only when no shared root sits deeper — a nested shared root wins.
+        guard let poolMatch, poolMatch.count > (sharedMatch?.count ?? -1),
+              let queued = Self.deletionQueueEntry(of: cwd, pool: poolMatch)
+        else { return .outside }
+        return .dead(DeadWorktreeRoot(path: queued, archivedAt: nil))
     }
 
-    /// `gcGraceSeconds` measured from `archivedAt` where a row survives, and
-    /// from process start time where it does not. An unparseable start time
+    /// `gcGraceSeconds` measured from `archivedAt` where an archived row
+    /// established the death, and from process start time for a `.deleting/`
+    /// queue entry, which carries no such instant. An unparseable start time
     /// keeps the process.
     func graceElapsed(
         root: DeadWorktreeRoot, entry: ProcessSnapshotEntry, graceSeconds: Int
@@ -624,18 +644,16 @@ public struct OrphanProcessCollector: Sendable {
         return path == prefix || path.hasPrefix(prefix.hasSuffix("/") ? prefix : prefix + "/")
     }
 
-    /// The worktree-shaped child of `pool` that `cwd` sits under: one component
-    /// normally, two for a `<pool>/.deleting/<uuid>` queue entry, since the
-    /// queue directory itself owns nothing.
-    static func poolChild(of cwd: String, pool: String) -> String {
+    /// The `<pool>/.deleting/<uuid>` queue entry `cwd` sits inside, or `nil`
+    /// when it sits under no such entry — which includes every ordinary child
+    /// of the pool, and the queue directory itself, since that directory owns
+    /// nothing and its own death is not attested by anything.
+    static func deletionQueueEntry(of cwd: String, pool: String) -> String? {
         let base = pool.hasSuffix("/") ? String(pool.dropLast()) : pool
-        guard cwd.count > base.count else { return base }
+        guard cwd.count > base.count else { return nil }
         let rest = cwd.dropFirst(base.count + 1).split(separator: "/").map(String.init)
-        guard let first = rest.first else { return base }
-        if first == WorktreeDeletionQueue.dirName, rest.count > 1 {
-            return base + "/" + first + "/" + rest[1]
-        }
-        return base + "/" + first
+        guard rest.count > 1, rest[0] == WorktreeDeletionQueue.dirName else { return nil }
+        return base + "/" + rest[0] + "/" + rest[1]
     }
 
     // MARK: - Real `ps` snapshot

--- a/Sources/TBDDaemon/Process/ProcessSignaller.swift
+++ b/Sources/TBDDaemon/Process/ProcessSignaller.swift
@@ -13,6 +13,16 @@ public protocol ProcessSignaller: Sendable {
     func terminate(_ pid: Int32)
     /// Send SIGKILL with the same group-vs-single semantics as `terminate`.
     func forceKill(_ pid: Int32)
+    /// Send SIGTERM to **exactly this pid**, never to its process group.
+    ///
+    /// For callers that have already enumerated the set they mean to signal
+    /// and must not exceed it. `terminate`'s group escalation is a superset of
+    /// the process *group*, not of that set: a group can hold a process the
+    /// caller deliberately excluded, and on a reused pid `getpgid` resolves to
+    /// a stranger's group entirely.
+    func terminateProcessOnly(_ pid: Int32)
+    /// Send SIGKILL to exactly this pid, never to its process group.
+    func forceKillProcessOnly(_ pid: Int32)
     /// Pids whose parent pid == `serverPID` (one generation; tmux panes are
     /// direct children of the server process).
     func children(ofServerPID serverPID: Int32) -> [Int32]
@@ -21,6 +31,15 @@ public protocol ProcessSignaller: Sendable {
     /// `ps -o stat=` for the pid (e.g. "S+", "Ss"), or nil when the pid is
     /// gone. The trailing `+` marks the tty's foreground process group.
     func stat(_ pid: Int32) -> String?
+}
+
+public extension ProcessSignaller {
+    /// Defaults so existing conformers — the test fakes in particular — keep
+    /// recording through the signalling method they already implement. Only
+    /// `ProductionProcessSignaller` needs the distinction, because only it
+    /// reaches a real `kill(2)`.
+    func terminateProcessOnly(_ pid: Int32) { terminate(pid) }
+    func forceKillProcessOnly(_ pid: Int32) { forceKill(pid) }
 }
 
 public struct ProductionProcessSignaller: ProcessSignaller {
@@ -34,6 +53,14 @@ public struct ProductionProcessSignaller: ProcessSignaller {
 
     public func terminate(_ pid: Int32) { signal(pid, SIGTERM) }
     public func forceKill(_ pid: Int32) { signal(pid, SIGKILL) }
+
+    public func terminateProcessOnly(_ pid: Int32) { signalPIDOnly(pid, SIGTERM) }
+    public func forceKillProcessOnly(_ pid: Int32) { signalPIDOnly(pid, SIGKILL) }
+
+    private func signalPIDOnly(_ pid: Int32, _ sig: Int32) {
+        guard pid > 1 else { return }  // never signal pid<=1
+        _ = Foundation.kill(pid, sig)
+    }
 
     private func signal(_ pid: Int32, _ sig: Int32) {
         guard pid > 1 else { return }  // never signal pid<=1

--- a/Sources/TBDDaemon/Process/ProcessSignaller.swift
+++ b/Sources/TBDDaemon/Process/ProcessSignaller.swift
@@ -34,10 +34,11 @@ public protocol ProcessSignaller: Sendable {
 }
 
 public extension ProcessSignaller {
-    /// Defaults so existing conformers — the test fakes in particular — keep
-    /// recording through the signalling method they already implement. Only
-    /// `ProductionProcessSignaller` needs the distinction, because only it
-    /// reaches a real `kill(2)`.
+    /// Defaults so adding these requirements does not break a conformer that
+    /// has no use for the distinction: only an implementation that reaches a
+    /// real `kill(2)` can widen a signal to a process group in the first
+    /// place, so for everyone else the pid-exact door and the ordinary one are
+    /// the same door.
     func terminateProcessOnly(_ pid: Int32) { terminate(pid) }
     func forceKillProcessOnly(_ pid: Int32) { forceKill(pid) }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -200,6 +200,27 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the orphaned-process collector gate — the default-off soak
+    /// switch for reclaiming processes that outlived the worktree they were
+    /// rooted in, read on top of the GC master switch.
+    ///
+    /// This is how the soak is turned on. Its sibling gates all have an RPC,
+    /// and this one is the phase that signals processes, so leaving it
+    /// reachable only by hand-editing `~/tbd/state.db` would have made the one
+    /// irreversible phase the one with no supported way to enable it — against
+    /// a database the project's own rules say not to go behind.
+    ///
+    /// Like the master switch, flipping it off does not cancel an in-progress
+    /// sweep: `OrphanGC.sweep` re-reads the flag on its next pass.
+    func handleConfigSetGCOrphanProcessesEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetGCOrphanProcessesEnabledParams.self, from: paramsData)
+        try await db.config.setGCOrphanProcessesEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the fleet supervision brake (design 2026-07-26 §3, §7) — the
     /// fleet-wide on/off switch for supervision. Shipped OFF; nothing in the
     /// daemon reads this column to gate an actuation yet, because the acting

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -615,6 +615,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetGCEnabled(request.paramsData)
             case RPCMethod.configSetGCProfileDirsEnabled:
                 return try await handleConfigSetGCProfileDirsEnabled(request.paramsData)
+            case RPCMethod.configSetGCOrphanProcessesEnabled:
+                return try await handleConfigSetGCOrphanProcessesEnabled(request.paramsData)
             case RPCMethod.configSetSupervisionEnabled:
                 return try await handleConfigSetSupervisionEnabled(request.paramsData)
             case RPCMethod.remoteProviders:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1277,6 +1277,20 @@ public struct Config: Codable, Sendable, Equatable {
     /// so this property is
     /// `claude_cloud_enabled ?? Config.claudeCloudEnabledDefault`.
     public var claudeCloudEnabled: Bool
+    /// Gate for the orphan-GC phase that reclaims processes which outlived the
+    /// worktree they were rooted in
+    /// (`docs/specs/2026-08-18-orphan-process-gc-design.md`). Read on top of
+    /// `gcEnabled`: both must be on for the phase to run. It ships OFF because
+    /// this is the one GC phase that signals processes rather than moving
+    /// bytes, and a process it misjudges cannot be restored.
+    ///
+    /// **Resolved, not stored**, like `gcProfileDirsEnabled`: the backing
+    /// column carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `gc_orphan_processes_enabled ?? Config.gcOrphanProcessesEnabledDefault`.
+    /// NULL means "never chose" and follows the shipped default wherever it
+    /// goes; `0`/`1` is an explicit gesture and is honored forever.
+    public var gcOrphanProcessesEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -1311,6 +1325,11 @@ public struct Config: Codable, Sendable, Equatable {
     /// lives. Cloud ships off; graduating it is a change to this constant — no
     /// forcing `UPDATE` migration, and an explicit opt-out is left alone.
     public static let claudeCloudEnabledDefault = false
+    /// The shipped default for `gcOrphanProcessesEnabled`, and the single place
+    /// it lives. The orphaned-process collector ships off; graduating it is a
+    /// change to this constant — no forcing `UPDATE` migration, and an explicit
+    /// opt-out is left alone.
+    public static let gcOrphanProcessesEnabledDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1340,7 +1359,8 @@ public struct Config: Codable, Sendable, Equatable {
                 queuedPromptEnabled: Bool = Config.queuedPromptDefault,
                 supervisionEnabled: Bool = Config.supervisionEnabledDefault,
                 gcProfileDirsEnabled: Bool = Config.gcProfileDirsEnabledDefault,
-                claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault) {
+                claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault,
+                gcOrphanProcessesEnabled: Bool = Config.gcOrphanProcessesEnabledDefault) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -1370,6 +1390,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.supervisionEnabled = supervisionEnabled
         self.gcProfileDirsEnabled = gcProfileDirsEnabled
         self.claudeCloudEnabled = claudeCloudEnabled
+        self.gcOrphanProcessesEnabled = gcOrphanProcessesEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1440,6 +1461,11 @@ public struct Config: Codable, Sendable, Equatable {
             Bool.self, forKey: .gcProfileDirsEnabled) ?? Config.gcProfileDirsEnabledDefault
         claudeCloudEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .claudeCloudEnabled) ?? Config.claudeCloudEnabledDefault
+        // Same tri-state again: absent means the sender knew nothing about the
+        // flag, which is the NULL column's situation — follow the shipped
+        // default rather than hardcoding `false`.
+        gcOrphanProcessesEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .gcOrphanProcessesEnabled) ?? Config.gcOrphanProcessesEnabledDefault
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1595,6 +1595,25 @@ public enum ReapKind: String, Codable, Sendable {
     /// is already gone, so renaming it back would just recreate an orphan for
     /// the next sweep.
     case profileDir
+    /// A process that outlived the worktree it was rooted in — reclaimed by
+    /// `OrphanProcessCollector`
+    /// (`docs/specs/2026-08-18-orphan-process-gc-design.md`).
+    ///
+    /// The record describes a **kill**, not a directory, so it reads the
+    /// `ReapRecord` fields differently from every other kind:
+    /// - `worktreePath` is the dead worktree the process was rooted in — the
+    ///   TBD-managed root its resolved cwd fell under, not a path this reap
+    ///   removed. Nothing on disk was touched.
+    /// - `processDescription` carries the pid and a truncated argv, so the
+    ///   record says *what* was killed and not merely where it lived.
+    /// - `branch`, `headSHA`, `snapshotRef` and `quarantinePath` are unused
+    ///   and always `nil`: they are path- and git-shaped, and a process has
+    ///   neither a git identity nor a quarantine.
+    ///
+    /// It is **not restorable** — `OrphanGC.restore` rejects it explicitly. A
+    /// killed process cannot be brought back, so the record is an audit trail
+    /// rather than an undo.
+    case orphanProcess
 }
 
 /// Record of a directory the daemon-owned orphan GC swept and (optionally)
@@ -1620,12 +1639,17 @@ public struct ReapRecord: Codable, Sendable, Identifiable, Equatable {
     /// `OrphanGC.restore` rejects `.profileDir` — but the path a user needs to
     /// retrieve anything by hand before the retention window expires.
     public var quarantinePath: String?
+    /// What was killed (`orphanProcess` only): the pid and a truncated argv.
+    /// `nil` for every directory-shaped kind, and for rows written before the
+    /// column existed.
+    public var processDescription: String?
     public var reapedAt: Date
     public var restoredAt: Date?
 
     public init(id: UUID = UUID(), kind: ReapKind, repoPath: String, worktreePath: String,
                 branch: String? = nil, headSHA: String? = nil, snapshotRef: String? = nil,
                 apparentBytes: Int64? = nil, quarantinePath: String? = nil,
+                processDescription: String? = nil,
                 reapedAt: Date = Date(), restoredAt: Date? = nil) {
         self.id = id
         self.kind = kind
@@ -1636,6 +1660,7 @@ public struct ReapRecord: Codable, Sendable, Identifiable, Equatable {
         self.snapshotRef = snapshotRef
         self.apparentBytes = apparentBytes
         self.quarantinePath = quarantinePath
+        self.processDescription = processDescription
         self.reapedAt = reapedAt
         self.restoredAt = restoredAt
     }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -282,6 +282,7 @@ public enum RPCMethod {
     public static let gcSweepNow = "gc.sweepNow"
     public static let configSetGCEnabled = "config.setGCEnabled"
     public static let configSetGCProfileDirsEnabled = "config.setGCProfileDirsEnabled"
+    public static let configSetGCOrphanProcessesEnabled = "config.setGCOrphanProcessesEnabled"
     public static let remoteProviders = "remote.providers"
     public static let remoteSessions = "remote.sessions"
     public static let remoteCreate = "remote.create"
@@ -2562,6 +2563,15 @@ public struct ConfigSetGCEnabledParams: Codable, Sendable {
 /// collector, which reclaims orphaned `~/tbd/profiles/<uuid>/` directories
 /// (default OFF during soak, on top of the GC master switch).
 public struct ConfigSetGCProfileDirsEnabledParams: Codable, Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setGCOrphanProcessesEnabled` — the gate for the
+/// orphaned-process collector, which reclaims processes that outlived the
+/// worktree they were rooted in (default OFF during soak, on top of the GC
+/// master switch). Design: `docs/specs/2026-08-18-orphan-process-gc-design.md`.
+public struct ConfigSetGCOrphanProcessesEnabledParams: Codable, Sendable {
     public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -369,4 +369,134 @@ struct ConfigStoreTests {
         try await db.config.setGCProfileDirsEnabled(false)
         #expect(try await db.config.get().gcProfileDirsEnabled == false)
     }
+
+    // MARK: - v81: `gc_orphan_processes_enabled` is genuinely tri-state
+
+    /// **The storage guard.** The `config` singleton row is inserted by v1, so
+    /// every install — fresh or years old — has a row that predates v81. After
+    /// v81 that row's `gc_orphan_processes_enabled` must read NULL, not `0`: a
+    /// SQL default would backfill it and make "never chose" indistinguishable
+    /// from a deliberate opt-out. If someone adds `defaults:` to
+    /// `v81_config_gc_orphan_processes`, this goes red — that is its only job.
+    @Test func gcOrphanProcessesIsNullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.gc_orphan_processes_enabled == nil,
+            """
+            config.gc_orphan_processes_enabled must be NULL until the toggle is \
+            touched — read back \
+            \(String(describing: record.gc_orphan_processes_enabled)). A non-nil \
+            value here means v81_config_gc_orphan_processes grew a `defaults:` \
+            argument; remove it.
+            """
+        )
+    }
+
+    /// The same guard against a row written by a real pre-v81 daemon: migrate
+    /// only through v80, write to the config row, then finish migrating.
+    @Test func rowWrittenBeforeV81StillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v80_clear_scratch_pr_observation")
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID]
+            )
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["gc_orphan_processes_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before v81 must read NULL, not \(raw)"
+            )
+            // The pre-existing write survived — v81 is purely additive.
+            #expect(row["gc_enabled"] == true)
+        }
+    }
+
+    /// NULL follows `Config.gcOrphanProcessesEnabledDefault` wherever it goes;
+    /// an explicit `false` does not. That property is what makes graduation a
+    /// one-line constant change with no forcing `UPDATE` migration. Exercised
+    /// against BOTH possible default values, so it fails if the resolution is
+    /// ever wired as `?? false`.
+    @Test func gcOrphanProcessesExplicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.gc_orphan_processes_enabled == nil)
+        #expect(untouched.toModel(gcOrphanProcessesDefault: false).gcOrphanProcessesEnabled == false)
+        #expect(
+            untouched.toModel(gcOrphanProcessesDefault: true).gcOrphanProcessesEnabled == true,
+            "a never-chosen row must pick up a changed shipped default"
+        )
+
+        try await db.config.setGCOrphanProcessesEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.gc_orphan_processes_enabled == false)
+        #expect(
+            explicitlyOff.toModel(gcOrphanProcessesDefault: false).gcOrphanProcessesEnabled == false)
+        #expect(
+            explicitlyOff.toModel(gcOrphanProcessesDefault: true).gcOrphanProcessesEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes"
+        )
+    }
+
+    /// Mirrored for an explicit `true`: an operator who opted into the soak
+    /// stays opted in even if the shipped default never moves.
+    @Test func gcOrphanProcessesExplicitTrueSticks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.gc_orphan_processes_enabled == true)
+        #expect(explicitlyOn.toModel(gcOrphanProcessesDefault: false).gcOrphanProcessesEnabled == true)
+        #expect(explicitlyOn.toModel(gcOrphanProcessesDefault: true).gcOrphanProcessesEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard from the STORAGE guard by constructing a
+    /// `ConfigRecord` directly — no database, no migration. It catches a
+    /// hardening of `?? gcOrphanProcessesDefault` into `?? false` even if the
+    /// migration guard were broken at the same time.
+    @Test func gcOrphanProcessesToModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", gc_orphan_processes_enabled: nil)
+        #expect(record.toModel(gcOrphanProcessesDefault: false).gcOrphanProcessesEnabled == false)
+        #expect(
+            record.toModel(gcOrphanProcessesDefault: true).gcOrphanProcessesEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false"
+        )
+    }
+
+    /// The shipped default today: OFF. This is the one GC phase that signals
+    /// processes rather than moving bytes, and what it misjudges cannot be
+    /// restored. Graduation edits this constant and nothing else.
+    @Test func gcOrphanProcessesShipsOff() async throws {
+        #expect(Config.gcOrphanProcessesEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().gcOrphanProcessesEnabled == false)
+    }
+
+    @Test func setGCOrphanProcessesEnabledRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        #expect(try await db.config.get().gcOrphanProcessesEnabled == true)
+        try await db.config.setGCOrphanProcessesEnabled(false)
+        #expect(try await db.config.get().gcOrphanProcessesEnabled == false)
+    }
+
+    /// An absent JSON key means the sender knew nothing about the flag — the
+    /// NULL column's situation — so it follows the shipped default rather than
+    /// decoding as a hardcoded `false`.
+    @Test func gcOrphanProcessesDecodesFromJSONWithoutTheKey() throws {
+        let json = Data("{}".utf8)
+        let decoded = try JSONDecoder().decode(Config.self, from: json)
+        #expect(decoded.gcOrphanProcessesEnabled == Config.gcOrphanProcessesEnabledDefault)
+    }
 }

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -370,14 +370,14 @@ struct ConfigStoreTests {
         #expect(try await db.config.get().gcProfileDirsEnabled == false)
     }
 
-    // MARK: - v81: `gc_orphan_processes_enabled` is genuinely tri-state
+    // MARK: - v83: `gc_orphan_processes_enabled` is genuinely tri-state
 
     /// **The storage guard.** The `config` singleton row is inserted by v1, so
-    /// every install — fresh or years old — has a row that predates v81. After
-    /// v81 that row's `gc_orphan_processes_enabled` must read NULL, not `0`: a
+    /// every install — fresh or years old — has a row that predates v83. After
+    /// v83 that row's `gc_orphan_processes_enabled` must read NULL, not `0`: a
     /// SQL default would backfill it and make "never chose" indistinguishable
     /// from a deliberate opt-out. If someone adds `defaults:` to
-    /// `v81_config_gc_orphan_processes`, this goes red — that is its only job.
+    /// `v83_config_gc_orphan_processes`, this goes red — that is its only job.
     @Test func gcOrphanProcessesIsNullBeforeAnyGesture() async throws {
         let db = try TBDDatabase(inMemory: true)
         let record = try #require(try await fetchConfigRecord(db))
@@ -387,15 +387,16 @@ struct ConfigStoreTests {
             config.gc_orphan_processes_enabled must be NULL until the toggle is \
             touched — read back \
             \(String(describing: record.gc_orphan_processes_enabled)). A non-nil \
-            value here means v81_config_gc_orphan_processes grew a `defaults:` \
+            value here means v83_config_gc_orphan_processes grew a `defaults:` \
             argument; remove it.
             """
         )
     }
 
-    /// The same guard against a row written by a real pre-v81 daemon: migrate
-    /// only through v80, write to the config row, then finish migrating.
-    @Test func rowWrittenBeforeV81StillReadsNull() throws {
+    /// The same guard against a row written by a real pre-v83 daemon: migrate
+    /// only through v80 — a schema state this column had not reached — write to
+    /// the config row, then finish migrating.
+    @Test func rowWrittenBeforeV83StillReadsNull() throws {
         let queue = try DatabaseQueue()
         let migrator = TBDDatabase.buildMigratorForTests()
         try migrator.migrate(queue, upTo: "v80_clear_scratch_pr_observation")
@@ -416,9 +417,9 @@ struct ConfigStoreTests {
             let raw: DatabaseValue = row["gc_orphan_processes_enabled"]
             #expect(
                 raw.isNull,
-                "a config row written before v81 must read NULL, not \(raw)"
+                "a config row written before v83 must read NULL, not \(raw)"
             )
-            // The pre-existing write survived — v81 is purely additive.
+            // The pre-existing write survived — v83 is purely additive.
             #expect(row["gc_enabled"] == true)
         }
     }

--- a/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
@@ -465,6 +465,38 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         #expect(result.planned.contains("KEEP ps-unavailable orphan-processes"))
     }
 
+    /// The Claude scratchpad base is shared with every Claude Code session on
+    /// the machine, TBD-managed or not. A directory there naming no worktree
+    /// TBD knows is somebody else's, and its processes are not this sweep's to
+    /// kill — the whitelist side `ScratchpadCollector.reconcile` already takes.
+    @Test("a scratchpad naming no TBD worktree is never a candidate")
+    func strayScratchpadIsNeverACandidate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        // A Claude session run straight from a checkout TBD has never managed.
+        let stray = scratchpadBase.appendingPathComponent(
+            ScratchpadCollector.slug(forWorktreePath: "/Users/someone/projects/acme"),
+            isDirectory: true)
+        try fm.createDirectory(at: stray, withIntermediateDirectories: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[4243] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242), entry(pid: 4243)],
+            cwdByPID: [4242: canon(stray) + "/sub", 4243: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(!signaller.terminated.contains(4242))
+        #expect(!result.planned.contains { $0.contains("pid=4242") })
+        // The genuine orphan in the same sweep proves the phase ran at all.
+        #expect(signaller.terminated == [4243])
+    }
+
     @Test("a process outside every TBD pool is never a candidate")
     func outsideEveryPoolIsNeverACandidate() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
@@ -1,0 +1,492 @@
+import Foundation
+import Security
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Tier 2: a real filesystem sandbox plus an in-memory database. The `ps`
+/// snapshot, the pid-to-cwd map and the signaller are all injected, so nothing
+/// here spawns a process or sends a real signal — the same discipline
+/// `AgentReaperTests` keeps, which drives the identical escalation at
+/// `.milliseconds(1)`.
+@Suite("OrphanGC reclaims orphaned processes")
+struct OrphanGCOrphanProcessTests: ~Copyable {
+    let fm = FileManager.default
+    /// Sandbox root for this test instance; everything lives under it.
+    let sandbox: URL
+    /// The repo's worktree pool (`repo.worktreeRoot` override), so the
+    /// canonical `~/tbd/worktrees` layout is never consulted.
+    let pool: URL
+    let repoDir: URL
+    /// Injected scratchpad base, so the sweep's scratchpad phase can never
+    /// reach the developer's real Claude store.
+    let scratchpadBase: URL
+
+    init() {
+        sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-process-\(UUID().uuidString)", isDirectory: true)
+        pool = sandbox.appendingPathComponent("pool", isDirectory: true)
+        repoDir = sandbox.appendingPathComponent("repo", isDirectory: true)
+        scratchpadBase = sandbox.appendingPathComponent("scratchpads", isDirectory: true)
+        try? fm.createDirectory(at: pool, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: scratchpadBase, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? fm.removeItem(at: sandbox)
+    }
+
+    // MARK: - Fixtures
+
+    /// `realpath`, matching what `lsof` reports and what the sweep resolves
+    /// both sides of every comparison to. `NSTemporaryDirectory()` sits under
+    /// macOS's `/var` -> `/private/var` symlink, so a fixture path that skips
+    /// this lines up with nothing.
+    private func canon(_ url: URL) -> String {
+        guard let resolved = realpath(url.path, nil) else { return url.path }
+        defer { free(resolved) }
+        return String(cString: resolved)
+    }
+
+    private func makeGC(
+        db: TBDDatabase,
+        signaller: ProcessSignaller,
+        processes: [ProcessSnapshotEntry],
+        cwdByPID: [Int32: String],
+        now: Date,
+        processSnapshotAvailable: Bool = true
+    ) -> OrphanGC {
+        OrphanGC(
+            db: db, git: GitManager(),
+            broadcast: { _ in },
+            liveCWDsProvider: { [] },
+            scratchpadBase: scratchpadBase,
+            now: { now },
+            beforeInterruptedArchiveReap: nil,
+            profileDirBase: sandbox.appendingPathComponent("profiles", isDirectory: true),
+            credentialsKeychain: NoopKeychain(),
+            beforeProfileDirReap: nil,
+            processCWDsProvider: { cwdByPID },
+            processSnapshotProvider: { processSnapshotAvailable ? processes : nil },
+            signaller: signaller,
+            orphanProcessGraceAttempts: 2,
+            orphanProcessPollInterval: .milliseconds(1)
+        )
+    }
+
+    /// A repo row whose worktree pool is the sandbox `pool` directory.
+    private func makeRepo(db: TBDDatabase) async throws -> Repo {
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        try await db.repos.updateWorktreeRoot(id: repo.id, path: pool.path)
+        return try #require(try await db.repos.get(id: repo.id))
+    }
+
+    /// A worktree row plus its directory under the pool. `archived` decides
+    /// whether the row is a live one or one the developer has finished with.
+    @discardableResult
+    private func makeWorktree(
+        db: TBDDatabase, repo: Repo, name: String, archived: Bool
+    ) async throws -> String {
+        let dir = pool.appendingPathComponent(name, isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: name,
+            path: dir.path, tmuxServer: "tbd-test")
+        if archived {
+            try await db.worktrees.archive(id: row.id)
+        }
+        return canon(dir)
+    }
+
+    /// A stray `.deleting/<uuid>` entry, drained by the deletion-queue
+    /// collector on every sweep regardless of any soak flag. Present in the
+    /// flag tests as the control: it proves the ungated collectors still ran.
+    private func makeQueuedEntry() throws -> String {
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool.path)
+        let entry = queueDir + "/" + UUID().uuidString
+        try fm.createDirectory(atPath: entry, withIntermediateDirectories: true)
+        return entry
+    }
+
+    private func entry(
+        pid: Int32, ppid: Int32 = 1, pgid: Int32? = nil,
+        elapsed: TimeInterval? = 86_400, command: String = "/usr/bin/node server.js"
+    ) -> ProcessSnapshotEntry {
+        ProcessSnapshotEntry(
+            pid: pid, ppid: ppid, pgid: pgid ?? pid, uid: getuid(),
+            elapsedSeconds: elapsed, command: command)
+    }
+
+    // MARK: - Flag branches
+
+    @Test("the flag ships off: a matching orphan survives a real sweep untouched")
+    func flagOffLeavesTheOrphanRunning() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let queued = try makeQueuedEntry()
+        let signaller = FakeProcessSignaller()
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242)],
+            cwdByPID: [4242: dead + "/sub"],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated.isEmpty)
+        #expect(signaller.killed.isEmpty)
+        #expect(!result.planned.contains { $0.hasPrefix("REAP orphan-process") })
+        #expect(try await db.reapRecords.list(repoPath: nil).allSatisfy { $0.kind != .orphanProcess })
+        // The control: ungated GC behavior is unaffected by the flag's state.
+        #expect(result.planned.contains("REAP queued-deletion \(queued)"))
+        #expect(!fm.fileExists(atPath: queued))
+    }
+
+    @Test("flag on: the same orphan is reclaimed and recorded")
+    func flagOnReclaimsTheOrphan() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let queued = try makeQueuedEntry()
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[4242] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242, command: "/usr/bin/node server.js --port 3000")],
+            cwdByPID: [4242: dead + "/sub"],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated == [4242])
+        #expect(signaller.killed.isEmpty, "a process that honors SIGTERM is never SIGKILLed")
+        #expect(result.planned.contains("REAP orphan-process pid=4242 tree=1 \(dead)"))
+
+        let record = try #require(
+            try await db.reapRecords.list(repoPath: nil).first { $0.kind == .orphanProcess })
+        #expect(record.worktreePath == dead, "the dead worktree the process was rooted in")
+        #expect(record.repoPath == repoDir.path)
+        let description = try #require(record.processDescription)
+        #expect(description.hasPrefix("pid=4242 tree=1 "))
+        #expect(description.contains("--port 3000"))
+        // The path- and git-shaped fields go unused for this kind.
+        #expect(record.branch == nil)
+        #expect(record.headSHA == nil)
+        #expect(record.snapshotRef == nil)
+        #expect(record.quarantinePath == nil)
+        // Still unaffected in the other direction.
+        #expect(result.planned.contains("REAP queued-deletion \(queued)"))
+    }
+
+    @Test("gcEnabled off keeps everything even with the orphan-process flag on")
+    func masterSwitchStillGoverns() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242)],
+            cwdByPID: [4242: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(result.planned == ["gc disabled"])
+        #expect(signaller.terminated.isEmpty)
+    }
+
+    @Test("with the flag off a dry run still plans what enabling it would reclaim")
+    func flagOffDryRunStillPlans() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242)],
+            cwdByPID: [4242: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep(dryRun: true)
+
+        #expect(result.planned.contains("REAP orphan-process pid=4242 tree=1 \(dead)"))
+        #expect(result.reaped == 0)
+        #expect(signaller.terminated.isEmpty, "a dry run touches nothing")
+        #expect(signaller.killed.isEmpty)
+    }
+
+    // MARK: - Descendant closure
+
+    @Test("a three-generation tree is reclaimed whole, leaf-first, across process groups")
+    func reclaimsTheWholeSubtree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        for pid: Int32 in [700, 701, 702] {
+            signaller.behaviors[pid] = .init(aliveAfterTerminate: false)
+        }
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [
+                entry(pid: 700, ppid: 1, pgid: 698, command: "process-compose up"),
+                entry(pid: 701, ppid: 700, pgid: 698, command: "prefect server start"),
+                // The case a plain killpg misses: a grandchild in a process
+                // group of its own, unreachable from the root's group.
+                entry(pid: 702, ppid: 701, pgid: 702, command: "uvicorn app:api"),
+            ],
+            cwdByPID: [700: dead, 701: dead, 702: dead + "/nested"],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated == [702, 701, 700], "leaf-first, deepest generation first")
+        #expect(result.planned.contains("REAP orphan-process pid=700 tree=3 \(dead)"))
+        let record = try #require(
+            try await db.reapRecords.list(repoPath: nil).first { $0.kind == .orphanProcess })
+        #expect(try #require(record.processDescription).hasPrefix("pid=700 tree=3 "))
+        // Only the ppid==1 root is a candidate; the children are reclaimed as
+        // part of its closure, not as roots of their own.
+        #expect(result.planned.filter { $0.hasPrefix("REAP orphan-process") }.count == 1)
+    }
+
+    @Test("a subtree member that ignores SIGTERM is escalated to SIGKILL")
+    func escalatesSurvivors() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[800] = .init(aliveAfterTerminate: true, aliveAfterKill: false)
+        signaller.behaviors[801] = .init(aliveAfterTerminate: false)
+
+        _ = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 800), entry(pid: 801, ppid: 800)],
+            cwdByPID: [800: dead, 801: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated == [801, 800])
+        #expect(signaller.killed == [800], "only the process still alive after the grace window")
+    }
+
+    // MARK: - Keep gates
+
+    @Test("a process inside a LIVE worktree is never a candidate, even at ppid 1")
+    func liveWorktreeIsNeverACandidate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let alive = try await makeWorktree(db: db, repo: repo, name: "working", archived: false)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[901] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 900), entry(pid: 901)],
+            cwdByPID: [900: alive + "/src", 901: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(!signaller.terminated.contains(900), "a detached dev server in live work is safe")
+        // The dead one in the same sweep proves the phase ran at all.
+        #expect(signaller.terminated == [901])
+        #expect(!result.planned.contains { $0.contains("pid=900") })
+    }
+
+    @Test("a LIVE worktree's Claude scratchpad is classified with its worktree, not as an orphan")
+    func liveWorktreeScratchpadIsNeverACandidate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let alive = pool.appendingPathComponent("working", isDirectory: true)
+        try await makeWorktree(db: db, repo: repo, name: "working", archived: false)
+        // The scratchpad base is itself a TBD-managed pool, so without owner
+        // resolution this path would fall into the "absent from the database"
+        // arm and become reclaimable while the work is still going on.
+        let scratchpad = scratchpadBase.appendingPathComponent(
+            ScratchpadCollector.slug(forWorktreePath: alive.path), isDirectory: true)
+        try fm.createDirectory(at: scratchpad, withIntermediateDirectories: true)
+        let signaller = FakeProcessSignaller()
+
+        _ = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242)],
+            cwdByPID: [4242: canon(scratchpad)],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated.isEmpty)
+    }
+
+    @Test("grace is honored: too young survives, the same orphan is reclaimed once it passes")
+    func graceIsHonored() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+
+        // `archive` stamps the row with the real clock, so a sweep clock a
+        // minute later is well inside the 3600s window.
+        let tooSoon = FakeProcessSignaller()
+        _ = await makeGC(
+            db: db, signaller: tooSoon,
+            processes: [entry(pid: 4242)], cwdByPID: [4242: dead],
+            now: Date().addingTimeInterval(60)
+        ).sweep()
+        #expect(tooSoon.terminated.isEmpty, "an orphan younger than gcGraceSeconds survives")
+
+        let later = FakeProcessSignaller()
+        later.behaviors[4242] = .init(aliveAfterTerminate: false)
+        _ = await makeGC(
+            db: db, signaller: later,
+            processes: [entry(pid: 4242)], cwdByPID: [4242: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+        #expect(later.terminated == [4242], "the same orphan is reclaimed once the window passes")
+    }
+
+    @Test("a directory with no row at all measures grace from process start instead")
+    func graceFromProcessStartWhenNoRowSurvives() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        _ = try await makeRepo(db: db)
+        // Under the pool, but no worktree row ever existed for it.
+        let stray = pool.appendingPathComponent("forgotten", isDirectory: true)
+        try fm.createDirectory(at: stray, withIntermediateDirectories: true)
+
+        let young = FakeProcessSignaller()
+        _ = await makeGC(
+            db: db, signaller: young,
+            processes: [entry(pid: 550, elapsed: 60)], cwdByPID: [550: canon(stray)],
+            now: Date()
+        ).sweep()
+        #expect(young.terminated.isEmpty)
+
+        let old = FakeProcessSignaller()
+        old.behaviors[550] = .init(aliveAfterTerminate: false)
+        _ = await makeGC(
+            db: db, signaller: old,
+            processes: [entry(pid: 550, elapsed: 86_400)], cwdByPID: [550: canon(stray)],
+            now: Date()
+        ).sweep()
+        #expect(old.terminated == [550])
+    }
+
+    @Test("the daemon is never signalled, even with its cwd inside the archived worktree")
+    func daemonSelfExclusion() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[999] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [
+                entry(pid: 111, command: dead + "/.build/debug/TBDDaemon"),
+                entry(pid: 112, command: dead + "/.build/debug/TBD.app/Contents/MacOS/TBDApp"),
+                entry(pid: 999, command: "/usr/bin/node server.js"),
+            ],
+            cwdByPID: [111: dead, 112: dead, 999: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(!signaller.terminated.contains(111), "the sweep must never SIGKILL its own daemon")
+        #expect(!signaller.terminated.contains(112))
+        #expect(!signaller.killed.contains(111))
+        #expect(!signaller.killed.contains(112))
+        // The ordinary orphan in the same sweep proves the phase ran.
+        #expect(signaller.terminated == [999])
+        #expect(!result.planned.contains { $0.contains("pid=111") || $0.contains("pid=112") })
+    }
+
+    @Test("a candidate whose cwd could not be read is skipped, never reclaimed")
+    func unreadableCWDIsASkip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[601] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            // 600 is absent from the cwd map entirely — absence of evidence.
+            processes: [entry(pid: 600), entry(pid: 601)],
+            cwdByPID: [601: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(!signaller.terminated.contains(600))
+        #expect(signaller.terminated == [601])
+        #expect(!result.planned.contains { $0.contains("pid=600") })
+    }
+
+    @Test("an unavailable ps snapshot skips the phase rather than reading it as no orphans")
+    func psUnavailableSkipsThePhase() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242)], cwdByPID: [4242: dead],
+            now: Date().addingTimeInterval(7200),
+            processSnapshotAvailable: false
+        ).sweep()
+
+        #expect(signaller.terminated.isEmpty)
+        #expect(result.planned.contains("KEEP ps-unavailable orphan-processes"))
+    }
+
+    @Test("a process outside every TBD pool is never a candidate")
+    func outsideEveryPoolIsNeverACandidate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        _ = try await makeRepo(db: db)
+        let signaller = FakeProcessSignaller()
+
+        _ = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242)],
+            cwdByPID: [4242: canon(sandbox) + "/elsewhere"],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated.isEmpty)
+    }
+}
+
+/// A keychain that records nothing and deletes nothing — this suite never
+/// creates a profile dir, so the profile-dir phase has no work, but the sweep
+/// still needs a collaborator that cannot reach the real login keychain.
+private struct NoopKeychain: ClaudeCredentialsKeychainDeleting {
+    func deleteGenericPassword(service: String) -> OSStatus { errSecItemNotFound }
+}

--- a/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
@@ -61,7 +61,8 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         processes: [ProcessSnapshotEntry],
         cwdByPID: [Int32: String],
         now: Date,
-        processSnapshotAvailable: Bool = true
+        processSnapshotAvailable: Bool = true,
+        snapshotProvider: (@Sendable () async -> [ProcessSnapshotEntry]?)? = nil
     ) -> OrphanGC {
         OrphanGC(
             db: db, git: GitManager(),
@@ -74,7 +75,8 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
             credentialsKeychain: NoopKeychain(),
             beforeProfileDirReap: nil,
             processCWDsProvider: { cwdByPID },
-            processSnapshotProvider: { processSnapshotAvailable ? processes : nil },
+            processSnapshotProvider: snapshotProvider
+                ?? { processSnapshotAvailable ? processes : nil },
             signaller: signaller,
             orphanProcessGraceAttempts: 2,
             orphanProcessPollInterval: .milliseconds(1)
@@ -636,6 +638,98 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         ).sweep()
 
         #expect(signaller.terminated.isEmpty)
+    }
+
+    // MARK: - Identity at signal time, across a multi-candidate sweep
+
+    /// The amplification case the root-only `age >= cwdAge` gate cannot reach.
+    /// `reclaimOrphanProcesses` signals candidates one after another and each
+    /// reap blocks for up to `graceAttempts × pollInterval` before the next
+    /// one is even examined, so with the half-dozen simultaneous orphans a
+    /// field census found, the LAST candidate's tree is signalled many seconds
+    /// after the reading that named its pids. Its identity check therefore has
+    /// to run at ITS volley, not at the sweep's plan.
+    @Test("a later candidate in a multi-orphan sweep is identity-checked at its own volley")
+    func lateCandidateIsIdentityChecked() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        // Both honor SIGTERM, so neither reap reaches the SIGKILL escalation
+        // and the readings below line up one-to-one with the volleys.
+        signaller.behaviors[4242] = .init(aliveAfterTerminate: false)
+        signaller.behaviors[4343] = .init(aliveAfterTerminate: false)
+
+        let plan = [entry(pid: 4242), entry(pid: 4343)]
+        // While the first candidate was being reaped, 4343 exited and the
+        // kernel handed its pid to an unrelated, live, same-uid process.
+        let afterFirstReap = [entry(pid: 4242), entry(pid: 4343, elapsed: 4)]
+        let readings = ScriptedReadings([plan, plan, afterFirstReap])
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: plan,
+            cwdByPID: [4242: dead, 4343: dead],
+            now: Date().addingTimeInterval(7200),
+            snapshotProvider: { readings.next() }
+        ).sweep()
+
+        #expect(signaller.terminated == [4242], "the first candidate still verified and was reclaimed")
+        #expect(
+            !signaller.terminated.contains(4343),
+            "the last candidate's pid was reissued mid-sweep and must not be signalled")
+        #expect(signaller.killed.isEmpty)
+        #expect(result.planned.contains("KEEP nothing-signalled \(dead)"))
+        #expect(result.reaped == 1)
+        let records = try await db.reapRecords.list(repoPath: nil).filter { $0.kind == .orphanProcess }
+        #expect(records.count == 1)
+        #expect(try #require(records.first?.processDescription).hasPrefix("pid=4242 tree=1 "))
+    }
+
+    @Test("a ps reading that fails at signal time signals nothing and records nothing")
+    func unreadableIdentityAtSignalTimeKeeps() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        let plan = [entry(pid: 4242)]
+        // The planning reading succeeds; the pre-signal re-read does not.
+        let readings = ScriptedReadings([plan, nil])
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: plan,
+            cwdByPID: [4242: dead],
+            now: Date().addingTimeInterval(7200),
+            snapshotProvider: { readings.next() }
+        ).sweep()
+
+        #expect(signaller.terminated.isEmpty, "an identity that cannot be re-read is a skip")
+        #expect(signaller.killed.isEmpty)
+        #expect(result.reaped == 0)
+        #expect(result.planned.contains("REAP orphan-process pid=4242 tree=1 \(dead)"))
+        #expect(result.planned.contains("KEEP nothing-signalled \(dead)"))
+    }
+}
+
+/// Hands out one `ps` reading per call and then repeats the last, so a test can
+/// make the process table change between the reading a sweep planned from and
+/// the volley that acts on it. `nil` stands for a reading that could not be
+/// taken at all.
+private final class ScriptedReadings: @unchecked Sendable {
+    private let lock = NSLock()
+    private var readings: [[ProcessSnapshotEntry]?]
+
+    init(_ readings: [[ProcessSnapshotEntry]?]) {
+        self.readings = readings.isEmpty ? [[]] : readings
+    }
+
+    func next() -> [ProcessSnapshotEntry]? {
+        lock.withLock { readings.count > 1 ? readings.removeFirst() : readings[0] }
     }
 }
 

--- a/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
@@ -344,9 +344,8 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         let repo = try await makeRepo(db: db)
         let alive = pool.appendingPathComponent("working", isDirectory: true)
         try await makeWorktree(db: db, repo: repo, name: "working", archived: false)
-        // The scratchpad base is itself a TBD-managed pool, so without owner
-        // resolution this path would fall into the "absent from the database"
-        // arm and become reclaimable while the work is still going on.
+        // Resolved through its worktree's owner, so a live worktree's
+        // scratchpad is classified `live` rather than left unjudged.
         let scratchpad = scratchpadBase.appendingPathComponent(
             ScratchpadCollector.slug(forWorktreePath: alive.path), isDirectory: true)
         try fm.createDirectory(at: scratchpad, withIntermediateDirectories: true)
@@ -390,32 +389,111 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         #expect(later.terminated == [4242], "the same orphan is reclaimed once the window passes")
     }
 
-    @Test("a directory with no row at all measures grace from process start instead")
-    func graceFromProcessStartWhenNoRowSurvives() async throws {
+    /// A `.deleting/<uuid>` entry carries no archived row, so there is no
+    /// archive instant to grace from and process start stands in for it.
+    @Test("a `.deleting/` entry measures grace from process start instead")
+    func graceFromProcessStartForAQueueEntry() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setGCEnabled(true)
         try await db.config.setGCOrphanProcessesEnabled(true)
         _ = try await makeRepo(db: db)
-        // Under the pool, but no worktree row ever existed for it.
-        let stray = pool.appendingPathComponent("forgotten", isDirectory: true)
-        try fm.createDirectory(at: stray, withIntermediateDirectories: true)
+        let queued = try makeQueuedEntry()
+        let canonQueued = canon(URL(fileURLWithPath: queued, isDirectory: true))
 
         let young = FakeProcessSignaller()
         _ = await makeGC(
             db: db, signaller: young,
-            processes: [entry(pid: 550, elapsed: 60)], cwdByPID: [550: canon(stray)],
+            processes: [entry(pid: 550, elapsed: 60)], cwdByPID: [550: canonQueued],
             now: Date()
         ).sweep()
         #expect(young.terminated.isEmpty)
 
+        // Re-create it: the ungated deletion-queue collector drained the
+        // directory on the sweep above, and this half is about the process.
+        let requeued = try makeQueuedEntry()
+        let canonRequeued = canon(URL(fileURLWithPath: requeued, isDirectory: true))
         let old = FakeProcessSignaller()
         old.behaviors[550] = .init(aliveAfterTerminate: false)
         _ = await makeGC(
             db: db, signaller: old,
-            processes: [entry(pid: 550, elapsed: 86_400)], cwdByPID: [550: canon(stray)],
+            processes: [entry(pid: 550, elapsed: 86_400)], cwdByPID: [550: canonRequeued],
             now: Date()
         ).sweep()
         #expect(old.terminated == [550])
+    }
+
+    /// The absence of a row is not evidence of death. Only three call sites
+    /// reach `WorktreeLifecycle.reconcile` — daemon startup, `repo.add` and the
+    /// cleanup RPC — and no timer is one of them, so on a daemon up for days a
+    /// directory a person created under the pool by hand never acquires a row
+    /// at all. Reclaiming its processes would kill live work nobody archived,
+    /// on the strength of TBD not recognizing a name.
+    @Test("a directory created under the pool by hand is never a candidate")
+    func handMadePoolChildIsNeverACandidate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        // A worktree someone added with a bare `git worktree add`, or a plain
+        // `mkdir`. TBD never saw it, so it names no row.
+        let byHand = pool.appendingPathComponent("hand-made", isDirectory: true)
+        try fm.createDirectory(at: byHand, withIntermediateDirectories: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[5300] = .init(aliveAfterTerminate: false)
+        signaller.behaviors[5301] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 5300, elapsed: 864_000), entry(pid: 5301)],
+            cwdByPID: [5300: canon(byHand) + "/src", 5301: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(!signaller.terminated.contains(5300))
+        #expect(!signaller.killed.contains(5300))
+        #expect(!result.planned.contains { $0.contains("pid=5300") })
+        #expect(fm.fileExists(atPath: byHand.path))
+        // The archived worktree's orphan in the same sweep proves the hand-made
+        // directory survived a phase that genuinely ran.
+        #expect(signaller.terminated == [5301])
+    }
+
+    /// `worktree.forget` means "stop tracking this, leave the directory alone",
+    /// and the person may well still be working in it. Its processes are
+    /// therefore out of this sweep's reach — a deliberate limit, not an
+    /// oversight: neither orphan measured in the field was of this kind, both
+    /// having been archived rather than forgotten.
+    @Test("a forgotten worktree whose directory remains is never a candidate")
+    func forgottenWorktreeIsNeverACandidate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let forgottenDir = pool.appendingPathComponent("forgotten", isDirectory: true)
+        try fm.createDirectory(at: forgottenDir, withIntermediateDirectories: true)
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: "forgotten", branch: "forgotten",
+            path: forgottenDir.path, tmuxServer: "tbd-test")
+        // Forget: the row goes, the directory stays.
+        try await db.worktrees.delete(id: row.id)
+        #expect(fm.fileExists(atPath: forgottenDir.path))
+
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[5400] = .init(aliveAfterTerminate: false)
+        signaller.behaviors[5401] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 5400, elapsed: 864_000), entry(pid: 5401)],
+            cwdByPID: [5400: canon(forgottenDir) + "/src", 5401: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(!signaller.terminated.contains(5400))
+        #expect(!result.planned.contains { $0.contains("pid=5400") })
+        #expect(signaller.terminated == [5401])
     }
 
     @Test("the daemon is never signalled, even with its cwd inside the archived worktree")
@@ -589,9 +667,8 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
     /// The other half, and the reason the adopted path goes in as a SHARED
     /// root rather than a pool: the directory the user picked is the user's,
     /// and its neighbours are unrelated checkouts, loose files, sometimes a
-    /// home directory. A pool would put every one of them in the
-    /// "absent from the database" arm and make a stranger's live session
-    /// reclaimable.
+    /// home directory. A pool asserts that TBD owns the whole tree, which is
+    /// exactly what is not true here.
     @Test("an unrelated sibling of an adopted worktree is never a candidate")
     func adoptedWorktreeSiblingIsNeverACandidate() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
@@ -497,6 +497,35 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         #expect(signaller.terminated == [4243])
     }
 
+    /// The sibling of the `ps`-unavailable skip, and the reason both row reads
+    /// moved inside the phase: a partial view of which worktrees are alive is
+    /// the one input that could turn live work into a candidate.
+    @Test("a failed row read skips the phase rather than proceeding on a partial view")
+    func dbUnavailableSkipsThePhase() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let dead = try await makeWorktree(db: db, repo: repo, name: "gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[4242] = .init(aliveAfterTerminate: false)
+        // Make every worktree read fail, the way a corrupt or locked database
+        // would, rather than return an empty list.
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: "DROP TABLE worktree")
+        }
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 4242)], cwdByPID: [4242: dead],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated.isEmpty)
+        #expect(signaller.killed.isEmpty)
+        #expect(result.planned.contains("KEEP db-unavailable orphan-processes"))
+    }
+
     @Test("a process outside every TBD pool is never a candidate")
     func outsideEveryPoolIsNeverACandidate() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCOrphanProcessTests.swift
@@ -21,6 +21,10 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
     /// Injected scratchpad base, so the sweep's scratchpad phase can never
     /// reach the developer's real Claude store.
     let scratchpadBase: URL
+    /// A directory of the user's own, standing in for the arbitrary location an
+    /// adopted worktree lives at. Deliberately outside `pool`, and it holds
+    /// things TBD has never managed.
+    let adoptionParent: URL
 
     init() {
         sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -28,9 +32,11 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         pool = sandbox.appendingPathComponent("pool", isDirectory: true)
         repoDir = sandbox.appendingPathComponent("repo", isDirectory: true)
         scratchpadBase = sandbox.appendingPathComponent("scratchpads", isDirectory: true)
+        adoptionParent = sandbox.appendingPathComponent("user-projects", isDirectory: true)
         try? fm.createDirectory(at: pool, withIntermediateDirectories: true)
         try? fm.createDirectory(at: repoDir, withIntermediateDirectories: true)
         try? fm.createDirectory(at: scratchpadBase, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: adoptionParent, withIntermediateDirectories: true)
     }
 
     deinit {
@@ -90,6 +96,24 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         db: TBDDatabase, repo: Repo, name: String, archived: Bool
     ) async throws -> String {
         let dir = pool.appendingPathComponent(name, isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: name,
+            path: dir.path, tmuxServer: "tbd-test")
+        if archived {
+            try await db.worktrees.archive(id: row.id)
+        }
+        return canon(dir)
+    }
+
+    /// A worktree row at a path the user chose, the way `adoptWorktree` makes
+    /// one: under no worktree pool at all, next to whatever else the user keeps
+    /// in that directory.
+    @discardableResult
+    private func makeAdoptedWorktree(
+        db: TBDDatabase, repo: Repo, name: String, archived: Bool
+    ) async throws -> String {
+        let dir = adoptionParent.appendingPathComponent(name, isDirectory: true)
         try fm.createDirectory(at: dir, withIntermediateDirectories: true)
         let row = try await db.worktrees.create(
             repoID: repo.id, name: name, branch: name,
@@ -524,6 +548,76 @@ struct OrphanGCOrphanProcessTests: ~Copyable {
         #expect(signaller.terminated.isEmpty)
         #expect(signaller.killed.isEmpty)
         #expect(result.planned.contains("KEEP db-unavailable orphan-processes"))
+    }
+
+    // MARK: - Adopted worktrees
+
+    /// `adoptWorktree` puts a row at a path the user chose, under no pool at
+    /// all. The classifier gates on pool-or-shared-root membership before it
+    /// ever consults the dead list, so without the row's own path admitted as a
+    /// shared root this orphan would be `.outside` forever — the very leak this
+    /// phase exists to close, for every adopted worktree.
+    @Test("an orphan inside an ARCHIVED adopted worktree is reclaimed")
+    func archivedAdoptedWorktreeYieldsItsOrphan() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let adopted = try await makeAdoptedWorktree(
+            db: db, repo: repo, name: "adopted-gone", archived: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[5100] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 5100, command: "/usr/bin/node server.js --port 4000")],
+            cwdByPID: [5100: adopted + "/sub"],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(signaller.terminated == [5100])
+        #expect(result.planned.contains("REAP orphan-process pid=5100 tree=1 \(adopted)"))
+        let record = try #require(
+            try await db.reapRecords.list(repoPath: nil).first { $0.kind == .orphanProcess })
+        #expect(record.worktreePath == adopted)
+        // The row names its repo even though no pool contains its path.
+        #expect(record.repoPath == repoDir.path)
+    }
+
+    /// The other half, and the reason the adopted path goes in as a SHARED
+    /// root rather than a pool: the directory the user picked is the user's,
+    /// and its neighbours are unrelated checkouts, loose files, sometimes a
+    /// home directory. A pool would put every one of them in the
+    /// "absent from the database" arm and make a stranger's live session
+    /// reclaimable.
+    @Test("an unrelated sibling of an adopted worktree is never a candidate")
+    func adoptedWorktreeSiblingIsNeverACandidate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        try await db.config.setGCOrphanProcessesEnabled(true)
+        let repo = try await makeRepo(db: db)
+        let adopted = try await makeAdoptedWorktree(
+            db: db, repo: repo, name: "adopted-gone", archived: true)
+        // A checkout of the user's own, sitting next to the adopted worktree
+        // and never known to TBD.
+        let sibling = adoptionParent.appendingPathComponent("unrelated", isDirectory: true)
+        try fm.createDirectory(at: sibling, withIntermediateDirectories: true)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[5200] = .init(aliveAfterTerminate: false)
+        signaller.behaviors[5201] = .init(aliveAfterTerminate: false)
+
+        let result = await makeGC(
+            db: db, signaller: signaller,
+            processes: [entry(pid: 5200), entry(pid: 5201)],
+            cwdByPID: [5200: canon(sibling) + "/src", 5201: adopted],
+            now: Date().addingTimeInterval(7200)
+        ).sweep()
+
+        #expect(!signaller.terminated.contains(5200))
+        #expect(!result.planned.contains { $0.contains("pid=5200") })
+        // The adopted worktree's own orphan in the same sweep proves the
+        // sibling survived a phase that genuinely ran.
+        #expect(signaller.terminated == [5201])
     }
 
     @Test("a process outside every TBD pool is never a candidate")

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -354,7 +354,7 @@ struct OrphanGCTests {
         """
         let outcome = BoundedProcessOutcome.completed(status: 0, stdout: Data(stdout.utf8), stderr: Data())
         let parsed = OrphanGC.parseLiveCWDs(outcome)
-        #expect(parsed == ["/nonexistent/gc-test/wt-a", "/nonexistent/gc-test/wt-b"])
+        #expect(parsed?.paths == ["/nonexistent/gc-test/wt-a", "/nonexistent/gc-test/wt-b"])
     }
 
     // MARK: - lsof unavailable skips the entire sweep

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -260,6 +260,29 @@ struct OrphanGCTests {
         #expect(fetched?.quarantinePath == record.quarantinePath)
     }
 
+    /// `.orphanProcess` is the one kind where "un-restorable" is physical
+    /// rather than contractual: the process is dead. The record is an audit
+    /// trail, and a refused restore must leave it intact to stay one.
+    @Test("restore refuses an orphanProcess record and leaves the audit trail intact")
+    func restoreRejectsOrphanProcessRecords() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = ReapRecord(
+            kind: .orphanProcess,
+            repoPath: "/tmp/acme",
+            worktreePath: "/tmp/acme/worktrees/gone",
+            processDescription: "pid=4242 tree=3 /usr/bin/node server.js"
+        )
+        try await db.reapRecords.insert(record)
+        let gc = OrphanGC(db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] })
+
+        await #expect(throws: OrphanGCError.unsupportedKind(.orphanProcess)) {
+            try await gc.restore(recordID: record.id)
+        }
+        let fetched = try await db.reapRecords.get(id: record.id)
+        #expect(fetched?.restoredAt == nil)
+        #expect(fetched?.processDescription == record.processDescription)
+    }
+
     /// Every other kind deletes outright, so the column stays NULL for them —
     /// and a record written without one must decode as `nil`, not as "".
     @Test("a non-quarantined reap record round-trips with a nil quarantine path")

--- a/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
+++ b/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
@@ -239,26 +239,48 @@ struct OrphanProcessCollectorTests {
             == .dead(DeadWorktreeRoot(path: shared + "/-dead", archivedAt: nil)))
     }
 
-    /// A shared root nested inside a pool must win: its strays stay unowned.
-    @Test("a shared root nested inside a pool keeps that pool's stray arm out")
+    /// A shared root nested inside a pool must win: the pool's `.deleting/`
+    /// claim stops at its edge.
+    @Test("a shared root nested inside a pool keeps that pool's deleting arm out")
     func nestedSharedRootWins() {
         let nested = TBDProcessRoots(
             pools: [pool], sharedRoots: [pool + "/shared"], live: [], dead: [])
-        #expect(collector().ownership(ofCWD: pool + "/shared/stray", roots: nested) == .outside)
-        #expect(collector().ownership(ofCWD: pool + "/stray", roots: nested)
-            == .dead(DeadWorktreeRoot(path: pool + "/stray", archivedAt: nil)))
+        #expect(
+            collector().ownership(ofCWD: pool + "/shared/.deleting/abc/x", roots: nested)
+                == .outside)
+        #expect(collector().ownership(ofCWD: pool + "/.deleting/abc/x", roots: nested)
+            == .dead(DeadWorktreeRoot(path: pool + "/.deleting/abc", archivedAt: nil)))
     }
 
-    @Test("a pool path with no row at all is dead with no archive instant")
-    func absentFromTheDatabase() {
+    /// The only stray a pool claims. TBD renamed the directory into
+    /// `.deleting/` itself, so it is garbage by construction — the positive
+    /// evidence the arm requires.
+    @Test("a `.deleting/<uuid>` entry is dead with no archive instant")
+    func deletionQueueEntryIsDead() {
         let subject = collector()
         let onlyPool = TBDProcessRoots(pools: [pool], live: [], dead: [])
-        #expect(subject.ownership(ofCWD: "/pool/forgotten/sub", roots: onlyPool)
-            == .dead(DeadWorktreeRoot(path: "/pool/forgotten", archivedAt: nil)))
-        // A `.deleting/<uuid>` entry takes two components: the queue directory
-        // itself owns nothing.
         #expect(subject.ownership(ofCWD: "/pool/.deleting/abc/sub", roots: onlyPool)
             == .dead(DeadWorktreeRoot(path: "/pool/.deleting/abc", archivedAt: nil)))
+        #expect(subject.ownership(ofCWD: "/pool/.deleting/abc", roots: onlyPool)
+            == .dead(DeadWorktreeRoot(path: "/pool/.deleting/abc", archivedAt: nil)))
+        // The queue directory itself names no entry, so nothing attests to it.
+        #expect(subject.ownership(ofCWD: "/pool/.deleting", roots: onlyPool) == .outside)
+    }
+
+    /// The absence of a row is not evidence of death. `WorktreeLifecycle`
+    /// backfills a row for a directory TBD did not create only from startup,
+    /// `repo.add` and the cleanup RPC — no timer calls it — so on a daemon up
+    /// for days a worktree someone made by hand under the pool, or a bare
+    /// `mkdir`, names no row and never will. TBD cannot tell that from
+    /// leftover garbage, and this file resolves ambiguity by keeping.
+    @Test("a pool child with no row at all is outside, not dead")
+    func unrecognizedPoolChildIsKept() {
+        let subject = collector()
+        let onlyPool = TBDProcessRoots(pools: [pool], live: [], dead: [])
+        #expect(subject.ownership(ofCWD: "/pool/hand-made/sub", roots: onlyPool) == .outside)
+        #expect(subject.ownership(ofCWD: "/pool/hand-made", roots: onlyPool) == .outside)
+        // Not even the pool itself.
+        #expect(subject.ownership(ofCWD: pool, roots: onlyPool) == .outside)
     }
 
     // MARK: - Grace
@@ -273,7 +295,7 @@ struct OrphanProcessCollectorTests {
         #expect(subject.graceElapsed(root: old, entry: entry(pid: 5), graceSeconds: 3600))
     }
 
-    @Test("grace runs from process start where no row survives, and an unknown age keeps")
+    @Test("grace runs from process start for a queue entry, and an unknown age keeps")
     func graceFromProcessStart() {
         let subject = collector()
         let noRow = DeadWorktreeRoot(path: dead, archivedAt: nil)

--- a/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
+++ b/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
@@ -13,9 +13,12 @@ struct OrphanProcessCollectorTests {
     private let dead = "/pool/gone"
     private let alive = "/pool/working"
 
+    private let shared = "/shared"
+
     private func roots(archivedAt: Date? = Date(timeIntervalSince1970: 0)) -> TBDProcessRoots {
         TBDProcessRoots(
             pools: [pool],
+            sharedRoots: [shared],
             live: [alive],
             dead: [DeadWorktreeRoot(path: dead, archivedAt: archivedAt)])
     }
@@ -44,7 +47,8 @@ struct OrphanProcessCollectorTests {
     func onlyPPID1() {
         let found = collector().candidates(
             processes: [entry(pid: 50, ppid: 42)],
-            cwdByPID: [50: dead], roots: roots(),
+            cwdByPID: [50: dead], cwdsCapturedAt: Date(timeIntervalSince1970: 1_000_000),
+            roots: roots(),
             ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
         #expect(found.isEmpty)
     }
@@ -53,7 +57,8 @@ struct OrphanProcessCollectorTests {
     func onlyOurUID() {
         let found = collector().candidates(
             processes: [entry(pid: 50, uid: getuid() &+ 1)],
-            cwdByPID: [50: dead], roots: roots(),
+            cwdByPID: [50: dead], cwdsCapturedAt: Date(timeIntervalSince1970: 1_000_000),
+            roots: roots(),
             ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
         #expect(found.isEmpty)
     }
@@ -62,7 +67,8 @@ struct OrphanProcessCollectorTests {
     func neverPID1() {
         let found = collector().candidates(
             processes: [entry(pid: 1, ppid: 1)],
-            cwdByPID: [1: dead], roots: roots(),
+            cwdByPID: [1: dead], cwdsCapturedAt: Date(timeIntervalSince1970: 1_000_000),
+            roots: roots(),
             ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
         #expect(found.isEmpty)
     }
@@ -86,11 +92,12 @@ struct OrphanProcessCollectorTests {
         let found = collector().candidates(
             processes: processes,
             cwdByPID: [ours: dead, 4000: dead, 4001: dead],
+            cwdsCapturedAt: Date(timeIntervalSince1970: 1_000_000),
             roots: roots(), ourUID: getuid(), ourPID: ours, graceSeconds: 3600)
         #expect(found.map(\.pid) == [4001])
     }
 
-    @Test("TBDDaemon and TBDApp are recognized by argv[0]'s basename, not by substring")
+    @Test("TBDDaemon and TBDApp are recognized by a path component's basename, not by substring")
     func tbdBinaryMatching() {
         #expect(OrphanProcessCollector.isTBDBinary("/w/tbd/.build/debug/TBDDaemon --foo"))
         #expect(OrphanProcessCollector.isTBDBinary("/w/.build/debug/TBD.app/Contents/MacOS/TBDApp"))
@@ -99,10 +106,59 @@ struct OrphanProcessCollectorTests {
         #expect(!OrphanProcessCollector.isTBDBinary("/usr/bin/node"))
     }
 
+    /// `ps -o command=` prints argv space-joined and unquoted, so a home
+    /// directory with a space in it splits argv[0] in two. Reading only the
+    /// first token would leave `TBDApp` — whose only protection this is —
+    /// unrecognized and reapable.
+    @Test("a space in the executable's own path does not defeat the TBD-binary match")
+    func tbdBinaryMatchingSurvivesSpacedPaths() {
+        #expect(OrphanProcessCollector.isTBDBinary(
+            "/Users/Jane Roe/tbd/.build/debug/TBDDaemon"))
+        #expect(OrphanProcessCollector.isTBDBinary(
+            "/Users/Jane Roe/tbd/.build/debug/TBD.app/Contents/MacOS/TBDApp --verbose"))
+        // Still not a substring match, spaces or no spaces.
+        #expect(!OrphanProcessCollector.isTBDBinary(
+            "/Users/Jane Roe/tbd/worktrees/TBDApp/node server.js"))
+    }
+
+    /// The cwd map and the `ps` snapshot are two readings joined by pid alone,
+    /// and macOS recycles pids. A process younger than the gap between them
+    /// cannot be the one lsof saw.
+    @Test("a process younger than the cwd reading is skipped as a possible pid reuse")
+    func youngerThanTheCWDReadingIsSkipped() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let subject = collector(now: now)
+        // lsof ran 10 minutes before this snapshot; the process is 5 old.
+        let reused = subject.candidates(
+            processes: [entry(pid: 50, elapsed: 300)],
+            cwdByPID: [50: dead], cwdsCapturedAt: now.addingTimeInterval(-600),
+            roots: roots(), ourUID: getuid(), ourPID: 12_345, graceSeconds: 0)
+        #expect(reused.isEmpty)
+
+        // The same process, old enough to have existed when lsof ran.
+        let genuine = subject.candidates(
+            processes: [entry(pid: 50, elapsed: 900)],
+            cwdByPID: [50: dead], cwdsCapturedAt: now.addingTimeInterval(-600),
+            roots: roots(), ourUID: getuid(), ourPID: 12_345, graceSeconds: 0)
+        #expect(genuine.map(\.pid) == [50])
+    }
+
+    @Test("an unreadable process age keeps the process even when the row carries archivedAt")
+    func unknownAgeKeepsOnTheArchivedAtArm() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let found = collector(now: now).candidates(
+            processes: [entry(pid: 50, elapsed: nil)],
+            cwdByPID: [50: dead], cwdsCapturedAt: now,
+            roots: roots(archivedAt: now.addingTimeInterval(-86_400)),
+            ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
+        #expect(found.isEmpty)
+    }
+
     @Test("an unreadable cwd is a skip, never a reclaim")
     func unreadableCWDSkips() {
         let found = collector().candidates(
-            processes: [entry(pid: 50)], cwdByPID: [:], roots: roots(),
+            processes: [entry(pid: 50)], cwdByPID: [:],
+            cwdsCapturedAt: Date(timeIntervalSince1970: 1_000_000), roots: roots(),
             ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
         #expect(found.isEmpty)
     }
@@ -127,6 +183,35 @@ struct OrphanProcessCollectorTests {
             pools: ["/pool"], live: ["/pool/work"], dead: [])
         #expect(subject.ownership(ofCWD: "/pool/work-2", roots: sibling) != .live(path: "/pool/work"))
         #expect(subject.ownership(ofCWD: "/poolside/x", roots: sibling) == .outside)
+    }
+
+    /// The Claude scratchpad base holds one directory per project Claude Code
+    /// has ever run in — most of them nothing to do with TBD. A stray there is
+    /// NOT a dead worktree, and treating it as one would put a stranger's live
+    /// session on the kill list.
+    @Test("an unrecognized child of a shared root is never a candidate")
+    func strayUnderASharedRootIsKept() {
+        let subject = collector()
+        #expect(subject.ownership(ofCWD: shared + "/-Users-me-projects-acme/x", roots: roots())
+            == .outside)
+        // Only what an explicit live/dead entry names is classified there.
+        let known = TBDProcessRoots(
+            pools: [pool], sharedRoots: [shared], live: [shared + "/-live"],
+            dead: [DeadWorktreeRoot(path: shared + "/-dead", archivedAt: nil)])
+        #expect(subject.ownership(ofCWD: shared + "/-live/x", roots: known)
+            == .live(path: shared + "/-live"))
+        #expect(subject.ownership(ofCWD: shared + "/-dead/x", roots: known)
+            == .dead(DeadWorktreeRoot(path: shared + "/-dead", archivedAt: nil)))
+    }
+
+    /// A shared root nested inside a pool must win: its strays stay unowned.
+    @Test("a shared root nested inside a pool keeps that pool's stray arm out")
+    func nestedSharedRootWins() {
+        let nested = TBDProcessRoots(
+            pools: [pool], sharedRoots: [pool + "/shared"], live: [], dead: [])
+        #expect(collector().ownership(ofCWD: pool + "/shared/stray", roots: nested) == .outside)
+        #expect(collector().ownership(ofCWD: pool + "/stray", roots: nested)
+            == .dead(DeadWorktreeRoot(path: pool + "/stray", archivedAt: nil)))
     }
 
     @Test("a pool path with no row at all is dead with no archive instant")

--- a/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
+++ b/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
@@ -34,11 +34,45 @@ struct OrphanProcessCollectorTests {
 
     private func collector(
         signaller: ProcessSignaller = FakeProcessSignaller(),
-        now: Date = Date(timeIntervalSince1970: 1_000_000)
+        now: Date = Date(timeIntervalSince1970: 1_000_000),
+        snapshots: ScriptedSnapshots = ScriptedSnapshots([])
     ) -> OrphanProcessCollector {
         OrphanProcessCollector(
-            signaller: signaller, now: { now },
+            signaller: signaller,
+            snapshotProvider: { await snapshots.next() },
+            now: { now },
             graceAttempts: 2, pollInterval: .milliseconds(1))
+    }
+
+    /// Hands out one `ps` reading per call and then repeats the last, so a test
+    /// can make the process table change between the reading a tree was planned
+    /// from and the volley that acts on it. `nil` stands for a reading that
+    /// could not be taken at all.
+    final class ScriptedSnapshots: @unchecked Sendable {
+        private let lock = NSLock()
+        private var readings: [[ProcessSnapshotEntry]?]
+        private(set) var calls = 0
+
+        init(_ readings: [[ProcessSnapshotEntry]?]) {
+            self.readings = readings.isEmpty ? [[]] : readings
+        }
+
+        func next() -> [ProcessSnapshotEntry]? {
+            lock.withLock {
+                calls += 1
+                return readings.count > 1 ? readings.removeFirst() : readings[0]
+            }
+        }
+    }
+
+    /// The start instants a plan would have recorded for `processes`, stamped
+    /// at the collector's own `now` so an unchanged process table verifies
+    /// exactly.
+    private func plannedStarts(
+        _ processes: [ProcessSnapshotEntry],
+        at now: Date = Date(timeIntervalSince1970: 1_000_000)
+    ) -> [Int32: Date] {
+        OrphanProcessCollector.startInstants(processes, capturedAt: now)
     }
 
     // MARK: - Exclusions
@@ -314,11 +348,13 @@ struct OrphanProcessCollectorTests {
         let signaller = FakeProcessSignaller()
         signaller.behaviors[701] = .init(aliveAfterTerminate: false)
         signaller.behaviors[700] = .init(aliveAfterTerminate: true, aliveAfterKill: false)
-        let subject = collector(signaller: signaller)
+        let table = [entry(pid: 700), entry(pid: 701, ppid: 700)]
+        let subject = collector(signaller: signaller, snapshots: ScriptedSnapshots([table]))
         let candidate = OrphanProcessCandidate(
             pid: 700, cwd: dead, rootPath: dead, command: "/usr/bin/node server.js --port 3000")
 
-        let record = await subject.reap(candidate, tree: [701, 700], repoPath: "/repo")
+        let record = await subject.reap(
+            candidate, tree: [701, 700], plannedStarts: plannedStarts(table), repoPath: "/repo")
 
         #expect(signaller.terminated == [701, 700])
         #expect(signaller.killed == [700])
@@ -339,8 +375,99 @@ struct OrphanProcessCollectorTests {
     func emptySubtreeRecordsNothing() async {
         let record = await collector().reap(
             OrphanProcessCandidate(pid: 700, cwd: dead, rootPath: dead, command: "x"),
-            tree: [], repoPath: "")
+            tree: [], plannedStarts: [:], repoPath: "")
         #expect(record == nil)
+    }
+
+    // MARK: - Identity at signal time
+
+    /// The root's `age >= cwdAge` gate in `candidates(…)` never sees a
+    /// descendant: descendants enter a tree purely through the snapshot's ppid
+    /// chain. So the pid the kernel reissued into a descendant slot is caught
+    /// here or nowhere.
+    @Test("a descendant whose start time moved between the plan and the volley is not signalled")
+    func descendantSubstitutionIsSkipped() async throws {
+        let signaller = FakeProcessSignaller()
+        for pid: Int32 in [700, 702] { signaller.behaviors[pid] = .init(aliveAfterTerminate: false) }
+        let planned = [entry(pid: 700), entry(pid: 701, ppid: 700), entry(pid: 702, ppid: 700)]
+        // 701 exited and its pid was reissued to a stranger: same pid, same
+        // uid, same parent slot, but a start time of seconds ago rather than a
+        // day ago.
+        let atVolley = [entry(pid: 700), entry(pid: 701, ppid: 700, elapsed: 3), entry(pid: 702, ppid: 700)]
+        // `reap` is called directly here, so its first reading IS the volley's.
+        let subject = collector(signaller: signaller, snapshots: ScriptedSnapshots([atVolley]))
+
+        let record = await subject.reap(
+            OrphanProcessCandidate(pid: 700, cwd: dead, rootPath: dead, command: "process-compose up"),
+            tree: [701, 702, 700], plannedStarts: plannedStarts(planned), repoPath: "/repo")
+
+        #expect(
+            !signaller.terminated.contains(701),
+            "a reissued pid names an unrelated live process and must never be signalled")
+        #expect(signaller.terminated == [702, 700], "the rest of the tree is still reclaimed")
+        #expect(signaller.killed.isEmpty)
+        #expect(try #require(record).processDescription == "pid=700 tree=2 process-compose up")
+    }
+
+    /// The escalation is a second volley, separated from the first by
+    /// `graceAttempts × pollInterval` of wall time, and SIGKILL is the signal
+    /// nothing survives. It gets its own check rather than the SIGTERM
+    /// volley's now-stale conclusion.
+    @Test("the SIGKILL escalation re-checks identity rather than reusing the SIGTERM volley's")
+    func escalationRechecksIdentity() async throws {
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[700] = .init(aliveAfterTerminate: true, aliveAfterKill: false)
+        let planned = [entry(pid: 700)]
+        let reissued = [entry(pid: 700, elapsed: 1)]
+        let subject = collector(
+            signaller: signaller, snapshots: ScriptedSnapshots([planned, reissued]))
+
+        _ = await subject.reap(
+            OrphanProcessCandidate(pid: 700, cwd: dead, rootPath: dead, command: "x"),
+            tree: [700], plannedStarts: plannedStarts(planned), repoPath: "/repo")
+
+        #expect(signaller.terminated == [700], "identity still matched when SIGTERM was sent")
+        #expect(
+            signaller.killed.isEmpty,
+            "the pid was reissued during the grace window, so SIGKILL must not follow")
+    }
+
+    @Test("an identity that cannot be re-read is a skip, never a kill")
+    func unreadableIdentityKeeps() async throws {
+        let signaller = FakeProcessSignaller()
+        let planned = [entry(pid: 700), entry(pid: 701, ppid: 700)]
+        let subject = collector(
+            signaller: signaller, snapshots: ScriptedSnapshots([nil]))
+
+        let record = await subject.reap(
+            OrphanProcessCandidate(pid: 700, cwd: dead, rootPath: dead, command: "x"),
+            tree: [701, 700], plannedStarts: plannedStarts(planned), repoPath: "/repo")
+
+        #expect(signaller.terminated.isEmpty, "a ps that did not answer signals nothing")
+        #expect(signaller.killed.isEmpty)
+        #expect(record == nil, "nothing was signalled, so nothing is recorded")
+    }
+
+    @Test("a pid whose etime did not parse can never be verified, so it is never signalled")
+    func unparseableAgeIsNeverSignalled() async throws {
+        let signaller = FakeProcessSignaller()
+        let planned = [entry(pid: 700), entry(pid: 701, ppid: 700, elapsed: nil)]
+        let subject = collector(signaller: signaller, snapshots: ScriptedSnapshots([planned]))
+
+        _ = await subject.reap(
+            OrphanProcessCandidate(pid: 700, cwd: dead, rootPath: dead, command: "x"),
+            tree: [701, 700], plannedStarts: plannedStarts(planned), repoPath: "/repo")
+
+        #expect(signaller.terminated == [700])
+    }
+
+    @Test("start instants are the snapshot's capture time minus etime, and skip unparseable rows")
+    func startInstantsDeriveFromETime() {
+        let at = Date(timeIntervalSince1970: 1_000_000)
+        let map = OrphanProcessCollector.startInstants(
+            [entry(pid: 5, elapsed: 60), entry(pid: 6, elapsed: nil)], capturedAt: at)
+        #expect(map[5] == at.addingTimeInterval(-60))
+        #expect(map[6] == nil, "an unparseable etime yields no identity, so the pid never verifies")
     }
 
     // MARK: - Parsing

--- a/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
+++ b/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
@@ -84,7 +84,8 @@ struct OrphanProcessCollectorTests {
             entry(pid: 4000, ppid: 1),
             entry(pid: 4001, ppid: 1),
         ]
-        let protected = collector().protectedPIDs(processes: processes, ourPID: ours)
+        let protected = collector().protectedPIDs(
+            processes: processes, ourPID: ours, ourUID: getuid())
         #expect(protected.contains(ours))
         #expect(protected.contains(4000), "our parent")
         #expect(!protected.contains(4001), "an unrelated ppid==1 process is not protected")
@@ -275,10 +276,35 @@ struct OrphanProcessCollectorTests {
             entry(pid: 701, ppid: 700, command: "/w/.build/debug/TBDDaemon"),
             entry(pid: 702, ppid: 701),
         ]
-        let protected = collector().protectedPIDs(processes: processes, ourPID: 99_999)
+        let protected = collector().protectedPIDs(
+            processes: processes, ourPID: 99_999, ourUID: getuid())
         let order = collector().descendantClosure(
             of: 700, processes: processes, protected: protected)
         #expect(order == [700])
+    }
+
+    /// The uid exclusion is a claim about every process this sweep signals, not
+    /// only about the root that entered the closure. A foreign-uid descendant is
+    /// fully protected — not signalled, and not walked through — so a process of
+    /// ours sitting under another user's stays running rather than being reached
+    /// for across a privilege boundary.
+    @Test("a descendant owned by another uid is neither signalled nor descended through")
+    func closureStopsAtForeignUID() {
+        let processes = [
+            entry(pid: 700, ppid: 1),
+            entry(pid: 701, ppid: 700, uid: getuid() &+ 1),
+            entry(pid: 702, ppid: 701),
+            entry(pid: 703, ppid: 700),
+        ]
+        let protected = collector().protectedPIDs(
+            processes: processes, ourPID: 99_999, ourUID: getuid())
+
+        #expect(protected.contains(701), "a foreign-uid process is protected")
+        let order = collector().descendantClosure(
+            of: 700, processes: processes, protected: protected)
+        #expect(
+            order == [703, 700],
+            "the foreign-uid child and the grandchild below it are both left alone")
     }
 
     // MARK: - Reclamation

--- a/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
+++ b/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
@@ -1,0 +1,283 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Tier 1: pure classification and parsing. No database, no filesystem, no
+/// subprocess and no real signal — the collector is handed its `ps` snapshot,
+/// its pid-to-cwd map and its root classification, and answers.
+@Suite("OrphanProcessCollector")
+struct OrphanProcessCollectorTests {
+
+    private let pool = "/pool"
+    private let dead = "/pool/gone"
+    private let alive = "/pool/working"
+
+    private func roots(archivedAt: Date? = Date(timeIntervalSince1970: 0)) -> TBDProcessRoots {
+        TBDProcessRoots(
+            pools: [pool],
+            live: [alive],
+            dead: [DeadWorktreeRoot(path: dead, archivedAt: archivedAt)])
+    }
+
+    private func entry(
+        pid: Int32, ppid: Int32 = 1, pgid: Int32? = nil, uid: uid_t? = nil,
+        elapsed: TimeInterval? = 86_400, command: String = "/usr/bin/node server.js"
+    ) -> ProcessSnapshotEntry {
+        ProcessSnapshotEntry(
+            pid: pid, ppid: ppid, pgid: pgid ?? pid, uid: uid ?? getuid(),
+            elapsedSeconds: elapsed, command: command)
+    }
+
+    private func collector(
+        signaller: ProcessSignaller = FakeProcessSignaller(),
+        now: Date = Date(timeIntervalSince1970: 1_000_000)
+    ) -> OrphanProcessCollector {
+        OrphanProcessCollector(
+            signaller: signaller, now: { now },
+            graceAttempts: 2, pollInterval: .milliseconds(1))
+    }
+
+    // MARK: - Exclusions
+
+    @Test("a process that is not reparented to launchd is never a candidate")
+    func onlyPPID1() {
+        let found = collector().candidates(
+            processes: [entry(pid: 50, ppid: 42)],
+            cwdByPID: [50: dead], roots: roots(),
+            ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
+        #expect(found.isEmpty)
+    }
+
+    @Test("a process owned by another uid is never a candidate")
+    func onlyOurUID() {
+        let found = collector().candidates(
+            processes: [entry(pid: 50, uid: getuid() &+ 1)],
+            cwdByPID: [50: dead], roots: roots(),
+            ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
+        #expect(found.isEmpty)
+    }
+
+    @Test("pid 1 is never a candidate even if everything else matches")
+    func neverPID1() {
+        let found = collector().candidates(
+            processes: [entry(pid: 1, ppid: 1)],
+            cwdByPID: [1: dead], roots: roots(),
+            ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
+        #expect(found.isEmpty)
+    }
+
+    /// The sweep runs inside the daemon, so the daemon's own pid and its whole
+    /// ancestry have to be unreachable by construction, not merely by the
+    /// binary-name check.
+    @Test("our own pid and its ancestors are protected")
+    func selfAndAncestorsProtected() {
+        let ours = getpid()
+        let processes = [
+            entry(pid: ours, ppid: 4000),
+            entry(pid: 4000, ppid: 1),
+            entry(pid: 4001, ppid: 1),
+        ]
+        let protected = collector().protectedPIDs(processes: processes, ourPID: ours)
+        #expect(protected.contains(ours))
+        #expect(protected.contains(4000), "our parent")
+        #expect(!protected.contains(4001), "an unrelated ppid==1 process is not protected")
+
+        let found = collector().candidates(
+            processes: processes,
+            cwdByPID: [ours: dead, 4000: dead, 4001: dead],
+            roots: roots(), ourUID: getuid(), ourPID: ours, graceSeconds: 3600)
+        #expect(found.map(\.pid) == [4001])
+    }
+
+    @Test("TBDDaemon and TBDApp are recognized by argv[0]'s basename, not by substring")
+    func tbdBinaryMatching() {
+        #expect(OrphanProcessCollector.isTBDBinary("/w/tbd/.build/debug/TBDDaemon --foo"))
+        #expect(OrphanProcessCollector.isTBDBinary("/w/.build/debug/TBD.app/Contents/MacOS/TBDApp"))
+        // A path that merely contains the name — every TBD worktree does.
+        #expect(!OrphanProcessCollector.isTBDBinary("/Users/me/tbd/worktrees/TBDDaemon/node"))
+        #expect(!OrphanProcessCollector.isTBDBinary("/usr/bin/node"))
+    }
+
+    @Test("an unreadable cwd is a skip, never a reclaim")
+    func unreadableCWDSkips() {
+        let found = collector().candidates(
+            processes: [entry(pid: 50)], cwdByPID: [:], roots: roots(),
+            ourUID: getuid(), ourPID: 12_345, graceSeconds: 3600)
+        #expect(found.isEmpty)
+    }
+
+    // MARK: - Ownership
+
+    @Test("a cwd under a live worktree is live, under a dead one is dead, elsewhere is outside")
+    func ownershipClassification() {
+        let subject = collector()
+        #expect(subject.ownership(ofCWD: alive + "/src", roots: roots()) == .live(path: alive))
+        #expect(subject.ownership(ofCWD: "/elsewhere", roots: roots()) == .outside)
+        #expect(subject.ownership(ofCWD: dead + "/a/b", roots: roots())
+            == .dead(DeadWorktreeRoot(path: dead, archivedAt: Date(timeIntervalSince1970: 0))))
+    }
+
+    /// Component-wise, so a sibling pool that merely shares a string prefix is
+    /// never read as living inside the other.
+    @Test("prefix matching is component-wise")
+    func componentWisePrefixes() {
+        let subject = collector()
+        let sibling = TBDProcessRoots(
+            pools: ["/pool"], live: ["/pool/work"], dead: [])
+        #expect(subject.ownership(ofCWD: "/pool/work-2", roots: sibling) != .live(path: "/pool/work"))
+        #expect(subject.ownership(ofCWD: "/poolside/x", roots: sibling) == .outside)
+    }
+
+    @Test("a pool path with no row at all is dead with no archive instant")
+    func absentFromTheDatabase() {
+        let subject = collector()
+        let onlyPool = TBDProcessRoots(pools: [pool], live: [], dead: [])
+        #expect(subject.ownership(ofCWD: "/pool/forgotten/sub", roots: onlyPool)
+            == .dead(DeadWorktreeRoot(path: "/pool/forgotten", archivedAt: nil)))
+        // A `.deleting/<uuid>` entry takes two components: the queue directory
+        // itself owns nothing.
+        #expect(subject.ownership(ofCWD: "/pool/.deleting/abc/sub", roots: onlyPool)
+            == .dead(DeadWorktreeRoot(path: "/pool/.deleting/abc", archivedAt: nil)))
+    }
+
+    // MARK: - Grace
+
+    @Test("grace runs from archivedAt where a row survives")
+    func graceFromArchivedAt() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let subject = collector(now: now)
+        let young = DeadWorktreeRoot(path: dead, archivedAt: now.addingTimeInterval(-60))
+        let old = DeadWorktreeRoot(path: dead, archivedAt: now.addingTimeInterval(-7200))
+        #expect(!subject.graceElapsed(root: young, entry: entry(pid: 5), graceSeconds: 3600))
+        #expect(subject.graceElapsed(root: old, entry: entry(pid: 5), graceSeconds: 3600))
+    }
+
+    @Test("grace runs from process start where no row survives, and an unknown age keeps")
+    func graceFromProcessStart() {
+        let subject = collector()
+        let noRow = DeadWorktreeRoot(path: dead, archivedAt: nil)
+        #expect(!subject.graceElapsed(
+            root: noRow, entry: entry(pid: 5, elapsed: 60), graceSeconds: 3600))
+        #expect(subject.graceElapsed(
+            root: noRow, entry: entry(pid: 5, elapsed: 7200), graceSeconds: 3600))
+        #expect(!subject.graceElapsed(
+            root: noRow, entry: entry(pid: 5, elapsed: nil), graceSeconds: 3600),
+            "an unparseable start time is too young to touch")
+    }
+
+    // MARK: - Descendant closure
+
+    @Test("the closure is leaf-first and independent of process group")
+    func closureIsLeafFirst() {
+        let processes = [
+            entry(pid: 700, ppid: 1, pgid: 698),
+            entry(pid: 701, ppid: 700, pgid: 698),
+            entry(pid: 702, ppid: 701, pgid: 702),
+            entry(pid: 703, ppid: 700, pgid: 698),
+            entry(pid: 900, ppid: 1),
+        ]
+        let order = collector().descendantClosure(
+            of: 700, processes: processes, protected: [0, 1])
+        #expect(order == [702, 701, 703, 700])
+        #expect(!order.contains(900), "an unrelated root is not in the closure")
+    }
+
+    @Test("a protected pid is neither signalled nor descended into")
+    func closureStopsAtProtected() {
+        let processes = [
+            entry(pid: 700, ppid: 1),
+            entry(pid: 701, ppid: 700, command: "/w/.build/debug/TBDDaemon"),
+            entry(pid: 702, ppid: 701),
+        ]
+        let protected = collector().protectedPIDs(processes: processes, ourPID: 99_999)
+        let order = collector().descendantClosure(
+            of: 700, processes: processes, protected: protected)
+        #expect(order == [700])
+    }
+
+    // MARK: - Reclamation
+
+    @Test("reap SIGTERMs leaf-first and SIGKILLs only what survives the grace window")
+    func reapEscalates() async throws {
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[701] = .init(aliveAfterTerminate: false)
+        signaller.behaviors[700] = .init(aliveAfterTerminate: true, aliveAfterKill: false)
+        let subject = collector(signaller: signaller)
+        let candidate = OrphanProcessCandidate(
+            pid: 700, cwd: dead, rootPath: dead, command: "/usr/bin/node server.js --port 3000")
+
+        let record = await subject.reap(candidate, tree: [701, 700], repoPath: "/repo")
+
+        #expect(signaller.terminated == [701, 700])
+        #expect(signaller.killed == [700])
+        let unwrapped = try #require(record)
+        #expect(unwrapped.kind == .orphanProcess)
+        #expect(unwrapped.worktreePath == dead)
+        #expect(unwrapped.repoPath == "/repo")
+        #expect(unwrapped.processDescription == "pid=700 tree=2 /usr/bin/node server.js --port 3000")
+        #expect(unwrapped.quarantinePath == nil)
+    }
+
+    @Test("an empty subtree records nothing")
+    func emptySubtreeRecordsNothing() async {
+        let record = await collector().reap(
+            OrphanProcessCandidate(pid: 700, cwd: dead, rootPath: dead, command: "x"),
+            tree: [], repoPath: "")
+        #expect(record == nil)
+    }
+
+    // MARK: - Parsing
+
+    @Test("the ps snapshot parses five fixed fields plus a command that may contain spaces")
+    func parsesPSLines() {
+        let rows = OrphanProcessCollector.parseProcessLines("""
+            1     0     1     0 11-23:23:11 /sbin/launchd
+          228 98372 42549   501 01-09:07:58 /Applications/Some App/Helper --node-ipc
+          244     1 81603   501       50:44 /usr/bin/node
+        """)
+        #expect(rows.count == 3)
+        #expect(rows[1].pid == 228)
+        #expect(rows[1].ppid == 98_372)
+        #expect(rows[1].pgid == 42_549)
+        #expect(rows[1].uid == 501)
+        #expect(rows[1].command == "/Applications/Some App/Helper --node-ipc")
+        #expect(rows[2].elapsedSeconds == TimeInterval(50 * 60 + 44))
+    }
+
+    @Test("etime parses every shape ps emits and refuses anything else")
+    func parsesETime() {
+        #expect(OrphanProcessCollector.parseETime("50:44") == 3044)
+        #expect(OrphanProcessCollector.parseETime("01:02:03") == 3723)
+        #expect(OrphanProcessCollector.parseETime("11-23:23:11") == TimeInterval(11 * 86_400 + 84_191))
+        #expect(OrphanProcessCollector.parseETime("garbage") == nil)
+        #expect(OrphanProcessCollector.parseETime("") == nil)
+    }
+
+    /// The pid header lsof always printed and `parseLiveCWDs` used to discard.
+    /// Both shapes come from one pass, and the path list is unchanged.
+    @Test("parseLiveCWDs yields both the deduped path list and the pid-to-cwd map")
+    func parseLiveCWDsKeepsThePID() throws {
+        let stdout = Data("p100\nn/tmp/a\np200\nn/tmp/b\np300\nn/tmp/a\n".utf8)
+        let parsed = try #require(
+            OrphanGC.parseLiveCWDs(.completed(status: 0, stdout: stdout, stderr: Data())))
+        #expect(parsed.paths == ["/tmp/a", "/tmp/b"])
+        #expect(parsed.cwdByPID == [100: "/tmp/a", 200: "/tmp/b", 300: "/tmp/a"])
+    }
+
+    @Test("an unavailable lsof invalidates both halves together")
+    func parseLiveCWDsFailsWhole() {
+        #expect(OrphanGC.parseLiveCWDs(.timedOut) == nil)
+        #expect(OrphanGC.parseLiveCWDs(
+            .completed(status: 1, stdout: Data("p1\nn/tmp/a\n".utf8), stderr: Data())) == nil)
+    }
+
+    @Test("an unavailable ps snapshot is nil, never an empty list")
+    func parseProcessSnapshotFailsWhole() {
+        #expect(OrphanProcessCollector.parseProcessSnapshot(.timedOut) == nil)
+        #expect(OrphanProcessCollector.parseProcessSnapshot(
+            .completed(status: 1, stdout: Data(), stderr: Data())) == nil)
+        #expect(OrphanProcessCollector.parseProcessSnapshot(
+            .completed(status: 0, stdout: Data(), stderr: Data()))?.isEmpty == true)
+    }
+}

--- a/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
+++ b/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
@@ -296,6 +296,11 @@ struct OrphanProcessCollectorTests {
 
         #expect(signaller.terminated == [701, 700])
         #expect(signaller.killed == [700])
+        // Through the pid-exact door, never the one that escalates to a group
+        // kill: a process group is a superset of the group, not of this
+        // closure, and could hold a pid the sweep protected.
+        #expect(signaller.terminatedProcessOnly == [701, 700])
+        #expect(signaller.killedProcessOnly == [700])
         let unwrapped = try #require(record)
         #expect(unwrapped.kind == .orphanProcess)
         #expect(unwrapped.worktreePath == dead)

--- a/Tests/TBDDaemonTests/Process/FakeProcessSignaller.swift
+++ b/Tests/TBDDaemonTests/Process/FakeProcessSignaller.swift
@@ -18,6 +18,12 @@ final class FakeProcessSignaller: ProcessSignaller, @unchecked Sendable {
     var stats: [Int32: String] = [:]
     private(set) var terminated: [Int32] = []
     private(set) var killed: [Int32] = []
+    /// Only the pid-exact variants, recorded separately so a caller that must
+    /// never widen its target to a process group can assert which door it went
+    /// through. Both still fall through to `terminated`/`killed`, so callers
+    /// that do not care keep asserting on those.
+    private(set) var terminatedProcessOnly: [Int32] = []
+    private(set) var killedProcessOnly: [Int32] = []
     private var terminatedSet: Set<Int32> = []
     private var killedSet: Set<Int32> = []
 
@@ -34,6 +40,16 @@ final class FakeProcessSignaller: ProcessSignaller, @unchecked Sendable {
     func children(ofServerPID serverPID: Int32) -> [Int32] { lock.withLock { childrenByServer[serverPID] ?? [] } }
     func commandLine(_ pid: Int32) -> String? { lock.withLock { cmdlines[pid] } }
     func stat(_ pid: Int32) -> String? { lock.withLock { stats[pid] } }
+
+    func terminateProcessOnly(_ pid: Int32) {
+        lock.withLock { terminatedProcessOnly.append(pid) }
+        terminate(pid)
+    }
+
+    func forceKillProcessOnly(_ pid: Int32) {
+        lock.withLock { killedProcessOnly.append(pid) }
+        forceKill(pid)
+    }
 }
 
 final class FakeTmuxQuerier: TmuxProcessQuerying, @unchecked Sendable {

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -1,0 +1,286 @@
+# Orphaned-process GC: a reconciler for processes that outlive their worktree
+
+## Problem
+
+A process started inside a TBD terminal can outlive every structure TBD uses to
+find it. When the pane dies, such a process is reparented to launchd, keeps its
+memory, and nothing ever reclaims it. Observed instances have run for **days**
+against **seconds** of CPU — parked, not working — in worktrees that had since
+been archived.
+
+Two measured examples, both `ppid=1`, both with a cwd inside a worktree whose
+row read `status=archived`:
+
+- `process-compose up -f <worktree>/process-compose.yaml` — 11 days 18 hours
+  elapsed, 4 minutes 41 seconds of CPU, holding a live subtree of its own
+  (`prefect server start`, a gateway supervisor, a prefect `serve(...)`).
+- A `pnpm storybook --ci` tree — 10 days elapsed, 4.7 seconds of CPU, never
+  having bound a listening socket, so it had not finished starting up.
+
+A single-point census of one developer machine found roughly half a dozen such
+processes alive at once, so this is a steady-state population rather than a
+one-off.
+
+## Why they escape
+
+The escape is a property of job control, not of any exotic daemonizing. Under
+an interactive shell **every job runs in its own process group**, distinct from
+the pane process's group. Measured against a pane at pid 52269 (pgid 52269), its
+four children carried pgids 53668, 53703, 53735 and 53820 — none of them the
+pane's.
+
+So `killpg(pane_pid, …)` reaches the shell and nothing else. What actually kills
+a normal foreground job is the **kernel**, which sends SIGHUP to the controlling
+terminal's foreground process group when the pty hangs up. Anything outside that
+foreground group is signalled by nobody.
+
+Running `tmux kill-window` — the primitive every TBD teardown path calls — against
+a pane with one child of each kind gives:
+
+- **Foreground job** – dies. The kernel hangs up the tty and signals the
+  foreground process group.
+- **Plain background job (`&`)** – dies. zsh sends SIGHUP to its own jobs as it
+  exits.
+- **`& disown`** – **survives**, reparented to `ppid=1`.
+- **`nohup … &`** – **survives**, reparented to `ppid=1`.
+
+Anything that calls `setsid` or double-forks escapes the same way. `disown` and
+`nohup` matter most in practice because they are what a person or an agent
+reaches for when they want a server to keep running while they do something
+else in the same terminal.
+
+## Why nothing reclaims them
+
+`AgentReaper` is the only process-shaped reconciler TBD has, and it cannot see
+these, three times over:
+
+- **It walks one generation.** `ProcessSignaller.children(ofServerPID:)` runs
+  `ps -axo pid=,ppid=` and keeps pids whose `ppid` equals the tmux server's pid.
+  A process started inside a pane is a grandchild at best, and once orphaned its
+  parent is launchd.
+- **Its per-teardown escalation is already too late.**
+  `AgentReaper.escalateAfterHangup(panePID)` returns immediately, because the
+  pane pid is dead — which is precisely why its children orphaned.
+- **Its ownership gate excludes them deliberately.** `isTBDOwned` requires
+  `argv[0]`'s basename to be `claude` or `codex`, or the command line to carry a
+  TBD spawn marker. `pnpm`, `node` and `process-compose` fail that gate by
+  design; the code comment says the gate exists to avoid "reaping a non-agent
+  process a user detached inside a TBD shell pane (e.g. `nohup make`,
+  `node script.js`)".
+
+That third point is why this is a design change rather than a bug fix. TBD
+already holds a written position that detached non-agent processes are not
+teardown's business. This spec revises that position for one specific case — the
+worktree they were rooted in is gone — and leaves it standing everywhere else.
+
+`OrphanGC` covers worktree rows, scratchpads, interrupted archives and profile
+directories; none of those is a process. The doctrine in CLAUDE.md requires every
+durable external resource to name a reconciler, and an escaped descendant process
+currently has none.
+
+## Scope
+
+**In scope:** processes whose cwd resolves inside a TBD-managed worktree,
+`.deleting/` entry, or scratchpad, and whose owning worktree no longer exists.
+
+**Out of scope, tracked as issue #678:** leaked tmux servers and their
+`tmux -CC attach` control-mode clients. A tmux server `chdir`s to `/` when it
+daemonizes — measured directly against a live TBD server, which reported
+`cwd=/` — so a cwd-keyed rule structurally cannot see one. That class needs a
+matcher keyed on server identity instead, and it carries a second half about
+test-suite cleanup that does not belong here.
+
+**Out of scope, deliberately deferred to its own spec:** making teardown itself
+reap. Eleven of TBD's fifteen teardown call sites use a bare `tmux.killWindow`
+with no reaping at all, including `terminal.delete`, `worktree.forget`,
+`scratch.delete`, `scratch.archive` and desk close. Only explicit archive and
+three branches of `reconcile` go through `killWindowAndReap`. Closing a terminal
+will therefore still strand a detached dev server until the next sweep.
+
+That ordering is deliberate. Neither measured orphan would have been caught by
+teardown-time logic — both had already escaped before the teardown that should
+have caught them — so the sweep is both the lower-risk feature and the one that
+reclaims more. Teardown-time killing also reverses the `isTBDOwned` position at
+the moment of a user gesture, which deserves its own examination.
+
+## Identification
+
+One `ps` snapshot per sweep supplies pid, ppid, pgid and start time for every
+process. For each candidate with `ppid == 1` owned by our uid, the collector
+reads the cwd through `proc_pidinfo(PROC_PIDVNODEPATHINFO)`. This needs no
+elevated privileges for same-uid processes and no per-pid `lsof` subprocess;
+root-owned processes return `EPERM` and are skipped, which is correct, since TBD
+never spawns any.
+
+The call returns a fully resolved path (`/private/var/...` rather than
+`/var/...`), so both sides of every comparison resolve symlinks first — the same
+care `WorktreeLifecycle+Archive.swift` already takes when matching a worktree
+path against `git worktree list` output.
+
+A process is a candidate for reclamation when **both** hold:
+
+- Its resolved cwd lies inside a TBD-managed root: a worktree pool directory,
+  a `<pool>/.deleting/` entry, or a scratchpad directory.
+- The worktree owning that path is archived, absent from the database, or its
+  directory no longer exists.
+
+A cwd inside a **live** worktree is never a candidate, whatever the process is.
+That is what keeps the rule narrow: a deliberately detached dev server is
+reclaimed only after the worktree it belonged to has been archived, which is
+already the gesture that says the work is over.
+
+## Exclusions
+
+These are the safety core, and the first is not hypothetical.
+
+- **The daemon and the app.** `TBDDaemon` runs at `ppid=1` with its cwd inside a
+  TBD-managed tree — measured at `ppid=1, cwd=/Users/<user>/projects/tbd`, and
+  when `scripts/restart.sh` is run from a worktree the daemon's cwd is that
+  worktree. Archiving it would otherwise have the sweep SIGKILL the live daemon
+  that is running the sweep. `TBDDaemon`, `TBDApp`, `getpid()` and its ancestors
+  are never signalled.
+- **pid <= 1**, already refused inside `ProcessSignaller`.
+- **Processes not owned by our uid.**
+- **Anything whose cwd could not be read.** Absence of evidence is not evidence
+  of an orphan; an unreadable cwd means skip, never reclaim.
+
+## Reclamation
+
+`ProcessSignaller.terminate` group-kills only when the pid is its own group
+leader, and that is not dependable here. The `process-compose` orphan was a
+leader (`pid == pgid == 70473`), so a group kill would have reached its prefect
+children; `just backend local` was not (`pid=1450, pgid=1448`, its leader already
+dead), so the same call would have signalled one process and left its children
+running.
+
+The collector therefore computes the **descendant closure** of each orphan root
+from the `ps` snapshot it already holds, and signals the whole subtree leaf-first:
+SIGTERM, poll for liveness, SIGKILL anything still alive at the end of the grace
+window. Leaf-first so a parent cannot fork a replacement child while its subtree
+is being torn down.
+
+This is the capability `ProcessSignaller.children(ofServerPID:)` lacks by
+construction, and it is why the collector computes the closure itself rather than
+calling that helper in a loop.
+
+## Grace
+
+Reclamation waits out `gcGraceSeconds` (3600 today), measured from `archivedAt`
+where a worktree row survives, and from process start time where it does not.
+Reusing the existing knob keeps one dial rather than two, and an hour is far
+below the multi-day lifetimes every observed orphan reached.
+
+The grace comparison uses the date seam (`Date` is data). The SIGTERM-to-SIGKILL
+poll takes an injected `Clock` (`Duration` is behavior), matching
+`AgentReaper`'s `graceAttempts` / `pollInterval` parameters.
+
+## Flag mechanics
+
+The column is `gc_orphan_processes_enabled`, added by migration **with no SQL
+default**, so "nobody has chosen" stays a third state distinct from an explicit
+`false`. The shipped default lives in exactly one place,
+`Config.gcOrphanProcessesEnabledDefault = false`, and `ConfigRecord.toModel()`
+resolves the column as `?? Config.gcOrphanProcessesEnabledDefault` — never
+`?? false`, which would make the constant unreachable in any real install.
+
+This follows `gc_profile_dirs_enabled`, the most recent flag to use the
+tri-state pattern, and avoids the `auto_hibernate_enabled` defect: passing
+`defaults:` makes `ADD COLUMN ... DEFAULT` backfill every existing row, after
+which flipping the default needs a forcing `UPDATE` migration and a deliberate
+opt-in becomes indistinguishable from a backfilled value.
+
+The flag gates the collector **on top of** `gcEnabled`, the same way
+`gcProfileDirsEnabled` does, so the GC master switch still turns everything off.
+
+Migration, GRDB record and Codable model land in one commit, with the model
+field optional so existing rows and JSON still decode.
+
+**Enabling it for a soak:** set `gc_orphan_processes_enabled = 1` on the
+singleton `config` row. **Graduation:** once reap records across a soak show it
+only ever caught real garbage, flip
+`Config.gcOrphanProcessesEnabledDefault` to `true` — a one-line change that
+reaches everyone who never touched the toggle while preserving every explicit
+opt-out. The flag is deleted a release later.
+
+## Record and restore
+
+A new `ReapKind.orphanProcess` case joins `agentWorktree`, `scratchpad`,
+`archivedWorktree` and `profileDir`. `worktreePath` carries the dead worktree the
+process was rooted in, and a new optional `processDescription` field carries the
+pid and a truncated argv, so a reap record says what was killed and not merely
+where it lived.
+
+`ReapRecord`'s remaining fields (`branch`, `headSHA`, `snapshotRef`,
+`quarantinePath`) are path- and git-shaped and go unused. That is a real cost of
+hosting this in `OrphanGC` rather than standing up a new reconciler with its own
+record type, and it is accepted: one reconciler with an imperfect record beats a
+fourth sweep with its own scheduling, flags and wiring.
+
+`restore(recordID:)` gains an explicit unsupported branch for `.orphanProcess`,
+alongside the ones already there for `.scratchpad` and `.profileDir`. A killed
+process cannot be restored, and the record exists as an audit trail rather than
+an undo.
+
+## Testing
+
+- **Both flag branches.** With the flag off, a matching orphan survives a sweep
+  untouched. With it on, the same orphan is reclaimed. Ungated GC behavior — the
+  four existing collectors — is unaffected either way.
+- **The three config states are distinguishable.** A pre-migration row reads
+  NULL rather than `0`; an explicit `false` survives a change to
+  `Config.gcOrphanProcessesEnabledDefault`; NULL follows it.
+- **Descendant closure.** A three-generation tree is reclaimed whole, including
+  a grandchild whose pgid differs from the root's, which is the case a plain
+  `killpg` misses.
+- **Live worktrees are untouched.** A process whose cwd is inside an active
+  worktree is never a candidate, even when its ppid is 1.
+- **Grace is honored.** An orphan younger than `gcGraceSeconds` survives; the
+  same orphan is reclaimed once the window has passed.
+- **Daemon self-exclusion.** With the daemon's own cwd inside the archived
+  worktree, the sweep does not signal it.
+- **Unreadable cwd is a skip.** A candidate whose cwd cannot be read is never
+  reclaimed.
+
+Process-level tests inject the signaller and the `ps` snapshot rather than
+spawning real processes, following `AgentReaperTests`, which drives the same
+escalation logic at `.milliseconds(1)`.
+
+## Rejected alternatives
+
+**Kill the escaped tree at teardown time instead of sweeping.** Neither observed
+orphan would have been caught: both had already escaped before the teardown that
+should have caught them. It is also the destructive-at-a-user-gesture path and it
+reverses the `isTBDOwned` position. Deferred to its own spec rather than
+rejected outright.
+
+**Identify by TBD ancestry fingerprint rather than cwd.** Most precise about
+ownership, and it misses exactly the observed cases: `pnpm` and `process-compose`
+inherit no TBD marker in their argv, and macOS hides another process's
+environment, so an env-var marker cannot be read at all.
+
+**Reclaim any orphan under a TBD worktree whose terminal row is gone, without
+requiring the worktree to be dead.** Catches more, and reclaims processes inside
+worktrees the developer is actively using — far too easy to surprise someone
+holding a deliberately detached server.
+
+**Detect and report only, never kill.** Zero destructive risk and it solves
+nothing: `HibernationCoordinator.detectOrphanedClaudeProcesses()` already scans
+for `ppid == 1` and its results are, in the code's own words, "logged but not
+killed in v1". An orphan surviving 11 days is direct evidence that nobody reads
+such a log.
+
+**An exemption mechanism so a user can protect a process.** Not in this version.
+The flag is default-off and the worktree must already be archived, so the only
+process at risk is one whose work the developer has already declared finished. An
+escape hatch is cheap to add later if a soak shows real need, and every version
+of it — a pattern file, an argv marker — is surface that has to be right the
+first time.
+
+## Reconciler doctrine
+
+This spec answers the doctrine's question for a resource class that previously
+had no answer: processes rooted in a worktree, escaped from every pane and
+server structure, reclaimed by a named collector inside `OrphanGC`. The two
+gaps it does not close are named rather than left implicit — tmux servers and
+control-mode clients in issue #678, and teardown-time reaping in a follow-on
+spec.

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -129,7 +129,8 @@ A process is a candidate for reclamation when **all** of these hold:
 - `ppid == 1`. It has been reparented to launchd, i.e. it really did escape.
   A process still held by a live parent is that parent's business.
 - Its resolved cwd lies inside a TBD-managed root: a worktree pool directory,
-  a `<pool>/.deleting/` entry, or a scratchpad directory.
+  a `<pool>/.deleting/` entry, an adopted worktree's own directory, or a
+  scratchpad directory.
 - The worktree owning that path is archived or absent from the database.
 - It is at least as old as the cwd reading it was matched against.
 
@@ -151,17 +152,36 @@ construction. Two kinds of root therefore behave differently:
   scratch-worktree pool. Everything under one of these was put there by TBD, so
   a child naming no row is a leftover this sweep owns, and `.deleting/<uuid>`
   entries land here.
-- **Shared** — the Claude scratchpad base. Claude Code creates one directory
-  there per project it has ever been run in, and TBD manages almost none of
-  them: a census of one developer machine found 86 entries, of which 9 named
-  no worktree at all — plain checkouts, a home directory, and loose files. A
-  cwd under a shared root is classified only by an explicit live or dead entry,
-  derived from a worktree row via `ScratchpadCollector`'s slug; an unrecognized
-  child is never a candidate.
+- **Shared** — the Claude scratchpad base, and every adopted worktree's own
+  directory. Claude Code creates one directory in the scratchpad base per
+  project it has ever been run in, and TBD manages almost none of them: a
+  census of one developer machine found 86 entries, of which 9 named no
+  worktree at all — plain checkouts, a home directory, and loose files. A cwd
+  under a shared root is classified only by an explicit live or dead entry —
+  derived from a worktree row via `ScratchpadCollector`'s slug for a
+  scratchpad, and from the row's own path for an adopted worktree; an
+  unrecognized child is never a candidate.
 
 `ScratchpadCollector.reconcile` already draws exactly this line for a merely
 destructive operation — "Unrelated directories in the base are untouched" — and
 this phase kills processes, so it draws the line no further out.
+
+`adoptWorktree` inserts a worktree row at a path the user chose, so an adopted
+worktree lies under no pool at all. Without an entry of its own it would fail
+the root test above and stay `.outside` forever, reproducing this phase's whole
+subject for that class of worktree — so the row's own path is admitted, as a
+shared root. Not as a pool, and not its parent directory: the location is the
+user's, its neighbours are unrelated checkouts and loose files, and admitting
+the neighbourhood as owned would put every one of them in the "absent from the
+database" arm and make a stranger's live session reclaimable. A shared root
+classifies exactly the adopted worktree and nothing beside it. Since no pool
+contains the path, the reap record takes its repo from the row's own `repoID`
+rather than from the pool-to-repo map.
+
+`reclaimDeletionQueue` widens its own pool set from adopted rows for a related
+reason, and can take the whole parent directory: an entry sitting in
+`.deleting/<uuid>` is there because TBD renamed it there, so draining it needs
+no provenance gate. Killing a process does.
 
 ### Two readings, joined by pid
 

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -183,16 +183,66 @@ reason, and can take the whole parent directory: an entry sitting in
 `.deleting/<uuid>` is there because TBD renamed it there, so draining it needs
 no provenance gate. Killing a process does.
 
-### Two readings, joined by pid
+### Pid reuse, from identification through to the signal
 
-The cwd map and the `ps` snapshot are read at different moments in one sweep and
-joined by pid alone, and macOS reissues pids. A pid that named an orphan when
-lsof ran can name an unrelated new process by the time `ps` runs, and that
-process would inherit the dead one's cwd. So a candidate must be at least as old
-as the gap between the two readings; anything younger is a possible reuse and is
-skipped. A process whose age could not be parsed fails this gate too, which is
-what makes "an unparseable start time keeps the process" true on both grace arms
-rather than only the one that has no archive instant.
+macOS reissues pids, and this phase touches pids at three separate moments: when
+the cwd map is joined to the `ps` snapshot, when a tree is planned from that
+snapshot, and when each member of that tree is signalled. Every one of those
+joins is by pid alone, so each needs its own answer.
+
+**Identification.** The cwd map and the `ps` snapshot are read at different
+moments in one sweep. A pid that named an orphan when lsof ran can name an
+unrelated new process by the time `ps` runs, and that process would inherit the
+dead one's cwd. So a candidate must be at least as old as the gap between the
+two readings; anything younger is a possible reuse and is skipped. A process
+whose age could not be parsed fails this gate too, which is what makes "an
+unparseable start time keeps the process" true on both grace arms rather than
+only the one that has no archive instant.
+
+**Signalling.** That age gate is about one pid — the orphan root — at one
+moment. It says nothing about the two things that follow it. Descendants enter a
+tree purely through the snapshot's ppid chain, with no reading of their own to
+be older than. And reclamation is sequential: each reap blocks for up to
+`graceAttempts × pollInterval` (≈3 s by default) before the next candidate's
+tree is examined at all, so with the half-dozen simultaneous orphans the field
+census found, the last candidate's tree is signalled many seconds after the
+snapshot that named its pids. A pid reissued anywhere in those windows, to a
+descendant slot or to a late candidate's root, would be SIGTERM'd and then
+SIGKILL'd — precisely the harm this mechanism exists to prevent.
+
+The identity of a process across time is **pid plus start time**: a reissued pid
+necessarily started after the reading that recorded the pid it replaced, so its
+start instant has moved. The `ps` snapshot already carries `etime`, so stamping
+each snapshot with its capture instant turns every row into a start instant at
+no extra cost.
+
+So the collector re-reads the process table **immediately before each volley** —
+the SIGTERM one and the SIGKILL escalation alike, roots and descendants alike —
+and signals only the pids whose start instant still matches what the plan
+recorded. A pid whose identity moved is dropped from the volley; a re-reading
+that fails at all drops the whole volley, because an identity that cannot be
+re-read is a skip and never a kill. A row whose `etime` did not parse yields no
+identity, so it can never verify and is never signalled.
+
+That costs **one `/bin/ps` per volley** — one per candidate, plus one more for
+each candidate that actually has a SIGTERM survivor — rather than one per pid.
+Re-reading per pid would be marginally tighter and costs a subprocess for every
+member of a tree (the measured `process-compose` orphan held four), spent at the
+moment the daemon is already doing the one thing in this sweep it cannot undo. A
+whole-table reading per volley bounds staleness by the volley's own re-read
+rather than by the sweep's, which is what the amplification needed, and it
+reuses the reader and the `etime` parser the phase already has.
+
+The comparison carries a two-second tolerance, because `etime` is whole seconds
+truncated and a snapshot is stamped at a slightly different instant than the
+kernel fills it in. That does not weaken the test it guards: a reissued pid's
+start instant moves by the whole age of the process it replaced — days, in every
+orphan measured here — never by a second.
+
+Trees are all planned from the one snapshot before anything is signalled, so the
+plan is a single consistent reading of the process graph rather than one
+interleaved with its own destruction. That is an ordering property, not a bound
+on staleness; the per-volley re-read is what bounds staleness.
 
 The worktree rows have their own staleness problem and the phase reads them
 itself for the same reason: the archived list and the live list have to agree
@@ -251,6 +301,11 @@ ancestor is asked to shut down. It is an ordering rather than a barrier — the
 volley does not wait between generations — so a process that forks during its own
 SIGTERM handling can still leave a child behind; that residue is an orphan of its
 own by the next sweep.
+
+Every pid in that subtree is re-verified against the plan's recorded start time
+immediately before it is signalled, so the closure is a list of candidates for a
+signal rather than a licence to send one — see "Pid reuse, from identification
+through to the signal".
 
 Every signal goes to exactly one pid. `ProcessSignaller.terminate` escalates to
 a group kill whenever the pid is its own group leader, and a process group is a
@@ -349,6 +404,12 @@ an undo.
   worktree's own scratchpad still is.
 - **A pid younger than the cwd reading is a skip**, and so is one whose age
   could not be parsed, on both grace arms.
+- **Identity is re-checked at signal time.** A descendant whose start time moved
+  between the plan and the volley is not signalled while the rest of its tree
+  still is; a later candidate in a multi-candidate sweep is checked at its own
+  volley rather than at the sweep's plan; the SIGKILL escalation re-checks
+  rather than reusing the SIGTERM volley's conclusion; and a re-reading that
+  fails signals nothing and records nothing.
 
 Process-level tests inject the signaller and the `ps` snapshot rather than
 spawning real processes, following `AgentReaperTests`, which drives the same

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -274,7 +274,8 @@ A new `ReapKind.orphanProcess` case joins `agentWorktree`, `scratchpad`,
 `archivedWorktree` and `profileDir`. `worktreePath` carries the dead worktree the
 process was rooted in, and a new optional `processDescription` field carries the
 pid and a truncated argv, so a reap record says what was killed and not merely
-where it lived.
+where it lived. `tbd gc list` prints it: this is the one kind whose reap removed
+nothing from disk, so `worktreePath` alone would say only where.
 
 `ReapRecord`'s remaining fields (`branch`, `headSHA`, `snapshotRef`,
 `quarantinePath`) are path- and git-shaped and go unused. That is a real cost of

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -174,6 +174,14 @@ skipped. A process whose age could not be parsed fails this gate too, which is
 what makes "an unparseable start time keeps the process" true on both grace arms
 rather than only the one that has no archive instant.
 
+The worktree rows have their own staleness problem and the phase reads them
+itself for the same reason: the archived list and the live list have to agree
+with each other, and a row archived between them belongs to neither. It would
+then reach the "absent from the database" arm and be graced from process start
+rather than from `archivedAt` — the weaker gate, on the exact row whose grace was
+just supposed to begin. Both reads happen together, inside the phase, and a
+failure on either skips it.
+
 ## Exclusions
 
 These are the safety core, and the first is not hypothetical.

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -81,7 +81,8 @@ currently has none.
 ## Scope
 
 **In scope:** processes whose cwd resolves inside a TBD-managed worktree,
-`.deleting/` entry, or scratchpad, and whose owning worktree no longer exists.
+`.deleting/` entry, or scratchpad that something positively attests is dead —
+an archived worktree row, or the deletion queue TBD renamed the directory into.
 
 **Out of scope, tracked as issue #678:** leaked tmux servers and their
 `tmux -CC attach` control-mode clients. A tmux server `chdir`s to `/` when it
@@ -131,7 +132,12 @@ A process is a candidate for reclamation when **all** of these hold:
 - Its resolved cwd lies inside a TBD-managed root: a worktree pool directory,
   a `<pool>/.deleting/` entry, an adopted worktree's own directory, or a
   scratchpad directory.
-- The worktree owning that path is archived or absent from the database.
+- Something **positively attests that the owning directory is dead**. There are
+  exactly two such attestations, and nothing else counts:
+  - a worktree row whose status is `archived` — for the worktree's own
+    directory and for its Claude scratchpad alike; or
+  - the directory sitting in a `<pool>/.deleting/<uuid>` queue entry, which is
+    where TBD itself renamed it on the way to deleting it.
 - It is at least as old as the cwd reading it was matched against.
 
 A cwd inside a **live** worktree is never a candidate, whatever the process is.
@@ -142,16 +148,41 @@ archived counts as live whether or not its directory still exists on disk: that
 combination is a broken worktree, and a broken worktree is a reconcile problem,
 not a licence to kill.
 
+### The absence of a row attests to nothing
+
+A directory under a worktree pool that names no row at all is **ambiguous**, and
+ambiguity keeps. TBD cannot tell a worktree a person added by hand — a bare
+`git worktree add`, or a plain `mkdir` — from garbage some earlier failure left
+behind, and only one of those two is safe to kill processes in.
+
+Nor does time resolve the ambiguity. A row is backfilled for a directory TBD did
+not create only by `WorktreeLifecycle.reconcile`, which runs at daemon startup,
+on `repo.add`, and from the cleanup RPC — **no timer calls it**, and it adopts
+only entries `git worktree list` already reports. This sweep, by contrast, runs
+at startup and then hourly forever. So on a daemon up for days, a hand-made
+directory under the pool is not "not recognized yet"; it is not recognized, full
+stop, and treating that as a death certificate would have the sweep kill live
+work nobody ever archived.
+
+The consequence, accepted deliberately: a worktree whose row was hard-deleted by
+`worktree.forget` while its directory remained keeps its processes. `forget`
+means "stop tracking this, leave the directory alone", and the person may well
+still be working in it. Both orphans measured in the field were rooted in
+**archived** worktrees, so no evidenced coverage rests on the forgotten case.
+
+`.deleting/<uuid>` entries are the one stray a pool still claims, and they are
+not an exception to the rule: TBD renamed the directory there itself, so the
+entry *is* the attestation. It carries no archive instant — there is no row left
+to hold one — so its grace runs from process start instead.
+
 ### Owned roots and shared roots
 
-The "absent from the database" arm makes an unrecognized child of a root
-reclaimable, and that is only sound where every child of the root is TBD's by
-construction. Two kinds of root therefore behave differently:
+Two kinds of root behave differently, because only one of them is where TBD's
+own `.deleting/` queues live:
 
 - **Owned** — each repo's worktree pool (canonical and legacy) and the
-  scratch-worktree pool. Everything under one of these was put there by TBD, so
-  a child naming no row is a leftover this sweep owns, and `.deleting/<uuid>`
-  entries land here.
+  scratch-worktree pool. TBD owns these trees outright, `.deleting/<uuid>`
+  entries land in them, and a cwd inside such an entry is reclaimable.
 - **Shared** — the Claude scratchpad base, and every adopted worktree's own
   directory. Claude Code creates one directory in the scratchpad base per
   project it has ever been run in, and TBD manages almost none of them: a
@@ -159,8 +190,9 @@ construction. Two kinds of root therefore behave differently:
   worktree at all — plain checkouts, a home directory, and loose files. A cwd
   under a shared root is classified only by an explicit live or dead entry —
   derived from a worktree row via `ScratchpadCollector`'s slug for a
-  scratchpad, and from the row's own path for an adopted worktree; an
-  unrecognized child is never a candidate.
+  scratchpad, and from the row's own path for an adopted worktree. TBD queues
+  no deletions here, so nothing under a shared root is claimable on any other
+  ground, and a shared root nested inside a pool wins over it.
 
 `ScratchpadCollector.reconcile` already draws exactly this line for a merely
 destructive operation — "Unrelated directories in the base are untouched" — and
@@ -170,13 +202,12 @@ this phase kills processes, so it draws the line no further out.
 worktree lies under no pool at all. Without an entry of its own it would fail
 the root test above and stay `.outside` forever, reproducing this phase's whole
 subject for that class of worktree — so the row's own path is admitted, as a
-shared root. Not as a pool, and not its parent directory: the location is the
-user's, its neighbours are unrelated checkouts and loose files, and admitting
-the neighbourhood as owned would put every one of them in the "absent from the
-database" arm and make a stranger's live session reclaimable. A shared root
-classifies exactly the adopted worktree and nothing beside it. Since no pool
-contains the path, the reap record takes its repo from the row's own `repoID`
-rather than from the pool-to-repo map.
+shared root. Not as a pool, and not its parent directory: a pool asserts that
+TBD owns the whole tree, which is exactly what is untrue of a location the user
+picked, where the neighbours are unrelated checkouts and loose files. A shared
+root classifies exactly the adopted worktree and nothing beside it. Since no
+pool contains the path, the reap record takes its repo from the row's own
+`repoID` rather than from the pool-to-repo map.
 
 `reclaimDeletionQueue` widens its own pool set from adopted rows for a related
 reason, and can take the whole parent directory: an entry sitting in
@@ -246,11 +277,11 @@ on staleness; the per-volley re-read is what bounds staleness.
 
 The worktree rows have their own staleness problem and the phase reads them
 itself for the same reason: the archived list and the live list have to agree
-with each other, and a row archived between them belongs to neither. It would
-then reach the "absent from the database" arm and be graced from process start
-rather than from `archivedAt` — the weaker gate, on the exact row whose grace was
-just supposed to begin. Both reads happen together, inside the phase, and a
-failure on either skips it.
+with each other, and a row archived between them belongs to neither, leaving the
+phase to judge one worktree on two readings that disagree. Both reads happen
+together, inside the phase, and a failure on either skips it — where the sweep's
+own `try? … ?? []` would have read "no archived worktrees" and reported a clean
+sweep of a phase that never ran.
 
 ## Exclusions
 
@@ -321,7 +352,8 @@ calling that helper in a loop.
 ## Grace
 
 Reclamation waits out `gcGraceSeconds` (3600 today), measured from `archivedAt`
-where a worktree row survives, and from process start time where it does not.
+where an archived row is what attests to the death, and from process start time
+for a `.deleting/` queue entry, which has no row left to carry an instant.
 Reusing the existing knob keeps one dial rather than two, and an hour is far
 below the multi-day lifetimes every observed orphan reached.
 
@@ -402,6 +434,14 @@ an undo.
 - **A stray scratchpad is a skip.** A directory under the Claude scratchpad base
   that names no worktree TBD knows is never a candidate, while an archived
   worktree's own scratchpad still is.
+- **An unrecognized pool child is a skip.** A directory created directly under a
+  worktree pool by hand, holding a `ppid == 1` process far older than
+  `gcGraceSeconds`, is never a candidate — while a `<pool>/.deleting/<uuid>`
+  entry in the same sweep still is, and the `.deleting/` queue directory itself
+  is not, since it names no entry.
+- **A forgotten worktree is a skip.** A row hard-deleted by `worktree.forget`
+  with the directory left intact keeps its processes, pinning that coverage
+  limit as deliberate.
 - **A pid younger than the cwd reading is a skip**, and so is one whose age
   could not be parsed, on both grace arms.
 - **Identity is re-checked at signal time.** A descendant whose start time moved

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -114,8 +114,9 @@ no additional cost — no new subprocess, no per-pid syscall, and the establishe
 That failure direction matters more here than anywhere else in the sweep: a
 missing cwd map must never be read as "this process is not in a worktree".
 
-A second `ps -axo pid=,ppid=,pgid=` snapshot supplies the process graph, which
-lsof does not carry. It is the same `/bin/ps` invocation shape
+A second `ps -axww -o pid=,ppid=,pgid=,uid=,etime=,command=` snapshot supplies
+the process graph, the ownership and age fields, and the argv the reap record
+names — none of which lsof carries. It is the same `/bin/ps` invocation shape
 `ProcessSignaller` already uses.
 
 `lsof` reports fully resolved paths (`/private/var/...` rather than
@@ -123,17 +124,55 @@ lsof does not carry. It is the same `/bin/ps` invocation shape
 care `WorktreeLifecycle+Archive.swift` already takes when matching a worktree
 path against `git worktree list` output.
 
-A process is a candidate for reclamation when **both** hold:
+A process is a candidate for reclamation when **all** of these hold:
 
+- `ppid == 1`. It has been reparented to launchd, i.e. it really did escape.
+  A process still held by a live parent is that parent's business.
 - Its resolved cwd lies inside a TBD-managed root: a worktree pool directory,
   a `<pool>/.deleting/` entry, or a scratchpad directory.
-- The worktree owning that path is archived, absent from the database, or its
-  directory no longer exists.
+- The worktree owning that path is archived or absent from the database.
+- It is at least as old as the cwd reading it was matched against.
 
 A cwd inside a **live** worktree is never a candidate, whatever the process is.
 That is what keeps the rule narrow: a deliberately detached dev server is
 reclaimed only after the worktree it belonged to has been archived, which is
-already the gesture that says the work is over.
+already the gesture that says the work is over. A row that is present and not
+archived counts as live whether or not its directory still exists on disk: that
+combination is a broken worktree, and a broken worktree is a reconcile problem,
+not a licence to kill.
+
+### Owned roots and shared roots
+
+The "absent from the database" arm makes an unrecognized child of a root
+reclaimable, and that is only sound where every child of the root is TBD's by
+construction. Two kinds of root therefore behave differently:
+
+- **Owned** — each repo's worktree pool (canonical and legacy) and the
+  scratch-worktree pool. Everything under one of these was put there by TBD, so
+  a child naming no row is a leftover this sweep owns, and `.deleting/<uuid>`
+  entries land here.
+- **Shared** — the Claude scratchpad base. Claude Code creates one directory
+  there per project it has ever been run in, and TBD manages almost none of
+  them: a census of one developer machine found 86 entries, of which 9 named
+  no worktree at all — plain checkouts, a home directory, and loose files. A
+  cwd under a shared root is classified only by an explicit live or dead entry,
+  derived from a worktree row via `ScratchpadCollector`'s slug; an unrecognized
+  child is never a candidate.
+
+`ScratchpadCollector.reconcile` already draws exactly this line for a merely
+destructive operation — "Unrelated directories in the base are untouched" — and
+this phase kills processes, so it draws the line no further out.
+
+### Two readings, joined by pid
+
+The cwd map and the `ps` snapshot are read at different moments in one sweep and
+joined by pid alone, and macOS reissues pids. A pid that named an orphan when
+lsof ran can name an unrelated new process by the time `ps` runs, and that
+process would inherit the dead one's cwd. So a candidate must be at least as old
+as the gap between the two readings; anything younger is a possible reuse and is
+skipped. A process whose age could not be parsed fails this gate too, which is
+what makes "an unparseable start time keeps the process" true on both grace arms
+rather than only the one that has no archive instant.
 
 ## Exclusions
 
@@ -145,6 +184,14 @@ These are the safety core, and the first is not hypothetical.
   worktree. Archiving it would otherwise have the sweep SIGKILL the live daemon
   that is running the sweep. `TBDDaemon`, `TBDApp`, `getpid()` and its ancestors
   are never signalled.
+
+  `getpid()` and its ancestors cover the running daemon; the binary-name check
+  is what covers `TBDApp` and any sibling worktree's daemon, neither of which is
+  in this process's ancestry. It matches the basename of any path component in
+  the command line, not just of the first token: `ps` prints argv space-joined
+  and unquoted, so a home directory with a space in it would otherwise split
+  argv[0] and leave the app unrecognized. Over-matching is the keep-favoring
+  direction and is accepted.
 - **pid <= 1**, already refused inside `ProcessSignaller`.
 - **Processes not owned by our uid.**
 - **Anything whose cwd could not be read.** Absence of evidence is not evidence
@@ -162,8 +209,18 @@ running.
 The collector therefore computes the **descendant closure** of each orphan root
 from the `ps` snapshot it already holds, and signals the whole subtree leaf-first:
 SIGTERM, poll for liveness, SIGKILL anything still alive at the end of the grace
-window. Leaf-first so a parent cannot fork a replacement child while its subtree
-is being torn down.
+window. Leaf-first so no descendant is still unsignalled at the moment its
+ancestor is asked to shut down. It is an ordering rather than a barrier — the
+volley does not wait between generations — so a process that forks during its own
+SIGTERM handling can still leave a child behind; that residue is an orphan of its
+own by the next sweep.
+
+Every signal goes to exactly one pid. `ProcessSignaller.terminate` escalates to
+a group kill whenever the pid is its own group leader, and a process group is a
+superset of the *group*, not of the closure: it can contain a pid this sweep
+deliberately protected, and on a reused pid `getpgid` resolves to a stranger's
+group outright. The exclusion list is only a guarantee if nothing widens the
+target after it has been applied.
 
 This is the capability `ProcessSignaller.children(ofServerPID:)` lacks by
 construction, and it is why the collector computes the closure itself rather than
@@ -201,8 +258,11 @@ The flag gates the collector **on top of** `gcEnabled`, the same way
 Migration, GRDB record and Codable model land in one commit, with the model
 field optional so existing rows and JSON still decode.
 
-**Enabling it for a soak:** set `gc_orphan_processes_enabled = 1` on the
-singleton `config` row. **Graduation:** once reap records across a soak show it
+**Enabling it for a soak:** call the `config.setGCOrphanProcessesEnabled` RPC,
+which writes `gc_orphan_processes_enabled` on the singleton `config` row. It has
+an RPC for the same reason its sibling gates do — the one phase whose mistakes
+cannot be undone should not also be the one whose only switch is behind a
+hand-edit of `state.db`. **Graduation:** once reap records across a soak show it
 only ever caught real garbage, flip
 `Config.gcOrphanProcessesEnabledDefault` to `true` — a one-line change that
 reaches everyone who never touched the toggle while preserving every explicit
@@ -246,6 +306,11 @@ an undo.
   worktree, the sweep does not signal it.
 - **Unreadable cwd is a skip.** A candidate whose cwd cannot be read is never
   reclaimed.
+- **A stray scratchpad is a skip.** A directory under the Claude scratchpad base
+  that names no worktree TBD knows is never a candidate, while an archived
+  worktree's own scratchpad still is.
+- **A pid younger than the cwd reading is a skip**, and so is one whose age
+  could not be parsed, on both grace arms.
 
 Process-level tests inject the signaller and the `ps` snapshot rather than
 spawning real processes, following `AgentReaperTests`, which drives the same

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -105,14 +105,20 @@ the moment of a user gesture, which deserves its own examination.
 
 ## Identification
 
-One `ps` snapshot per sweep supplies pid, ppid, pgid and start time for every
-process. For each candidate with `ppid == 1` owned by our uid, the collector
-reads the cwd through `proc_pidinfo(PROC_PIDVNODEPATHINFO)`. This needs no
-elevated privileges for same-uid processes and no per-pid `lsof` subprocess;
-root-owned processes return `EPERM` and are skipped, which is correct, since TBD
-never spawns any.
+Cwd comes from the `lsof -d cwd -Fn` pass `OrphanGC` already runs once per
+sweep. That pass prints a `p<pid>` header followed by an `n<path>` line per
+process, and `parseLiveCWDs` currently keeps only the paths. Retaining the pid
+alongside the path yields a pid-to-cwd map for every process on the machine at
+no additional cost — no new subprocess, no per-pid syscall, and the established
+"lsof unavailable means skip the entire sweep" direction already guards it.
+That failure direction matters more here than anywhere else in the sweep: a
+missing cwd map must never be read as "this process is not in a worktree".
 
-The call returns a fully resolved path (`/private/var/...` rather than
+A second `ps -axo pid=,ppid=,pgid=` snapshot supplies the process graph, which
+lsof does not carry. It is the same `/bin/ps` invocation shape
+`ProcessSignaller` already uses.
+
+`lsof` reports fully resolved paths (`/private/var/...` rather than
 `/var/...`), so both sides of every comparison resolve symlinks first — the same
 care `WorktreeLifecycle+Archive.swift` already takes when matching a worktree
 path against `git worktree list` output.

--- a/docs/specs/2026-08-18-orphan-process-gc-design.md
+++ b/docs/specs/2026-08-18-orphan-process-gc-design.md
@@ -221,7 +221,16 @@ These are the safety core, and the first is not hypothetical.
   argv[0] and leave the app unrecognized. Over-matching is the keep-favoring
   direction and is accepted.
 - **pid <= 1**, already refused inside `ProcessSignaller`.
-- **Processes not owned by our uid.**
+- **Processes not owned by our uid.** The gate sits in the protected set, next
+  to the binary-name check, rather than only on the orphan root — a root-only
+  gate would let every descendant into the volley whatever its own uid was, and
+  leave the promise resting on `kill(2)` returning `EPERM` across uids, which is
+  the kernel's guarantee rather than this sweep's. A foreign uid protects the
+  process entirely: the walk stops there, so a process of ours running below
+  another user's keeps running, because reclaiming it would mean reaching across
+  a privilege boundary on the strength of a parent link. It is not lost to the
+  reconciler — once its foreign parent exits it reparents to launchd, and the
+  next sweep sees it as an orphan root of its own.
 - **Anything whose cwd could not be read.** Absence of evidence is not evidence
   of an orphan; an unreadable cwd means skip, never reclaim.
 


### PR DESCRIPTION
## Summary

Start a dev server in a TBD terminal, archive the worktree, and the server keeps running — forever. It holds its memory, nothing owns it, and no sweep has ever looked for it. Two were found on one machine running for **10 and 11 days** against seconds of CPU, in worktrees archived a week earlier; a single census turned up roughly half a dozen alive at once, so this is a steady state, not a fluke.

This adds a fifth `OrphanGC` collector that reclaims them: a process reparented to launchd whose working directory sits inside a worktree that has since been archived or deleted. It ships behind a default-off flag.

## Why this shape

The escape is ordinary job control, not exotic daemonizing. Under an interactive shell **every job runs in its own process group**, so `killpg(pane_pid, …)` reaches the shell and nothing else — a foreground job only dies because the *kernel* hangs up the tty. Measured against `tmux kill-window`: a foreground job and a plain `&` job die; `& disown` and `nohup … &` survive and reparent to `ppid=1`.

`AgentReaper` cannot see these three times over — it walks one generation from the tmux server, its per-teardown escalation targets an already-dead pane pid, and its `isTBDOwned` gate excludes non-agent binaries *deliberately* ("a user detached inside a TBD shell pane"). That last point is why this needed a spec rather than a patch: the repo already held a written position on the other side of it. This revises that position for one case — the worktree is gone — and leaves it standing everywhere else.

Design and rejected alternatives: [`docs/specs/2026-08-18-orphan-process-gc-design.md`](docs/specs/2026-08-18-orphan-process-gc-design.md). Worth naming here:

- **Teardown-time killing was rejected for this PR** and deferred to its own spec. Neither observed orphan would have been caught by it — both escaped before the teardown that should have caught them. It is also the destructive-at-a-user-gesture path.
- **Detect-and-report-only was rejected.** `HibernationCoordinator.detectOrphanedClaudeProcesses()` already scans for `ppid == 1` and, in its own words, results are "logged but not killed in v1". An orphan surviving 11 days is evidence nobody reads that log.
- **No exemption mechanism.** The flag is off by default and the worktree must already be archived, so the only process at risk belongs to work the developer has declared finished.

## What this PR does

- **`OrphanProcessCollector`** (`Sources/TBDDaemon/GC/OrphanProcessCollector.swift`) — identifies orphans, computes the descendant closure, and reclaims leaf-first with SIGTERM → poll → SIGKILL.
- **Cwd comes free.** `OrphanGC` already runs `lsof -d cwd -Fn` once per sweep and discarded the pid; it now keeps it. A `ps -axww` snapshot supplies the process graph, uid and age.
- **Group kills are not used.** A process group is a superset of the *group*, not of the computed closure — it can contain a pid the sweep deliberately protected. `ProcessSignaller` gains pid-exact `terminateProcessOnly` / `forceKillProcessOnly` (protocol requirements with extension defaults, so no conformer broke).
- **Reclamation requires positive evidence of death.** A worktree row marked archived, or a `<pool>/.deleting/<uuid>` entry TBD renamed there itself. The absence of a row attests to nothing: `reconcile` runs only at startup, `repo.add` and the cleanup RPC — never on a timer — while the sweep runs hourly forever, so on a long-uptime daemon a hand-made directory under a pool simply never gets a row. Unrecognized strays are ambiguous and are kept, not reclaimed.
- **Exclusions:** `pid <= 1`, other uids, `getpid()` and its ancestors, and any `TBDDaemon`/`TBDApp`. Protected pids are never signalled *and never descended into*. This is not hypothetical — the daemon runs at `ppid=1` with its cwd inside a TBD tree.
- **Everything fails toward keeping.** An unavailable `ps` or `lsof` pass, an unreadable cwd, an unparseable age, or a failed DB read skips rather than reading as "no orphans".
- **`tbd gc orphan-processes on|off`** — the soak switch, plus `processDescription` on the reap record so `tbd gc list` says *what* was killed, not only where it lived.

## Flag & rollout

**Flag:** `gc_orphan_processes_enabled`, **default OFF**, gating on top of `gcEnabled`.

Tri-state per CLAUDE.md: the column is added with **no SQL default**, so NULL means nobody has chosen and the shipped default lives in exactly one place, `Config.gcOrphanProcessesEnabledDefault`, resolved as `?? Config.gcOrphanProcessesEnabledDefault` — never `?? false`. This avoids the `auto_hibernate_enabled` defect, where `ADD COLUMN … DEFAULT` backfilled every row and a later force-off could not tell a deliberate opt-in from a backfilled value.

**Enable for the soak:** `tbd gc orphan-processes on` (and `off` to disable).

**Graduation:** once reap records across a soak show it only ever caught real garbage, flip `Config.gcOrphanProcessesEnabledDefault` to `true` — one line, reaching everyone who never touched the toggle while preserving every explicit opt-out. Delete the flag a release later.

## Assumptions

- **A worktree hard-deleted via `worktree.forget`, directory intact, is not reclaimed.** `forget` means "stop tracking this, leave the directory alone", so processes in it are left running. Deliberate: neither observed leak was of that kind.
- **Archiving a worktree means the work in it is over.** A dev server deliberately left running is reclaimed once its worktree is archived. A field census found `pgbouncer` and an OrbStack helper running for days with cwds inside *live* worktrees — those are safe today, but archiving such a worktree will kill them and their subtrees. Worth knowing before enabling the flag.
- **`lsof` and `ps` are available and same-uid readable.** If either is unavailable the phase skips entirely rather than guessing.
- **Pids are matched across two snapshots taken moments apart.** macOS reuses pids, so a candidate must be at least as old as the gap between the readings.

## Evidence & verification

**The mechanism was measured, not reasoned.** Against a real pane at pid 52269 (pgid 52269), four children carried pgids 53668/53703/53735/53820 — none the pane's. After `tmux kill-window`, the `disown`ed and `nohup`ed children survived at `ppid=1` while the foreground and plain-background ones died.

**Both flag branches are tested,** plus the three distinguishable config states (a pre-migration row reads NULL; an explicit `false` survives a change to the default constant; NULL follows it). Also covered: the leaf-first closure across process groups, SIGTERM escalating to SIGKILL, grace from `archivedAt` and from process start, the daemon self-exclusion, stray and nested shared roots, a spaced-path binary match, the pid-reuse age gate, an unreadable cwd, an unavailable `ps` snapshot, a failed DB read, and `.orphanProcess` restore rejection. Each new test fails against the pre-fix code.

**Two defects were caught by review and fixed before merge**, both verified against this machine:
- The scratchpad base was treated as an owned pool. Of its 85 entries, 9 name no worktree at all — plain checkouts, a home directory, loose files — so `ppid==1` processes in them were SIGKILL candidates after an hour.
- `isTBDBinary` read only the first whitespace token of a space-joined argv, so a home directory containing a space defeated the `TBDApp` protection, which is that process's *only* guard.

**Suite:** 7038 tests in 717 suites, 86 known issues, no unknown failures. The two that appeared in one run (`CodexUsageFetcherLifecycleTests`, `MarkdownStylesheetTests` FileWatcher) each passed on isolated re-run — known flakes under parallel load. `swiftlint --strict`: 0 violations across 769 files.

**Not covered by this PR:** leaked tmux servers and `-CC attach` clients, which a cwd-keyed rule structurally cannot see because a tmux server `chdir`s to `/` — filed as #678.

[🧟 Teardown leaves orphan processes](https://cheapsteak.github.io/tbd/open/?worktree=E44EBD47-FC86-49C1-AEC8-DC7E6FEB3125)
