### PR TITLE
Fix: Stop Codex thinking indicators from getting stuck

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -728,6 +728,7 @@ extension Terminal {
         let currentOrderObservedAt = current.activityStateOrderObservedAt
             ?? current.activityStateObservedAt
         let shouldKeepCurrent: Bool
+        let shouldPreserveCurrentSemanticFact: Bool
         if incomingIsComplete,
            currentIsComplete,
            let incomingOrderObservedAt,
@@ -737,10 +738,15 @@ extension Terminal {
                     && current.preservesActivityAtEqualOrder(
                         over: activityState,
                         source: activityStateSource))
+            shouldPreserveCurrentSemanticFact = !shouldKeepCurrent
+                && activityState == current.activityState
+                && !isMeaningfulSameStateReplacement(source: activityStateSource)
         } else if !incomingIsComplete, currentIsComplete {
             shouldKeepCurrent = activityState == current.activityState
+            shouldPreserveCurrentSemanticFact = false
         } else {
             shouldKeepCurrent = false
+            shouldPreserveCurrentSemanticFact = false
         }
 
         if shouldKeepCurrent {
@@ -748,6 +754,10 @@ extension Terminal {
             activityStateSource = current.activityStateSource
             activityStateObservedAt = current.activityStateObservedAt
             activityStateOrderObservedAt = current.activityStateOrderObservedAt
+        } else if shouldPreserveCurrentSemanticFact {
+            activityStateSource = current.activityStateSource
+            activityStateObservedAt = current.activityStateObservedAt
+            activityStateOrderObservedAt = incomingOrderObservedAt
         } else if !incomingIsComplete {
             activityStateSource = nil
             activityStateObservedAt = nil
@@ -759,7 +769,9 @@ extension Terminal {
     /// raw hook timestamps do not order it. Legacy responses with no timestamp
     /// remain arrival-ordered until a timestamped observation has been adopted.
     /// On an exact tie, a non-working result wins because false working is the
-    /// costlier error and nil is a real "could not establish activity" result.
+    /// costlier error. A timestamped nil is authoritative "could not establish
+    /// activity" evidence (unreadable, incomplete, or capped), so it clears a
+    /// prior working presentation instead of serving cached positive state.
     private mutating func reconcilePresentationObservation(against current: Terminal) {
         let shouldKeepCurrent: Bool
         switch (presentationActivityObservedAt, current.presentationActivityObservedAt) {
@@ -788,6 +800,16 @@ extension Terminal {
         if activityStateSource == .terminalInterrupt { return true }
         if activityState == .waitingForUser, incomingState != .waitingForUser { return true }
         return activityState != .working && incomingState == .working
+    }
+
+    private func isMeaningfulSameStateReplacement(source: FactSource?) -> Bool {
+        source == .terminalInterrupt || source == .hookEvent("SessionStart")
+    }
+
+    private func canReplacePresentation(observedAt incomingObservedAt: Date?) -> Bool {
+        guard let presentationActivityObservedAt else { return true }
+        guard let incomingObservedAt else { return false }
+        return incomingObservedAt >= presentationActivityObservedAt
     }
 
     /// Apply a pushed activity observation under the same ordering and legacy
@@ -824,13 +846,21 @@ extension Terminal {
             return
         }
 
+        if currentIsComplete,
+           delta.activityState == activityState,
+           !isMeaningfulSameStateReplacement(source: delta.activityStateSource) {
+            activityStateOrderObservedAt = incomingOrderObservedAt
+            return
+        }
+
         activityState = delta.activityState
         activityStateSource = delta.activityStateSource
         activityStateObservedAt = delta.activityStateObservedAt
         activityStateOrderObservedAt = delta.activityStateOrderObservedAt
         if isCodexTerminal,
            delta.activityState == .idle,
-           delta.activityStateSource == .hookEvent("SessionStart") {
+           delta.activityStateSource == .hookEvent("SessionStart"),
+           canReplacePresentation(observedAt: incomingOrderObservedAt) {
             presentationActivityState = .idle
             presentationActivityObservedAt = incomingOrderObservedAt
         }

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -186,6 +186,7 @@ extension AppState {
             terminals[worktreeID, default: []].append(terminal)
             inserted = true
         }
+        replaceTerminalObservationOrder(with: terminal)
         let splitRepresentationTabIDs = Set((tabs[worktreeID] ?? []).compactMap { tab -> UUID? in
             guard let layout = layouts[tab.id],
                   case .split = layout,
@@ -277,6 +278,7 @@ extension AppState {
                   $0.id == terminal.id
               }) else { return }
         terminals[terminal.worktreeID]?[index] = terminal
+        replaceTerminalObservationOrder(with: terminal)
     }
 
     /// Adopt a daemon snapshot without allowing a response that overlaps an
@@ -296,6 +298,35 @@ extension AppState {
                   recentlyDeletedTerminalIDs[snapshot.id] == nil else { return nil }
             var merged = snapshot
             let current = existingByID[snapshot.id]
+            let incomingActivityOrderObservedAt = snapshot.activityStateOrderObservedAt
+                ?? snapshot.activityStateObservedAt
+            let currentSessionOrderObservedAt = terminalSessionOrderObservedAt[snapshot.id]
+                ?? current.flatMap { terminal in
+                    guard terminal.activityStateSource == .hookEvent("SessionStart") else {
+                        return nil
+                    }
+                    return terminal.activityStateOrderObservedAt
+                        ?? terminal.activityStateObservedAt
+                }
+            let identityChanged = current.map {
+                snapshot.claudeSessionID != $0.claudeSessionID
+                    || snapshot.transcriptPath != $0.transcriptPath
+            } ?? false
+            let shouldKeepCurrentIdentity = identityChanged
+                && currentSessionOrderObservedAt.map { currentOrder in
+                    incomingActivityOrderObservedAt.map { $0 <= currentOrder } ?? true
+                } == true
+            if shouldKeepCurrentIdentity, let current {
+                merged.claudeSessionID = current.claudeSessionID
+                merged.transcriptPath = current.transcriptPath
+            } else if current == nil || identityChanged {
+                if let incomingActivityOrderObservedAt,
+                   snapshot.claudeSessionID != nil || snapshot.transcriptPath != nil {
+                    terminalSessionOrderObservedAt[snapshot.id] = incomingActivityOrderObservedAt
+                } else {
+                    terminalSessionOrderObservedAt.removeValue(forKey: snapshot.id)
+                }
+            }
             let presentationOrderObservedAt = merged.reconcileActivityObservation(
                 against: current,
                 presentationOrderObservedAt: terminalPresentationOrderObservedAt[snapshot.id]
@@ -310,6 +341,7 @@ extension AppState {
         let visibleIDs = Set(visible.map(\.id))
         for terminal in existing where !visibleIDs.contains(terminal.id) {
             terminalPresentationOrderObservedAt.removeValue(forKey: terminal.id)
+            terminalSessionOrderObservedAt.removeValue(forKey: terminal.id)
         }
         guard visible != existing else { return }
         terminals[worktreeID] = visible
@@ -479,12 +511,32 @@ extension AppState {
     /// Preserve an active recreation claim across removal; otherwise discard
     /// recovery history immediately. Shared by terminal and worktree removal.
     func recordTerminalRemoval(terminalID: UUID, date: Date = Date()) {
+        terminalPresentationOrderObservedAt.removeValue(forKey: terminalID)
+        terminalSessionOrderObservedAt.removeValue(forKey: terminalID)
         pruneRecentTerminalDeletions(date: date)
         recentlyDeletedTerminalIDs[terminalID] = date
         if recreatingTerminalIDs.contains(terminalID) {
             terminalDeletionsAwaitingRecreationCompletion.insert(terminalID)
         } else {
             terminalRecoveryBudget.reset(for: terminalID)
+        }
+    }
+
+    /// A replacement Terminal is a new observation generation even when its
+    /// UUID is reused. Seed both hidden ordering rails from that row rather
+    /// than retaining watermarks from the terminal incarnation it replaced.
+    private func replaceTerminalObservationOrder(with terminal: Terminal) {
+        if let observedAt = terminal.presentationActivityObservedAt {
+            terminalPresentationOrderObservedAt[terminal.id] = observedAt
+        } else {
+            terminalPresentationOrderObservedAt.removeValue(forKey: terminal.id)
+        }
+        if terminal.claudeSessionID != nil || terminal.transcriptPath != nil,
+           let observedAt = terminal.activityStateOrderObservedAt
+            ?? terminal.activityStateObservedAt {
+            terminalSessionOrderObservedAt[terminal.id] = observedAt
+        } else {
+            terminalSessionOrderObservedAt.removeValue(forKey: terminal.id)
         }
     }
 

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -289,11 +289,15 @@ extension AppState {
         date: Date = Date()
     ) {
         pruneRecentTerminalDeletions(date: date)
-        let visible = snapshots.filter {
-            !terminalDeletionsAwaitingRecreationCompletion.contains($0.id)
-                && recentlyDeletedTerminalIDs[$0.id] == nil
-        }
         let existing = terminals[worktreeID] ?? []
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        let visible = snapshots.compactMap { snapshot -> Terminal? in
+            guard !terminalDeletionsAwaitingRecreationCompletion.contains(snapshot.id),
+                  recentlyDeletedTerminalIDs[snapshot.id] == nil else { return nil }
+            var merged = snapshot
+            merged.reconcileActivityObservation(against: existingByID[snapshot.id])
+            return merged
+        }
         guard visible != existing else { return }
         terminals[worktreeID] = visible
         reconcileTabs(worktreeID: worktreeID, terminals: visible)
@@ -691,6 +695,90 @@ extension AppState {
         } catch {
             showAlert("Failed to cancel scheduled resume: \(error.localizedDescription)",
                       isError: true)
+        }
+    }
+}
+
+extension Terminal {
+    /// Merge the activity fact carried by a `terminal.list` row without
+    /// letting an older response roll back a newer local or pushed fact.
+    /// Provenance is one atomic pair: a partial incoming pair is either ignored
+    /// as a same-value legacy echo or applied with both halves cleared. When
+    /// timestamps tie, an explicit interrupt wins over a hook fact because the
+    /// clock cannot establish order and a false working indicator is costlier.
+    mutating func reconcileActivityObservation(against current: Terminal?) {
+        let incomingIsComplete = activityStateSource != nil && activityStateObservedAt != nil
+        guard let current else {
+            if !incomingIsComplete {
+                activityStateSource = nil
+                activityStateObservedAt = nil
+            }
+            return
+        }
+
+        let currentIsComplete = current.activityStateSource != nil
+            && current.activityStateObservedAt != nil
+        let shouldKeepCurrent: Bool
+        if incomingIsComplete,
+           currentIsComplete,
+           let incomingObservedAt = activityStateObservedAt,
+           let currentObservedAt = current.activityStateObservedAt {
+            shouldKeepCurrent = incomingObservedAt < currentObservedAt
+                || (incomingObservedAt == currentObservedAt
+                    && current.activityStateSource == .terminalInterrupt
+                    && activityStateSource != .terminalInterrupt)
+        } else if !incomingIsComplete, currentIsComplete {
+            shouldKeepCurrent = activityState == current.activityState
+        } else {
+            shouldKeepCurrent = false
+        }
+
+        if shouldKeepCurrent {
+            activityState = current.activityState
+            activityStateSource = current.activityStateSource
+            activityStateObservedAt = current.activityStateObservedAt
+            presentationActivityState = current.presentationActivityState
+        } else if !incomingIsComplete {
+            activityStateSource = nil
+            activityStateObservedAt = nil
+        }
+    }
+
+    /// Apply a pushed activity observation under the same ordering and legacy
+    /// rules used for snapshots. SessionStart is the sole idle hook entitled
+    /// to clear transcript presentation, and only after its complete fact wins
+    /// the timestamp comparison.
+    mutating func applyActivityDelta(_ delta: TerminalActivityDelta) {
+        let incomingIsComplete = delta.activityStateSource != nil
+            && delta.activityStateObservedAt != nil
+        let currentIsComplete = activityStateSource != nil && activityStateObservedAt != nil
+
+        if incomingIsComplete,
+           currentIsComplete,
+           let incomingObservedAt = delta.activityStateObservedAt,
+           let currentObservedAt = activityStateObservedAt,
+           incomingObservedAt < currentObservedAt
+            || (incomingObservedAt == currentObservedAt
+                && activityStateSource == .terminalInterrupt
+                && delta.activityStateSource != .terminalInterrupt) {
+            return
+        }
+
+        if !incomingIsComplete {
+            if currentIsComplete, delta.activityState == activityState { return }
+            activityState = delta.activityState
+            activityStateSource = nil
+            activityStateObservedAt = nil
+            return
+        }
+
+        activityState = delta.activityState
+        activityStateSource = delta.activityStateSource
+        activityStateObservedAt = delta.activityStateObservedAt
+        if isCodexTerminal,
+           delta.activityState == .idle,
+           delta.activityStateSource == .hookEvent("SessionStart") {
+            presentationActivityState = .idle
         }
     }
 }

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -295,8 +295,21 @@ extension AppState {
             guard !terminalDeletionsAwaitingRecreationCompletion.contains(snapshot.id),
                   recentlyDeletedTerminalIDs[snapshot.id] == nil else { return nil }
             var merged = snapshot
-            merged.reconcileActivityObservation(against: existingByID[snapshot.id])
+            let current = existingByID[snapshot.id]
+            let presentationOrderObservedAt = merged.reconcileActivityObservation(
+                against: current,
+                presentationOrderObservedAt: terminalPresentationOrderObservedAt[snapshot.id]
+                    ?? current?.presentationActivityObservedAt)
+            if let presentationOrderObservedAt {
+                terminalPresentationOrderObservedAt[snapshot.id] = presentationOrderObservedAt
+            } else {
+                terminalPresentationOrderObservedAt.removeValue(forKey: snapshot.id)
+            }
             return merged
+        }
+        let visibleIDs = Set(visible.map(\.id))
+        for terminal in existing where !visibleIDs.contains(terminal.id) {
+            terminalPresentationOrderObservedAt.removeValue(forKey: terminal.id)
         }
         guard visible != existing else { return }
         terminals[worktreeID] = visible
@@ -708,7 +721,11 @@ extension Terminal {
     /// as a same-value legacy echo or applied with both halves cleared. When
     /// timestamps tie, explicit interrupts and permission waits are preserved,
     /// while ambiguous working/non-working ties resolve toward non-working.
-    mutating func reconcileActivityObservation(against current: Terminal?) {
+    @discardableResult
+    mutating func reconcileActivityObservation(
+        against current: Terminal?,
+        presentationOrderObservedAt: Date?
+    ) -> Date? {
         let incomingIsComplete = activityStateSource != nil && activityStateObservedAt != nil
         guard let current else {
             if !incomingIsComplete {
@@ -716,10 +733,12 @@ extension Terminal {
                 activityStateObservedAt = nil
                 activityStateOrderObservedAt = nil
             }
-            return
+            return self.presentationActivityObservedAt
         }
 
-        reconcilePresentationObservation(against: current)
+        let reconciledPresentationOrderObservedAt = reconcilePresentationObservation(
+            against: current,
+            orderObservedAt: presentationOrderObservedAt)
 
         let currentIsComplete = current.activityStateSource != nil
             && current.activityStateObservedAt != nil
@@ -763,6 +782,7 @@ extension Terminal {
             activityStateObservedAt = nil
             activityStateOrderObservedAt = nil
         }
+        return reconciledPresentationOrderObservedAt
     }
 
     /// Transcript presentation is response-derived and has its own ordering;
@@ -772,9 +792,23 @@ extension Terminal {
     /// costlier error. A timestamped nil is authoritative "could not establish
     /// activity" evidence (unreadable, incomplete, or capped), so it clears a
     /// prior working presentation instead of serving cached positive state.
-    private mutating func reconcilePresentationObservation(against current: Terminal) {
+    private mutating func reconcilePresentationObservation(
+        against current: Terminal,
+        orderObservedAt: Date?
+    ) -> Date? {
+        let identityIsUnchanged = claudeSessionID == current.claudeSessionID
+            && transcriptPath == current.transcriptPath
+        // Presentation ordering is scoped to one transcript identity. A new
+        // identity must not inherit either positive state or an ordering
+        // watermark from the transcript it replaced; legacy rows without a
+        // timestamp therefore conservatively clear a prior working result.
+        guard identityIsUnchanged else { return presentationActivityObservedAt }
+
+        let currentOrderObservedAt = orderObservedAt
+            ?? current.presentationActivityObservedAt
+        let incomingObservedAt = presentationActivityObservedAt
         let shouldKeepCurrent: Bool
-        switch (presentationActivityObservedAt, current.presentationActivityObservedAt) {
+        switch (incomingObservedAt, currentOrderObservedAt) {
         case let (incomingAt?, currentAt?) where incomingAt < currentAt:
             shouldKeepCurrent = true
         case let (incomingAt?, currentAt?) where incomingAt == currentAt:
@@ -786,10 +820,18 @@ extension Terminal {
             shouldKeepCurrent = false
         }
 
-        if shouldKeepCurrent {
+        let stableValue = presentationActivityState == current.presentationActivityState
+            && identityIsUnchanged
+        if shouldKeepCurrent || stableValue {
             presentationActivityState = current.presentationActivityState
             presentationActivityObservedAt = current.presentationActivityObservedAt
         }
+        guard !shouldKeepCurrent else { return currentOrderObservedAt }
+        if let incomingObservedAt,
+           let currentOrderObservedAt {
+            return max(incomingObservedAt, currentOrderObservedAt)
+        }
+        return incomingObservedAt ?? currentOrderObservedAt
     }
 
     private func preservesActivityAtEqualOrder(

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -296,6 +296,15 @@ extension AppState {
         let visible = snapshots.compactMap { snapshot -> Terminal? in
             guard !terminalDeletionsAwaitingRecreationCompletion.contains(snapshot.id),
                   recentlyDeletedTerminalIDs[snapshot.id] == nil else { return nil }
+            guard snapshot.isCodexTerminal else {
+                // Claude and shell rows retain terminal.list's established
+                // arrival-order replacement. The hidden ordering rails belong
+                // only to Codex transcript presentation and must not survive a
+                // terminal incarnation changing away from Codex.
+                terminalPresentationOrderObservedAt.removeValue(forKey: snapshot.id)
+                terminalSessionOrderObservedAt.removeValue(forKey: snapshot.id)
+                return snapshot
+            }
             var merged = snapshot
             let current = existingByID[snapshot.id]
             let incomingActivityOrderObservedAt = snapshot.activityStateOrderObservedAt
@@ -463,11 +472,13 @@ extension AppState {
 
         // Remaining terminals: Codex (Ctrl+C), Claude, or legacy nil-kind sessions.
         if let idx = terminals[terminal.worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
-            let observedAt = Date()
             terminals[terminal.worktreeID]?[idx].activityState = .idle
-            terminals[terminal.worktreeID]?[idx].activityStateSource = .terminalInterrupt
-            terminals[terminal.worktreeID]?[idx].activityStateObservedAt = observedAt
-            terminals[terminal.worktreeID]?[idx].activityStateOrderObservedAt = observedAt
+            if isCodex {
+                let observedAt = Date()
+                terminals[terminal.worktreeID]?[idx].activityStateSource = .terminalInterrupt
+                terminals[terminal.worktreeID]?[idx].activityStateObservedAt = observedAt
+                terminals[terminal.worktreeID]?[idx].activityStateOrderObservedAt = observedAt
+            }
         }
 
         Task {
@@ -475,7 +486,7 @@ extension AppState {
                 try await daemonClient.setTerminalActivity(
                     terminalID: terminalID,
                     activityState: .idle,
-                    origin: .userInterrupt
+                    origin: isCodex ? .userInterrupt : nil
                 )
             } catch {
                 logger.debug("Failed to publish terminal interrupt state: \(error.localizedDescription, privacy: .public)")
@@ -556,6 +567,11 @@ extension AppState {
     /// UUID is reused. Seed both hidden ordering rails from that row rather
     /// than retaining watermarks from the terminal incarnation it replaced.
     private func replaceTerminalObservationOrder(with terminal: Terminal) {
+        guard terminal.isCodexTerminal else {
+            terminalPresentationOrderObservedAt.removeValue(forKey: terminal.id)
+            terminalSessionOrderObservedAt.removeValue(forKey: terminal.id)
+            return
+        }
         if let observedAt = terminal.presentationActivityObservedAt {
             terminalPresentationOrderObservedAt[terminal.id] = observedAt
         } else {

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -388,9 +388,11 @@ extension AppState {
 
         // Remaining terminals: Codex (Ctrl+C), Claude, or legacy nil-kind sessions.
         if let idx = terminals[terminal.worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
+            let observedAt = Date()
             terminals[terminal.worktreeID]?[idx].activityState = .idle
             terminals[terminal.worktreeID]?[idx].activityStateSource = .terminalInterrupt
-            terminals[terminal.worktreeID]?[idx].activityStateObservedAt = Date()
+            terminals[terminal.worktreeID]?[idx].activityStateObservedAt = observedAt
+            terminals[terminal.worktreeID]?[idx].activityStateOrderObservedAt = observedAt
         }
 
         Task {
@@ -704,29 +706,37 @@ extension Terminal {
     /// letting an older response roll back a newer local or pushed fact.
     /// Provenance is one atomic pair: a partial incoming pair is either ignored
     /// as a same-value legacy echo or applied with both halves cleared. When
-    /// timestamps tie, an explicit interrupt wins over a hook fact because the
-    /// clock cannot establish order and a false working indicator is costlier.
+    /// timestamps tie, explicit interrupts and permission waits are preserved,
+    /// while ambiguous working/non-working ties resolve toward non-working.
     mutating func reconcileActivityObservation(against current: Terminal?) {
         let incomingIsComplete = activityStateSource != nil && activityStateObservedAt != nil
         guard let current else {
             if !incomingIsComplete {
                 activityStateSource = nil
                 activityStateObservedAt = nil
+                activityStateOrderObservedAt = nil
             }
             return
         }
 
+        reconcilePresentationObservation(against: current)
+
         let currentIsComplete = current.activityStateSource != nil
             && current.activityStateObservedAt != nil
+        let incomingOrderObservedAt = activityStateOrderObservedAt
+            ?? activityStateObservedAt
+        let currentOrderObservedAt = current.activityStateOrderObservedAt
+            ?? current.activityStateObservedAt
         let shouldKeepCurrent: Bool
         if incomingIsComplete,
            currentIsComplete,
-           let incomingObservedAt = activityStateObservedAt,
-           let currentObservedAt = current.activityStateObservedAt {
-            shouldKeepCurrent = incomingObservedAt < currentObservedAt
-                || (incomingObservedAt == currentObservedAt
-                    && current.activityStateSource == .terminalInterrupt
-                    && activityStateSource != .terminalInterrupt)
+           let incomingOrderObservedAt,
+           let currentOrderObservedAt {
+            shouldKeepCurrent = incomingOrderObservedAt < currentOrderObservedAt
+                || (incomingOrderObservedAt == currentOrderObservedAt
+                    && current.preservesActivityAtEqualOrder(
+                        over: activityState,
+                        source: activityStateSource))
         } else if !incomingIsComplete, currentIsComplete {
             shouldKeepCurrent = activityState == current.activityState
         } else {
@@ -737,11 +747,47 @@ extension Terminal {
             activityState = current.activityState
             activityStateSource = current.activityStateSource
             activityStateObservedAt = current.activityStateObservedAt
-            presentationActivityState = current.presentationActivityState
+            activityStateOrderObservedAt = current.activityStateOrderObservedAt
         } else if !incomingIsComplete {
             activityStateSource = nil
             activityStateObservedAt = nil
+            activityStateOrderObservedAt = nil
         }
+    }
+
+    /// Transcript presentation is response-derived and has its own ordering;
+    /// raw hook timestamps do not order it. Legacy responses with no timestamp
+    /// remain arrival-ordered until a timestamped observation has been adopted.
+    /// On an exact tie, a non-working result wins because false working is the
+    /// costlier error and nil is a real "could not establish activity" result.
+    private mutating func reconcilePresentationObservation(against current: Terminal) {
+        let shouldKeepCurrent: Bool
+        switch (presentationActivityObservedAt, current.presentationActivityObservedAt) {
+        case let (incomingAt?, currentAt?) where incomingAt < currentAt:
+            shouldKeepCurrent = true
+        case let (incomingAt?, currentAt?) where incomingAt == currentAt:
+            shouldKeepCurrent = presentationActivityState == .working
+                && current.presentationActivityState != .working
+        case (nil, .some):
+            shouldKeepCurrent = true
+        default:
+            shouldKeepCurrent = false
+        }
+
+        if shouldKeepCurrent {
+            presentationActivityState = current.presentationActivityState
+            presentationActivityObservedAt = current.presentationActivityObservedAt
+        }
+    }
+
+    private func preservesActivityAtEqualOrder(
+        over incomingState: TerminalActivityState,
+        source incomingSource: FactSource?
+    ) -> Bool {
+        if incomingSource == .terminalInterrupt { return false }
+        if activityStateSource == .terminalInterrupt { return true }
+        if activityState == .waitingForUser, incomingState != .waitingForUser { return true }
+        return activityState != .working && incomingState == .working
     }
 
     /// Apply a pushed activity observation under the same ordering and legacy
@@ -752,15 +798,20 @@ extension Terminal {
         let incomingIsComplete = delta.activityStateSource != nil
             && delta.activityStateObservedAt != nil
         let currentIsComplete = activityStateSource != nil && activityStateObservedAt != nil
+        let incomingOrderObservedAt = delta.activityStateOrderObservedAt
+            ?? delta.activityStateObservedAt
+        let currentOrderObservedAt = activityStateOrderObservedAt
+            ?? activityStateObservedAt
 
         if incomingIsComplete,
            currentIsComplete,
-           let incomingObservedAt = delta.activityStateObservedAt,
-           let currentObservedAt = activityStateObservedAt,
-           incomingObservedAt < currentObservedAt
-            || (incomingObservedAt == currentObservedAt
-                && activityStateSource == .terminalInterrupt
-                && delta.activityStateSource != .terminalInterrupt) {
+           let incomingOrderObservedAt,
+           let currentOrderObservedAt,
+           incomingOrderObservedAt < currentOrderObservedAt
+            || (incomingOrderObservedAt == currentOrderObservedAt
+                && preservesActivityAtEqualOrder(
+                    over: delta.activityState,
+                    source: delta.activityStateSource)) {
             return
         }
 
@@ -769,16 +820,19 @@ extension Terminal {
             activityState = delta.activityState
             activityStateSource = nil
             activityStateObservedAt = nil
+            activityStateOrderObservedAt = nil
             return
         }
 
         activityState = delta.activityState
         activityStateSource = delta.activityStateSource
         activityStateObservedAt = delta.activityStateObservedAt
+        activityStateOrderObservedAt = delta.activityStateOrderObservedAt
         if isCodexTerminal,
            delta.activityState == .idle,
            delta.activityStateSource == .hookEvent("SessionStart") {
             presentationActivityState = .idle
+            presentationActivityObservedAt = incomingOrderObservedAt
         }
     }
 }

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -316,6 +316,10 @@ extension AppState {
                 && currentSessionOrderObservedAt.map { currentOrder in
                     incomingActivityOrderObservedAt.map { $0 <= currentOrder } ?? true
                 } == true
+            let snapshotPredatesCurrentSession = current != nil
+                && currentSessionOrderObservedAt.map { currentOrder in
+                    incomingActivityOrderObservedAt.map { $0 < currentOrder } ?? true
+                } == true
             if shouldKeepCurrentIdentity, let current {
                 merged.claudeSessionID = current.claudeSessionID
                 merged.transcriptPath = current.transcriptPath
@@ -326,6 +330,14 @@ extension AppState {
                 } else {
                     terminalSessionOrderObservedAt.removeValue(forKey: snapshot.id)
                 }
+            }
+            // A list response may have scanned the same transcript path before
+            // an accepted SessionStart boundary. Its later response timestamp
+            // does not make that pre-boundary presentation current.
+            if shouldKeepCurrentIdentity || snapshotPredatesCurrentSession,
+               let current {
+                merged.presentationActivityState = current.presentationActivityState
+                merged.presentationActivityObservedAt = current.presentationActivityObservedAt
             }
             let presentationOrderObservedAt = merged.reconcileActivityObservation(
                 against: current,
@@ -900,17 +912,27 @@ extension Terminal {
         source == .terminalInterrupt || source == .hookEvent("SessionStart")
     }
 
-    private func canReplacePresentation(observedAt incomingObservedAt: Date?) -> Bool {
-        guard let presentationActivityObservedAt else { return true }
+    private func canReplacePresentation(
+        observedAt incomingObservedAt: Date?,
+        orderObservedAt: Date?
+    ) -> Bool {
+        guard let currentObservedAt = orderObservedAt
+            ?? presentationActivityObservedAt else { return true }
         guard let incomingObservedAt else { return false }
-        return incomingObservedAt >= presentationActivityObservedAt
+        return incomingObservedAt >= currentObservedAt
     }
 
     /// Apply a pushed activity observation under the same ordering and legacy
     /// rules used for snapshots. SessionStart is the sole idle hook entitled
     /// to clear transcript presentation, and only after its complete fact wins
     /// the timestamp comparison.
-    mutating func applyActivityDelta(_ delta: TerminalActivityDelta) {
+    @discardableResult
+    mutating func applyActivityDelta(
+        _ delta: TerminalActivityDelta,
+        presentationOrderObservedAt: Date?
+    ) -> Date? {
+        let currentPresentationOrderObservedAt = presentationOrderObservedAt
+            ?? self.presentationActivityObservedAt
         let incomingIsComplete = delta.activityStateSource != nil
             && delta.activityStateObservedAt != nil
         let currentIsComplete = activityStateSource != nil && activityStateObservedAt != nil
@@ -928,23 +950,25 @@ extension Terminal {
                 && preservesActivityAtEqualOrder(
                     over: delta.activityState,
                     source: delta.activityStateSource)) {
-            return
+            return currentPresentationOrderObservedAt
         }
 
         if !incomingIsComplete {
-            if currentIsComplete, delta.activityState == activityState { return }
+            if currentIsComplete, delta.activityState == activityState {
+                return currentPresentationOrderObservedAt
+            }
             activityState = delta.activityState
             activityStateSource = nil
             activityStateObservedAt = nil
             activityStateOrderObservedAt = nil
-            return
+            return currentPresentationOrderObservedAt
         }
 
         if currentIsComplete,
            delta.activityState == activityState,
            !isMeaningfulSameStateReplacement(source: delta.activityStateSource) {
             activityStateOrderObservedAt = incomingOrderObservedAt
-            return
+            return currentPresentationOrderObservedAt
         }
 
         activityState = delta.activityState
@@ -954,9 +978,13 @@ extension Terminal {
         if isCodexTerminal,
            delta.activityState == .idle,
            delta.activityStateSource == .hookEvent("SessionStart"),
-           canReplacePresentation(observedAt: incomingOrderObservedAt) {
+           canReplacePresentation(
+               observedAt: incomingOrderObservedAt,
+               orderObservedAt: currentPresentationOrderObservedAt) {
             presentationActivityState = .idle
             presentationActivityObservedAt = incomingOrderObservedAt
+            return incomingOrderObservedAt
         }
+        return currentPresentationOrderObservedAt
     }
 }

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -385,13 +385,16 @@ extension AppState {
         // Remaining terminals: Codex (Ctrl+C), Claude, or legacy nil-kind sessions.
         if let idx = terminals[terminal.worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
             terminals[terminal.worktreeID]?[idx].activityState = .idle
+            terminals[terminal.worktreeID]?[idx].activityStateSource = .terminalInterrupt
+            terminals[terminal.worktreeID]?[idx].activityStateObservedAt = Date()
         }
 
         Task {
             do {
                 try await daemonClient.setTerminalActivity(
                     terminalID: terminalID,
-                    activityState: .idle
+                    activityState: .idle,
+                    origin: .userInterrupt
                 )
             } catch {
                 logger.debug("Failed to publish terminal interrupt state: \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -300,7 +300,10 @@ extension AppState {
             let current = existingByID[snapshot.id]
             let incomingActivityOrderObservedAt = snapshot.activityStateOrderObservedAt
                 ?? snapshot.activityStateObservedAt
+            let incomingSessionOrderObservedAt = snapshot.sessionOrderObservedAt
+                ?? incomingActivityOrderObservedAt
             let currentSessionOrderObservedAt = terminalSessionOrderObservedAt[snapshot.id]
+                ?? current?.sessionOrderObservedAt
                 ?? current.flatMap { terminal in
                     guard terminal.activityStateSource == .hookEvent("SessionStart") else {
                         return nil
@@ -314,7 +317,11 @@ extension AppState {
             } ?? false
             let shouldKeepCurrentIdentity = identityChanged
                 && currentSessionOrderObservedAt.map { currentOrder in
-                    incomingActivityOrderObservedAt.map { $0 <= currentOrder } ?? true
+                    incomingSessionOrderObservedAt.map { $0 <= currentOrder } ?? true
+                } == true
+            let shouldKeepCurrentSessionOrder = current != nil
+                && currentSessionOrderObservedAt.map { currentOrder in
+                    incomingSessionOrderObservedAt.map { $0 < currentOrder } ?? true
                 } == true
             let snapshotPredatesCurrentSession = current != nil
                 && currentSessionOrderObservedAt.map { currentOrder in
@@ -323,13 +330,24 @@ extension AppState {
             if shouldKeepCurrentIdentity, let current {
                 merged.claudeSessionID = current.claudeSessionID
                 merged.transcriptPath = current.transcriptPath
+            }
+            if shouldKeepCurrentIdentity || shouldKeepCurrentSessionOrder, let current {
+                merged.sessionOrderObservedAt = current.sessionOrderObservedAt
+                    ?? currentSessionOrderObservedAt
+                if let currentSessionOrderObservedAt {
+                    terminalSessionOrderObservedAt[snapshot.id] = currentSessionOrderObservedAt
+                }
             } else if current == nil || identityChanged {
-                if let incomingActivityOrderObservedAt,
+                if let incomingSessionOrderObservedAt,
                    snapshot.claudeSessionID != nil || snapshot.transcriptPath != nil {
-                    terminalSessionOrderObservedAt[snapshot.id] = incomingActivityOrderObservedAt
+                    terminalSessionOrderObservedAt[snapshot.id] = incomingSessionOrderObservedAt
                 } else {
                     terminalSessionOrderObservedAt.removeValue(forKey: snapshot.id)
                 }
+            } else if let incomingSessionOrderObservedAt,
+                      currentSessionOrderObservedAt.map({ incomingSessionOrderObservedAt > $0 })
+                        != false {
+                terminalSessionOrderObservedAt[snapshot.id] = incomingSessionOrderObservedAt
             }
             // A list response may have scanned the same transcript path before
             // an accepted SessionStart boundary. Its later response timestamp
@@ -544,7 +562,8 @@ extension AppState {
             terminalPresentationOrderObservedAt.removeValue(forKey: terminal.id)
         }
         if terminal.claudeSessionID != nil || terminal.transcriptPath != nil,
-           let observedAt = terminal.activityStateOrderObservedAt
+           let observedAt = terminal.sessionOrderObservedAt
+            ?? terminal.activityStateOrderObservedAt
             ?? terminal.activityStateObservedAt {
             terminalSessionOrderObservedAt[terminal.id] = observedAt
         } else {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2197,6 +2197,11 @@ final class AppState: ObservableObject {
             return
         }
         terminals[delta.worktreeID]?[idx].activityState = delta.activityState
+        if let source = delta.activityStateSource,
+           let observedAt = delta.activityStateObservedAt {
+            terminals[delta.worktreeID]?[idx].activityStateSource = source
+            terminals[delta.worktreeID]?[idx].activityStateObservedAt = observedAt
+        }
     }
 
     /// Seamless in-place "Switch account": the terminal row is unchanged except

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -174,6 +174,10 @@ final class AppState: ObservableObject {
     /// response stamp advanced; still rejects an older overlapping response
     /// that carries a different value.
     var terminalPresentationOrderObservedAt: [UUID: Date] = [:]
+    /// Session identity ordering is independent of the published Terminal row
+    /// so a pushed SessionStart can fence an older list response even in the
+    /// brief interval before its activity delta arrives.
+    var terminalSessionOrderObservedAt: [UUID: Date] = [:]
     @Published var notes: [UUID: [Note]] = [:]
     @Published var focusedTabCloseContext: TabCloseContext?
     /// Unread notification summaries keyed by worktree ID. The cmd-K jump
@@ -2188,13 +2192,44 @@ final class AppState: ObservableObject {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
             return
         }
-        terminals[delta.worktreeID]?[idx].claudeSessionID = delta.sessionID
+        let currentTerminal = terminals[delta.worktreeID]![idx]
+        var terminal = currentTerminal
+        if let incomingOrder = delta.sessionOrderObservedAt,
+           let currentOrder = terminalSessionOrderObservedAt[delta.terminalID],
+           incomingOrder <= currentOrder {
+            return
+        }
+        let effectiveTranscriptPath = delta.transcriptPath ?? terminal.transcriptPath
+        let identityChanged = terminal.claudeSessionID != delta.sessionID
+            || terminal.transcriptPath != effectiveTranscriptPath
+        terminal.claudeSessionID = delta.sessionID
         // Mirror TerminalStore.updateSession's preserve-on-nil: a delta with
         // nil transcriptPath means the SessionStart payload didn't carry a
         // path even though sessionID rolled. Keep the previous value so the
         // in-memory model doesn't drift from the DB.
         if let tp = delta.transcriptPath {
-            terminals[delta.worktreeID]?[idx].transcriptPath = tp
+            terminal.transcriptPath = tp
+        }
+        // Presentation belongs to one session identity. An ordered delta is
+        // an accepted SessionStart boundary even when Codex reused the same
+        // session/path; an unordered legacy delta is a boundary only when the
+        // effective identity changed.
+        if identityChanged || delta.sessionOrderObservedAt != nil {
+            terminal.presentationActivityState = nil
+            terminal.presentationActivityObservedAt = nil
+            if let incomingOrder = delta.sessionOrderObservedAt {
+                terminalPresentationOrderObservedAt[delta.terminalID] = incomingOrder
+            } else {
+                terminalPresentationOrderObservedAt.removeValue(forKey: delta.terminalID)
+            }
+        }
+        if let incomingOrder = delta.sessionOrderObservedAt {
+            terminalSessionOrderObservedAt[delta.terminalID] = incomingOrder
+        } else if identityChanged {
+            terminalSessionOrderObservedAt.removeValue(forKey: delta.terminalID)
+        }
+        if terminal != currentTerminal {
+            terminals[delta.worktreeID]?[idx] = terminal
         }
     }
 
@@ -2202,7 +2237,19 @@ final class AppState: ObservableObject {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
             return
         }
-        terminals[delta.worktreeID]?[idx].applyActivityDelta(delta)
+        var terminal = terminals[delta.worktreeID]![idx]
+        let previousPresentationState = terminal.presentationActivityState
+        let previousPresentationObservedAt = terminal.presentationActivityObservedAt
+        terminal.applyActivityDelta(delta)
+        if terminal.presentationActivityState != previousPresentationState
+            || terminal.presentationActivityObservedAt != previousPresentationObservedAt {
+            if let observedAt = terminal.presentationActivityObservedAt {
+                terminalPresentationOrderObservedAt[delta.terminalID] = observedAt
+            } else {
+                terminalPresentationOrderObservedAt.removeValue(forKey: delta.terminalID)
+            }
+        }
+        terminals[delta.worktreeID]?[idx] = terminal
     }
 
     /// Seamless in-place "Switch account": the terminal row is unchanged except

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -168,6 +168,12 @@ final class AppState: ObservableObject {
         return index
     }
     @Published var terminals: [UUID: [Terminal]] = [:]
+    /// Ordering watermark for transcript presentation snapshots whose value
+    /// did not change. Kept outside `Terminal` so a two-second poll confirming
+    /// the same state does not publish a different row solely because its
+    /// response stamp advanced; still rejects an older overlapping response
+    /// that carries a different value.
+    var terminalPresentationOrderObservedAt: [UUID: Date] = [:]
     @Published var notes: [UUID: [Note]] = [:]
     @Published var focusedTabCloseContext: TabCloseContext?
     /// Unread notification summaries keyed by worktree ID. The cmd-K jump

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2215,6 +2215,11 @@ final class AppState: ObservableObject {
         if let tp = delta.transcriptPath {
             terminal.transcriptPath = tp
         }
+        if let incomingOrder = delta.sessionOrderObservedAt {
+            terminal.sessionOrderObservedAt = incomingOrder
+        } else if identityChanged {
+            terminal.sessionOrderObservedAt = nil
+        }
         // Presentation belongs to one session identity. An ordered delta is
         // an accepted SessionStart boundary even when Codex reused the same
         // session/path; an unordered legacy delta is a boundary only when the

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2238,16 +2238,14 @@ final class AppState: ObservableObject {
             return
         }
         var terminal = terminals[delta.worktreeID]![idx]
-        let previousPresentationState = terminal.presentationActivityState
-        let previousPresentationObservedAt = terminal.presentationActivityObservedAt
-        terminal.applyActivityDelta(delta)
-        if terminal.presentationActivityState != previousPresentationState
-            || terminal.presentationActivityObservedAt != previousPresentationObservedAt {
-            if let observedAt = terminal.presentationActivityObservedAt {
-                terminalPresentationOrderObservedAt[delta.terminalID] = observedAt
-            } else {
-                terminalPresentationOrderObservedAt.removeValue(forKey: delta.terminalID)
-            }
+        let presentationOrderObservedAt = terminal.applyActivityDelta(
+            delta,
+            presentationOrderObservedAt: terminalPresentationOrderObservedAt[delta.terminalID]
+                ?? terminal.presentationActivityObservedAt)
+        if let presentationOrderObservedAt {
+            terminalPresentationOrderObservedAt[delta.terminalID] = presentationOrderObservedAt
+        } else {
+            terminalPresentationOrderObservedAt.removeValue(forKey: delta.terminalID)
         }
         terminals[delta.worktreeID]?[idx] = terminal
     }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2197,6 +2197,24 @@ final class AppState: ObservableObject {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
             return
         }
+        guard terminals[delta.worktreeID]![idx].isCodexTerminal else {
+            // Preserve the pre-Codex-reconciliation contract for Claude and
+            // shell: the last arriving session delta wins, and nil path keeps
+            // the current path. Ordering/presentation watermarks are Codex-only.
+            let currentTerminal = terminals[delta.worktreeID]![idx]
+            var terminal = currentTerminal
+            terminal.claudeSessionID = delta.sessionID
+            if let transcriptPath = delta.transcriptPath {
+                terminal.transcriptPath = transcriptPath
+            }
+            terminal.sessionOrderObservedAt = nil
+            terminalPresentationOrderObservedAt.removeValue(forKey: delta.terminalID)
+            terminalSessionOrderObservedAt.removeValue(forKey: delta.terminalID)
+            if terminal != currentTerminal {
+                terminals[delta.worktreeID]?[idx] = terminal
+            }
+            return
+        }
         let currentTerminal = terminals[delta.worktreeID]![idx]
         var terminal = currentTerminal
         if let incomingOrder = delta.sessionOrderObservedAt,
@@ -2245,6 +2263,14 @@ final class AppState: ObservableObject {
 
     private func applyTerminalActivityDelta(_ delta: TerminalActivityDelta) {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
+            return
+        }
+        guard terminals[delta.worktreeID]![idx].isCodexTerminal else {
+            // Claude and shell activity deltas remain raw last-arrival state;
+            // provenance ordering is part of the Codex presentation fix only.
+            terminals[delta.worktreeID]?[idx].activityState = delta.activityState
+            terminalPresentationOrderObservedAt.removeValue(forKey: delta.terminalID)
+            terminalSessionOrderObservedAt.removeValue(forKey: delta.terminalID)
             return
         }
         var terminal = terminals[delta.worktreeID]![idx]

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2196,17 +2196,7 @@ final class AppState: ObservableObject {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
             return
         }
-        terminals[delta.worktreeID]?[idx].activityState = delta.activityState
-        if let source = delta.activityStateSource,
-           let observedAt = delta.activityStateObservedAt {
-            terminals[delta.worktreeID]?[idx].activityStateSource = source
-            terminals[delta.worktreeID]?[idx].activityStateObservedAt = observedAt
-            if terminals[delta.worktreeID]?[idx].isCodexTerminal == true,
-               delta.activityState == .idle,
-               source == .hookEvent("SessionStart") {
-                terminals[delta.worktreeID]?[idx].presentationActivityState = .idle
-            }
-        }
+        terminals[delta.worktreeID]?[idx].applyActivityDelta(delta)
     }
 
     /// Seamless in-place "Switch account": the terminal row is unchanged except

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2201,6 +2201,11 @@ final class AppState: ObservableObject {
            let observedAt = delta.activityStateObservedAt {
             terminals[delta.worktreeID]?[idx].activityStateSource = source
             terminals[delta.worktreeID]?[idx].activityStateObservedAt = observedAt
+            if terminals[delta.worktreeID]?[idx].isCodexTerminal == true,
+               delta.activityState == .idle,
+               source == .hookEvent("SessionStart") {
+                terminals[delta.worktreeID]?[idx].presentationActivityState = .idle
+            }
         }
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -724,12 +724,17 @@ actor DaemonClient {
     }
 
     /// Publish an explicit terminal activity state transition.
-    func setTerminalActivity(terminalID: UUID, activityState: TerminalActivityState) async throws {
+    func setTerminalActivity(
+        terminalID: UUID,
+        activityState: TerminalActivityState,
+        origin: TerminalActivityEventOrigin? = nil
+    ) async throws {
         try await callVoidAsync(
             method: RPCMethod.terminalActivityEvent,
             params: TerminalActivityEventParams(
                 terminalID: terminalID,
-                activityState: activityState
+                activityState: activityState,
+                origin: origin
             )
         )
     }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -97,13 +97,15 @@ struct WorktreeRowView: View {
 
     /// Whether one terminal has trustworthy foreground work to animate in the
     /// sidebar. Codex's hook state can remain latched after a turn ends, so its
-    /// transcript-derived presentation state is authoritative here. Missing
-    /// transcript evidence deliberately renders idle instead of preserving a
-    /// false thinking indicator. Other terminal kinds retain their existing
+    /// transcript-derived presentation state is authoritative here unless the
+    /// hook reports that Codex is waiting for the user. Missing transcript
+    /// evidence deliberately renders idle instead of preserving a false
+    /// thinking indicator. Other terminal kinds retain their existing
     /// hook-backed behavior.
     nonisolated static func isForegroundWorking(_ terminal: Terminal) -> Bool {
         if terminal.isCodexTerminal {
-            return terminal.presentationActivityState == .working
+            return terminal.activityState != .waitingForUser
+                && terminal.presentationActivityState == .working
         }
         return terminal.activityState == .working
     }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -104,7 +104,8 @@ struct WorktreeRowView: View {
     /// hook-backed behavior.
     nonisolated static func isForegroundWorking(_ terminal: Terminal) -> Bool {
         if terminal.isCodexTerminal {
-            return terminal.activityState != .waitingForUser
+            return terminal.activityStateSource != .terminalInterrupt
+                && terminal.activityState != .waitingForUser
                 && terminal.presentationActivityState == .working
         }
         return terminal.activityState == .working

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -92,7 +92,25 @@ struct WorktreeRowView: View {
 
     private var hasWorkingTerminal: Bool {
         let terminals = appState.terminals[worktree.id] ?? []
-        return terminals.contains { $0.activityState == .working }
+        return Self.hasForegroundWork(in: terminals)
+    }
+
+    /// Whether one terminal has trustworthy foreground work to animate in the
+    /// sidebar. Codex's hook state can remain latched after a turn ends, so its
+    /// transcript-derived presentation state is authoritative here. Missing
+    /// transcript evidence deliberately renders idle instead of preserving a
+    /// false thinking indicator. Other terminal kinds retain their existing
+    /// hook-backed behavior.
+    nonisolated static func isForegroundWorking(_ terminal: Terminal) -> Bool {
+        if terminal.isCodexTerminal {
+            return terminal.presentationActivityState == .working
+        }
+        return terminal.activityState == .working
+    }
+
+    /// The collection form used by the row and by pure presentation tests.
+    nonisolated static func hasForegroundWork(in terminals: [Terminal]) -> Bool {
+        terminals.contains(where: isForegroundWorking)
     }
 
     @ViewBuilder

--- a/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
+++ b/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
@@ -34,6 +34,20 @@ struct TerminalActivityEventCommand: AsyncParsableCommand {
     @Argument(help: "Activity state to publish")
     var state: ActivityArgument
 
+    @Flag(help: "Read Codex hook identity from stdin")
+    var readHookPayload = false
+
+    private struct HookPayload: Decodable {
+        let session_id: String?
+    }
+
+    static func sessionID(fromHookPayload data: Data) -> String? {
+        guard !data.isEmpty, data.count <= 1 << 20,
+              let sessionID = try? JSONDecoder().decode(HookPayload.self, from: data).session_id,
+              !sessionID.isEmpty else { return nil }
+        return sessionID
+    }
+
     mutating func run() async throws {
         guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
               let terminalID = UUID(uuidString: terminalIDString) else {
@@ -48,11 +62,15 @@ struct TerminalActivityEventCommand: AsyncParsableCommand {
         }
 
         do {
+            let sessionID = readHookPayload
+                ? Self.sessionID(fromHookPayload: FileHandle.standardInput.readDataToEndOfFile())
+                : nil
             try client.callVoid(
                 method: RPCMethod.terminalActivityEvent,
                 params: TerminalActivityEventParams(
                     terminalID: terminalID,
-                    activityState: state.activityState
+                    activityState: state.activityState,
+                    sessionID: sessionID
                 )
             )
         } catch {

--- a/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
+++ b/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
@@ -9,6 +9,8 @@ private let activityLogger = Logger(subsystem: "com.tbd.cli", category: "termina
 /// is intentionally generic so Codex hooks can publish explicit lifecycle
 /// changes without the app scraping tmux pane titles.
 struct TerminalActivityEventCommand: AsyncParsableCommand {
+    private static let hookPayloadByteLimit = 1 << 20
+
     static let configuration = CommandConfiguration(
         commandName: "terminal-activity",
         abstract: "Internal: bridge terminal activity state changes into TBD",
@@ -41,8 +43,25 @@ struct TerminalActivityEventCommand: AsyncParsableCommand {
         let session_id: String?
     }
 
+    static func readBoundedHookPayload(from handle: FileHandle) -> Data? {
+        var data = Data()
+        while data.count <= hookPayloadByteLimit {
+            let remaining = hookPayloadByteLimit + 1 - data.count
+            let chunk: Data
+            do {
+                guard let next = try handle.read(upToCount: remaining) else { return data }
+                chunk = next
+            } catch {
+                return nil
+            }
+            guard !chunk.isEmpty else { return data }
+            data.append(chunk)
+        }
+        return nil
+    }
+
     static func sessionID(fromHookPayload data: Data) -> String? {
-        guard !data.isEmpty, data.count <= 1 << 20,
+        guard !data.isEmpty, data.count <= hookPayloadByteLimit,
               let sessionID = try? JSONDecoder().decode(HookPayload.self, from: data).session_id,
               !sessionID.isEmpty else { return nil }
         return sessionID
@@ -63,7 +82,8 @@ struct TerminalActivityEventCommand: AsyncParsableCommand {
 
         do {
             let sessionID = readHookPayload
-                ? Self.sessionID(fromHookPayload: FileHandle.standardInput.readDataToEndOfFile())
+                ? Self.readBoundedHookPayload(from: FileHandle.standardInput)
+                    .flatMap(Self.sessionID(fromHookPayload:))
                 : nil
             try client.callVoid(
                 method: RPCMethod.terminalActivityEvent,

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -56,12 +56,12 @@ enum CodexHookOverlay {
     static let relativePath = "hooks/hooks.json"
 
     static let sessionStartCommand =
-        #"tbd session-event 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
+        #"PAYLOAD=$(cat); printf '%s' "$PAYLOAD" | tbd session-event 2>/dev/null || true; printf '%s' "$PAYLOAD" | tbd terminal-activity idle --read-hook-payload 2>/dev/null || true"#
 
     // Only an active goal can cross a Stop hook into autonomous continuation.
     // Paused and limited goals have stopped the current run, so they publish idle.
     static let responseCompleteCommand =
-        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' ORDER BY updated_at_ms DESC, created_at_ms DESC, rowid DESC LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || tbd terminal-activity idle 2>/dev/null || true"#
+        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' ORDER BY updated_at_ms DESC, created_at_ms DESC, rowid DESC LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || printf '%s' "$PAYLOAD" | tbd terminal-activity idle --read-hook-payload 2>/dev/null || true"#
 
     static let stopRenameCheckCommand =
         #"tbd hooks stop-rename-check 2>/dev/null || true"#
@@ -70,10 +70,10 @@ enum CodexHookOverlay {
         #"PAYLOAD=$(cat); RENAME_RESULT=$(printf '%s' "$PAYLOAD" | \#(stopRenameCheckCommand)); if [ -n "$RENAME_RESULT" ]; then printf '%s\n' "$RENAME_RESULT"; else \#(responseCompleteCommand); fi"#
 
     static let workingCommand =
-        #"tbd terminal-activity working 2>/dev/null || true"#
+        #"tbd terminal-activity working --read-hook-payload 2>/dev/null || true"#
 
     static let waitingForUserCommand =
-        #"tbd terminal-activity waiting_for_user 2>/dev/null || true"#
+        #"tbd terminal-activity waiting_for_user --read-hook-payload 2>/dev/null || true"#
     static func hookPath(in pluginRoot: URL) -> URL {
         pluginRoot.appendingPathComponent(relativePath, isDirectory: false)
     }

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -46,17 +46,19 @@ struct CodexTurnLifecycleReducer: Sendable {
 }
 
 /// Reconstructs a Codex session's turn activity from its append-only JSONL
-/// transcript. Each path is scanned from byte zero once, then only from the
-/// last successfully-read offset on later observations.
+/// transcript. Each path is bootstrapped from a bounded tail once, then only
+/// from the last successfully-read offset on later observations.
 actor CodexTranscriptActivityTracker {
     private struct Baseline {
         var worktreeID: UUID
         var offset: UInt64
         var pendingFragment: Data
+        var discardingLeadingPartialLine: Bool
         var reducer: CodexTurnLifecycleReducer
     }
 
     private static let readChunkSize = 64 * 1024
+    static let initialTailByteLimit: UInt64 = 1024 * 1024
     private var baselines: [String: Baseline] = [:]
 
     var baselineCount: Int { baselines.count }
@@ -66,29 +68,28 @@ actor CodexTranscriptActivityTracker {
     /// an inaccessible transcript is still active.
     func observe(transcriptPath: String, worktreeID: UUID) -> TerminalActivityState? {
         let previous = baselines[transcriptPath]
-        var baseline = previous ?? Baseline(
-            worktreeID: worktreeID,
-            offset: 0,
-            pendingFragment: Data(),
-            reducer: CodexTurnLifecycleReducer())
 
         do {
             let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath))
             defer { try? handle.close() }
 
             let fileSize = try handle.seekToEnd()
-            if fileSize < baseline.offset {
-                baseline = Baseline(
-                    worktreeID: worktreeID,
-                    offset: 0,
-                    pendingFragment: Data(),
-                    reducer: CodexTurnLifecycleReducer())
-            } else {
+            var baseline: Baseline
+            if let previous, fileSize >= previous.offset {
+                baseline = previous
                 baseline.worktreeID = worktreeID
+            } else {
+                baseline = try makeTailBaseline(
+                    handle: handle,
+                    fileSize: fileSize,
+                    worktreeID: worktreeID)
             }
 
             try handle.seek(toOffset: baseline.offset)
-            while let chunk = try handle.read(upToCount: Self.readChunkSize), !chunk.isEmpty {
+            while baseline.offset < fileSize {
+                let remaining = fileSize - baseline.offset
+                let count = Int(min(UInt64(Self.readChunkSize), remaining))
+                guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else { return nil }
                 baseline.offset += UInt64(chunk.count)
                 consumeCompleteLines(from: chunk, into: &baseline)
             }
@@ -116,7 +117,40 @@ actor CodexTranscriptActivityTracker {
         baselines[transcriptPath] != nil
     }
 
+    private func makeTailBaseline(
+        handle: FileHandle,
+        fileSize: UInt64,
+        worktreeID: UUID
+    ) throws -> Baseline {
+        let startOffset = fileSize > Self.initialTailByteLimit
+            ? fileSize - Self.initialTailByteLimit
+            : 0
+        var discardingLeadingPartialLine = false
+
+        if startOffset > 0 {
+            try handle.seek(toOffset: startOffset - 1)
+            let precedingByte = try handle.read(upToCount: 1)?.first
+            discardingLeadingPartialLine = precedingByte != 0x0A
+        }
+
+        return Baseline(
+            worktreeID: worktreeID,
+            offset: startOffset,
+            pendingFragment: Data(),
+            discardingLeadingPartialLine: discardingLeadingPartialLine,
+            reducer: CodexTurnLifecycleReducer())
+    }
+
     private func consumeCompleteLines(from chunk: Data, into baseline: inout Baseline) {
+        if baseline.discardingLeadingPartialLine {
+            guard let newline = chunk.firstIndex(of: 0x0A) else { return }
+            baseline.discardingLeadingPartialLine = false
+            let afterNewline = chunk.index(after: newline)
+            guard afterNewline != chunk.endIndex else { return }
+            consumeCompleteLines(from: Data(chunk[afterNewline...]), into: &baseline)
+            return
+        }
+
         baseline.pendingFragment.append(chunk)
         var lineStart = baseline.pendingFragment.startIndex
 

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -43,10 +43,15 @@ struct CodexTurnLifecycleReducer: Sendable {
             currentTurn = Turn(id: turnID, startedAt: envelope.payload.startedAt)
         case "task_complete", "turn_aborted":
             hasLifecycleEvidence = true
+            // Some rollout writers rewrite the close ID and omit started_at.
+            // With no correlation key left, prefer false idle to a permanent
+            // false-working indicator. A present timestamp still protects a
+            // newer turn from a late close belonging to an older one.
             if let currentTurn,
                currentTurn.id == turnID
                 || currentTurn.startedAt != nil
-                && currentTurn.startedAt == envelope.payload.startedAt {
+                && currentTurn.startedAt == envelope.payload.startedAt
+                || envelope.payload.startedAt == nil {
                 self.currentTurn = nil
             }
         default:
@@ -91,11 +96,19 @@ actor CodexTranscriptActivityTracker {
         let status: Status
     }
 
+    // A 64 KiB read is the fairness and I/O quantum: each active transcript
+    // gets one bounded step before another path can consume the shared budget.
     private static let readChunkSize = 64 * 1024
+    // terminal.list is a two-second polling hot path. One MiB bounds all
+    // transcript work per request while still covering ordinary rollout tails.
     static let initialTailByteLimit: UInt64 = 1024 * 1024
     static let incrementalReadByteLimit = initialTailByteLimit
     static let requestReadByteLimit = incrementalReadByteLimit
+    // Sixteen 64 KiB steps cap zero-byte metadata work as well as byte reads,
+    // so missing or truncated files cannot expand one request without bound.
     static let requestStepLimit = Int(requestReadByteLimit) / readChunkSize
+    // Observed lifecycle records are tens of KiB or less; one MiB leaves broad
+    // margin while preventing a malformed unterminated record from growing.
     static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
     private var baselines: [String: Baseline] = [:]
     private var nextBatchPathOrder: [String] = []
@@ -211,7 +224,7 @@ actor CodexTranscriptActivityTracker {
             onlyIfAbsent: false)
     }
 
-    /// Reconstruct the boundary from a persisted SessionStart activity fact
+    /// Reconstruct the boundary from a persisted SessionStart generation
     /// after daemon restart. Existing baselines always win: repeatedly moving
     /// a live baseline to EOF would hide a genuine turn appended since start.
     func establishSessionBoundariesIfAbsent(transcripts: [Target]) {

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -42,3 +42,89 @@ struct CodexTurnLifecycleReducer: Sendable {
         }
     }
 }
+
+/// Reconstructs a Codex session's turn activity from its append-only JSONL
+/// transcript. Each path is scanned from byte zero once, then only from the
+/// last successfully-read offset on later observations.
+actor CodexTranscriptActivityTracker {
+    private struct Baseline {
+        var worktreeID: UUID
+        var offset: UInt64
+        var pendingFragment: Data
+        var reducer: CodexTurnLifecycleReducer
+    }
+
+    private static let readChunkSize = 64 * 1024
+    private var baselines: [String: Baseline] = [:]
+
+    var baselineCount: Int { baselines.count }
+
+    /// Returns nil when the transcript cannot be read for this observation.
+    /// In particular, a cached positive state is never served as evidence that
+    /// an inaccessible transcript is still active.
+    func observe(transcriptPath: String, worktreeID: UUID) -> TerminalActivityState? {
+        let previous = baselines[transcriptPath]
+        var baseline = previous ?? Baseline(
+            worktreeID: worktreeID,
+            offset: 0,
+            pendingFragment: Data(),
+            reducer: CodexTurnLifecycleReducer())
+
+        do {
+            let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath))
+            defer { try? handle.close() }
+
+            let fileSize = try handle.seekToEnd()
+            if fileSize < baseline.offset {
+                baseline = Baseline(
+                    worktreeID: worktreeID,
+                    offset: 0,
+                    pendingFragment: Data(),
+                    reducer: CodexTurnLifecycleReducer())
+            } else {
+                baseline.worktreeID = worktreeID
+            }
+
+            try handle.seek(toOffset: baseline.offset)
+            while let chunk = try handle.read(upToCount: Self.readChunkSize), !chunk.isEmpty {
+                baseline.offset += UInt64(chunk.count)
+                consumeCompleteLines(from: chunk, into: &baseline)
+            }
+
+            baselines[transcriptPath] = baseline
+            return baseline.reducer.activityState
+        } catch {
+            return nil
+        }
+    }
+
+    /// `scope == nil` means the supplied paths cover the whole fleet. A UUID
+    /// limits pruning to baselines last observed in that worktree.
+    func retain(transcriptPaths: Set<String>, scope worktreeID: UUID?) {
+        guard let worktreeID else {
+            baselines = baselines.filter { transcriptPaths.contains($0.key) }
+            return
+        }
+        baselines = baselines.filter {
+            $0.value.worktreeID != worktreeID || transcriptPaths.contains($0.key)
+        }
+    }
+
+    func hasBaseline(transcriptPath: String) -> Bool {
+        baselines[transcriptPath] != nil
+    }
+
+    private func consumeCompleteLines(from chunk: Data, into baseline: inout Baseline) {
+        baseline.pendingFragment.append(chunk)
+        var lineStart = baseline.pendingFragment.startIndex
+
+        while let newline = baseline.pendingFragment[lineStart...].firstIndex(of: 0x0A) {
+            baseline.reducer.consume(line: Data(baseline.pendingFragment[lineStart..<newline]))
+            lineStart = baseline.pendingFragment.index(after: newline)
+        }
+
+        if lineStart != baseline.pendingFragment.startIndex {
+            baseline.pendingFragment = Data(baseline.pendingFragment[lineStart...])
+        }
+    }
+}

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -220,6 +220,10 @@ actor CodexTranscriptActivityTracker {
             guard baseline.offset == fileSize else {
                 return StepResult(state: nil, bytesRead: bytesRead, status: .behind)
             }
+            guard baseline.pendingFragment.isEmpty,
+                  !baseline.discardingCurrentLine else {
+                return StepResult(state: nil, bytesRead: bytesRead, status: .caughtUp)
+            }
             return StepResult(
                 state: baseline.reducer.activityState,
                 bytesRead: bytesRead,

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -51,6 +51,11 @@ struct CodexTurnLifecycleReducer: Sendable {
 /// advances by a bounded amount and reports no state until it reaches the EOF
 /// captured at its start, so partially-reduced lifecycle history is never shown.
 actor CodexTranscriptActivityTracker {
+    struct Target: Sendable {
+        let transcriptPath: String
+        let worktreeID: UUID
+    }
+
     private struct Baseline {
         var worktreeID: UUID
         var offset: UInt64
@@ -59,11 +64,25 @@ actor CodexTranscriptActivityTracker {
         var reducer: CodexTurnLifecycleReducer
     }
 
+    private struct StepResult {
+        enum Status {
+            case caughtUp
+            case behind
+            case unavailable
+        }
+
+        let state: TerminalActivityState?
+        let bytesRead: UInt64
+        let status: Status
+    }
+
     private static let readChunkSize = 64 * 1024
     static let initialTailByteLimit: UInt64 = 1024 * 1024
     static let incrementalReadByteLimit = initialTailByteLimit
+    static let requestReadByteLimit = incrementalReadByteLimit
     static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
     private var baselines: [String: Baseline] = [:]
+    private var nextBatchStartPath: String?
 
     var baselineCount: Int { baselines.count }
 
@@ -71,7 +90,84 @@ actor CodexTranscriptActivityTracker {
     /// In particular, a cached positive state is never served as evidence that
     /// an inaccessible transcript is still active.
     func observe(transcriptPath: String, worktreeID: UUID) -> TerminalActivityState? {
+        let result = observeStep(
+            transcriptPath: transcriptPath,
+            worktreeID: worktreeID,
+            byteLimit: Self.incrementalReadByteLimit)
+        guard case .caughtUp = result.status else { return nil }
+        return result.state
+    }
+
+    /// Observes several transcripts under one shared byte budget. Paths still
+    /// behind their observed EOF are revisited in round-robin order, including
+    /// across calls, and do not publish an intermediate reducer state.
+    func observe(
+        transcripts: [Target],
+        totalByteLimit: UInt64 = requestReadByteLimit
+    ) -> [String: TerminalActivityState] {
+        guard totalByteLimit > 0 else { return [:] }
+
+        var seenPaths: Set<String> = []
+        let uniqueTargets = transcripts.filter {
+            seenPaths.insert($0.transcriptPath).inserted
+        }
+        guard !uniqueTargets.isEmpty else { return [:] }
+
+        let startIndex = nextBatchStartPath.flatMap { path in
+            uniqueTargets.firstIndex { $0.transcriptPath == path }
+        } ?? 0
+        let targets = Array(uniqueTargets[startIndex...] + uniqueTargets[..<startIndex])
+        var active = Array(repeating: true, count: targets.count)
+        var activeCount = targets.count
+        var cursor = 0
+        var remainingByteCount = totalByteLimit
+        var states: [String: TerminalActivityState] = [:]
+
+        while remainingByteCount > 0, activeCount > 0 {
+            if active[cursor] {
+                let target = targets[cursor]
+                let result = observeStep(
+                    transcriptPath: target.transcriptPath,
+                    worktreeID: target.worktreeID,
+                    byteLimit: min(UInt64(Self.readChunkSize), remainingByteCount))
+                remainingByteCount -= result.bytesRead
+
+                switch result.status {
+                case .caughtUp:
+                    if let state = result.state {
+                        states[target.transcriptPath] = state
+                    }
+                    active[cursor] = false
+                    activeCount -= 1
+                case .unavailable:
+                    active[cursor] = false
+                    activeCount -= 1
+                case .behind:
+                    if result.bytesRead == 0 {
+                        // A future scanner change must not turn a no-progress
+                        // result into a tight loop on the terminal-list path.
+                        active[cursor] = false
+                        activeCount -= 1
+                    }
+                }
+            }
+            cursor = (cursor + 1) % targets.count
+        }
+
+        nextBatchStartPath = targets[cursor].transcriptPath
+        return states
+    }
+
+    private func observeStep(
+        transcriptPath: String,
+        worktreeID: UUID,
+        byteLimit: UInt64
+    ) -> StepResult {
+        guard byteLimit > 0 else {
+            return StepResult(state: nil, bytesRead: 0, status: .behind)
+        }
         let previous = baselines[transcriptPath]
+        var bytesRead: UInt64 = 0
 
         do {
             let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath))
@@ -83,29 +179,39 @@ actor CodexTranscriptActivityTracker {
                 baseline = previous
                 baseline.worktreeID = worktreeID
             } else {
-                baseline = try makeTailBaseline(
+                let prepared = try makeTailBaseline(
                     handle: handle,
                     fileSize: fileSize,
                     worktreeID: worktreeID)
+                baseline = prepared.baseline
+                bytesRead = prepared.bytesRead
             }
 
             let unreadByteCount = fileSize - baseline.offset
-            let readByteCount = min(unreadByteCount, Self.incrementalReadByteLimit)
+            let readByteCount = min(unreadByteCount, byteLimit - bytesRead)
             let observationEndOffset = baseline.offset + readByteCount
             try handle.seek(toOffset: baseline.offset)
             while baseline.offset < observationEndOffset {
                 let remaining = observationEndOffset - baseline.offset
                 let count = Int(min(UInt64(Self.readChunkSize), remaining))
-                guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else { return nil }
+                guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else {
+                    return StepResult(state: nil, bytesRead: bytesRead, status: .unavailable)
+                }
                 baseline.offset += UInt64(chunk.count)
+                bytesRead += UInt64(chunk.count)
                 consumeCompleteLines(from: chunk, into: &baseline)
             }
 
             baselines[transcriptPath] = baseline
-            guard baseline.offset == fileSize else { return nil }
-            return baseline.reducer.activityState
+            guard baseline.offset == fileSize else {
+                return StepResult(state: nil, bytesRead: bytesRead, status: .behind)
+            }
+            return StepResult(
+                state: baseline.reducer.activityState,
+                bytesRead: bytesRead,
+                status: .caughtUp)
         } catch {
-            return nil
+            return StepResult(state: nil, bytesRead: bytesRead, status: .unavailable)
         }
     }
 
@@ -134,24 +240,28 @@ actor CodexTranscriptActivityTracker {
         handle: FileHandle,
         fileSize: UInt64,
         worktreeID: UUID
-    ) throws -> Baseline {
+    ) throws -> (baseline: Baseline, bytesRead: UInt64) {
         let startOffset = fileSize > Self.initialTailByteLimit
             ? fileSize - Self.initialTailByteLimit
             : 0
         var discardingCurrentLine = false
+        var bytesRead: UInt64 = 0
 
         if startOffset > 0 {
             try handle.seek(toOffset: startOffset - 1)
             let precedingByte = try handle.read(upToCount: 1)?.first
+            bytesRead = precedingByte == nil ? 0 : 1
             discardingCurrentLine = precedingByte != 0x0A
         }
 
-        return Baseline(
-            worktreeID: worktreeID,
-            offset: startOffset,
-            pendingFragment: Data(),
-            discardingCurrentLine: discardingCurrentLine,
-            reducer: CodexTurnLifecycleReducer())
+        return (
+            Baseline(
+                worktreeID: worktreeID,
+                offset: startOffset,
+                pendingFragment: Data(),
+                discardingCurrentLine: discardingCurrentLine,
+                reducer: CodexTurnLifecycleReducer()),
+            bytesRead)
     }
 
     private func consumeCompleteLines(from chunk: Data, into baseline: inout Baseline) {

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -47,7 +47,9 @@ struct CodexTurnLifecycleReducer: Sendable {
 
 /// Reconstructs a Codex session's turn activity from its append-only JSONL
 /// transcript. Each path is bootstrapped from a bounded tail once, then only
-/// from the last successfully-read offset on later observations.
+/// from the last successfully-read offset on later observations. An observation
+/// advances by a bounded amount and reports no state until it reaches the EOF
+/// captured at its start, so partially-reduced lifecycle history is never shown.
 actor CodexTranscriptActivityTracker {
     private struct Baseline {
         var worktreeID: UUID
@@ -59,6 +61,7 @@ actor CodexTranscriptActivityTracker {
 
     private static let readChunkSize = 64 * 1024
     static let initialTailByteLimit: UInt64 = 1024 * 1024
+    static let incrementalReadByteLimit = initialTailByteLimit
     static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
     private var baselines: [String: Baseline] = [:]
 
@@ -86,9 +89,12 @@ actor CodexTranscriptActivityTracker {
                     worktreeID: worktreeID)
             }
 
+            let unreadByteCount = fileSize - baseline.offset
+            let readByteCount = min(unreadByteCount, Self.incrementalReadByteLimit)
+            let observationEndOffset = baseline.offset + readByteCount
             try handle.seek(toOffset: baseline.offset)
-            while baseline.offset < fileSize {
-                let remaining = fileSize - baseline.offset
+            while baseline.offset < observationEndOffset {
+                let remaining = observationEndOffset - baseline.offset
                 let count = Int(min(UInt64(Self.readChunkSize), remaining))
                 guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else { return nil }
                 baseline.offset += UInt64(chunk.count)
@@ -96,6 +102,7 @@ actor CodexTranscriptActivityTracker {
             }
 
             baselines[transcriptPath] = baseline
+            guard baseline.offset == fileSize else { return nil }
             return baseline.reducer.activityState
         } catch {
             return nil

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -17,12 +17,12 @@ struct CodexTurnLifecycleReducer: Sendable {
         }
     }
 
-    private var openTurnIDs: Set<String> = []
+    private var currentTurnID: String?
     private var hasLifecycleEvidence = false
 
     var activityState: TerminalActivityState? {
         guard hasLifecycleEvidence else { return nil }
-        return openTurnIDs.isEmpty ? .idle : .working
+        return currentTurnID == nil ? .idle : .working
     }
 
     mutating func consume(line: Data) {
@@ -33,10 +33,12 @@ struct CodexTurnLifecycleReducer: Sendable {
         switch envelope.payload.type {
         case "task_started":
             hasLifecycleEvidence = true
-            openTurnIDs.insert(turnID)
+            currentTurnID = turnID
         case "task_complete", "turn_aborted":
             hasLifecycleEvidence = true
-            openTurnIDs.remove(turnID)
+            if currentTurnID == turnID {
+                currentTurnID = nil
+            }
         default:
             break
         }

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -1,0 +1,44 @@
+import Foundation
+import TBDShared
+
+struct CodexTurnLifecycleReducer: Sendable {
+    private struct EventEnvelope: Decodable {
+        let type: String
+        let payload: Payload
+    }
+
+    private struct Payload: Decodable {
+        let type: String
+        let turnID: String?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case turnID = "turn_id"
+        }
+    }
+
+    private var openTurnIDs: Set<String> = []
+    private var hasLifecycleEvidence = false
+
+    var activityState: TerminalActivityState? {
+        guard hasLifecycleEvidence else { return nil }
+        return openTurnIDs.isEmpty ? .idle : .working
+    }
+
+    mutating func consume(line: Data) {
+        guard let envelope = try? JSONDecoder().decode(EventEnvelope.self, from: line),
+              envelope.type == "event_msg",
+              let turnID = envelope.payload.turnID else { return }
+
+        switch envelope.payload.type {
+        case "task_started":
+            hasLifecycleEvidence = true
+            openTurnIDs.insert(turnID)
+        case "task_complete", "turn_aborted":
+            hasLifecycleEvidence = true
+            openTurnIDs.remove(turnID)
+        default:
+            break
+        }
+    }
+}

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -34,21 +34,22 @@ struct CodexTurnLifecycleReducer: Sendable {
 
     mutating func consume(line: Data) {
         guard let envelope = try? JSONDecoder().decode(EventEnvelope.self, from: line),
-              envelope.type == "event_msg",
-              let turnID = envelope.payload.turnID else { return }
+              envelope.type == "event_msg" else { return }
 
         switch envelope.payload.type {
         case "task_started":
+            guard let turnID = envelope.payload.turnID else { return }
             hasLifecycleEvidence = true
             currentTurn = Turn(id: turnID, startedAt: envelope.payload.startedAt)
         case "task_complete", "turn_aborted":
             hasLifecycleEvidence = true
-            // Some rollout writers rewrite the close ID and omit started_at.
-            // With no correlation key left, prefer false idle to a permanent
-            // false-working indicator. A present timestamp still protects a
-            // newer turn from a late close belonging to an older one.
+            // Some rollout writers omit or rewrite the close ID. With no
+            // trustworthy identity key, prefer false idle to a permanent
+            // false-working indicator. When both records carry identity, a
+            // present timestamp still protects a newer turn from a late close.
             if let currentTurn,
-               currentTurn.id == turnID
+               envelope.payload.turnID == nil
+                || currentTurn.id == envelope.payload.turnID
                 || currentTurn.startedAt != nil
                 && currentTurn.startedAt == envelope.payload.startedAt
                 || envelope.payload.startedAt == nil {

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -198,6 +198,38 @@ actor CodexTranscriptActivityTracker {
         )
     }
 
+    /// Establish a lifecycle boundary for an accepted SessionStart without
+    /// re-reading history before that event. This matters when Codex reuses the
+    /// same transcript path after an interrupted turn: an unmatched historical
+    /// `task_started` must not become current-session working evidence again.
+    /// Bytes appended after the captured EOF are reduced normally, so the next
+    /// genuine turn supersedes the boundary.
+    func establishSessionBoundary(transcriptPath: String, worktreeID: UUID) {
+        batchPathWorktreeIDs[transcriptPath] = worktreeID
+        do {
+            let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath))
+            defer { try? handle.close() }
+            let fileSize = try handle.seekToEnd()
+            var discardingCurrentLine = false
+            if fileSize > 0 {
+                try handle.seek(toOffset: fileSize - 1)
+                let lastByte = try handle.read(upToCount: 1)?.first
+                discardingCurrentLine = lastByte != 0x0A
+            }
+            baselines[transcriptPath] = Baseline(
+                worktreeID: worktreeID,
+                offset: fileSize,
+                pendingFragment: Data(),
+                discardingCurrentLine: discardingCurrentLine,
+                reducer: CodexTurnLifecycleReducer())
+        } catch {
+            // Never retain positive evidence across a session boundary when
+            // the file is temporarily unavailable. A later list observation
+            // may bootstrap once the new session creates the path.
+            baselines.removeValue(forKey: transcriptPath)
+        }
+    }
+
     private func advanceBatchPath(_ transcriptPath: String) {
         guard let index = nextBatchPathOrder.firstIndex(of: transcriptPath) else { return }
         nextBatchPathOrder.remove(at: index)

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -205,6 +205,30 @@ actor CodexTranscriptActivityTracker {
     /// Bytes appended after the captured EOF are reduced normally, so the next
     /// genuine turn supersedes the boundary.
     func establishSessionBoundary(transcriptPath: String, worktreeID: UUID) {
+        establishSessionBoundary(
+            transcriptPath: transcriptPath,
+            worktreeID: worktreeID,
+            onlyIfAbsent: false)
+    }
+
+    /// Reconstruct the boundary from a persisted SessionStart activity fact
+    /// after daemon restart. Existing baselines always win: repeatedly moving
+    /// a live baseline to EOF would hide a genuine turn appended since start.
+    func establishSessionBoundariesIfAbsent(transcripts: [Target]) {
+        for transcript in transcripts where baselines[transcript.transcriptPath] == nil {
+            establishSessionBoundary(
+                transcriptPath: transcript.transcriptPath,
+                worktreeID: transcript.worktreeID,
+                onlyIfAbsent: true)
+        }
+    }
+
+    private func establishSessionBoundary(
+        transcriptPath: String,
+        worktreeID: UUID,
+        onlyIfAbsent: Bool
+    ) {
+        if onlyIfAbsent, baselines[transcriptPath] != nil { return }
         batchPathWorktreeIDs[transcriptPath] = worktreeID
         do {
             let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath))

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -10,19 +10,26 @@ struct CodexTurnLifecycleReducer: Sendable {
     private struct Payload: Decodable {
         let type: String
         let turnID: String?
+        let startedAt: Double?
 
         enum CodingKeys: String, CodingKey {
             case type
             case turnID = "turn_id"
+            case startedAt = "started_at"
         }
     }
 
-    private var currentTurnID: String?
+    private struct Turn: Sendable {
+        let id: String
+        let startedAt: Double?
+    }
+
+    private var currentTurn: Turn?
     private var hasLifecycleEvidence = false
 
     var activityState: TerminalActivityState? {
         guard hasLifecycleEvidence else { return nil }
-        return currentTurnID == nil ? .idle : .working
+        return currentTurn == nil ? .idle : .working
     }
 
     mutating func consume(line: Data) {
@@ -33,11 +40,14 @@ struct CodexTurnLifecycleReducer: Sendable {
         switch envelope.payload.type {
         case "task_started":
             hasLifecycleEvidence = true
-            currentTurnID = turnID
+            currentTurn = Turn(id: turnID, startedAt: envelope.payload.startedAt)
         case "task_complete", "turn_aborted":
             hasLifecycleEvidence = true
-            if currentTurnID == turnID {
-                currentTurnID = nil
+            if let currentTurn,
+               currentTurn.id == turnID
+                || currentTurn.startedAt != nil
+                && currentTurn.startedAt == envelope.payload.startedAt {
+                self.currentTurn = nil
             }
         default:
             break

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -90,6 +90,7 @@ actor CodexTranscriptActivityTracker {
     static let initialTailByteLimit: UInt64 = 1024 * 1024
     static let incrementalReadByteLimit = initialTailByteLimit
     static let requestReadByteLimit = incrementalReadByteLimit
+    static let requestStepLimit = Int(requestReadByteLimit) / readChunkSize
     static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
     private var baselines: [String: Baseline] = [:]
     private var nextBatchPathOrder: [String] = []
@@ -138,11 +139,13 @@ actor CodexTranscriptActivityTracker {
         var activeCount = targets.count
         var cursor = 0
         var remainingByteCount = totalByteLimit
+        var remainingStepCount = Self.requestStepLimit
         var states: [String: TerminalActivityState] = [:]
 
-        while remainingByteCount > 0, activeCount > 0 {
+        while remainingByteCount > 0, remainingStepCount > 0, activeCount > 0 {
             if active[cursor] {
                 let target = targets[cursor]
+                remainingStepCount -= 1
                 let result = observeStep(
                     transcriptPath: target.transcriptPath,
                     worktreeID: target.worktreeID,

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -53,12 +53,13 @@ actor CodexTranscriptActivityTracker {
         var worktreeID: UUID
         var offset: UInt64
         var pendingFragment: Data
-        var discardingLeadingPartialLine: Bool
+        var discardingCurrentLine: Bool
         var reducer: CodexTurnLifecycleReducer
     }
 
     private static let readChunkSize = 64 * 1024
     static let initialTailByteLimit: UInt64 = 1024 * 1024
+    static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
     private var baselines: [String: Baseline] = [:]
 
     var baselineCount: Int { baselines.count }
@@ -117,6 +118,11 @@ actor CodexTranscriptActivityTracker {
         baselines[transcriptPath] != nil
     }
 
+    func bufferedRecordState(transcriptPath: String) -> (byteCount: Int, isDiscarding: Bool)? {
+        guard let baseline = baselines[transcriptPath] else { return nil }
+        return (baseline.pendingFragment.count, baseline.discardingCurrentLine)
+    }
+
     private func makeTailBaseline(
         handle: FileHandle,
         fileSize: UInt64,
@@ -125,42 +131,51 @@ actor CodexTranscriptActivityTracker {
         let startOffset = fileSize > Self.initialTailByteLimit
             ? fileSize - Self.initialTailByteLimit
             : 0
-        var discardingLeadingPartialLine = false
+        var discardingCurrentLine = false
 
         if startOffset > 0 {
             try handle.seek(toOffset: startOffset - 1)
             let precedingByte = try handle.read(upToCount: 1)?.first
-            discardingLeadingPartialLine = precedingByte != 0x0A
+            discardingCurrentLine = precedingByte != 0x0A
         }
 
         return Baseline(
             worktreeID: worktreeID,
             offset: startOffset,
             pendingFragment: Data(),
-            discardingLeadingPartialLine: discardingLeadingPartialLine,
+            discardingCurrentLine: discardingCurrentLine,
             reducer: CodexTurnLifecycleReducer())
     }
 
     private func consumeCompleteLines(from chunk: Data, into baseline: inout Baseline) {
-        if baseline.discardingLeadingPartialLine {
+        var scanStart = chunk.startIndex
+
+        if baseline.discardingCurrentLine {
             guard let newline = chunk.firstIndex(of: 0x0A) else { return }
-            baseline.discardingLeadingPartialLine = false
-            let afterNewline = chunk.index(after: newline)
-            guard afterNewline != chunk.endIndex else { return }
-            consumeCompleteLines(from: Data(chunk[afterNewline...]), into: &baseline)
+            baseline.discardingCurrentLine = false
+            scanStart = chunk.index(after: newline)
+        }
+
+        while scanStart != chunk.endIndex {
+            if let newline = chunk[scanStart...].firstIndex(of: 0x0A) {
+                let segmentCount = chunk.distance(from: scanStart, to: newline)
+                if segmentCount <= Self.maxBufferedRecordByteCount - baseline.pendingFragment.count {
+                    baseline.pendingFragment.append(contentsOf: chunk[scanStart..<newline])
+                    baseline.reducer.consume(line: baseline.pendingFragment)
+                }
+                baseline.pendingFragment.removeAll(keepingCapacity: false)
+                scanStart = chunk.index(after: newline)
+                continue
+            }
+
+            let segmentCount = chunk.distance(from: scanStart, to: chunk.endIndex)
+            if segmentCount <= Self.maxBufferedRecordByteCount - baseline.pendingFragment.count {
+                baseline.pendingFragment.append(contentsOf: chunk[scanStart...])
+            } else {
+                baseline.pendingFragment.removeAll(keepingCapacity: false)
+                baseline.discardingCurrentLine = true
+            }
             return
-        }
-
-        baseline.pendingFragment.append(chunk)
-        var lineStart = baseline.pendingFragment.startIndex
-
-        while let newline = baseline.pendingFragment[lineStart...].firstIndex(of: 0x0A) {
-            baseline.reducer.consume(line: Data(baseline.pendingFragment[lineStart..<newline]))
-            lineStart = baseline.pendingFragment.index(after: newline)
-        }
-
-        if lineStart != baseline.pendingFragment.startIndex {
-            baseline.pendingFragment = Data(baseline.pendingFragment[lineStart...])
         }
     }
 }

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -82,7 +82,7 @@ actor CodexTranscriptActivityTracker {
     static let requestReadByteLimit = incrementalReadByteLimit
     static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
     private var baselines: [String: Baseline] = [:]
-    private var nextBatchStartPath: String?
+    private var nextBatchPathOrder: [String] = []
 
     var baselineCount: Int { baselines.count }
 
@@ -113,6 +113,8 @@ actor CodexTranscriptActivityTracker {
         }
         guard !uniqueTargets.isEmpty else { return [:] }
 
+        let currentPaths = Set(uniqueTargets.map(\.transcriptPath))
+        let nextBatchStartPath = nextBatchPathOrder.first(where: currentPaths.contains)
         let startIndex = nextBatchStartPath.flatMap { path in
             uniqueTargets.firstIndex { $0.transcriptPath == path }
         } ?? 0
@@ -154,7 +156,9 @@ actor CodexTranscriptActivityTracker {
             cursor = (cursor + 1) % targets.count
         }
 
-        nextBatchStartPath = targets[cursor].transcriptPath
+        nextBatchPathOrder =
+            targets[cursor...].map(\.transcriptPath)
+            + targets[..<cursor].map(\.transcriptPath)
         return states
     }
 

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -66,6 +66,11 @@ actor CodexTranscriptActivityTracker {
         let worktreeID: UUID
     }
 
+    struct StampedObservation: Sendable {
+        let states: [String: TerminalActivityState]
+        let observedAt: Date
+    }
+
     private struct Baseline {
         var worktreeID: UUID
         var offset: UInt64
@@ -176,6 +181,21 @@ actor CodexTranscriptActivityTracker {
         }
 
         return states
+    }
+
+    /// Couples a batch result to the actor order in which its transcript
+    /// observation completed. Minting the timestamp before this actor accepts
+    /// another call prevents reversed RPC completions from assigning a newer
+    /// timestamp to an older transcript result.
+    func observeStamped(
+        transcripts: [Target],
+        totalByteLimit: UInt64 = requestReadByteLimit,
+        now: @Sendable () -> Date
+    ) -> StampedObservation {
+        StampedObservation(
+            states: observe(transcripts: transcripts, totalByteLimit: totalByteLimit),
+            observedAt: now()
+        )
     }
 
     private func advanceBatchPath(_ transcriptPath: String) {

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -93,6 +93,7 @@ actor CodexTranscriptActivityTracker {
     static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
     private var baselines: [String: Baseline] = [:]
     private var nextBatchPathOrder: [String] = []
+    private var batchPathWorktreeIDs: [String: UUID] = [:]
 
     var baselineCount: Int { baselines.count }
 
@@ -123,12 +124,16 @@ actor CodexTranscriptActivityTracker {
         }
         guard !uniqueTargets.isEmpty else { return [:] }
 
-        let currentPaths = Set(uniqueTargets.map(\.transcriptPath))
-        let nextBatchStartPath = nextBatchPathOrder.first(where: currentPaths.contains)
-        let startIndex = nextBatchStartPath.flatMap { path in
-            uniqueTargets.firstIndex { $0.transcriptPath == path }
-        } ?? 0
-        let targets = Array(uniqueTargets[startIndex...] + uniqueTargets[..<startIndex])
+        let targetsByPath = Dictionary(
+            uniqueKeysWithValues: uniqueTargets.map { ($0.transcriptPath, $0) })
+        var knownPaths = Set(nextBatchPathOrder)
+        for target in uniqueTargets {
+            batchPathWorktreeIDs[target.transcriptPath] = target.worktreeID
+            if knownPaths.insert(target.transcriptPath).inserted {
+                nextBatchPathOrder.append(target.transcriptPath)
+            }
+        }
+        let targets = nextBatchPathOrder.compactMap { targetsByPath[$0] }
         var active = Array(repeating: true, count: targets.count)
         var activeCount = targets.count
         var cursor = 0
@@ -143,6 +148,7 @@ actor CodexTranscriptActivityTracker {
                     worktreeID: target.worktreeID,
                     byteLimit: min(UInt64(Self.readChunkSize), remainingByteCount))
                 remainingByteCount -= result.bytesRead
+                advanceBatchPath(target.transcriptPath)
 
                 switch result.status {
                 case .caughtUp:
@@ -166,10 +172,13 @@ actor CodexTranscriptActivityTracker {
             cursor = (cursor + 1) % targets.count
         }
 
-        nextBatchPathOrder =
-            targets[cursor...].map(\.transcriptPath)
-            + targets[..<cursor].map(\.transcriptPath)
         return states
+    }
+
+    private func advanceBatchPath(_ transcriptPath: String) {
+        guard let index = nextBatchPathOrder.firstIndex(of: transcriptPath) else { return }
+        nextBatchPathOrder.remove(at: index)
+        nextBatchPathOrder.append(transcriptPath)
     }
 
     private func observeStep(
@@ -238,10 +247,21 @@ actor CodexTranscriptActivityTracker {
     func retain(transcriptPaths: Set<String>, scope worktreeID: UUID?) {
         guard let worktreeID else {
             baselines = baselines.filter { transcriptPaths.contains($0.key) }
+            nextBatchPathOrder.removeAll { !transcriptPaths.contains($0) }
+            batchPathWorktreeIDs = batchPathWorktreeIDs.filter {
+                transcriptPaths.contains($0.key)
+            }
             return
         }
         baselines = baselines.filter {
             $0.value.worktreeID != worktreeID || transcriptPaths.contains($0.key)
+        }
+        let removedPaths = Set(batchPathWorktreeIDs.compactMap { path, owner in
+            owner == worktreeID && !transcriptPaths.contains(path) ? path : nil
+        })
+        nextBatchPathOrder.removeAll { removedPaths.contains($0) }
+        batchPathWorktreeIDs = batchPathWorktreeIDs.filter {
+            !removedPaths.contains($0.key)
         }
     }
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1549,6 +1549,17 @@ public final class TBDDatabase: Sendable {
                 defaults: DatabaseValue.null)
         }
 
+        // Session identity has its own event order. Permission and activity
+        // hooks can arrive after a real SessionStart even though they describe
+        // the previous session, so neither timestamp can safely order the
+        // session ID/path pair. NULL preserves the unknown state for rows that
+        // predate this independently observed fact.
+        migrator.registerMigration("v86_terminal_session_order") { db in
+            try db.addColumnIfMissing(
+                table: "terminal", column: "sessionOrderObservedAt", type: .datetime,
+                defaults: DatabaseValue.null)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1440,6 +1440,17 @@ public final class TBDDatabase: Sendable {
                 table: "reap_records", column: "quarantinePath", type: .text)
         }
 
+        // Event ordering is not the same timestamp as the semantic activity
+        // transition: repeated same-state observations must advance the former
+        // without resetting hibernation's at-rest-since clock. Its explicit
+        // NULL default preserves the unknown third state, so old rows fall back
+        // to activityStateObservedAt without inventing a timestamp.
+        migrator.registerMigration("v80_terminal_activity_order") { db in
+            try db.addColumnIfMissing(
+                table: "terminal", column: "activityStateOrderObservedAt", type: .datetime,
+                defaults: DatabaseValue.null)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -21,6 +21,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var suspendedSnapshot: String?
     var profile_id: String?
     var transcriptPath: String?
+    var sessionOrderObservedAt: Date?
     var kind: String?
     var activityState: String?
     var hibernatedAt: Date?
@@ -52,6 +53,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.suspendedSnapshot = terminal.suspendedSnapshot
         self.profile_id = terminal.profileID?.uuidString
         self.transcriptPath = terminal.transcriptPath
+        self.sessionOrderObservedAt = terminal.sessionOrderObservedAt
         self.kind = terminal.kind?.rawValue
         self.activityState = terminal.activityState.rawValue
         self.hibernatedAt = terminal.hibernatedAt
@@ -91,6 +93,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             suspendedSnapshot: suspendedSnapshot,
             profileID: profile_id.flatMap(UUID.init(uuidString:)),
             transcriptPath: transcriptPath,
+            sessionOrderObservedAt: sessionOrderObservedAt,
             kind: kind.flatMap(TerminalKind.init(rawValue:)),
             activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown,
             hibernatedAt: hibernatedAt,
@@ -392,19 +395,17 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Apply a SessionStart as one ordered database fact. Session identity,
-    /// prompt retraction, the shared event-order watermark, and Codex's idle
-    /// transition either all advance together or none do.
+    /// Apply a SessionStart with independently ordered session, prompt, and
+    /// activity facts in one database transaction.
     ///
-    /// A prompt at the same timestamp wins the tie, matching
-    /// `SessionStateResolver`: SessionStart cannot prove whether that more
-    /// specific wait was raised before or after it. SessionStart itself is
-    /// first-wins at an equal activity watermark: a differently-identified
-    /// event cannot roll identity backward, while an exact retry is an
-    /// idempotent no-op and therefore cannot move a transcript boundary.
-    /// Claude does not assert an activity value here, but still advances the
-    /// ordering watermark so an older activity or SessionStart cannot finish
-    /// late and roll the row back.
+    /// Session identity is ordered only against other SessionStarts. A delayed
+    /// permission or activity hook can carry a later server-receipt timestamp
+    /// while still describing the previous session, so it must not suppress a
+    /// genuine identity rollover. Prompt and activity each retain their own
+    /// conservative ordering: a same/newer prompt survives, and an older
+    /// SessionStart cannot regress newer activity. SessionStart is first-wins
+    /// at an equal session watermark; an exact retry is an idempotent no-op and
+    /// therefore cannot move a transcript boundary.
     func applySessionStart(
         id: UUID,
         sessionID: String,
@@ -415,33 +416,29 @@ public struct TerminalStore: Sendable {
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
-            if record.awaitingInputObservedAt.map({ $0 >= observedAt }) == true {
+            if let storedSessionOrder = record.sessionOrderObservedAt,
+               storedSessionOrder >= observedAt {
                 return nil
             }
-            let storedOrderObservedAt = record.activityStateOrderObservedAt
-                ?? record.activityStateObservedAt
-            if storedOrderObservedAt == observedAt {
-                return nil
-            }
+            record.sessionOrderObservedAt = observedAt
 
             let isCodex = record.kind == TerminalKind.codex.rawValue
                 || record.label == TerminalLabel.codex
             let activityObservation: AppliedTerminalActivityObservation?
             if isCodex {
-                guard let applied = applyActivityObservationToRecord(
+                activityObservation = applyActivityObservationToRecord(
                     to: &record,
                     activityState: .idle,
                     source: .hookEvent("SessionStart"),
                     observedAt: observedAt,
                     replaceSameValue: true
-                ) else { return nil }
-                activityObservation = applied
+                )
             } else {
-                if let storedOrderObservedAt, storedOrderObservedAt > observedAt {
-                    return nil
+                let storedActivityOrder = record.activityStateOrderObservedAt
+                    ?? record.activityStateObservedAt
+                if storedActivityOrder.map({ $0 < observedAt }) != false {
+                    record.activityStateOrderObservedAt = observedAt
                 }
-                record.activityStateOrderObservedAt = observedAt
-                clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
                 activityObservation = nil
             }
 
@@ -449,9 +446,10 @@ public struct TerminalStore: Sendable {
             if let transcriptPath {
                 record.transcriptPath = transcriptPath
             }
-            // The activity helper already performs this for Codex. Keep the
-            // call here so Claude and any future non-Codex agent share the
-            // same strict-older prompt retraction rule.
+            // The activity helper performs this when it accepts Codex's idle
+            // fact. Keep the independent call so a rejected stale activity
+            // transition and every non-Codex SessionStart still retract only
+            // a prompt known to be strictly older.
             clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
             try record.update(db)
             return AppliedTerminalSessionStart(
@@ -475,6 +473,7 @@ public struct TerminalStore: Sendable {
             }
             record.claudeSessionID = nil
             record.transcriptPath = nil
+            record.sessionOrderObservedAt = nil
             record.suspendedAt = nil
             record.suspendedSnapshot = nil
             record.hibernatedAt = nil

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -141,7 +141,7 @@ public struct AppliedTerminalActivityObservation: Sendable {
 struct AppliedTerminalSessionStart: Sendable {
     let sessionID: String
     let transcriptPath: String?
-    let orderObservedAt: Date
+    let orderObservedAt: Date?
     let activityObservation: AppliedTerminalActivityObservation?
 }
 
@@ -395,17 +395,18 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Apply a SessionStart with independently ordered session, prompt, and
-    /// activity facts in one database transaction.
+    /// Apply a SessionStart in one database transaction. Codex session,
+    /// prompt, and activity facts use independent ordering rails; other agent
+    /// kinds retain their established last-writer session semantics.
     ///
-    /// Session identity is ordered only against other SessionStarts. A delayed
-    /// permission or activity hook can carry a later server-receipt timestamp
-    /// while still describing the previous session, so it must not suppress a
-    /// genuine identity rollover. Prompt and activity each retain their own
-    /// conservative ordering: a same/newer prompt survives, and an older
-    /// SessionStart cannot regress newer activity. SessionStart is first-wins
-    /// at an equal session watermark; an exact retry is an idempotent no-op and
-    /// therefore cannot move a transcript boundary.
+    /// Codex session identity is ordered only against other SessionStarts. A
+    /// delayed permission or activity hook can carry a later server-receipt
+    /// timestamp while still describing the previous session, so it must not
+    /// suppress a genuine identity rollover. Prompt and activity each retain
+    /// their own conservative ordering: a same/newer prompt survives, and an
+    /// older SessionStart cannot regress newer activity. Codex SessionStart is
+    /// first-wins at an equal session watermark; an exact retry is an
+    /// idempotent no-op and therefore cannot move a transcript boundary.
     func applySessionStart(
         id: UUID,
         sessionID: String,
@@ -416,31 +417,40 @@ public struct TerminalStore: Sendable {
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
+            let isCodex = record.kind == TerminalKind.codex.rawValue
+                || record.label == TerminalLabel.codex
+            guard isCodex else {
+                // Preserve the established Claude/shell hook behavior: the
+                // last SessionStart to finish replaces identity and retracts
+                // the prior prompt without changing activity. The ordering
+                // rail exists only for Codex transcript reconciliation.
+                record.claudeSessionID = sessionID
+                if let transcriptPath {
+                    record.transcriptPath = transcriptPath
+                }
+                record.sessionOrderObservedAt = nil
+                record.awaitingInputReason = nil
+                record.awaitingInputObservedAt = nil
+                try record.update(db)
+                return AppliedTerminalSessionStart(
+                    sessionID: sessionID,
+                    transcriptPath: record.transcriptPath,
+                    orderObservedAt: nil,
+                    activityObservation: nil)
+            }
             if let storedSessionOrder = record.sessionOrderObservedAt,
                storedSessionOrder >= observedAt {
                 return nil
             }
             record.sessionOrderObservedAt = observedAt
 
-            let isCodex = record.kind == TerminalKind.codex.rawValue
-                || record.label == TerminalLabel.codex
-            let activityObservation: AppliedTerminalActivityObservation?
-            if isCodex {
-                activityObservation = applyActivityObservationToRecord(
-                    to: &record,
-                    activityState: .idle,
-                    source: .hookEvent("SessionStart"),
-                    observedAt: observedAt,
-                    replaceSameValue: true
-                )
-            } else {
-                let storedActivityOrder = record.activityStateOrderObservedAt
-                    ?? record.activityStateObservedAt
-                if storedActivityOrder.map({ $0 < observedAt }) != false {
-                    record.activityStateOrderObservedAt = observedAt
-                }
-                activityObservation = nil
-            }
+            let activityObservation = applyActivityObservationToRecord(
+                to: &record,
+                activityState: .idle,
+                source: .hookEvent("SessionStart"),
+                observedAt: observedAt,
+                replaceSameValue: true
+            )
 
             record.claudeSessionID = sessionID
             if let transcriptPath {
@@ -448,8 +458,7 @@ public struct TerminalStore: Sendable {
             }
             // The activity helper performs this when it accepts Codex's idle
             // fact. Keep the independent call so a rejected stale activity
-            // transition and every non-Codex SessionStart still retract only
-            // a prompt known to be strictly older.
+            // transition still retracts only a prompt known to be older.
             clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
             try record.update(db)
             return AppliedTerminalSessionStart(
@@ -554,15 +563,15 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Apply an externally observed activity fact only when it is not older
-    /// than the ordering watermark already stored for the terminal.
+    /// Apply a Codex or explicit-interrupt activity fact only when it is not
+    /// older than the ordering watermark already stored for the terminal.
     ///
     /// The ordering comparison and write share one database-writer
     /// transaction. Callers may therefore do
     /// arbitrary asynchronous work between observing an event and reaching
     /// this method without allowing that older event to roll back a newer one.
     ///
-    /// A repeated generic value advances only the ordering watermark and clears
+    /// A repeated Codex value advances only the ordering watermark and clears
     /// an awaiting-input reason strictly older than itself. Its semantic transition
     /// timestamp and source remain unchanged, which both preserves
     /// hibernation's at-rest clock and prevents an idle echo from erasing an
@@ -571,7 +580,9 @@ public struct TerminalStore: Sendable {
     /// interrupt and SessionStart) opt into replacement. Exact timestamp ties
     /// cannot establish event order, so explicit interrupts and permission
     /// waits are preserved, while ambiguous working/non-working ties resolve
-    /// toward non-working; the next strictly newer hook advances order.
+    /// toward non-working; the next strictly newer hook advances order. Other
+    /// agent hooks retain their established changed-value replacement and
+    /// same-value no-op behavior.
     public func applyActivityObservation(
         id: UUID,
         activityState: TerminalActivityState,
@@ -582,6 +593,28 @@ public struct TerminalStore: Sendable {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
+            }
+            let usesOrderedCodexActivity = record.kind == TerminalKind.codex.rawValue
+                || record.label == TerminalLabel.codex
+                || source == .terminalInterrupt
+            guard usesOrderedCodexActivity else {
+                // This API is public to the daemon module, so keep the scope
+                // boundary here as well as at the RPC router. An accidental
+                // non-Codex caller must retain the pre-existing changed-value
+                // replacement and same-value no-op behavior.
+                guard record.activityState != activityState.rawValue else { return nil }
+                record.activityState = activityState.rawValue
+                record.activityStateSource = FactColumnJSON.encode(source)
+                record.activityStateObservedAt = observedAt
+                record.activityStateOrderObservedAt = observedAt
+                record.awaitingInputReason = nil
+                record.awaitingInputObservedAt = nil
+                try record.update(db)
+                return AppliedTerminalActivityObservation(
+                    activityState: activityState,
+                    source: source,
+                    observedAt: observedAt,
+                    orderObservedAt: observedAt)
             }
             guard let application = applyActivityObservationToRecord(
                 to: &record,

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -147,6 +147,15 @@ private func preservesStoredActivityAtEqualOrder(
     return storedState != .working && incomingState == .working
 }
 
+private func clearAwaitingInputIfNotNewer(
+    record: inout TerminalRecord,
+    than observedAt: Date
+) {
+    guard record.awaitingInputObservedAt.map({ $0 > observedAt }) != true else { return }
+    record.awaitingInputReason = nil
+    record.awaitingInputObservedAt = nil
+}
+
 /// Provides CRUD operations for terminals.
 public struct TerminalStore: Sendable {
     let writer: any DatabaseWriter
@@ -424,9 +433,10 @@ public struct TerminalStore: Sendable {
     /// this method without allowing that older event to roll back a newer one.
     ///
     /// A repeated generic value advances only the ordering watermark and clears
-    /// an obsolete awaiting-input reason. Its semantic transition timestamp and
-    /// source remain unchanged, which both preserves hibernation's at-rest
-    /// clock and prevents an idle echo from erasing an explicit interrupt.
+    /// an awaiting-input reason no newer than itself. Its semantic transition
+    /// timestamp and source remain unchanged, which both preserves
+    /// hibernation's at-rest clock and prevents an idle echo from erasing an
+    /// explicit interrupt.
     /// Events that establish meaningful same-value provenance (currently a user
     /// interrupt and SessionStart) opt into replacement. Exact timestamp ties
     /// cannot establish event order, so explicit interrupts and permission
@@ -469,8 +479,7 @@ public struct TerminalStore: Sendable {
                let storedSource,
                let storedObservedAt = record.activityStateObservedAt {
                 record.activityStateOrderObservedAt = observedAt
-                record.awaitingInputReason = nil
-                record.awaitingInputObservedAt = nil
+                clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
                 try record.update(db)
                 return AppliedTerminalActivityObservation(
                     activityState: activityState,
@@ -484,8 +493,7 @@ public struct TerminalStore: Sendable {
             record.activityStateSource = FactColumnJSON.encode(source)
             record.activityStateObservedAt = observedAt
             record.activityStateOrderObservedAt = observedAt
-            record.awaitingInputReason = nil
-            record.awaitingInputObservedAt = nil
+            clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
             try record.update(db)
             return AppliedTerminalActivityObservation(
                 activityState: activityState,

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -397,9 +397,13 @@ public struct TerminalStore: Sendable {
     ///
     /// A prompt at the same timestamp wins the tie, matching
     /// `SessionStateResolver`: SessionStart cannot prove whether that more
-    /// specific wait was raised before or after it. Claude does not assert an
-    /// activity value here, but still advances the ordering watermark so an
-    /// older activity or SessionStart cannot finish late and roll the row back.
+    /// specific wait was raised before or after it. SessionStart itself is
+    /// first-wins at an equal activity watermark: a differently-identified
+    /// event cannot roll identity backward, while an exact retry is an
+    /// idempotent no-op and therefore cannot move a transcript boundary.
+    /// Claude does not assert an activity value here, but still advances the
+    /// ordering watermark so an older activity or SessionStart cannot finish
+    /// late and roll the row back.
     func applySessionStart(
         id: UUID,
         sessionID: String,
@@ -411,6 +415,11 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             if record.awaitingInputObservedAt.map({ $0 >= observedAt }) == true {
+                return nil
+            }
+            let storedOrderObservedAt = record.activityStateOrderObservedAt
+                ?? record.activityStateObservedAt
+            if storedOrderObservedAt == observedAt {
                 return nil
             }
 
@@ -427,8 +436,6 @@ public struct TerminalStore: Sendable {
                 ) else { return nil }
                 activityObservation = applied
             } else {
-                let storedOrderObservedAt = record.activityStateOrderObservedAt
-                    ?? record.activityStateObservedAt
                 if let storedOrderObservedAt, storedOrderObservedAt > observedAt {
                     return nil
                 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -391,6 +391,55 @@ public struct TerminalStore: Sendable {
         }
     }
 
+    /// Apply an externally observed activity fact only when it is not older
+    /// than the fact already stored for the terminal.
+    ///
+    /// The timestamp comparison and the complete `{state, source, observedAt}`
+    /// write share one database-writer transaction. Callers may therefore do
+    /// arbitrary asynchronous work between observing an event and reaching
+    /// this method without allowing that older event to roll back a newer one.
+    ///
+    /// Repeated hook values remain no-ops by default so a generic idle echo
+    /// cannot erase more specific provenance such as an explicit interrupt.
+    /// Events that establish meaningful same-value provenance (currently a
+    /// user interrupt and SessionStart) opt into replacement. Exact timestamp
+    /// ties cannot establish event order, so an already-stored user interrupt
+    /// wins over a hook observation; the next strictly newer hook supersedes it.
+    public func applyActivityObservation(
+        id: UUID,
+        activityState: TerminalActivityState,
+        source: FactSource,
+        observedAt: Date,
+        replaceSameValue: Bool = false
+    ) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            if let storedObservedAt = record.activityStateObservedAt,
+               storedObservedAt > observedAt {
+                return false
+            }
+            if record.activityStateObservedAt == observedAt,
+               FactColumnJSON.decode(FactSource.self, from: record.activityStateSource)
+                == .terminalInterrupt,
+               source != .terminalInterrupt {
+                return false
+            }
+            if record.activityState == activityState.rawValue, !replaceSameValue {
+                return false
+            }
+
+            record.activityState = activityState.rawValue
+            record.activityStateSource = FactColumnJSON.encode(source)
+            record.activityStateObservedAt = observedAt
+            record.awaitingInputReason = nil
+            record.awaitingInputObservedAt = nil
+            try record.update(db)
+            return true
+        }
+    }
+
     /// Record a wait reason observed by a hook, WITHOUT asserting an activity
     /// state.
     ///

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -135,6 +135,12 @@ public struct AppliedTerminalActivityObservation: Sendable {
     public let orderObservedAt: Date
 }
 
+struct AppliedTerminalSessionStart: Sendable {
+    let sessionID: String
+    let transcriptPath: String?
+    let activityObservation: AppliedTerminalActivityObservation?
+}
+
 private func preservesStoredActivityAtEqualOrder(
     storedState: TerminalActivityState,
     storedSource: FactSource?,
@@ -151,9 +157,64 @@ private func clearAwaitingInputIfNotNewer(
     record: inout TerminalRecord,
     than observedAt: Date
 ) {
-    guard record.awaitingInputObservedAt.map({ $0 > observedAt }) != true else { return }
+    guard record.awaitingInputObservedAt.map({ $0 >= observedAt }) != true else { return }
     record.awaitingInputReason = nil
     record.awaitingInputObservedAt = nil
+}
+
+private func applyActivityObservationToRecord(
+    to record: inout TerminalRecord,
+    activityState: TerminalActivityState,
+    source: FactSource,
+    observedAt: Date,
+    replaceSameValue: Bool
+) -> AppliedTerminalActivityObservation? {
+    let storedOrderObservedAt = record.activityStateOrderObservedAt
+        ?? record.activityStateObservedAt
+    if let storedOrderObservedAt, storedOrderObservedAt > observedAt {
+        return nil
+    }
+    let storedSource = FactColumnJSON.decode(
+        FactSource.self, from: record.activityStateSource)
+    let storedState = record.activityState.flatMap(TerminalActivityState.init(rawValue:))
+        ?? .unknown
+    if storedOrderObservedAt == observedAt,
+       preservesStoredActivityAtEqualOrder(
+           storedState: storedState,
+           storedSource: storedSource,
+           incomingState: activityState,
+           incomingSource: source) {
+        return nil
+    }
+
+    let sameCompleteFact = record.activityState == activityState.rawValue
+        && storedSource != nil
+        && record.activityStateObservedAt != nil
+        && !replaceSameValue
+    if sameCompleteFact,
+       let storedSource,
+       let storedObservedAt = record.activityStateObservedAt {
+        record.activityStateOrderObservedAt = observedAt
+        clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
+        return AppliedTerminalActivityObservation(
+            activityState: activityState,
+            source: storedSource,
+            observedAt: storedObservedAt,
+            orderObservedAt: observedAt
+        )
+    }
+
+    record.activityState = activityState.rawValue
+    record.activityStateSource = FactColumnJSON.encode(source)
+    record.activityStateObservedAt = observedAt
+    record.activityStateOrderObservedAt = observedAt
+    clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
+    return AppliedTerminalActivityObservation(
+        activityState: activityState,
+        source: source,
+        observedAt: observedAt,
+        orderObservedAt: observedAt
+    )
 }
 
 /// Provides CRUD operations for terminals.
@@ -309,10 +370,9 @@ public struct TerminalStore: Sendable {
     }
 
     /// Update the Claude session ID and the absolute JSONL transcript path for
-    /// a terminal in one write. Used by the SessionStart hook bridge so the
-    /// transcript handler can target the exact file Claude is writing without
-    /// re-deriving the project directory from cwd (which is fragile across
-    /// `/clear` and `/compact` rollovers).
+    /// a terminal in one write. Direct lifecycle callers use this when they do
+    /// not have a SessionStart observation to order; the hook bridge uses
+    /// `applySessionStart` below.
     public func updateSession(id: UUID, sessionID: String, transcriptPath: String?) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
@@ -328,6 +388,68 @@ public struct TerminalStore: Sendable {
                 record.transcriptPath = transcriptPath
             }
             try record.update(db)
+        }
+    }
+
+    /// Apply a SessionStart as one ordered database fact. Session identity,
+    /// prompt retraction, the shared event-order watermark, and Codex's idle
+    /// transition either all advance together or none do.
+    ///
+    /// A prompt at the same timestamp wins the tie, matching
+    /// `SessionStateResolver`: SessionStart cannot prove whether that more
+    /// specific wait was raised before or after it. Claude does not assert an
+    /// activity value here, but still advances the ordering watermark so an
+    /// older activity or SessionStart cannot finish late and roll the row back.
+    func applySessionStart(
+        id: UUID,
+        sessionID: String,
+        transcriptPath: String?,
+        observedAt: Date
+    ) async throws -> AppliedTerminalSessionStart? {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            if record.awaitingInputObservedAt.map({ $0 >= observedAt }) == true {
+                return nil
+            }
+
+            let isCodex = record.kind == TerminalKind.codex.rawValue
+                || record.label == TerminalLabel.codex
+            let activityObservation: AppliedTerminalActivityObservation?
+            if isCodex {
+                guard let applied = applyActivityObservationToRecord(
+                    to: &record,
+                    activityState: .idle,
+                    source: .hookEvent("SessionStart"),
+                    observedAt: observedAt,
+                    replaceSameValue: true
+                ) else { return nil }
+                activityObservation = applied
+            } else {
+                let storedOrderObservedAt = record.activityStateOrderObservedAt
+                    ?? record.activityStateObservedAt
+                if let storedOrderObservedAt, storedOrderObservedAt > observedAt {
+                    return nil
+                }
+                record.activityStateOrderObservedAt = observedAt
+                clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
+                activityObservation = nil
+            }
+
+            record.claudeSessionID = sessionID
+            if let transcriptPath {
+                record.transcriptPath = transcriptPath
+            }
+            // The activity helper already performs this for Codex. Keep the
+            // call here so Claude and any future non-Codex agent share the
+            // same strict-older prompt retraction rule.
+            clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
+            try record.update(db)
+            return AppliedTerminalSessionStart(
+                sessionID: sessionID,
+                transcriptPath: record.transcriptPath,
+                activityObservation: activityObservation)
         }
     }
 
@@ -433,7 +555,7 @@ public struct TerminalStore: Sendable {
     /// this method without allowing that older event to roll back a newer one.
     ///
     /// A repeated generic value advances only the ordering watermark and clears
-    /// an awaiting-input reason no newer than itself. Its semantic transition
+    /// an awaiting-input reason strictly older than itself. Its semantic transition
     /// timestamp and source remain unchanged, which both preserves
     /// hibernation's at-rest clock and prevents an idle echo from erasing an
     /// explicit interrupt.
@@ -453,54 +575,15 @@ public struct TerminalStore: Sendable {
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
-            let storedOrderObservedAt = record.activityStateOrderObservedAt
-                ?? record.activityStateObservedAt
-            if let storedOrderObservedAt, storedOrderObservedAt > observedAt {
-                return nil
-            }
-            let storedSource = FactColumnJSON.decode(
-                FactSource.self, from: record.activityStateSource)
-            let storedState = record.activityState.flatMap(TerminalActivityState.init(rawValue:))
-                ?? .unknown
-            if storedOrderObservedAt == observedAt,
-               preservesStoredActivityAtEqualOrder(
-                   storedState: storedState,
-                   storedSource: storedSource,
-                   incomingState: activityState,
-                   incomingSource: source) {
-                return nil
-            }
-
-            let sameCompleteFact = record.activityState == activityState.rawValue
-                && storedSource != nil
-                && record.activityStateObservedAt != nil
-                && !replaceSameValue
-            if sameCompleteFact,
-               let storedSource,
-               let storedObservedAt = record.activityStateObservedAt {
-                record.activityStateOrderObservedAt = observedAt
-                clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
-                try record.update(db)
-                return AppliedTerminalActivityObservation(
-                    activityState: activityState,
-                    source: storedSource,
-                    observedAt: storedObservedAt,
-                    orderObservedAt: observedAt
-                )
-            }
-
-            record.activityState = activityState.rawValue
-            record.activityStateSource = FactColumnJSON.encode(source)
-            record.activityStateObservedAt = observedAt
-            record.activityStateOrderObservedAt = observedAt
-            clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
-            try record.update(db)
-            return AppliedTerminalActivityObservation(
+            guard let application = applyActivityObservationToRecord(
+                to: &record,
                 activityState: activityState,
                 source: source,
                 observedAt: observedAt,
-                orderObservedAt: observedAt
-            )
+                replaceSameValue: replaceSameValue
+            ) else { return nil }
+            try record.update(db)
+            return application
         }
     }
 

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -32,6 +32,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// written before v70 and on any row stamped without provenance.
     var activityStateSource: String?
     var activityStateObservedAt: Date?
+    var activityStateOrderObservedAt: Date?
     /// JSON-encoded `AwaitingInputReason`, carried verbatim from the
     /// `Notification` hook. nil when the session is not waiting, or when the
     /// wait carried no structured reason.
@@ -60,6 +61,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.watch_desk_role = terminal.watchDeskRole?.rawValue
         self.activityStateSource = FactColumnJSON.encode(terminal.activityStateSource)
         self.activityStateObservedAt = terminal.activityStateObservedAt
+        self.activityStateOrderObservedAt = terminal.activityStateOrderObservedAt
         self.awaitingInputReason = FactColumnJSON.encode(terminal.awaitingInputReason)
         self.awaitingInputObservedAt = terminal.awaitingInputObservedAt
     }
@@ -100,6 +102,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             },
             activityStateSource: FactColumnJSON.decode(FactSource.self, from: activityStateSource),
             activityStateObservedAt: activityStateObservedAt,
+            activityStateOrderObservedAt: activityStateOrderObservedAt,
             awaitingInputReason: FactColumnJSON.decode(AwaitingInputReason.self, from: awaitingInputReason),
             awaitingInputObservedAt: awaitingInputObservedAt
         )
@@ -123,6 +126,25 @@ enum FactColumnJSON {
         guard let json, let data = json.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(type, from: data)
     }
+}
+
+public struct AppliedTerminalActivityObservation: Sendable {
+    public let activityState: TerminalActivityState
+    public let source: FactSource
+    public let observedAt: Date
+    public let orderObservedAt: Date
+}
+
+private func preservesStoredActivityAtEqualOrder(
+    storedState: TerminalActivityState,
+    storedSource: FactSource?,
+    incomingState: TerminalActivityState,
+    incomingSource: FactSource
+) -> Bool {
+    if incomingSource == .terminalInterrupt { return false }
+    if storedSource == .terminalInterrupt { return true }
+    if storedState == .waitingForUser, incomingState != .waitingForUser { return true }
+    return storedState != .working && incomingState == .working
 }
 
 /// Provides CRUD operations for terminals.
@@ -322,6 +344,7 @@ public struct TerminalStore: Sendable {
             record.activityState = TerminalActivityState.unknown.rawValue
             record.activityStateSource = FactColumnJSON.encode(FactSource.derived)
             record.activityStateObservedAt = date
+            record.activityStateOrderObservedAt = date
             record.awaitingInputReason = nil
             record.awaitingInputObservedAt = nil
             try record.update(db)
@@ -379,6 +402,7 @@ public struct TerminalStore: Sendable {
             record.activityState = activityState.rawValue
             record.activityStateSource = FactColumnJSON.encode(source)
             record.activityStateObservedAt = observedAt
+            record.activityStateOrderObservedAt = observedAt
             // Unconditional, including the nil case: this IS the superseding
             // rail. A caller that observes a new activity state without naming
             // a reason clears the old one, so a "needs your permission"
@@ -392,51 +416,83 @@ public struct TerminalStore: Sendable {
     }
 
     /// Apply an externally observed activity fact only when it is not older
-    /// than the fact already stored for the terminal.
+    /// than the ordering watermark already stored for the terminal.
     ///
-    /// The timestamp comparison and the complete `{state, source, observedAt}`
-    /// write share one database-writer transaction. Callers may therefore do
+    /// The ordering comparison and write share one database-writer
+    /// transaction. Callers may therefore do
     /// arbitrary asynchronous work between observing an event and reaching
     /// this method without allowing that older event to roll back a newer one.
     ///
-    /// Repeated hook values remain no-ops by default so a generic idle echo
-    /// cannot erase more specific provenance such as an explicit interrupt.
-    /// Events that establish meaningful same-value provenance (currently a
-    /// user interrupt and SessionStart) opt into replacement. Exact timestamp
-    /// ties cannot establish event order, so an already-stored user interrupt
-    /// wins over a hook observation; the next strictly newer hook supersedes it.
+    /// A repeated generic value advances only the ordering watermark and clears
+    /// an obsolete awaiting-input reason. Its semantic transition timestamp and
+    /// source remain unchanged, which both preserves hibernation's at-rest
+    /// clock and prevents an idle echo from erasing an explicit interrupt.
+    /// Events that establish meaningful same-value provenance (currently a user
+    /// interrupt and SessionStart) opt into replacement. Exact timestamp ties
+    /// cannot establish event order, so explicit interrupts and permission
+    /// waits are preserved, while ambiguous working/non-working ties resolve
+    /// toward non-working; the next strictly newer hook advances order.
     public func applyActivityObservation(
         id: UUID,
         activityState: TerminalActivityState,
         source: FactSource,
         observedAt: Date,
         replaceSameValue: Bool = false
-    ) async throws -> Bool {
+    ) async throws -> AppliedTerminalActivityObservation? {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
-            if let storedObservedAt = record.activityStateObservedAt,
-               storedObservedAt > observedAt {
-                return false
+            let storedOrderObservedAt = record.activityStateOrderObservedAt
+                ?? record.activityStateObservedAt
+            if let storedOrderObservedAt, storedOrderObservedAt > observedAt {
+                return nil
             }
-            if record.activityStateObservedAt == observedAt,
-               FactColumnJSON.decode(FactSource.self, from: record.activityStateSource)
-                == .terminalInterrupt,
-               source != .terminalInterrupt {
-                return false
+            let storedSource = FactColumnJSON.decode(
+                FactSource.self, from: record.activityStateSource)
+            let storedState = record.activityState.flatMap(TerminalActivityState.init(rawValue:))
+                ?? .unknown
+            if storedOrderObservedAt == observedAt,
+               preservesStoredActivityAtEqualOrder(
+                   storedState: storedState,
+                   storedSource: storedSource,
+                   incomingState: activityState,
+                   incomingSource: source) {
+                return nil
             }
-            if record.activityState == activityState.rawValue, !replaceSameValue {
-                return false
+
+            let sameCompleteFact = record.activityState == activityState.rawValue
+                && storedSource != nil
+                && record.activityStateObservedAt != nil
+                && !replaceSameValue
+            if sameCompleteFact,
+               let storedSource,
+               let storedObservedAt = record.activityStateObservedAt {
+                record.activityStateOrderObservedAt = observedAt
+                record.awaitingInputReason = nil
+                record.awaitingInputObservedAt = nil
+                try record.update(db)
+                return AppliedTerminalActivityObservation(
+                    activityState: activityState,
+                    source: storedSource,
+                    observedAt: storedObservedAt,
+                    orderObservedAt: observedAt
+                )
             }
 
             record.activityState = activityState.rawValue
             record.activityStateSource = FactColumnJSON.encode(source)
             record.activityStateObservedAt = observedAt
+            record.activityStateOrderObservedAt = observedAt
             record.awaitingInputReason = nil
             record.awaitingInputObservedAt = nil
             try record.update(db)
-            return true
+            return AppliedTerminalActivityObservation(
+                activityState: activityState,
+                source: source,
+                observedAt: observedAt,
+                orderObservedAt: observedAt
+            )
         }
     }
 
@@ -576,6 +632,7 @@ public struct TerminalStore: Sendable {
             // awaiting-input reason is cleared with it.
             record.activityStateSource = FactColumnJSON.encode(FactSource.database)
             record.activityStateObservedAt = date
+            record.activityStateOrderObservedAt = date
             record.awaitingInputReason = nil
             record.awaitingInputObservedAt = nil
             try record.update(db)

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -588,6 +588,7 @@ public struct TerminalStore: Sendable {
         activityState: TerminalActivityState,
         source: FactSource,
         observedAt: Date,
+        sessionID: String? = nil,
         replaceSameValue: Bool = false
     ) async throws -> AppliedTerminalActivityObservation? {
         try await writer.write { db in
@@ -615,6 +616,15 @@ public struct TerminalStore: Sendable {
                     source: source,
                     observedAt: observedAt,
                     orderObservedAt: observedAt)
+            }
+            // Codex writes session identity into every supported hook payload.
+            // Check it in this transaction, rather than against the terminal
+            // loaded by the router, so a delayed old-session event cannot race
+            // an accepted SessionStart. Identity-free callers retain legacy
+            // behavior for already-running sessions with an older hook overlay
+            // and for the app's explicit interrupt.
+            if let sessionID, sessionID != record.claudeSessionID {
+                return nil
             }
             guard let application = applyActivityObservationToRecord(
                 to: &record,

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -138,6 +138,7 @@ public struct AppliedTerminalActivityObservation: Sendable {
 struct AppliedTerminalSessionStart: Sendable {
     let sessionID: String
     let transcriptPath: String?
+    let orderObservedAt: Date
     let activityObservation: AppliedTerminalActivityObservation?
 }
 
@@ -456,6 +457,7 @@ public struct TerminalStore: Sendable {
             return AppliedTerminalSessionStart(
                 sessionID: sessionID,
                 transcriptPath: record.transcriptPath,
+                orderObservedAt: observedAt,
                 activityObservation: activityObservation)
         }
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -519,10 +519,15 @@ extension RPCRouter {
                 worktreeID: terminals[index].worktreeID))
         }
 
-        let codexStates = await codexActivityTracker.observe(transcripts: codexTargets)
+        let codexObservation = await codexActivityTracker.observeStamped(
+            transcripts: codexTargets,
+            now: now)
         for index in terminals.indices where terminals[index].isCodexTerminal {
-            guard let transcriptPath = terminals[index].transcriptPath else { continue }
-            terminals[index].presentationActivityState = codexStates[transcriptPath]
+            let transcriptPath = terminals[index].transcriptPath
+            terminals[index].presentationActivityState = transcriptPath.flatMap {
+                codexObservation.states[$0]
+            }
+            terminals[index].presentationActivityObservedAt = codexObservation.observedAt
         }
 
         await codexActivityTracker.retain(
@@ -2854,7 +2859,7 @@ extension RPCRouter {
         // the machine signal that the pane is between turns; its ordered idle
         // observation is applied below.
         try await db.terminals.clearAwaitingInputReason(id: terminal.id)
-        let codexActivityApplied: Bool
+        let codexActivityApplication: AppliedTerminalActivityObservation?
         if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             // This handler is driven by the session-start hook, which is what
             // told us the session exists and is between turns.
@@ -2863,11 +2868,11 @@ extension RPCRouter {
             // every other stamp this file writes: `SessionStateResolver`'s
             // rung 4 *compares* it, and the store's default `Date()` is a
             // timestamp nothing outside the store can name.
-            codexActivityApplied = try await db.terminals.applyActivityObservation(
+            codexActivityApplication = try await db.terminals.applyActivityObservation(
                 id: terminal.id, activityState: .idle, source: .hookEvent("SessionStart"),
                 observedAt: observedAt, replaceSameValue: true)
         } else {
-            codexActivityApplied = false
+            codexActivityApplication = nil
         }
 
         // Invalidate cached transcript parse for the OLD session file (if any)
@@ -2890,13 +2895,14 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )))
-        if codexActivityApplied {
+        if let application = codexActivityApplication {
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
                 terminalID: terminal.id,
                 worktreeID: terminal.worktreeID,
-                activityState: .idle,
-                activityStateSource: .hookEvent("SessionStart"),
-                activityStateObservedAt: observedAt
+                activityState: application.activityState,
+                activityStateSource: application.source,
+                activityStateObservedAt: application.observedAt,
+                activityStateOrderObservedAt: application.orderObservedAt
             )))
         }
         return .ok()
@@ -3049,19 +3055,20 @@ extension RPCRouter {
         let source: FactSource = params.origin == .userInterrupt
             ? .terminalInterrupt
             : .hookEvent(RPCMethod.terminalActivityEvent)
-        let activityApplied = try await db.terminals.applyActivityObservation(
+        let activityApplication = try await db.terminals.applyActivityObservation(
             id: terminal.id,
             activityState: params.activityState,
             source: source,
             observedAt: observedAt,
             replaceSameValue: params.origin == .userInterrupt)
-        guard activityApplied else { return .ok() }
+        guard let activityApplication else { return .ok() }
         subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,
-            activityState: params.activityState,
-            activityStateSource: source,
-            activityStateObservedAt: observedAt
+            activityState: activityApplication.activityState,
+            activityStateSource: activityApplication.source,
+            activityStateObservedAt: activityApplication.observedAt,
+            activityStateOrderObservedAt: activityApplication.orderObservedAt
         )))
         return .ok()
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3070,10 +3070,7 @@ extension RPCRouter {
         // between exactly this stamp and the one `recordAwaitingInputReason`
         // writes above, so a test that cannot pin both ends cannot pin the
         // decision at all.
-        let source: FactSource = params.origin == .userInterrupt
-            ? .terminalInterrupt
-            : .hookEvent(RPCMethod.terminalActivityEvent)
-        guard terminal.isCodexTerminal || params.origin == .userInterrupt else {
+        guard terminal.isCodexTerminal else {
             // Claude and shell hooks retain their established last-writer
             // behavior. Their persisted activity is a hibernation input, not
             // Codex transcript presentation, so this fix must not impose the
@@ -3092,7 +3089,7 @@ extension RPCRouter {
             try await db.terminals.setActivityState(
                 id: terminal.id,
                 activityState: params.activityState,
-                source: source,
+                source: .hookEvent(RPCMethod.terminalActivityEvent),
                 observedAt: observedAt)
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
                 terminalID: terminal.id,
@@ -3101,6 +3098,9 @@ extension RPCRouter {
             )))
             return .ok()
         }
+        let source: FactSource = params.origin == .userInterrupt
+            ? .terminalInterrupt
+            : .hookEvent(RPCMethod.terminalActivityEvent)
         let activityApplication = try await db.terminals.applyActivityObservation(
             id: terminal.id,
             activityState: params.activityState,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -16,6 +16,7 @@ private struct TranscriptParseCacheEntry {
 private struct CodexPresentationIdentity: Equatable {
     let sessionID: String?
     let transcriptPath: String?
+    let activityOrderObservedAt: Date?
 }
 
 /// Caches the last `TranscriptParser.parse` result per session file path.
@@ -513,22 +514,36 @@ extension RPCRouter {
         let params = try decoder.decode(TerminalListParams.self, from: paramsData)
         var terminals = try await db.terminals.list(worktreeID: params.worktreeID)
         var codexTargets: [CodexTranscriptActivityTracker.Target] = []
+        var durableBoundaryTargets: [CodexTranscriptActivityTracker.Target] = []
         let observedIdentities = Dictionary(uniqueKeysWithValues: terminals
             .filter(\.isCodexTerminal)
             .map {
                 ($0.id, CodexPresentationIdentity(
                     sessionID: $0.claudeSessionID,
-                    transcriptPath: $0.transcriptPath))
+                    transcriptPath: $0.transcriptPath,
+                    activityOrderObservedAt: $0.activityStateOrderObservedAt
+                        ?? $0.activityStateObservedAt))
             })
 
         for index in terminals.indices where terminals[index].isCodexTerminal {
             guard let transcriptPath = terminals[index].transcriptPath,
                   !transcriptPath.isEmpty else { continue }
-            codexTargets.append(CodexTranscriptActivityTracker.Target(
+            let target = CodexTranscriptActivityTracker.Target(
                 transcriptPath: transcriptPath,
-                worktreeID: terminals[index].worktreeID))
+                worktreeID: terminals[index].worktreeID)
+            codexTargets.append(target)
+            if terminals[index].observedActivity?.source == .hookEvent("SessionStart") {
+                durableBoundaryTargets.append(target)
+            }
         }
 
+        // SessionStart's persisted activity fact is the restart-safe boundary
+        // cue. On a fresh tracker, start at the path's current EOF rather than
+        // replaying an orphan task_started from before that lifecycle event.
+        // Existing baselines are never moved, so later appended turns remain
+        // visible even while SessionStart is still the last raw hook fact.
+        await codexActivityTracker.establishSessionBoundariesIfAbsent(
+            transcripts: durableBoundaryTargets)
         let codexObservation = await codexActivityTracker.observeStamped(
             transcripts: codexTargets,
             now: now)
@@ -548,7 +563,9 @@ extension RPCRouter {
             }
             let currentIdentity = CodexPresentationIdentity(
                 sessionID: terminals[index].claudeSessionID,
-                transcriptPath: transcriptPath)
+                transcriptPath: transcriptPath,
+                activityOrderObservedAt: terminals[index].activityStateOrderObservedAt
+                    ?? terminals[index].activityStateObservedAt)
             guard observedIdentities[terminals[index].id] == currentIdentity else {
                 terminals[index].presentationActivityState = nil
                 terminals[index].presentationActivityObservedAt = codexObservation.observedAt

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3034,19 +3034,6 @@ extension RPCRouter {
             await sessionCounters.recordHookEvent(terminalID: terminal.id, at: observedAt)
         }
 
-        // UserPromptSubmit reaches the daemon as activity=working. If a
-        // session-limit auto-resume is pending, the user just continued
-        // manually — cancel it (spec §Cancellation). Guarded on the mirror
-        // field so the common case costs nothing. Note: the actuator's own
-        // "continue" also lands here; by then verification usually already
-        // moved the row out of pending, and a cancel-vs-sent race only
-        // affects the audit status, never causes a second send.
-        if params.activityState == .working, terminal.pendingResumeAt != nil {
-            if (try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)) == true {
-                await limitResumeScheduler?.wake()
-            }
-        }
-
         // Stop-hook transcript sync (Stop/StopFailure reach the daemon as
         // activity=idle): when a session finishes a turn and its recorded
         // transcript lives OUTSIDE the project dir derived from the worktree's
@@ -3091,6 +3078,16 @@ extension RPCRouter {
             // behavior. Their persisted activity is a hibernation input, not
             // Codex transcript presentation, so this fix must not impose the
             // new ordering and tie-precedence policy on them.
+            // UserPromptSubmit reaches the daemon as activity=working. If a
+            // session-limit auto-resume is pending, the user just continued
+            // manually — cancel it even when the legacy activity value is
+            // unchanged, preserving the established non-Codex behavior.
+            if params.activityState == .working, terminal.pendingResumeAt != nil {
+                if (try? await db.scheduledResumes.cancelPending(
+                    terminalID: terminal.id)) == true {
+                    await limitResumeScheduler?.wake()
+                }
+            }
             guard terminal.activityState != params.activityState else { return .ok() }
             try await db.terminals.setActivityState(
                 id: terminal.id,
@@ -3109,8 +3106,19 @@ extension RPCRouter {
             activityState: params.activityState,
             source: source,
             observedAt: observedAt,
+            sessionID: params.sessionID,
             replaceSameValue: params.origin == .userInterrupt)
         guard let activityApplication else { return .ok() }
+        // The transactional identity check above must accept a Codex working
+        // hook before it can cancel state belonging to the current session.
+        // The actuator's own "continue" also lands here; by then verification
+        // usually already moved the row out of pending, and a cancel-vs-sent
+        // race affects only audit status, never causes a second send.
+        if params.activityState == .working, terminal.pendingResumeAt != nil {
+            if (try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)) == true {
+                await limitResumeScheduler?.wake()
+            }
+        }
         subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2867,42 +2867,27 @@ extension RPCRouter {
             return p
         }()
 
-        try await db.terminals.updateSession(
+        // Session identity, prompt retraction, and (for Codex) the idle fact
+        // are one ordered store transaction. A delayed older SessionStart must
+        // not rewrite identity or clear a prompt before its activity fact is
+        // rejected as stale.
+        guard let sessionApplication = try await db.terminals.applySessionStart(
             id: terminal.id,
             sessionID: params.sessionID,
-            transcriptPath: cleanedPath
-        )
-        // A new session context has started in this pane — a `/clear`, a
-        // resume after an in-place profile swap, or a hand relaunch — so a
-        // wait reason recorded against the PREVIOUS one is not on screen any
-        // more. It has to be retracted here, from the event that establishes
-        // it, for two reasons `SessionStateResolver`'s rung 4 makes concrete.
-        // A `/clear` points `transcriptPath` at a file Claude Code creates
-        // lazily, so the growth fact is nil and "we could not look is not
-        // evidence it went away" keeps the dead prompt standing; and the
-        // overlay's own `tbd terminal-activity idle` — the rail that would
-        // otherwise clear the columns — no-ops when the row already reads idle
-        // and can be lost on its own while this call lands.
-        //
-        // Claude SessionStart says only that a session exists, not what it is
-        // doing, so it does not assert activity. Codex SessionStart is also
-        // the machine signal that the pane is between turns; its ordered idle
-        // observation is applied below.
-        try await db.terminals.clearAwaitingInputReason(id: terminal.id)
-        let codexActivityApplication: AppliedTerminalActivityObservation?
-        if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
-            // This handler is driven by the session-start hook, which is what
-            // told us the session exists and is between turns.
-            //
-            // `observedAt` from the router's date seam, for the same reason as
-            // every other stamp this file writes: `SessionStateResolver`'s
-            // rung 4 *compares* it, and the store's default `Date()` is a
-            // timestamp nothing outside the store can name.
-            codexActivityApplication = try await db.terminals.applyActivityObservation(
-                id: terminal.id, activityState: .idle, source: .hookEvent("SessionStart"),
-                observedAt: observedAt, replaceSameValue: true)
-        } else {
-            codexActivityApplication = nil
+            transcriptPath: cleanedPath,
+            observedAt: observedAt
+        ) else { return .ok() }
+
+        // The accepted SessionStart is also a lifecycle boundary in the Codex
+        // transcript reducer. Capture the current EOF even when the path is
+        // unchanged, so an unmatched task_started from the interrupted session
+        // cannot be re-published as working; later appended turns still win.
+        if sessionApplication.activityObservation != nil,
+           let transcriptPath = sessionApplication.transcriptPath,
+           !transcriptPath.isEmpty {
+            await codexActivityTracker.establishSessionBoundary(
+                transcriptPath: transcriptPath,
+                worktreeID: terminal.worktreeID)
         }
 
         // Invalidate cached transcript parse for the OLD session file (if any)
@@ -2911,7 +2896,7 @@ extension RPCRouter {
         // misses cache and re-parses — no explicit invalidation needed.)
 
         let source = params.source ?? "unknown"
-        logger.info("sessionEvent: terminal \(terminal.id.uuidString, privacy: .public) -> session \(params.sessionID, privacy: .public) (source=\(source, privacy: .public))")
+        logger.info("sessionEvent: terminal \(terminal.id.uuidString, privacy: .public) -> session \(sessionApplication.sessionID, privacy: .public) (source=\(source, privacy: .public))")
 
         // The readiness signal for a parked prompt on the paste path. This
         // hook is the machine fact that the agent is up — never the pane's
@@ -2922,10 +2907,10 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,
-            sessionID: params.sessionID,
-            transcriptPath: cleanedPath
+            sessionID: sessionApplication.sessionID,
+            transcriptPath: sessionApplication.transcriptPath
         )))
-        if let application = codexActivityApplication {
+        if let application = sessionApplication.activityObservation {
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
                 terminalID: terminal.id,
                 worktreeID: terminal.worktreeID,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -506,7 +506,20 @@ extension RPCRouter {
 
     func handleTerminalList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalListParams.self, from: paramsData)
-        let terminals = try await db.terminals.list(worktreeID: params.worktreeID)
+        var terminals = try await db.terminals.list(worktreeID: params.worktreeID)
+        var codexTranscriptPaths: Set<String> = []
+
+        for index in terminals.indices where terminals[index].isCodexTerminal {
+            guard let transcriptPath = terminals[index].transcriptPath,
+                  !transcriptPath.isEmpty else { continue }
+            codexTranscriptPaths.insert(transcriptPath)
+            terminals[index].presentationActivityState = await codexActivityTracker.observe(
+                transcriptPath: transcriptPath,
+                worktreeID: terminals[index].worktreeID)
+        }
+
+        await codexActivityTracker.retain(
+            transcriptPaths: codexTranscriptPaths, scope: params.worktreeID)
         return try RPCResponse(result: terminals)
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -16,7 +16,7 @@ private struct TranscriptParseCacheEntry {
 private struct CodexPresentationIdentity: Equatable {
     let sessionID: String?
     let transcriptPath: String?
-    let activityOrderObservedAt: Date?
+    let sessionOrderObservedAt: Date?
 }
 
 /// Caches the last `TranscriptParser.parse` result per session file path.
@@ -521,8 +521,7 @@ extension RPCRouter {
                 ($0.id, CodexPresentationIdentity(
                     sessionID: $0.claudeSessionID,
                     transcriptPath: $0.transcriptPath,
-                    activityOrderObservedAt: $0.activityStateOrderObservedAt
-                        ?? $0.activityStateObservedAt))
+                    sessionOrderObservedAt: $0.sessionOrderObservedAt))
             })
 
         for index in terminals.indices where terminals[index].isCodexTerminal {
@@ -532,16 +531,16 @@ extension RPCRouter {
                 transcriptPath: transcriptPath,
                 worktreeID: terminals[index].worktreeID)
             codexTargets.append(target)
-            if terminals[index].observedActivity?.source == .hookEvent("SessionStart") {
+            if terminals[index].sessionOrderObservedAt != nil {
                 durableBoundaryTargets.append(target)
             }
         }
 
-        // SessionStart's persisted activity fact is the restart-safe boundary
+        // SessionStart's persisted session generation is the restart-safe boundary
         // cue. On a fresh tracker, start at the path's current EOF rather than
         // replaying an orphan task_started from before that lifecycle event.
         // Existing baselines are never moved, so later appended turns remain
-        // visible even while SessionStart is still the last raw hook fact.
+        // visible after ordinary hooks replace the raw activity fact.
         await codexActivityTracker.establishSessionBoundariesIfAbsent(
             transcripts: durableBoundaryTargets)
         let codexObservation = await codexActivityTracker.observeStamped(
@@ -564,8 +563,7 @@ extension RPCRouter {
             let currentIdentity = CodexPresentationIdentity(
                 sessionID: terminals[index].claudeSessionID,
                 transcriptPath: transcriptPath,
-                activityOrderObservedAt: terminals[index].activityStateOrderObservedAt
-                    ?? terminals[index].activityStateObservedAt)
+                sessionOrderObservedAt: terminals[index].sessionOrderObservedAt)
             guard observedIdentities[terminals[index].id] == currentIdentity else {
                 terminals[index].presentationActivityState = nil
                 terminals[index].presentationActivityObservedAt = codexObservation.observedAt

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -508,14 +508,21 @@ extension RPCRouter {
         let params = try decoder.decode(TerminalListParams.self, from: paramsData)
         var terminals = try await db.terminals.list(worktreeID: params.worktreeID)
         var codexTranscriptPaths: Set<String> = []
+        var codexTargets: [CodexTranscriptActivityTracker.Target] = []
 
         for index in terminals.indices where terminals[index].isCodexTerminal {
             guard let transcriptPath = terminals[index].transcriptPath,
                   !transcriptPath.isEmpty else { continue }
             codexTranscriptPaths.insert(transcriptPath)
-            terminals[index].presentationActivityState = await codexActivityTracker.observe(
+            codexTargets.append(CodexTranscriptActivityTracker.Target(
                 transcriptPath: transcriptPath,
-                worktreeID: terminals[index].worktreeID)
+                worktreeID: terminals[index].worktreeID))
+        }
+
+        let codexStates = await codexActivityTracker.observe(transcripts: codexTargets)
+        for index in terminals.indices where terminals[index].isCodexTerminal {
+            guard let transcriptPath = terminals[index].transcriptPath else { continue }
+            terminals[index].presentationActivityState = codexStates[transcriptPath]
         }
 
         await codexActivityTracker.retain(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2882,11 +2882,10 @@ extension RPCRouter {
             return p
         }()
 
-        // Session identity, prompt retraction, and (for Codex) the idle fact
-        // are reconciled atomically on their independent ordering rails. A
-        // delayed old-session prompt must not suppress a genuine identity
-        // rollover, while a delayed SessionStart must not clear that newer
-        // prompt or regress activity.
+        // Codex session identity, prompt retraction, and the idle fact are
+        // reconciled atomically on independent ordering rails. Other agent
+        // kinds retain the established last-writer session and prompt update
+        // in the same transaction.
         guard let sessionApplication = try await db.terminals.applySessionStart(
             id: terminal.id,
             sessionID: params.sessionID,
@@ -3087,6 +3086,24 @@ extension RPCRouter {
         let source: FactSource = params.origin == .userInterrupt
             ? .terminalInterrupt
             : .hookEvent(RPCMethod.terminalActivityEvent)
+        guard terminal.isCodexTerminal || params.origin == .userInterrupt else {
+            // Claude and shell hooks retain their established last-writer
+            // behavior. Their persisted activity is a hibernation input, not
+            // Codex transcript presentation, so this fix must not impose the
+            // new ordering and tie-precedence policy on them.
+            guard terminal.activityState != params.activityState else { return .ok() }
+            try await db.terminals.setActivityState(
+                id: terminal.id,
+                activityState: params.activityState,
+                source: source,
+                observedAt: observedAt)
+            subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+                terminalID: terminal.id,
+                worktreeID: terminal.worktreeID,
+                activityState: params.activityState
+            )))
+            return .ok()
+        }
         let activityApplication = try await db.terminals.applyActivityObservation(
             id: terminal.id,
             activityState: params.activityState,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2839,6 +2839,7 @@ extension RPCRouter {
         // Deliberately NOT `setActivityState`: this event says a session
         // exists, not what it is doing, and `activityState` gates hibernation.
         try await db.terminals.clearAwaitingInputReason(id: terminal.id)
+        let codexActivityObservedAt: Date?
         if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             // This handler is driven by the session-start hook, which is what
             // told us the session exists and is between turns.
@@ -2847,9 +2848,13 @@ extension RPCRouter {
             // every other stamp this file writes: `SessionStateResolver`'s
             // rung 4 *compares* it, and the store's default `Date()` is a
             // timestamp nothing outside the store can name.
+            let observedAt = now()
+            codexActivityObservedAt = observedAt
             try await db.terminals.setActivityState(
                 id: terminal.id, activityState: .idle, source: .hookEvent("SessionStart"),
-                observedAt: now())
+                observedAt: observedAt)
+        } else {
+            codexActivityObservedAt = nil
         }
 
         // Invalidate cached transcript parse for the OLD session file (if any)
@@ -2872,11 +2877,13 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )))
-        if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
+        if let codexActivityObservedAt {
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
                 terminalID: terminal.id,
                 worktreeID: terminal.worktreeID,
-                activityState: .idle
+                activityState: .idle,
+                activityStateSource: .hookEvent("SessionStart"),
+                activityStateObservedAt: codexActivityObservedAt
             )))
         }
         return .ok()
@@ -2964,7 +2971,11 @@ extension RPCRouter {
         // and over is exactly the shape the counter exists to make visible, and
         // a count taken after that guard would report zero for it. One actor
         // hop and an integer add, which is the whole per-event budget.
-        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
+        // An app-originated interrupt shares this RPC but is a user action, not
+        // an agent hook, so it must not inflate the hook-event counter.
+        if params.origin == nil {
+            await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
+        }
 
         // UserPromptSubmit reaches the daemon as activity=working. If a
         // session-limit auto-resume is pending, the user just continued
@@ -3006,30 +3017,38 @@ extension RPCRouter {
             }
         }
 
-        guard terminal.activityState != params.activityState else {
+        // A user interrupt must replace provenance even when the raw value was
+        // already idle. Conversely, a repeated idle hook must not erase that
+        // explicit override; only a later value transition (notably a genuine
+        // working hook) supersedes it.
+        guard terminal.activityState != params.activityState || params.origin == .userInterrupt else {
             return .ok()
         }
 
-        // Every caller of this RPC is an agent hook bridged through
-        // `tbd terminal-activity`. The params do not yet carry WHICH hook event
-        // fired, so the RPC surface stands in as the source name until a later
-        // slice threads the event through — a coarser answer than we want, but
-        // a true one, and one no reader can mistake for an observation TBD made
-        // itself.
+        // Hook callers are bridged through `tbd terminal-activity`; the params
+        // do not yet carry WHICH hook event fired, so the RPC surface stands in
+        // as their source name. The app's explicit interrupt declares its
+        // origin separately and is persisted as a user action instead.
         // `observedAt` from the router's date seam, never the store's default
         // `Date()`. The resolver's rung-4 decision is an ordering comparison
         // between exactly this stamp and the one `recordAwaitingInputReason`
         // writes above, so a test that cannot pin both ends cannot pin the
         // decision at all.
+        let source: FactSource = params.origin == .userInterrupt
+            ? .terminalInterrupt
+            : .hookEvent(RPCMethod.terminalActivityEvent)
+        let observedAt = now()
         try await db.terminals.setActivityState(
             id: terminal.id,
             activityState: params.activityState,
-            source: .hookEvent(RPCMethod.terminalActivityEvent),
-            observedAt: now())
+            source: source,
+            observedAt: observedAt)
         subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,
-            activityState: params.activityState
+            activityState: params.activityState,
+            activityStateSource: source,
+            activityStateObservedAt: observedAt
         )))
         return .ok()
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2925,7 +2925,8 @@ extension RPCRouter {
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,
             sessionID: sessionApplication.sessionID,
-            transcriptPath: sessionApplication.transcriptPath
+            transcriptPath: sessionApplication.transcriptPath,
+            sessionOrderObservedAt: sessionApplication.orderObservedAt
         )))
         if let application = sessionApplication.activityObservation {
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2885,9 +2885,10 @@ extension RPCRouter {
         }()
 
         // Session identity, prompt retraction, and (for Codex) the idle fact
-        // are one ordered store transaction. A delayed older SessionStart must
-        // not rewrite identity or clear a prompt before its activity fact is
-        // rejected as stale.
+        // are reconciled atomically on their independent ordering rails. A
+        // delayed old-session prompt must not suppress a genuine identity
+        // rollover, while a delayed SessionStart must not clear that newer
+        // prompt or regress activity.
         guard let sessionApplication = try await db.terminals.applySessionStart(
             id: terminal.id,
             sessionID: params.sessionID,
@@ -2899,7 +2900,7 @@ extension RPCRouter {
         // transcript reducer. Capture the current EOF even when the path is
         // unchanged, so an unmatched task_started from the interrupted session
         // cannot be re-published as working; later appended turns still win.
-        if sessionApplication.activityObservation != nil,
+        if terminal.isCodexTerminal,
            let transcriptPath = sessionApplication.transcriptPath,
            !transcriptPath.isEmpty {
             await codexActivityTracker.establishSessionBoundary(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2791,6 +2791,12 @@ extension RPCRouter {
     /// terminal may have been deleted between hook fire and arrival).
     func handleTerminalSessionEvent(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSessionEventParams.self, from: paramsData)
+        // Establish event order before the first suspension. SessionStart and
+        // terminal.activityEvent share this activity-fact clock, so a fact with
+        // a later timestamp wins even when earlier handler work finishes
+        // afterward. The store gives explicit interrupts the safety tie-break
+        // when the date source returns an identical timestamp.
+        let observedAt = now()
 
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
             // Soft success — caller is a fire-and-forget hook, returning an
@@ -2798,7 +2804,7 @@ extension RPCRouter {
             logger.debug("sessionEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
             return .ok()
         }
-        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
+        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: observedAt)
 
         // `cwd` is optional for backward compatibility — when absent we cannot
         // validate, so we fall back to the old behavior.
@@ -2836,10 +2842,12 @@ extension RPCRouter {
         // otherwise clear the columns — no-ops when the row already reads idle
         // and can be lost on its own while this call lands.
         //
-        // Deliberately NOT `setActivityState`: this event says a session
-        // exists, not what it is doing, and `activityState` gates hibernation.
+        // Claude SessionStart says only that a session exists, not what it is
+        // doing, so it does not assert activity. Codex SessionStart is also
+        // the machine signal that the pane is between turns; its ordered idle
+        // observation is applied below.
         try await db.terminals.clearAwaitingInputReason(id: terminal.id)
-        let codexActivityObservedAt: Date?
+        let codexActivityApplied: Bool
         if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             // This handler is driven by the session-start hook, which is what
             // told us the session exists and is between turns.
@@ -2848,13 +2856,11 @@ extension RPCRouter {
             // every other stamp this file writes: `SessionStateResolver`'s
             // rung 4 *compares* it, and the store's default `Date()` is a
             // timestamp nothing outside the store can name.
-            let observedAt = now()
-            codexActivityObservedAt = observedAt
-            try await db.terminals.setActivityState(
+            codexActivityApplied = try await db.terminals.applyActivityObservation(
                 id: terminal.id, activityState: .idle, source: .hookEvent("SessionStart"),
-                observedAt: observedAt)
+                observedAt: observedAt, replaceSameValue: true)
         } else {
-            codexActivityObservedAt = nil
+            codexActivityApplied = false
         }
 
         // Invalidate cached transcript parse for the OLD session file (if any)
@@ -2877,13 +2883,13 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )))
-        if let codexActivityObservedAt {
+        if codexActivityApplied {
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
                 terminalID: terminal.id,
                 worktreeID: terminal.worktreeID,
                 activityState: .idle,
                 activityStateSource: .hookEvent("SessionStart"),
-                activityStateObservedAt: codexActivityObservedAt
+                activityStateObservedAt: observedAt
             )))
         }
         return .ok()
@@ -2960,6 +2966,13 @@ extension RPCRouter {
 
     func handleTerminalActivityEvent(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalActivityEventParams.self, from: paramsData)
+        guard params.origin != .userInterrupt || params.activityState == .idle else {
+            return RPCResponse(error: "user_interrupt origin requires idle activity")
+        }
+        // Timestamp receipt before any actor or database suspension. The
+        // conditional store write below uses this to prevent an earlier event
+        // whose handler finishes late from replacing a later observation.
+        let observedAt = now()
 
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
             logger.debug("activityEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
@@ -2974,7 +2987,7 @@ extension RPCRouter {
         // An app-originated interrupt shares this RPC but is a user action, not
         // an agent hook, so it must not inflate the hook-event counter.
         if params.origin == nil {
-            await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
+            await sessionCounters.recordHookEvent(terminalID: terminal.id, at: observedAt)
         }
 
         // UserPromptSubmit reaches the daemon as activity=working. If a
@@ -2999,7 +3012,7 @@ extension RPCRouter {
         // BEFORE the unchanged-state guard so repeated Stops keep converging.
         // Never rewrites terminal.transcriptPath: the live session keeps
         // appending to the original file; we only copy.
-        if params.activityState == .idle,
+        if params.origin == nil, params.activityState == .idle,
            let storedPath = terminal.transcriptPath, !storedPath.isEmpty,
            FileManager.default.fileExists(atPath: storedPath),
            let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) {
@@ -3017,14 +3030,6 @@ extension RPCRouter {
             }
         }
 
-        // A user interrupt must replace provenance even when the raw value was
-        // already idle. Conversely, a repeated idle hook must not erase that
-        // explicit override; only a later value transition (notably a genuine
-        // working hook) supersedes it.
-        guard terminal.activityState != params.activityState || params.origin == .userInterrupt else {
-            return .ok()
-        }
-
         // Hook callers are bridged through `tbd terminal-activity`; the params
         // do not yet carry WHICH hook event fired, so the RPC surface stands in
         // as their source name. The app's explicit interrupt declares its
@@ -3037,12 +3042,13 @@ extension RPCRouter {
         let source: FactSource = params.origin == .userInterrupt
             ? .terminalInterrupt
             : .hookEvent(RPCMethod.terminalActivityEvent)
-        let observedAt = now()
-        try await db.terminals.setActivityState(
+        let activityApplied = try await db.terminals.applyActivityObservation(
             id: terminal.id,
             activityState: params.activityState,
             source: source,
-            observedAt: observedAt)
+            observedAt: observedAt,
+            replaceSameValue: params.origin == .userInterrupt)
+        guard activityApplied else { return .ok() }
         subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -13,6 +13,11 @@ private struct TranscriptParseCacheEntry {
     let result: [TranscriptItem]
 }
 
+private struct CodexPresentationIdentity: Equatable {
+    let sessionID: String?
+    let transcriptPath: String?
+}
+
 /// Caches the last `TranscriptParser.parse` result per session file path.
 /// The fingerprint is the parent JSONL's mtime+size. Subagent files are
 /// re-read on cache miss, so the cache is invalidated whenever the parent
@@ -507,13 +512,18 @@ extension RPCRouter {
     func handleTerminalList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalListParams.self, from: paramsData)
         var terminals = try await db.terminals.list(worktreeID: params.worktreeID)
-        var codexTranscriptPaths: Set<String> = []
         var codexTargets: [CodexTranscriptActivityTracker.Target] = []
+        let observedIdentities = Dictionary(uniqueKeysWithValues: terminals
+            .filter(\.isCodexTerminal)
+            .map {
+                ($0.id, CodexPresentationIdentity(
+                    sessionID: $0.claudeSessionID,
+                    transcriptPath: $0.transcriptPath))
+            })
 
         for index in terminals.indices where terminals[index].isCodexTerminal {
             guard let transcriptPath = terminals[index].transcriptPath,
                   !transcriptPath.isEmpty else { continue }
-            codexTranscriptPaths.insert(transcriptPath)
             codexTargets.append(CodexTranscriptActivityTracker.Target(
                 transcriptPath: transcriptPath,
                 worktreeID: terminals[index].worktreeID))
@@ -522,8 +532,28 @@ extension RPCRouter {
         let codexObservation = await codexActivityTracker.observeStamped(
             transcripts: codexTargets,
             now: now)
+        // SessionStart can retarget a terminal while transcript observation is
+        // suspended on the tracker actor. Re-read as close to response encoding
+        // as possible, and only bind evidence to the exact session/path that
+        // was observed. A mismatch carries authoritative unknown at the
+        // actor-ordered observation stamp: old-path evidence cannot describe
+        // the new transcript, and leaving the stamp absent would let clients
+        // preserve stale working from the old path as a legacy observation.
+        terminals = try await db.terminals.list(worktreeID: params.worktreeID)
+        var codexTranscriptPaths: Set<String> = []
         for index in terminals.indices where terminals[index].isCodexTerminal {
             let transcriptPath = terminals[index].transcriptPath
+            if let transcriptPath, !transcriptPath.isEmpty {
+                codexTranscriptPaths.insert(transcriptPath)
+            }
+            let currentIdentity = CodexPresentationIdentity(
+                sessionID: terminals[index].claudeSessionID,
+                transcriptPath: transcriptPath)
+            guard observedIdentities[terminals[index].id] == currentIdentity else {
+                terminals[index].presentationActivityState = nil
+                terminals[index].presentationActivityObservedAt = codexObservation.observedAt
+                continue
+            }
             terminals[index].presentationActivityState = transcriptPath.flatMap {
                 codexObservation.states[$0]
             }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -187,6 +187,9 @@ public final class RPCRouter: Sendable {
     /// never interleave in one composer. Different terminals still send in
     /// parallel — see `TerminalSendSerializer`.
     let terminalSendSerializer = TerminalSendSerializer()
+    /// Daemon-lifetime incremental transcript baselines used only to enrich
+    /// terminal-list responses for Codex presentation state.
+    let codexActivityTracker = CodexTranscriptActivityTracker()
     /// Opt-in tmux control-mode wiring. `nil` when the daemon did not provide
     /// one (tests, older callers); when present, terminal handlers open a gated
     /// logging-only `tmux -CC` connection after each `ensureServer()`.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -547,6 +547,9 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var transcriptPath: String?
     public var kind: TerminalKind?
     public var activityState: TerminalActivityState
+    /// Activity reconstructed for display from the current agent transcript.
+    /// This is response-derived and is never persisted as hook activity.
+    public var presentationActivityState: TerminalActivityState?
     /// When set, the terminal is HIBERNATED: its `claude` process was
     /// gracefully terminated to reclaim memory, but the tmux window (and its
     /// shell) is kept alive. `claudeSessionID` still points at the session to
@@ -630,6 +633,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 transcriptPath: String? = nil,
                 kind: TerminalKind? = nil,
                 activityState: TerminalActivityState = .unknown,
+                presentationActivityState: TerminalActivityState? = nil,
                 hibernatedAt: Date? = nil,
                 hibernateReason: HibernateReason? = nil,
                 keepWarm: Bool = false,
@@ -653,6 +657,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.transcriptPath = transcriptPath
         self.kind = kind
         self.activityState = activityState
+        self.presentationActivityState = presentationActivityState
         self.hibernatedAt = hibernatedAt
         self.hibernateReason = hibernateReason
         self.keepWarm = keepWarm
@@ -667,7 +672,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
-        case activityState
+        case activityState, presentationActivityState
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
         case activityStateSource, activityStateObservedAt
         case awaitingInputReason, awaitingInputObservedAt
@@ -689,6 +694,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         transcriptPath = try c.decodeIfPresent(String.self, forKey: .transcriptPath)
         kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
+        presentationActivityState = try c.decodeIfPresent(
+            TerminalActivityState.self, forKey: .presentationActivityState)
         hibernatedAt = try c.decodeIfPresent(Date.self, forKey: .hibernatedAt)
         hibernateReason = try c.decodeIfPresent(HibernateReason.self, forKey: .hibernateReason)
         keepWarm = try c.decodeIfPresent(Bool.self, forKey: .keepWarm) ?? false

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -550,6 +550,9 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// Activity reconstructed for display from the current agent transcript.
     /// This is response-derived and is never persisted as hook activity.
     public var presentationActivityState: TerminalActivityState?
+    /// When the daemon completed the transcript observation that produced
+    /// `presentationActivityState`. Response-derived and never persisted.
+    public var presentationActivityObservedAt: Date?
     /// When set, the terminal is HIBERNATED: its `claude` process was
     /// gracefully terminated to reclaim memory, but the tmux window (and its
     /// shell) is kept alive. `claudeSessionID` still points at the session to
@@ -582,6 +585,11 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// When `activityState` was observed — the moment the machine fact was
     /// read, not the moment the row was written.
     public var activityStateObservedAt: Date?
+    /// Ordering watermark for activity events. Unlike
+    /// `activityStateObservedAt`, this advances for a newer observation that
+    /// confirms the same semantic state, so it must not be used as an
+    /// at-rest-since timestamp.
+    public var activityStateOrderObservedAt: Date?
     /// The structured reason this session is waiting, carried verbatim from
     /// Claude Code's `Notification` hook. Superseded by the next activity
     /// observation, so it describes the *current* wait or nothing at all.
@@ -634,6 +642,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 kind: TerminalKind? = nil,
                 activityState: TerminalActivityState = .unknown,
                 presentationActivityState: TerminalActivityState? = nil,
+                presentationActivityObservedAt: Date? = nil,
                 hibernatedAt: Date? = nil,
                 hibernateReason: HibernateReason? = nil,
                 keepWarm: Bool = false,
@@ -641,6 +650,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 watchDeskRole: WatchDeskRole? = nil,
                 activityStateSource: FactSource? = nil,
                 activityStateObservedAt: Date? = nil,
+                activityStateOrderObservedAt: Date? = nil,
                 awaitingInputReason: AwaitingInputReason? = nil,
                 awaitingInputObservedAt: Date? = nil) {
         self.id = id
@@ -658,6 +668,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.kind = kind
         self.activityState = activityState
         self.presentationActivityState = presentationActivityState
+        self.presentationActivityObservedAt = presentationActivityObservedAt
         self.hibernatedAt = hibernatedAt
         self.hibernateReason = hibernateReason
         self.keepWarm = keepWarm
@@ -665,6 +676,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.watchDeskRole = watchDeskRole
         self.activityStateSource = activityStateSource
         self.activityStateObservedAt = activityStateObservedAt
+        self.activityStateOrderObservedAt = activityStateOrderObservedAt
         self.awaitingInputReason = awaitingInputReason
         self.awaitingInputObservedAt = awaitingInputObservedAt
     }
@@ -672,9 +684,9 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
-        case activityState, presentationActivityState
+        case activityState, presentationActivityState, presentationActivityObservedAt
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
-        case activityStateSource, activityStateObservedAt
+        case activityStateSource, activityStateObservedAt, activityStateOrderObservedAt
         case awaitingInputReason, awaitingInputObservedAt
     }
 
@@ -696,6 +708,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
         presentationActivityState = try c.decodeIfPresent(
             TerminalActivityState.self, forKey: .presentationActivityState)
+        presentationActivityObservedAt = try c.decodeIfPresent(
+            Date.self, forKey: .presentationActivityObservedAt)
         hibernatedAt = try c.decodeIfPresent(Date.self, forKey: .hibernatedAt)
         hibernateReason = try c.decodeIfPresent(HibernateReason.self, forKey: .hibernateReason)
         keepWarm = try c.decodeIfPresent(Bool.self, forKey: .keepWarm) ?? false
@@ -706,6 +720,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         // `observedActivity` reports exactly that by returning nil.
         activityStateSource = try c.decodeIfPresent(FactSource.self, forKey: .activityStateSource)
         activityStateObservedAt = try c.decodeIfPresent(Date.self, forKey: .activityStateObservedAt)
+        activityStateOrderObservedAt = try c.decodeIfPresent(
+            Date.self, forKey: .activityStateOrderObservedAt)
         awaitingInputReason = try c.decodeIfPresent(AwaitingInputReason.self, forKey: .awaitingInputReason)
         awaitingInputObservedAt = try c.decodeIfPresent(Date.self, forKey: .awaitingInputObservedAt)
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -598,6 +598,10 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// `/compact` rollovers (where Claude may pick a different
     /// `~/.claude/projects/` subdirectory than cwd would suggest).
     public var transcriptPath: String?
+    /// Ordering watermark for accepted SessionStart identity rollovers.
+    /// Independent from activity and prompt timestamps because either hook
+    /// can arrive late while describing the previous session.
+    public var sessionOrderObservedAt: Date?
     public var kind: TerminalKind?
     public var activityState: TerminalActivityState
     /// Activity reconstructed for display from the current agent transcript.
@@ -692,6 +696,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 suspendedAt: Date? = nil, suspendedSnapshot: String? = nil,
                 profileID: UUID? = nil,
                 transcriptPath: String? = nil,
+                sessionOrderObservedAt: Date? = nil,
                 kind: TerminalKind? = nil,
                 activityState: TerminalActivityState = .unknown,
                 presentationActivityState: TerminalActivityState? = nil,
@@ -718,6 +723,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.suspendedSnapshot = suspendedSnapshot
         self.profileID = profileID
         self.transcriptPath = transcriptPath
+        self.sessionOrderObservedAt = sessionOrderObservedAt
         self.kind = kind
         self.activityState = activityState
         self.presentationActivityState = presentationActivityState
@@ -736,7 +742,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
-        case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
+        case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath
+        case sessionOrderObservedAt, kind
         case activityState, presentationActivityState, presentationActivityObservedAt
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
         case activityStateSource, activityStateObservedAt, activityStateOrderObservedAt
@@ -757,6 +764,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         suspendedSnapshot = try c.decodeIfPresent(String.self, forKey: .suspendedSnapshot)
         profileID = try c.decodeIfPresent(UUID.self, forKey: .profileID)
         transcriptPath = try c.decodeIfPresent(String.self, forKey: .transcriptPath)
+        sessionOrderObservedAt = try c.decodeIfPresent(Date.self, forKey: .sessionOrderObservedAt)
         kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
         presentationActivityState = try c.decodeIfPresent(

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3066,12 +3066,25 @@ public struct TerminalSessionEventParams: Codable, Sendable {
     }
 }
 
+public enum TerminalActivityEventOrigin: String, Codable, Sendable {
+    /// The app observed the user explicitly interrupting the foreground agent.
+    case userInterrupt = "user_interrupt"
+}
+
 public struct TerminalActivityEventParams: Codable, Sendable {
     public let terminalID: UUID
     public let activityState: TerminalActivityState
-    public init(terminalID: UUID, activityState: TerminalActivityState) {
+    /// Absent for the existing agent-hook bridge. Optional so older clients'
+    /// payloads continue to decode unchanged.
+    public let origin: TerminalActivityEventOrigin?
+    public init(
+        terminalID: UUID,
+        activityState: TerminalActivityState,
+        origin: TerminalActivityEventOrigin? = nil
+    ) {
         self.terminalID = terminalID
         self.activityState = activityState
+        self.origin = origin
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3144,16 +3144,21 @@ public enum TerminalActivityEventOrigin: String, Codable, Sendable {
 public struct TerminalActivityEventParams: Codable, Sendable {
     public let terminalID: UUID
     public let activityState: TerminalActivityState
+    /// Codex hook session identity when the caller consumed hook stdin.
+    /// Optional for older hook overlays and non-hook callers.
+    public let sessionID: String?
     /// Absent for the existing agent-hook bridge. Optional so older clients'
     /// payloads continue to decode unchanged.
     public let origin: TerminalActivityEventOrigin?
     public init(
         terminalID: UUID,
         activityState: TerminalActivityState,
+        sessionID: String? = nil,
         origin: TerminalActivityEventOrigin? = nil
     ) {
         self.terminalID = terminalID
         self.activityState = activityState
+        self.sessionID = sessionID
         self.origin = origin
     }
 }

--- a/Sources/TBDShared/SessionStateModel.swift
+++ b/Sources/TBDShared/SessionStateModel.swift
@@ -48,6 +48,10 @@ public enum FactSource: Sendable, Equatable, Hashable, Codable {
     /// name (`SessionStart`, `Stop`, `Notification`, …). The name is carried,
     /// never matched against a rendered screen.
     case hookEvent(String)
+    /// An explicit action taken by the person operating TBD. The associated
+    /// value names the action (`terminal-interrupt`, …), keeping user intent
+    /// distinct from an agent hook that happens to report the same value.
+    case userAction(String)
     /// The session's transcript JSONL, read from the tail.
     case transcriptTail
     /// The statusline wrapper's captured stdin JSON — the one surface on which
@@ -87,6 +91,7 @@ public enum FactSource: Sendable, Equatable, Hashable, Codable {
     public var kind: String {
         switch self {
         case .hookEvent: return "hook"
+        case .userAction: return "user-action"
         case .transcriptTail: return "transcript-tail"
         case .statuslineTee: return "statusline-tee"
         case .database: return "database"
@@ -101,8 +106,10 @@ public enum FactSource: Sendable, Equatable, Hashable, Codable {
 
     /// The kind's qualifier, when it has one.
     public var detail: String? {
-        if case .hookEvent(let event) = self { return event }
-        return nil
+        switch self {
+        case .hookEvent(let event), .userAction(let event): return event
+        default: return nil
+        }
     }
 
     /// One line, for composition into `ObservedFact.summary`.
@@ -124,6 +131,8 @@ public enum FactSource: Sendable, Equatable, Hashable, Codable {
             // what this decoder already does with a kind it cannot make sense
             // of, and which round-trips back to the same bytes.
             if let detail, !detail.isEmpty { self = .hookEvent(detail) } else { self = .unrecognized(kind) }
+        case "user-action":
+            if let detail, !detail.isEmpty { self = .userAction(detail) } else { self = .unrecognized(kind) }
         case "transcript-tail": self = .transcriptTail
         case "statusline-tee": self = .statuslineTee
         case "database": self = .database
@@ -141,6 +150,11 @@ public enum FactSource: Sendable, Equatable, Hashable, Codable {
         try c.encode(kind, forKey: .kind)
         try c.encodeIfPresent(detail, forKey: .detail)
     }
+}
+
+public extension FactSource {
+    /// Provenance written when the user presses an agent's interrupt key.
+    static let terminalInterrupt = FactSource.userAction("terminal-interrupt")
 }
 
 // MARK: - ObservedFact

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -169,10 +169,22 @@ public struct TerminalActivityDelta: Codable, Sendable {
     public let terminalID: UUID
     public let worktreeID: UUID
     public let activityState: TerminalActivityState
-    public init(terminalID: UUID, worktreeID: UUID, activityState: TerminalActivityState) {
+    /// Optional for wire compatibility with daemons that predate activity
+    /// provenance on this push event. New daemons send both halves together.
+    public let activityStateSource: FactSource?
+    public let activityStateObservedAt: Date?
+    public init(
+        terminalID: UUID,
+        worktreeID: UUID,
+        activityState: TerminalActivityState,
+        activityStateSource: FactSource? = nil,
+        activityStateObservedAt: Date? = nil
+    ) {
         self.terminalID = terminalID
         self.worktreeID = worktreeID
         self.activityState = activityState
+        self.activityStateSource = activityStateSource
+        self.activityStateObservedAt = activityStateObservedAt
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -157,11 +157,21 @@ public struct TerminalSessionDelta: Codable, Sendable {
     public let worktreeID: UUID
     public let sessionID: String
     public let transcriptPath: String?
-    public init(terminalID: UUID, worktreeID: UUID, sessionID: String, transcriptPath: String?) {
+    /// Ordering generation of the accepted SessionStart. Optional for wire
+    /// compatibility with older daemons and for non-hook session updates.
+    public let sessionOrderObservedAt: Date?
+    public init(
+        terminalID: UUID,
+        worktreeID: UUID,
+        sessionID: String,
+        transcriptPath: String?,
+        sessionOrderObservedAt: Date? = nil
+    ) {
         self.terminalID = terminalID
         self.worktreeID = worktreeID
         self.sessionID = sessionID
         self.transcriptPath = transcriptPath
+        self.sessionOrderObservedAt = sessionOrderObservedAt
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -173,18 +173,23 @@ public struct TerminalActivityDelta: Codable, Sendable {
     /// provenance on this push event. New daemons send both halves together.
     public let activityStateSource: FactSource?
     public let activityStateObservedAt: Date?
+    /// Optional ordering watermark for wire compatibility. Old daemons omit
+    /// it, in which case clients fall back to `activityStateObservedAt`.
+    public let activityStateOrderObservedAt: Date?
     public init(
         terminalID: UUID,
         worktreeID: UUID,
         activityState: TerminalActivityState,
         activityStateSource: FactSource? = nil,
-        activityStateObservedAt: Date? = nil
+        activityStateObservedAt: Date? = nil,
+        activityStateOrderObservedAt: Date? = nil
     ) {
         self.terminalID = terminalID
         self.worktreeID = worktreeID
         self.activityState = activityState
         self.activityStateSource = activityStateSource
         self.activityStateObservedAt = activityStateObservedAt
+        self.activityStateOrderObservedAt = activityStateOrderObservedAt
     }
 }
 

--- a/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
+++ b/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
@@ -280,8 +280,8 @@ struct DeltaIngestionTests {
         }
     }
 
-    /// A session rollover delta re-sent with the same session id and transcript
-    /// path: two unconditional subscript writes (`AppState.swift:2185`, `:2191`).
+    /// A session rollover delta re-sent with the same session identity is a
+    /// semantic no-op and must not republish the terminal collection.
     @Test("terminalSessionUpdated: the same session and transcript path")
     func identicalSessionDelta() {
         withEmissionState { state in
@@ -302,15 +302,7 @@ struct DeltaIngestionTests {
                 )))
             }
 
-            // KNOWN ISSUE — `AppState.terminals`, via
-            // `applyTerminalSessionDelta` (AppState.swift:2181). Ideal 0,
-            // observed 2 — the session id and the transcript path are two
-            // separate unconditional subscript writes, so one logical delta
-            // costs two full object-wide invalidations. Fix: compare the whole
-            // row once and assign once.
-            withKnownIssue("an unchanged session rollover republishes twice (#667)") {
-                #expect(count == 0)
-            }
+            #expect(count == 0)
         }
     }
 
@@ -335,12 +327,7 @@ struct DeltaIngestionTests {
             }
 
             #expect(state.terminals[worktreeID]?.first?.claudeSessionID == "def")
-            // KNOWN ISSUE — one logical session rollover should cost one
-            // invalidation. Ideal 1, observed 2 (two subscript writes). Fix:
-            // build the updated row locally, assign once.
-            withKnownIssue("one session rollover costs two publishes (#667)") {
-                #expect(count == 1)
-            }
+            #expect(count == 1)
         }
     }
 

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -57,6 +57,144 @@ private func decodedCodexSnapshot(
 }
 
 @MainActor
+@Test(
+    "non-Codex snapshots retain legacy arrival-order replacement",
+    arguments: [TerminalKind.claude, .shell]
+)
+func appState_nonCodexSnapshotRetainsLegacyArrivalOrder(kind: TerminalKind) {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let currentAt = Date(timeIntervalSinceReferenceDate: 20)
+    let incomingAt = Date(timeIntervalSinceReferenceDate: 10)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: kind == .claude ? "Claude" : "shell",
+                claudeSessionID: "current-session",
+                transcriptPath: "/tmp/current.jsonl",
+                sessionOrderObservedAt: currentAt,
+                kind: kind,
+                activityState: .idle,
+                activityStateSource: .terminalInterrupt,
+                activityStateObservedAt: currentAt,
+                activityStateOrderObservedAt: currentAt)
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] = currentAt
+    state.terminalSessionOrderObservedAt[terminalID] = currentAt
+    let snapshot = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: kind == .claude ? "Claude" : "shell",
+        claudeSessionID: "arrived-session",
+        transcriptPath: "/tmp/arrived.jsonl",
+        sessionOrderObservedAt: incomingAt,
+        kind: kind,
+        activityState: .working,
+        activityStateSource: .hookEvent("legacy"),
+        activityStateObservedAt: incomingAt,
+        activityStateOrderObservedAt: incomingAt)
+
+    state.adoptTerminalSnapshot([snapshot], worktreeID: worktreeID)
+
+    let adopted = state.terminals[worktreeID]![0]
+    #expect(adopted.claudeSessionID == "arrived-session")
+    #expect(adopted.transcriptPath == "/tmp/arrived.jsonl")
+    #expect(adopted.activityState == .working)
+    #expect(adopted.activityStateSource == .hookEvent("legacy"))
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == nil)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == nil)
+}
+
+@MainActor
+@Test(
+    "non-Codex session deltas retain legacy last-arrival identity",
+    arguments: [TerminalKind.claude, .shell]
+)
+func appState_nonCodexSessionDeltaRetainsLegacyArrivalOrder(kind: TerminalKind) {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let currentAt = Date(timeIntervalSinceReferenceDate: 20)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: kind == .claude ? "Claude" : "shell",
+                claudeSessionID: "current-session",
+                transcriptPath: "/tmp/current.jsonl",
+                sessionOrderObservedAt: currentAt,
+                kind: kind)
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] = currentAt
+    state.terminalSessionOrderObservedAt[terminalID] = currentAt
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "arrived-session",
+        transcriptPath: "/tmp/arrived.jsonl",
+        sessionOrderObservedAt: Date(timeIntervalSinceReferenceDate: 10))))
+
+    let adopted = state.terminals[worktreeID]![0]
+    #expect(adopted.claudeSessionID == "arrived-session")
+    #expect(adopted.transcriptPath == "/tmp/arrived.jsonl")
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == nil)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == nil)
+}
+
+@MainActor
+@Test(
+    "non-Codex activity deltas retain legacy raw last-arrival behavior",
+    arguments: [TerminalKind.claude, .shell]
+)
+func appState_nonCodexActivityDeltaRetainsLegacyArrivalOrder(kind: TerminalKind) {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let currentAt = Date(timeIntervalSinceReferenceDate: 20)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: kind == .claude ? "Claude" : "shell",
+                kind: kind,
+                activityState: .working,
+                activityStateSource: .hookEvent("current"),
+                activityStateObservedAt: currentAt,
+                activityStateOrderObservedAt: currentAt)
+        ]
+    ]
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .terminalInterrupt,
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 10),
+        activityStateOrderObservedAt: Date(timeIntervalSinceReferenceDate: 10))))
+
+    let adopted = state.terminals[worktreeID]![0]
+    #expect(adopted.activityState == .idle)
+    #expect(adopted.activityStateSource == .hookEvent("current"))
+    #expect(adopted.activityStateObservedAt == currentAt)
+}
+
+@MainActor
 @Test func appState_handlesTerminalActivityUpdatedDeltaInPlace() {
     let state = AppState()
     let worktreeID = UUID()
@@ -1612,7 +1750,40 @@ private func appState_halfProvenanceDeltaClearsBothHalvesWhenApplied(
 }
 
 @MainActor
-@Test func appState_escInterruptClearsClaudeActivityImmediately() {
+@Test(
+    "Claude Ctrl+C and Esc retain legacy raw-idle interrupt behavior",
+    arguments: [false, true]
+)
+func appState_claudeInterruptRetainsLegacyRawIdle(viaEscape: Bool) {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let observedAt = Date(timeIntervalSinceReferenceDate: 20)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Claude",
+                kind: .claude,
+                activityState: .working,
+                activityStateSource: .hookEvent("UserPromptSubmit"),
+                activityStateObservedAt: observedAt
+            )
+        ]
+    ]
+
+    state.handleTerminalInterrupt(terminalID: terminalID, viaEscape: viaEscape)
+
+    #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+    #expect(state.terminals[worktreeID]?[0].activityStateSource == .hookEvent("UserPromptSubmit"))
+    #expect(state.terminals[worktreeID]?[0].activityStateObservedAt == observedAt)
+}
+
+@MainActor
+@Test func appState_escDoesNotInterruptCodex() {
     let state = AppState()
     let worktreeID = UUID()
     let terminalID = UUID()
@@ -1623,14 +1794,15 @@ private func appState_halfProvenanceDeltaClearsBothHalvesWhenApplied(
                 worktreeID: worktreeID,
                 tmuxWindowID: "@1",
                 tmuxPaneID: "%1",
-                label: "Claude",
-                kind: .claude,
-                activityState: .working
-            )
+                label: "Codex",
+                kind: .codex,
+                activityState: .working,
+                presentationActivityState: .working)
         ]
     ]
 
     state.handleTerminalInterrupt(terminalID: terminalID, viaEscape: true)
 
-    #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+    #expect(state.terminals[worktreeID]?[0].activityState == .working)
+    #expect(state.terminals[worktreeID]?[0].presentationActivityState == .working)
 }

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -270,6 +270,77 @@ private func decodedCodexSnapshot(
 }
 
 @MainActor
+@Test func appState_newerSameStateHookDeltaAdvancesOrderWithoutErasingInterrupt() {
+    let fixture = interruptedCodexState()
+    let newerOrder = Date(timeIntervalSinceReferenceDate: 30)
+
+    fixture.state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: fixture.terminalID,
+        worktreeID: fixture.worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("Stop"),
+        activityStateObservedAt: newerOrder,
+        activityStateOrderObservedAt: newerOrder
+    )))
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
+    #expect(terminal.activityStateOrderObservedAt == newerOrder)
+}
+
+@MainActor
+@Test func appState_bestEffortInterruptSurvivesNewerSameStateHookSnapshot() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .working,
+                presentationActivityState: .working,
+                activityStateSource: .hookEvent("UserPromptSubmit"),
+                activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 10)
+            )
+        ]
+    ]
+
+    state.handleTerminalInterrupt(terminalID: terminalID)
+    let interrupted = try #require(state.terminals[worktreeID]?.first)
+    let interruptedAt = try #require(interrupted.activityStateObservedAt)
+    let newerOrder = interruptedAt.addingTimeInterval(1)
+    let snapshot = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .idle,
+        presentationActivityState: .idle,
+        activityStateSource: .hookEvent("Stop"),
+        activityStateObservedAt: newerOrder,
+        activityStateOrderObservedAt: newerOrder
+    )
+
+    state.adoptTerminalSnapshot([snapshot], worktreeID: worktreeID)
+
+    let terminal = try #require(state.terminals[worktreeID]?.first)
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == interruptedAt)
+    #expect(terminal.activityStateOrderObservedAt == newerOrder)
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
 @Test func appState_activityDeltaUsesOrderingWatermarkInsteadOfTransitionTime() throws {
     let state = AppState()
     let worktreeID = UUID()
@@ -511,6 +582,42 @@ private func decodedCodexSnapshot(
 }
 
 @MainActor
+@Test func appState_newerInterruptDeltaReplacesGenericSameStateFact() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+            )
+        ]
+    ]
+    let interruptAt = Date(timeIntervalSinceReferenceDate: 30)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .terminalInterrupt,
+        activityStateObservedAt: interruptAt,
+        activityStateOrderObservedAt: interruptAt
+    )))
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == interruptAt)
+}
+
+@MainActor
 @Test func appState_sameValueLegacyIdleDeltaPreservesCodexInterrupt() throws {
     let fixture = interruptedCodexState()
     let delta = try JSONDecoder().decode(
@@ -610,6 +717,91 @@ private func appState_halfProvenanceDeltaClearsBothHalvesWhenApplied(
 
     let terminal = state.terminals[worktreeID]![0]
     #expect(terminal.presentationActivityState == .idle)
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_olderSessionStartDoesNotClearNewerTranscriptWorkingPresentation() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let presentationAt = Date(timeIntervalSinceReferenceDate: 40)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                presentationActivityState: .working,
+                presentationActivityObservedAt: presentationAt,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+            )
+        ]
+    ]
+    let sessionStartAt = Date(timeIntervalSinceReferenceDate: 30)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: sessionStartAt,
+        activityStateOrderObservedAt: sessionStartAt
+    )))
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.activityStateSource == .hookEvent("SessionStart"))
+    #expect(terminal.presentationActivityState == .working)
+    #expect(terminal.presentationActivityObservedAt == presentationAt)
+}
+
+@MainActor
+@Test func appState_timestampedPathRolloverUnknownClearsPriorWorkingInsteadOfCachingIt() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                claudeSessionID: "old-session",
+                transcriptPath: "/tmp/old-session.jsonl",
+                kind: .codex,
+                presentationActivityState: .working,
+                presentationActivityObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+            )
+        ]
+    ]
+    let unavailableAt = Date(timeIntervalSinceReferenceDate: 30)
+    let snapshot = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        claudeSessionID: "current-session",
+        transcriptPath: "/tmp/current-session.jsonl",
+        kind: .codex,
+        presentationActivityState: nil,
+        presentationActivityObservedAt: unavailableAt
+    )
+
+    state.adoptTerminalSnapshot([snapshot], worktreeID: worktreeID)
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.claudeSessionID == "current-session")
+    #expect(terminal.transcriptPath == "/tmp/current-session.jsonl")
+    #expect(terminal.presentationActivityState == nil)
+    #expect(terminal.presentationActivityObservedAt == unavailableAt)
     #expect(!WorktreeRowView.isForegroundWorking(terminal))
 }
 

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -642,6 +642,7 @@ private func decodedCodexSnapshot(
     var terminal = state.terminals[worktreeID]?.first
     #expect(terminal?.claudeSessionID == "new-session")
     #expect(terminal?.transcriptPath == "/tmp/new-session.jsonl")
+    #expect(terminal?.sessionOrderObservedAt == sessionStartAt)
     #expect(terminal?.presentationActivityState == nil)
     #expect(state.terminalSessionOrderObservedAt[terminalID] == sessionStartAt)
 
@@ -655,6 +656,53 @@ private func decodedCodexSnapshot(
     terminal = state.terminals[worktreeID]?.first
     #expect(terminal?.activityStateSource == .hookEvent("SessionStart"))
     #expect(terminal?.presentationActivityState == .idle)
+}
+
+@MainActor
+@Test func appState_persistedSessionOrderFencesStaleSnapshotIdentity() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let oldActivityAt = Date(timeIntervalSinceReferenceDate: 20)
+    let staleSessionAt = Date(timeIntervalSinceReferenceDate: 25)
+    let currentSessionAt = Date(timeIntervalSinceReferenceDate: 30)
+    let misleadingNewerActivityAt = Date(timeIntervalSinceReferenceDate: 40)
+    let current = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        claudeSessionID: "current-session",
+        transcriptPath: "/tmp/current-session.jsonl",
+        sessionOrderObservedAt: currentSessionAt,
+        kind: .codex,
+        activityState: .idle,
+        activityStateSource: .hookEvent("Stop"),
+        activityStateObservedAt: oldActivityAt,
+        activityStateOrderObservedAt: oldActivityAt)
+    state.terminals = [worktreeID: [current]]
+
+    var stale = current
+    stale.claudeSessionID = "stale-session"
+    stale.transcriptPath = "/tmp/stale-session.jsonl"
+    stale.sessionOrderObservedAt = staleSessionAt
+    stale.activityStateOrderObservedAt = misleadingNewerActivityAt
+    state.adoptTerminalSnapshot([stale], worktreeID: worktreeID)
+
+    let terminal = state.terminals[worktreeID]?.first
+    #expect(terminal?.claudeSessionID == "current-session")
+    #expect(terminal?.transcriptPath == "/tmp/current-session.jsonl")
+    #expect(terminal?.sessionOrderObservedAt == currentSessionAt)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == currentSessionAt)
+
+    var sameIdentityStale = try #require(terminal)
+    sameIdentityStale.sessionOrderObservedAt = staleSessionAt
+    sameIdentityStale.activityStateOrderObservedAt = misleadingNewerActivityAt
+    state.adoptTerminalSnapshot([sameIdentityStale], worktreeID: worktreeID)
+
+    #expect(state.terminals[worktreeID]?.first?.sessionOrderObservedAt == currentSessionAt)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == currentSessionAt)
 }
 
 @MainActor

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -4,6 +4,37 @@ import Testing
 import TBDShared
 
 @MainActor
+private func interruptedCodexState(
+    observedAt: Date = Date(timeIntervalSinceReferenceDate: 20)
+) -> (state: AppState, worktreeID: UUID, terminalID: UUID) {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                presentationActivityState: .working,
+                activityStateSource: .terminalInterrupt,
+                activityStateObservedAt: observedAt
+            )
+        ]
+    ]
+    return (state, worktreeID, terminalID)
+}
+
+private enum PartialActivityProvenance: Sendable {
+    case sourceOnly
+    case observedAtOnly
+}
+
+@MainActor
 @Test func appState_handlesTerminalActivityUpdatedDeltaInPlace() {
     let state = AppState()
     let worktreeID = UUID()
@@ -28,6 +59,208 @@ import TBDShared
     )))
 
     #expect(state.terminals[worktreeID]?[0].activityState == .working)
+}
+
+@MainActor
+@Test func appState_olderSnapshotDoesNotRollbackCodexInterrupt() {
+    let fixture = interruptedCodexState()
+    let olderSnapshot = Terminal(
+        id: fixture.terminalID,
+        worktreeID: fixture.worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .working,
+        activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 10)
+    )
+
+    fixture.state.adoptTerminalSnapshot([olderSnapshot], worktreeID: fixture.worktreeID)
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_olderDeltaDoesNotRollbackCodexInterrupt() {
+    let fixture = interruptedCodexState()
+
+    fixture.state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: fixture.terminalID,
+        worktreeID: fixture.worktreeID,
+        activityState: .working,
+        activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 10)
+    )))
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_equalTimestampSnapshotDoesNotOverrideCodexInterrupt() {
+    let fixture = interruptedCodexState()
+    let snapshot = Terminal(
+        id: fixture.terminalID,
+        worktreeID: fixture.worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .working,
+        activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+    )
+
+    fixture.state.adoptTerminalSnapshot([snapshot], worktreeID: fixture.worktreeID)
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_equalTimestampDeltaDoesNotOverrideCodexInterrupt() {
+    let fixture = interruptedCodexState()
+
+    fixture.state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: fixture.terminalID,
+        worktreeID: fixture.worktreeID,
+        activityState: .working,
+        activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+    )))
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_newerWorkingSnapshotSupersedesCodexInterrupt() {
+    let fixture = interruptedCodexState()
+    let newerSnapshot = Terminal(
+        id: fixture.terminalID,
+        worktreeID: fixture.worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .working,
+        activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 30)
+    )
+
+    fixture.state.adoptTerminalSnapshot([newerSnapshot], worktreeID: fixture.worktreeID)
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .working)
+    #expect(terminal.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 30))
+    #expect(WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_newerSessionStartDeltaSupersedesCodexInterrupt() {
+    let fixture = interruptedCodexState()
+
+    fixture.state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: fixture.terminalID,
+        worktreeID: fixture.worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 30)
+    )))
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityStateSource == .hookEvent("SessionStart"))
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 30))
+    #expect(terminal.presentationActivityState == .idle)
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_sameValueLegacyIdleDeltaPreservesCodexInterrupt() throws {
+    let fixture = interruptedCodexState()
+    let delta = try JSONDecoder().decode(
+        TerminalActivityDelta.self,
+        from: Data(
+            #"{"terminalID":"\#(fixture.terminalID.uuidString)","worktreeID":"\#(fixture.worktreeID.uuidString)","activityState":"idle"}"#.utf8
+        )
+    )
+
+    fixture.state.handleDelta(.terminalActivityUpdated(delta))
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .terminalInterrupt)
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_legacyWorkingDeltaSupersedesInterruptWithoutMixingProvenance() throws {
+    let fixture = interruptedCodexState()
+    let delta = try JSONDecoder().decode(
+        TerminalActivityDelta.self,
+        from: Data(
+            #"{"terminalID":"\#(fixture.terminalID.uuidString)","worktreeID":"\#(fixture.worktreeID.uuidString)","activityState":"working"}"#.utf8
+        )
+    )
+
+    fixture.state.handleDelta(.terminalActivityUpdated(delta))
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .working)
+    #expect(terminal.activityStateSource == nil)
+    #expect(terminal.activityStateObservedAt == nil)
+    #expect(WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test(arguments: [PartialActivityProvenance.sourceOnly, .observedAtOnly])
+private func appState_halfProvenanceDeltaClearsBothHalvesWhenApplied(
+    partial: PartialActivityProvenance
+) {
+    let fixture = interruptedCodexState()
+    let delta: TerminalActivityDelta
+    switch partial {
+    case .sourceOnly:
+        delta = TerminalActivityDelta(
+            terminalID: fixture.terminalID,
+            worktreeID: fixture.worktreeID,
+            activityState: .working,
+            activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent)
+        )
+    case .observedAtOnly:
+        delta = TerminalActivityDelta(
+            terminalID: fixture.terminalID,
+            worktreeID: fixture.worktreeID,
+            activityState: .working,
+            activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 30)
+        )
+    }
+
+    fixture.state.handleDelta(.terminalActivityUpdated(delta))
+
+    let terminal = fixture.state.terminals[fixture.worktreeID]![0]
+    #expect(terminal.activityState == .working)
+    #expect(terminal.activityStateSource == nil)
+    #expect(terminal.activityStateObservedAt == nil)
 }
 
 @MainActor

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -333,6 +333,141 @@ private func decodedCodexSnapshot(
 }
 
 @MainActor
+@Test func appState_delayedSessionStartCannotRegressHiddenUnknownPresentationOrder() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let oldAt = Date(timeIntervalSinceReferenceDate: 20)
+    let sessionStartAt = Date(timeIntervalSinceReferenceDate: 30)
+    let delayedWorkingAt = Date(timeIntervalSinceReferenceDate: 35)
+    let unknownAt = Date(timeIntervalSinceReferenceDate: 40)
+    let newerSessionStartAt = Date(timeIntervalSinceReferenceDate: 50)
+    let original = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        claudeSessionID: "session",
+        transcriptPath: "/tmp/session.jsonl",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .working,
+        presentationActivityObservedAt: oldAt,
+        activityStateSource: .hookEvent("UserPromptSubmit"),
+        activityStateObservedAt: oldAt,
+        activityStateOrderObservedAt: oldAt)
+    state.terminals = [worktreeID: [original]]
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "session",
+        transcriptPath: "/tmp/session.jsonl",
+        sessionOrderObservedAt: sessionStartAt)))
+
+    var authoritativeUnknown = try #require(state.terminals[worktreeID]?.first)
+    authoritativeUnknown.activityState = .idle
+    authoritativeUnknown.activityStateSource = .hookEvent("SessionStart")
+    authoritativeUnknown.activityStateObservedAt = sessionStartAt
+    authoritativeUnknown.activityStateOrderObservedAt = sessionStartAt
+    authoritativeUnknown.presentationActivityState = nil
+    authoritativeUnknown.presentationActivityObservedAt = unknownAt
+    state.adoptTerminalSnapshot([authoritativeUnknown], worktreeID: worktreeID)
+
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == nil)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityObservedAt == nil)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == unknownAt)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: sessionStartAt,
+        activityStateOrderObservedAt: sessionStartAt)))
+
+    var delayedWorking = try #require(state.terminals[worktreeID]?.first)
+    delayedWorking.presentationActivityState = .working
+    delayedWorking.presentationActivityObservedAt = delayedWorkingAt
+    state.adoptTerminalSnapshot([delayedWorking], worktreeID: worktreeID)
+
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == nil)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == unknownAt)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: unknownAt,
+        activityStateOrderObservedAt: unknownAt)))
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == .idle)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == unknownAt)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: newerSessionStartAt,
+        activityStateOrderObservedAt: newerSessionStartAt)))
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == .idle)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == newerSessionStartAt)
+}
+
+@MainActor
+@Test func appState_samePathSessionBoundaryRejectsPreBoundaryPresentation() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let oldAt = Date(timeIntervalSinceReferenceDate: 20)
+    let sessionStartAt = Date(timeIntervalSinceReferenceDate: 30)
+    let stalePresentationAt = Date(timeIntervalSinceReferenceDate: 40)
+    let preBoundary = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        claudeSessionID: "session",
+        transcriptPath: "/tmp/session.jsonl",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .working,
+        presentationActivityObservedAt: stalePresentationAt,
+        activityStateSource: .hookEvent("UserPromptSubmit"),
+        activityStateObservedAt: oldAt,
+        activityStateOrderObservedAt: oldAt)
+    state.terminals = [worktreeID: [preBoundary]]
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "session",
+        transcriptPath: "/tmp/session.jsonl",
+        sessionOrderObservedAt: sessionStartAt)))
+    state.adoptTerminalSnapshot([preBoundary], worktreeID: worktreeID)
+
+    var terminal = try #require(state.terminals[worktreeID]?.first)
+    #expect(terminal.presentationActivityState == nil)
+    #expect(terminal.presentationActivityObservedAt == nil)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == sessionStartAt)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: sessionStartAt,
+        activityStateOrderObservedAt: sessionStartAt)))
+
+    terminal = try #require(state.terminals[worktreeID]?.first)
+    #expect(terminal.presentationActivityState == .idle)
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
 @Test func appState_sessionIdentityRolloverResetsPresentationOrder() {
     let state = AppState()
     let worktreeID = UUID()

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -34,6 +34,28 @@ private enum PartialActivityProvenance: Sendable {
     case observedAtOnly
 }
 
+private func decodedCodexSnapshot(
+    terminalID: UUID,
+    worktreeID: UUID,
+    presentationState: String?,
+    presentationObservedAt: Double?
+) throws -> Terminal {
+    let presentation = presentationState.map {
+        ",\"presentationActivityState\":\"\($0)\""
+    } ?? ""
+    let presentationTime = presentationObservedAt.map {
+        ",\"presentationActivityObservedAt\":\($0)"
+    } ?? ""
+    return try JSONDecoder().decode(
+        Terminal.self,
+        from: Data(
+            """
+            {"id":"\(terminalID.uuidString)","worktreeID":"\(worktreeID.uuidString)","tmuxWindowID":"@1","tmuxPaneID":"%1","label":"Codex","createdAt":0,"kind":"codex","activityState":"idle"\(presentation)\(presentationTime),"activityStateSource":{"kind":"hook","detail":"Stop"},"activityStateObservedAt":5}
+            """.utf8
+        )
+    )
+}
+
 @MainActor
 @Test func appState_handlesTerminalActivityUpdatedDeltaInPlace() {
     let state = AppState()
@@ -87,6 +109,148 @@ private enum PartialActivityProvenance: Sendable {
 }
 
 @MainActor
+@Test func appState_staleRawSnapshotStillAdoptsFreshTranscriptPresentation() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                presentationActivityState: .working,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+            )
+        ]
+    ]
+    let snapshot = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .idle,
+        activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 10)
+    )
+
+    state.adoptTerminalSnapshot([snapshot], worktreeID: worktreeID)
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .hookEvent("Stop"))
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
+    #expect(terminal.presentationActivityState == .idle)
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_reversedTranscriptSnapshotsKeepNewerIdlePresentation() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let newerIdle = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: "idle",
+        presentationObservedAt: 20
+    )
+    let olderWorking = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: "working",
+        presentationObservedAt: 10
+    )
+
+    state.adoptTerminalSnapshot([newerIdle], worktreeID: worktreeID)
+    state.adoptTerminalSnapshot([olderWorking], worktreeID: worktreeID)
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.presentationActivityState == .idle)
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_equalTranscriptTimestampPrefersIdleOverWorking() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let idle = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: "idle",
+        presentationObservedAt: 20
+    )
+    let working = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: "working",
+        presentationObservedAt: 20
+    )
+
+    state.adoptTerminalSnapshot([idle], worktreeID: worktreeID)
+    state.adoptTerminalSnapshot([working], worktreeID: worktreeID)
+
+    #expect(state.terminals[worktreeID]?[0].presentationActivityState == .idle)
+}
+
+@MainActor
+@Test func appState_reversedTranscriptSnapshotsKeepNewerUnknownPresentation() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let newerUnknown = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: nil,
+        presentationObservedAt: 20
+    )
+    let olderWorking = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: "working",
+        presentationObservedAt: 10
+    )
+
+    state.adoptTerminalSnapshot([newerUnknown], worktreeID: worktreeID)
+    state.adoptTerminalSnapshot([olderWorking], worktreeID: worktreeID)
+
+    #expect(state.terminals[worktreeID]?[0].presentationActivityState == nil)
+}
+
+@MainActor
+@Test func appState_legacyTranscriptSnapshotsRemainArrivalOrdered() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let idle = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: "idle",
+        presentationObservedAt: nil
+    )
+    let working = try decodedCodexSnapshot(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        presentationState: "working",
+        presentationObservedAt: nil
+    )
+
+    state.adoptTerminalSnapshot([idle], worktreeID: worktreeID)
+    state.adoptTerminalSnapshot([working], worktreeID: worktreeID)
+
+    #expect(state.terminals[worktreeID]?[0].presentationActivityState == .working)
+}
+
+@MainActor
 @Test func appState_olderDeltaDoesNotRollbackCodexInterrupt() {
     let fixture = interruptedCodexState()
 
@@ -103,6 +267,43 @@ private enum PartialActivityProvenance: Sendable {
     #expect(terminal.activityStateSource == .terminalInterrupt)
     #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
     #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_activityDeltaUsesOrderingWatermarkInsteadOfTransitionTime() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+            )
+        ]
+    ]
+    let delta = try JSONDecoder().decode(
+        TerminalActivityDelta.self,
+        from: Data(
+            """
+            {"terminalID":"\(terminalID.uuidString)","worktreeID":"\(worktreeID.uuidString)","activityState":"working","activityStateSource":{"kind":"hook","detail":"UserPromptSubmit"},"activityStateObservedAt":10,"activityStateOrderObservedAt":30}
+            """.utf8
+        )
+    )
+
+    state.handleDelta(.terminalActivityUpdated(delta))
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.activityState == .working)
+    #expect(terminal.activityStateSource == .hookEvent("UserPromptSubmit"))
+    #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 10))
 }
 
 @MainActor
@@ -147,6 +348,122 @@ private enum PartialActivityProvenance: Sendable {
     #expect(terminal.activityStateSource == .terminalInterrupt)
     #expect(terminal.activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 20))
     #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_equalTimestampWorkingDeltaDoesNotOverrideIdle() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let instant = Date(timeIntervalSinceReferenceDate: 20)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: instant,
+                activityStateOrderObservedAt: instant
+            )
+        ]
+    ]
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .working,
+        activityStateSource: .hookEvent("UserPromptSubmit"),
+        activityStateObservedAt: instant,
+        activityStateOrderObservedAt: instant
+    )))
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .hookEvent("Stop"))
+}
+
+@MainActor
+@Test func appState_equalTimestampWorkingSnapshotDoesNotOverrideIdle() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let instant = Date(timeIntervalSinceReferenceDate: 20)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: instant,
+                activityStateOrderObservedAt: instant
+            )
+        ]
+    ]
+    let snapshot = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .working,
+        activityStateSource: .hookEvent("UserPromptSubmit"),
+        activityStateObservedAt: instant,
+        activityStateOrderObservedAt: instant
+    )
+
+    state.adoptTerminalSnapshot([snapshot], worktreeID: worktreeID)
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.activityState == .idle)
+    #expect(terminal.activityStateSource == .hookEvent("Stop"))
+}
+
+@MainActor
+@Test func appState_equalTimestampIdleDeltaDoesNotOverrideWaitingForUser() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let instant = Date(timeIntervalSinceReferenceDate: 20)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .waitingForUser,
+                activityStateSource: .hookEvent("PermissionRequest"),
+                activityStateObservedAt: instant,
+                activityStateOrderObservedAt: instant
+            )
+        ]
+    ]
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("Stop"),
+        activityStateObservedAt: instant,
+        activityStateOrderObservedAt: instant
+    )))
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.activityState == .waitingForUser)
+    #expect(terminal.activityStateSource == .hookEvent("PermissionRequest"))
 }
 
 @MainActor

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -227,6 +227,58 @@ private func decodedCodexSnapshot(
 }
 
 @MainActor
+@Test func appState_stablePresentationAdvancesOrderWithoutChangingTerminal() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let firstAt = Date(timeIntervalSinceReferenceDate: 10)
+    let stableAt = Date(timeIntervalSinceReferenceDate: 20)
+    let newerAt = Date(timeIntervalSinceReferenceDate: 30)
+    let unavailableAt = Date(timeIntervalSinceReferenceDate: 40)
+    let original = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .idle,
+        presentationActivityState: .working,
+        presentationActivityObservedAt: firstAt,
+        activityStateSource: .hookEvent("Stop"),
+        activityStateObservedAt: firstAt,
+        activityStateOrderObservedAt: firstAt)
+    state.terminals = [worktreeID: [original]]
+
+    var stable = original
+    stable.presentationActivityObservedAt = stableAt
+    state.adoptTerminalSnapshot([stable], worktreeID: worktreeID)
+    #expect(try #require(state.terminals[worktreeID]?.first) == original)
+
+    // The non-published watermark still advances, so an overlapping older
+    // response with a different value cannot roll presentation backward.
+    var delayedIdle = original
+    delayedIdle.presentationActivityState = .idle
+    delayedIdle.presentationActivityObservedAt = firstAt.addingTimeInterval(5)
+    state.adoptTerminalSnapshot([delayedIdle], worktreeID: worktreeID)
+    #expect(try #require(state.terminals[worktreeID]?.first) == original)
+
+    var newerIdle = original
+    newerIdle.presentationActivityState = .idle
+    newerIdle.presentationActivityObservedAt = newerAt
+    state.adoptTerminalSnapshot([newerIdle], worktreeID: worktreeID)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == .idle)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityObservedAt == newerAt)
+
+    var authoritativeUnknown = newerIdle
+    authoritativeUnknown.presentationActivityState = nil
+    authoritativeUnknown.presentationActivityObservedAt = unavailableAt
+    state.adoptTerminalSnapshot([authoritativeUnknown], worktreeID: worktreeID)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == nil)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityObservedAt == unavailableAt)
+}
+
+@MainActor
 @Test func appState_legacyTranscriptSnapshotsRemainArrivalOrdered() throws {
     let state = AppState()
     let worktreeID = UUID()
@@ -803,6 +855,46 @@ private func appState_halfProvenanceDeltaClearsBothHalvesWhenApplied(
     #expect(terminal.presentationActivityState == nil)
     #expect(terminal.presentationActivityObservedAt == unavailableAt)
     #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_legacyPathRolloverDoesNotCarryPriorWorkingPresentation() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                claudeSessionID: "old-session",
+                transcriptPath: "/tmp/old-session.jsonl",
+                kind: .codex,
+                presentationActivityState: .working,
+                presentationActivityObservedAt: Date(timeIntervalSinceReferenceDate: 20))
+        ]
+    ]
+    let rollover = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        claudeSessionID: "current-session",
+        transcriptPath: "/tmp/current-session.jsonl",
+        kind: .codex,
+        presentationActivityState: nil,
+        presentationActivityObservedAt: nil)
+
+    state.adoptTerminalSnapshot([rollover], worktreeID: worktreeID)
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.claudeSessionID == "current-session")
+    #expect(terminal.presentationActivityState == nil)
+    #expect(terminal.presentationActivityObservedAt == nil)
 }
 
 @MainActor

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -44,7 +44,8 @@ import TBDShared
                 tmuxPaneID: "%1",
                 label: "Codex",
                 kind: .codex,
-                activityState: .working
+                activityState: .working,
+                presentationActivityState: .working
             )
         ]
     ]
@@ -52,6 +53,75 @@ import TBDShared
     state.handleTerminalInterrupt(terminalID: terminalID)
 
     #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+    #expect(state.terminals[worktreeID]?[0].activityStateSource?.kind == "user-action")
+    #expect(state.terminals[worktreeID]?[0].activityStateSource?.detail == "terminal-interrupt")
+    #expect(!WorktreeRowView.isForegroundWorking(state.terminals[worktreeID]![0]))
+}
+
+@MainActor
+@Test func appState_interruptRecordsProvenanceWhenCodexIsAlreadyRawIdle() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                presentationActivityState: .working
+            )
+        ]
+    ]
+
+    state.handleTerminalInterrupt(terminalID: terminalID)
+
+    #expect(state.terminals[worktreeID]?[0].activityStateSource?.kind == "user-action")
+    #expect(state.terminals[worktreeID]?[0].activityStateSource?.detail == "terminal-interrupt")
+    #expect(!WorktreeRowView.isForegroundWorking(state.terminals[worktreeID]![0]))
+}
+
+@MainActor
+@Test func appState_workingHookDeltaSupersedesCodexInterrupt() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let interruptSource = try JSONDecoder().decode(
+        FactSource.self,
+        from: Data(#"{"kind":"user-action","detail":"terminal-interrupt"}"#.utf8)
+    )
+    let delta = try JSONDecoder().decode(
+        TerminalActivityDelta.self,
+        from: Data(
+            #"{"terminalID":"\#(terminalID.uuidString)","worktreeID":"\#(worktreeID.uuidString)","activityState":"working","activityStateSource":{"kind":"hook","detail":"terminal.activityEvent"},"activityStateObservedAt":0}"#.utf8
+        )
+    )
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .idle,
+                presentationActivityState: .working,
+                activityStateSource: interruptSource
+            )
+        ]
+    ]
+
+    state.handleDelta(.terminalActivityUpdated(delta))
+
+    #expect(state.terminals[worktreeID]?[0].activityState == .working)
+    #expect(state.terminals[worktreeID]?[0].activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+    #expect(state.terminals[worktreeID]?[0].activityStateObservedAt == Date(timeIntervalSinceReferenceDate: 0))
+    #expect(WorktreeRowView.isForegroundWorking(state.terminals[worktreeID]![0]))
 }
 
 @MainActor

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -279,6 +279,386 @@ private func decodedCodexSnapshot(
 }
 
 @MainActor
+@Test func appState_sessionStartDeltaAdvancesPresentationOrderPastDelayedList() throws {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let initialAt = Date(timeIntervalSinceReferenceDate: 10)
+    let stableAt = Date(timeIntervalSinceReferenceDate: 20)
+    let delayedAt = Date(timeIntervalSinceReferenceDate: 25)
+    let sessionStartAt = Date(timeIntervalSinceReferenceDate: 30)
+    let newerAt = Date(timeIntervalSinceReferenceDate: 40)
+    let original = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        kind: .codex,
+        activityState: .idle,
+        presentationActivityState: .working,
+        presentationActivityObservedAt: initialAt,
+        activityStateSource: .hookEvent("Stop"),
+        activityStateObservedAt: initialAt,
+        activityStateOrderObservedAt: initialAt)
+    state.terminals = [worktreeID: [original]]
+
+    var stable = original
+    stable.presentationActivityObservedAt = stableAt
+    state.adoptTerminalSnapshot([stable], worktreeID: worktreeID)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == stableAt)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: sessionStartAt,
+        activityStateOrderObservedAt: sessionStartAt)))
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == .idle)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == sessionStartAt)
+
+    var delayedWorking = try #require(state.terminals[worktreeID]?.first)
+    delayedWorking.presentationActivityState = .working
+    delayedWorking.presentationActivityObservedAt = delayedAt
+    state.adoptTerminalSnapshot([delayedWorking], worktreeID: worktreeID)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == .idle)
+
+    var newerWorking = try #require(state.terminals[worktreeID]?.first)
+    newerWorking.presentationActivityState = .working
+    newerWorking.presentationActivityObservedAt = newerAt
+    state.adoptTerminalSnapshot([newerWorking], worktreeID: worktreeID)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == .working)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == newerAt)
+}
+
+@MainActor
+@Test func appState_sessionIdentityRolloverResetsPresentationOrder() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                claudeSessionID: "old-session",
+                transcriptPath: "/tmp/old-session.jsonl",
+                kind: .codex,
+                presentationActivityState: .working,
+                presentationActivityObservedAt:
+                    Date(timeIntervalSinceReferenceDate: 40))
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 20)
+    state.terminalSessionOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 20)
+    let sessionStartAt = Date(timeIntervalSinceReferenceDate: 30)
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "new-session",
+        transcriptPath: "/tmp/new-session.jsonl",
+        sessionOrderObservedAt: sessionStartAt)))
+
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == sessionStartAt)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == sessionStartAt)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == nil)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityObservedAt == nil)
+
+    // The activity delta belongs to the new identity. Its older wall-clock
+    // stamp must not be compared with presentation evidence from the old one.
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: sessionStartAt,
+        activityStateOrderObservedAt: sessionStartAt)))
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityState == .idle)
+    #expect(state.terminals[worktreeID]?.first?.presentationActivityObservedAt == sessionStartAt)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == sessionStartAt)
+}
+
+@MainActor
+@Test func appState_legacyNilPathSessionRolloverClearsOldPresentation() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let oldPath = "/tmp/existing-session.jsonl"
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                claudeSessionID: "old-session",
+                transcriptPath: oldPath,
+                kind: .codex,
+                presentationActivityState: .working,
+                presentationActivityObservedAt:
+                    Date(timeIntervalSinceReferenceDate: 40))
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 40)
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "new-session",
+        transcriptPath: nil)))
+
+    let terminal = state.terminals[worktreeID]?.first
+    #expect(terminal?.transcriptPath == oldPath)
+    #expect(terminal?.presentationActivityState == nil)
+    #expect(terminal?.presentationActivityObservedAt == nil)
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == nil)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == nil)
+}
+
+@MainActor
+@Test func appState_staleOldIdentityListCannotRollbackAcceptedSessionStart() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let oldAt = Date(timeIntervalSinceReferenceDate: 20)
+    let sessionStartAt = Date(timeIntervalSinceReferenceDate: 30)
+    let oldSnapshot = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        claudeSessionID: "old-session",
+        transcriptPath: "/tmp/old-session.jsonl",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .working,
+        presentationActivityObservedAt: oldAt,
+        activityStateSource: .hookEvent("UserPromptSubmit"),
+        activityStateObservedAt: oldAt,
+        activityStateOrderObservedAt: oldAt)
+    state.terminals = [worktreeID: [oldSnapshot]]
+    state.adoptTerminalSnapshot([oldSnapshot], worktreeID: worktreeID)
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "new-session",
+        transcriptPath: "/tmp/new-session.jsonl",
+        sessionOrderObservedAt: sessionStartAt)))
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: sessionStartAt,
+        activityStateOrderObservedAt: sessionStartAt)))
+
+    state.adoptTerminalSnapshot([oldSnapshot], worktreeID: worktreeID)
+
+    let terminal = state.terminals[worktreeID]?.first
+    #expect(terminal?.claudeSessionID == "new-session")
+    #expect(terminal?.transcriptPath == "/tmp/new-session.jsonl")
+    #expect(terminal?.activityStateSource == .hookEvent("SessionStart"))
+    #expect(terminal?.presentationActivityState == .idle)
+}
+
+@MainActor
+@Test func appState_sessionDeltaFencesStaleListBeforeActivityDelta() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let oldAt = Date(timeIntervalSinceReferenceDate: 20)
+    let sessionStartAt = Date(timeIntervalSinceReferenceDate: 30)
+    let oldSnapshot = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Codex",
+        claudeSessionID: "old-session",
+        transcriptPath: "/tmp/old-session.jsonl",
+        kind: .codex,
+        activityState: .working,
+        presentationActivityState: .working,
+        presentationActivityObservedAt: oldAt,
+        activityStateSource: .hookEvent("UserPromptSubmit"),
+        activityStateObservedAt: oldAt,
+        activityStateOrderObservedAt: oldAt)
+    state.terminals = [worktreeID: [oldSnapshot]]
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "new-session",
+        transcriptPath: "/tmp/new-session.jsonl",
+        sessionOrderObservedAt: sessionStartAt)))
+    state.adoptTerminalSnapshot([oldSnapshot], worktreeID: worktreeID)
+
+    var terminal = state.terminals[worktreeID]?.first
+    #expect(terminal?.claudeSessionID == "new-session")
+    #expect(terminal?.transcriptPath == "/tmp/new-session.jsonl")
+    #expect(terminal?.presentationActivityState == nil)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == sessionStartAt)
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: sessionStartAt,
+        activityStateOrderObservedAt: sessionStartAt)))
+    terminal = state.terminals[worktreeID]?.first
+    #expect(terminal?.activityStateSource == .hookEvent("SessionStart"))
+    #expect(terminal?.presentationActivityState == .idle)
+}
+
+@MainActor
+@Test func appState_sameSessionIdentityPreservesPresentationOrder() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let observedAt = Date(timeIntervalSinceReferenceDate: 20)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                claudeSessionID: "same-session",
+                transcriptPath: "/tmp/same-session.jsonl",
+                kind: .codex)
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] = observedAt
+
+    state.handleDelta(.terminalSessionUpdated(TerminalSessionDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        sessionID: "same-session",
+        transcriptPath: "/tmp/same-session.jsonl")))
+
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == observedAt)
+}
+
+@MainActor
+@Test func appState_terminalRemovalClearsPresentationOrder() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex)
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 20)
+
+    state.removeDeletedTerminalFromState(
+        terminalID: terminalID,
+        worktreeID: worktreeID)
+
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == nil)
+}
+
+@MainActor
+@Test func appState_recreatedTerminalReplacesPresentationOrder() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    let replacementAt = Date(timeIntervalSinceReferenceDate: 30)
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                claudeSessionID: "old-session",
+                transcriptPath: "/tmp/old-session.jsonl",
+                kind: .codex)
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 20)
+    state.terminalSessionOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 20)
+    let replacement = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@2",
+        tmuxPaneID: "%2",
+        label: "Codex",
+        claudeSessionID: "new-session",
+        transcriptPath: "/tmp/new-session.jsonl",
+        kind: .codex,
+        presentationActivityState: .idle,
+        presentationActivityObservedAt: replacementAt,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: replacementAt,
+        activityStateOrderObservedAt: replacementAt)
+
+    state.adoptRecreatedTerminal(replacement)
+
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == replacementAt)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == replacementAt)
+}
+
+@MainActor
+@Test func appState_createdTerminalReplacementResetsPresentationOrder() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                claudeSessionID: "old-session",
+                transcriptPath: "/tmp/old-session.jsonl",
+                kind: .codex)
+        ]
+    ]
+    state.terminalPresentationOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 20)
+    state.terminalSessionOrderObservedAt[terminalID] =
+        Date(timeIntervalSinceReferenceDate: 20)
+    let replacement = Terminal(
+        id: terminalID,
+        worktreeID: worktreeID,
+        tmuxWindowID: "@2",
+        tmuxPaneID: "%2",
+        label: "Codex",
+        kind: .codex)
+
+    state.mergeCreatedTerminal(replacement)
+
+    #expect(state.terminalPresentationOrderObservedAt[terminalID] == nil)
+    #expect(state.terminalSessionOrderObservedAt[terminalID] == nil)
+}
+
+@MainActor
 @Test func appState_legacyTranscriptSnapshotsRemainArrivalOrdered() throws {
     let state = AppState()
     let worktreeID = UUID()

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -31,6 +31,72 @@ import TBDShared
 }
 
 @MainActor
+@Test func appState_sessionStartDeltaClearsCodexPresentationActivityImmediately() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .working,
+                presentationActivityState: .working
+            )
+        ]
+    ]
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent("SessionStart"),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 1)
+    )))
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.presentationActivityState == .idle)
+    #expect(!WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
+@Test func appState_genericIdleHookPreservesCodexTranscriptWorkingActivity() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .working,
+                presentationActivityState: .working
+            )
+        ]
+    ]
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .idle,
+        activityStateSource: .hookEvent(RPCMethod.terminalActivityEvent),
+        activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 1)
+    )))
+
+    let terminal = state.terminals[worktreeID]![0]
+    #expect(terminal.presentationActivityState == .working)
+    #expect(WorktreeRowView.isForegroundWorking(terminal))
+}
+
+@MainActor
 @Test func appState_interruptClearsCodexActivityImmediately() {
     let state = AppState()
     let worktreeID = UUID()

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -44,6 +44,16 @@ struct WorktreeRowActivityTests {
         #expect(WorktreeRowView.isForegroundWorking(codex))
     }
 
+    @Test func codexPermissionWaitOverridesTranscriptWorkingActivity() {
+        let codex = terminal(
+            kind: .codex,
+            activityState: .waitingForUser,
+            presentationActivityState: .working
+        )
+
+        #expect(!WorktreeRowView.isForegroundWorking(codex))
+    }
+
     @Test func codexTranscriptIdleOverridesStaleRawWorkingActivity() {
         let codex = terminal(
             kind: .codex,

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -54,6 +54,20 @@ struct WorktreeRowActivityTests {
         #expect(!WorktreeRowView.isForegroundWorking(codex))
     }
 
+    @Test func codexExplicitInterruptOverridesTranscriptWorkingActivity() throws {
+        var codex = terminal(
+            kind: .codex,
+            activityState: .idle,
+            presentationActivityState: .working
+        )
+        codex.activityStateSource = try JSONDecoder().decode(
+            FactSource.self,
+            from: Data(#"{"kind":"user-action","detail":"terminal-interrupt"}"#.utf8)
+        )
+
+        #expect(!WorktreeRowView.isForegroundWorking(codex))
+    }
+
     @Test func codexTranscriptIdleOverridesStaleRawWorkingActivity() {
         let codex = terminal(
             kind: .codex,

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+@Suite("WorktreeRowView — foreground activity")
+struct WorktreeRowActivityTests {
+    private func terminal(
+        kind: TerminalKind,
+        activityState: TerminalActivityState,
+        presentationActivityState: TerminalActivityState? = nil
+    ) -> Terminal {
+        Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            kind: kind,
+            activityState: activityState,
+            presentationActivityState: presentationActivityState
+        )
+    }
+
+    @Test func claudeUsesRawWorkingActivity() {
+        let claude = terminal(kind: .claude, activityState: .working)
+
+        #expect(WorktreeRowView.isForegroundWorking(claude))
+    }
+
+    @Test func claudeRawNonworkingActivityDoesNotAnimate() {
+        let idle = terminal(kind: .claude, activityState: .idle)
+        let waiting = terminal(kind: .claude, activityState: .waitingForUser)
+
+        #expect(!WorktreeRowView.isForegroundWorking(idle))
+        #expect(!WorktreeRowView.isForegroundWorking(waiting))
+    }
+
+    @Test func codexUsesTranscriptWorkingActivity() {
+        let codex = terminal(
+            kind: .codex,
+            activityState: .idle,
+            presentationActivityState: .working
+        )
+
+        #expect(WorktreeRowView.isForegroundWorking(codex))
+    }
+
+    @Test func codexTranscriptIdleOverridesStaleRawWorkingActivity() {
+        let codex = terminal(
+            kind: .codex,
+            activityState: .working,
+            presentationActivityState: .idle
+        )
+
+        #expect(!WorktreeRowView.isForegroundWorking(codex))
+    }
+
+    @Test func codexWithoutTranscriptEvidencePrefersFalseIdle() {
+        let codex = terminal(
+            kind: .codex,
+            activityState: .working,
+            presentationActivityState: nil
+        )
+
+        #expect(!WorktreeRowView.isForegroundWorking(codex))
+    }
+
+    @Test func terminalCollectionReportsAnyTruthfulForegroundWork() {
+        let staleCodex = terminal(
+            kind: .codex,
+            activityState: .working,
+            presentationActivityState: .idle
+        )
+        let workingClaude = terminal(kind: .claude, activityState: .working)
+
+        #expect(WorktreeRowView.hasForegroundWork(in: [staleCodex, workingClaude]))
+        #expect(!WorktreeRowView.hasForegroundWork(in: [staleCodex]))
+        #expect(!WorktreeRowView.hasForegroundWork(in: []))
+    }
+}

--- a/Tests/TBDCLITests/TerminalActivityEventCommandTests.swift
+++ b/Tests/TBDCLITests/TerminalActivityEventCommandTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import TBDCLI
+
+@Suite struct TerminalActivityEventCommandTests {
+    @Test("hook payload parser extracts session identity")
+    func parsesHookSessionIdentity() {
+        let data = Data(
+            #"{"session_id":"session-current","transcript_path":"/tmp/session.jsonl","hook_event_name":"PermissionRequest"}"#.utf8)
+
+        #expect(TerminalActivityEventCommand.sessionID(fromHookPayload: data) == "session-current")
+    }
+
+    @Test("hook payload parser rejects absent, blank, and malformed identity")
+    func rejectsInvalidHookSessionIdentity() {
+        #expect(TerminalActivityEventCommand.sessionID(
+            fromHookPayload: Data(#"{"hook_event_name":"PermissionRequest"}"#.utf8)) == nil)
+        #expect(TerminalActivityEventCommand.sessionID(
+            fromHookPayload: Data(#"{"session_id":""}"#.utf8)) == nil)
+        #expect(TerminalActivityEventCommand.sessionID(
+            fromHookPayload: Data("not-json".utf8)) == nil)
+        let oversized = Data(
+            (#"{"session_id":"session-current","padding":""#
+                + String(repeating: "x", count: (1 << 20) + 1)
+                + #""}"#).utf8)
+        #expect(TerminalActivityEventCommand.sessionID(fromHookPayload: oversized) == nil)
+    }
+
+    @Test("hook stdin parsing is explicit")
+    func hookStdinParsingIsExplicit() throws {
+        let command = try TerminalActivityEventCommand.parse([
+            "working", "--read-hook-payload"
+        ])
+
+        #expect(command.readHookPayload)
+    }
+}

--- a/Tests/TBDCLITests/TerminalActivityEventCommandTests.swift
+++ b/Tests/TBDCLITests/TerminalActivityEventCommandTests.swift
@@ -34,4 +34,19 @@ import Testing
 
         #expect(command.readHookPayload)
     }
+
+    @Test("hook payload reader stops after detecting one byte over the limit")
+    func hookPayloadReaderStopsAtOverflowBoundary() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("terminal-activity-hook-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data(repeating: 0x61, count: (1 << 20) + 512).write(to: url)
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        let payload = TerminalActivityEventCommand.readBoundedHookPayload(from: handle)
+
+        #expect(payload == nil)
+        #expect(try handle.offset() == UInt64((1 << 20) + 1))
+    }
 }

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -6,6 +6,8 @@ import TestSupport
 
 @Suite("codex activity reconciliation")
 struct CodexActivityReconciliationTests {
+    private static let raceRendezvousTimeout: Duration = .seconds(30)
+
     let db: TBDDatabase
     let router: RPCRouter
     let presentationObservedAt: Date
@@ -399,17 +401,22 @@ struct CodexActivityReconciliationTests {
                 source: "SessionStart"))
 
         let staleList = Task { await router.handle(list) }
-        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+        guard await waitUntil(
+            { dates.firstCallIsBlocked }, timeout: Self.raceRendezvousTimeout
+        ) else {
             dates.releaseFirstCall()
             _ = await staleList.value
             Issue.record("first terminal.list never reached its transcript stamp")
             return
         }
         let sessionUpdate = Task { await router.handle(sessionStart) }
-        guard await waitUntilAsync({
-            let current = try? await db.terminals.get(id: terminal.id)
-            return current?.claudeSessionID == "current-session"
-        }) else {
+        guard await waitUntilAsync(
+            {
+                let current = try? await db.terminals.get(id: terminal.id)
+                return current?.claudeSessionID == "current-session"
+            },
+            timeout: Self.raceRendezvousTimeout
+        ) else {
             dates.releaseFirstCall()
             _ = await staleList.value
             _ = await sessionUpdate.value
@@ -482,17 +489,22 @@ struct CodexActivityReconciliationTests {
                 transcriptPath: transcript.path, source: "SessionStart"))
 
         let staleList = Task { await raceRouter.handle(list) }
-        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+        guard await waitUntil(
+            { dates.firstCallIsBlocked }, timeout: Self.raceRendezvousTimeout
+        ) else {
             dates.releaseFirstCall()
             _ = await staleList.value
             Issue.record("terminal.list never reached its transcript stamp")
             return
         }
         let sessionUpdate = Task { await raceRouter.handle(sessionStart) }
-        guard await waitUntilAsync({
-            let current = try? await db.terminals.get(id: terminal.id)
-            return current?.activityStateOrderObservedAt == sessionAt
-        }) else {
+        guard await waitUntilAsync(
+            {
+                let current = try? await db.terminals.get(id: terminal.id)
+                return current?.activityStateOrderObservedAt == sessionAt
+            },
+            timeout: Self.raceRendezvousTimeout
+        ) else {
             dates.releaseFirstCall()
             _ = await staleList.value
             _ = await sessionUpdate.value

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -26,8 +26,8 @@ struct CodexActivityReconciliationTests {
         )
     }
 
-    @Test("terminal.list does not infer codex activity from transcript path")
-    func terminalListDoesNotReconcileActivity() async throws {
+    @Test("terminal.list exposes transcript working without changing persisted hook activity")
+    func terminalListExposesWorkingPresentationWithoutMutation() async throws {
         let repo = try await db.repos.create(
             path: "/tmp/car-repo-\(UUID().uuidString)",
             displayName: "car-repo",
@@ -41,16 +41,9 @@ struct CodexActivityReconciliationTests {
             tmuxServer: "tbd-car"
         )
 
-        let transcriptDir = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tbd-codex-activity-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: transcriptDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: transcriptDir) }
-
-        let transcriptPath = transcriptDir.appendingPathComponent("session.jsonl")
-        let jsonl = """
-        {"timestamp":"2026-05-26T13:20:25.252Z","type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}
-        """
-        try jsonl.write(to: transcriptPath, atomically: true, encoding: .utf8)
+        let transcriptPath = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}"# + "\n")
+        defer { try? FileManager.default.removeItem(at: transcriptPath.deletingLastPathComponent()) }
 
         let terminal = try await db.terminals.create(
             worktreeID: wt.id,
@@ -64,6 +57,10 @@ struct CodexActivityReconciliationTests {
             sessionID: "codex-session",
             transcriptPath: transcriptPath.path
         )
+        let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .idle,
+            source: .hookEvent("Stop"), observedAt: observedAt)
 
         let request = try RPCRequest(
             method: RPCMethod.terminalList,
@@ -74,14 +71,20 @@ struct CodexActivityReconciliationTests {
 
         let terminals = try response.decodeResult([Terminal].self)
         #expect(terminals.count == 1)
-        #expect(terminals[0].activityState == .unknown)
+        #expect(terminals[0].presentationActivityState == .working)
+        #expect(terminals[0].activityState == .idle)
+        #expect(terminals[0].activityStateSource == .hookEvent("Stop"))
+        #expect(terminals[0].activityStateObservedAt == observedAt)
 
         let persisted = try await db.terminals.get(id: terminal.id)
-        #expect(persisted?.activityState == .unknown)
+        #expect(persisted?.presentationActivityState == nil)
+        #expect(persisted?.activityState == .idle)
+        #expect(persisted?.activityStateSource == .hookEvent("Stop"))
+        #expect(persisted?.activityStateObservedAt == observedAt)
     }
 
-    @Test("terminal.list does not overwrite explicit idle with transcript working")
-    func terminalListPreservesExplicitIdle() async throws {
+    @Test("matching transcript completion clears presentation while missed Stop remains persisted working")
+    func terminalListObservesAppendedCompletionWithoutMutation() async throws {
         let repo = try await db.repos.create(
             path: "/tmp/car-idle-repo-\(UUID().uuidString)",
             displayName: "car-idle-repo",
@@ -95,16 +98,9 @@ struct CodexActivityReconciliationTests {
             tmuxServer: "tbd-car-idle"
         )
 
-        let transcriptDir = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tbd-codex-activity-idle-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: transcriptDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: transcriptDir) }
-
-        let transcriptPath = transcriptDir.appendingPathComponent("session.jsonl")
-        let jsonl = """
-        {"timestamp":"2026-05-26T13:20:25.252Z","type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}
-        """
-        try jsonl.write(to: transcriptPath, atomically: true, encoding: .utf8)
+        let transcriptPath = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}"# + "\n")
+        defer { try? FileManager.default.removeItem(at: transcriptPath.deletingLastPathComponent()) }
 
         let terminal = try await db.terminals.create(
             worktreeID: wt.id,
@@ -118,21 +114,128 @@ struct CodexActivityReconciliationTests {
             sessionID: "codex-session",
             transcriptPath: transcriptPath.path
         )
-        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle, source: .derived)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working, source: .hookEvent("TurnStart"),
+            observedAt: Date(timeIntervalSince1970: 1_780_000_000))
 
         let request = try RPCRequest(
             method: RPCMethod.terminalList,
             params: TerminalListParams(worktreeID: wt.id)
         )
+        let workingResponse = await router.handle(request)
+        #expect(workingResponse.success)
+        let working = try workingResponse.decodeResult([Terminal].self)
+        #expect(working.first?.presentationActivityState == .working)
+
+        let handle = try FileHandle(forWritingTo: transcriptPath)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(
+            (#"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"a"}}"# + "\n").utf8))
+        try handle.close()
+
+        let idleResponse = await router.handle(request)
+        #expect(idleResponse.success)
+        let idle = try idleResponse.decodeResult([Terminal].self)
+        #expect(idle.first?.presentationActivityState == .idle)
+        #expect(idle.first?.activityState == .working)
+
+        let persisted = try await db.terminals.get(id: terminal.id)
+        #expect(persisted?.presentationActivityState == nil)
+        #expect(persisted?.activityState == .working)
+    }
+
+    @Test("terminal.list leaves presentation unknown for unreadable Codex transcript and Claude")
+    func terminalListUsesPresentationOnlyForReadableCodexTranscript() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-scope-repo-\(UUID().uuidString)",
+            displayName: "car-scope-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-scope-wt-\(UUID().uuidString)", tmuxServer: "tbd-car-scope")
+        let missingPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString).jsonl").path
+
+        let codex = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        try await db.terminals.updateSession(
+            id: codex.id, sessionID: "codex-session", transcriptPath: missingPath)
+        try await db.terminals.setActivityState(
+            id: codex.id, activityState: .working, source: .hookEvent("TurnStart"))
+
+        let claudeTranscript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}"# + "\n")
+        defer { try? FileManager.default.removeItem(at: claudeTranscript.deletingLastPathComponent()) }
+        let claude = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "Claude", kind: .claude)
+        try await db.terminals.updateSession(
+            id: claude.id, sessionID: "claude-session", transcriptPath: claudeTranscript.path)
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalList, params: TerminalListParams(worktreeID: wt.id))
         let response = await router.handle(request)
         #expect(response.success)
 
         let terminals = try response.decodeResult([Terminal].self)
-        #expect(terminals.count == 1)
-        #expect(terminals[0].activityState == .idle)
+        #expect(terminals.first(where: { $0.id == codex.id })?.presentationActivityState == nil)
+        #expect(terminals.first(where: { $0.id == codex.id })?.activityState == .working)
+        #expect(terminals.first(where: { $0.id == claude.id })?.presentationActivityState == nil)
+    }
 
-        let persisted = try await db.terminals.get(id: terminal.id)
-        #expect(persisted?.activityState == .idle)
+    @Test("terminal.list retention respects worktree and fleet scopes")
+    func terminalListRetainsTrackerBaselinesByRequestScope() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-retain-repo-\(UUID().uuidString)",
+            displayName: "car-retain-repo", defaultBranch: "main")
+        let firstWorktree = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "first",
+            path: "/tmp/car-retain-first-\(UUID().uuidString)", tmuxServer: "tbd-car-first")
+        let secondWorktree = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "second",
+            path: "/tmp/car-retain-second-\(UUID().uuidString)", tmuxServer: "tbd-car-second")
+        let firstPath = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}"# + "\n")
+        let secondPath = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"b"}}"# + "\n")
+        defer {
+            try? FileManager.default.removeItem(at: firstPath.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: secondPath.deletingLastPathComponent())
+        }
+        let first = try await db.terminals.create(
+            worktreeID: firstWorktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1", kind: .codex)
+        let second = try await db.terminals.create(
+            worktreeID: secondWorktree.id, tmuxWindowID: "@2", tmuxPaneID: "%2", kind: .codex)
+        try await db.terminals.updateSession(
+            id: first.id, sessionID: "first", transcriptPath: firstPath.path)
+        try await db.terminals.updateSession(
+            id: second.id, sessionID: "second", transcriptPath: secondPath.path)
+
+        let fleetRequest = try RPCRequest(
+            method: RPCMethod.terminalList, params: TerminalListParams())
+        #expect(await router.handle(fleetRequest).success)
+        #expect(await router.codexActivityTracker.baselineCount == 2)
+
+        try await db.terminals.delete(id: first.id)
+        let scopedRequest = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: firstWorktree.id))
+        #expect(await router.handle(scopedRequest).success)
+        #expect(!(await router.codexActivityTracker.hasBaseline(transcriptPath: firstPath.path)))
+        #expect(await router.codexActivityTracker.hasBaseline(transcriptPath: secondPath.path))
+
+        try await db.terminals.delete(id: second.id)
+        #expect(await router.handle(fleetRequest).success)
+        #expect(await router.codexActivityTracker.baselineCount == 0)
+    }
+
+    private func makeTranscript(_ contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-activity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = directory.appendingPathComponent("session.jsonl")
+        try contents.write(to: path, atomically: true, encoding: .utf8)
+        return path
     }
 
     // MARK: - The date seam on the two handlers that WRITE codex activity

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -103,6 +103,74 @@ struct CodexActivityReconciliationTests {
         #expect(persisted?.activityStateObservedAt == observedAt)
     }
 
+    @Test("ordinary activity hooks do not invalidate an in-flight transcript observation")
+    func ordinaryActivityHookKeepsTranscriptEvidence() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-hook-race-repo-\(UUID().uuidString)",
+            displayName: "car-hook-race-repo",
+            defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/car-hook-race-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-hook-race")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex)
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "current-session",
+            transcriptPath: transcript.path)
+        let initialActivityAt = Date(timeIntervalSince1970: 1_790_000_010)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .idle,
+            source: .hookEvent("Stop"),
+            observedAt: initialActivityAt)
+
+        let listAt = initialActivityAt.addingTimeInterval(1)
+        let hookAt = listAt.addingTimeInterval(1)
+        let dates = BlockingListDates(first: listAt, subsequent: hookAt)
+        let raceRouter = makeRouter(now: dates.provider)
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id))
+        let hook = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .working))
+
+        let inFlightList = Task { await raceRouter.handle(list) }
+        guard await waitUntil(
+            { dates.firstCallIsBlocked }, timeout: Self.raceRendezvousTimeout
+        ) else {
+            dates.releaseFirstCall()
+            _ = await inFlightList.value
+            Issue.record("terminal.list never reached its transcript stamp")
+            return
+        }
+        #expect((await raceRouter.handle(hook)).success)
+        dates.releaseFirstCall()
+
+        let response = await inFlightList.value
+        #expect(response.success)
+        let listed = try #require(
+            response.decodeResult([Terminal].self).first(where: { $0.id == terminal.id }))
+        #expect(listed.activityState == .working)
+        #expect(listed.activityStateOrderObservedAt == hookAt)
+        #expect(listed.presentationActivityState == .working)
+        #expect(listed.presentationActivityObservedAt == listAt)
+    }
+
     @Test("accepted same-path SessionStart supersedes an orphan transcript turn")
     func samePathSessionStartResetsTranscriptLifecycle() async throws {
         let repo = try await db.repos.create(
@@ -185,6 +253,11 @@ struct CodexActivityReconciliationTests {
                 terminalID: terminal.id, sessionID: "same-session",
                 transcriptPath: transcript.path, source: "SessionStart"))
         #expect((await router.handle(sessionStart)).success)
+        _ = try await db.terminals.applyActivityObservation(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent(RPCMethod.terminalActivityEvent),
+            observedAt: presentationObservedAt.addingTimeInterval(1))
 
         let restartedRouter = makeRouter(now: { presentationObservedAt })
         let list = try RPCRequest(

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -339,6 +339,7 @@ struct CodexActivityReconciliationTests {
 
     @Test(
         "terminal.list binds presentation to the post-observation transcript identity",
+        .serialized,
         arguments: [true, false]
     )
     func terminalListRejectsPresentationFromRetargetedTranscript(
@@ -453,6 +454,7 @@ struct CodexActivityReconciliationTests {
 
     @Test(
         "terminal.list rejects a pre-boundary observation when the path is unchanged",
+        .serialized,
         arguments: [true, false]
     )
     func terminalListRejectsPreBoundarySamePathObservation(

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -229,6 +229,87 @@ struct CodexActivityReconciliationTests {
         #expect(await router.codexActivityTracker.baselineCount == 0)
     }
 
+    @Test("terminal.list shares its transcript byte budget fairly across Codex terminals")
+    func terminalListSharesTranscriptBudgetFairly() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-budget-repo-\(UUID().uuidString)",
+            displayName: "car-budget-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-budget-wt-\(UUID().uuidString)", tmuxServer: "tbd-car-budget")
+        let paths = try ["first", "second"].map { turnID in
+            try makeTranscript(String(decoding: lifecycleEvent(
+                type: "task_complete", turnID: turnID), as: UTF8.self))
+        }
+        defer {
+            for path in paths {
+                try? FileManager.default.removeItem(at: path.deletingLastPathComponent())
+            }
+        }
+
+        for (index, path) in paths.enumerated() {
+            let terminal = try await db.terminals.create(
+                worktreeID: wt.id,
+                tmuxWindowID: "@\(index + 1)", tmuxPaneID: "%\(index + 1)",
+                label: "Codex \(index + 1)", kind: .codex)
+            try await db.terminals.updateSession(
+                id: terminal.id, sessionID: "codex-\(index + 1)", transcriptPath: path.path)
+        }
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id))
+        #expect(await router.handle(request).success)
+
+        let oversizedRecordByteCount = CodexTranscriptActivityTracker.maxBufferedRecordByteCount + 128
+        for (index, path) in paths.enumerated() {
+            try append(
+                lifecycleEvent(
+                    type: "agent_message", turnID: "padding-\(index)",
+                    exactByteCount: oversizedRecordByteCount)
+                    + lifecycleEvent(type: "task_started", turnID: "turn-\(index)"),
+                to: path)
+        }
+
+        let firstResponse = await router.handle(request)
+        #expect(firstResponse.success)
+        let firstTerminals = try firstResponse.decodeResult([Terminal].self)
+        #expect(firstTerminals.allSatisfy { $0.presentationActivityState == nil })
+
+        var bufferedByteCount = 0
+        var progressedPathCount = 0
+        for path in paths {
+            let buffered = await router.codexActivityTracker.bufferedRecordState(
+                transcriptPath: path.path)
+            bufferedByteCount += buffered?.byteCount ?? 0
+            if let buffered, buffered.byteCount > 0 {
+                progressedPathCount += 1
+            }
+        }
+        #expect(bufferedByteCount == Int(CodexTranscriptActivityTracker.requestReadByteLimit))
+        #expect(progressedPathCount == paths.count)
+
+        try append(
+            lifecycleEvent(
+                type: "agent_message", turnID: "first-keeps-growing",
+                exactByteCount: 64 * 1024),
+            to: paths[0])
+        let secondResponse = await router.handle(request)
+        #expect(secondResponse.success)
+        let secondTerminals = try secondResponse.decodeResult([Terminal].self)
+        #expect(secondTerminals.allSatisfy { $0.presentationActivityState == nil })
+
+        try append(
+            lifecycleEvent(
+                type: "agent_message", turnID: "first-still-growing",
+                exactByteCount: 64 * 1024),
+            to: paths[0])
+        let finalResponse = await router.handle(request)
+        #expect(finalResponse.success)
+        let finalTerminals = try finalResponse.decodeResult([Terminal].self)
+        #expect(finalTerminals.allSatisfy { $0.presentationActivityState == .working })
+    }
+
     private func makeTranscript(_ contents: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-activity-\(UUID().uuidString)", isDirectory: true)
@@ -236,6 +317,31 @@ struct CodexActivityReconciliationTests {
         let path = directory.appendingPathComponent("session.jsonl")
         try contents.write(to: path, atomically: true, encoding: .utf8)
         return path
+    }
+
+    private func lifecycleEvent(
+        type: String,
+        turnID: String,
+        exactByteCount: Int? = nil
+    ) -> Data {
+        func encoded(padding: String?) -> Data {
+            let paddingField = padding.map { #", "padding":"\#($0)""# } ?? ""
+            return Data((
+                #"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"\#(paddingField)}}"#
+                    + "\n").utf8)
+        }
+
+        guard let exactByteCount else { return encoded(padding: nil) }
+        let emptyPadded = encoded(padding: "")
+        precondition(exactByteCount >= emptyPadded.count)
+        return encoded(padding: String(repeating: "x", count: exactByteCount - emptyPadded.count))
+    }
+
+    private func append(_ data: Data, to path: URL) throws {
+        let handle = try FileHandle(forWritingTo: path)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
     }
 
     // MARK: - The date seam on the two handlers that WRITE codex activity

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -192,6 +192,102 @@ struct CodexActivityReconciliationTests {
         #expect(terminals.first(where: { $0.id == claude.id })?.presentationActivityObservedAt == nil)
     }
 
+    @Test(
+        "terminal.list binds presentation to the post-observation transcript identity",
+        arguments: [true, false]
+    )
+    func terminalListRejectsPresentationFromRetargetedTranscript(
+        scoped: Bool
+    ) async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-rollover-repo-\(UUID().uuidString)",
+            displayName: "car-rollover-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-rollover-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-rollover")
+        let oldTranscript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old"}}"#
+                + "\n")
+        let currentTranscript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"current"}}"#
+                + "\n")
+        defer {
+            try? FileManager.default.removeItem(
+                at: oldTranscript.deletingLastPathComponent())
+            try? FileManager.default.removeItem(
+                at: currentTranscript.deletingLastPathComponent())
+        }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "old-session",
+            transcriptPath: oldTranscript.path)
+
+        let firstAt = Date(timeIntervalSince1970: 1_790_000_100)
+        let currentAt = firstAt.addingTimeInterval(1)
+        let dates = BlockingListDates(first: firstAt, subsequent: currentAt)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            now: dates.provider,
+            actuationLog: makeTestActuationLog())
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: scoped ? wt.id : nil))
+        let priorResponse = await self.router.handle(list)
+        #expect(priorResponse.success)
+        let priorTerminal = try #require(
+            priorResponse.decodeResult([Terminal].self).first(where: { $0.id == terminal.id }))
+        #expect(priorTerminal.presentationActivityState == .working)
+        #expect(priorTerminal.presentationActivityObservedAt == presentationObservedAt)
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "current-session",
+                transcriptPath: currentTranscript.path,
+                source: "SessionStart"))
+
+        let staleList = Task { await router.handle(list) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await staleList.value
+            Issue.record("first terminal.list never reached its transcript stamp")
+            return
+        }
+        #expect((await router.handle(sessionStart)).success)
+        let currentList = Task { await router.handle(list) }
+        dates.releaseFirstCall()
+
+        let staleResponse = await staleList.value
+        let currentResponse = await currentList.value
+        #expect(staleResponse.success)
+        #expect(currentResponse.success)
+        let staleTerminal = try #require(
+            staleResponse.decodeResult([Terminal].self).first(where: { $0.id == terminal.id }))
+        let currentTerminal = try #require(
+            currentResponse.decodeResult([Terminal].self).first(where: { $0.id == terminal.id }))
+
+        #expect(staleTerminal.claudeSessionID == "current-session")
+        #expect(staleTerminal.transcriptPath == currentTranscript.path)
+        #expect(staleTerminal.presentationActivityState == nil)
+        #expect(staleTerminal.presentationActivityObservedAt == firstAt)
+        #expect(currentTerminal.transcriptPath == currentTranscript.path)
+        #expect(currentTerminal.presentationActivityState == .idle)
+        #expect(currentTerminal.presentationActivityObservedAt == currentAt)
+        #expect(!(await router.codexActivityTracker.hasBaseline(
+            transcriptPath: oldTranscript.path)))
+        #expect(await router.codexActivityTracker.hasBaseline(
+            transcriptPath: currentTranscript.path))
+    }
+
     @Test("terminal.list retention respects worktree and fleet scopes")
     func terminalListRetainsTrackerBaselinesByRequestScope() async throws {
         let repo = try await db.repos.create(
@@ -440,5 +536,41 @@ struct CodexActivityReconciliationTests {
         #expect(after.activityState == .unknown)
         #expect(after.activityStateObservedAt == Self.observedAt)
         #expect(after.observedActivity?.observedAt == Self.observedAt)
+    }
+}
+
+private final class BlockingListDates: @unchecked Sendable {
+    private let lock = NSLock()
+    private let first: Date
+    private let subsequent: Date
+    private let release = DispatchSemaphore(value: 0)
+    private var callCount = 0
+    private var firstBlocked = false
+
+    init(first: Date, subsequent: Date) {
+        self.first = first
+        self.subsequent = subsequent
+    }
+
+    var firstCallIsBlocked: Bool {
+        lock.withLock { firstBlocked }
+    }
+
+    var provider: @Sendable () -> Date {
+        { [self] in
+            let call = lock.withLock { () -> Int in
+                let call = callCount
+                callCount += 1
+                if call == 0 { firstBlocked = true }
+                return call
+            }
+            guard call == 0 else { return subsequent }
+            release.wait()
+            return first
+        }
+    }
+
+    func releaseFirstCall() {
+        release.signal()
     }
 }

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -89,6 +89,65 @@ struct CodexActivityReconciliationTests {
         #expect(persisted?.activityStateObservedAt == observedAt)
     }
 
+    @Test("accepted same-path SessionStart supersedes an orphan transcript turn")
+    func samePathSessionStartResetsTranscriptLifecycle() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-reset-repo-\(UUID().uuidString)",
+            displayName: "car-reset-repo",
+            defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/car-reset-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-reset")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"orphan"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex)
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "same-session",
+            transcriptPath: transcript.path)
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id))
+
+        let before = await router.handle(list)
+        #expect(before.success)
+        #expect(try before.decodeResult([Terminal].self).first?
+            .presentationActivityState == .working)
+
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "same-session",
+                transcriptPath: transcript.path,
+                source: "resume"))
+        #expect((await router.handle(sessionStart)).success)
+
+        let afterBoundary = await router.handle(list)
+        #expect(afterBoundary.success)
+        #expect(try afterBoundary.decodeResult([Terminal].self).first?
+            .presentationActivityState == nil)
+
+        try append(
+            Data((#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"later"}}"#
+                + "\n").utf8),
+            to: transcript)
+        let afterLaterTurn = await router.handle(list)
+        #expect(afterLaterTurn.success)
+        #expect(try afterLaterTurn.decodeResult([Terminal].self).first?
+            .presentationActivityState == .working)
+    }
+
     @Test("matching transcript completion clears presentation while missed Stop remains persisted working")
     func terminalListObservesAppendedCompletionWithoutMutation() async throws {
         let repo = try await db.repos.create(
@@ -262,11 +321,22 @@ struct CodexActivityReconciliationTests {
             Issue.record("first terminal.list never reached its transcript stamp")
             return
         }
-        #expect((await router.handle(sessionStart)).success)
+        let sessionUpdate = Task { await router.handle(sessionStart) }
+        guard await waitUntilAsync({
+            let current = try? await db.terminals.get(id: terminal.id)
+            return current?.claudeSessionID == "current-session"
+        }) else {
+            dates.releaseFirstCall()
+            _ = await staleList.value
+            _ = await sessionUpdate.value
+            Issue.record("SessionStart never committed its atomic retarget")
+            return
+        }
         let currentList = Task { await router.handle(list) }
         dates.releaseFirstCall()
 
         let staleResponse = await staleList.value
+        #expect((await sessionUpdate.value).success)
         let currentResponse = await currentList.value
         #expect(staleResponse.success)
         #expect(currentResponse.success)
@@ -280,7 +350,9 @@ struct CodexActivityReconciliationTests {
         #expect(staleTerminal.presentationActivityState == nil)
         #expect(staleTerminal.presentationActivityObservedAt == firstAt)
         #expect(currentTerminal.transcriptPath == currentTranscript.path)
-        #expect(currentTerminal.presentationActivityState == .idle)
+        // SessionStart establishes a boundary at the transcript's current EOF,
+        // so pre-boundary lifecycle events are not evidence for the new session.
+        #expect(currentTerminal.presentationActivityState == nil)
         #expect(currentTerminal.presentationActivityObservedAt == currentAt)
         #expect(!(await router.codexActivityTracker.hasBaseline(
             transcriptPath: oldTranscript.path)))
@@ -537,6 +609,19 @@ struct CodexActivityReconciliationTests {
         #expect(after.activityStateObservedAt == Self.observedAt)
         #expect(after.observedActivity?.observedAt == Self.observedAt)
     }
+}
+
+private func waitUntilAsync(
+    _ condition: @escaping @Sendable () async -> Bool,
+    timeout: Duration = .seconds(2)
+) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    repeat {
+        if await condition() { return true }
+        await Task.yield()
+    } while clock.now < deadline
+    return false
 }
 
 private final class BlockingListDates: @unchecked Sendable {

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -8,10 +8,13 @@ import TestSupport
 struct CodexActivityReconciliationTests {
     let db: TBDDatabase
     let router: RPCRouter
+    let presentationObservedAt: Date
 
     init() throws {
         let db = try TBDDatabase(inMemory: true)
+        let presentationObservedAt = Date(timeIntervalSince1970: 1_790_000_000)
         self.db = db
+        self.presentationObservedAt = presentationObservedAt
         self.router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
@@ -22,6 +25,7 @@ struct CodexActivityReconciliationTests {
             ),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
+            now: { presentationObservedAt },
             actuationLog: makeTestActuationLog()
         )
     }
@@ -72,12 +76,14 @@ struct CodexActivityReconciliationTests {
         let terminals = try response.decodeResult([Terminal].self)
         #expect(terminals.count == 1)
         #expect(terminals[0].presentationActivityState == .working)
+        #expect(terminals[0].presentationActivityObservedAt == presentationObservedAt)
         #expect(terminals[0].activityState == .idle)
         #expect(terminals[0].activityStateSource == .hookEvent("Stop"))
         #expect(terminals[0].activityStateObservedAt == observedAt)
 
         let persisted = try await db.terminals.get(id: terminal.id)
         #expect(persisted?.presentationActivityState == nil)
+        #expect(persisted?.presentationActivityObservedAt == nil)
         #expect(persisted?.activityState == .idle)
         #expect(persisted?.activityStateSource == .hookEvent("Stop"))
         #expect(persisted?.activityStateObservedAt == observedAt)
@@ -179,8 +185,11 @@ struct CodexActivityReconciliationTests {
 
         let terminals = try response.decodeResult([Terminal].self)
         #expect(terminals.first(where: { $0.id == codex.id })?.presentationActivityState == nil)
+        #expect(terminals.first(where: { $0.id == codex.id })?.presentationActivityObservedAt
+            == presentationObservedAt)
         #expect(terminals.first(where: { $0.id == codex.id })?.activityState == .working)
         #expect(terminals.first(where: { $0.id == claude.id })?.presentationActivityState == nil)
+        #expect(terminals.first(where: { $0.id == claude.id })?.presentationActivityObservedAt == nil)
     }
 
     @Test("terminal.list retention respects worktree and fleet scopes")

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -30,6 +30,18 @@ struct CodexActivityReconciliationTests {
         )
     }
 
+    private func makeRouter(now: @escaping @Sendable () -> Date) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            now: now,
+            actuationLog: makeTestActuationLog())
+    }
+
     @Test("terminal.list exposes transcript working without changing persisted hook activity")
     func terminalListExposesWorkingPresentationWithoutMutation() async throws {
         let repo = try await db.repos.create(
@@ -145,6 +157,78 @@ struct CodexActivityReconciliationTests {
         let afterLaterTurn = await router.handle(list)
         #expect(afterLaterTurn.success)
         #expect(try afterLaterTurn.decodeResult([Terminal].self).first?
+            .presentationActivityState == .working)
+    }
+
+    @Test("a persisted SessionStart boundary survives a fresh tracker")
+    func samePathSessionBoundarySurvivesFreshTracker() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-restart-repo-\(UUID().uuidString)",
+            displayName: "car-restart-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-restart-wt-\(UUID().uuidString)", tmuxServer: "tbd-car-restart")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"orphan"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "same-session", transcriptPath: transcript.path)
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "same-session",
+                transcriptPath: transcript.path, source: "SessionStart"))
+        #expect((await router.handle(sessionStart)).success)
+
+        let restartedRouter = makeRouter(now: { presentationObservedAt })
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id))
+        let afterRestart = await restartedRouter.handle(list)
+        #expect(afterRestart.success)
+        #expect(try afterRestart.decodeResult([Terminal].self).first?
+            .presentationActivityState == nil)
+    }
+
+    @Test("an equal-stamped duplicate SessionStart does not hide a later turn")
+    func duplicateSessionStartDoesNotResetLaterTurn() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-duplicate-repo-\(UUID().uuidString)",
+            displayName: "car-duplicate-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-duplicate-wt-\(UUID().uuidString)", tmuxServer: "tbd-car-duplicate")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"orphan"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "same-session", transcriptPath: transcript.path)
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "same-session",
+                transcriptPath: transcript.path, source: "SessionStart"))
+        #expect((await router.handle(sessionStart)).success)
+        try append(
+            Data((#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"later"}}"#
+                + "\n").utf8),
+            to: transcript)
+
+        #expect((await router.handle(sessionStart)).success)
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id))
+        let response = await router.handle(list)
+        #expect(response.success)
+        #expect(try response.decodeResult([Terminal].self).first?
             .presentationActivityState == .working)
     }
 
@@ -358,6 +442,74 @@ struct CodexActivityReconciliationTests {
             transcriptPath: oldTranscript.path)))
         #expect(await router.codexActivityTracker.hasBaseline(
             transcriptPath: currentTranscript.path))
+    }
+
+    @Test(
+        "terminal.list rejects a pre-boundary observation when the path is unchanged",
+        arguments: [true, false]
+    )
+    func terminalListRejectsPreBoundarySamePathObservation(
+        scoped: Bool
+    ) async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-generation-repo-\(UUID().uuidString)",
+            displayName: "car-generation-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-generation-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-generation")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"orphan"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "same-session", transcriptPath: transcript.path)
+
+        let listAt = Date(timeIntervalSince1970: 1_790_000_200)
+        let sessionAt = listAt.addingTimeInterval(1)
+        let dates = BlockingListDates(first: listAt, subsequent: sessionAt)
+        let raceRouter = makeRouter(now: dates.provider)
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: scoped ? wt.id : nil))
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "same-session",
+                transcriptPath: transcript.path, source: "SessionStart"))
+
+        let staleList = Task { await raceRouter.handle(list) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await staleList.value
+            Issue.record("terminal.list never reached its transcript stamp")
+            return
+        }
+        let sessionUpdate = Task { await raceRouter.handle(sessionStart) }
+        guard await waitUntilAsync({
+            let current = try? await db.terminals.get(id: terminal.id)
+            return current?.activityStateOrderObservedAt == sessionAt
+        }) else {
+            dates.releaseFirstCall()
+            _ = await staleList.value
+            _ = await sessionUpdate.value
+            Issue.record("same-path SessionStart never advanced its activity generation")
+            return
+        }
+        dates.releaseFirstCall()
+
+        let staleResponse = await staleList.value
+        #expect((await sessionUpdate.value).success)
+        #expect(staleResponse.success)
+        let staleTerminal = try #require(
+            staleResponse.decodeResult([Terminal].self).first(where: { $0.id == terminal.id }))
+        #expect(staleTerminal.claudeSessionID == "same-session")
+        #expect(staleTerminal.transcriptPath == transcript.path)
+        #expect(staleTerminal.presentationActivityState == nil)
+        #expect(staleTerminal.presentationActivityObservedAt == listAt)
     }
 
     @Test("terminal.list retention respects worktree and fleet scopes")

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -5,6 +5,10 @@ import TBDShared
 
 @Suite struct CodexHookOverlayTests {
 
+    private func invokedIdleActivity(_ invocations: [String]) -> Bool {
+        invocations.contains { $0.hasPrefix("terminal-activity idle") }
+    }
+
     private func runStopHook(
         goalStatus: String,
         sessionID: String = "a1b2c3d4-e5f6-4789-abcd-0123456789ab",
@@ -23,6 +27,10 @@ import TBDShared
         try """
         #!/bin/sh
         printf '%s\\n' "$*" >> "$TBD_HOOK_TEST_LOG"
+        if [ "$1" = terminal-activity ]; then
+          ACTIVITY_PAYLOAD=$(cat)
+          printf 'activity-payload=%s\\n' "$ACTIVITY_PAYLOAD" >> "$TBD_HOOK_TEST_LOG"
+        fi
         if [ "$1" = notify ]; then
           printf 'notify-message=%s\\n' "$5" >> "$TBD_HOOK_TEST_LOG"
         fi
@@ -152,6 +160,7 @@ import TBDShared
             return inner.compactMap { $0["command"] as? String }
         }
         #expect(promptCommands.contains { $0.contains("tbd terminal-activity working") })
+        #expect(promptCommands.contains { $0.contains("--read-hook-payload") })
 
         let permissionRequest = hooks?["PermissionRequest"] as? [[String: Any]]
         let permissionCommands: [String] = (permissionRequest ?? []).flatMap { entry -> [String] in
@@ -159,6 +168,58 @@ import TBDShared
             return inner.compactMap { $0["command"] as? String }
         }
         #expect(permissionCommands.contains { $0.contains("tbd terminal-activity waiting_for_user") })
+        #expect(permissionCommands.contains { $0.contains("--read-hook-payload") })
+    }
+
+    @Test func sessionStartForwardsTheExactPayloadToBothBridges() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-session-hook-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tbdPath = directory.appendingPathComponent("tbd")
+        try """
+        #!/bin/sh
+        if [ "$1" = session-event ]; then
+          cat > "$TBD_SESSION_STDIN"
+        elif [ "$1" = terminal-activity ]; then
+          printf '%s\n' "$*" > "$TBD_ACTIVITY_ARGS"
+          cat > "$TBD_ACTIVITY_STDIN"
+        fi
+        """.write(to: tbdPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tbdPath.path)
+        let sessionInput = directory.appendingPathComponent("session-input")
+        let activityInput = directory.appendingPathComponent("activity-input")
+        let activityArgs = directory.appendingPathComponent("activity-args")
+        let payload = #"{"session_id":"session-current","value":"$(touch should-not-run); ' \""}"#
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", CodexHookOverlay.sessionStartCommand]
+        process.currentDirectoryURL = directory
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(directory.path):/usr/bin:/bin"
+        environment["TBD_SESSION_STDIN"] = sessionInput.path
+        environment["TBD_ACTIVITY_STDIN"] = activityInput.path
+        environment["TBD_ACTIVITY_ARGS"] = activityArgs.path
+        process.environment = environment
+        let input = Pipe()
+        process.standardInput = input
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        input.fileHandleForWriting.write(Data(payload.utf8))
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+        #expect(try String(contentsOf: sessionInput, encoding: .utf8) == payload)
+        #expect(try String(contentsOf: activityInput, encoding: .utf8) == payload)
+        #expect(try String(contentsOf: activityArgs, encoding: .utf8)
+            == "terminal-activity idle --read-hook-payload\n")
+        #expect(!FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("should-not-run").path))
     }
 
     @Test func stopHookGatesIdleBehindRenameCheck() throws {
@@ -182,7 +243,7 @@ import TBDShared
         let invocations = try runStopHook(goalStatus: "active")
 
         #expect(invocations.contains { $0.hasPrefix("notify --type response_complete") })
-        #expect(!invocations.contains("terminal-activity idle"))
+        #expect(!invokedIdleActivity(invocations))
     }
 
     @Test func stopHookReadsSessionIDFromPayloadJSON() throws {
@@ -191,7 +252,17 @@ import TBDShared
             sessionID: "b2c3d4e5-f607-489a-bcde-1234567890ab"
         )
 
-        #expect(!invocations.contains("terminal-activity idle"))
+        #expect(!invokedIdleActivity(invocations))
+    }
+
+    @Test func stopHookForwardsPayloadToIdleActivityBridge() throws {
+        let sessionID = "c3d4e5f6-0718-49ab-cdef-2345678901bc"
+        let invocations = try runStopHook(goalStatus: "complete", sessionID: sessionID)
+
+        #expect(invocations.contains("terminal-activity idle --read-hook-payload"))
+        #expect(invocations.contains { line in
+            line.hasPrefix("activity-payload=") && line.contains(sessionID)
+        })
     }
 
     @Test func stopHookReadsAssistantMessageFromPayloadJSON() throws {
@@ -209,7 +280,7 @@ import TBDShared
             priorGoalStatus: "complete"
         )
 
-        #expect(!invocations.contains("terminal-activity idle"))
+        #expect(!invokedIdleActivity(invocations))
     }
 
     @Test func stopHookIgnoresStaleActiveGoalIfLatestStateIsComplete() throws {
@@ -218,7 +289,7 @@ import TBDShared
             priorGoalStatus: "active"
         )
 
-        #expect(invocations.contains("terminal-activity idle"))
+        #expect(invokedIdleActivity(invocations))
     }
 
     @Test func stopHookUsesLatestActiveStateWhenGoalTimestampsTie() throws {
@@ -228,7 +299,7 @@ import TBDShared
             goalTimestampsTie: true
         )
 
-        #expect(!invocations.contains("terminal-activity idle"))
+        #expect(!invokedIdleActivity(invocations))
     }
 
     @Test func stopHookUsesLatestCompleteStateWhenGoalTimestampsTie() throws {
@@ -238,7 +309,7 @@ import TBDShared
             goalTimestampsTie: true
         )
 
-        #expect(invocations.contains("terminal-activity idle"))
+        #expect(invokedIdleActivity(invocations))
     }
 
     @Test func stopHookUsesCreatedAtWhenUpdatedTimesTieBeforeInsertionOrder() throws {
@@ -248,27 +319,27 @@ import TBDShared
             createdAtBreaksUpdateTie: true
         )
 
-        #expect(!invocations.contains("terminal-activity idle"))
+        #expect(!invokedIdleActivity(invocations))
     }
 
     @Test func stopHookPublishesIdleWhenCodexGoalIsComplete() throws {
         let invocations = try runStopHook(goalStatus: "complete")
 
         #expect(invocations.contains { $0.hasPrefix("notify --type response_complete") })
-        #expect(invocations.contains("terminal-activity idle"))
+        #expect(invokedIdleActivity(invocations))
     }
 
     @Test func stopHookPublishesIdleWhenCodexGoalIsBlocked() throws {
         let invocations = try runStopHook(goalStatus: "blocked")
 
-        #expect(invocations.contains("terminal-activity idle"))
+        #expect(invokedIdleActivity(invocations))
     }
 
     @Test(arguments: ["paused", "usage_limited", "budget_limited"])
     func stopHookPublishesIdleWhenCodexGoalCannotContinue(status: String) throws {
         let invocations = try runStopHook(goalStatus: status)
 
-        #expect(invocations.contains("terminal-activity idle"))
+        #expect(invokedIdleActivity(invocations))
     }
 
     @Test func roundtripsAsValidJSON() throws {

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -37,6 +37,30 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == .idle)
     }
 
+    @Test func rewrittenCompletionIDClosesTurnWithMatchingStartTime() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(
+            type: "task_started", turnID: "started-id", startedAt: 1_785_908_531))
+
+        reducer.consume(line: event(
+            type: "task_complete", turnID: "completed-id", startedAt: 1_785_908_531,
+            completedAt: 1_785_908_636))
+
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func rewrittenAbortIDClosesTurnWithMatchingStartTime() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(
+            type: "task_started", turnID: "started-id", startedAt: 1_785_898_845))
+
+        reducer.consume(line: event(
+            type: "turn_aborted", turnID: "aborted-id", startedAt: 1_785_898_845,
+            completedAt: 1_785_898_898))
+
+        #expect(reducer.activityState == .idle)
+    }
+
     @Test func completionForUnknownTurnDoesNotCloseOpenTurn() {
         var reducer = CodexTurnLifecycleReducer()
         reducer.consume(line: event(type: "task_started", turnID: "a"))
@@ -75,6 +99,37 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == .working)
 
         reducer.consume(line: event(type: "task_complete", turnID: "b"))
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func lateRewrittenCloseForOlderStartTimeDoesNotCloseCurrentTurn() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(
+            type: "task_started", turnID: "older-start", startedAt: 100))
+        reducer.consume(line: event(
+            type: "task_started", turnID: "current-start", startedAt: 200))
+
+        reducer.consume(line: event(
+            type: "task_complete", turnID: "older-complete", startedAt: 100,
+            completedAt: 250))
+        #expect(reducer.activityState == .working)
+
+        reducer.consume(line: event(
+            type: "task_complete", turnID: "current-complete", startedAt: 200,
+            completedAt: 300))
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func subagentRolloutUsesTheSameLifecycleCorrelation() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: Data(#"{"type":"session_meta","payload":{"source":{"subagent":{"thread_spawn":{"depth":2}}}}}"#.utf8))
+        reducer.consume(line: event(
+            type: "task_started", turnID: "nested-start", startedAt: 300))
+
+        reducer.consume(line: event(
+            type: "task_complete", turnID: "nested-complete", startedAt: 300,
+            completedAt: 400))
+
         #expect(reducer.activityState == .idle)
     }
 
@@ -633,15 +688,19 @@ struct CodexTranscriptActivityTrackerTests {
     private func event(
         type: String,
         turnID: String,
+        startedAt: Int? = nil,
+        completedAt: Int? = nil,
         terminated: Bool = true,
         padding: String? = nil,
         exactByteCount: Int? = nil
     ) -> Data {
         let newline = terminated ? "\n" : ""
         func encoded(padding: String?) -> Data {
+            let startedAtField = startedAt.map { #", "started_at":\#($0)"# } ?? ""
+            let completedAtField = completedAt.map { #", "completed_at":\#($0)"# } ?? ""
             let paddingField = padding.map { #", "padding":"\#($0)""# } ?? ""
             return Data((
-                #"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"\#(paddingField)}}"#
+                #"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"\#(startedAtField)\#(completedAtField)\#(paddingField)}}"#
                     + newline).utf8)
         }
 

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -61,11 +61,24 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == .idle)
     }
 
-    @Test func completionForUnknownTurnDoesNotCloseOpenTurn() {
+    @Test(
+        "a rewritten close without start time prefers false idle",
+        arguments: ["task_complete", "turn_aborted"]
+    )
+    func rewrittenCloseWithoutStartTimePrefersFalseIdle(type: String) {
         var reducer = CodexTurnLifecycleReducer()
-        reducer.consume(line: event(type: "task_started", turnID: "a"))
+        reducer.consume(line: event(type: "task_started", turnID: "started-id"))
 
-        reducer.consume(line: event(type: "task_complete", turnID: "b"))
+        reducer.consume(line: event(type: type, turnID: "rewritten-close-id"))
+
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func closeForKnownOlderStartTimeDoesNotCloseOpenTurn() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "current", startedAt: 200))
+
+        reducer.consume(line: event(type: "task_complete", turnID: "older", startedAt: 100))
 
         #expect(reducer.activityState == .working)
     }
@@ -92,13 +105,13 @@ struct CodexTranscriptActivityTrackerTests {
 
     @Test func lateCloseForSupersededTurnDoesNotCloseCurrentTurn() {
         var reducer = CodexTurnLifecycleReducer()
-        reducer.consume(line: event(type: "task_started", turnID: "a"))
-        reducer.consume(line: event(type: "task_started", turnID: "b"))
+        reducer.consume(line: event(type: "task_started", turnID: "a", startedAt: 100))
+        reducer.consume(line: event(type: "task_started", turnID: "b", startedAt: 200))
 
-        reducer.consume(line: event(type: "task_complete", turnID: "a"))
+        reducer.consume(line: event(type: "task_complete", turnID: "a", startedAt: 100))
         #expect(reducer.activityState == .working)
 
-        reducer.consume(line: event(type: "task_complete", turnID: "b"))
+        reducer.consume(line: event(type: "task_complete", turnID: "b", startedAt: 200))
         #expect(reducer.activityState == .idle)
     }
 
@@ -307,7 +320,7 @@ struct CodexTranscriptActivityTrackerTests {
         let worktreeID = UUID()
         _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
 
-        let crossingStart = event(type: "task_started", turnID: "a")
+        let crossingStart = event(type: "task_started", turnID: "a", startedAt: 200)
         let firstPadding = event(
             type: "agent_message", turnID: "first-padding",
             exactByteCount: Self.incrementalReadByteLimit - crossingStart.count / 2)
@@ -318,7 +331,7 @@ struct CodexTranscriptActivityTrackerTests {
             firstPadding
                 + crossingStart
                 + secondPadding
-                + event(type: "task_complete", turnID: "different-turn"))
+                + event(type: "task_complete", turnID: "different-turn", startedAt: 100))
 
         let firstCatchUp = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -74,6 +74,28 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == .idle)
     }
 
+    @Test(
+        "a close without a turn ID prefers false idle",
+        arguments: ["task_complete", "turn_aborted"]
+    )
+    func closeWithoutTurnIDPrefersFalseIdle(type: String) {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(
+            type: "task_started", turnID: "started-id", startedAt: 200))
+
+        reducer.consume(line: event(type: type, turnID: nil, startedAt: 100))
+
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func startWithoutTurnIDIsIgnored() {
+        var reducer = CodexTurnLifecycleReducer()
+
+        reducer.consume(line: event(type: "task_started", turnID: nil))
+
+        #expect(reducer.activityState == nil)
+    }
+
     @Test func closeForKnownOlderStartTimeDoesNotCloseOpenTurn() {
         var reducer = CodexTurnLifecycleReducer()
         reducer.consume(line: event(type: "task_started", turnID: "current", startedAt: 200))
@@ -804,7 +826,7 @@ struct CodexTranscriptActivityTrackerTests {
 
     private func event(
         type: String,
-        turnID: String,
+        turnID: String?,
         startedAt: Int? = nil,
         completedAt: Int? = nil,
         terminated: Bool = true,
@@ -813,11 +835,12 @@ struct CodexTranscriptActivityTrackerTests {
     ) -> Data {
         let newline = terminated ? "\n" : ""
         func encoded(padding: String?) -> Data {
+            let turnIDField = turnID.map { #", "turn_id":"\#($0)""# } ?? ""
             let startedAtField = startedAt.map { #", "started_at":\#($0)"# } ?? ""
             let completedAtField = completedAt.map { #", "completed_at":\#($0)"# } ?? ""
             let paddingField = padding.map { #", "padding":"\#($0)""# } ?? ""
             return Data((
-                #"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"\#(startedAtField)\#(completedAtField)\#(paddingField)}}"#
+                #"{"type":"event_msg","payload":{"type":"\#(type)"\#(turnIDField)\#(startedAtField)\#(completedAtField)\#(paddingField)}}"#
                     + newline).utf8)
         }
 

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -6,6 +6,8 @@ import Testing
 @Suite("Codex transcript activity tracker")
 struct CodexTranscriptActivityTrackerTests {
     private static let initialTailByteLimit = Int(CodexTranscriptActivityTracker.initialTailByteLimit)
+    private static let maxBufferedRecordByteCount =
+        CodexTranscriptActivityTracker.maxBufferedRecordByteCount
 
     @Test func taskStartedProducesWorking() {
         var reducer = CodexTurnLifecycleReducer()
@@ -241,6 +243,54 @@ struct CodexTranscriptActivityTrackerTests {
 
         #expect(beforeNewline == nil)
         #expect(afterNewline == .working)
+    }
+
+    @Test func oversizedUnterminatedRecordIsDiscardedWithoutGrowingTheBuffer() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "a"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.append(event(
+            type: "agent_message", turnID: "oversized",
+            terminated: false,
+            exactByteCount: Self.maxBufferedRecordByteCount + 128))
+        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+        let discarding = await tracker.bufferedRecordState(transcriptPath: fixture.path)
+
+        #expect(discarding?.byteCount == 0)
+        #expect(discarding?.isDiscarding == true)
+
+        try fixture.append(
+            Data([0x0A]) + event(type: "task_complete", turnID: "a"))
+        let recovered = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        let recoveredBuffer = await tracker.bufferedRecordState(transcriptPath: fixture.path)
+
+        #expect(recovered == .idle)
+        #expect(recoveredBuffer?.byteCount == 0)
+        #expect(recoveredBuffer?.isDiscarding == false)
+    }
+
+    @Test func oversizedCompleteRecordIsNotDecodedBeforeLaterLifecycleEvent() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "a"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.append(
+            event(
+                type: "task_started", turnID: "oversized",
+                exactByteCount: Self.maxBufferedRecordByteCount + 128)
+                + event(type: "task_complete", turnID: "a"))
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(state == .idle)
     }
 
     @Test func lifecycleRecordCrossingReadChunkBoundaryIsReassembled() async throws {

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -561,6 +561,39 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(caughtUp[fixture.path] == .working)
     }
 
+    @Test func batchStepLimitBoundsCaughtUpAndUnreadablePaths() async throws {
+        let stepLimit = 16
+        let unreadable = try (0..<(stepLimit / 2)).map { _ in
+            try TranscriptFixture()
+        }
+        let readable = try (0...(stepLimit / 2)).map { _ in
+            try TranscriptFixture()
+        }
+        defer {
+            for fixture in unreadable + readable {
+                fixture.remove()
+            }
+        }
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        for fixture in readable {
+            try fixture.write(event(type: "task_complete", turnID: fixture.path))
+            _ = await tracker.observe(
+                transcriptPath: fixture.path, worktreeID: worktreeID)
+        }
+        let targets = (unreadable + readable).map {
+            CodexTranscriptActivityTracker.Target(
+                transcriptPath: $0.path, worktreeID: worktreeID)
+        }
+
+        let first = await tracker.observe(transcripts: targets)
+        let second = await tracker.observe(transcripts: targets)
+
+        #expect(first.count == stepLimit / 2)
+        #expect(first[readable.last!.path] == nil)
+        #expect(second[readable.last!.path] == .idle)
+    }
+
     @Test func batchCursorRotatesWhenTheFirstTranscriptKeepsGrowing() async throws {
         let first = try TranscriptFixture()
         let second = try TranscriptFixture()

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -131,9 +131,12 @@ struct CodexTranscriptActivityTrackerTests {
         try fixture.write(prefix + event(type: "task_started", turnID: "latest"))
         let tracker = CodexTranscriptActivityTracker()
 
+        let firstSlice = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
         let state = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: UUID())
 
+        #expect(firstSlice == nil)
         #expect(state == .working)
     }
 
@@ -148,9 +151,12 @@ struct CodexTranscriptActivityTrackerTests {
         try fixture.write(prefix + start + tailPadding)
         let tracker = CodexTranscriptActivityTracker()
 
+        let firstSlice = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
         let state = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: UUID())
 
+        #expect(firstSlice == nil)
         #expect(state == .working)
     }
 
@@ -163,9 +169,12 @@ struct CodexTranscriptActivityTrackerTests {
         try fixture.write(partialStart + event(type: "task_complete", turnID: "other"))
         let tracker = CodexTranscriptActivityTracker()
 
+        let firstSlice = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
         let state = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: UUID())
 
+        #expect(firstSlice == nil)
         #expect(state == .idle)
     }
 
@@ -181,6 +190,8 @@ struct CodexTranscriptActivityTrackerTests {
         try fixture.write(prefix + initialStart)
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
+        let initialSlice = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
         let initial = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
 
@@ -189,6 +200,7 @@ struct CodexTranscriptActivityTrackerTests {
         let completed = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
 
+        #expect(initialSlice == nil)
         #expect(initial == .working)
         #expect(completed == .idle)
     }
@@ -447,6 +459,107 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(firstState == .working)
         #expect(secondState == .idle)
         #expect(firstAgain == .working)
+    }
+
+    @Test func zeroBatchBudgetDoesNotReadOrCreateABaseline() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let record = event(type: "task_started", turnID: "a")
+        try fixture.write(record)
+        let tracker = CodexTranscriptActivityTracker()
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path, worktreeID: UUID())
+
+        let noBudget = await tracker.observe(
+            transcripts: [target], totalByteLimit: 0)
+
+        #expect(noBudget.isEmpty)
+        #expect(!(await tracker.hasBaseline(transcriptPath: fixture.path)))
+
+        let caughtUp = await tracker.observe(
+            transcripts: [target], totalByteLimit: UInt64(record.count))
+        #expect(caughtUp[fixture.path] == .working)
+    }
+
+    @Test func batchCursorRotatesWhenTheFirstTranscriptKeepsGrowing() async throws {
+        let first = try TranscriptFixture()
+        let second = try TranscriptFixture()
+        defer {
+            first.remove()
+            second.remove()
+        }
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let targets = [first, second].map {
+            CodexTranscriptActivityTracker.Target(
+                transcriptPath: $0.path, worktreeID: worktreeID)
+        }
+        for fixture in [first, second] {
+            try fixture.write(
+                event(type: "task_complete", turnID: fixture.path)
+                    + event(
+                        type: "agent_message", turnID: "backlog",
+                        terminated: false,
+                        exactByteCount: Self.initialTailByteLimit))
+        }
+        let onePathBudget: UInt64 = 2
+
+        _ = await tracker.observe(transcripts: targets, totalByteLimit: onePathBudget)
+        let firstAfterOne = await tracker.bufferedRecordState(transcriptPath: first.path)
+        let secondAfterOne = await tracker.bufferedRecordState(transcriptPath: second.path)
+        #expect([firstAfterOne?.byteCount, secondAfterOne?.byteCount].compactMap { $0 }
+            .sorted() == [Int(onePathBudget) - 1])
+
+        try first.append(event(type: "agent_message", turnID: "still-growing"))
+        _ = await tracker.observe(transcripts: targets, totalByteLimit: onePathBudget)
+        let firstAfterTwo = await tracker.bufferedRecordState(transcriptPath: first.path)
+        let secondAfterTwo = await tracker.bufferedRecordState(transcriptPath: second.path)
+
+        #expect(firstAfterTwo?.byteCount == Int(onePathBudget) - 1)
+        #expect(secondAfterTwo?.byteCount == Int(onePathBudget) - 1)
+    }
+
+    @Test func batchCursorRecoversWhenItsSavedPathDisappearsAndInputsReorder() async throws {
+        let first = try TranscriptFixture()
+        let removed = try TranscriptFixture()
+        let third = try TranscriptFixture()
+        defer {
+            first.remove()
+            removed.remove()
+            third.remove()
+        }
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let targets = [first, removed, third].map {
+            CodexTranscriptActivityTracker.Target(
+                transcriptPath: $0.path, worktreeID: worktreeID)
+        }
+        for fixture in [first, removed, third] {
+            try fixture.write(
+                event(type: "task_complete", turnID: fixture.path)
+                    + event(
+                        type: "agent_message", turnID: "backlog",
+                        terminated: false,
+                        exactByteCount: Self.initialTailByteLimit))
+        }
+        let onePathBudget: UInt64 = 2
+
+        _ = await tracker.observe(transcripts: targets, totalByteLimit: onePathBudget)
+        #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
+            == Int(onePathBudget) - 1)
+
+        let withoutSavedPath = [targets[2], targets[0]]
+        _ = await tracker.observe(
+            transcripts: withoutSavedPath, totalByteLimit: onePathBudget)
+        #expect(await tracker.bufferedRecordState(transcriptPath: third.path)?.byteCount
+            == Int(onePathBudget) - 1)
+        #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
+            == Int(onePathBudget) - 1)
+
+        _ = await tracker.observe(
+            transcripts: withoutSavedPath, totalByteLimit: onePathBudget)
+        #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
+            == Int(onePathBudget) * 2 - 1)
     }
 
     @Test func unreadablePathReturnsNilInsteadOfCachedWorking() async throws {

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -643,6 +643,52 @@ struct CodexTranscriptActivityTrackerTests {
             == Int(onePathBudget) * 2 - 1)
     }
 
+    @Test func scopedPollDoesNotResetFleetBatchCursor() async throws {
+        let first = try TranscriptFixture()
+        let second = try TranscriptFixture()
+        defer {
+            first.remove()
+            second.remove()
+        }
+        let tracker = CodexTranscriptActivityTracker()
+        let firstWorktreeID = UUID()
+        let secondWorktreeID = UUID()
+        let firstTarget = CodexTranscriptActivityTracker.Target(
+            transcriptPath: first.path, worktreeID: firstWorktreeID)
+        let secondTarget = CodexTranscriptActivityTracker.Target(
+            transcriptPath: second.path, worktreeID: secondWorktreeID)
+        for fixture in [first, second] {
+            try fixture.write(
+                event(type: "task_complete", turnID: fixture.path)
+                    + event(
+                        type: "agent_message", turnID: "backlog",
+                        terminated: false,
+                        exactByteCount: Self.initialTailByteLimit))
+        }
+        let onePathBudget: UInt64 = 2
+
+        _ = await tracker.observe(
+            transcripts: [firstTarget, secondTarget], totalByteLimit: onePathBudget)
+        await tracker.retain(
+            transcriptPaths: [first.path, second.path], scope: nil)
+
+        _ = await tracker.observe(
+            transcripts: [firstTarget], totalByteLimit: onePathBudget)
+        await tracker.retain(
+            transcriptPaths: [first.path], scope: firstWorktreeID)
+        let firstAfterScopedPoll = await tracker.bufferedRecordState(
+            transcriptPath: first.path)?.byteCount
+
+        _ = await tracker.observe(
+            transcripts: [firstTarget, secondTarget], totalByteLimit: onePathBudget)
+
+        #expect(firstAfterScopedPoll == Int(onePathBudget) * 2 - 1)
+        #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
+            == firstAfterScopedPoll)
+        #expect(await tracker.bufferedRecordState(transcriptPath: second.path)?.byteCount
+            == Int(onePathBudget) - 1)
+    }
+
     @Test func unreadablePathReturnsNilInsteadOfCachedWorking() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -78,7 +78,192 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == nil)
     }
 
-    private func event(type: String, turnID: String) -> Data {
-        Data((#"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"}}"# + "\n").utf8)
+    @Test func firstObservationRebuildsPreExistingOpenTurn() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "a"))
+        let tracker = CodexTranscriptActivityTracker()
+
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
+
+        #expect(state == .working)
+    }
+
+    @Test func secondObservationReadsAppendedCompletion() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "a"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.append(event(type: "task_complete", turnID: "a"))
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(state == .idle)
+    }
+
+    @Test func unterminatedRecordWaitsForNewline() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let record = event(type: "task_started", turnID: "a", terminated: false)
+        try fixture.write(record)
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+
+        let beforeNewline = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(Data([0x0A]))
+        let afterNewline = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(beforeNewline == nil)
+        #expect(afterNewline == .working)
+    }
+
+    @Test func truncationResetsAndRebuildsFromByteZero() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(
+            event(type: "task_started", turnID: "a")
+                + event(type: "agent_message", turnID: "padding"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let initial = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.write(event(type: "task_complete", turnID: "replacement"))
+        let rebuilt = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(initial == .working)
+        #expect(rebuilt == .idle)
+    }
+
+    @Test func transcriptPathsHaveIndependentBaselines() async throws {
+        let first = try TranscriptFixture()
+        let second = try TranscriptFixture()
+        defer {
+            first.remove()
+            second.remove()
+        }
+        try first.write(event(type: "task_started", turnID: "a"))
+        try second.write(event(type: "task_complete", turnID: "b"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+
+        let firstState = await tracker.observe(
+            transcriptPath: first.path, worktreeID: worktreeID)
+        let secondState = await tracker.observe(
+            transcriptPath: second.path, worktreeID: worktreeID)
+        let firstAgain = await tracker.observe(
+            transcriptPath: first.path, worktreeID: worktreeID)
+
+        #expect(firstState == .working)
+        #expect(secondState == .idle)
+        #expect(firstAgain == .working)
+    }
+
+    @Test func unreadablePathReturnsNilInsteadOfCachedWorking() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "a"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let initial = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.replaceFileWithDirectory()
+
+        let unreadable = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(initial == .working)
+        #expect(unreadable == nil)
+    }
+
+    @Test func fleetWideRetainPrunesEveryMissingTranscript() async throws {
+        let first = try TranscriptFixture()
+        let second = try TranscriptFixture()
+        defer {
+            first.remove()
+            second.remove()
+        }
+        try first.write(event(type: "task_started", turnID: "a"))
+        try second.write(event(type: "task_started", turnID: "b"))
+        let tracker = CodexTranscriptActivityTracker()
+        _ = await tracker.observe(transcriptPath: first.path, worktreeID: UUID())
+        _ = await tracker.observe(transcriptPath: second.path, worktreeID: UUID())
+
+        await tracker.retain(transcriptPaths: [first.path], scope: nil)
+
+        #expect(await tracker.baselineCount == 1)
+    }
+
+    @Test func worktreeScopedRetainDoesNotPruneAnotherWorktree() async throws {
+        let keptHere = try TranscriptFixture()
+        let prunedHere = try TranscriptFixture()
+        let keptThere = try TranscriptFixture()
+        defer {
+            keptHere.remove()
+            prunedHere.remove()
+            keptThere.remove()
+        }
+        for fixture in [keptHere, prunedHere, keptThere] {
+            try fixture.write(event(type: "task_started", turnID: fixture.path))
+        }
+        let tracker = CodexTranscriptActivityTracker()
+        let here = UUID()
+        let there = UUID()
+        _ = await tracker.observe(transcriptPath: keptHere.path, worktreeID: here)
+        _ = await tracker.observe(transcriptPath: prunedHere.path, worktreeID: here)
+        _ = await tracker.observe(transcriptPath: keptThere.path, worktreeID: there)
+
+        await tracker.retain(transcriptPaths: [keptHere.path], scope: here)
+
+        #expect(await tracker.baselineCount == 2)
+        #expect(await tracker.hasBaseline(transcriptPath: keptHere.path))
+        #expect(!(await tracker.hasBaseline(transcriptPath: prunedHere.path)))
+        #expect(await tracker.hasBaseline(transcriptPath: keptThere.path))
+    }
+
+    private func event(type: String, turnID: String, terminated: Bool = true) -> Data {
+        let newline = terminated ? "\n" : ""
+        return Data((#"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"}}"# + newline).utf8)
+    }
+}
+
+private final class TranscriptFixture: @unchecked Sendable {
+    private let directory: URL
+    private let file: URL
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-transcript-activity-\(UUID().uuidString)")
+        file = directory.appendingPathComponent("rollout.jsonl")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    var path: String { file.path }
+
+    func write(_ data: Data) throws {
+        try data.write(to: file)
+    }
+
+    func append(_ data: Data) throws {
+        let handle = try FileHandle(forWritingTo: file)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+    }
+
+    func replaceFileWithDirectory() throws {
+        try FileManager.default.removeItem(at: file)
+        try FileManager.default.createDirectory(at: file, withIntermediateDirectories: false)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directory)
     }
 }

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -105,6 +105,27 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(state == .idle)
     }
 
+    @Test func laterObservationsDoNotRescanAlreadyConsumedBytes() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let initial = event(type: "task_started", turnID: "a")
+        let replacement = event(type: "task_started", turnID: "b")
+        #expect(initial.count == replacement.count)
+        try fixture.write(initial)
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let firstState = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.overwriteBeginning(with: replacement)
+        try fixture.append(event(type: "task_complete", turnID: "a"))
+        let appendedState = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(firstState == .working)
+        #expect(appendedState == .idle)
+    }
+
     @Test func unterminatedRecordWaitsForNewline() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
@@ -121,6 +142,22 @@ struct CodexTranscriptActivityTrackerTests {
 
         #expect(beforeNewline == nil)
         #expect(afterNewline == .working)
+    }
+
+    @Test func lifecycleRecordCrossingReadChunkBoundaryIsReassembled() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let record = event(
+            type: "task_started", turnID: "a",
+            padding: String(repeating: "x", count: 64 * 1024))
+        #expect(record.count > 64 * 1024)
+        try fixture.write(record)
+        let tracker = CodexTranscriptActivityTracker()
+
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
+
+        #expect(state == .working)
     }
 
     @Test func truncationResetsAndRebuildsFromByteZero() async throws {
@@ -169,7 +206,8 @@ struct CodexTranscriptActivityTrackerTests {
     @Test func unreadablePathReturnsNilInsteadOfCachedWorking() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
-        try fixture.write(event(type: "task_started", turnID: "a"))
+        try fixture.write(
+            event(type: "task_started", turnID: "a", padding: String(repeating: "x", count: 256)))
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
         let initial = await tracker.observe(
@@ -178,9 +216,13 @@ struct CodexTranscriptActivityTrackerTests {
 
         let unreadable = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.replaceDirectoryWithFile(event(type: "task_complete", turnID: "replacement"))
+        let recovered = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
 
         #expect(initial == .working)
         #expect(unreadable == nil)
+        #expect(recovered == .idle)
     }
 
     @Test func fleetWideRetainPrunesEveryMissingTranscript() async throws {
@@ -228,9 +270,17 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(await tracker.hasBaseline(transcriptPath: keptThere.path))
     }
 
-    private func event(type: String, turnID: String, terminated: Bool = true) -> Data {
+    private func event(
+        type: String,
+        turnID: String,
+        terminated: Bool = true,
+        padding: String? = nil
+    ) -> Data {
         let newline = terminated ? "\n" : ""
-        return Data((#"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"}}"# + newline).utf8)
+        let paddingField = padding.map { #", "padding":"\#($0)""# } ?? ""
+        return Data((
+            #"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"\#(paddingField)}}"#
+                + newline).utf8)
     }
 }
 
@@ -258,9 +308,21 @@ private final class TranscriptFixture: @unchecked Sendable {
         try handle.write(contentsOf: data)
     }
 
+    func overwriteBeginning(with data: Data) throws {
+        let handle = try FileHandle(forWritingTo: file)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: 0)
+        try handle.write(contentsOf: data)
+    }
+
     func replaceFileWithDirectory() throws {
         try FileManager.default.removeItem(at: file)
         try FileManager.default.createDirectory(at: file, withIntermediateDirectories: false)
+    }
+
+    func replaceDirectoryWithFile(_ data: Data) throws {
+        try FileManager.default.removeItem(at: file)
+        try data.write(to: file)
     }
 
     func remove() {

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -5,6 +5,8 @@ import Testing
 
 @Suite("Codex transcript activity tracker")
 struct CodexTranscriptActivityTrackerTests {
+    private static let initialTailByteLimit = Int(CodexTranscriptActivityTracker.initialTailByteLimit)
+
     @Test func taskStartedProducesWorking() {
         var reducer = CodexTurnLifecycleReducer()
 
@@ -100,6 +102,93 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(state == .working)
     }
 
+    @Test func firstObservationDoesNotDecodeLifecycleOlderThanTailLimit() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let oldStart = event(type: "task_started", turnID: "old")
+        let tail = event(
+            type: "agent_message", turnID: "padding",
+            exactByteCount: Self.initialTailByteLimit)
+        try fixture.write(oldStart + tail)
+        let tracker = CodexTranscriptActivityTracker()
+
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
+
+        #expect(state == nil)
+    }
+
+    @Test func firstObservationReconstructsLifecycleInsideOversizedTranscriptTail() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let prefix = event(
+            type: "agent_message", turnID: "padding",
+            exactByteCount: Self.initialTailByteLimit + 128)
+        try fixture.write(prefix + event(type: "task_started", turnID: "latest"))
+        let tracker = CodexTranscriptActivityTracker()
+
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
+
+        #expect(state == .working)
+    }
+
+    @Test func tailStartingOnRecordBoundaryRetainsFirstRecord() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let prefix = event(type: "agent_message", turnID: "prefix")
+        let start = event(type: "task_started", turnID: "boundary")
+        let tailPadding = event(
+            type: "agent_message", turnID: "padding",
+            exactByteCount: Self.initialTailByteLimit - start.count)
+        try fixture.write(prefix + start + tailPadding)
+        let tracker = CodexTranscriptActivityTracker()
+
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
+
+        #expect(state == .working)
+    }
+
+    @Test func tailStartingMidRecordDiscardsOnlyLeadingPartialRecord() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let partialStart = event(
+            type: "task_started", turnID: "old",
+            exactByteCount: Self.initialTailByteLimit + 128)
+        try fixture.write(partialStart + event(type: "task_complete", turnID: "other"))
+        let tracker = CodexTranscriptActivityTracker()
+
+        let state = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: UUID())
+
+        #expect(state == .idle)
+    }
+
+    @Test func appendedCompletionAfterTailBootstrapDoesNotRescanHistory() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let prefix = event(
+            type: "agent_message", turnID: "padding",
+            exactByteCount: Self.initialTailByteLimit + 128)
+        let initialStart = event(type: "task_started", turnID: "a")
+        let replacementStart = event(type: "task_started", turnID: "b")
+        #expect(initialStart.count == replacementStart.count)
+        try fixture.write(prefix + initialStart)
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let initial = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.overwrite(at: UInt64(prefix.count), with: replacementStart)
+        try fixture.append(event(type: "task_complete", turnID: "a"))
+        let completed = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(initial == .working)
+        #expect(completed == .idle)
+    }
+
     @Test func secondObservationReadsAppendedCompletion() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
@@ -187,6 +276,33 @@ struct CodexTranscriptActivityTrackerTests {
 
         #expect(initial == .working)
         #expect(rebuilt == .idle)
+    }
+
+    @Test func truncationRebuildUsesBoundedTailPolicy() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let initialPrefix = event(
+            type: "agent_message", turnID: "initial-padding",
+            exactByteCount: Self.initialTailByteLimit + 512)
+        try fixture.write(
+            initialPrefix
+                + event(type: "task_started", turnID: "initial")
+                + event(
+                    type: "agent_message", turnID: "more-padding",
+                    exactByteCount: Self.initialTailByteLimit + 512))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        let oldStart = event(type: "task_started", turnID: "old")
+        let replacementTail = event(
+            type: "agent_message", turnID: "replacement-padding",
+            exactByteCount: Self.initialTailByteLimit)
+        try fixture.write(oldStart + replacementTail)
+        let rebuilt = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(rebuilt == nil)
     }
 
     @Test func transcriptPathsHaveIndependentBaselines() async throws {
@@ -284,13 +400,24 @@ struct CodexTranscriptActivityTrackerTests {
         type: String,
         turnID: String,
         terminated: Bool = true,
-        padding: String? = nil
+        padding: String? = nil,
+        exactByteCount: Int? = nil
     ) -> Data {
         let newline = terminated ? "\n" : ""
-        let paddingField = padding.map { #", "padding":"\#($0)""# } ?? ""
-        return Data((
-            #"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"\#(paddingField)}}"#
-                + newline).utf8)
+        func encoded(padding: String?) -> Data {
+            let paddingField = padding.map { #", "padding":"\#($0)""# } ?? ""
+            return Data((
+                #"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"\#(paddingField)}}"#
+                    + newline).utf8)
+        }
+
+        let base = encoded(padding: padding)
+        guard let exactByteCount else { return base }
+
+        let emptyPadded = encoded(padding: "")
+        precondition(exactByteCount >= emptyPadded.count)
+        let exactPadding = String(repeating: "x", count: exactByteCount - emptyPadded.count)
+        return encoded(padding: exactPadding)
     }
 }
 
@@ -319,9 +446,13 @@ private final class TranscriptFixture: @unchecked Sendable {
     }
 
     func overwriteBeginning(with data: Data) throws {
+        try overwrite(at: 0, with: data)
+    }
+
+    func overwrite(at offset: UInt64, with data: Data) throws {
         let handle = try FileHandle(forWritingTo: file)
         defer { try? handle.close() }
-        try handle.seek(toOffset: 0)
+        try handle.seek(toOffset: offset)
         try handle.write(contentsOf: data)
     }
 

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -6,6 +6,8 @@ import Testing
 @Suite("Codex transcript activity tracker")
 struct CodexTranscriptActivityTrackerTests {
     private static let initialTailByteLimit = Int(CodexTranscriptActivityTracker.initialTailByteLimit)
+    private static let incrementalReadByteLimit =
+        Int(CodexTranscriptActivityTracker.incrementalReadByteLimit)
     private static let maxBufferedRecordByteCount =
         CodexTranscriptActivityTracker.maxBufferedRecordByteCount
 
@@ -206,6 +208,63 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(state == .idle)
     }
 
+    @Test func incrementalBacklogDoesNotPublishIntermediateLifecycleState() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_complete", turnID: "seed"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.append(
+            event(type: "task_started", turnID: "a")
+                + event(
+                    type: "agent_message", turnID: "padding",
+                    exactByteCount: Self.incrementalReadByteLimit)
+                + event(type: "task_complete", turnID: "a"))
+
+        let catchingUp = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        let caughtUp = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(catchingUp == nil)
+        #expect(caughtUp == .idle)
+    }
+
+    @Test func incrementalBacklogPreservesRecordCrossingPollBoundaries() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_complete", turnID: "seed"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        let crossingStart = event(type: "task_started", turnID: "a")
+        let firstPadding = event(
+            type: "agent_message", turnID: "first-padding",
+            exactByteCount: Self.incrementalReadByteLimit - crossingStart.count / 2)
+        let secondPadding = event(
+            type: "agent_message", turnID: "second-padding",
+            exactByteCount: Self.incrementalReadByteLimit)
+        try fixture.append(
+            firstPadding
+                + crossingStart
+                + secondPadding
+                + event(type: "task_complete", turnID: "different-turn"))
+
+        let firstCatchUp = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        let secondCatchUp = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        let caughtUp = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(firstCatchUp == nil)
+        #expect(secondCatchUp == nil)
+        #expect(caughtUp == .working)
+    }
+
     @Test func laterObservationsDoNotRescanAlreadyConsumedBytes() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
@@ -257,6 +316,14 @@ struct CodexTranscriptActivityTrackerTests {
             type: "agent_message", turnID: "oversized",
             terminated: false,
             exactByteCount: Self.maxBufferedRecordByteCount + 128))
+        let catchingUp = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        let boundedBuffer = await tracker.bufferedRecordState(transcriptPath: fixture.path)
+
+        #expect(catchingUp == nil)
+        #expect(boundedBuffer?.byteCount == Self.maxBufferedRecordByteCount)
+        #expect(boundedBuffer?.isDiscarding == false)
+
         _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
         let discarding = await tracker.bufferedRecordState(transcriptPath: fixture.path)
 
@@ -287,9 +354,12 @@ struct CodexTranscriptActivityTrackerTests {
                 type: "task_started", turnID: "oversized",
                 exactByteCount: Self.maxBufferedRecordByteCount + 128)
                 + event(type: "task_complete", turnID: "a"))
+        let catchingUp = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
         let state = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
 
+        #expect(catchingUp == nil)
         #expect(state == .idle)
     }
 

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -371,6 +371,29 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(afterNewline == .working)
     }
 
+    @Test func partialLifecycleRecordAtEOFDoesNotRepublishCachedState() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "a"))
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let working = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.append(event(
+            type: "task_complete", turnID: "a", terminated: false))
+        let partial = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        try fixture.append(Data([0x0A]))
+        let completed = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+
+        #expect(working == .working)
+        #expect(partial == nil)
+        #expect(completed == .idle)
+    }
+
     @Test func oversizedUnterminatedRecordIsDiscardedWithoutGrowingTheBuffer() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
@@ -391,9 +414,11 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(boundedBuffer?.byteCount == Self.maxBufferedRecordByteCount)
         #expect(boundedBuffer?.isDiscarding == false)
 
-        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
+        let discardedAtEOF = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
         let discarding = await tracker.bufferedRecordState(transcriptPath: fixture.path)
 
+        #expect(discardedAtEOF == nil)
         #expect(discarding?.byteCount == 0)
         #expect(discarding?.isDiscarding == true)
 

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("Codex transcript activity tracker")
+struct CodexTranscriptActivityTrackerTests {
+    @Test func taskStartedProducesWorking() {
+        var reducer = CodexTurnLifecycleReducer()
+
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+
+        #expect(reducer.activityState == .working)
+    }
+
+    @Test func matchingTaskCompleteProducesIdle() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+
+        reducer.consume(line: event(type: "task_complete", turnID: "a"))
+
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func matchingTurnAbortedProducesIdle() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+
+        reducer.consume(line: event(type: "turn_aborted", turnID: "a"))
+
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func completionForUnknownTurnDoesNotCloseOpenTurn() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+
+        reducer.consume(line: event(type: "task_complete", turnID: "b"))
+
+        #expect(reducer.activityState == .working)
+    }
+
+    @Test func duplicateStartsAreIdempotent() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+
+        reducer.consume(line: event(type: "task_complete", turnID: "a"))
+
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func multipleTurnsRemainWorkingUntilAllClose() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+        reducer.consume(line: event(type: "task_started", turnID: "b"))
+
+        reducer.consume(line: event(type: "task_complete", turnID: "a"))
+        #expect(reducer.activityState == .working)
+
+        reducer.consume(line: event(type: "turn_aborted", turnID: "b"))
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func malformedUnrelatedAndWrongOuterRecordsAreIgnored() {
+        var reducer = CodexTurnLifecycleReducer()
+
+        reducer.consume(line: Data("not json\n".utf8))
+        reducer.consume(line: Data(#"{"type":"response_item","payload":{"type":"task_started","turn_id":"a"}}"#.utf8))
+        reducer.consume(line: event(type: "agent_message", turnID: "a"))
+
+        #expect(reducer.activityState == nil)
+    }
+
+    @Test func noLifecycleEvidenceProducesNil() {
+        let reducer = CodexTurnLifecycleReducer()
+
+        #expect(reducer.activityState == nil)
+    }
+
+    private func event(type: String, turnID: String) -> Data {
+        Data((#"{"type":"event_msg","payload":{"type":"\#(type)","turn_id":"\#(turnID)"}}"# + "\n").utf8)
+    }
+}

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -50,7 +50,17 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == .idle)
     }
 
-    @Test func multipleTurnsRemainWorkingUntilAllClose() {
+    @Test func laterTurnSupersedesUnmatchedHistoricalTurn() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+        reducer.consume(line: event(type: "task_started", turnID: "b"))
+
+        reducer.consume(line: event(type: "task_complete", turnID: "b"))
+
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test func lateCloseForSupersededTurnDoesNotCloseCurrentTurn() {
         var reducer = CodexTurnLifecycleReducer()
         reducer.consume(line: event(type: "task_started", turnID: "a"))
         reducer.consume(line: event(type: "task_started", turnID: "b"))
@@ -58,7 +68,7 @@ struct CodexTranscriptActivityTrackerTests {
         reducer.consume(line: event(type: "task_complete", turnID: "a"))
         #expect(reducer.activityState == .working)
 
-        reducer.consume(line: event(type: "turn_aborted", turnID: "b"))
+        reducer.consume(line: event(type: "task_complete", turnID: "b"))
         #expect(reducer.activityState == .idle)
     }
 

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -548,7 +548,7 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
             == Int(onePathBudget) - 1)
 
-        let withoutSavedPath = [targets[2], targets[0]]
+        let withoutSavedPath = [targets[0], targets[2]]
         _ = await tracker.observe(
             transcripts: withoutSavedPath, totalByteLimit: onePathBudget)
         #expect(await tracker.bufferedRecordState(transcriptPath: third.path)?.byteCount
@@ -556,8 +556,9 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
             == Int(onePathBudget) - 1)
 
+        let reordered = [targets[2], targets[0]]
         _ = await tracker.observe(
-            transcripts: withoutSavedPath, totalByteLimit: onePathBudget)
+            transcripts: reordered, totalByteLimit: onePathBudget)
         #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
             == Int(onePathBudget) * 2 - 1)
     }

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -75,6 +75,22 @@ struct CodexTranscriptActivityTrackerTests {
     }
 
     @Test(
+        "a mismatched no-time close idles a genuinely open successor",
+        arguments: ["task_complete", "turn_aborted"]
+    )
+    func mismatchedNoTimeCloseIdlesOpenSuccessor(type: String) {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: event(type: "task_started", turnID: "a"))
+        reducer.consume(line: event(type: "task_started", turnID: "b"))
+
+        reducer.consume(line: event(type: type, turnID: "a"))
+
+        // With no started_at there is no trustworthy correlation key. The
+        // product policy deliberately prefers false idle to a stuck spinner.
+        #expect(reducer.activityState == .idle)
+    }
+
+    @Test(
         "a close without a turn ID prefers false idle",
         arguments: ["task_complete", "turn_aborted"]
     )

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -171,6 +171,22 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == .idle)
     }
 
+    @Test func threadSpawnChildCloseDoesNotRestoreCopiedParentTurn() {
+        var reducer = CodexTurnLifecycleReducer()
+        reducer.consume(line: Data(
+            #"{"type":"session_meta","payload":{"source":{"subagent":{"thread_spawn":{"depth":1}}}}}"#.utf8))
+        reducer.consume(line: event(
+            type: "task_started", turnID: "copied-parent", startedAt: 100))
+        reducer.consume(line: event(
+            type: "task_started", turnID: "child", startedAt: 200))
+
+        reducer.consume(line: event(
+            type: "task_complete", turnID: "child", startedAt: 200,
+            completedAt: 300))
+
+        #expect(reducer.activityState == .idle)
+    }
+
     @Test func subagentRolloutUsesTheSameLifecycleCorrelation() {
         var reducer = CodexTurnLifecycleReducer()
         reducer.consume(line: Data(#"{"type":"session_meta","payload":{"source":{"subagent":{"thread_spawn":{"depth":2}}}}}"#.utf8))

--- a/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+@Suite("Codex transcript presentation observations")
+struct CodexPresentationObservationTests {
+    @Test("presentation stamps are minted in tracker observation order")
+    func presentationStampsFollowTrackerOrder() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-presentation-order-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let transcript = directory.appendingPathComponent("rollout.jsonl")
+        try Data(
+            (#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}"# + "\n").utf8
+        ).write(to: transcript)
+
+        let firstAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let secondAt = firstAt.addingTimeInterval(1)
+        let dates = BlockingPresentationDates(first: firstAt, subsequent: secondAt)
+        let tracker = CodexTranscriptActivityTracker()
+        let targets = [CodexTranscriptActivityTracker.Target(
+            transcriptPath: transcript.path,
+            worktreeID: UUID()
+        )]
+
+        let first = Task {
+            await tracker.observeStamped(transcripts: targets, now: dates.provider)
+        }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await first.value
+            Issue.record("first observation never reached its actor stamp")
+            return
+        }
+
+        let handle = try FileHandle(forWritingTo: transcript)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(
+            (#"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"a"}}"# + "\n").utf8
+        ))
+        try handle.close()
+        let second = Task {
+            await tracker.observeStamped(transcripts: targets, now: dates.provider)
+        }
+
+        dates.releaseFirstCall()
+        let firstObservation = await first.value
+        let secondObservation = await second.value
+
+        #expect(firstObservation.states[transcript.path] == .working)
+        #expect(firstObservation.observedAt == firstAt)
+        #expect(secondObservation.states[transcript.path] == .idle)
+        #expect(secondObservation.observedAt == secondAt)
+    }
+}
+
+private final class BlockingPresentationDates: @unchecked Sendable {
+    private let lock = NSLock()
+    private let first: Date
+    private let subsequent: Date
+    private let release = DispatchSemaphore(value: 0)
+    private var callCount = 0
+    private var firstBlocked = false
+
+    init(first: Date, subsequent: Date) {
+        self.first = first
+        self.subsequent = subsequent
+    }
+
+    var firstCallIsBlocked: Bool {
+        lock.withLock { firstBlocked }
+    }
+
+    var provider: @Sendable () -> Date {
+        { [self] in
+            let call = lock.withLock { () -> Int in
+                let call = callCount
+                callCount += 1
+                if call == 0 { firstBlocked = true }
+                return call
+            }
+            guard call == 0 else { return subsequent }
+            release.wait()
+            return first
+        }
+    }
+
+    func releaseFirstCall() {
+        release.signal()
+    }
+}

--- a/Tests/TBDDaemonTests/MigrationV75StateProvenanceTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV75StateProvenanceTests.swift
@@ -232,10 +232,16 @@ import Testing
         try await db.terminals.setActivityState(
             id: terminal.id, activityState: .working,
             source: .hookEvent("UserPromptSubmit"), observedAt: epoch)
+        _ = try await db.terminals.applySessionStart(
+            id: terminal.id,
+            sessionID: "session-before-recreation",
+            transcriptPath: "/tmp/session-before-recreation.jsonl",
+            observedAt: epoch.addingTimeInterval(10))
 
         try await db.terminals.clearRecreated(id: terminal.id, at: epoch.addingTimeInterval(30))
 
         let recreated = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(recreated.sessionOrderObservedAt == nil)
         #expect(recreated.activityState == .unknown)
         #expect(recreated.activityStateSource == .derived)
         #expect(recreated.activityStateObservedAt == epoch.addingTimeInterval(30))

--- a/Tests/TBDDaemonTests/MigrationV80TerminalActivityOrderTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV80TerminalActivityOrderTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV80TerminalActivityOrderTests {
+    @Test func forwardMigrationAddsNullableOrderingWatermark() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v79_reap_records_quarantine_path")
+        let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+        let repoID = UUID().uuidString
+        let worktreeID = UUID().uuidString
+        let terminalID = UUID().uuidString
+        let source = FactColumnJSON.encode(FactSource.hookEvent("UserPromptSubmit"))
+        try queue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                    VALUES (?, '/tmp/v80-repo', 'V80', 'main', ?)
+                    """,
+                arguments: [repoID, epoch]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO worktree
+                        (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                    VALUES (?, ?, 'w', 'w', 'main', '/tmp/v80-wt', 'active', ?, 'tbd-v80')
+                    """,
+                arguments: [worktreeID, repoID, epoch]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO terminal
+                        (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt,
+                         activityState, activityStateSource, activityStateObservedAt)
+                    VALUES (?, ?, '@1', '%1', ?, 'working', ?, ?)
+                    """,
+                arguments: [terminalID, worktreeID, epoch, source, epoch]
+            )
+        }
+
+        let columnsBefore = try queue.read { db in
+            try Row.fetchAll(db, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+        }
+        #expect(!columnsBefore.contains("activityStateOrderObservedAt"))
+
+        try migrator.migrate(queue)
+
+        let column = try queue.read { db in
+            try Row.fetchAll(db, sql: "PRAGMA table_info(terminal)")
+                .first { ($0["name"] as String?) == "activityStateOrderObservedAt" }
+        }
+        #expect(column != nil)
+        #expect((column?["dflt_value"] as String?)?.uppercased() == "NULL")
+
+        let record = try queue.read { db in
+            try TerminalRecord.fetchOne(db, key: terminalID)
+        }
+        let terminal = try #require(record?.toModel())
+        #expect(terminal.activityState == .working)
+        #expect(terminal.activityStateSource == .hookEvent("UserPromptSubmit"))
+        #expect(terminal.activityStateObservedAt == epoch)
+        #expect(terminal.activityStateOrderObservedAt == nil)
+        #expect(terminal.observedActivity?.observedAt == epoch)
+    }
+}

--- a/Tests/TBDDaemonTests/MigrationV86TerminalSessionOrderTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV86TerminalSessionOrderTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct MigrationV86TerminalSessionOrderTests {
+    @Test func forwardMigrationAddsNullableSessionOrderingWatermark() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v85_terminal_activity_order")
+        let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+        let repoID = UUID().uuidString
+        let worktreeID = UUID().uuidString
+        let terminalID = UUID().uuidString
+        try queue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                    VALUES (?, '/tmp/v86-repo', 'V86', 'main', ?)
+                    """,
+                arguments: [repoID, epoch]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO worktree
+                        (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                    VALUES (?, ?, 'w', 'w', 'main', '/tmp/v86-wt', 'active', ?, 'tbd-v86')
+                    """,
+                arguments: [worktreeID, repoID, epoch]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO terminal
+                        (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt,
+                         claudeSessionID, transcriptPath, activityStateOrderObservedAt)
+                    VALUES (?, ?, '@1', '%1', ?, 'current-session', '/tmp/current.jsonl', ?)
+                    """,
+                arguments: [terminalID, worktreeID, epoch, epoch]
+            )
+        }
+
+        let columnsBefore = try queue.read { db in
+            try Row.fetchAll(db, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+        }
+        #expect(!columnsBefore.contains("sessionOrderObservedAt"))
+
+        try migrator.migrate(queue, upTo: "v86_terminal_session_order")
+
+        let column = try queue.read { db in
+            try Row.fetchAll(db, sql: "PRAGMA table_info(terminal)")
+                .first { ($0["name"] as String?) == "sessionOrderObservedAt" }
+        }
+        #expect(column != nil)
+        #expect((column?["dflt_value"] as String?)?.uppercased() == "NULL")
+
+        let row = try queue.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM terminal WHERE id = ?", arguments: [terminalID])
+        }
+        #expect((row?["claudeSessionID"] as String?) == "current-session")
+        #expect((row?["transcriptPath"] as String?) == "/tmp/current.jsonl")
+        #expect((row?["activityStateOrderObservedAt"] as Date?) == epoch)
+        #expect((row?["sessionOrderObservedAt"] as Date?) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -81,6 +81,18 @@ import TestSupport
         try #require(try await db.terminals.get(id: terminalID))
     }
 
+    private func activityRouter(observedAt: Date) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            now: { observedAt },
+            actuationLog: makeTestActuationLog())
+    }
+
     /// The park decision for the current row, plus the raw activity triple —
     /// the two things this slice must leave alone.
     private func parkDecision(_ terminal: Terminal) -> HibernationGate.Decision {
@@ -233,7 +245,7 @@ import TestSupport
 
     // MARK: - Superseding
 
-    /// The rail that keeps a recorded reason honest: the next activity
+    /// The rail that keeps a recorded reason honest: the next newer activity
     /// observation clears it, so a "needs your permission" cannot outlive the
     /// prompt it described.
     @Test func theNextActivityObservationSupersedesTheRecordedReason() async throws {
@@ -245,7 +257,8 @@ import TestSupport
         let request = try RPCRequest(
             method: RPCMethod.terminalActivityEvent,
             params: TerminalActivityEventParams(terminalID: terminalID, activityState: .working))
-        #expect(await router.handle(request).success)
+        #expect(await activityRouter(
+            observedAt: Self.observedAt.addingTimeInterval(1)).handle(request).success)
 
         let after = try await terminal()
         #expect(after.awaitingInputReason == nil)
@@ -316,7 +329,8 @@ import TestSupport
         let request = try RPCRequest(
             method: RPCMethod.terminalActivityEvent,
             params: TerminalActivityEventParams(terminalID: terminalID, activityState: .working))
-        #expect(await router.handle(request).success)
+        #expect(await activityRouter(
+            observedAt: Self.observedAt.addingTimeInterval(1)).handle(request).success)
 
         #expect(try await terminal().awaitingInputReason == nil)
     }

--- a/Tests/TBDDaemonTests/StopHookTranscriptSyncTests.swift
+++ b/Tests/TBDDaemonTests/StopHookTranscriptSyncTests.swift
@@ -71,10 +71,18 @@ struct StopHookTranscriptSyncTests {
         return (terminal, worktreePath, transcript, derived)
     }
 
-    private func send(_ terminalID: UUID, _ state: TerminalActivityState) async throws -> RPCResponse {
+    private func send(
+        _ terminalID: UUID,
+        _ state: TerminalActivityState,
+        origin: TerminalActivityEventOrigin? = nil
+    ) async throws -> RPCResponse {
         await router.handle(try RPCRequest(
             method: RPCMethod.terminalActivityEvent,
-            params: TerminalActivityEventParams(terminalID: terminalID, activityState: state)))
+            params: TerminalActivityEventParams(
+                terminalID: terminalID,
+                activityState: state,
+                origin: origin
+            )))
     }
 
     @Test func idleSyncsTranscriptStoredOutsideDerivedDir() async throws {
@@ -112,6 +120,17 @@ struct StopHookTranscriptSyncTests {
         let fx = try await makeFixture(outsideDerivedDir: true)
 
         let resp = try await send(fx.terminal.id, .working)
+
+        #expect(resp.success)
+        #expect(!FileManager.default.fileExists(
+            atPath: fx.derived.appendingPathComponent("sess-1.jsonl").path))
+    }
+
+    @Test func userInterruptIdleDoesNotSyncTranscript() async throws {
+        defer { try? FileManager.default.removeItem(at: home) }
+        let fx = try await makeFixture(outsideDerivedDir: true)
+
+        let resp = try await send(fx.terminal.id, .idle, origin: .userInterrupt)
 
         #expect(resp.success)
         #expect(!FileManager.default.fileExists(

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -89,6 +89,40 @@ struct TerminalActivityEventHandlerTests {
         #expect(updated?.activityState == .working)
     }
 
+    @Test("Claude activity hooks retain legacy unordered replacement semantics")
+    func claudeActivityHookRetainsLegacyUnorderedReplacement() async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        let olderHookAt = Date(timeIntervalSince1970: 1_700_000_100)
+        let newerStoredAt = olderHookAt.addingTimeInterval(1)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: newerStoredAt)
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: AwaitingInputReason(
+                message: "Claude needs permission",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: newerStoredAt)
+        let router = makeRouter(now: { olderHookAt })
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .idle))
+
+        #expect((await router.handle(request)).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(updated.activityStateObservedAt == olderHookAt)
+        #expect(updated.awaitingInputReason == nil)
+        #expect(updated.awaitingInputObservedAt == nil)
+    }
+
     @Test("unknown terminalID is a soft no-op")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(
@@ -414,10 +448,10 @@ struct TerminalActivityEventHandlerTests {
     }
 
     @Test(
-        "a delayed activity observation cannot erase a newer permission prompt",
+        "Claude activity retains legacy changed-value prompt retraction",
         arguments: [TerminalActivityState.working, .idle]
     )
-    func delayedActivityPreservesNewerPermissionPrompt(
+    func claudeActivityRetainsLegacyPromptRetraction(
         activityState: TerminalActivityState
     ) async throws {
         let terminal = try await makeTerminal(kind: .claude, label: "Claude")
@@ -462,13 +496,15 @@ struct TerminalActivityEventHandlerTests {
         #expect((await earlier.value).success)
 
         let updated = try #require(await db.terminals.get(id: terminal.id))
-        let reason = try #require(updated.awaitingInputReason)
-        #expect(reason.classification == .promptOnScreen)
-        #expect(updated.awaitingInputObservedAt == laterPromptAt)
-        let resolved = SessionStateResolver(now: { laterPromptAt }).resolve(
-            SessionStateFacts(terminal: updated))
-        #expect(resolved.value == .awaitingInput(reason: reason))
-        #expect(resolved.observedAt == laterPromptAt)
+        if activityState == .working {
+            let reason = try #require(updated.awaitingInputReason)
+            #expect(reason.classification == .promptOnScreen)
+            #expect(updated.awaitingInputObservedAt == laterPromptAt)
+        } else {
+            #expect(updated.activityState == .idle)
+            #expect(updated.awaitingInputReason == nil)
+            #expect(updated.awaitingInputObservedAt == nil)
+        }
     }
 
     @Test(
@@ -478,7 +514,7 @@ struct TerminalActivityEventHandlerTests {
     func equalTimeActivityPreservesPermissionPrompt(
         activityState: TerminalActivityState
     ) async throws {
-        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        let terminal = try await makeTerminal(kind: .codex, label: TerminalLabel.codex)
         let baseline = Date(timeIntervalSince1970: 1_700_000_000)
         let instant = baseline.addingTimeInterval(1)
         let reason = AwaitingInputReason(

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -246,6 +246,32 @@ struct TerminalActivityEventHandlerTests {
         #expect(updated.awaitingInputObservedAt == nil)
     }
 
+    @Test("Claude user-interrupt origin retains legacy unordered persistence")
+    func claudeUserInterruptRetainsLegacyUnorderedPersistence() async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        let olderInterruptAt = Date(timeIntervalSince1970: 1_700_000_100)
+        let newerStoredAt = olderInterruptAt.addingTimeInterval(1)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: newerStoredAt)
+        let router = makeRouter(now: { olderInterruptAt })
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .idle,
+                origin: .userInterrupt))
+
+        #expect((await router.handle(request)).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(updated.activityStateObservedAt == olderInterruptAt)
+    }
+
     @Test("unknown terminalID is a soft no-op")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -5,7 +5,10 @@ import Testing
 @testable import TBDShared
 import TestSupport
 
-@Suite("terminal.activityEvent handler")
+// Several race regressions intentionally block a synchronous date provider.
+// Serial execution prevents those waits from occupying every cooperative
+// executor thread before their test bodies can signal the matching release.
+@Suite("terminal.activityEvent handler", .serialized)
 struct TerminalActivityEventHandlerTests {
     let db: TBDDatabase
     let router: RPCRouter

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -89,6 +89,129 @@ struct TerminalActivityEventHandlerTests {
         #expect(updated?.activityState == .working)
     }
 
+    @Test(
+        "old-session Codex activity cannot overwrite a newer session",
+        arguments: [TerminalActivityState.working, .waitingForUser]
+    )
+    func oldSessionActivityCannotOverwriteNewSession(
+        activityState: TerminalActivityState
+    ) async throws {
+        let terminal = try await makeTerminal()
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "session-current",
+                transcriptPath: nil,
+                source: "startup"))
+        #expect((await router.handle(sessionStart)).success)
+        let currentPrompt = AwaitingInputReason(
+            message: "Current session needs permission",
+            hookEventName: "Notification",
+            notificationType: "permission_prompt")
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: currentPrompt,
+            observedAt: Date())
+
+        let staleActivity = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: activityState,
+                sessionID: "session-previous"))
+        #expect((await router.handle(staleActivity)).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.claudeSessionID == "session-current")
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .hookEvent("SessionStart"))
+        #expect(updated.awaitingInputReason == currentPrompt)
+    }
+
+    @Test("old-session working activity cannot cancel the new session's scheduled resume")
+    func oldSessionWorkingCannotCancelScheduledResume() async throws {
+        let terminal = try await makeTerminal()
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "session-current",
+                transcriptPath: nil,
+                source: "startup"))
+        #expect((await router.handle(sessionStart)).success)
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            resetsAt: Date().addingTimeInterval(3_600),
+            fireAt: Date().addingTimeInterval(3_660),
+            limitType: "session",
+            rawMessage: "rate limit"))
+
+        let staleActivity = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .working,
+                sessionID: "session-previous"))
+        #expect((await router.handle(staleActivity)).success)
+
+        #expect(try await db.scheduledResumes.pending(terminalID: terminal.id) != nil)
+    }
+
+    @Test(
+        "same-session Codex activity supersedes SessionStart",
+        arguments: [TerminalActivityState.working, .waitingForUser]
+    )
+    func sameSessionActivitySupersedesSessionStart(
+        activityState: TerminalActivityState
+    ) async throws {
+        let terminal = try await makeTerminal()
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "session-current",
+                transcriptPath: nil,
+                source: "startup"))
+        #expect((await router.handle(sessionStart)).success)
+
+        let currentActivity = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: activityState,
+                sessionID: "session-current"))
+        #expect((await router.handle(currentActivity)).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == activityState)
+        #expect(updated.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+    }
+
+    @Test("legacy identity-free Codex permission activity remains accepted")
+    func legacyPermissionActivityRemainsAccepted() async throws {
+        let terminal = try await makeTerminal()
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "session-current",
+                transcriptPath: nil,
+                source: "startup"))
+        #expect((await router.handle(sessionStart)).success)
+
+        let legacyPermission = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .waitingForUser))
+        #expect((await router.handle(legacyPermission)).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .waitingForUser)
+    }
+
     @Test("Claude activity hooks retain legacy unordered replacement semantics")
     func claudeActivityHookRetainsLegacyUnorderedReplacement() async throws {
         let terminal = try await makeTerminal(kind: .claude, label: "Claude")

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -26,6 +26,22 @@ struct TerminalActivityEventHandlerTests {
         )
     }
 
+    private func makeRouter(now: @escaping @Sendable () -> Date) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            now: now,
+            actuationLog: makeTestActuationLog()
+        )
+    }
+
     private func makeTerminal() async throws -> Terminal {
         let repo = try await db.repos.create(
             path: "/tmp/ta-repo-\(UUID().uuidString)",
@@ -197,5 +213,213 @@ struct TerminalActivityEventHandlerTests {
             commitsUnchangedSince: nil
         ))
         #expect(counters.hookEventsInWindow == 0)
+    }
+
+    @Test("user interrupt origin rejects a non-idle state without mutation or hook count")
+    func userInterruptRejectsNonIdleState() async throws {
+        let terminal = try await makeTerminal()
+        let originalObservedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .idle,
+            source: .hookEvent(RPCMethod.terminalActivityEvent),
+            observedAt: originalObservedAt
+        )
+        let transcript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("invalid-terminal-activity-\(UUID().uuidString).jsonl")
+        try Data().write(to: transcript)
+        defer { try? FileManager.default.removeItem(at: transcript) }
+        let request = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"working","origin":"user_interrupt"}"#
+        )
+
+        let response = await router.handle(request)
+
+        #expect(!response.success)
+        #expect(response.error == "user_interrupt origin requires idle activity")
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(updated.activityStateObservedAt == originalObservedAt)
+        let counters = try #require(await router.sessionCounters.sample(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            transcriptPath: transcript.path,
+            commitsUnchangedSince: nil
+        ))
+        #expect(counters.hookEventsInWindow == 0)
+    }
+
+    @Test("an earlier idle hook cannot erase a later explicit interrupt")
+    func earlierIdleHookCannotEraseLaterInterrupt() async throws {
+        let terminal = try await makeTerminal()
+        let old = Date(timeIntervalSince1970: 1_700_000_000)
+        let new = old.addingTimeInterval(1)
+        let dates = BlockingDateSequence(first: old, subsequent: new)
+        let router = makeRouter(now: dates.provider)
+        let idle = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .idle)
+        )
+        let interrupt = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+
+        let earlier = Task { await router.handle(idle) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier idle event never reached the date seam")
+            return
+        }
+        #expect((await router.handle(interrupt)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .terminalInterrupt)
+        #expect(updated.activityStateObservedAt == new)
+    }
+
+    @Test("a later working hook cannot be lost behind an earlier interrupt")
+    func laterWorkingCannotBeLostBehindEarlierInterrupt() async throws {
+        let terminal = try await makeTerminal()
+        let old = Date(timeIntervalSince1970: 1_700_000_000)
+        let new = old.addingTimeInterval(1)
+        let dates = BlockingDateSequence(first: old, subsequent: new)
+        let router = makeRouter(now: dates.provider)
+        let interrupt = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+        let working = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .working)
+        )
+
+        let earlier = Task { await router.handle(interrupt) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier interrupt never reached the date seam")
+            return
+        }
+        #expect((await router.handle(working)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .working)
+        #expect(updated.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(updated.activityStateObservedAt == new)
+    }
+
+    @Test("a same-time earlier working hook cannot erase a later interrupt")
+    func sameTimeEarlierWorkingCannotEraseLaterInterrupt() async throws {
+        let terminal = try await makeTerminal()
+        let instant = Date(timeIntervalSince1970: 1_700_000_000)
+        let dates = BlockingDateSequence(first: instant, subsequent: instant)
+        let router = makeRouter(now: dates.provider)
+        let working = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .working)
+        )
+        let interrupt = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+
+        let earlier = Task { await router.handle(working) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier working event never reached the date seam")
+            return
+        }
+        #expect((await router.handle(interrupt)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .terminalInterrupt)
+        #expect(updated.activityStateObservedAt == instant)
+    }
+
+    @Test("an earlier SessionStart cannot erase a later explicit interrupt")
+    func earlierSessionStartCannotEraseLaterInterrupt() async throws {
+        let terminal = try await makeTerminal()
+        let old = Date(timeIntervalSince1970: 1_700_000_000)
+        let new = old.addingTimeInterval(1)
+        let dates = BlockingDateSequence(first: old, subsequent: new)
+        let router = makeRouter(now: dates.provider)
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "new-session",
+                transcriptPath: nil,
+                source: "startup"
+            )
+        )
+        let interrupt = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+
+        let earlier = Task { await router.handle(sessionStart) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier SessionStart never reached the date seam")
+            return
+        }
+        #expect((await router.handle(interrupt)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .terminalInterrupt)
+        #expect(updated.activityStateObservedAt == new)
+    }
+}
+
+private final class BlockingDateSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private let first: Date
+    private let subsequent: Date
+    private let release = DispatchSemaphore(value: 0)
+    private var callCount = 0
+    private var firstBlocked = false
+
+    init(first: Date, subsequent: Date) {
+        self.first = first
+        self.subsequent = subsequent
+    }
+
+    var firstCallIsBlocked: Bool {
+        lock.withLock { firstBlocked }
+    }
+
+    var provider: @Sendable () -> Date {
+        { [self] in
+            let call = lock.withLock { () -> Int in
+                let call = callCount
+                callCount += 1
+                if call == 0 { firstBlocked = true }
+                return call
+            }
+            guard call == 0 else { return subsequent }
+            release.wait()
+            return first
+        }
+    }
+
+    func releaseFirstCall() {
+        release.signal()
     }
 }

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -468,6 +468,45 @@ struct TerminalActivityEventHandlerTests {
         #expect(resolved.observedAt == laterPromptAt)
     }
 
+    @Test(
+        "an equal-time activity observation preserves a permission prompt",
+        arguments: [TerminalActivityState.working, .idle]
+    )
+    func equalTimeActivityPreservesPermissionPrompt(
+        activityState: TerminalActivityState
+    ) async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        let baseline = Date(timeIntervalSince1970: 1_700_000_000)
+        let instant = baseline.addingTimeInterval(1)
+        let reason = AwaitingInputReason(
+            message: "Claude needs permission",
+            hookEventName: "Notification",
+            notificationType: "permission_prompt")
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: baseline)
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: reason,
+            observedAt: instant)
+
+        _ = try await db.terminals.applyActivityObservation(
+            id: terminal.id,
+            activityState: activityState,
+            source: .hookEvent(RPCMethod.terminalActivityEvent),
+            observedAt: instant)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.awaitingInputReason == reason)
+        #expect(updated.awaitingInputObservedAt == instant)
+        let resolved = SessionStateResolver(now: { instant }).resolve(
+            SessionStateFacts(terminal: updated))
+        #expect(resolved.value == .awaitingInput(reason: reason))
+        #expect(resolved.observedAt == instant)
+    }
+
     @Test("a same-time earlier working hook cannot erase a later interrupt")
     func sameTimeEarlierWorkingCannotEraseLaterInterrupt() async throws {
         let terminal = try await makeTerminal()

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -317,6 +318,95 @@ struct TerminalActivityEventHandlerTests {
         #expect(updated.activityStateObservedAt == new)
     }
 
+    @Test("a later same-state working hook advances order ahead of a delayed idle")
+    func laterSameStateWorkingAdvancesOrderAheadOfDelayedIdle() async throws {
+        let terminal = try await makeTerminal()
+        let initial = Date(timeIntervalSince1970: 1_700_000_000)
+        let earlierIdleAt = initial.addingTimeInterval(1)
+        let laterWorkingAt = initial.addingTimeInterval(2)
+        let originalSource = FactSource.hookEvent("UserPromptSubmit")
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: originalSource,
+            observedAt: initial,
+            awaitingInputReason: AwaitingInputReason(
+                message: "stale prompt",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt"
+            )
+        )
+        let dates = BlockingDateSequence(first: earlierIdleAt, subsequent: laterWorkingAt)
+        let router = makeRouter(now: dates.provider)
+        let idle = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .idle)
+        )
+        let working = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .working)
+        )
+
+        let earlier = Task { await router.handle(idle) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier idle event never reached the date seam")
+            return
+        }
+        #expect((await router.handle(working)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .working)
+        #expect(updated.activityStateSource == originalSource)
+        #expect(updated.activityStateObservedAt == initial)
+        #expect(updated.awaitingInputReason == nil)
+        #expect(updated.awaitingInputObservedAt == nil)
+        let orderObservedAt = try await db.writerForTests.read { db in
+            try Date.fetchOne(
+                db,
+                sql: "SELECT activityStateOrderObservedAt FROM terminal WHERE id = ?",
+                arguments: [terminal.id.uuidString]
+            )
+        }
+        #expect(orderObservedAt == laterWorkingAt)
+    }
+
+    @Test("a newer same-state idle hook advances order without erasing interrupt provenance")
+    func newerSameStateIdleAdvancesOrderWithoutErasingInterrupt() async throws {
+        let terminal = try await makeTerminal()
+        let interruptedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let refreshedAt = interruptedAt.addingTimeInterval(1)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .idle,
+            source: .terminalInterrupt,
+            observedAt: interruptedAt
+        )
+
+        _ = try await db.terminals.applyActivityObservation(
+            id: terminal.id,
+            activityState: .idle,
+            source: .hookEvent(RPCMethod.terminalActivityEvent),
+            observedAt: refreshedAt
+        )
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .terminalInterrupt)
+        #expect(updated.activityStateObservedAt == interruptedAt)
+        let orderObservedAt = try await db.writerForTests.read { db in
+            try Date.fetchOne(
+                db,
+                sql: "SELECT activityStateOrderObservedAt FROM terminal WHERE id = ?",
+                arguments: [terminal.id.uuidString]
+            )
+        }
+        #expect(orderObservedAt == refreshedAt)
+    }
+
     @Test("a same-time earlier working hook cannot erase a later interrupt")
     func sameTimeEarlierWorkingCannotEraseLaterInterrupt() async throws {
         let terminal = try await makeTerminal()
@@ -346,6 +436,70 @@ struct TerminalActivityEventHandlerTests {
         let updated = try #require(await db.terminals.get(id: terminal.id))
         #expect(updated.activityState == .idle)
         #expect(updated.activityStateSource == .terminalInterrupt)
+        #expect(updated.activityStateObservedAt == instant)
+    }
+
+    @Test("a same-time earlier working hook cannot erase a later idle hook")
+    func sameTimeEarlierWorkingCannotEraseLaterIdle() async throws {
+        let terminal = try await makeTerminal()
+        let instant = Date(timeIntervalSince1970: 1_700_000_000)
+        let dates = BlockingDateSequence(first: instant, subsequent: instant)
+        let router = makeRouter(now: dates.provider)
+        let working = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .working)
+        )
+        let idle = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .idle)
+        )
+
+        let earlier = Task { await router.handle(working) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier working event never reached the date seam")
+            return
+        }
+        #expect((await router.handle(idle)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+        #expect(updated.activityStateObservedAt == instant)
+        let orderObservedAt = try await db.writerForTests.read { db in
+            try Date.fetchOne(
+                db,
+                sql: "SELECT activityStateOrderObservedAt FROM terminal WHERE id = ?",
+                arguments: [terminal.id.uuidString]
+            )
+        }
+        #expect(orderObservedAt == instant)
+    }
+
+    @Test("a same-time idle hook cannot erase a permission wait")
+    func sameTimeIdleCannotEraseWaitingForUser() async throws {
+        let terminal = try await makeTerminal()
+        let instant = Date(timeIntervalSince1970: 1_700_000_000)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .waitingForUser,
+            source: .hookEvent("PermissionRequest"),
+            observedAt: instant
+        )
+
+        _ = try await db.terminals.applyActivityObservation(
+            id: terminal.id,
+            activityState: .idle,
+            source: .hookEvent("Stop"),
+            observedAt: instant
+        )
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .waitingForUser)
+        #expect(updated.activityStateSource == .hookEvent("PermissionRequest"))
         #expect(updated.activityStateObservedAt == instant)
     }
 

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -43,7 +43,10 @@ struct TerminalActivityEventHandlerTests {
         )
     }
 
-    private func makeTerminal() async throws -> Terminal {
+    private func makeTerminal(
+        kind: TerminalKind = .codex,
+        label: String = "Codex"
+    ) async throws -> Terminal {
         let repo = try await db.repos.create(
             path: "/tmp/ta-repo-\(UUID().uuidString)",
             displayName: "ta-repo",
@@ -60,8 +63,8 @@ struct TerminalActivityEventHandlerTests {
             worktreeID: wt.id,
             tmuxWindowID: "@1",
             tmuxPaneID: "%1",
-            label: "Codex",
-            kind: .codex
+            label: label,
+            kind: kind
         )
     }
 
@@ -405,6 +408,64 @@ struct TerminalActivityEventHandlerTests {
             )
         }
         #expect(orderObservedAt == refreshedAt)
+    }
+
+    @Test(
+        "a delayed activity observation cannot erase a newer permission prompt",
+        arguments: [TerminalActivityState.working, .idle]
+    )
+    func delayedActivityPreservesNewerPermissionPrompt(
+        activityState: TerminalActivityState
+    ) async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        let baseline = Date(timeIntervalSince1970: 1_700_000_000)
+        let earlierActivityAt = baseline.addingTimeInterval(1)
+        let laterPromptAt = baseline.addingTimeInterval(2)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: baseline
+        )
+        let dates = BlockingDateSequence(
+            first: earlierActivityAt,
+            subsequent: laterPromptAt)
+        let router = makeRouter(now: dates.provider)
+        let activity = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: activityState
+            )
+        )
+        let notification = try RPCRequest(
+            method: RPCMethod.terminalNotificationEvent,
+            params: TerminalNotificationEventParams(
+                terminalID: terminal.id,
+                notificationType: "permission_prompt",
+                message: "Claude needs permission"
+            )
+        )
+
+        let earlier = Task { await router.handle(activity) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier activity never reached the date seam")
+            return
+        }
+        #expect((await router.handle(notification)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        let reason = try #require(updated.awaitingInputReason)
+        #expect(reason.classification == .promptOnScreen)
+        #expect(updated.awaitingInputObservedAt == laterPromptAt)
+        let resolved = SessionStateResolver(now: { laterPromptAt }).resolve(
+            SessionStateFacts(terminal: updated))
+        #expect(resolved.value == .awaitingInput(reason: reason))
+        #expect(resolved.observedAt == laterPromptAt)
     }
 
     @Test("a same-time earlier working hook cannot erase a later interrupt")

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -80,4 +80,122 @@ struct TerminalActivityEventHandlerTests {
         #expect(response.success)
         #expect(response.error == nil)
     }
+
+    @Test("user interrupt persists distinct provenance from working state")
+    func userInterruptPersistsProvenanceFromWorking() async throws {
+        let terminal = try await makeTerminal()
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent(RPCMethod.terminalActivityEvent)
+        )
+        let request = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource?.kind == "user-action")
+        #expect(updated.activityStateSource?.detail == "terminal-interrupt")
+    }
+
+    @Test("user interrupt replaces provenance when raw state is already idle")
+    func userInterruptPersistsProvenanceFromIdle() async throws {
+        let terminal = try await makeTerminal()
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .idle,
+            source: .hookEvent(RPCMethod.terminalActivityEvent)
+        )
+        let request = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .idle)
+        #expect(updated.activityStateSource?.kind == "user-action")
+        #expect(updated.activityStateSource?.detail == "terminal-interrupt")
+    }
+
+    @Test("same-state hook does not erase an explicit interrupt")
+    func sameStateHookPreservesInterrupt() async throws {
+        let terminal = try await makeTerminal()
+        let interruptSource = try JSONDecoder().decode(
+            FactSource.self,
+            from: Data(#"{"kind":"user-action","detail":"terminal-interrupt"}"#.utf8)
+        )
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .idle,
+            source: interruptSource
+        )
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .idle
+            )
+        )
+
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityStateSource?.kind == "user-action")
+        #expect(updated.activityStateSource?.detail == "terminal-interrupt")
+    }
+
+    @Test("later working hook supersedes an explicit interrupt")
+    func laterWorkingHookSupersedesInterrupt() async throws {
+        let terminal = try await makeTerminal()
+        let interrupt = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+        #expect((await router.handle(interrupt)).success)
+
+        let working = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .working
+            )
+        )
+        #expect((await router.handle(working)).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.activityState == .working)
+        #expect(updated.activityStateSource == .hookEvent(RPCMethod.terminalActivityEvent))
+    }
+
+    @Test("user interrupt is not counted as an agent hook event")
+    func userInterruptDoesNotIncrementHookCounter() async throws {
+        let terminal = try await makeTerminal()
+        let transcript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("terminal-activity-\(UUID().uuidString).jsonl")
+        try Data().write(to: transcript)
+        defer { try? FileManager.default.removeItem(at: transcript) }
+        let request = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
+        )
+
+        #expect((await router.handle(request)).success)
+
+        let counters = try #require(await router.sessionCounters.sample(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            transcriptPath: transcript.path,
+            commitsUnchangedSince: nil
+        ))
+        #expect(counters.hookEventsInWindow == 0)
+    }
 }

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -250,10 +250,60 @@ struct TerminalSessionEventHandlerTests {
         #expect(after.activityStateObservedAt == idleAt)
     }
 
+    @Test("a delayed old-session prompt cannot suppress a genuine new SessionStart identity")
+    func delayedOldPromptPreservesNewSessionIdentity() async throws {
+        let (terminal, _) = try await makeTerminal(initialSession: "old-session")
+        let baseline = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionStartAt = baseline.addingTimeInterval(1)
+        let delayedPromptAt = baseline.addingTimeInterval(2)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: baseline)
+
+        let dates = BlockingSessionDates(first: sessionStartAt, subsequent: delayedPromptAt)
+        let raceRouter = makeRouter(now: dates.provider)
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "new-session",
+                transcriptPath: "/tmp/new-session.jsonl",
+                source: "resume"))
+        let delayedPrompt = try RPCRequest(
+            method: RPCMethod.terminalNotificationEvent,
+            params: TerminalNotificationEventParams(
+                terminalID: terminal.id,
+                notificationType: "permission_prompt",
+                message: "The old session needs permission"))
+
+        let sessionUpdate = Task { await raceRouter.handle(sessionStart) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await sessionUpdate.value
+            Issue.record("SessionStart never reached the date seam")
+            return
+        }
+        #expect((await raceRouter.handle(delayedPrompt)).success)
+        dates.releaseFirstCall()
+        #expect((await sessionUpdate.value).success)
+
+        let updated = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(updated.claudeSessionID == "new-session")
+        #expect(updated.transcriptPath == "/tmp/new-session.jsonl")
+        #expect(updated.sessionOrderObservedAt == sessionStartAt)
+        #expect(updated.awaitingInputReason?.classification == .promptOnScreen)
+        #expect(updated.awaitingInputObservedAt == delayedPromptAt)
+        #expect(updated.activityState == .working)
+        #expect(updated.activityStateSource == .hookEvent("UserPromptSubmit"))
+        #expect(updated.activityStateObservedAt == baseline)
+    }
+
     @Test("an older SessionStart cannot roll back identity or erase a newer prompt")
     func olderSessionStartPreservesNewerSessionAndPrompt() async throws {
         let (terminal, worktree) = try await makeTerminal(
-            initialSession: "current-session", label: "Codex", kind: .codex)
+            initialSession: "initial-session", label: "Codex", kind: .codex)
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-session-race-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -263,7 +313,7 @@ struct TerminalSessionEventHandlerTests {
             + "\n").write(to: transcript, atomically: true, encoding: .utf8)
         try await db.terminals.updateSession(
             id: terminal.id,
-            sessionID: "current-session",
+            sessionID: "initial-session",
             transcriptPath: transcript.path)
 
         let baseline = Date(timeIntervalSince1970: 1_700_000_000)
@@ -287,6 +337,13 @@ struct TerminalSessionEventHandlerTests {
                 sessionID: "stale-session",
                 transcriptPath: transcript.path,
                 source: "resume"))
+        let currentSession = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "current-session",
+                transcriptPath: transcript.path,
+                source: "resume"))
         let prompt = try RPCRequest(
             method: RPCMethod.terminalNotificationEvent,
             params: TerminalNotificationEventParams(
@@ -301,6 +358,16 @@ struct TerminalSessionEventHandlerTests {
             Issue.record("earlier SessionStart never reached the date seam")
             return
         }
+        #expect((await raceRouter.handle(currentSession)).success)
+        let handle = try FileHandle(forWritingTo: transcript)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(
+            (#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current-after-boundary"}}"#
+                + "\n").utf8))
+        try handle.close()
+        #expect(await raceRouter.codexActivityTracker.observe(
+            transcriptPath: transcript.path,
+            worktreeID: worktree.id) == .working)
         #expect((await raceRouter.handle(prompt)).success)
         dates.releaseFirstCall()
         #expect((await earlier.value).success)
@@ -352,6 +419,7 @@ struct TerminalSessionEventHandlerTests {
         let updated = try #require(try await db.terminals.get(id: terminal.id))
         #expect(updated.claudeSessionID == "first-session")
         #expect(updated.transcriptPath == "/tmp/first-session.jsonl")
+        #expect(updated.sessionOrderObservedAt == observedAt)
         #expect(updated.activityStateOrderObservedAt == observedAt)
     }
 

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -119,7 +119,7 @@ struct TerminalSessionEventHandlerTests {
             Issue.record("expected terminalSessionUpdated")
             return
         }
-        #expect(session.sessionOrderObservedAt == observedAt)
+        #expect(session.sessionOrderObservedAt == nil)
     }
 
     @Test("ignores non-absolute transcriptPath but still updates sessionID")
@@ -250,8 +250,44 @@ struct TerminalSessionEventHandlerTests {
         #expect(after.activityStateObservedAt == idleAt)
     }
 
-    @Test("a delayed old-session prompt cannot suppress a genuine new SessionStart identity")
-    func delayedOldPromptPreservesNewSessionIdentity() async throws {
+    @Test("Claude SessionStart retains legacy unordered identity and prompt semantics")
+    func claudeSessionStartRetainsLegacyUnorderedSemantics() async throws {
+        let (terminal, _) = try await makeTerminal(initialSession: "initial-session")
+        let olderSessionAt = Date(timeIntervalSince1970: 1_700_000_100)
+        let newerSessionAt = olderSessionAt.addingTimeInterval(1)
+        _ = try await db.terminals.applySessionStart(
+            id: terminal.id,
+            sessionID: "newer-session",
+            transcriptPath: "/tmp/newer-session.jsonl",
+            observedAt: newerSessionAt)
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: AwaitingInputReason(
+                message: "Claude needs permission",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: newerSessionAt)
+        let router = makeRouter(now: { olderSessionAt })
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "last-arriving-session",
+                transcriptPath: "/tmp/last-arriving-session.jsonl",
+                source: "resume"))
+
+        #expect((await router.handle(request)).success)
+
+        let updated = try #require(await db.terminals.get(id: terminal.id))
+        #expect(updated.claudeSessionID == "last-arriving-session")
+        #expect(updated.transcriptPath == "/tmp/last-arriving-session.jsonl")
+        #expect(updated.sessionOrderObservedAt == nil)
+        #expect(updated.awaitingInputReason == nil)
+        #expect(updated.awaitingInputObservedAt == nil)
+    }
+
+    @Test("a later-completing Claude SessionStart retains legacy prompt retraction")
+    func laterCompletingClaudeSessionStartRetractsPrompt() async throws {
         let (terminal, _) = try await makeTerminal(initialSession: "old-session")
         let baseline = Date(timeIntervalSince1970: 1_700_000_000)
         let sessionStartAt = baseline.addingTimeInterval(1)
@@ -292,9 +328,9 @@ struct TerminalSessionEventHandlerTests {
         let updated = try #require(try await db.terminals.get(id: terminal.id))
         #expect(updated.claudeSessionID == "new-session")
         #expect(updated.transcriptPath == "/tmp/new-session.jsonl")
-        #expect(updated.sessionOrderObservedAt == sessionStartAt)
-        #expect(updated.awaitingInputReason?.classification == .promptOnScreen)
-        #expect(updated.awaitingInputObservedAt == delayedPromptAt)
+        #expect(updated.sessionOrderObservedAt == nil)
+        #expect(updated.awaitingInputReason == nil)
+        #expect(updated.awaitingInputObservedAt == nil)
         #expect(updated.activityState == .working)
         #expect(updated.activityStateSource == .hookEvent("UserPromptSubmit"))
         #expect(updated.activityStateObservedAt == baseline)
@@ -388,7 +424,7 @@ struct TerminalSessionEventHandlerTests {
     }
 
     @Test(
-        "the first differently-identified SessionStart wins an equal timestamp",
+        "SessionStart tie ordering is scoped to Codex",
         arguments: [TerminalKind.codex, .claude]
     )
     func equalTimeDifferentSessionStartPreservesFirstIdentity(
@@ -417,10 +453,17 @@ struct TerminalSessionEventHandlerTests {
         #expect((await sameTimeRouter.handle(second)).success)
 
         let updated = try #require(try await db.terminals.get(id: terminal.id))
-        #expect(updated.claudeSessionID == "first-session")
-        #expect(updated.transcriptPath == "/tmp/first-session.jsonl")
-        #expect(updated.sessionOrderObservedAt == observedAt)
-        #expect(updated.activityStateOrderObservedAt == observedAt)
+        if kind == .codex {
+            #expect(updated.claudeSessionID == "first-session")
+            #expect(updated.transcriptPath == "/tmp/first-session.jsonl")
+            #expect(updated.sessionOrderObservedAt == observedAt)
+            #expect(updated.activityStateOrderObservedAt == observedAt)
+        } else {
+            #expect(updated.claudeSessionID == "second-session")
+            #expect(updated.transcriptPath == "/tmp/second-session.jsonl")
+            #expect(updated.sessionOrderObservedAt == nil)
+            #expect(updated.activityStateOrderObservedAt == nil)
+        }
     }
 
     @Test("unknown terminalID is a soft no-op (success, no error)")

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -305,6 +305,41 @@ struct TerminalSessionEventHandlerTests {
             worktreeID: worktree.id) == .working)
     }
 
+    @Test(
+        "the first differently-identified SessionStart wins an equal timestamp",
+        arguments: [TerminalKind.codex, .claude]
+    )
+    func equalTimeDifferentSessionStartPreservesFirstIdentity(
+        kind: TerminalKind
+    ) async throws {
+        let label = kind == .codex ? TerminalLabel.codex : "Claude"
+        let (terminal, _) = try await makeTerminal(label: label, kind: kind)
+        let observedAt = Date(timeIntervalSince1970: 1_700_000_100)
+        let sameTimeRouter = makeRouter(now: { observedAt })
+        let first = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "first-session",
+                transcriptPath: "/tmp/first-session.jsonl",
+                source: "SessionStart"))
+        let second = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "second-session",
+                transcriptPath: "/tmp/second-session.jsonl",
+                source: "SessionStart"))
+
+        #expect((await sameTimeRouter.handle(first)).success)
+        #expect((await sameTimeRouter.handle(second)).success)
+
+        let updated = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(updated.claudeSessionID == "first-session")
+        #expect(updated.transcriptPath == "/tmp/first-session.jsonl")
+        #expect(updated.activityStateOrderObservedAt == observedAt)
+    }
+
     @Test("unknown terminalID is a soft no-op (success, no error)")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -90,6 +90,13 @@ struct TerminalSessionEventHandlerTests {
     @Test("updates sessionID + transcriptPath in DB on a fresh SessionStart")
     func updatesSessionAndBroadcasts() async throws {
         let (terminal, _) = try await makeTerminal(initialSession: "old-id")
+        let observedAt = Date(timeIntervalSinceReferenceDate: 123)
+        let orderedRouter = makeRouter(now: { observedAt })
+        let captured = SessionDeltaCapture()
+        orderedRouter.subscriptions.addSubscriber { data in
+            captured.append(data)
+            return true
+        }
         let request = try RPCRequest(
             method: RPCMethod.terminalSessionEvent,
             params: TerminalSessionEventParams(
@@ -99,12 +106,20 @@ struct TerminalSessionEventHandlerTests {
                 source: "clear"
             )
         )
-        let response = await router.handle(request)
+        let response = await orderedRouter.handle(request)
         #expect(response.success)
 
         let updated = try await db.terminals.get(id: terminal.id)
         #expect(updated?.claudeSessionID == "new-id")
         #expect(updated?.transcriptPath == "/Users/me/.claude/projects/-x/new-id.jsonl")
+        let delta = try #require(captured.values.compactMap {
+            try? JSONDecoder().decode(StateDelta.self, from: $0)
+        }.first)
+        guard case let .terminalSessionUpdated(session) = delta else {
+            Issue.record("expected terminalSessionUpdated")
+            return
+        }
+        #expect(session.sessionOrderObservedAt == observedAt)
     }
 
     @Test("ignores non-absolute transcriptPath but still updates sessionID")
@@ -499,6 +514,17 @@ struct TerminalSessionEventHandlerTests {
         let result = try resp.decodeResult(TerminalTranscriptResult.self)
         #expect(result.sessionID == "logical-session-id")
         #expect(!result.messages.isEmpty)
+    }
+}
+
+private final class SessionDeltaCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Data] = []
+
+    var values: [Data] { lock.withLock { storage } }
+
+    func append(_ data: Data) {
+        lock.withLock { storage.append(data) }
     }
 }
 

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -26,7 +26,27 @@ struct TerminalSessionEventHandlerTests {
         )
     }
 
-    private func makeTerminal(initialSession: String? = nil) async throws -> (Terminal, Worktree) {
+    private func makeRouter(now: @escaping @Sendable () -> Date) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            now: now,
+            actuationLog: makeTestActuationLog()
+        )
+    }
+
+    private func makeTerminal(
+        initialSession: String? = nil,
+        label: String = "claude",
+        kind: TerminalKind? = nil
+    ) async throws -> (Terminal, Worktree) {
         let repo = try await db.repos.create(
             path: "/tmp/se-repo-\(UUID().uuidString)",
             displayName: "se-repo",
@@ -43,8 +63,9 @@ struct TerminalSessionEventHandlerTests {
             worktreeID: wt.id,
             tmuxWindowID: "@1",
             tmuxPaneID: "%1",
-            label: "claude",
-            claudeSessionID: initialSession
+            label: label,
+            claudeSessionID: initialSession,
+            kind: kind
         )
         return (terminal, wt)
     }
@@ -214,6 +235,76 @@ struct TerminalSessionEventHandlerTests {
         #expect(after.activityStateObservedAt == idleAt)
     }
 
+    @Test("an older SessionStart cannot roll back identity or erase a newer prompt")
+    func olderSessionStartPreservesNewerSessionAndPrompt() async throws {
+        let (terminal, worktree) = try await makeTerminal(
+            initialSession: "current-session", label: "Codex", kind: .codex)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-session-race-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let transcript = directory.appendingPathComponent("current.jsonl")
+        try (#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current"}}"#
+            + "\n").write(to: transcript, atomically: true, encoding: .utf8)
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "current-session",
+            transcriptPath: transcript.path)
+
+        let baseline = Date(timeIntervalSince1970: 1_700_000_000)
+        let earlierSessionAt = baseline.addingTimeInterval(1)
+        let laterPromptAt = baseline.addingTimeInterval(2)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: baseline)
+        let dates = BlockingSessionDates(first: earlierSessionAt, subsequent: laterPromptAt)
+        let raceRouter = makeRouter(now: dates.provider)
+        #expect(await raceRouter.codexActivityTracker.observe(
+            transcriptPath: transcript.path,
+            worktreeID: worktree.id) == .working)
+
+        let staleSession = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "stale-session",
+                transcriptPath: transcript.path,
+                source: "resume"))
+        let prompt = try RPCRequest(
+            method: RPCMethod.terminalNotificationEvent,
+            params: TerminalNotificationEventParams(
+                terminalID: terminal.id,
+                notificationType: "permission_prompt",
+                message: "Codex needs permission"))
+
+        let earlier = Task { await raceRouter.handle(staleSession) }
+        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+            dates.releaseFirstCall()
+            _ = await earlier.value
+            Issue.record("earlier SessionStart never reached the date seam")
+            return
+        }
+        #expect((await raceRouter.handle(prompt)).success)
+        dates.releaseFirstCall()
+        #expect((await earlier.value).success)
+
+        let updated = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(updated.claudeSessionID == "current-session")
+        #expect(updated.transcriptPath == transcript.path)
+        #expect(updated.awaitingInputReason?.classification == .promptOnScreen)
+        #expect(updated.awaitingInputObservedAt == laterPromptAt)
+        #expect(SessionStateResolver(now: { laterPromptAt })
+            .resolve(SessionStateFacts(terminal: updated)).value
+            == .awaitingInput(reason: updated.awaitingInputReason))
+        // A rejected old SessionStart must not reset the current transcript's
+        // reducer; only an accepted lifecycle boundary may do that.
+        #expect(await raceRouter.codexActivityTracker.observe(
+            transcriptPath: transcript.path,
+            worktreeID: worktree.id) == .working)
+    }
+
     @Test("unknown terminalID is a soft no-op (success, no error)")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(
@@ -373,5 +464,41 @@ struct TerminalSessionEventHandlerTests {
         let result = try resp.decodeResult(TerminalTranscriptResult.self)
         #expect(result.sessionID == "logical-session-id")
         #expect(!result.messages.isEmpty)
+    }
+}
+
+private final class BlockingSessionDates: @unchecked Sendable {
+    private let lock = NSLock()
+    private let first: Date
+    private let subsequent: Date
+    private let release = DispatchSemaphore(value: 0)
+    private var callCount = 0
+    private var firstBlocked = false
+
+    init(first: Date, subsequent: Date) {
+        self.first = first
+        self.subsequent = subsequent
+    }
+
+    var firstCallIsBlocked: Bool {
+        lock.withLock { firstBlocked }
+    }
+
+    var provider: @Sendable () -> Date {
+        { [self] in
+            let call = lock.withLock { () -> Int in
+                let call = callCount
+                callCount += 1
+                if call == 0 { firstBlocked = true }
+                return call
+            }
+            guard call == 0 else { return subsequent }
+            release.wait()
+            return first
+        }
+    }
+
+    func releaseFirstCall() {
+        release.signal()
     }
 }

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -52,6 +52,7 @@ import Testing
 }
 
 @Test func testTerminalRoundTrip() throws {
+    let sessionOrderObservedAt = Date(timeIntervalSinceReferenceDate: 30)
     let terminal = Terminal(
         id: UUID(),
         worktreeID: UUID(),
@@ -59,6 +60,7 @@ import Testing
         tmuxPaneID: "%3",
         label: "editor",
         createdAt: Date(),
+        sessionOrderObservedAt: sessionOrderObservedAt,
         activityState: .working,
         presentationActivityState: .idle
     )
@@ -67,6 +69,7 @@ import Testing
     #expect(terminal.id == decoded.id)
     #expect(decoded.tmuxWindowID == "@1")
     #expect(decoded.label == "editor")
+    #expect(decoded.sessionOrderObservedAt == sessionOrderObservedAt)
     #expect(decoded.activityState == .working)
     #expect(decoded.presentationActivityState == .idle)
 }
@@ -250,6 +253,7 @@ import Testing
     let decoded = try JSONDecoder().decode(Terminal.self, from: json)
     #expect(decoded.activityState == .unknown)
     #expect(decoded.presentationActivityState == nil)
+    #expect(decoded.sessionOrderObservedAt == nil)
 }
 
 // MARK: - Hibernation fields + gating helpers

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -59,7 +59,8 @@ import Testing
         tmuxPaneID: "%3",
         label: "editor",
         createdAt: Date(),
-        activityState: .working
+        activityState: .working,
+        presentationActivityState: .idle
     )
     let data = try JSONEncoder().encode(terminal)
     let decoded = try JSONDecoder().decode(Terminal.self, from: data)
@@ -67,6 +68,7 @@ import Testing
     #expect(decoded.tmuxWindowID == "@1")
     #expect(decoded.label == "editor")
     #expect(decoded.activityState == .working)
+    #expect(decoded.presentationActivityState == .idle)
 }
 
 @Test func testNotificationRoundTrip() throws {
@@ -247,6 +249,7 @@ import Testing
 
     let decoded = try JSONDecoder().decode(Terminal.self, from: json)
     #expect(decoded.activityState == .unknown)
+    #expect(decoded.presentationActivityState == nil)
 }
 
 // MARK: - Hibernation fields + gating helpers

--- a/Tests/TBDSharedTests/SessionStateModelTests.swift
+++ b/Tests/TBDSharedTests/SessionStateModelTests.swift
@@ -237,6 +237,16 @@ import Testing
         #expect(decoded.summary == "hook:Notification")
     }
 
+    @Test func userActionSourceCarriesItsActionName() throws {
+        let json = #"{"kind":"user-action","detail":"terminal-interrupt"}"#
+        let decoded = try JSONDecoder().decode(FactSource.self, from: Data(json.utf8))
+
+        #expect(decoded.kind == "user-action")
+        #expect(decoded.detail == "terminal-interrupt")
+        #expect(decoded.summary == "user-action:terminal-interrupt")
+        #expect(try roundTrip(decoded) == decoded)
+    }
+
     // MARK: - ObservedFact.summary
 
     /// Assert on the COMPOSED line, not on the presence of the three fields:

--- a/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
+++ b/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite struct TerminalActivityEventParamsCodingTests {
+    @Test("legacy activity payload without session identity still decodes")
+    func legacyPayloadStillDecodes() throws {
+        let terminalID = UUID()
+        let data = Data(
+            #"{"terminalID":"\#(terminalID.uuidString)","activityState":"working"}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(TerminalActivityEventParams.self, from: data)
+
+        #expect(decoded.terminalID == terminalID)
+        #expect(decoded.activityState == .working)
+        #expect(decoded.sessionID == nil)
+    }
+
+    @Test("activity payload carries optional Codex session identity")
+    func sessionIdentityRoundTrips() throws {
+        let params = TerminalActivityEventParams(
+            terminalID: UUID(),
+            activityState: .waitingForUser,
+            sessionID: "session-current")
+
+        let decoded = try JSONDecoder().decode(
+            TerminalActivityEventParams.self,
+            from: JSONEncoder().encode(params))
+
+        #expect(decoded.sessionID == "session-current")
+    }
+}

--- a/Tests/TBDSharedTests/TerminalSessionDeltaCodingTests.swift
+++ b/Tests/TBDSharedTests/TerminalSessionDeltaCodingTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("TerminalSessionDelta coding")
+struct TerminalSessionDeltaCodingTests {
+    @Test("legacy payload without an order generation still decodes")
+    func legacyPayloadDecodes() throws {
+        let terminalID = UUID()
+        let worktreeID = UUID()
+        let json = """
+        {"terminalID":"\(terminalID.uuidString)","worktreeID":"\(worktreeID.uuidString)","sessionID":"session","transcriptPath":null}
+        """
+
+        let delta = try JSONDecoder().decode(
+            TerminalSessionDelta.self,
+            from: Data(json.utf8))
+
+        #expect(delta.terminalID == terminalID)
+        #expect(delta.sessionOrderObservedAt == nil)
+    }
+
+    @Test("the session order generation round trips")
+    func orderGenerationRoundTrips() throws {
+        let observedAt = Date(timeIntervalSinceReferenceDate: 123)
+        let original = TerminalSessionDelta(
+            terminalID: UUID(),
+            worktreeID: UUID(),
+            sessionID: "session",
+            transcriptPath: "/tmp/session.jsonl",
+            sessionOrderObservedAt: observedAt)
+
+        let decoded = try JSONDecoder().decode(
+            TerminalSessionDelta.self,
+            from: JSONEncoder().encode(original))
+
+        #expect(decoded.sessionOrderObservedAt == observedAt)
+    }
+}

--- a/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
+++ b/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
@@ -40,7 +40,18 @@ The Codex presentation state follows this precedence:
 
 Ctrl+C is an explicit user action and must not wait for Codex to append `turn_aborted`. A later valid event from the current session may supersede the interrupt. A permission request must remain visible even while the transcript contains an open task.
 
-This path is enabled by default and has no feature flag. It replaces a known-unreliable Codex indicator, performs no destructive or autonomous action, and fails conservatively to idle. Maintaining two selectable interpretations would create competing answers to the same status question and preserve the failure mode this design removes.
+This path is enabled by default and has no feature flag. Although it wholesale replaces the Codex working/idle presentation signal, it is classified as a bug fix under the repository's rollout policy: it restores the existing indicator's intended meaning instead of adding an optional capability. It performs no destructive or autonomous action and fails conservatively to idle. Maintaining two selectable interpretations would create competing answers to the same status question and preserve the failure mode this design removes.
+
+## Required invariants
+
+- A Codex terminal presents working only from complete lifecycle evidence associated with its current transcript identity and session generation.
+- Unknown transcript evidence never reuses cached working evidence.
+- A session-bound hook from an older Codex session changes no terminal fact and does not cancel current-session scheduled work.
+- Ctrl+C clears working immediately and remains authoritative until a valid later current-session event supersedes it.
+- A current permission wait defeats transcript working.
+- SessionStart applies identity and its eligible prompt/activity effects atomically; an event rejected by one ordering rail cannot partially roll identity backward.
+- Session identity, raw activity, attention state, and transcript presentation are ordered by the timestamps that describe those specific facts.
+- Claude and shell terminals do not enter Codex reconciliation or acquire its ordering behavior.
 
 ## Authoritative signals
 
@@ -67,7 +78,7 @@ An accepted `SessionStart` establishes the current session identity and transcri
 
 For Codex, an accepted start also establishes a lifecycle boundary at the transcript's current end. Events before that boundary do not become current work after a same-path resume or daemon restart. The persisted SessionStart fact lets a new tracker reconstruct the boundary conservatively at the current end when actor memory is unavailable.
 
-Rejected or stale SessionStart events do not change identity, transcript path, attention state, activity, or tracker boundaries. Equal-time competing starts are first-wins so completion order cannot roll identity backward.
+Rejected or stale SessionStart events do not change identity, transcript path, attention state, activity, or tracker boundaries. Equal-time competing starts are first-wins so completion order cannot roll identity backward. A permission fact observed at the same time as, or after, SessionStart survives it; only a strictly older permission fact is retracted.
 
 ### Transcript tracker
 
@@ -87,11 +98,12 @@ A completion or abort closes the current task when:
 
 - its `turn_id` matches the current start;
 - its non-null `started_at` matches the current start; or
-- it cannot be correlated because identity or start time is absent.
+- the close record omits `turn_id`; or
+- the close record omits `started_at` and its `turn_id` does not match.
 
-The last case deliberately clears to idle under the false-thinking safety policy. When a close carries a different, older `started_at`, it does not close a newer task. A start without a `turn_id` is ignored because it cannot establish useful identity.
+The uncorrelated cases deliberately clear to idle under the false-thinking safety policy. This means a mismatched close without `started_at` can clear a different, genuinely open successor. That known false-idle risk is preferable to allowing the observed rewritten-close shape to leave working latched indefinitely. When a close carries a different, older `started_at`, it does not close a newer task. A start without a `turn_id` is ignored because it cannot establish useful identity.
 
-The reducer does not maintain a task stack. Separate subagents have separate rollout files, and copied parent starts are historical prefixes. Restoring an older start after the child turn closes would manufacture active work that Codex does not report.
+The reducer does not maintain a task stack. `session_meta` and `thread_spawn` describe rollout provenance, not nested task lifecycle inside one file, so they do not change reducer state. Separate subagents have separate rollout files, and a child file can contain copied parent lifecycle records as a historical prefix. A newer child `task_started` supersedes that copied prefix. Restoring an older parent start after the child turn closes would manufacture active work that Codex does not report.
 
 ### Terminal-list presentation
 
@@ -181,7 +193,7 @@ Reducer tests cover:
 - matching, older, and missing `started_at`;
 - missing task identity;
 - later-start supersession;
-- copied parent prefix followed by a child start and close;
+- `session_meta`/`thread_spawn` plus a copied parent prefix followed by a child start and close;
 - completion and abort variants;
 - malformed and unrelated JSONL records.
 

--- a/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
+++ b/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
@@ -1,0 +1,232 @@
+# Codex Activity Reconciliation Design
+
+## Purpose
+
+TBD needs one reliable answer to a narrow presentation question: should a Codex terminal appear to be working, waiting for the user, or idle?
+
+The persisted hook state is not sufficient on its own. Hooks can be delayed, omitted after interruption, or delivered after a session has moved to another rollout. Codex rollout transcripts contain task lifecycle events that more directly describe whether the current turn is open, but transcript evidence also has gaps: files can be incomplete, temporarily unreadable, very large, or contain copied history from a parent agent.
+
+This design replaces the Codex sidebar's legacy working/idle interpretation with a reconciled presentation state. It is enabled for every Codex terminal. Claude and shell terminals retain their existing behavior.
+
+The central safety policy is that false thinking is worse than false idle. Ambiguous evidence therefore resolves to idle rather than leaving an indefinite spinner.
+
+## Goals
+
+- Derive Codex working and idle presentation from rollout lifecycle events.
+- Clear stale working indicators after interruption, restart, resumed sessions, and rewritten lifecycle identifiers.
+- Preserve explicit user-attention states and immediate Ctrl+C feedback.
+- Reject delayed activity hooks from an older Codex session.
+- Handle root sessions and spawned subagents without treating copied parent history as nested active work.
+- Keep terminal-list polling bounded and fair across a fleet.
+- Preserve wire and database compatibility during upgrades.
+- Leave Claude and shell activity semantics unchanged.
+
+## Non-goals
+
+- Inferring state from rendered terminal text or TUI glyphs.
+- Reporting the internal progress of every nested tool or process inside a turn.
+- Reconstructing lifecycle history older than the bounded transcript window when no current evidence exists.
+- Changing Claude hooks, shell activity, hibernation policy, or notification policy.
+- Introducing a general event-sourcing framework for terminal state.
+
+## Product semantics
+
+The Codex presentation state follows this precedence:
+
+1. An explicit Ctrl+C interrupt presents idle immediately.
+2. A current permission request presents waiting for the user.
+3. Otherwise, complete transcript lifecycle evidence determines working or idle.
+4. Missing, incomplete, unreadable, oversized, stale, or not-yet-caught-up transcript evidence presents idle.
+
+Ctrl+C is an explicit user action and must not wait for Codex to append `turn_aborted`. A later valid event from the current session may supersede the interrupt. A permission request must remain visible even while the transcript contains an open task.
+
+This path is enabled by default and has no feature flag. It replaces a known-unreliable Codex indicator, performs no destructive or autonomous action, and fails conservatively to idle. Maintaining two selectable interpretations would create competing answers to the same status question and preserve the failure mode this design removes.
+
+## Authoritative signals
+
+TBD uses two machine-readable sources:
+
+- **Codex hook payloads** identify session boundaries, permission waits, user prompt submission, stops, and explicit TBD-originated interrupts.
+- **Codex rollout JSONL** supplies task lifecycle events used for working and idle presentation.
+
+Rendered terminal content is not an input. TBD does not parse prompts, status text, composer glyphs, or `tmux capture-pane` output.
+
+## Components and data flow
+
+### Hook overlay and CLI bridge
+
+The generated Codex hook overlay forwards hook JSON from standard input to TBD. `SessionStart`, `UserPromptSubmit`, `PermissionRequest`, and `Stop` payloads include the Codex `session_id`; their `transcript_path` may be absent.
+
+The CLI accepts a dedicated hook-payload mode rather than consuming standard input for ordinary commands. Input is bounded to 1 MiB and decoded into an optional, backward-compatible session identity on the terminal activity RPC. Payload reuse must preserve the same JSON for commands that perform more than one actuation.
+
+Already-running installations may still send activity events without a session identity until their generated overlay is refreshed. Identity-free events remain accepted during this upgrade window. Events that do carry an identity are validated transactionally against the terminal's current Codex session before they mutate activity, attention state, ordering watermarks, or scheduled-resume state.
+
+### SessionStart and durable boundaries
+
+An accepted `SessionStart` establishes the current session identity and transcript path. Session identity has its own persisted observation order, separate from activity and attention timestamps. This prevents a delayed event from one rail from incorrectly ordering another rail.
+
+For Codex, an accepted start also establishes a lifecycle boundary at the transcript's current end. Events before that boundary do not become current work after a same-path resume or daemon restart. The persisted SessionStart fact lets a new tracker reconstruct the boundary conservatively at the current end when actor memory is unavailable.
+
+Rejected or stale SessionStart events do not change identity, transcript path, attention state, activity, or tracker boundaries. Equal-time competing starts are first-wins so completion order cannot roll identity backward.
+
+### Transcript tracker
+
+A daemon actor owns transcript baselines, incremental offsets, partial records, reducer state, and presentation observation ordering. Serial actor access gives observations a stable order without blocking on unrelated database state.
+
+The tracker reads appended JSONL incrementally. Initial observation and truncation recovery inspect only a bounded tail. It preserves an unterminated fragment across reads, discards a record that grows beyond the record cap, and resumes at the next newline.
+
+Fleet and worktree-scoped observations share a fair cyclic path order. Scoped polling cannot reset fleet progress or starve a deferred transcript. A terminal-list response revalidates terminal identity, transcript path, and session generation after the actor observation. If the transcript changed during the scan, the response returns the current identity with a newly ordered unknown presentation rather than stale activity from the old file.
+
+### Lifecycle reducer
+
+Only recognized lifecycle records inside `event_msg` envelopes affect activity.
+
+The reducer tracks one current task because a Codex session has one active turn. A later `task_started` supersedes an unmatched earlier start. This is essential for resumed sessions and spawned agents: child rollout files can copy a parent lifecycle prefix, but that copied start is not concurrent child work.
+
+A completion or abort closes the current task when:
+
+- its `turn_id` matches the current start;
+- its non-null `started_at` matches the current start; or
+- it cannot be correlated because identity or start time is absent.
+
+The last case deliberately clears to idle under the false-thinking safety policy. When a close carries a different, older `started_at`, it does not close a newer task. A start without a `turn_id` is ignored because it cannot establish useful identity.
+
+The reducer does not maintain a task stack. Separate subagents have separate rollout files, and copied parent starts are historical prefixes. Restoring an older start after the child turn closes would manufacture active work that Codex does not report.
+
+### Terminal-list presentation
+
+The daemon exposes transcript-derived presentation activity separately from persisted raw hook activity. A complete observation carries its own timestamp. An authoritative unknown observation is also timestamped so it can clear an older working presentation without being mistaken for missing legacy metadata.
+
+Raw activity, session identity, and transcript presentation are ordered independently. Their timestamps describe different facts and cannot safely substitute for one another.
+
+### App reconciliation
+
+The app merges terminal snapshots and pushed deltas using three independent rails:
+
+- session identity and transcript-path order;
+- persisted raw activity and its event-order watermark;
+- response-derived presentation activity and its observation watermark.
+
+This separation prevents an overlapping older `terminal.list` response from rolling back a newer SessionStart, permission state, interrupt, or transcript completion. Identity changes clear presentation evidence from the old transcript. Same-identity SessionStart boundaries also fence presentation observations derived from a pre-boundary activity generation.
+
+Hidden ordering watermarks are cleared when terminals are removed and reseeded when terminal observations are replaced. Legacy payloads without the new optional fields retain compatible arrival-order behavior.
+
+These reconciliation rules apply only to Codex terminals. Claude and shell snapshots, deltas, and interrupts continue to use their established raw activity semantics.
+
+### Sidebar rendering
+
+The sidebar renders Codex state using the product precedence:
+
+- explicit terminal interrupt: idle;
+- waiting for user: attention state;
+- transcript working: working animation;
+- all other cases: idle.
+
+Raw generic idle hooks do not defeat a valid open transcript. Raw generic working hooks do not create a Codex spinner without transcript evidence.
+
+## Bounded I/O and fairness
+
+Terminal-list polling must not decode unbounded transcript history or perform unbounded zero-byte filesystem work.
+
+- An initial or truncation bootstrap reads at most 1 MiB of transcript content, plus the bounded boundary check.
+- A terminal-list observation has a shared 1 MiB byte budget across Codex transcripts.
+- Pending transcripts receive 64 KiB round-robin quanta.
+- One observation performs at most 16 filesystem steps, including caught-up and unreadable paths that consume no content bytes.
+- A single JSONL record is capped at 1 MiB. Oversized records are discarded through their newline.
+- Partial, discarding, untouched, and not-yet-caught-up paths publish unknown rather than cached working.
+
+Large backlogs converge over multiple polls. A continuously growing early path cannot consume every request because the cyclic cursor advances across requests and survives scoped polling and path removal.
+
+Field measurements found lifecycle lines near 3 KiB at the 99th percentile and about 21 KiB at the observed maximum. The 1 MiB record cap leaves substantial margin while bounding memory and scan cost.
+
+## Failure handling
+
+- **Incomplete final record** — retain the bounded fragment, publish unknown, and retry after more bytes arrive.
+- **Oversized record** — discard through the next newline, publish unknown while discarding, then resume normal parsing.
+- **Unreadable file** — publish unknown and retry on a later observation.
+- **Truncation or replacement** — rebuild from the bounded tail and do not reuse incompatible reducer evidence.
+- **Backlog beyond the request budget** — preserve incremental progress and publish unknown until caught up.
+- **Transcript identity changes during a scan** — discard the old-path result and publish an ordered unknown for the current identity.
+- **Daemon restart after SessionStart** — reconstruct the boundary conservatively at the current end so an orphaned historical start cannot restore working.
+- **Delayed old-session hook with identity** — reject it before any mutation.
+- **Legacy hook without identity** — accept it for upgrade compatibility; subsequent session-bound hooks restore full protection.
+
+These cases intentionally favor temporary idle over stale working.
+
+## Evidence informing the reducer
+
+Aggregate rollout analysis established the following public-safe characteristics:
+
+- In 1,003 recent rollouts, 150 closes rewrote the task identifier while retaining the start timestamp: 127 exec sessions, 18 subagent sessions, and 5 CLI sessions.
+- Across more than 43,000 lifecycle records, 64 rewritten-identifier completions omitted `started_at` while a task was open. Strict identifier matching would leave those sessions working indefinitely.
+- The audited Codex 0.147 lifecycle records all supplied `turn_id`, but the decoder remains tolerant of missing identity for future or partial schemas.
+- Codex creates spawned agents as distinct sessions and rollout files with one active task per session. Forked rollouts can copy parent lifecycle history.
+- Across 2,640 examined rollouts, 2,096 apparent overlapping starts were observed, predominantly copied into spawned-agent histories. No case later closed both the older and newer start. A stack reducer would therefore resurrect copied or orphaned work after the current child task completed.
+
+The design uses aggregate counts and schema behavior only. No rollout content or organization-specific context belongs in the repository.
+
+## Persistence and compatibility
+
+New shared-model and RPC fields are optional so older JSON continues to decode. Database ordering fields are nullable so pre-migration rows retain an explicit unknown state and fall back to their existing semantic timestamps where required.
+
+Session identity order is persisted independently from activity order. Presentation order is transient because it describes observations produced by the live transcript tracker rather than a durable user or hook fact.
+
+Generated hook configuration is refreshed through the existing plugin installation path. Mixed-version clients remain usable because identity-free activity events are accepted and new wire fields are optional.
+
+## Testing strategy
+
+Reducer tests cover:
+
+- matching and rewritten task identifiers;
+- matching, older, and missing `started_at`;
+- missing task identity;
+- later-start supersession;
+- copied parent prefix followed by a child start and close;
+- completion and abort variants;
+- malformed and unrelated JSONL records.
+
+Tracker tests cover:
+
+- initial tail bootstrap, truncation, and incremental reads;
+- 64 KiB boundaries and unterminated fragments;
+- oversized-record discard and recovery;
+- unreadable-file recovery;
+- per-request byte and step limits;
+- fleet fairness, scoped polling, path removal, and reordering;
+- SessionStart boundaries, daemon reconstruction, and same-path invalidation;
+- transcript identity rollover during concurrent list calls.
+
+Daemon and wire tests cover:
+
+- current-session hook acceptance and stale-session rejection;
+- legacy identity-free hook compatibility;
+- atomic ordering of session, activity, and attention facts;
+- equal-time precedence;
+- Ctrl+C persistence and later supersession;
+- bounded hook-payload parsing and JSON round trips;
+- migration of nullable ordering fields.
+
+App and sidebar tests cover:
+
+- Ctrl+C and permission precedence;
+- transcript working and authoritative unknown;
+- reversed snapshot and delta delivery;
+- same-path and changed-path SessionStart fences;
+- hidden-watermark monotonicity and cleanup;
+- Claude and shell regression behavior.
+
+Verification includes focused suites for each layer, `scripts/swift-safe build`, strict SwiftLint, and the fenced full `scripts/test.sh` suite for daemon or shared changes.
+
+## Alternatives rejected
+
+- **Hooks alone** — hooks do not reliably close every interrupted or resumed turn and can arrive after session rollover.
+- **Transcript alone** — it cannot provide immediate Ctrl+C feedback or preserve a permission prompt over an open task.
+- **A task stack** — copied parent history and orphaned starts would be restored after the current subagent task closes, creating false working.
+- **A default-off flag** — the legacy path is the known failure and parallel modes would preserve conflicting interpretations. Conservative idle fallback bounds the replacement's risk.
+- **Terminal screen scraping** — rendered TUI text is not a stable machine interface.
+
+## Operational impact
+
+The design adds no new durable external resource and requires no new reconciler. It reads existing rollout files, persists ordering metadata in the existing terminal record, and uses existing RPC and hook installation paths.
+
+No automatic process control, input injection, deletion, or background actuation is introduced. The change affects only Codex activity observation and presentation.

--- a/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
+++ b/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
@@ -40,7 +40,7 @@ The Codex presentation state follows this precedence:
 
 Ctrl+C is an explicit user action and must not wait for Codex to append `turn_aborted`. A later valid event from the current session may supersede the interrupt. A permission request must remain visible even while the transcript contains an open task.
 
-This path is enabled by default and has no feature flag. Although it wholesale replaces the Codex working/idle presentation signal, it is classified as a bug fix under the repository's rollout policy: it restores the existing indicator's intended meaning instead of adding an optional capability. It performs no destructive or autonomous action and fails conservatively to idle. Maintaining two selectable interpretations would create competing answers to the same status question and preserve the failure mode this design removes.
+This path is the shipped default for every Codex terminal and has no feature flag. Although it wholesale replaces the Codex working/idle presentation signal, it is classified as a bug fix under the repository's rollout policy: it restores the existing indicator's intended meaning instead of adding an optional capability. It performs no destructive or autonomous action and fails conservatively to idle. The stale legacy interpretation is not a supported mode; maintaining two selectable interpretations would create competing answers to the same status question and preserve the failure mode this design removes.
 
 ## Required invariants
 


### PR DESCRIPTION
## What's broken

Codex terminals can leave the sidebar's thinking dots running after the turn has ended, been interrupted, or resumed into a new session. The opposite failure also matters: a transcript-derived working result can hide a permission prompt or undo the immediate idle state from Ctrl+C.

The stale indicator can persist indefinitely when a transcript has an unmatched historical turn, Codex rewrites a turn ID on completion, a nested run changes the active rollout, or asynchronous hook, list, and subscription responses arrive out of order.

## Why it happens

The sidebar reads the persisted hook activity state, but Codex's hook rail is not a complete turn-lifecycle signal. A working hook can remain latched after the transcript records completion, and an interrupted turn may never append a matching abort record.

The first transcript reconciliation path also treated activity, session identity, and presentation as one loosely ordered value. A delayed list response or same-state hook could therefore overwrite a newer interrupt, permission wait, SessionStart, transcript boundary, or presentation observation. Rebuilding a long transcript on the two-second terminal-list path would also make the fix expensive at fleet scale.

## What this PR does

- Reconstructs Codex presentation activity from JSONL lifecycle records: `task_started`, `task_complete`, and `turn_aborted`.
- Correlates rewritten completion IDs by `started_at`, lets a later turn supersede an orphaned historical start, and ignores timestamped late closes for older turns. When a close lacks a usable correlation key, it resolves to idle under the explicit false-thinking-worse policy; missing-identity starts remain ignored. A sample of 1,003 recent rollouts contained 150 matching-start-time ID rewrites across CLI, exec, and subagent sources; a broader aggregate scan found 64 open-turn rewritten completions without `started_at`.
- Adds an incremental transcript tracker with bounded tail bootstrap, bounded record buffering, one shared per-request byte budget, a filesystem-step cap, and fair progress across fleet and worktree-scoped polls.
- Treats unreadable, partial, oversized, or not-yet-caught-up evidence as unknown. This deliberately prefers temporary false idle over preserving a false thinking indicator.
- Keeps persisted semantic activity separate from response-derived presentation activity and from their ordering watermarks.
- Gives Codex permission waits and explicit interrupts precedence over transcript working, while allowing genuinely later work and SessionStart events to supersede them. Claude and shell activity and SessionStart retain their main-branch semantics.
- Binds new Codex activity hooks to the required `session_id` from hook stdin, rejecting delayed old-session work or permission events before they can mutate activity, prompt state, ordering, or scheduled resumes. The optional wire field preserves compatibility with already-running legacy hook configurations, and explicit interrupts remain identity-free and authoritative.
- Applies SessionStart identity, prompt retraction, and activity atomically while ordering identity on its own durable SessionStart watermark; persists enough ordering to survive daemon restart; and establishes transcript boundaries so interrupted historical turns are not replayed.
- Fences daemon and app reconciliation against delayed snapshots, deltas, equal timestamps, same-path restarts, and session rollovers. Stable polls advance hidden ordering without republishing unchanged terminal rows.
- Adds backward-compatible optional wire fields and nullable activity/session-order database migrations.
- Records the reconciliation theory, precedence, failure policy, field evidence, and rejected alternatives in [`docs/specs/2026-08-19-codex-activity-reconciliation-design.md`](https://github.com/cheapsteak/tbd/blob/clear-stale-thinking/docs/specs/2026-08-19-codex-activity-reconciliation-design.md).

## Assumptions

- Codex rollout files are append-oriented; truncation is detected and conservatively rebuilt.
- Lifecycle records are much smaller than the 1 MiB record cap. A lifecycle record over that cap is ignored.
- Aggregate field measurements put lifecycle lines around 3 KiB at p99 and 20.8 KiB maximum. The 1 MiB record/read limit therefore leaves substantial format-growth margin while bounding each two-second list request; 64 KiB quanta provide fair progress, and the 16-step cap bounds zero-byte metadata work.
- The transcript bootstrap and catch-up budgets can temporarily omit current work after a restart or large backlog. That is intentional: ambiguous evidence must not keep the sidebar falsely animated.
- Already-running legacy Codex hook configurations may omit activity session identity until the plugin is refreshed. Those events retain legacy behavior so genuine permission prompts are not lost; newly generated hooks carry identity and receive strict session binding.

## Scope and rollout classification

This is a bug fix restoring the existing user-visible contract: the thinking indicator should represent current work and must yield to an interrupt or permission wait. It does not add a feature, autonomous action, destructive behavior, or new user-facing mode, so the repository's bug-fix exemption applies. The human-approved design is nevertheless committed because the lifecycle correlation and ordering machinery establish an important reconciliation theory across asynchronous machine signals.

This wholesale replaces the Codex working/idle presentation signal, but not the persisted activity rail. Hook-derived state remains the semantic source for Codex permission waits and explicit interrupts, and Claude/shell keep their pre-existing last-arrival snapshot, activity, SessionStart, and interrupt behavior. Ordered reconciliation and its app-side ordering sidecars are gated end-to-end as a Codex-only path; transcript evidence supplies Codex's missing turn-completion signal to the presentation value. A default-off flag would retain the known stale-indicator failure for the default path and create two competing interpretations of the same status without providing a useful soak escape hatch. The approved design therefore ships the direct Codex-scoped bug fix by default, with conservative unknown-to-idle behavior and regression coverage for both precedence branches.

## Evidence & verification

- Regression tests cover orphaned and rewritten turns, copied-parent subagent rollouts, partial and oversized records, truncation, unreadable files, bounded catch-up, shared-budget fairness, and scoped/fleet polling.
- Race tests cover permission waits, Ctrl+C, SessionStart, daemon restart, same-path boundaries, stale list responses, legacy deltas, equal timestamps, session identity rollover, and app-side presentation watermarks.
- The session-binding verification passed 109 focused and adjacent tests across shared wire, CLI parsing, Codex hook overlay, activity/session handlers, tracker, app, and sidebar suites. The final end-to-end scope verification passed its focused regressions plus 200 adjacent tests across 14 suites.
- Final build and lint: `scripts/swift-safe build` and `swiftlint --strict --quiet` passed.
- Final full fenced run: 7,533 tests across 746 suites with exactly the established baseline of eight unrelated unexpected issues and 84 known issues. The unexpected issues remain three ScratchpadCollector assertions, four Markdown web-view configuration assertions, and one transcript-estimator accuracy assertion; no changed-area test failed.
- Final independent review reported no actionable findings. A separate Codex review only raised the intentionally conservative false-idle behavior for ambiguous restart/backlog evidence.
