### PR TITLE
fix: spawn panes as login shells so user profiles build the PATH

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -192,7 +192,8 @@ enum ClaudeSpawnCommandBuilder {
 
         // Re-export the profile ROUTING env inline, ahead of the claude
         // invocation. tmux's `-e KEY=VALUE` seeds the pane's initial process
-        // environment, but the window runs `$SHELL -ilc <command>` and an
+        // environment, but the window runs `$SHELL -i -l -c <command>`
+        // (see TmuxManager.shellFlags(forShell:)) and an
         // interactive login shell sources profile and rc files (~/.zshenv,
         // /etc/zprofile, ~/.zprofile, ~/.zshrc) BEFORE the -c command — any
         // `export CLAUDE_CONFIG_DIR=...` in those files silently clobbers the

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -178,7 +178,7 @@ enum ClaudeSpawnCommandBuilder {
         // (`cmd` / `shellFallback`, early-returned above) keep update checks.
         // Deliberately NOT a routing key: it must be in the process env
         // BEFORE .zshrc runs, which only tmux's `-e` flag achieves — an
-        // inline export executes after rc files and would be useless.
+        // inline export executes after all startup files and would be useless.
         env["DISABLE_AUTO_UPDATE"] = "true"
         // Registry-driven Claude spawn-env settings. This block only runs in
         // the Claude branches — the `cmd` / `shellFallback` branches return
@@ -192,13 +192,14 @@ enum ClaudeSpawnCommandBuilder {
 
         // Re-export the profile ROUTING env inline, ahead of the claude
         // invocation. tmux's `-e KEY=VALUE` seeds the pane's initial process
-        // environment, but the window runs `$SHELL -ic <command>` and an
-        // interactive shell sources rc files (~/.zshenv, ~/.zshrc) BEFORE the
-        // -c command — any `export CLAUDE_CONFIG_DIR=...` in those files
-        // silently clobbers the -e value. That is exactly what broke profile
-        // login sessions for users running a shell-based Claude account
-        // switcher: every "isolated" session inherited the rc file's config
-        // dir instead of the profile's. Inline exports execute AFTER rc files,
+        // environment, but the window runs `$SHELL -ilc <command>` and an
+        // interactive login shell sources profile and rc files (~/.zshenv,
+        // /etc/zprofile, ~/.zprofile, ~/.zshrc) BEFORE the -c command — any
+        // `export CLAUDE_CONFIG_DIR=...` in those files silently clobbers the
+        // -e value. That is exactly what broke profile login sessions for
+        // users running a shell-based Claude account switcher: every
+        // "isolated" session inherited the rc file's config dir instead of
+        // the profile's. Inline exports execute AFTER every startup file,
         // so they deterministically win.
         //
         // Scope: only the profile routing keys (config dir, base URL, model,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -61,8 +61,9 @@ extension WorktreeLifecycle {
     /// `createWindow(sensitiveEnv:)` so tmux injects it with `-e KEY=VALUE` —
     /// i.e. into the PROCESS environment before zsh starts. The regular
     /// `env:` dict is inlined as `export KEY='V'; ` statements inside the
-    /// `-c` command string, which runs AFTER `.zshrc` completes, so it cannot
-    /// affect anything the rc files do. oh-my-zsh's tools/check_for_upgrade.sh
+    /// `-c` command string, which runs AFTER every startup file (profile and
+    /// rc) completes, so it cannot affect anything the startup files do.
+    /// oh-my-zsh's tools/check_for_upgrade.sh
     /// honors the legacy `DISABLE_AUTO_UPDATE` var (mapped to
     /// `zstyle ':omz:update' mode disabled`), so this skips its interactive
     /// "Would you like to update?" prompt that would otherwise block the hook

--- a/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
+++ b/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
@@ -328,9 +328,10 @@ actor ProviderEventsSupervisor {
         // Teardown is driven by process EXIT, not by pipe EOF. A provider that
         // leaves a grandchild holding the pipe's write end (the stub in the
         // live test does exactly that, and `BoundedProcessRunner` documents
-        // the same caveat for `[shell, -ilc, cmd]` call sites) never delivers
-        // EOF, so waiting for it would wedge this supervisor permanently. The
-        // short grace lets bytes already in the kernel buffer land first.
+        // the same caveat: any spawned process can fork grandchildren that
+        // inherit the write ends) never delivers EOF, so waiting for it would
+        // wedge this supervisor permanently. The short grace lets bytes
+        // already in the kernel buffer land first.
         let exitWatcher = Task { [clock] in
             await exitGate.wait()
             try? await clock.sleep(for: Self.drainGrace)

--- a/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
+++ b/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
@@ -328,7 +328,7 @@ actor ProviderEventsSupervisor {
         // Teardown is driven by process EXIT, not by pipe EOF. A provider that
         // leaves a grandchild holding the pipe's write end (the stub in the
         // live test does exactly that, and `BoundedProcessRunner` documents
-        // the same caveat for `[shell, -ic, cmd]` call sites) never delivers
+        // the same caveat for `[shell, -ilc, cmd]` call sites) never delivers
         // EOF, so waiting for it would wedge this supervisor permanently. The
         // short grace lets bytes already in the kernel buffer land first.
         let exitWatcher = Task { [clock] in

--- a/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
+++ b/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
@@ -328,8 +328,9 @@ enum BoundedProcessRunnerError: Error, Equatable, LocalizedError {
 /// on a busy machine, ~72KB) would otherwise block writing to the full pipe
 /// while we wait for it to exit — a mutual deadlock resolved only by the
 /// timeout. The drain never waits for pipe EOF: real call sites run
-/// `[shell, "-ic", cmd]`, and rc files can fork background grandchildren that
-/// inherit the write ends, so EOF may never arrive after the direct child dies.
+/// `[shell, "-ilc", cmd]`, and startup files (profile and rc) can fork
+/// background grandchildren that inherit the write ends, so EOF may never
+/// arrive after the direct child dies.
 /// Termination, timeout, and spawn-failure all snapshot what has already arrived
 /// and close the parent read ends — no thread, FD, or closure outlives the call.
 ///

--- a/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
+++ b/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
@@ -327,10 +327,9 @@ enum BoundedProcessRunnerError: Error, Equatable, LocalizedError {
 /// runs — a macOS pipe buffer is 64KB, so a child emitting more (e.g. `ps -Ao`
 /// on a busy machine, ~72KB) would otherwise block writing to the full pipe
 /// while we wait for it to exit — a mutual deadlock resolved only by the
-/// timeout. The drain never waits for pipe EOF: real call sites run
-/// `[shell, "-ilc", cmd]`, and startup files (profile and rc) can fork
-/// background grandchildren that inherit the write ends, so EOF may never
-/// arrive after the direct child dies.
+/// timeout. The drain never waits for pipe EOF: any spawned process can fork
+/// background grandchildren that inherit the pipe write ends, so EOF may
+/// never arrive after the direct child dies.
 /// Termination, timeout, and spawn-failure all snapshot what has already arrived
 /// and close the parent read ends — no thread, FD, or closure outlives the call.
 ///

--- a/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
+++ b/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
@@ -69,7 +69,7 @@ public struct ClaudeStateDetector: Sendable {
             let pidStr = try await tmux.panePID(server: server, paneID: paneID)
             guard let panePID = Int(pidStr) else { return nil }
 
-            // With `zsh -ic "claude ..."`, zsh may exec into Claude directly,
+            // With `zsh -ilc "claude ..."`, zsh may exec into Claude directly,
             // so pane_pid IS the Claude process (not a shell parent).
             // Try the pane PID's session file first.
             if let id = readSessionID(forPID: panePID) { return id }

--- a/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
+++ b/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
@@ -69,7 +69,8 @@ public struct ClaudeStateDetector: Sendable {
             let pidStr = try await tmux.panePID(server: server, paneID: paneID)
             guard let panePID = Int(pidStr) else { return nil }
 
-            // With `zsh -ilc "claude ..."`, zsh may exec into Claude directly,
+            // With `zsh -i -l -c "claude ..."` (see
+            // TmuxManager.shellFlags(forShell:)), zsh may exec into Claude directly,
             // so pane_pid IS the Claude process (not a shell parent).
             // Try the pane PID's session file first.
             if let id = readSessionID(forPID: panePID) { return id }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -255,8 +255,11 @@ public struct TmuxManager: Sendable {
     }
 
     public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) -> [String] {
-        // Use shell -ic so commands with arguments work (e.g. "claude --dangerously-skip-permissions")
-        // -i keeps it interactive (loads .zshrc), -c runs the command
+        // Use shell -ilc so commands with arguments work (e.g. "claude --dangerously-skip-permissions")
+        // -i keeps it interactive (loads rc files such as .zshrc), -l makes it
+        // a login shell (loads profile files: /etc/zprofile's path_helper and
+        // ~/.zprofile supply the /usr/local/bin and Homebrew PATH entries; see
+        // docs/specs/2026-08-19-login-shell-panes-design.md), -c runs the command.
         // After the command exits, the pane closes (tmux default behavior)
         let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         let fullCommand = envExportPrefixed(shellCommand, env: env)
@@ -269,9 +272,10 @@ public struct TmuxManager: Sendable {
         //     tmux invocation's own argv during fork/exec, but tmux re-execs
         //     and its server process does not retain the original argv
         //     visibly.)
-        //   - rc-affecting toggles (e.g. DISABLE_AUTO_UPDATE on hook panes):
-        //     the `env` export-prefix runs after `.zshrc` completes, so only
-        //     -e values are visible while rc files execute.
+        //   - startup-file-affecting toggles (e.g. DISABLE_AUTO_UPDATE on hook
+        //     panes): the `env` export-prefix runs after every startup file
+        //     (profile and rc) completes, so only -e values are visible while
+        //     profile and rc files execute.
         let eFlags = sensitiveEnvFlags(sensitiveEnv)
         // Note: size flags (-x/-y) are intentionally NOT emitted here. tmux's
         // `new-window` does not support those flags (only `new-session`,
@@ -284,17 +288,19 @@ public struct TmuxManager: Sendable {
         _ = rows
         return ["-L", server, "new-window", "-t", session, "-c", cwd]
             + eFlags
-            + ["-PF", "#{window_id} #{pane_id}", userShell, "-ic", fullCommand]
+            + ["-PF", "#{window_id} #{pane_id}", userShell, "-ilc", fullCommand]
     }
 
     /// Respawn (replace the running program of) an existing window's pane
     /// IN PLACE, keeping the same window id and pane id. Shares
     /// `newWindowCommand`'s env handling through `envExportPrefixed` and
     /// `sensitiveEnvFlags` — the `env` map is inlined as an
-    /// `export …; ` prefix on the shell command (runs AFTER rc files), while
-    /// `sensitiveEnv` is passed via tmux `-e KEY=VALUE` so it's in the process
-    /// environment before the shell starts (kept out of `ps aux`, and visible
-    /// during rc execution). `-k` kills the pane's current program first.
+    /// `export …; ` prefix on the shell command (runs AFTER all startup files,
+    /// profile and rc alike), while `sensitiveEnv` is passed via tmux
+    /// `-e KEY=VALUE` so it's in the process environment before the shell
+    /// starts (kept out of `ps aux`, and visible during profile and rc
+    /// execution). Spawns `$SHELL -ilc` like `newWindowCommand`. `-k` kills
+    /// the pane's current program first.
     ///
     /// Used by the seamless in-place account switch: same tab, same terminal
     /// row, new profile's `claude --resume` command. See PR 5222a79 for why the
@@ -313,7 +319,7 @@ public struct TmuxManager: Sendable {
         let eFlags = sensitiveEnvFlags(sensitiveEnv)
         return ["-L", server, "respawn-window", "-k", "-t", windowID, "-c", cwd]
             + eFlags
-            + [userShell, "-ic", fullCommand]
+            + [userShell, "-ilc", fullCommand]
     }
 
     /// Resize an existing tmux window to the given cell dimensions.

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -254,38 +254,54 @@ public struct TmuxManager: Sendable {
         return eFlags
     }
 
-    /// Combined shell flags for spawning the user's shell with a command
-    /// string, chosen by the shell's basename. csh and tcsh reject the
-    /// clustered `-ilc` outright and cannot combine -l with -c at all (tcsh
-    /// accepts -l only as its sole argument), so they keep the pre-login-shell
-    /// `-ic`; every other shell gets `-ilc` (interactive login shell, see
+    /// Shell flags for spawning the user's shell with a command string,
+    /// chosen by the shell's lowercased basename (the same derivation as
+    /// `CLIInstaller.shellRCAndExport`, so "/bin/TCSH" and wrapper paths
+    /// behave consistently across both). Flags are separate argv elements
+    /// (`-i -l -c`, never clustered `-ilc`): some shells (e.g. nushell)
+    /// accept the individual flags but reject GNU-style clustering, and a
+    /// rejected spawn kills every pane silently. csh and tcsh cannot combine
+    /// -l with -c at all (tcsh accepts -l only as its sole argument), so
+    /// they keep the pre-login-shell `-i -c`; every other shell gets
+    /// `-i -l -c` (interactive login shell, see
     /// docs/specs/2026-08-19-login-shell-panes-design.md).
     ///
-    /// Measured on this macOS host (2026-08-19):
-    ///   tcsh -ic 'echo ok' -> ok;  tcsh -ilc -> exit 1, "Unknown option: `-lc'"
-    ///   csh  -ic 'echo ok' -> ok;  csh  -ilc -> exit 1, "Unknown option: `-lc'"
-    ///   zsh -ilc, bash -ilc, dash -ilc -> ok (fish not installed to measure)
-    static func shellFlags(forShell shellPath: String) -> String {
-        let basename = shellPath.split(separator: "/").last.map(String.init) ?? shellPath
+    /// Measured on this macOS host (2026-08-19), separate flags behaving
+    /// identically to the clustered forms:
+    ///   zsh  -i -l -c 'echo ok' -> ok, exit 0 (same as -ilc)
+    ///   bash -i -l -c 'echo ok' -> ok, exit 0 (same as -ilc)
+    ///   dash -i -l -c 'echo ok' -> ok, exit 0 (same as -ilc)
+    ///   tcsh -i -c 'echo ok' -> ok, exit 0 (same as -ic);
+    ///        tcsh -i -l -c -> exit 1, "Unknown option: `-l'"
+    ///   csh  -i -c 'echo ok' -> ok, exit 0 (same as -ic);
+    ///        csh  -i -l -c -> exit 1, "Unknown option: `-l'"
+    ///   (fish not installed to measure)
+    static func shellFlags(forShell shellPath: String) -> [String] {
+        let basename = (shellPath as NSString).lastPathComponent.lowercased()
         switch basename {
         case "csh", "tcsh":
-            return "-ic"
+            return ["-i", "-c"]
         default:
-            return "-ilc"
+            return ["-i", "-l", "-c"]
         }
     }
 
-    /// The `[shell, flags, command]` argv tail appended by both spawn
+    /// The `[shell] + flags + [command]` argv tail appended by both spawn
     /// builders. Shared for the same drift-hazard reason as
     /// `envExportPrefixed`: `newWindowCommand` and `respawnWindowCommand`
     /// must spawn through the identical shell invocation, and the per-shell
     /// flag choice (`shellFlags(forShell:)`) must not fork between them.
-    static func shellInvocation(_ fullCommand: String) -> [String] {
-        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
-        return [userShell, shellFlags(forShell: userShell), fullCommand]
+    /// The defaulted `environment` parameter is the test seam for the SHELL
+    /// read, matching the `TBDConstants.*(environment:)` idiom.
+    static func shellInvocation(
+        _ fullCommand: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String] {
+        let userShell = environment["SHELL"] ?? "/bin/zsh"
+        return [userShell] + shellFlags(forShell: userShell) + [fullCommand]
     }
 
-    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) -> [String] {
+    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil, environment: [String: String] = ProcessInfo.processInfo.environment) -> [String] {
         // Spawn `shell <flags> <cmd>` (via shellInvocation) so commands with
         // arguments work (e.g. "claude --dangerously-skip-permissions").
         // -i keeps it interactive, -l makes it a login shell, -c runs the
@@ -295,7 +311,9 @@ public struct TmuxManager: Sendable {
         // /etc/zprofile's path_helper and ~/.zprofile supply the
         // /usr/local/bin and Homebrew PATH entries; see
         // docs/specs/2026-08-19-login-shell-panes-design.md. csh/tcsh cannot
-        // combine -l with -c and keep -ic (see shellFlags(forShell:)).
+        // combine -l with -c and keep -i -c (see shellFlags(forShell:)).
+        // `environment` is the test seam for the SHELL read; production call
+        // sites take the default.
         // After the command exits, the pane closes (tmux default behavior)
         let fullCommand = envExportPrefixed(shellCommand, env: env)
         // `sensitiveEnv` carries values that must be in the spawned window's
@@ -324,7 +342,7 @@ public struct TmuxManager: Sendable {
         return ["-L", server, "new-window", "-t", session, "-c", cwd]
             + eFlags
             + ["-PF", "#{window_id} #{pane_id}"]
-            + shellInvocation(fullCommand)
+            + shellInvocation(fullCommand, environment: environment)
     }
 
     /// Respawn (replace the running program of) an existing window's pane
@@ -338,9 +356,10 @@ public struct TmuxManager: Sendable {
     /// execution). Spawns the same interactive login-shell invocation as
     /// `newWindowCommand` via `shellInvocation` (zsh sources
     /// zshenv + zprofile + zshrc; bash login shells source profile files
-    /// only, relying on .bash_profile sourcing .bashrc; csh/tcsh keep -ic,
+    /// only, relying on .bash_profile sourcing .bashrc; csh/tcsh keep -i -c,
     /// see `shellFlags(forShell:)`). `-k` kills the pane's current program
-    /// first.
+    /// first. `environment` is the test seam for the SHELL read; production
+    /// call sites take the default.
     ///
     /// Used by the seamless in-place account switch: same tab, same terminal
     /// row, new profile's `claude --resume` command. See PR 5222a79 for why the
@@ -352,13 +371,14 @@ public struct TmuxManager: Sendable {
         cwd: String,
         shellCommand: String,
         env: [String: String] = [:],
-        sensitiveEnv: [String: String] = [:]
+        sensitiveEnv: [String: String] = [:],
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> [String] {
         let fullCommand = envExportPrefixed(shellCommand, env: env)
         let eFlags = sensitiveEnvFlags(sensitiveEnv)
         return ["-L", server, "respawn-window", "-k", "-t", windowID, "-c", cwd]
             + eFlags
-            + shellInvocation(fullCommand)
+            + shellInvocation(fullCommand, environment: environment)
     }
 
     /// Resize an existing tmux window to the given cell dimensions.

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -254,14 +254,49 @@ public struct TmuxManager: Sendable {
         return eFlags
     }
 
-    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) -> [String] {
-        // Use shell -ilc so commands with arguments work (e.g. "claude --dangerously-skip-permissions")
-        // -i keeps it interactive (loads rc files such as .zshrc), -l makes it
-        // a login shell (loads profile files: /etc/zprofile's path_helper and
-        // ~/.zprofile supply the /usr/local/bin and Homebrew PATH entries; see
-        // docs/specs/2026-08-19-login-shell-panes-design.md), -c runs the command.
-        // After the command exits, the pane closes (tmux default behavior)
+    /// Combined shell flags for spawning the user's shell with a command
+    /// string, chosen by the shell's basename. csh and tcsh reject the
+    /// clustered `-ilc` outright and cannot combine -l with -c at all (tcsh
+    /// accepts -l only as its sole argument), so they keep the pre-login-shell
+    /// `-ic`; every other shell gets `-ilc` (interactive login shell, see
+    /// docs/specs/2026-08-19-login-shell-panes-design.md).
+    ///
+    /// Measured on this macOS host (2026-08-19):
+    ///   tcsh -ic 'echo ok' -> ok;  tcsh -ilc -> exit 1, "Unknown option: `-lc'"
+    ///   csh  -ic 'echo ok' -> ok;  csh  -ilc -> exit 1, "Unknown option: `-lc'"
+    ///   zsh -ilc, bash -ilc, dash -ilc -> ok (fish not installed to measure)
+    static func shellFlags(forShell shellPath: String) -> String {
+        let basename = shellPath.split(separator: "/").last.map(String.init) ?? shellPath
+        switch basename {
+        case "csh", "tcsh":
+            return "-ic"
+        default:
+            return "-ilc"
+        }
+    }
+
+    /// The `[shell, flags, command]` argv tail appended by both spawn
+    /// builders. Shared for the same drift-hazard reason as
+    /// `envExportPrefixed`: `newWindowCommand` and `respawnWindowCommand`
+    /// must spawn through the identical shell invocation, and the per-shell
+    /// flag choice (`shellFlags(forShell:)`) must not fork between them.
+    static func shellInvocation(_ fullCommand: String) -> [String] {
         let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        return [userShell, shellFlags(forShell: userShell), fullCommand]
+    }
+
+    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) -> [String] {
+        // Spawn `shell <flags> <cmd>` (via shellInvocation) so commands with
+        // arguments work (e.g. "claude --dangerously-skip-permissions").
+        // -i keeps it interactive, -l makes it a login shell, -c runs the
+        // command. zsh sources zshenv + zprofile + zshrc; bash login shells
+        // source profile files only, relying on the near-universal convention
+        // that .bash_profile sources .bashrc (same behavior as Terminal.app).
+        // /etc/zprofile's path_helper and ~/.zprofile supply the
+        // /usr/local/bin and Homebrew PATH entries; see
+        // docs/specs/2026-08-19-login-shell-panes-design.md. csh/tcsh cannot
+        // combine -l with -c and keep -ic (see shellFlags(forShell:)).
+        // After the command exits, the pane closes (tmux default behavior)
         let fullCommand = envExportPrefixed(shellCommand, env: env)
         // `sensitiveEnv` carries values that must be in the spawned window's
         // PROCESS environment before the shell starts, via tmux's -e KEY=VALUE
@@ -288,7 +323,8 @@ public struct TmuxManager: Sendable {
         _ = rows
         return ["-L", server, "new-window", "-t", session, "-c", cwd]
             + eFlags
-            + ["-PF", "#{window_id} #{pane_id}", userShell, "-ilc", fullCommand]
+            + ["-PF", "#{window_id} #{pane_id}"]
+            + shellInvocation(fullCommand)
     }
 
     /// Respawn (replace the running program of) an existing window's pane
@@ -299,8 +335,12 @@ public struct TmuxManager: Sendable {
     /// profile and rc alike), while `sensitiveEnv` is passed via tmux
     /// `-e KEY=VALUE` so it's in the process environment before the shell
     /// starts (kept out of `ps aux`, and visible during profile and rc
-    /// execution). Spawns `$SHELL -ilc` like `newWindowCommand`. `-k` kills
-    /// the pane's current program first.
+    /// execution). Spawns the same interactive login-shell invocation as
+    /// `newWindowCommand` via `shellInvocation` (zsh sources
+    /// zshenv + zprofile + zshrc; bash login shells source profile files
+    /// only, relying on .bash_profile sourcing .bashrc; csh/tcsh keep -ic,
+    /// see `shellFlags(forShell:)`). `-k` kills the pane's current program
+    /// first.
     ///
     /// Used by the seamless in-place account switch: same tab, same terminal
     /// row, new profile's `claude --resume` command. See PR 5222a79 for why the
@@ -314,12 +354,11 @@ public struct TmuxManager: Sendable {
         env: [String: String] = [:],
         sensitiveEnv: [String: String] = [:]
     ) -> [String] {
-        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         let fullCommand = envExportPrefixed(shellCommand, env: env)
         let eFlags = sensitiveEnvFlags(sensitiveEnv)
         return ["-L", server, "respawn-window", "-k", "-t", windowID, "-c", cwd]
             + eFlags
-            + [userShell, "-ilc", fullCommand]
+            + shellInvocation(fullCommand)
     }
 
     /// Resize an existing tmux window to the given cell dimensions.

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
@@ -106,9 +106,8 @@ struct SubprocessTimeoutTests {
     }
 
     @Test func runExternalCommandTimesOutPromptlyWhenGrandchildHoldsPipeOpen() async {
-        // Real call sites run `[shell, "-ilc", cmd]`, and startup files
-        // (profile and rc) can fork background children that inherit the
-        // pipe write ends. The deadline
+        // Any spawned process can fork background grandchildren that
+        // inherit the pipe write ends. The deadline
         // kills only the DIRECT child, so EOF never arrives on the pipes. The
         // old blocking `readDataToEndOfFile` drain leaked two parked
         // global-queue threads + two pipe FDs (+ retained closures) per

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
@@ -106,8 +106,9 @@ struct SubprocessTimeoutTests {
     }
 
     @Test func runExternalCommandTimesOutPromptlyWhenGrandchildHoldsPipeOpen() async {
-        // Real call sites run `[shell, "-ic", cmd]`, and rc files can fork
-        // background children that inherit the pipe write ends. The deadline
+        // Real call sites run `[shell, "-ilc", cmd]`, and startup files
+        // (profile and rc) can fork background children that inherit the
+        // pipe write ends. The deadline
         // kills only the DIRECT child, so EOF never arrives on the pipes. The
         // old blocking `readDataToEndOfFile` drain leaked two parked
         // global-queue threads + two pipe FDs (+ retained closures) per

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -993,12 +993,13 @@ struct ClaudeSpawnCommandBuilderEnvTests {
 
     // MARK: - Inline re-export of profile routing env (rc-clobber defense)
 
-    /// REGRESSION: tmux `-e CLAUDE_CONFIG_DIR=...` is clobbered by shell rc
-    /// files (`zsh -ic` sources ~/.zshenv BEFORE the -c command — a
-    /// `export CLAUDE_CONFIG_DIR=...` account switcher there silently
-    /// redirected every "isolated" profile session to the rc's config dir).
-    /// The builder must ALSO re-export the routing env inline in the command,
-    /// which runs after rc files and therefore wins.
+    /// REGRESSION: tmux `-e CLAUDE_CONFIG_DIR=...` is clobbered by shell
+    /// startup files (`zsh -ilc` sources ~/.zshenv, profile files, and
+    /// ~/.zshrc BEFORE the -c command — a `export CLAUDE_CONFIG_DIR=...`
+    /// account switcher there silently redirected every "isolated" profile
+    /// session to that config dir). The builder must ALSO re-export the
+    /// routing env inline in the command, which runs after every startup
+    /// file and therefore wins.
     @Test("profile config dir is re-exported inline so rc files cannot clobber it")
     func configDirInlineExported() {
         let r = ClaudeSpawnCommandBuilder.build(

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -994,7 +994,8 @@ struct ClaudeSpawnCommandBuilderEnvTests {
     // MARK: - Inline re-export of profile routing env (rc-clobber defense)
 
     /// REGRESSION: tmux `-e CLAUDE_CONFIG_DIR=...` is clobbered by shell
-    /// startup files (`zsh -ilc` sources ~/.zshenv, profile files, and
+    /// startup files (`zsh -i -l -c`, see TmuxManager.shellFlags(forShell:),
+    /// sources ~/.zshenv, profile files, and
     /// ~/.zshrc BEFORE the -c command — a `export CLAUDE_CONFIG_DIR=...`
     /// account switcher there silently redirected every "isolated" profile
     /// session to that config dir). The builder must ALSO re-export the

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -149,7 +149,7 @@ struct PaneSendTargetQueryTests {
     @Test("the quoted export form TBD actually plants is read back exactly")
     func resolveQuotedExport() {
         // The literal shape `newWindowCommand` produces from the `env` map.
-        let command = "/bin/zsh -ic \"export TBD_TERMINAL_ID='\(Self.plantedID)'; "
+        let command = "/bin/zsh -ilc \"export TBD_TERMINAL_ID='\(Self.plantedID)'; "
             + "export TBD_WORKTREE_ID='11'; claude\""
         #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
             == Self.plantedID)

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -147,10 +147,19 @@ struct PaneSendTargetQueryTests {
     // MARK: - Identity resolution
 
     @Test("the quoted export form TBD actually plants is read back exactly")
-    func resolveQuotedExport() {
-        // The literal shape `newWindowCommand` produces from the `env` map.
-        let command = "/bin/zsh -ilc \"export TBD_TERMINAL_ID='\(Self.plantedID)'; "
-            + "export TBD_WORKTREE_ID='11'; claude\""
+    func resolveQuotedExport() throws {
+        // Derived from the real builder so the fixture tracks it: the body is
+        // `newWindowCommand`'s final argv element, and tmux reports the argv
+        // in `#{pane_start_command}` with the separate shell flags
+        // (`-i -l -c`, see TmuxManager.shellFlags(forShell:)) and the body
+        // quoted as the final argument.
+        let args = TmuxManager.newWindowCommand(
+            server: "tbd-acme", session: "main", cwd: "/tmp",
+            shellCommand: "claude",
+            env: ["TBD_TERMINAL_ID": Self.plantedID, "TBD_WORKTREE_ID": "11"],
+            environment: ["SHELL": "/bin/zsh"])
+        let body = try #require(args.last)
+        let command = "/bin/zsh -i -l -c \"" + body + "\""
         #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
             == Self.plantedID)
     }

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -33,7 +33,7 @@ private final class RecordedCommands: @unchecked Sendable {
 }
 
 /// Returns the shell command body (last argument of `new-window`) for any
-/// recorded `new-window` invocation. tmux argv ends with `<shell> -ic <body>`
+/// recorded `new-window` invocation. tmux argv ends with `<shell> -ilc <body>`
 /// when env vars are inlined, so the body is the last element.
 private func newWindowBodies(_ recorded: [[String]]) -> [String] {
     recorded.compactMap { call in

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -33,8 +33,10 @@ private final class RecordedCommands: @unchecked Sendable {
 }
 
 /// Returns the shell command body (last argument of `new-window`) for any
-/// recorded `new-window` invocation. tmux argv ends with `<shell> -ilc <body>`
-/// when env vars are inlined, so the body is the last element.
+/// recorded `new-window` invocation. tmux argv ends with
+/// `<shell> -i -l -c <body>` (separate flag elements, see
+/// TmuxManager.shellFlags(forShell:)) when env vars are inlined, so the body
+/// is the last element.
 private func newWindowBodies(_ recorded: [[String]]) -> [String] {
     recorded.compactMap { call in
         guard call.contains("new-window") else { return nil }

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -91,17 +91,25 @@ import Testing
 }
 
 @Test func testShellFlagsPerShellFamily() {
-    // Each branch of the flag choice: csh and tcsh cannot combine -l with -c
-    // (measured: "Unknown option: `-lc'", and tcsh accepts -l only as the
-    // sole flag), so they keep the pre-login-shell -ic. Every other shell
-    // gets the interactive login -ilc.
-    #expect(TmuxManager.shellFlags(forShell: "/bin/tcsh") == "-ic")
-    #expect(TmuxManager.shellFlags(forShell: "/bin/csh") == "-ic")
-    // The basename decides, not the full path.
-    #expect(TmuxManager.shellFlags(forShell: "/usr/local/bin/tcsh") == "-ic")
-    #expect(TmuxManager.shellFlags(forShell: "/bin/zsh") == "-ilc")
-    #expect(TmuxManager.shellFlags(forShell: "/bin/bash") == "-ilc")
-    #expect(TmuxManager.shellFlags(forShell: "/opt/homebrew/bin/fish") == "-ilc")
+    // Each branch of the flag choice, with hardcoded expectations: csh and
+    // tcsh reject -l when combined with -c (measured: "Unknown option: `-l'"),
+    // so they keep the pre-login-shell -i -c. Every other shell gets the
+    // interactive login -i -l -c. Flags are separate argv elements, never
+    // clustered, because some shells (e.g. nushell) reject GNU-style
+    // clustering while accepting the individual flags.
+    #expect(TmuxManager.shellFlags(forShell: "/bin/tcsh") == ["-i", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/bin/csh") == ["-i", "-c"])
+    // The lowercased basename decides, not the full path or its case.
+    #expect(TmuxManager.shellFlags(forShell: "/usr/local/bin/tcsh") == ["-i", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/bin/TCSH") == ["-i", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/opt/weird/wrappers/deep/path/csh") == ["-i", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/bin/zsh") == ["-i", "-l", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/bin/bash") == ["-i", "-l", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/opt/homebrew/bin/fish") == ["-i", "-l", "-c"])
+    // Degenerate paths fall into the default branch rather than crashing.
+    #expect(TmuxManager.shellFlags(forShell: "") == ["-i", "-l", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/") == ["-i", "-l", "-c"])
+    #expect(TmuxManager.shellFlags(forShell: "/bin/") == ["-i", "-l", "-c"])
 }
 
 @Test func testNewWindowCommandRunsLoginShell() throws {
@@ -110,34 +118,55 @@ import Testing
     // profile files only, relying on the near-universal convention that
     // .bash_profile sources .bashrc (same behavior as Terminal.app).
     // /etc/zprofile's path_helper and ~/.zprofile supply /usr/local/bin and
-    // the Homebrew PATH entries; a non-login -ic shell skips profile files
-    // and leaves user tools like `code` unresolvable. csh/tcsh keep -ic
-    // (see testShellFlagsPerShellFamily), so the expected flag is derived
-    // from the same function the builder uses, keyed on the test process's
-    // ambient SHELL. See docs/specs/2026-08-19-login-shell-panes-design.md.
+    // the Homebrew PATH entries; a non-login -i -c shell skips profile files
+    // and leaves user tools like `code` unresolvable. The environment seam
+    // pins SHELL so the expected argv tail is hardcoded, not derived.
+    // See docs/specs/2026-08-19-login-shell-panes-design.md.
     let args = TmuxManager.newWindowCommand(
         server: "tbd-a1b2c3d4",
         session: "main",
         cwd: "/tmp/worktree",
         shellCommand: "claude",
         env: ["TBD_TERMINAL_ID": "abc-123"],
-        sensitiveEnv: ["ANTHROPIC_API_KEY": "sk-test"]
+        sensitiveEnv: ["ANTHROPIC_API_KEY": "sk-test"],
+        environment: ["SHELL": "/bin/zsh"]
     )
-    let expectedFlags = TmuxManager.shellFlags(
-        forShell: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh")
-    let flagIndex = try #require(args.firstIndex(of: expectedFlags))
-    // The flag sits between the shell and the command string, which stays
-    // the final positional argument.
-    #expect(flagIndex == args.count - 2)
-    // The env map is still inlined as an export prefix on the command string,
-    // which runs after every startup file (profile and rc), so it stays the
-    // last writer.
-    #expect(args.last == "export TBD_TERMINAL_ID='abc-123'; claude")
+    // The shell invocation is the exact argv tail: shell, separate flags,
+    // then the command string as the final positional argument. The env map
+    // is inlined as an export prefix on the command string, which runs after
+    // every startup file (profile and rc), so it stays the last writer.
+    #expect(args.suffix(5) == ["/bin/zsh", "-i", "-l", "-c", "export TBD_TERMINAL_ID='abc-123'; claude"])
     // sensitiveEnv still lands via tmux -e: in the process environment before
     // the shell starts, visible during profile files and rc files alike.
     let eIndex = try #require(args.firstIndex(of: "ANTHROPIC_API_KEY=sk-test"))
     #expect(eIndex > 0)
     #expect(args[eIndex - 1] == "-e")
+}
+
+@Test func testNewWindowCommandCshFamilyOmitsLoginFlag() {
+    // csh/tcsh reject -l combined with -c, so the csh branch must reach the
+    // real builder: pin SHELL to tcsh through the environment seam and assert
+    // the hardcoded -i -c tail.
+    let args = TmuxManager.newWindowCommand(
+        server: "tbd-a1b2c3d4",
+        session: "main",
+        cwd: "/tmp/worktree",
+        shellCommand: "claude",
+        environment: ["SHELL": "/bin/tcsh"]
+    )
+    #expect(args.suffix(4) == ["/bin/tcsh", "-i", "-c", "claude"])
+}
+
+@Test func testNewWindowCommandFallsBackToZshWithoutSHELL() {
+    // An empty environment (no SHELL) falls back to /bin/zsh.
+    let args = TmuxManager.newWindowCommand(
+        server: "tbd-a1b2c3d4",
+        session: "main",
+        cwd: "/tmp/worktree",
+        shellCommand: "claude",
+        environment: [:]
+    )
+    #expect(args.suffix(5) == ["/bin/zsh", "-i", "-l", "-c", "claude"])
 }
 
 @Test func testRespawnWindowCommandRunsLoginShell() throws {
@@ -150,18 +179,28 @@ import Testing
         cwd: "/tmp/worktree",
         shellCommand: "claude --resume",
         env: ["CLAUDE_CONFIG_DIR": "/tmp/profile"],
-        sensitiveEnv: ["ANTHROPIC_API_KEY": "sk-test"]
+        sensitiveEnv: ["ANTHROPIC_API_KEY": "sk-test"],
+        environment: ["SHELL": "/bin/zsh"]
     )
     #expect(args.contains("respawn-window"))
     #expect(args.contains("-k"))
-    let expectedFlags = TmuxManager.shellFlags(
-        forShell: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh")
-    let flagIndex = try #require(args.firstIndex(of: expectedFlags))
-    #expect(flagIndex == args.count - 2)
-    #expect(args.last == "export CLAUDE_CONFIG_DIR='/tmp/profile'; claude --resume")
+    #expect(args.suffix(5) == ["/bin/zsh", "-i", "-l", "-c", "export CLAUDE_CONFIG_DIR='/tmp/profile'; claude --resume"])
     let eIndex = try #require(args.firstIndex(of: "ANTHROPIC_API_KEY=sk-test"))
     #expect(eIndex > 0)
     #expect(args[eIndex - 1] == "-e")
+}
+
+@Test func testRespawnWindowCommandCshFamilyOmitsLoginFlag() {
+    // The respawn builder must fork on the same csh branch as
+    // newWindowCommand: same seam, same hardcoded -i -c tail.
+    let args = TmuxManager.respawnWindowCommand(
+        server: "tbd-a1b2c3d4",
+        windowID: "@5",
+        cwd: "/tmp/worktree",
+        shellCommand: "claude --resume",
+        environment: ["SHELL": "/bin/tcsh"]
+    )
+    #expect(args.suffix(4) == ["/bin/tcsh", "-i", "-c", "claude --resume"])
 }
 
 @Test func testNewWindowCommandSensitiveEnvUsesEFlag() {

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -90,13 +90,31 @@ import Testing
     #expect(args.contains("claude --dangerously-skip-permissions"))
 }
 
+@Test func testShellFlagsPerShellFamily() {
+    // Each branch of the flag choice: csh and tcsh cannot combine -l with -c
+    // (measured: "Unknown option: `-lc'", and tcsh accepts -l only as the
+    // sole flag), so they keep the pre-login-shell -ic. Every other shell
+    // gets the interactive login -ilc.
+    #expect(TmuxManager.shellFlags(forShell: "/bin/tcsh") == "-ic")
+    #expect(TmuxManager.shellFlags(forShell: "/bin/csh") == "-ic")
+    // The basename decides, not the full path.
+    #expect(TmuxManager.shellFlags(forShell: "/usr/local/bin/tcsh") == "-ic")
+    #expect(TmuxManager.shellFlags(forShell: "/bin/zsh") == "-ilc")
+    #expect(TmuxManager.shellFlags(forShell: "/bin/bash") == "-ilc")
+    #expect(TmuxManager.shellFlags(forShell: "/opt/homebrew/bin/fish") == "-ilc")
+}
+
 @Test func testNewWindowCommandRunsLoginShell() throws {
     // Spawned panes run the user's shell as an interactive LOGIN shell:
-    // -i sources rc files, -l sources profile files (/etc/zprofile's
-    // path_helper and ~/.zprofile, which supply /usr/local/bin and the
-    // Homebrew PATH entries), -c runs the command. A non-login -ic shell
-    // skips profile files and leaves user tools like `code` unresolvable.
-    // See docs/specs/2026-08-19-login-shell-panes-design.md.
+    // zsh sources zshenv + zprofile + zshrc; bash login shells source
+    // profile files only, relying on the near-universal convention that
+    // .bash_profile sources .bashrc (same behavior as Terminal.app).
+    // /etc/zprofile's path_helper and ~/.zprofile supply /usr/local/bin and
+    // the Homebrew PATH entries; a non-login -ic shell skips profile files
+    // and leaves user tools like `code` unresolvable. csh/tcsh keep -ic
+    // (see testShellFlagsPerShellFamily), so the expected flag is derived
+    // from the same function the builder uses, keyed on the test process's
+    // ambient SHELL. See docs/specs/2026-08-19-login-shell-panes-design.md.
     let args = TmuxManager.newWindowCommand(
         server: "tbd-a1b2c3d4",
         session: "main",
@@ -105,8 +123,9 @@ import Testing
         env: ["TBD_TERMINAL_ID": "abc-123"],
         sensitiveEnv: ["ANTHROPIC_API_KEY": "sk-test"]
     )
-    #expect(!args.contains("-ic"), "non-login interactive shells skip profile files")
-    let flagIndex = try #require(args.firstIndex(of: "-ilc"))
+    let expectedFlags = TmuxManager.shellFlags(
+        forShell: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh")
+    let flagIndex = try #require(args.firstIndex(of: expectedFlags))
     // The flag sits between the shell and the command string, which stays
     // the final positional argument.
     #expect(flagIndex == args.count - 2)
@@ -135,8 +154,9 @@ import Testing
     )
     #expect(args.contains("respawn-window"))
     #expect(args.contains("-k"))
-    #expect(!args.contains("-ic"), "non-login interactive shells skip profile files")
-    let flagIndex = try #require(args.firstIndex(of: "-ilc"))
+    let expectedFlags = TmuxManager.shellFlags(
+        forShell: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh")
+    let flagIndex = try #require(args.firstIndex(of: expectedFlags))
     #expect(flagIndex == args.count - 2)
     #expect(args.last == "export CLAUDE_CONFIG_DIR='/tmp/profile'; claude --resume")
     let eIndex = try #require(args.firstIndex(of: "ANTHROPIC_API_KEY=sk-test"))

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -90,10 +90,64 @@ import Testing
     #expect(args.contains("claude --dangerously-skip-permissions"))
 }
 
+@Test func testNewWindowCommandRunsLoginShell() throws {
+    // Spawned panes run the user's shell as an interactive LOGIN shell:
+    // -i sources rc files, -l sources profile files (/etc/zprofile's
+    // path_helper and ~/.zprofile, which supply /usr/local/bin and the
+    // Homebrew PATH entries), -c runs the command. A non-login -ic shell
+    // skips profile files and leaves user tools like `code` unresolvable.
+    // See docs/specs/2026-08-19-login-shell-panes-design.md.
+    let args = TmuxManager.newWindowCommand(
+        server: "tbd-a1b2c3d4",
+        session: "main",
+        cwd: "/tmp/worktree",
+        shellCommand: "claude",
+        env: ["TBD_TERMINAL_ID": "abc-123"],
+        sensitiveEnv: ["ANTHROPIC_API_KEY": "sk-test"]
+    )
+    #expect(!args.contains("-ic"), "non-login interactive shells skip profile files")
+    let flagIndex = try #require(args.firstIndex(of: "-ilc"))
+    // The flag sits between the shell and the command string, which stays
+    // the final positional argument.
+    #expect(flagIndex == args.count - 2)
+    // The env map is still inlined as an export prefix on the command string,
+    // which runs after every startup file (profile and rc), so it stays the
+    // last writer.
+    #expect(args.last == "export TBD_TERMINAL_ID='abc-123'; claude")
+    // sensitiveEnv still lands via tmux -e: in the process environment before
+    // the shell starts, visible during profile files and rc files alike.
+    let eIndex = try #require(args.firstIndex(of: "ANTHROPIC_API_KEY=sk-test"))
+    #expect(eIndex > 0)
+    #expect(args[eIndex - 1] == "-e")
+}
+
+@Test func testRespawnWindowCommandRunsLoginShell() throws {
+    // The in-place respawn path (seamless profile swap) must spawn through
+    // the same interactive login-shell shape as newWindowCommand, with the
+    // same env-prefix and -e handling.
+    let args = TmuxManager.respawnWindowCommand(
+        server: "tbd-a1b2c3d4",
+        windowID: "@5",
+        cwd: "/tmp/worktree",
+        shellCommand: "claude --resume",
+        env: ["CLAUDE_CONFIG_DIR": "/tmp/profile"],
+        sensitiveEnv: ["ANTHROPIC_API_KEY": "sk-test"]
+    )
+    #expect(args.contains("respawn-window"))
+    #expect(args.contains("-k"))
+    #expect(!args.contains("-ic"), "non-login interactive shells skip profile files")
+    let flagIndex = try #require(args.firstIndex(of: "-ilc"))
+    #expect(flagIndex == args.count - 2)
+    #expect(args.last == "export CLAUDE_CONFIG_DIR='/tmp/profile'; claude --resume")
+    let eIndex = try #require(args.firstIndex(of: "ANTHROPIC_API_KEY=sk-test"))
+    #expect(eIndex > 0)
+    #expect(args[eIndex - 1] == "-e")
+}
+
 @Test func testNewWindowCommandSensitiveEnvUsesEFlag() {
     // sensitiveEnv must land in the process environment via tmux's
-    // `-e KEY=VALUE` flag (visible while .zshrc runs), never as an
-    // `export` prefix inside the -c command string (which runs after).
+    // `-e KEY=VALUE` flag (visible while profile and rc files run), never as
+    // an `export` prefix inside the -c command string (which runs after).
     let args = TmuxManager.newWindowCommand(
         server: "tbd-a1b2c3d4",
         session: "main",

--- a/docs/specs/2026-08-11-tmux-executable-resolution-design.md
+++ b/docs/specs/2026-08-11-tmux-executable-resolution-design.md
@@ -172,11 +172,18 @@ could make subprocess behavior differ from the installation environment.
 
 ### Login shell or `path_helper`
 
-Starting a login shell or invoking `path_helper` would execute user-controlled startup
-configuration, add latency, and produce an environment that may differ from the one
-used to install TBD. It also makes binary selection depend on shell choice and startup
-file health. Installation-time `PATH` capture is deterministic and does not run shell
-initialization during app startup.
+Starting a login shell or invoking `path_helper` to discover executables would execute
+user-controlled startup configuration, add latency, and produce an environment that may
+differ from the one used to install TBD. It also makes binary selection depend on shell
+choice and startup file health. Installation-time `PATH` capture is deterministic and
+does not run shell initialization during app startup.
+
+This rejection is scoped to executable discovery inside the daemon and app. The
+interactive shells spawned in panes are a different concern: they run as login shells
+so the user's own profile builds the interactive environment (see
+[`2026-08-19-login-shell-panes-design.md`](2026-08-19-login-shell-panes-design.md)).
+That does not feed back into resolution here, which reads only the inherited `PATH`
+and the saved fallback.
 
 ### Persisting the whole environment
 

--- a/docs/specs/2026-08-19-login-shell-panes-design.md
+++ b/docs/specs/2026-08-19-login-shell-panes-design.md
@@ -37,7 +37,12 @@ with rc-file directories but no `/usr/local/bin` or `/opt/homebrew/bin`.
 
 Spawned panes run the user's shell as an interactive **login** shell: the two
 spawn builders in `TmuxManager` (`newWindowCommand` and
-`respawnWindowCommand`) pass `-ilc` instead of `-ic`. This is the convention
+`respawnWindowCommand`) pass `-ilc` instead of `-ic`, through one shared
+shell-invocation helper. Exception: `csh` and `tcsh` reject the clustered
+`-ilc` (and tcsh accepts `-l` only as the sole flag, so login cannot be
+combined with `-c` at all), so csh-family shells, detected by the shell
+path's basename, keep `-ic`: their pre-change behavior, since the
+alternative is a pane whose shell exits immediately. This is the convention
 every terminal emulator follows (Terminal.app, iTerm2, the VS Code integrated
 terminal), for exactly this reason: the base environment handed to a GUI-born
 process is minimal, and the user's own profile is the authoritative,
@@ -46,10 +51,13 @@ policy; nix, MacPorts, Homebrew, and hand-rolled setups all get whatever their
 own profile says.
 
 For zsh this adds `/etc/zprofile` and `~/.zprofile` (and the zlogin files) to
-the existing zshenv/zshrc sequence. For bash, a login shell reads
-`~/.bash_profile` (or `~/.profile`) rather than only `~/.bashrc`;
-conventionally `.bash_profile` sources `.bashrc`, which matches what the same
-user already experiences in Terminal.app.
+the existing zshenv/zshrc sequence. Bash is different: a login shell reads
+`~/.bash_profile` (or `~/.profile`) **instead of** `~/.bashrc`, so a bash
+user whose `.bash_profile` does not source `.bashrc` loses rc-only
+configuration in panes. This is accepted deliberately: it is exactly what
+Terminal.app already does to the same user, and sourcing `.bashrc` from
+`.bash_profile` is the near-universal convention that terminal-emulator
+behavior has enforced for decades.
 
 This also removes the `restart.sh` poisoning loop at its root. A login pane
 rebuilds `PATH` from profile files even over a bare inherited base
@@ -64,8 +72,17 @@ rebuilds `PATH` from profile files even over a bare inherited base
   to the command.
 - **sensitiveEnv** still lands via tmux `-e KEY=VALUE` in the process
   environment before the shell starts, and is therefore visible during all
-  startup files: now including the profile files, which is a strict widening
-  of the previous guarantee (rc files only).
+  startup files, now including the profile files. Visibility widens, but
+  survivability narrows: startup files could always overwrite a `-e` value
+  before the command runs, and the profile files join that set. Profile
+  routing keys are already defended by the inline re-export (which runs after
+  every startup file and wins deterministically). Values that cannot be
+  inlined without leaking into `ps` argv, such as `ANTHROPIC_API_KEY` and the
+  env overrides that ride sensitiveEnv, accept the widened clobber surface: a
+  user profile that exports the same variable wins, exactly as it always has
+  for the rc files. Anyone adding a new `-e`-only key must weigh this; the
+  inline re-export is the defense, and it is only available for non-secret
+  values.
 - **Pane identity**: `resolvePaneTerminalID` parses the
   `export TBD_TERMINAL_ID='…'` shape out of `#{pane_start_command}`. The
   command string is unchanged; only the shell's flag argument changes. Tests
@@ -133,6 +150,13 @@ behavior the well-understood default.
   new Terminal.app window. Profiles that print output add noise before the
   command starts; profiles that hang would hang the pane, as they would any
   terminal tab.
+- **Pre-session hook panes** share the pane spawn path, so a profile that
+  blocks (a passphrase prompt, a hung network mount) now consumes the hook's
+  marker-wait budget; on timeout the existing behavior notifies and spawns
+  agents on the unprepared tree anyway. Accepted: a profile that blocks
+  breaks every terminal on the machine, so it does not survive long in the
+  wild, and special-casing hook panes to non-login would silently deny hooks
+  the same PATH repair this change exists to provide.
 - **Nested shells**: a plain shell tab runs `$SHELL -ilc $SHELL`. The inner
   shell is interactive non-login, inherits the outer's exported environment,
   and re-runs only rc files. Directories can appear twice in `PATH`; harmless
@@ -143,7 +167,9 @@ behavior the well-understood default.
 
 ## Verification
 
-- Unit: `TmuxManagerTests` assert both spawn builders emit `-ilc`, and that
-  the env-export prefix and `-e` flag handling are unchanged.
+- Unit: `TmuxManagerTests` assert both spawn builders emit the login-shell
+  invocation, that the flag choice branches correctly per shell basename
+  (csh-family gets `-ic`, everything else `-ilc`), and that the env-export
+  prefix and `-e` flag handling are unchanged.
 - Field: after `scripts/restart.sh`, a new shell tab resolves `code` and
   `tmux`, and its `PATH` contains the `path_helper` and profile directories.

--- a/docs/specs/2026-08-19-login-shell-panes-design.md
+++ b/docs/specs/2026-08-19-login-shell-panes-design.md
@@ -92,7 +92,8 @@ invocation at all.
 - **Pane identity**: `resolvePaneTerminalID` parses the
   `export TBD_TERMINAL_ID='…'` shape out of `#{pane_start_command}`. The
   command string is unchanged; only the shell's flag argument changes. Tests
-  that assert the full argv update from `-ic` to `-ilc` in the same commit.
+  that assert the full argv update from `-ic` to the separate `-i -l -c`
+  elements in the same commit.
 - **Daemon environment policy is untouched.** Installation-time `PATH`
   capture, the filesystem-only tmux executable resolver, and the saved tmux
   fallback stay exactly as specified in
@@ -156,6 +157,16 @@ behavior the well-understood default.
   new Terminal.app window. Profiles that print output add noise before the
   command starts; profiles that hang would hang the pane, as they would any
   terminal tab.
+- **Exec-into-agent detection**: for zsh, the shell still execs into the
+  final `-c` command under login flags (re-measured), so `pane_pid` remains
+  the agent for default configs. An EXIT trap in any sourced startup file
+  defeats that exec, and `-l` widens the set of files that can plant one
+  (`/etc/zprofile`, `~/.zprofile`, zlogin/zlogout machinery): the shell then
+  stays `pane_pid`, and PID-based kill, escalation, and reap paths that
+  assume the pane process is the agent do not reach the agent grandchild.
+  Pre-existing exposure through the rc files, widened here; recorded with
+  the affected consumers in
+  [`reaping-orphaned-agents-design.md`](reaping-orphaned-agents-design.md).
 - **Pre-session hook panes** share the pane spawn path, so a profile that
   blocks (a passphrase prompt, a hung network mount) now consumes the hook's
   marker-wait budget; on timeout the existing behavior notifies and spawns
@@ -163,7 +174,7 @@ behavior the well-understood default.
   breaks every terminal on the machine, so it does not survive long in the
   wild, and special-casing hook panes to non-login would silently deny hooks
   the same PATH repair this change exists to provide.
-- **Nested shells**: a plain shell tab runs `$SHELL -ilc $SHELL`. The inner
+- **Nested shells**: a plain shell tab runs `$SHELL -i -l -c $SHELL`. The inner
   shell is interactive non-login, inherits the outer's exported environment,
   and re-runs only rc files. Directories can appear twice in `PATH`; harmless
   and already true of the rc-added directories today.

--- a/docs/specs/2026-08-19-login-shell-panes-design.md
+++ b/docs/specs/2026-08-19-login-shell-panes-design.md
@@ -1,0 +1,149 @@
+# Login-shell panes: design
+
+Status: **implemented**.
+
+## Problem
+
+Every tmux pane TBD spawns runs the user's shell as an interactive non-login
+shell (`$SHELL -ic <command>`). On macOS the directories most user-facing tools
+live in are supplied by login-shell startup files: `/etc/zprofile` runs
+`path_helper`, which prepends the `/etc/paths` and `/etc/paths.d` entries
+(including `/usr/local/bin`), and `~/.zprofile` conventionally holds
+`eval "$(brew shellenv)"` (which prepends `/opt/homebrew/bin`) plus
+version-manager hooks. A non-login shell skips both files, so a pane sees only
+the environment inherited from the tmux server plus whatever `~/.zshrc` adds.
+
+The inherited base is deliberately minimal. The daemon passes its own
+environment to the tmux server verbatim, and that environment is the
+installation-captured `PATH` described in
+[`2026-08-11-tmux-executable-resolution-design.md`](2026-08-11-tmux-executable-resolution-design.md),
+or in degraded cases the bare LaunchServices default
+(`/usr/bin:/bin:/usr/sbin:/sbin`). Field measurement on a live install
+(2026-08-19): the tmux server's global `PATH` was the bare default, pane shells
+ran as `/bin/zsh` (argv0 without the login dash), and `code` (a symlink in
+`/usr/local/bin`) was unresolvable in every TBD tab, while nix and cargo
+directories added by `~/.zshrc` were present. The asymmetry (rc-file
+directories present, profile-file directories absent) is the fingerprint of a
+non-login interactive shell.
+
+A second-order effect compounds it. `scripts/restart.sh` captures the invoking
+shell's `PATH` into the app bundle's `LSEnvironment.PATH`. When an agent runs
+`restart.sh` from inside a TBD tab, the deficient pane `PATH` is captured and
+becomes the daemon's `PATH` on subsequent launches: a self-sustaining loop.
+The same field measurement found the live bundle carrying a captured `PATH`
+with rc-file directories but no `/usr/local/bin` or `/opt/homebrew/bin`.
+
+## Design
+
+Spawned panes run the user's shell as an interactive **login** shell: the two
+spawn builders in `TmuxManager` (`newWindowCommand` and
+`respawnWindowCommand`) pass `-ilc` instead of `-ic`. This is the convention
+every terminal emulator follows (Terminal.app, iTerm2, the VS Code integrated
+terminal), for exactly this reason: the base environment handed to a GUI-born
+process is minimal, and the user's own profile is the authoritative,
+per-user way to rebuild it. No hardcoded directory list, no second search
+policy; nix, MacPorts, Homebrew, and hand-rolled setups all get whatever their
+own profile says.
+
+For zsh this adds `/etc/zprofile` and `~/.zprofile` (and the zlogin files) to
+the existing zshenv/zshrc sequence. For bash, a login shell reads
+`~/.bash_profile` (or `~/.profile`) rather than only `~/.bashrc`;
+conventionally `.bash_profile` sources `.bashrc`, which matches what the same
+user already experiences in Terminal.app.
+
+This also removes the `restart.sh` poisoning loop at its root. A login pane
+rebuilds `PATH` from profile files even over a bare inherited base
+(`path_helper` and `brew shellenv` prepend their directories regardless), so a
+`restart.sh` run from inside a TBD tab captures a healthy `PATH`.
+
+### Preserved contracts
+
+- **env overrides** (the `export KEY='…'; ` prefix inlined into the command
+  string) still execute after every startup file, so they remain the last
+  writer. Adding profile files to the sequence does not reorder them relative
+  to the command.
+- **sensitiveEnv** still lands via tmux `-e KEY=VALUE` in the process
+  environment before the shell starts, and is therefore visible during all
+  startup files: now including the profile files, which is a strict widening
+  of the previous guarantee (rc files only).
+- **Pane identity**: `resolvePaneTerminalID` parses the
+  `export TBD_TERMINAL_ID='…'` shape out of `#{pane_start_command}`. The
+  command string is unchanged; only the shell's flag argument changes. Tests
+  that assert the full argv update from `-ic` to `-ilc` in the same commit.
+- **Daemon environment policy is untouched.** Installation-time `PATH`
+  capture, the filesystem-only tmux executable resolver, and the saved tmux
+  fallback stay exactly as specified in
+  [`2026-08-11-tmux-executable-resolution-design.md`](2026-08-11-tmux-executable-resolution-design.md).
+  That spec rejects login shells for *executable discovery inside the daemon*;
+  this change runs the user's startup files inside the user's own interactive
+  pane, where they are the intended mechanism. The two policies compose: the
+  daemon finds its tools deterministically, and interactive shells build the
+  interactive environment.
+
+### Not gated by a flag
+
+This is a bug fix, not new behavior: it restores the environment users already
+get from every other terminal on the machine. The change is one flag at two
+spawn sites. The risk it introduces (a slow or side-effectful `~/.zprofile`
+now runs in TBD tabs) is identical to the risk the same profile already poses
+in Terminal.app, and profile files are written to be idempotent because login
+shells are the terminal-emulator default.
+
+## Rejected alternatives
+
+### Restore the daemon-side PATH augmenter
+
+A hardcoded prepend of `/opt/homebrew/bin`, `/opt/homebrew/sbin`,
+`/usr/local/bin`, `/usr/local/sbin` in the daemon (the deleted
+`ToolPathAugmenter`) would incidentally fix panes too, but it is the hidden
+second search policy the executable-resolution spec already rejects: wrong for
+nix and MacPorts installs, and it covers only four directories rather than the
+user's actual profile (version managers, `~/.zprofile` additions).
+
+### Daemon login-shell PATH probe
+
+Deriving the daemon's `PATH` once at startup from `$SHELL -lc 'echo $PATH'`
+would cover daemon-spawned helpers (`git-lfs`, `gh`) even under a degraded
+capture, but it executes user startup configuration inside the daemon, is
+nondeterministic across shell health, and overturns an explicit rejection in
+the executable-resolution spec. With login panes in place the remaining
+exposure is small and recoverable, and capability migrates inward only on
+field evidence.
+
+### Guarding `restart.sh` against degraded capture
+
+A refusal, warning, or capture-reuse rule in `restart.sh` for deficient
+invoking `PATH`s defends against a state this change removes: the deficient
+environments that fed the loop were TBD's own panes. The residual exposure
+(a capture taken from some other profile-less context, such as a bare ssh
+session) affects only daemon-side tool lookups and recovers with one restart
+from any healthy shell, which does not justify standing machinery.
+
+### Feature flag
+
+A default-off config column would leave every install broken until
+graduation, and a default-on one contradicts the flag doctrine. The change
+does not meet the flag battery (no autonomous action, no destroyed state, no
+wholesale path replacement), and terminal-emulator precedent makes the chosen
+behavior the well-understood default.
+
+## Risks
+
+- **Profile side effects** now run once per spawned pane: identical to every
+  new Terminal.app window. Profiles that print output add noise before the
+  command starts; profiles that hang would hang the pane, as they would any
+  terminal tab.
+- **Nested shells**: a plain shell tab runs `$SHELL -ilc $SHELL`. The inner
+  shell is interactive non-login, inherits the outer's exported environment,
+  and re-runs only rc files. Directories can appear twice in `PATH`; harmless
+  and already true of the rc-added directories today.
+- **Existing tmux servers** keep their old global environment until they
+  exit, but because the login shell rebuilds `PATH` itself, new panes are
+  healed even on stale servers as soon as the new daemon binary spawns them.
+
+## Verification
+
+- Unit: `TmuxManagerTests` assert both spawn builders emit `-ilc`, and that
+  the env-export prefix and `-e` flag handling are unchanged.
+- Field: after `scripts/restart.sh`, a new shell tab resolves `code` and
+  `tmux`, and its `PATH` contains the `path_helper` and profile directories.

--- a/docs/specs/2026-08-19-login-shell-panes-design.md
+++ b/docs/specs/2026-08-19-login-shell-panes-design.md
@@ -36,13 +36,15 @@ with rc-file directories but no `/usr/local/bin` or `/opt/homebrew/bin`.
 ## Design
 
 Spawned panes run the user's shell as an interactive **login** shell: the two
-spawn builders in `TmuxManager` (`newWindowCommand` and
-`respawnWindowCommand`) pass `-ilc` instead of `-ic`, through one shared
-shell-invocation helper. Exception: `csh` and `tcsh` reject the clustered
-`-ilc` (and tcsh accepts `-l` only as the sole flag, so login cannot be
-combined with `-c` at all), so csh-family shells, detected by the shell
-path's basename, keep `-ic`: their pre-change behavior, since the
-alternative is a pane whose shell exits immediately. This is the convention
+spawn builders in `TmuxManager` pass the separate flags `-i -l -c` instead of
+`-ic`, through one shared shell-invocation helper. Separate argv elements
+rather than a clustered `-ilc` string, because clustering is a GNU-ism some
+shells reject even though they accept each flag individually, and a rejected
+flag means a pane whose shell exits instantly with the error destroyed by the
+pane closing. Exception: csh-family shells (`csh`, `tcsh`, matched on the
+shell path's lowercased basename) cannot combine `-l` with `-c` at all (tcsh
+accepts `-l` only as its sole argument), so they omit `-l` and keep their
+pre-change interactive non-login behavior. This is the convention
 every terminal emulator follows (Terminal.app, iTerm2, the VS Code integrated
 terminal), for exactly this reason: the base environment handed to a GUI-born
 process is minimal, and the user's own profile is the authoritative,
@@ -59,10 +61,14 @@ Terminal.app already does to the same user, and sourcing `.bashrc` from
 `.bash_profile` is the near-universal convention that terminal-emulator
 behavior has enforced for decades.
 
-This also removes the `restart.sh` poisoning loop at its root. A login pane
-rebuilds `PATH` from profile files even over a bare inherited base
-(`path_helper` and `brew shellenv` prepend their directories regardless), so a
-`restart.sh` run from inside a TBD tab captures a healthy `PATH`.
+This also removes the `restart.sh` poisoning loop for every login-capable
+shell. A login pane rebuilds `PATH` from profile files even over a bare
+inherited base (`path_helper` and `brew shellenv` prepend their directories
+regardless), so a `restart.sh` run from inside a TBD tab captures a healthy
+`PATH`. Residual: csh-family panes keep the non-login flags, so for a
+csh-family `SHELL` the deficient pane `PATH` and the capture loop persist;
+accepted, because those shells offer no compatible login-plus-command
+invocation at all.
 
 ### Preserved contracts
 
@@ -161,6 +167,21 @@ behavior the well-understood default.
   shell is interactive non-login, inherits the outer's exported environment,
   and re-runs only rc files. Directories can appear twice in `PATH`; harmless
   and already true of the rc-added directories today.
+- **Profiles that exec into another shell** (`exec fish` behind an
+  interactivity guard is a known pattern for users who avoid `chsh`) swallow
+  the `-c` command: the replacement shell knows nothing about the payload, so
+  the pane lands at that shell's prompt and the agent or hook command never
+  starts. Accepted: the failure is visible (a shell prompt where an agent
+  should be) rather than silent, and unlike a hanging profile this pattern
+  does not break Terminal.app, so it can persist in the wild; a user who hits
+  it must guard the exec against non-login or TBD-spawned shells. Hook panes
+  under such a profile consume their marker-wait budget as described above.
+- **Agent binary resolution follows the profile PATH.** A bare `claude` or
+  `codex` in a spawn command now resolves through the profile-rebuilt `PATH`,
+  so panes launch the same binary the user's own terminal would, which can
+  differ from what the daemon-captured `PATH` would have chosen (for example
+  a Homebrew-installed copy shadowing another install). This is the intended
+  alignment: the pane behaves like the user's terminal.
 - **Existing tmux servers** keep their old global environment until they
   exit, but because the login shell rebuilds `PATH` itself, new panes are
   healed even on stale servers as soon as the new daemon binary spawns them.
@@ -168,8 +189,8 @@ behavior the well-understood default.
 ## Verification
 
 - Unit: `TmuxManagerTests` assert both spawn builders emit the login-shell
-  invocation, that the flag choice branches correctly per shell basename
-  (csh-family gets `-ic`, everything else `-ilc`), and that the env-export
-  prefix and `-e` flag handling are unchanged.
+  invocation through an injected environment (csh-family omits `-l`,
+  everything else gets `-i -l -c`, unset `SHELL` falls back to `/bin/zsh`),
+  and that the env-export prefix and `-e` flag handling are unchanged.
 - Field: after `scripts/restart.sh`, a new shell tab resolves `code` and
   `tmux`, and its `PATH` contains the `path_helper` and profile directories.

--- a/docs/specs/reaping-orphaned-agents-design.md
+++ b/docs/specs/reaping-orphaned-agents-design.md
@@ -34,7 +34,7 @@ be hot at sweep time.
 How TBD spawns and tracks agents:
 
 - **Spawn**: `ClaudeSpawnCommandBuilder` builds a command string; `TmuxManager.createWindow`
-  runs `tmux -L <server> new-window … <shell> -ic <cmd>`
+  runs `tmux -L <server> new-window … <shell> -ilc <cmd>`
   (`Sources/TBDDaemon/Tmux/TmuxManager.swift:128`). The shell exec's into `claude`, so the
   pane process *is* the agent (confirmed live: agent `ppid` == the tmux server pid, not a
   shell).

--- a/docs/specs/reaping-orphaned-agents-design.md
+++ b/docs/specs/reaping-orphaned-agents-design.md
@@ -34,8 +34,8 @@ be hot at sweep time.
 How TBD spawns and tracks agents:
 
 - **Spawn**: `ClaudeSpawnCommandBuilder` builds a command string; `TmuxManager.createWindow`
-  runs `tmux -L <server> new-window … <shell> -ilc <cmd>` (csh-family shells get `-ic`;
-  see `newWindowCommand` in `Sources/TBDDaemon/Tmux/TmuxManager.swift`). The shell
+  runs `tmux -L <server> new-window … <shell> -i -l -c <cmd>` (csh-family shells omit
+  `-l`; see `newWindowCommand` in `Sources/TBDDaemon/Tmux/TmuxManager.swift`). The shell
   exec's into `claude`, so the pane process *is* the agent (confirmed live 2026-06-15
   under the then-current `-ic` spawn shape: agent `ppid` == the tmux server pid, not a
   shell; re-verified 2026-08-19 that `zsh -ilc` still execs into the final command for

--- a/docs/specs/reaping-orphaned-agents-design.md
+++ b/docs/specs/reaping-orphaned-agents-design.md
@@ -34,10 +34,14 @@ be hot at sweep time.
 How TBD spawns and tracks agents:
 
 - **Spawn**: `ClaudeSpawnCommandBuilder` builds a command string; `TmuxManager.createWindow`
-  runs `tmux -L <server> new-window … <shell> -ilc <cmd>`
-  (`Sources/TBDDaemon/Tmux/TmuxManager.swift:128`). The shell exec's into `claude`, so the
-  pane process *is* the agent (confirmed live: agent `ppid` == the tmux server pid, not a
-  shell).
+  runs `tmux -L <server> new-window … <shell> -ilc <cmd>` (csh-family shells get `-ic`;
+  see `newWindowCommand` in `Sources/TBDDaemon/Tmux/TmuxManager.swift`). The shell
+  exec's into `claude`, so the pane process *is* the agent (confirmed live 2026-06-15
+  under the then-current `-ic` spawn shape: agent `ppid` == the tmux server pid, not a
+  shell; re-verified 2026-08-19 that `zsh -ilc` still execs into the final command for
+  default configs). Caveat: an EXIT trap in any sourced startup file (including the
+  profile files `-l` adds) defeats the exec, leaving the shell as the pane process and
+  `claude` as a grandchild that PID-based kill/reap paths do not see.
 - **What TBD records**: only tmux identifiers — `Terminal.tmuxWindowID` (`@3`),
   `tmuxPaneID` (`%5`), `Worktree.tmuxServer` (`tbd-<hash>`), and the resumable
   `claudeSessionID` (`Sources/TBDShared/Models.swift`). **No OS PID is ever persisted.**

--- a/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
@@ -112,7 +112,7 @@ Steps 1–5 are cancellable (the coordinator can cancel the suspend task during 
 
 Steps 1–5 that skip leave the terminal running — conservative by default.
 
-**No suspend message for v1**: TBD-created panes use `zsh -ic <command>` — the pane dies when Claude exits, so there's no shell to echo into. The user sees the terminal resume when they switch back, which is sufficient feedback.
+**No suspend message for v1**: TBD-created panes use `zsh -ilc <command>` — the pane dies when Claude exits, so there's no shell to echo into. The user sees the terminal resume when they switch back, which is sufficient feedback.
 
 **Race condition note**: Claude could start working between `isIdleConfirmed()` and the `/exit` send. This is benign — Claude Code queues `/exit` and processes it after the current turn completes. The session is preserved. Since `/exit` is past the point of no return, the terminal is always marked as suspended once step 6 executes.
 
@@ -123,7 +123,7 @@ Triggered when a worktree is selected. Orchestrated by the `SuspendResumeCoordin
 For each terminal in the **arriving** worktree where `suspendedAt != nil`:
 
 1. **Check if Claude is already running**: `pane_current_command` matches Claude. This could mean the user manually restarted it, OR a timed-out suspend's `/exit` hasn't been processed yet. **Do not clear `suspendedAt` in this case** — wait for Claude to exit (the queued `/exit` will eventually process). If the terminal is still running after another 5s, then assume the user restarted it intentionally: clear `suspendedAt`, re-capture session ID, done.
-2. **Check pane is alive**: verify the tmux pane/window still exists via `TmuxManager.windowExists()`. The pane will almost always be dead (TBD-created panes use `zsh -ic` — the shell exits when Claude exits).
+2. **Check pane is alive**: verify the tmux pane/window still exists via `TmuxManager.windowExists()`. The pane will almost always be dead (TBD-created panes use `zsh -ilc` — the shell exits when Claude exits).
 3. **Build resume command**: `claude --resume <claudeSessionID> --dangerously-skip-permissions` (daemon always launches managed Claude with this flag today)
 4. **Create new tmux window**: call `TmuxManager.createWindow(server:session:cwd:shellCommand:)` with the resume command. Update the terminal record's `tmuxWindowID` and `tmuxPaneID` to the new values.
 5. **Force app UI reconnection**: the state delta broadcast must cause the app to recreate the `TerminalPanelView` for this terminal. Since `TerminalPanelView` binds tmux in `makeNSView` (which only runs once) and `updateNSView` is a no-op, a changed `tmuxWindowID` won't rebind the view. **Fix**: include `tmuxWindowID` in the view's `.id()` modifier (e.g. `.id("\(terminalID)-\(tmuxWindowID)")`), so SwiftUI destroys and recreates the view when the window ID changes.


### PR DESCRIPTION
## What's broken

Tools that live in profile-supplied PATH directories are unresolvable inside every TBD terminal tab. On a stock macOS setup that includes anything under `/usr/local/bin` (the `code` CLI, for example) and everything Homebrew installs, while directories added by `~/.zshrc` (nix, cargo, and friends) work fine. The asymmetry made the failure look mysterious rather than systematic, and it fed a second failure: an agent running `scripts/restart.sh` from inside a TBD tab captured the deficient PATH into the app bundle's `LSEnvironment.PATH`, so the daemon itself inherited it on later launches. Field measurement found a live install whose bundle capture had lost `/usr/local/bin` and `/opt/homebrew/bin` this way, a loop that could not heal from inside TBD.

## Why it happens

Panes spawned by the daemon ran the user's shell as an interactive non-login shell (`$SHELL -ic <command>`). On macOS the load-bearing PATH directories come from login-shell startup files: `/etc/zprofile` runs `path_helper` (which supplies `/usr/local/bin` from `/etc/paths`), and `~/.zprofile` conventionally holds `eval "$(brew shellenv)"`. A non-login shell skips both, so a pane sees only the tmux server's inherited environment (the daemon's PATH, or in degraded cases the bare launchd default `/usr/bin:/bin:/usr/sbin:/sbin`) plus whatever `~/.zshrc` adds. Every terminal emulator (Terminal.app, iTerm2, VS Code) spawns login shells for exactly this reason; TBD did not.

## What this PR does

Both spawn builders (`TmuxManager.newWindowCommand`, `respawnWindowCommand`) now emit the user's shell as an interactive login shell, through one shared `shellInvocation` helper. Design decisions, each argued in the committed spec (`docs/specs/2026-08-19-login-shell-panes-design.md`):

- **Separate flag argv elements** (`-i`, `-l`, `-c`), never a clustered `-ilc` string: some shells accept the individual flags but reject GNU-style clustering, and a rejected flag means a pane that dies instantly with the error destroyed by the pane closing.
- **csh-family shells omit `-l`** (matched on lowercased basename): csh and tcsh reject `-l` combined with `-c` even unclustered (measured on this machine and recorded in the helper's doc comment), so they keep their pre-change interactive non-login behavior rather than dying.
- **An injected `environment:` seam** (defaulted, last parameter) on the helper and both builders, so both flag branches are tested through the real builders without `setenv`.
- **No flag**: this is a bug fix restoring the environment users already get from every other terminal; rationale in the spec's "Not gated by a flag" section.
- **Daemon-side environment policy untouched**: the installation-PATH capture and tmux executable resolver from `docs/specs/2026-08-11-tmux-executable-resolution-design.md` stay as-is; that spec's login-shell rejection is now explicitly scoped to executable resolution.

Comments, older spec passages, and test fixtures that described the old spawn shape were updated to stay truthful, including scoping the reaping doc's "confirmed live" ppid evidence to the `-ic` shape it was measured under.

No new durable resource kinds or creation paths are introduced; panes are created through the existing window-spawn path that `WorktreeLifecycle+Reconcile` and `AgentReaper` already cover.

## Assumptions

- Assumes the user's profile files are safe to run once per spawned pane, as every terminal emulator assumes. Two accepted residuals are documented in the spec's Risks: a profile that execs into another shell swallows the `-c` payload (visible failure, pane shows a shell prompt), and a profile export of an `-e`-only secret such as `ANTHROPIC_API_KEY` wins over the per-profile value (the pre-existing rc-file clobber surface, widened to profile files; secrets cannot use the inline re-export defense without leaking into `ps` argv).
- Assumes zsh's exec-into-last-command optimization keeps `pane_pid` == the agent for default configs (re-measured for login flags). An EXIT trap in a profile file defeats it; the reaper-visibility consequence is recorded in the spec and in `docs/specs/reaping-orphaned-agents-design.md` as a pre-existing, marginally widened exposure.

## Evidence & verification

- Repro: on a live install, panes were `/bin/zsh` (argv0 without the login dash), the tmux server's global PATH was the bare launchd default, `code` was unresolvable in every tab, and the app bundle's captured `LSEnvironment.PATH` had lost `/usr/local/bin` and `/opt/homebrew/bin` after an in-tab restart.
- Discriminating tests: the new builder tests failed for the right reason before the source change (argv contained `-ic`, no login flag). Both flag branches are covered through the real builders via the environment seam (`SHELL=/bin/zsh` gets `-i -l -c`; `SHELL=/bin/tcsh` gets `-i -c`; unset `SHELL` falls back to `/bin/zsh`), plus hardcoded per-basename tests for the pure flag-choice function, including uppercase and deep-path edge cases.
- Shell matrix measured on this machine: `zsh`/`bash`/`dash` accept `-i -l -c` identically to the clustered form; `tcsh`/`csh` run `-i -c` but reject `-l` in any combination with `-c`.
- End-to-end: a pane spawned through a scratch tmux server with the exact new argv and a deliberately bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin` rebuilt the full user PATH (path_helper, brew shellenv, mise, nix, cargo) and resolved both `code` and `tmux`.
- Full daemon suite: 3,851 tests in 353 suites pass; `swiftlint --strict` clean.

## Follow-up (deliberately out of scope)

Two pre-existing sites hardcode shell flag shapes this PR's measurements show are wrong for csh-family shells: the CLI installer's login-shell PATH probe (clustered `-ilc` in `TBDShared/CLIInstaller.swift`) and the remote-auth remediation argv (clustered `-lc`, no csh handling). They fail the same way on `main` today and are one logical change of their own: hoist the per-shell flag policy into `TBDShared` and route all three call sites through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
