### PR TITLE
Feat: Make an armed archive-on-merge impossible to miss

### DIFF
--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -329,6 +329,54 @@ struct StatusBarView: View {
         isHovering ? untrackLabel(chip) : openLabel(chip)
     }
 
+    /// What the bar says when the selected worktree is armed to archive itself
+    /// on merge. A plain value so the wording can be asserted without a view.
+    ///
+    /// `nonisolated` for the same reason as `PRChip` above — `StatusBarView`'s
+    /// `View` conformance infers whole-type `@MainActor` isolation onto a
+    /// nested value type, and a main-actor `init` reached from a nonisolated
+    /// context traps at runtime rather than failing to compile.
+    nonisolated struct AutoArchiveChip: Equatable {
+        let label: String
+        let tooltip: String
+        let accessibilityLabel: String
+    }
+
+    /// nil when nothing is armed: the resting state gets no chip, because a
+    /// chip on every worktree would say nothing and cost the bar its width.
+    ///
+    /// `blocked` deliberately changes the tooltip and not the label. The arming
+    /// is a property of the worktree, and it survives a blocked merge, so the
+    /// label keeps stating what the worktree is armed to do and the tooltip
+    /// carries the qualification — the same division the toolbar makes, whose
+    /// armed badge keys on `armed` alone while only its help string mentions
+    /// the block (`ContentView.prSplitButtonHelp`).
+    ///
+    /// The qualification says the archive is **skipped**, not paused, because
+    /// nothing re-attempts it when the children go away.
+    /// `AutoArchiveOnMergeCoordinator` bails on `hasActiveChildren`, and the
+    /// `AllResolvedMergeTrigger` that drives the fan-out reaching it is
+    /// edge-triggered on all-bindings-resolved going false→true — so a
+    /// skipped archive runs only
+    /// on a fresh edge (a `tbd pr detach`/`attach`, or the trigger's
+    /// deliberately unpersisted memory being lost across a daemon restart).
+    /// A tooltip promising "paused" would have the operator wait for something
+    /// that never arrives.
+    nonisolated static func autoArchiveChip(
+        armed: Bool,
+        blocked: Bool,
+        displayName: String
+    ) -> AutoArchiveChip? {
+        guard armed else { return nil }
+        return AutoArchiveChip(
+            label: "Archive on merge",
+            tooltip: blocked
+                ? "Auto-archive is armed, but archiving is skipped while child worktrees exist. Click to cancel."
+                : "This worktree archives itself when its PR merges. Click to cancel.",
+            accessibilityLabel: "Archive on merge armed for \(displayName)"
+        )
+    }
+
     private var footerLabel: (text: String, tooltip: String?) {
         let version = "v\(TBDConstants.version)"
         guard let sourcePath = Self.sourceWorktreePath,
@@ -399,6 +447,23 @@ struct StatusBarView: View {
                         // version/display-name label rather than squeezing it.
                         .layoutPriority(-1)
                 }
+            }
+            // Arming is otherwise nearly invisible — a badge baked into the
+            // toolbar's PR icon — while what it promises is a worktree that
+            // disappears when its PR merges. The bar is the surface that is
+            // always on screen and already scoped to the selection, so this is
+            // where that promise gets said out loud, with its own way out.
+            //
+            // Local worktrees only, like every other cluster in this bar:
+            // `selected` is a `LocalWorktree`, which a remote row cannot be.
+            // The daemon does auto-archive remote lanes, so a remote worktree's
+            // arming is still stated by the toolbar badge and its help text.
+            if let selected,
+               let chip = Self.autoArchiveChip(
+                   armed: appState.effectiveAutoArchive(for: selected.worktree),
+                   blocked: !appState.children(of: selected.id).isEmpty,
+                   displayName: selected.displayName) {
+                AutoArchiveChipView(worktreeID: selected.id, chip: chip)
             }
             Spacer()
             if let info = selectedInfo {
@@ -759,6 +824,116 @@ private struct ParkedPromptStatusItem: View {
         .accessibilityLabel("First message cannot be delivered for \(worktree.displayName)")
         .accessibilityHint(tooltip)
         .accessibilityAddTraits(.isButton)
+    }
+}
+
+/// The armed auto-archive-on-merge chip.
+///
+/// The one loud thing in a bar of grey secondary text, and deliberately so: it
+/// is the only always-visible statement that this worktree will archive itself,
+/// and nobody should meet that outcome by surprise. The purple is taken from
+/// the shared PR palette rather than written here, so the chip reads as the
+/// state it is waiting for and cannot drift from the merged-PR glyph beside it
+/// — the same reason `PRChipView.dotColor` reaches for that palette.
+///
+/// The whole capsule is the way out, so cancelling never requires finding the
+/// toolbar menu and never requires hitting a glyph-sized target. The leading
+/// icon carries that: `archivebox` at rest, the same symbol the toolbar's armed
+/// badge uses so both surfaces name this state alike, swapping to an `xmark`
+/// under the pointer to say what a click will do before it lands. The container
+/// carries the accessibility element, so its default action performs the same
+/// cancel for anyone activating the chip rather than clicking it.
+///
+/// ## Why this does not reuse `PRChipView`'s icon slot
+///
+/// `PRChipView` grew a hover-swapped icon slot in the same bar, and the two
+/// share exactly one rule — a fixed square holding both glyphs, so a chip is
+/// the same width hovered as at rest. Everything else that slot carries exists
+/// to arbitrate between **two sibling click targets**: `untrackHitSide`'s
+/// transparent overlay, the `zIndex(1)` that wins the hit test against the
+/// number's leading padding, `iconTextGap` applied as padding so the gap
+/// belongs to the open target, and `iconSlotLabel`, which derives the slot's
+/// *action* from the same flag as its *glyph* so a drawn dot can never untrack.
+///
+/// This chip has one target and one action. The glyph announces the cancel; it
+/// does not own it, so a stale `isHovering` can only draw the wrong symbol,
+/// never perform the wrong gesture — the hazard that machinery is there to
+/// close cannot arise here. Adopting it would add three constants and an
+/// overlay that resolve an ambiguity this chip does not have.
+private struct AutoArchiveChipView: View {
+    @EnvironmentObject var appState: AppState
+    let worktreeID: UUID
+    let chip: StatusBarView.AutoArchiveChip
+
+    @State private var isHovering = false
+
+    /// The fixed square `archivebox` and `xmark` share, named to match
+    /// `PRChipView.iconSlotSide` because it holds the same invariant: sized for
+    /// the larger of the two glyphs, both centred, so the capsule cannot change
+    /// width when the pointer crosses it.
+    ///
+    /// 11, not `PRChipView`'s 9, and the difference is not drift. That slot is
+    /// sized to a 6pt status dot; this one holds SF Symbols, so it takes the
+    /// size the bar's other symbol slot already uses — `CopyableStatusText`
+    /// frames its leading `GitBranchIcon` at 11×11 to match the caption text
+    /// this bar is set in. Following the neighbour that hosts the same kind of
+    /// glyph is what keeps the bar even.
+    private static let iconSlotSide: CGFloat = 11
+
+    /// Writes an explicit `false` override even when the arming came from the
+    /// global default — the same thing the toolbar's toggle does, and the only
+    /// reading of the gesture that survives the next default change.
+    private func cancel() {
+        Task { await appState.setAutoArchive(worktreeID: worktreeID, enabled: false) }
+    }
+
+    /// The capsule fill, resolved through the shared PR palette so it tracks
+    /// whatever `.merged` is tuned to. The synthetic `PRStatus` exists only to
+    /// reach that palette — the same trick, and the same reason, as
+    /// `PRChipView.dotColor`.
+    private var mergePurple: Color {
+        PRStatusPresentation.make(
+            for: PRStatus(number: 0, url: "", state: .merged)
+        )?.color ?? .purple
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            // `archivebox` and `xmark` are different widths, so a slot that
+            // hugged the symbol would shove the label sideways every time the
+            // pointer crossed the capsule — see `iconSlotSide`. `.small` keeps
+            // the boxier `archivebox` inside the slot while both symbols still
+            // read at this size. The swap is deliberately instant — the chip is
+            // a cancel affordance, and the glyph has to answer "what does a
+            // click do" the moment the pointer lands, not a beat later.
+            Image(systemName: isHovering ? "xmark" : "archivebox")
+                .imageScale(.small)
+                .frame(width: Self.iconSlotSide, height: Self.iconSlotSide)
+                .animation(nil, value: isHovering)
+            // `lineLimit(1)` for the same reason the status items beside it
+            // carry it — `CopyableStatusText`, `PRChipView`, the `+N` menu,
+            // `ParkedPromptStatusItem`: the bar is one line tall, so a squeeze
+            // has to truncate the label rather than wrap it and grow the bar.
+            Text(chip.label)
+                .lineLimit(1)
+        }
+        .font(.caption)
+        .fontWeight(.semibold)
+        .foregroundStyle(.white)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(mergePurple, in: Capsule())
+        // The capsule, padding included, is one click target — the icon is
+        // where the cancel is *announced*, not the only place it can be aimed.
+        .contentShape(Capsule())
+        .help(chip.tooltip)
+        .modifier(StatusBarHoverAffordance(isHovering: $isHovering))
+        .onTapGesture(perform: cancel)
+        .accessibilityElement()
+        .accessibilityLabel(chip.accessibilityLabel)
+        .accessibilityHint(chip.tooltip)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { cancel() }
     }
 }
 

--- a/Tests/TBDAppTests/StatusBarViewAutoArchiveChipTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewAutoArchiveChipTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+// Tier 1: the pure value behind the status bar's auto-archive chip. Only the
+// transform is exercised — the view, the cancel gesture and the purple are not.
+//
+// A `@Suite` struct for the same reason `StatusBarViewChipsTests` is one:
+// `--filter` matches the test ID, which carries the SUITE name, so free
+// functions would be invisible to `--filter StatusBarView`.
+@Suite("StatusBarView auto-archive chip")
+struct StatusBarViewAutoArchiveChipTests {
+
+    @Test("an unarmed worktree gets no chip at all")
+    func notArmed() {
+        #expect(StatusBarView.autoArchiveChip(
+            armed: false, blocked: false, displayName: "invisible-armadillo") == nil)
+        // Children do not conjure a chip for a worktree that never armed.
+        #expect(StatusBarView.autoArchiveChip(
+            armed: false, blocked: true, displayName: "invisible-armadillo") == nil)
+    }
+
+    @Test("an armed worktree says it archives itself on merge")
+    func armed() throws {
+        let chip = try #require(StatusBarView.autoArchiveChip(
+            armed: true, blocked: false, displayName: "invisible-armadillo"))
+        #expect(chip.label == "Archive on merge")
+        #expect(chip.tooltip
+                == "This worktree archives itself when its PR merges. Click to cancel.")
+        #expect(chip.accessibilityLabel == "Archive on merge armed for invisible-armadillo")
+    }
+
+    // "skipped", not "paused" — nothing re-attempts the archive once the
+    // children are gone (`AllResolvedMergeTrigger` is edge-triggered), so the
+    // wording must not have the operator waiting for a resume.
+    @Test("child worktrees skip the archiving, and the tooltip says so")
+    func blocked() throws {
+        let chip = try #require(StatusBarView.autoArchiveChip(
+            armed: true, blocked: true, displayName: "invisible-armadillo"))
+        #expect(chip.tooltip
+                == "Auto-archive is armed, but archiving is skipped while child worktrees exist. Click to cancel.")
+        #expect(!chip.tooltip.contains("paused"))
+    }
+
+    // The whole capsule takes the click, so no tooltip may send the operator
+    // aiming at the ✕ — the glyph is where the cancel is announced, not the
+    // only place it can be hit.
+    @Test("no tooltip names the ✕ as the thing to click")
+    func tooltipsDoNotNameTheGlyph() throws {
+        for blocked in [false, true] {
+            let chip = try #require(StatusBarView.autoArchiveChip(
+                armed: true, blocked: blocked, displayName: "invisible-armadillo"))
+            #expect(!chip.tooltip.contains("✕"))
+            #expect(chip.tooltip.hasSuffix("Click to cancel."))
+        }
+    }
+
+    // Being blocked is not a disarming: the worktree stays armed, so the chip
+    // must not soften its claim. The qualification lives in the tooltip alone.
+    @Test("the label is the same whether or not children block the archiving")
+    func labelStableAcrossBlocking() throws {
+        let unblocked = try #require(StatusBarView.autoArchiveChip(
+            armed: true, blocked: false, displayName: "invisible-armadillo"))
+        let blocked = try #require(StatusBarView.autoArchiveChip(
+            armed: true, blocked: true, displayName: "invisible-armadillo"))
+        #expect(unblocked.label == blocked.label)
+        #expect(unblocked.accessibilityLabel == blocked.accessibilityLabel)
+        #expect(unblocked.tooltip != blocked.tooltip)
+    }
+}


### PR DESCRIPTION
## Summary

Arming a worktree to archive itself when its PR merges is a promise that the worktree will disappear — but until now the only always-on evidence of it was a 12×12 `archivebox` badge composited into the toolbar's PR icon. That is easy to arm once and forget, and the outcome is a worktree that vanishes out from under you.

The status bar now carries a loud purple `Archive on merge` chip whenever the selected worktree is armed, and clicking it disarms in place. The bar is the right home: it is always on screen and already scoped to the current selection, and it has room for words rather than a glyph.

## Why this shape

**No spec.** This is a minor UI change under CLAUDE.md's rule — it adds a second view onto state that already exists and revises no theory of the system. No flag, no migration, no new RPC: `effectiveAutoArchive(for:)`, `setAutoArchive(worktreeID:enabled:)` and `children(of:)` were all already there.

**Loud on purpose.** It is the one non-secondary element in a bar of grey text. The purple is the merge purple `PRStatusPresentation` gives a merged PR, resolved through that shared palette rather than hard-coded, so the chip reads as the state it is waiting for and cannot drift from the sidebar glyph or toolbar icon.

**The whole capsule is the cancel target, and the icon says so.** The leading glyph is `archivebox` at rest — the same symbol the toolbar's armed badge uses, so both surfaces name this state alike — and swaps to an `xmark` under the pointer to announce what a click will do before it lands. The swap is instant and sits in a fixed 11×11 slot, because the two symbols differ in width and the label must not shift on hover. Cancelling therefore never requires finding the toolbar menu or hitting a glyph-sized target. The container carries the accessibility element, so assistive-tech activation performs the same cancel.

**Blocked-by-children changes the tooltip, not the label.** `AutoArchiveOnMergeCoordinator` bails on `hasActiveChildren` and returns `false`. That skip is not a deferral: the archive is driven by a merged *transition*, so it does not re-fire when the children go away. The tooltip therefore says archiving is **skipped** while child worktrees exist rather than "paused", and a test pins that the word "paused" cannot come back. The worktree is still armed, which is why the label keeps saying so — the same division the toolbar's help text makes.

**Cancelling always writes an explicit `false`.** Even when the arming came from the global default. Same as the toolbar toggle, and the only reading of the gesture that survives a later change to that default.

## What this PR does

- `StatusBarView.AutoArchiveChip` + `autoArchiveChip(armed:blocked:displayName:)` — a `nonisolated` pure helper returning the label, tooltip and accessibility label, so the wording is assertable without a view.
- `AutoArchiveChipView` — the rendered chip, in the single-selection cluster after the PR chips. The whole capsule is the click target and the hover state drives the `archivebox`→`xmark` swap.
- Tests in `Tests/TBDAppTests/StatusBarViewAutoArchiveChipTests.swift`.

Two behaviors worth naming for a reviewer, both deliberate:

- The chip does not render for **remote** worktrees, because the bar's `selected` is a `LocalWorktree`. The path/branch and PR clusters are gated identically; the toolbar badge still covers remote. Widening the bar's scope is its own change.
- The toolbar's auto-archive `Toggle` is `.disabled(blocked)`, but the chip will disarm even with children present. Intentional: disarming is always safe, and being able to cancel matters most exactly when the chip is confusing you.

## Assumptions

Assumes the toolbar's PR control remains the primary place arming happens. Note that the control is gated on `!bindings.isEmpty`, so on a worktree with **no PR yet** there is no in-app way to arm auto-archive at all — only `tbd worktree add --archive-on-merge` at creation, or the global default in Settings. That is pre-existing and unchanged here, but it does mean this chip is currently one-way on such a worktree: cancel it and there is no in-app way back until the worktree has a PR.

## Evidence & verification

- Four tests covering both branches of the conditional: not armed → no chip; armed and unblocked → the "archives itself" tooltip; armed and blocked → the "skipped" tooltip; label and accessibility label identical across blocking while the tooltips differ. They fail without the change — the helper is new.
- `scripts/test.sh --filter StatusBarView` → 20 tests in 2 suites passed.
- `scripts/swift-safe build` clean, grepped for `error:` rather than trusting the exit code. `swiftlint --strict` → 0 violations in 788 files.
- Live: app rebuilt and restarted from this worktree, the worktree armed via `worktree.setAutoArchive`, and the chip confirmed on screen in the running app — including the hover swap, the fixed glyph slot, and a click actually disarming.
- The `.imageScale(.small)` was measured, not guessed: at the chip's 10 pt semibold, SwiftUI's default `.medium` scale renders `archivebox` at 13×12, which overflows an 11×11 slot; `.small` gives 10×9 against `xmark`'s 9×8.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=6E2926EC-1A63-4F08-88B1-85DCEC869E55)
