### PR TITLE
Fix: Transcript dropped every prompt you queued while the agent was busy (1331 rows across 92 of 120 sessions)

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
@@ -292,6 +292,16 @@ enum ClaudeSessionScanner {
     /// If `transcriptFilePath` is provided and the file exists, it takes
     /// precedence over project directory resolution. This bypasses stale
     /// cache entries and mirrors the pattern used by `handleTerminalTranscript`.
+    ///
+    /// Queued prompts are deliberately NOT counted, unlike in `parseSummary`
+    /// above, and the asymmetry is safe rather than an oversight: a prompt can
+    /// only be QUEUED while the agent is mid-turn, so a file carrying one
+    /// always carries the user and assistant rows of the turn it interrupted.
+    /// A "blank" session holding nothing but a queued prompt is therefore not
+    /// a reachable state — measured 0 of 701 local session files. Teaching
+    /// this scan the attachment shape would cost a JSON decode of every
+    /// attachment row on a path whose whole point is to stop at the first
+    /// content-bearing line.
     static func isSessionBlank(
         sessionID: String,
         worktreePath: String,

--- a/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
@@ -198,6 +198,15 @@ enum ClaudeSessionScanner {
     ///
     /// Returns nil for a queued row that classifies as a system envelope —
     /// a background-task notification is not something the user said.
+    ///
+    /// Peer traffic is NOT filtered, and that is deliberate: an
+    /// `<agent-message>` or `<cross-session-message>` envelope matches no
+    /// system prefix, so it classifies as a real prompt and can become the
+    /// subtitle. It arrives only queued — no `type:"user"` line ever carries
+    /// one — so there is no typed twin to match, and the choice is between
+    /// showing it and showing a subtitle that predates it. It IS a message
+    /// this session received, so it is shown; deciding it deserves its own
+    /// kind would be a design change, not a parser fix.
     private static func userPromptText(_ json: [String: Any]) -> String? {
         if UserMessageClassifier.isRealUserMessage(json) {
             return UserMessageClassifier.extractText(json)

--- a/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
@@ -189,6 +189,26 @@ enum ClaudeSessionScanner {
 
     // MARK: Private
 
+    /// The user-authored prompt text of one JSONL line, whichever way Claude
+    /// Code recorded it: a `type:"user"` line when the prompt was typed at an
+    /// idle agent, or a `queued_command` attachment when it was queued
+    /// mid-turn (in which case no user line is ever written). Reading only the
+    /// former left the subtitle stale, or empty, for a session whose prompts
+    /// all arrived while it was busy.
+    ///
+    /// Returns nil for a queued row that classifies as a system envelope —
+    /// a background-task notification is not something the user said.
+    private static func userPromptText(_ json: [String: Any]) -> String? {
+        if UserMessageClassifier.isRealUserMessage(json) {
+            return UserMessageClassifier.extractText(json)
+        }
+        if let queued = TranscriptParser.queuedCommandText(from: json),
+           UserMessageClassifier.classify(text: queued) == nil {
+            return queued
+        }
+        return nil
+    }
+
     private static func parseSummary(file: URL) -> SessionSummary? {
         let rv = try? file.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
         let modifiedAt = rv?.contentModificationDate ?? Date.distantPast
@@ -217,8 +237,7 @@ enum ClaudeSessionScanner {
                 cwd        = json["cwd"]        as? String
                 gitBranch  = json["gitBranch"]  as? String
             }
-            if UserMessageClassifier.isRealUserMessage(json),
-               let text = UserMessageClassifier.extractText(json) {
+            if let text = userPromptText(json) {
                 let truncated = String(text.prefix(300))
                 if firstUserMessage == nil { firstUserMessage = truncated }
                 lastUserMessage = truncated

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -224,6 +224,20 @@ enum TranscriptParser {
             let timestamp = (json["timestamp"] as? String).flatMap { iso8601.date(from: $0) }
             let typeStr = json["type"] as? String
 
+            // A prompt typed while the agent was mid-turn is QUEUED, and Claude
+            // Code never writes a `type:"user"` line for it — the delivery is
+            // recorded only as this attachment. Route its text through the same
+            // classification and emit decision as a typed prompt so the two
+            // recording shapes render identically.
+            if typeStr == "attachment", let text = queuedCommandText(from: json) {
+                items.append(promptItem(
+                    id: lineUUID,
+                    kind: UserMessageClassifier.classify(text: text),
+                    text: text,
+                    timestamp: timestamp))
+                continue
+            }
+
             // Hook- and CLAUDE.md-injected context arrives as `type:"attachment"`
             // rows, which carry no `message` and so match none of the branches
             // below. Always `continue` — an attachment never falls through.
@@ -244,29 +258,17 @@ enum TranscriptParser {
             }
 
             if typeStr == "user", let kind = UserMessageClassifier.classify(json) {
-                let text = extractUserText(from: json) ?? ""
-                // NOTE: TranscriptItem.slashCommand is no longer emitted — slash commands
-                // are flattened into .userPrompt so they render as the user's chat bubble
-                // (the slash command IS what the user typed). The case remains in the
-                // enum for Codable compatibility with any persisted state.
-                if kind == .slashEnvelope {
-                    let (name, args) = parseSlashEnvelope(text)
-                    let bubbleText: String
-                    if let args, !args.isEmpty {
-                        bubbleText = "/\(name) \(args)"
-                    } else {
-                        bubbleText = "/\(name)"
-                    }
-                    items.append(.userPrompt(id: lineUUID, text: bubbleText, timestamp: timestamp))
-                } else {
-                    items.append(.systemReminder(id: lineUUID, kind: kind, text: text, timestamp: timestamp))
-                }
+                items.append(promptItem(
+                    id: lineUUID,
+                    kind: kind,
+                    text: extractUserText(from: json) ?? "",
+                    timestamp: timestamp))
                 continue
             }
 
             if typeStr == "user", UserMessageClassifier.isRealUserMessage(json),
                let text = UserMessageClassifier.extractText(json) {
-                items.append(.userPrompt(id: lineUUID, text: text, timestamp: timestamp))
+                items.append(promptItem(id: lineUUID, kind: nil, text: text, timestamp: timestamp))
                 continue
             }
 
@@ -331,6 +333,61 @@ enum TranscriptParser {
         return items
     }
 
+    /// The item one prompt renders as, given its body and its classification.
+    ///
+    /// The single emit decision for user-authored input, shared by the
+    /// `type:"user"` line branch and the `queued_command` attachment branch —
+    /// a prompt must look the same whether it was typed at an idle agent or
+    /// queued mid-turn, and one helper is what keeps the two from drifting.
+    ///
+    /// NOTE: TranscriptItem.slashCommand is no longer emitted — slash commands
+    /// are flattened into .userPrompt so they render as the user's chat bubble
+    /// (the slash command IS what the user typed). The case remains in the
+    /// enum for Codable compatibility with any persisted state.
+    private static func promptItem(
+        id: String, kind: SystemKind?, text: String, timestamp: Date?
+    ) -> TranscriptItem {
+        guard let kind else {
+            return .userPrompt(id: id, text: text, timestamp: timestamp)
+        }
+        guard kind == .slashEnvelope else {
+            return .systemReminder(id: id, kind: kind, text: text, timestamp: timestamp)
+        }
+        let (name, args) = parseSlashEnvelope(text)
+        let bubbleText: String
+        if let args, !args.isEmpty {
+            bubbleText = "/\(name) \(args)"
+        } else {
+            bubbleText = "/\(name)"
+        }
+        return .userPrompt(id: id, text: bubbleText, timestamp: timestamp)
+    }
+
+    /// The prompt body of a `queued_command` attachment, or nil for every other
+    /// row. `attachment.prompt` is usually a String but is an array of content
+    /// blocks for a multimodal paste, in which case every `text` block joins —
+    /// the same rule `UserMessageClassifier.extractText` applies to a
+    /// `type:"user"` line's content array.
+    ///
+    /// The sibling `type:"queue-operation"` rows (`enqueue`/`remove`/`dequeue`)
+    /// are queue bookkeeping, not the delivery record, and deliberately match
+    /// nothing here — a queued prompt would otherwise render once per queue
+    /// event.
+    static func queuedCommandText(from json: [String: Any]) -> String? {
+        guard json["type"] as? String == "attachment",
+              let att = json["attachment"] as? [String: Any],
+              att["type"] as? String == "queued_command" else {
+            return nil
+        }
+        if let s = att["prompt"] as? String {
+            return s.isEmpty ? nil : s
+        }
+        if let blocks = att["prompt"] as? [[String: Any]] {
+            return UserMessageClassifier.joinTextBlocks(blocks)
+        }
+        return nil
+    }
+
     /// Extract a `TokenUsage` from `message.usage` if all three input-token
     /// fields are present. Output tokens, cache breakdowns, and other fields
     /// are ignored — we only care about the prompt-size signal.
@@ -365,9 +422,11 @@ enum TranscriptParser {
     /// Extracts every injected-context payload from one JSONL row, in emission
     /// order. Returns `[]` for non-attachment rows and for flavors that carry
     /// no injected *prose* context: `*_delta`, `command_permissions`,
-    /// `queued_command`, `diagnostics`, and `edited_text_file` have no
-    /// `content` field at all, while `task_reminder`'s `content` is a
-    /// structured array of todo objects, not renderable text.
+    /// `diagnostics`, and `edited_text_file` have no `content` field at all,
+    /// while `task_reminder`'s `content` is a structured array of todo objects,
+    /// not renderable text. `queued_command` has no `content` either — its
+    /// prompt is user-authored input rather than injected context, and is
+    /// handled by `queuedCommandText(from:)`.
     ///
     /// `attachment.content` has a DIFFERENT native JSON type per flavor —
     /// object for `nested_memory`, array for `hook_additional_context`, string
@@ -742,6 +801,12 @@ enum TranscriptParser {
                 // can never recover their (truncated) body. Re-run the same
                 // extraction `buildItems` used and return it whole, alongside
                 // the injection metadata the overlay renders.
+                // A queued prompt is an attachment row too, but it renders as
+                // the user's own bubble rather than an injected-context row.
+                if let queued = queuedCommandText(from: json) {
+                    return ItemDetail(text: queued, attachment: nil)
+                }
+
                 let payloads = attachmentPayloads(from: json)
                 if !payloads.isEmpty {
                     let meta = attachmentMetadata(from: json, toolSummaries: toolSummaries)

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -229,6 +229,22 @@ enum TranscriptParser {
             // recorded only as this attachment. Route its text through the same
             // classification and emit decision as a typed prompt so the two
             // recording shapes render identically.
+            //
+            // "Queued" covers more than human typing: peer traffic
+            // (`<agent-message>`, `<cross-session-message>`) arrives this way
+            // and this way only. Those envelopes match no system prefix, so
+            // they classify as real prompts and render as bubbles. That is the
+            // intent — they are messages this session received, and the
+            // alternative is the pre-fix behavior of dropping them silently.
+            //
+            // Deliberately NOT `truncate`d, unlike the injected-context
+            // attachment branch below: this is delivered input rather than
+            // injected context, and a prompt that arrived on a `type:"user"`
+            // line is not truncated either. Truncating here would make the
+            // same prompt render
+            // differently depending on when it landed, which is the whole
+            // defect being fixed. The measured cost is a median of ~6 KB of
+            // extra body per session.
             if typeStr == "attachment", let text = queuedCommandText(from: json) {
                 items.append(promptItem(
                     id: lineUUID,
@@ -367,12 +383,23 @@ enum TranscriptParser {
     /// row. `attachment.prompt` is usually a String but is an array of content
     /// blocks for a multimodal paste, in which case every `text` block joins —
     /// the same rule `UserMessageClassifier.extractText` applies to a
-    /// `type:"user"` line's content array.
+    /// `type:"user"` line's content array. Both shapes are measured, not
+    /// assumed: across 701 local session JSONLs, 5876 of 5887 queued rows
+    /// carry a String and 11 carry the array form — a paste of one `text`
+    /// block alongside a base64 `image` block.
     ///
-    /// The sibling `type:"queue-operation"` rows (`enqueue`/`remove`/`dequeue`)
-    /// are queue bookkeeping, not the delivery record, and deliberately match
-    /// nothing here — a queued prompt would otherwise render once per queue
-    /// event.
+    /// Every other shape — `prompt` absent, empty, an empty array, an array
+    /// whose blocks carry no text, a number, an object, an array of bare
+    /// strings — returns nil, and the row then falls through to the general
+    /// attachment branch, which has no `queued_command` case and emits
+    /// nothing. That is exactly where such a row sat before this function
+    /// existed: an empty bubble would be worse than no bubble.
+    ///
+    /// The sibling `enqueue`/`remove`/`dequeue` rows are queue bookkeeping,
+    /// not the delivery record. They are a distinct TOP-LEVEL
+    /// `type:"queue-operation"` rather than an attachment flavor, so they fail
+    /// the first guard below and reach no rendering path — which is what keeps
+    /// one queued prompt from rendering once per queue event.
     static func queuedCommandText(from json: [String: Any]) -> String? {
         guard json["type"] as? String == "attachment",
               let att = json["attachment"] as? [String: Any],
@@ -424,9 +451,10 @@ enum TranscriptParser {
     /// no injected *prose* context: `*_delta`, `command_permissions`,
     /// `diagnostics`, and `edited_text_file` have no `content` field at all,
     /// while `task_reminder`'s `content` is a structured array of todo objects,
-    /// not renderable text. `queued_command` has no `content` either — its
-    /// prompt is user-authored input rather than injected context, and is
-    /// handled by `queuedCommandText(from:)`.
+    /// not renderable text. `queued_command` has no `content` either — it
+    /// carries a delivered *prompt* rather than injected context, and is
+    /// handled by `queuedCommandText(from:)`. (Measured: 0 of 5887
+    /// `queued_command` rows in the local corpus carry a `content` field.)
     ///
     /// `attachment.content` has a DIFFERENT native JSON type per flavor —
     /// object for `nested_memory`, array for `hook_additional_context`, string

--- a/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
+++ b/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
@@ -93,6 +93,11 @@ enum UserMessageClassifier {
     /// the measured corpus that meta line is the only user message that ever
     /// carries more than one text block, so joining is a strict repair.
     ///
+    /// The same rule serves `queued_command.prompt`'s array form, which the
+    /// original measurement did not cover. Re-measured for that call site: the
+    /// array form appears on 11 queued rows in the local corpus and none carry
+    /// more than one text block, so joining is a strict repair there too.
+    ///
     /// Returns nil when no non-empty text block is present.
     static func joinTextBlocks(_ blocks: [[String: Any]]) -> String? {
         let texts = blocks

--- a/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
+++ b/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
@@ -37,7 +37,7 @@ enum UserMessageClassifier {
         else { return false }
 
         if let content = message["content"] as? String {
-            return !hasSystemPrefix(content)
+            return isRealUserMessage(text: content)
         }
 
         if let array = message["content"] as? [[String: Any]] {
@@ -48,12 +48,25 @@ enum UserMessageClassifier {
             // Check the first text block's content
             if let firstText = array.first(where: { $0["type"] as? String == "text" }),
                let text = firstText["text"] as? String {
-                return !hasSystemPrefix(text)
+                return isRealUserMessage(text: text)
             }
             return false
         }
 
         return false
+    }
+
+    /// Returns true if a prompt *body* is user-authored rather than a system
+    /// envelope.
+    ///
+    /// Claude Code records the same prompt two different ways depending on when
+    /// it lands: typed while the agent is idle it becomes a `type:"user"` line,
+    /// while a prompt queued mid-turn is only ever recorded as a
+    /// `queued_command` attachment carrying the raw text. Both shapes must
+    /// classify identically, so the rule lives here on the text and the
+    /// dictionary-shaped entry points above delegate to it.
+    static func isRealUserMessage(text: String) -> Bool {
+        !hasSystemPrefix(text)
     }
 
     /// Extracts display text from a real user message line. Returns nil if empty.
@@ -67,20 +80,26 @@ enum UserMessageClassifier {
         }
 
         if let array = message["content"] as? [[String: Any]] {
-            // EVERY text block, not just the first. Claude Code emits one text
-            // block PER attached image when it records where it spooled them
-            // (`[Image: source: …]`), so taking only the first silently dropped
-            // every image after the first in a multi-image paste. In the measured
-            // corpus that meta line is the only user message that ever carries
-            // more than one text block, so joining is a strict repair.
-            let texts = array
-                .filter { $0["type"] as? String == "text" }
-                .compactMap { $0["text"] as? String }
-                .filter { !$0.isEmpty }
-            return texts.isEmpty ? nil : texts.joined(separator: "\n")
+            return joinTextBlocks(array)
         }
 
         return nil
+    }
+
+    /// Joins EVERY `text` block of a content-block array, not just the first.
+    /// Claude Code emits one text block PER attached image when it records
+    /// where it spooled them (`[Image: source: …]`), so taking only the first
+    /// silently dropped every image after the first in a multi-image paste. In
+    /// the measured corpus that meta line is the only user message that ever
+    /// carries more than one text block, so joining is a strict repair.
+    ///
+    /// Returns nil when no non-empty text block is present.
+    static func joinTextBlocks(_ blocks: [[String: Any]]) -> String? {
+        let texts = blocks
+            .filter { $0["type"] as? String == "text" }
+            .compactMap { $0["text"] as? String }
+            .filter { !$0.isEmpty }
+        return texts.isEmpty ? nil : texts.joined(separator: "\n")
     }
 
     /// Returns the typed system kind for a user-role JSONL line if it's a
@@ -106,6 +125,14 @@ enum UserMessageClassifier {
             return nil
         }
 
+        return classify(text: text)
+    }
+
+    /// Returns the typed system kind for a prompt *body*, or nil when it is a
+    /// real user prompt. See `isRealUserMessage(text:)` for why the rule lives
+    /// on the text: a queued prompt never gets a `type:"user"` line, so the
+    /// only thing the two recording shapes share is the body itself.
+    static func classify(text: String) -> SystemKind? {
         // Background-task notifications are harness-injected into the user role.
         // Surface them as a dedicated system kind so they render as a clickable
         // activity row (with the full text available in the detail overlay).
@@ -131,11 +158,11 @@ enum UserMessageClassifier {
         // The known prefixes above match real Claude Code injections. The
         // generic-tag heuristic below is for future injections we haven't
         // seen yet — but it also catches user-typed XML/HTML prompts. If
-        // isRealUserMessage already accepts this line as a real user
+        // isRealUserMessage already accepts this text as a real user
         // message, prefer that over the speculative system-injection
         // catch-all. New unknown injections degrade to plain user prompts
         // rather than being hidden as system noise.
-        if isRealUserMessage(line) { return nil }
+        if isRealUserMessage(text: text) { return nil }
 
         // Unknown tag-like prefix → generic "other" injection. The tag must
         // start with `<`, contain only letters/underscores/hyphens, and end at

--- a/Tests/Fixtures/sample-session.jsonl
+++ b/Tests/Fixtures/sample-session.jsonl
@@ -8,4 +8,6 @@
 {"type":"assistant","message":{"role":"assistant","content":"Here are the tests..."},"sessionId":"abc123de-0000-0000-0000-000000000001"}
 {"type":"user","message":{"role":"user","content":"<tool_result>tool output here</tool_result>"},"sessionId":"abc123de-0000-0000-0000-000000000001"}
 {"type":"user","message":{"role":"user","content":"What does this error mean?"},"sessionId":"abc123de-0000-0000-0000-000000000001"}
+{"type":"queue-operation","operation":"enqueue","timestamp":"2026-08-19T21:10:05.400Z","content":"Also check the retry path while you are in there.","sessionId":"abc123de-0000-0000-0000-000000000001"}
+{"type":"attachment","uuid":"queued-1","timestamp":"2026-08-19T21:10:05.458Z","attachment":{"type":"queued_command","prompt":"Also check the retry path while you are in there.","commandMode":"prompt","origin":{"kind":"human"}},"sessionId":"abc123de-0000-0000-0000-000000000001"}
 {"type":"file-history-snapshot","snapshot":{},"sessionId":"abc123de-0000-0000-0000-000000000001"}

--- a/Tests/TBDDaemonTests/ClaudeSessionScannerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSessionScannerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import TBDShared
 @testable import TBDDaemonLib
 
 @Suite("ClaudeSessionScanner")
@@ -18,7 +19,7 @@ struct ClaudeSessionScannerTests {
         let dir = fixtureURL.deletingLastPathComponent()
         let summaries = ClaudeSessionScanner.listSessions(projectDir: dir)
         let summary = try #require(summaries.first(where: { $0.filePath.hasSuffix("sample-session.jsonl") }))
-        #expect(summary.lineCount == 11)
+        #expect(summary.lineCount == 13)
     }
 
     @Test("first user message is the first real user turn")
@@ -29,12 +30,54 @@ struct ClaudeSessionScannerTests {
         #expect(summary.firstUserMessage == "Hello, can you help me refactor this function?")
     }
 
-    @Test("last user message is the last real user turn")
+    /// The fixture's last prompt was QUEUED while the agent was busy, so Claude
+    /// Code recorded it as a `queued_command` attachment and never wrote a
+    /// `type:"user"` line for it. Reading only user lines left the subtitle
+    /// stuck on the previous turn.
+    @Test("last user message is the last real user turn, queued or typed")
     func lastUserMessage() throws {
         let dir = fixtureURL.deletingLastPathComponent()
         let summaries = ClaudeSessionScanner.listSessions(projectDir: dir)
         let summary = try #require(summaries.first(where: { $0.filePath.hasSuffix("sample-session.jsonl") }))
-        #expect(summary.lastUserMessage == "What does this error mean?")
+        #expect(summary.lastUserMessage == "Also check the retry path while you are in there.")
+    }
+
+    @Test("a session whose only prompt was queued still gets a subtitle")
+    func queuedOnlySessionHasSubtitle() throws {
+        let line = #"""
+        {"type":"attachment","uuid":"q1","timestamp":"2026-08-19T21:10:05.458Z","attachment":{"type":"queued_command","prompt":"only ever queued","commandMode":"prompt"}}
+        """#
+        let summary = try scanOneSession(named: "queued-only", lines: [line])
+        #expect(summary.firstUserMessage == "only ever queued")
+        #expect(summary.lastUserMessage == "only ever queued")
+    }
+
+    /// A queued background-task notification is harness-injected, not something
+    /// the user said — it must never become the session's subtitle.
+    @Test("queued task notification is not treated as a user message")
+    func queuedTaskNotificationIsNotASubtitle() throws {
+        let lines = [
+            #"{"type":"user","uuid":"u1","message":{"role":"user","content":"real question"}}"#,
+            #"""
+            {"type":"attachment","uuid":"q1","attachment":{"type":"queued_command","prompt":"<task-notification>\n<task-id>abc</task-id>\n</task-notification>","commandMode":"task-notification"}}
+            """#,
+        ]
+        let summary = try scanOneSession(named: "queued-notification", lines: lines)
+        #expect(summary.firstUserMessage == "real question")
+        #expect(summary.lastUserMessage == "real question")
+    }
+
+    /// Writes `lines` as a lone session file in a fresh temp project dir and
+    /// returns its summary.
+    private func scanOneSession(named: String, lines: [String]) throws -> SessionSummary {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scanner-\(named)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try (lines.joined(separator: "\n") + "\n")
+            .write(to: tmp.appendingPathComponent("\(named).jsonl"), atomically: true, encoding: .utf8)
+        let summaries = ClaudeSessionScanner.listSessions(projectDir: tmp)
+        return try #require(summaries.first)
     }
 
     @Test("scanner truncates first/last user message to 300 chars")

--- a/Tests/TBDDaemonTests/ClaudeSessionScannerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSessionScannerTests.swift
@@ -67,6 +67,26 @@ struct ClaudeSessionScannerTests {
         #expect(summary.lastUserMessage == "real question")
     }
 
+    /// Peer traffic is the other thing that only ever arrives queued, and it
+    /// matches no system prefix, so it classifies as a real prompt and DOES
+    /// become the subtitle. Pinned deliberately: it is a message this session
+    /// received, and the alternative was showing a subtitle that predates it.
+    /// Giving peer messages their own kind is a design change, and this test
+    /// is what makes that change deliberate rather than accidental.
+    @Test("a queued peer message becomes the subtitle")
+    func queuedPeerMessageIsASubtitle() throws {
+        let peer = #"<cross-session-message from-name="acme-worker">[note] standing down</cross-session-message>"#
+        let lines = [
+            #"{"type":"user","uuid":"u1","message":{"role":"user","content":"real question"}}"#,
+            #"""
+            {"type":"attachment","uuid":"q1","attachment":{"type":"queued_command","prompt":"<cross-session-message from-name=\"acme-worker\">[note] standing down</cross-session-message>","commandMode":"prompt","isMeta":true}}
+            """#,
+        ]
+        let summary = try scanOneSession(named: "queued-peer", lines: lines)
+        #expect(summary.firstUserMessage == "real question")
+        #expect(summary.lastUserMessage == peer)
+    }
+
     /// Writes `lines` as a lone session file in a fresh temp project dir and
     /// returns its summary.
     private func scanOneSession(named: String, lines: [String]) throws -> SessionSummary {

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -25,6 +25,21 @@ struct TranscriptParserTests {
         #expect(!userPrompts.isEmpty, "expected at least one user prompt in fixture")
     }
 
+    /// The fixture's last two lines document the queued shape: an `enqueue`
+    /// bookkeeping row that must render nothing, followed by the
+    /// `queued_command` attachment that IS the delivery record.
+    @Test func parses_queued_prompt_from_fixture() throws {
+        let items = TranscriptParser.parse(filePath: fixturePath)
+        let queued = items.filter {
+            if case .userPrompt(let id, _, _) = $0 { return id == "queued-1" }
+            return false
+        }
+        #expect(queued.count == 1, "the fixture's queued prompt must render exactly once")
+        if case .userPrompt(_, let text, _)? = queued.first {
+            #expect(text == "Also check the retry path while you are in there.")
+        }
+    }
+
     @Test func parses_assistant_text() throws {
         let items = TranscriptParser.parse(filePath: fixturePath)
         let assistantTexts = items.compactMap { item -> String? in
@@ -772,11 +787,13 @@ struct TranscriptParserTests {
         #expect(row.text == "acme-deploy, acme-review")
     }
 
+    /// Flavors that carry no injected *prose* context. `queued_command` is
+    /// deliberately absent: it carries the user's own prompt and renders as a
+    /// chat bubble — see the queued-prompt tests below.
     @Test func attachment_payloadless_flavors_emit_nothing() throws {
         let lines = [
             try attachmentLine(uuid: "att-tr", ["type": "task_reminder", "content": [], "itemCount": 0]),
             try attachmentLine(uuid: "att-cp", ["type": "command_permissions", "allowedTools": ["Bash"]]),
-            try attachmentLine(uuid: "att-qc", ["type": "queued_command", "prompt": "go"]),
             try attachmentLine(uuid: "att-dd", ["type": "deferred_tools_delta", "addedNames": ["X"]])
         ].joined(separator: "\n")
         let tmp = try writeTempJSONL(lines)
@@ -1080,6 +1097,149 @@ struct TranscriptParserTests {
             name: "Bash", input: ["command": String(repeating: "acme ", count: 40)])
         #expect(summary.count <= "Bash ".count + 41)
         #expect(summary.hasSuffix("…"))
+    }
+
+    // MARK: - queued prompts
+    //
+    // A prompt typed while the agent is mid-turn is QUEUED, and Claude Code
+    // never writes a `type:"user"` line for it — the delivery is recorded only
+    // as a `queued_command` attachment. Measured over 120 recent session files,
+    // 92 of them carried such rows and only 3 of 1331 were mirrored by a user
+    // line, so every one of these prompts used to vanish from the transcript.
+
+    /// Builds one `type:"attachment"` queued-prompt row. `prompt` is `Any` so a
+    /// test can pass the array-of-content-blocks form a multimodal paste uses.
+    private func queuedLine(uuid: String, prompt: Any, commandMode: String = "prompt") throws -> String {
+        try attachmentLine(uuid: uuid, [
+            "type": "queued_command",
+            "prompt": prompt,
+            "commandMode": commandMode,
+            "origin": ["kind": "human"]
+        ])
+    }
+
+    private func userPrompts(_ items: [TranscriptItem]) -> [(id: String, text: String)] {
+        items.compactMap {
+            if case .userPrompt(let id, let text, _) = $0 { return (id, text) }
+            return nil
+        }
+    }
+
+    @Test func queued_typed_prompt_renders_as_a_user_bubble() throws {
+        let tmp = try writeTempJSONL(
+            try queuedLine(uuid: "q1", prompt: "is the sonnet subagent what the codex subagent does?"))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1, "a queued prompt must render, not vanish")
+        let prompts = userPrompts(items)
+        #expect(prompts.count == 1)
+        #expect(prompts.first?.id == "q1", "the row uses the line's own uuid")
+        #expect(prompts.first?.text == "is the sonnet subagent what the codex subagent does?")
+    }
+
+    @Test func queued_cross_session_message_renders_as_a_user_bubble() throws {
+        // Agent-to-agent traffic arrives queued and is real conversation, not
+        // harness noise — it renders exactly as a typed prompt does.
+        let text = #"<cross-session-message from-name="acme-worker">[note] standing down</cross-session-message>"#
+        let tmp = try writeTempJSONL(try queuedLine(uuid: "q1", prompt: text))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(userPrompts(TranscriptParser.parse(filePath: tmp)).first?.text == text)
+    }
+
+    @Test func queued_task_notification_is_a_system_row_not_a_user_bubble() throws {
+        let text = "<task-notification>\n<task-id>bpzi7e9op</task-id>\n</task-notification>"
+        let tmp = try writeTempJSONL(
+            try queuedLine(uuid: "q1", prompt: text, commandMode: "task-notification"))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1)
+        #expect(userPrompts(items).isEmpty, "a task notification is not something the user said")
+        guard case .systemReminder(let id, let kind, let rowText, _, _, _) = items[0] else {
+            Issue.record("expected .systemReminder"); return
+        }
+        #expect(id == "q1")
+        #expect(kind == .taskNotification)
+        #expect(rowText == text)
+    }
+
+    @Test func queued_slash_envelope_flattens_to_the_command_line() throws {
+        let text = "<command-name>commit</command-name><command-args>--amend</command-args>"
+        let tmp = try writeTempJSONL(try queuedLine(uuid: "q1", prompt: text))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1)
+        #expect(userPrompts(items).first?.text == "/commit --amend",
+                "a queued slash command flattens exactly like a typed one")
+    }
+
+    @Test func queued_prompt_as_content_blocks_joins_every_text_block() throws {
+        // Multimodal paste: `prompt` is an array of content blocks. Every text
+        // block joins, mirroring the `type:"user"` content-array rule.
+        let blocks: [[String: Any]] = [
+            ["type": "text", "text": "first line"],
+            ["type": "image", "source": ["type": "base64"]],
+            ["type": "text", "text": "second line"]
+        ]
+        let tmp = try writeTempJSONL(try queuedLine(uuid: "q1", prompt: blocks))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1)
+        #expect(userPrompts(items).first?.text == "first line\nsecond line")
+    }
+
+    @Test func queued_prompt_full_body_is_recoverable_by_line_uuid() throws {
+        let text = "the queued question in full"
+        let tmp = try writeTempJSONL(try queuedLine(uuid: "q1", prompt: text))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: "q1") == text)
+    }
+
+    @Test func queue_operation_rows_render_nothing() throws {
+        // `enqueue`/`remove`/`dequeue` are queue bookkeeping, not the delivery
+        // record. If they rendered, one queued prompt would appear several times.
+        let lines = [
+            #"{"type":"queue-operation","operation":"enqueue","timestamp":"2026-08-19T21:13:08.194Z","content":"do the thing"}"#,
+            #"{"type":"queue-operation","operation":"dequeue","timestamp":"2026-08-19T21:13:09.194Z","content":"do the thing"}"#,
+            #"{"type":"queue-operation","operation":"remove","timestamp":"2026-08-19T21:13:10.194Z","content":"do the thing"}"#,
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(TranscriptParser.parse(filePath: tmp).isEmpty)
+    }
+
+    @Test func parseTail_window_with_a_queued_row_matches_the_full_parse() throws {
+        // The purity contract: `buildItems` sees only the lines in the tail's
+        // byte window, so a queued row must be derivable from itself alone —
+        // no cross-row dedup against a user line that may sit outside the window.
+        var lines: [String] = []
+        for i in 0..<20 {
+            let ts = "2026-05-05T10:00:\(String(format: "%02d", i))Z"
+            lines.append(
+                "{\"type\":\"assistant\",\"uuid\":\"a\(i)\",\"timestamp\":\"\(ts)\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"reply \(i)\"}]}}")
+        }
+        lines.append(#"{"type":"queue-operation","operation":"enqueue","content":"queued near the end"}"#)
+        lines.append(try queuedLine(uuid: "qtail", prompt: "queued near the end"))
+        lines.append(
+            #"{"type":"assistant","uuid":"alast","timestamp":"2026-05-05T10:00:59Z","message":{"role":"assistant","content":[{"type":"text","text":"on it"}]}}"#)
+
+        let tmp = try writeTempJSONL(lines.joined(separator: "\n"))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let full = TranscriptParser.parse(filePath: tmp)
+        #expect(full.contains { if case .userPrompt(let id, _, _) = $0 { return id == "qtail" }; return false },
+                "the queued row must be in the full parse for the comparison to mean anything")
+
+        let tail = TranscriptParser.parseTail(filePath: tmp, limit: 5)
+        #expect(tail.count == 5)
+        #expect(full.suffix(5).map(signature) == tail.map(signature),
+                "a tail window containing a queued row must equal the bottom of the full parse")
     }
 
     // MARK: - helpers

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -1200,6 +1200,62 @@ struct TranscriptParserTests {
         #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: "q1") == text)
     }
 
+    /// Every degenerate `prompt` shape must leave the row exactly where it was
+    /// before the queued branch existed: matched by no payload extractor, and
+    /// therefore rendering nothing. An empty bubble is worse than no bubble,
+    /// and `as? [[String: Any]]` is element-wise — an array of bare strings
+    /// fails the cast rather than yielding a partial join.
+    @Test func queued_prompt_with_no_usable_text_renders_nothing() throws {
+        let lines = try [
+            attachmentLine(uuid: "q-absent", ["type": "queued_command", "commandMode": "prompt"]),
+            attachmentLine(uuid: "q-empty", ["type": "queued_command", "prompt": ""]),
+            attachmentLine(uuid: "q-emptyArray", ["type": "queued_command", "prompt": [] as [Any]]),
+            attachmentLine(uuid: "q-noTextBlock", ["type": "queued_command",
+                "prompt": [["type": "image", "source": ["type": "base64"]]] as [[String: Any]]]),
+            attachmentLine(uuid: "q-blankBlocks", ["type": "queued_command",
+                "prompt": [["type": "text", "text": ""]] as [[String: Any]]]),
+            attachmentLine(uuid: "q-number", ["type": "queued_command", "prompt": 42]),
+            attachmentLine(uuid: "q-object", ["type": "queued_command", "prompt": ["text": "not a block array"]]),
+            attachmentLine(uuid: "q-stringArray", ["type": "queued_command", "prompt": ["a", "b"] as [Any]])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(TranscriptParser.parse(filePath: tmp).isEmpty)
+        for uuid in ["q-absent", "q-empty", "q-emptyArray", "q-noTextBlock",
+                     "q-blankBlocks", "q-number", "q-object", "q-stringArray"] {
+            #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: uuid) == nil,
+                    "\(uuid) has no recoverable body")
+        }
+    }
+
+    /// The queued branch returns early from `lookupDetail`, before the general
+    /// `attachmentPayloads` extraction. Injected-context rows in the same file
+    /// must still resolve their body AND their injection metadata — the early
+    /// return is keyed on the row, not on the file.
+    @Test func lookupDetail_still_resolves_injected_rows_alongside_a_queued_row() throws {
+        let absolute = "\(NSHomeDirectory())/acme-prod/CLAUDE.md"
+        let lines = try [
+            queuedLine(uuid: "q1", prompt: "queued while busy"),
+            attachmentLine(uuid: "att-mem", [
+                "type": "nested_memory",
+                "displayPath": "CLAUDE.md",
+                "path": absolute,
+                "content": ["path": absolute, "type": "Project", "content": "# acme rules"]
+            ])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let queued = TranscriptParser.lookupDetail(filePath: tmp, itemID: "q1")
+        #expect(queued.text == "queued while busy")
+        #expect(queued.attachment == nil, "a queued prompt is the user's own input, not injected context")
+
+        let injected = TranscriptParser.lookupDetail(filePath: tmp, itemID: "att-mem")
+        #expect(injected.text == "# acme rules")
+        #expect(injected.attachment?.memoryType == "Project")
+    }
+
     @Test func queue_operation_rows_render_nothing() throws {
         // `enqueue`/`remove`/`dequeue` are queue bookkeeping, not the delivery
         // record. If they rendered, one queued prompt would appear several times.

--- a/Tests/TBDDaemonTests/UserMessageClassifierTests.swift
+++ b/Tests/TBDDaemonTests/UserMessageClassifierTests.swift
@@ -221,4 +221,60 @@ struct UserMessageClassifierClassifyTests {
         #expect(UserMessageClassifier.classify(line) == .taskNotification)
         #expect(UserMessageClassifier.isRealUserMessage(line) == false)
     }
+
+    // MARK: - text entry points
+    //
+    // A prompt queued while the agent was busy is recorded ONLY as a
+    // `queued_command` attachment — it has no `type:"user"` line and no
+    // `message` dict — so the classification rules must be reachable from the
+    // raw text. The dictionary-shaped entry points above delegate to these, so
+    // a queued prompt and a typed one can never be classified differently.
+
+    @Test func text_and_line_entry_points_agree() {
+        let bodies = [
+            "plain typed prompt",
+            "<cross-session-message from-name=\"acme-worker\">[note] done</cross-session-message>",
+            "<task-notification>\n<task-id>abc</task-id>\n</task-notification>",
+            "[SYSTEM NOTIFICATION - NOT USER INPUT]\nbackground event",
+            "<command-name>commit</command-name>",
+            "<system-reminder>x</system-reminder>",
+            "<local-command-stdout>ok</local-command-stdout>",
+            "<environment_details>cwd</environment_details>",
+            "Base directory for this skill: /skills/pr",
+            "# Git repository context\nbranch: main",
+            "<unknown-tag>future injection</unknown-tag>",
+            "<html>my page</html> please review",
+            "<3 hearts to you",
+        ]
+        for body in bodies {
+            let l = userLine(body)
+            #expect(UserMessageClassifier.classify(text: body) == UserMessageClassifier.classify(l),
+                    "classification diverged for: \(body)")
+            #expect(UserMessageClassifier.isRealUserMessage(text: body)
+                    == UserMessageClassifier.isRealUserMessage(l),
+                    "real-message verdict diverged for: \(body)")
+        }
+    }
+
+    @Test func text_classification_matches_the_documented_kinds() {
+        #expect(UserMessageClassifier.classify(text: "just asking a question") == nil)
+        #expect(UserMessageClassifier.isRealUserMessage(text: "just asking a question") == true)
+        #expect(UserMessageClassifier.classify(text: "<task-notification>x</task-notification>") == .taskNotification)
+        #expect(UserMessageClassifier.classify(text: "<command-name>pr</command-name>") == .slashEnvelope)
+        #expect(UserMessageClassifier.classify(text: "<system-reminder>x</system-reminder>") == .toolReminder)
+        #expect(UserMessageClassifier.isRealUserMessage(text: "<task-notification>x") == false)
+    }
+
+    /// The multi-text-block join is the same rule for a `type:"user"` content
+    /// array and a queued prompt's content-block array.
+    @Test func joinTextBlocks_joins_text_and_skips_everything_else() {
+        let blocks: [[String: Any]] = [
+            ["type": "text", "text": "first"],
+            ["type": "image", "source": ["type": "base64"]],
+            ["type": "text", "text": "second"],
+        ]
+        #expect(UserMessageClassifier.joinTextBlocks(blocks) == "first\nsecond")
+        #expect(UserMessageClassifier.joinTextBlocks([["type": "image"]]) == nil)
+        #expect(UserMessageClassifier.joinTextBlocks([]) == nil)
+    }
 }


### PR DESCRIPTION
## What's broken

Type a message while Claude is mid-turn and it queues — and then it never appears in TBD's transcript. The reply to it does. You scroll back through a session, find Claude answering a question, and the question is simply not there.

It reads as an archived-worktree problem, because that is where you notice it: a session you are watching live is one you type into while it is idle, and a long unattended run — the kind you later archive — is where you queue mid-turn. But the archived and live viewers share one parser and one renderer; `HistoryPaneView` is the same view for an archived worktree and for a live worktree's History tab. Nothing about archiving is involved. The split is *when you typed*, not *where you are looking*.

It is not only your own typing. Cross-session and agent messages, and background-task notifications, all arrive queued when the receiving session is busy, and all vanish the same way.

Measured over the 120 most recently modified session transcripts: **1331 dropped rows across 92 of them** — 110 human-typed prompts, 75 agent and cross-session messages, 1145 task-notification envelopes. Only 3 of the 1331 were also recorded in the shape TBD does read, so this is a near-total silent drop rather than duplicate suppression.

## Why it happens

Claude Code records the same prompt two different ways depending on when it lands.

Typed at an idle agent, it becomes an ordinary `type:"user"` line, which TBD reads. Queued mid-turn, **no user line is ever written** — the delivery is recorded only as an attachment row, `{"type":"attachment","attachment":{"type":"queued_command","prompt": …}}`, with the text under `prompt`.

`TranscriptParser` routes every attachment row through `attachmentPayloads`, whose job is to pull *injected context* — CLAUDE.md bodies, hook output, @-mentioned files — out of the flavors that carry it. Its `switch` has no case for `queued_command`, so the row hits `default: return []` and disappears before anything downstream can render it.

## When it broke

Not a regression: this row was never rendered. Before #493 the parser ignored attachments wholesale. #493 surveyed the attachment flavors and listed `queued_command` among those carrying "no injected prose context" — true on its own terms, since it has no `content` field, but the survey asked only which flavors carry *injected context*, never whether one carried *user input* under a different key. The mis-scoping was invisible because the failure is silent: a dropped row leaves no gap, no placeholder, and no log line, so the transcript looks complete. It bites harder now simply because queuing mid-turn has become the normal way to steer a running session.

## What this PR does

A queued prompt is now classified and emitted **exactly as if its text had arrived on a user line**, so identical content renders identically whichever way it was recorded: typed text and peer messages become chat bubbles, `<task-notification>` becomes the same task-notification row it already becomes when delivered idle, and a `<command-…>` envelope flattens to `/name args`.

The point of the change is that there is now one rule rather than two that can drift:

- `UserMessageClassifier` grows text-based `isRealUserMessage(text:)` and `classify(text:)`, and the existing dictionary-shaped entry points delegate to them. A queued prompt has no `message` envelope at all, so the body is the only thing the two recording shapes share — the rule has to live on the text.
- `TranscriptParser.promptItem` makes the one emit decision (slash-envelope flattening vs chat bubble vs system row) for both branches.
- `queuedCommandText` reads `prompt` in both its shapes: usually a String, occasionally an array of content blocks for a multimodal paste, where every text block joins — the same rule already applied to a user line's content array.

`buildItems` stays a pure function of the rows in its window: the queued row is derived from itself alone, with no cross-row dedup, so `parseTail` still returns exactly the bottom of the full parse. The 3-in-1331 rows recorded both ways will render twice; that is the deliberate trade, because a duplicate bubble beats a silent drop and a dedup set would break the tail contract.

Two adjacent surfaces:

- `ClaudeSessionScanner` had the same blind spot, so a session whose prompts all arrived queued showed a stale or empty subtitle in the session list. It now reads queued rows too, counting only those that classify as a real prompt — a background-task notification is not something you said.
- `lookupDetail` resolves a queued row's full body by line UUID, so the detail overlay can open one.

## Assumptions

- Assumes Claude Code keeps recording a queued delivery as a `queued_command` attachment with the text under `prompt`. If that key or flavor name changes, queued prompts go silently missing again — the same way they were missing before this PR.
- Assumes a queued prompt gets no `type:"user"` line. It held for 1328 of 1331 measured rows; where both exist the prompt renders twice rather than not at all.
- Assumes `isSessionBlank`'s user/assistant-only scan is safe to leave alone: a prompt can only be queued while the agent is mid-turn, so the file always carries the interrupted turn. 0 of 701 local session files would flip. Recorded in a comment at the call site.

## Evidence & verification

**Repro, on real data.** In an archived session, the assistant answers a question ("Yes — identical shape, and I verified it rather than assuming…") that is nowhere in the rendered transcript. The question — "is the sonnet subagent what the codex subagent does? (and confirming we want sonnet not haiku?)" — is at JSONL line 999 of that session, in a `queued_command` attachment.

**Before/after through the real parser**, same session file: **2 user bubbles / 338 items → 3 / 348**, with the missing question present. The other nine recovered rows are that session's queued task-notification envelopes, now `.systemReminder(kind: .taskNotification)` instead of dropped. The "before" figure was independently confirmed by probing the running daemon over its socket, not only by reading code.

**Discriminating tests.** Every new test was checked to fail against pre-fix code by neutralizing the new branches and re-running — `items.count → 0`, `firstUserMessage → nil`, the fixture's `lastUserMessage` falling back to the older typed prompt. Coverage: queued typed prompt renders as a bubble; queued task notification is a system row and *not* a bubble; queued slash envelope flattens to the command line; a content-block prompt joins every text block; `queue-operation` bookkeeping rows render nothing; the eight degenerate `prompt` shapes (absent, empty, empty array, no text blocks, array of bare strings, non-string non-array) each fall through to nothing; a mixed queued + `nested_memory` file still resolves both through `lookupDetail`; and `parseTail` over a window containing a queued row matches the tail of the full parse.

**Comment claims are measured, not asserted.** Across 701 local session JSONLs: 0 of 5887 `queued_command` rows carry a `content` field; 5876 carry a String prompt and 11 the content-block form, none with more than one text block. The decision not to truncate a queued body matches the typed path, which never truncates either (1445 user-line task notifications, longest 29,840 chars, all untruncated) — truncating only the queued side would reintroduce the asymmetry this PR exists to remove.

**Suite.** `scripts/swift-safe build` exit 0 with zero `error:` lines; full `scripts/test.sh` 7411 tests in 738 suites passed, 86 known issues, 0 non-known failures; `swiftlint --strict` clean across 787 files.

**Known gap, deliberately out of scope.** `RPCRouter+TerminalHandlers.readSessionMessages`, which powers worktree conversation carryover, reads only `assistant`/`user` entries and still drops queued prompts. Same bug class, different subsystem — fixing it means extending the `SessionEntry` model and answering whether a peer message counts as a user message for carryover. Left for a follow-up.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=3EF663EA-D0DE-4E3C-86B3-73DE1B7A2C8E)

https://claude.ai/code/session_01Y97PDsBMNEnF7JJms4fPgg