### PR TITLE
Fix: Stop every cloud lane being named after its raw session id

### DIFF
--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreate.swift
@@ -176,6 +176,10 @@ extension ClaudeCloudInvoker {
                     let title = ClaudeCloudCreateOutputParser.title(fromOutput: output)
                     try await db.claudeCloudSessions.resolve(
                         id: row.id, sessionID: sessionID, title: title, now: now())
+                    if title == nil {
+                        claudeCloudLogger.error(
+                            "claude-cloud create parsed a session id but not its title; received: \(ClaudeCloudCreateOutputParser.boundedQuote(output), privacy: .public)")
+                    }
                     claudeCloudLogger.error(
                         "claude-cloud create exited \(status, privacy: .public) after printing a session id; recording it before reporting failure")
                     return Self.errorResult(
@@ -203,8 +207,16 @@ extension ClaudeCloudInvoker {
                 return Self.errorResult(exitCode: 2, code: "contract_bug", message: message)
             case .success(let sessionID):
                 // Lenient by design: a missing title costs friendliness, not
-                // the lane, so it never fails a create that succeeded.
+                // the lane, so it never fails a create that succeeded. It is
+                // not silent, though — a title that failed to parse despite a
+                // readable id is otherwise undetectable except by a human
+                // noticing a session named from its raw id, which is exactly
+                // how this bug shipped.
                 let title = ClaudeCloudCreateOutputParser.title(fromOutput: output)
+                if title == nil {
+                    claudeCloudLogger.error(
+                        "claude-cloud create parsed a session id but not its title; received: \(ClaudeCloudCreateOutputParser.boundedQuote(output), privacy: .public)")
+                }
                 let resolvedAt = now()
                 try await db.claudeCloudSessions.resolve(
                     id: row.id, sessionID: sessionID, title: title, now: resolvedAt)

--- a/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
+++ b/Sources/TBDDaemon/Remote/ClaudeCloud/ClaudeCloudCreateOutputParser.swift
@@ -89,6 +89,15 @@ enum ClaudeCloudCreateOutputParser {
     /// Everything after the prefix up to the next KNOWN line is joined with
     /// single spaces, because a child that formatted to a narrower width than
     /// the pty reports inserts a real newline mid-title.
+    ///
+    /// The prefix is located WITHIN the line, not required at position 0.
+    /// `ANSIEscape.strip` covers every escape form measured so far, but a
+    /// pty's leading terminal-setup bytes are not all escape sequences — bare
+    /// C0 controls (a capture backspace) and capture-tool artifacts survive
+    /// stripping and land before the real text. `hasPrefix` would silently
+    /// drop the title on any such residue; searching for the prefix and
+    /// taking the title from after it tolerates leading noise this parser
+    /// cannot fully enumerate in advance.
     static func title(fromOutput raw: String) -> String? {
         let text = ANSIEscape.strip(raw)
         // `split(separator: "\n")` treats `\n` as one specific Character and
@@ -99,10 +108,12 @@ enum ClaudeCloudCreateOutputParser {
         // `\r\n`, lone `\r`, and lone `\n` alike as one separator each.
         let lines = text.split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })
             .map { String($0).trimmingCharacters(in: .whitespaces) }
-        guard let start = lines.firstIndex(where: { $0.hasPrefix(titlePrefix) }) else {
+        guard let start = lines.firstIndex(where: { $0.contains(titlePrefix) }),
+              let prefixRange = lines[start].range(of: titlePrefix)
+        else {
             return nil
         }
-        var parts = [String(lines[start].dropFirst(titlePrefix.count))]
+        var parts = [String(lines[start][prefixRange.upperBound...])]
         for line in lines[(start + 1)...] {
             // The two other measured lines end the title; so does a blank one.
             if line.isEmpty || line.hasPrefix("View:") || line.hasPrefix("Resume with:") { break }

--- a/Sources/TBDShared/ANSIEscape.swift
+++ b/Sources/TBDShared/ANSIEscape.swift
@@ -8,10 +8,30 @@ import Foundation
 /// cannot interpret escapes, strips them here for plain-text display.
 /// (Deliberate v1: colors in the viewer can come later.)
 public enum ANSIEscape {
-    /// CSI (`ESC [ … final-byte`) and OSC (`ESC ] … BEL|ST`) sequences.
-    /// Mirrors the scrubber pattern used elsewhere in TBD.
+    /// Three forms, matched in this order so the more specific CSI/OSC
+    /// alternatives claim their sequences before the generic fallback can:
+    ///
+    /// 1. CSI (`ESC [ … final-byte`) — parameter bytes widened to the full
+    ///    ECMA-48 range `0-9 : ; < = > ?` (0x30-0x3F), not just digits and
+    ///    `?`. Real CLIs emit private-prefixed forms like `ESC [ < u` (Kitty
+    ///    keyboard protocol queries) and `ESC [ > 4;2 m` (modifyOtherKeys) —
+    ///    `<`, `>` and `=` are legal CSI parameter bytes, and without them
+    ///    here the whole sequence fails to match and survives verbatim.
+    /// 2. OSC (`ESC ] … BEL|ST`).
+    /// 3. Generic two-byte-or-more escape sequences with no `[` or `]`:
+    ///    `ESC` + zero or more intermediate bytes (0x20-0x2F, e.g. the `(`
+    ///    / `)` charset-selector introducer) + one final byte (0x30-0x7E).
+    ///    Covers `ESC 7` / `ESC 8` (save/restore cursor) and `ESC ( B` /
+    ///    `ESC ) 0` (charset designation) — none of which start with `[` or
+    ///    `]`, so alternatives 1 and 2 never see them.
+    ///
+    /// Mirrors the scrubber pattern used elsewhere in TBD, widened against a
+    /// real `claude --cloud` capture whose first line survived stripping
+    /// intact because of exactly the gaps closed above.
     private static let regex = try! NSRegularExpression(
-        pattern: "\u{1B}\\[[0-9;?]*[ -/]*[@-~]|\u{1B}\\][^\u{07}\u{1B}]*(?:\u{07}|\u{1B}\\\\)"
+        pattern: "\u{1B}\\[[0-9:;<=>?]*[ -/]*[@-~]"
+            + "|\u{1B}\\][^\u{07}\u{1B}]*(?:\u{07}|\u{1B}\\\\)"
+            + "|\u{1B}[ -/]*[0-~]"
     )
 
     /// Remove all ANSI/OSC escape sequences, leaving the visible text.

--- a/Tests/TBDDaemonTests/ClaudeCloudCreateOutputParserTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudCreateOutputParserTests.swift
@@ -143,4 +143,44 @@ struct ClaudeCloudCreateOutputParserTests {
         #expect(ClaudeCloudCreateOutputParser.title(fromOutput: output)
             == "Add probe pong reply")
     }
+
+    // MARK: - Tolerant of leading residue (the field bug this pins)
+
+    /// The exact bytes measured from a real `claude --cloud` pty capture
+    /// (`claude` 2.1.235, `TERM=xterm-256color COLUMNS=400 LINES=200`), built
+    /// by explicit concatenation rather than a string literal so every
+    /// control byte and escape sequence is unambiguous — a triple-quoted
+    /// literal normalizes to bare `\n` and could not construct this. Before
+    /// this fix, `ANSIEscape.strip` left `ESC 7`, `ESC 8` and the
+    /// `<`/`>`-prefixed CSI queries in place, and even with those stripped,
+    /// `title(fromOutput:)`'s `hasPrefix` required the prefix at position 0
+    /// — so the bare backspaces and the capture tool's leading `^D` (two
+    /// literal characters, not the 0x04 byte) alone were enough to lose the
+    /// title. The ledger row still resolved from the id on the other two
+    /// lines; only the title came back nil.
+    @Test func theRealCapturedLeadInStillYieldsTheTitle() throws {
+        let firstLine = "^D" + "\u{08}\u{08}"
+            + "\u{1B}7" + "\u{1B}[r" + "\u{1B}8"
+            + "\u{1B}[?25h" + "\u{1B}[?25l" + "\u{1B}[?2004h" + "\u{1B}[?1004h" + "\u{1B}[?2031h"
+            + "\u{1B}[<u" + "\u{1B}[>1u" + "\u{1B}[>4;2m" + "\u{1B}[>0q"
+            + "Created cloud session: Probe reply OK then stop"
+        let secondLine = "View: https://claude.ai/code/session_01BBBBBBBBBBBBBBBBBBBBBB?from=cli&m=0\r"
+        let thirdLine = "Resume with: claude --teleport session_01BBBBBBBBBBBBBBBBBBBBBB\r"
+        let raw = firstLine + "\r\n" + secondLine + "\n" + thirdLine
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: raw)
+            == "Probe reply OK then stop")
+        #expect(try ClaudeCloudCreateOutputParser.sessionID(fromOutput: raw).get()
+            == "session_01BBBBBBBBBBBBBBBBBBBBBB")
+    }
+
+    /// The title-line prefix is located WITHIN the line, not required at
+    /// position 0 — synthetic version of the case above, isolating just the
+    /// leading-residue tolerance without the full captured byte sequence.
+    @Test func aPrefixNotAtTheStartOfTheLineStillYieldsTheTitle() {
+        let output = "^D\u{08}\u{08}Created cloud session: Probe reply OK then stop\n"
+            + "View: https://claude.ai/code/session_01AAA?from=cli\n"
+            + "Resume with: claude --teleport session_01AAA\n"
+        #expect(ClaudeCloudCreateOutputParser.title(fromOutput: output)
+            == "Probe reply OK then stop")
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudInvokerTests.swift
@@ -400,6 +400,13 @@ struct ClaudeCloudInvokerTests {
 
     /// The opposite posture, and the pair that discriminates: an unreadable
     /// TITLE must never fail a create that produced a readable id.
+    ///
+    /// This is also the only exercisable coverage for the `.error` log this
+    /// case now emits (`claudeCloudLogger`, `ClaudeCloudCreate.swift`): there
+    /// is no injected-logger or `OSLogStore` seam in this tree to assert the
+    /// line itself was written, so this test proves the TRIGGER condition —
+    /// a readable id paired with a nil title — reaches the exact branch the
+    /// log call sits in, without asserting the log call's side effect.
     @Test func anUnreadableTitleStillSucceedsAndNamesTheRowFromItsID() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await seedRepo(db)

--- a/Tests/TBDSharedTests/ANSIEscapeTests.swift
+++ b/Tests/TBDSharedTests/ANSIEscapeTests.swift
@@ -21,4 +21,47 @@ import Foundation
         let plain = "no escapes here\njust text"
         #expect(ANSIEscape.strip(plain) == plain)
     }
+
+    // MARK: - Widened coverage (measured against a real `claude --cloud` pty capture)
+
+    /// Save/restore cursor: `ESC 7` / `ESC 8`. Two-byte, no `[`, so the
+    /// original CSI-only pattern never matched them.
+    @Test func stripsTwoByteSaveRestoreCursorSequences() {
+        let raw = "\u{1B}7before\u{1B}8after"
+        #expect(ANSIEscape.strip(raw) == "beforeafter")
+    }
+
+    /// Charset designation: `ESC ( B` (US ASCII) and `ESC ) 0` (line
+    /// drawing) — an intermediate byte (`(`/`)`) followed by a final byte,
+    /// the three-byte form the CSI/OSC-only pattern also missed.
+    @Test func stripsCharsetSelectorSequences() {
+        let raw = "\u{1B}(Bplain\u{1B})0lines"
+        #expect(ANSIEscape.strip(raw) == "plainlines")
+    }
+
+    /// CSI private-parameter prefixes `<`, `>`, `=` (Kitty keyboard-protocol
+    /// queries and modifyOtherKeys replies) — legal CSI parameter bytes the
+    /// original `[0-9;?]*` class excluded, so the whole sequence fell through
+    /// to `[@-~]` and never matched at all.
+    @Test func stripsCSIPrivateParameterPrefixedSequences() {
+        let raw = "\u{1B}[<u\u{1B}[>1u\u{1B}[>4;2mCreated"
+        #expect(ANSIEscape.strip(raw) == "Created")
+    }
+
+    /// The exact leading bytes measured from a real `claude --cloud` pty
+    /// capture (`claude` 2.1.235, `TERM=xterm-256color COLUMNS=400
+    /// LINES=200`) ahead of its first printed line. Built by explicit
+    /// concatenation, not a string literal, so every control byte and escape
+    /// sequence is unambiguous. `^D` here is two literal characters (caret,
+    /// `D`) left by the `script` capture tool, not the 0x04 control byte —
+    /// deliberately left untouched, since ANSIEscape strips escape sequences
+    /// and C0 controls, not printable capture-tool artifacts.
+    @Test func stripsTheMeasuredCloudCreateLeadInIntact() {
+        let raw = "^D" + "\u{08}\u{08}"
+            + "\u{1B}7" + "\u{1B}[r" + "\u{1B}8"
+            + "\u{1B}[?25h" + "\u{1B}[?25l" + "\u{1B}[?2004h" + "\u{1B}[?1004h" + "\u{1B}[?2031h"
+            + "\u{1B}[<u" + "\u{1B}[>1u" + "\u{1B}[>4;2m" + "\u{1B}[>0q"
+            + "Created cloud session: Probe reply OK then stop"
+        #expect(ANSIEscape.strip(raw) == "^D\u{08}\u{08}Created cloud session: Probe reply OK then stop")
+    }
 }


### PR DESCRIPTION
## What's broken

Every Claude cloud session created from TBD shows up in the sidebar named after its raw session id — a row called `session_01HLaoq…` rather than the session's title. It is the only handle you have on a cloud lane, and it tells you nothing about what the session is doing. In practice it reads as "the session didn't get created", because nothing recognisable appears.

The create itself succeeded every time. The ledger row resolves, the mirror picks it up, the worktree row is minted and bound correctly. Only the title is missing.

## Why it happens

`create` runs on a pseudo-terminal, and the vendor CLI opens by negotiating the terminal: it emits a run of escape sequences before it prints anything readable. Its first line really looks like this, with the setup sequences and the prose sharing one line:

```
^[7^[[r^[8^[[?25h^[[?2004h^[[<u^[[>1u^[[>4;2m^[[>0q^[[cCreated cloud session: <title>
```

`ANSIEscape.strip` was matching two forms — CSI (`ESC [ … final`) and OSC — with CSI parameter bytes limited to `[0-9;?]`. Three of the sequences above fall outside that:

- **CSI with private parameter bytes.** `<`, `=` and `>` are legal ECMA-48 parameter bytes, so `ESC [ < u` and `ESC [ > 4;2 m` are well-formed CSI. They matched none of the pattern's character classes, so each survived whole.
- **Two-byte escapes with no bracket.** `ESC 7` and `ESC 8` (save/restore cursor) never reach an alternative that begins `ESC [`.
- **Charset selectors.** `ESC ( B` likewise.

So the title line arrived at the parser with residue still attached, and `title(fromOutput:)` asks for `hasPrefix("Created cloud session: ")` — a position-sensitive check that the residue defeats. The session id was unaffected, because it is found by a regex that matches anywhere in the line. That asymmetry is exactly why creates kept succeeding while every single one lost its title.

The failure was also **silent by design**. A cosmetic parse must never fail a create that otherwise worked, so a nil title falls back to the id — but nothing logged it, so there was no signal anywhere. A person noticing an odd row name was the only detector this had.

## When it broke

It never worked. The parser shipped with the provider, and its tests fed synthetic clean text — the three prose lines with no terminal negotiation in front of them. A real pty capture was never used as a fixture, so nothing exercised the path a real create actually takes. This is the same shape as the CRLF bug fixed in this file earlier: clean literals in a test cannot detect what raw terminal bytes do.

## What this PR does

- **Widens `ANSIEscape`** to honour its own doc comment. CSI parameter bytes become the full ECMA-48 range `0-9 : ; < = > ?`; a third alternative covers `ESC` + intermediates + final for the bracket-less forms. The alternatives are ordered so the specific CSI/OSC patterns still claim their own sequences before the generic one can.
- **Makes the title parse tolerant of leading residue** — it locates the prefix within the line rather than requiring it at position zero. Defence in depth, so the next unstripped byte cannot cost the title again.
- **Logs the raw output when an id parses but a title does not.** The non-fatal behaviour is unchanged; what changes is that the next occurrence leaves evidence instead of nothing.

## Assumptions

- Assumes the vendor keeps `Created cloud session: ` as the title prefix. It still does — the prefix was never the problem here. If it changes, the title falls back to the session id and now says so in the log.
- Assumes stripping more aggressively is safe for the other consumer of `ANSIEscape`, the read-only closed-terminal history viewer. That path strips for display only and never touches the raw capture file used for revive and replay, so a wider strip removes more junk from view and nothing else.

## Evidence & verification

- **The bug was reproduced against the real CLI**, not inferred. A create was captured under a pty with the daemon's own environment (`TERM=xterm-256color`, `COLUMNS=400`, `LINES=200`), and the current stripper was run over those exact bytes: the result still begins with escape residue, `hasPrefix` returns false, and `contains` returns true — the precise failure.
- **The regression tests use those captured bytes**, built by explicit escaping rather than a multiline literal, because Swift normalises literals to bare `\n` and a clean-text fixture cannot detect this class of bug at all.
- **Mutation-checked.** Reverting the tolerant-prefix change makes both new title tests fail with `→ nil`; restored in the same command and re-confirmed green.
- Full suite: 7325 tests in 736 suites, one unrelated known FileWatcher flake that passes on re-run. `swiftlint --strict` clean.

Live verification against a running app is not included: enabling the feature requires a daemon restart, which would disrupt sessions currently running on this machine. The fix is proven against the bytes a real create produced.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=BBA22690-7E4E-4F7F-A4F8-A71351FA5FD5)
