### PR TITLE
feat: warn before archiving a worktree with dev servers still running

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -584,11 +584,54 @@ extension AppState {
     /// spaces are delegated to `archiveScratch(id:)` — the repo-worktree
     /// `worktree.archive` RPC rejects them with `repoNotFound` — so callers
     /// don't have to route per collection.
-    func archiveWorktree(id: UUID, force: Bool = false) async {
+    /// Archive, unless the worktree still has declared dev servers running.
+    ///
+    /// Archiving removes the checkout and kills the terminal windows the
+    /// worktree's sessions live in — but a dev server started inside it does not
+    /// necessarily die with them. A detached supervisor, or one whose parent has
+    /// already exited, is reparented to `launchd` and keeps holding memory and a
+    /// port with nothing left pointing at it. Once the directory is gone, the
+    /// only remaining pointer is a record in a registry nobody thinks to read.
+    ///
+    /// So the first archive attempt asks. Confirming calls back in with
+    /// `devServersConfirmed: true` — the question has been answered, and
+    /// re-asking would make the second click do nothing.
+    ///
+    /// `devServersConfirmed` is a SEPARATE flag from `force`, deliberately.
+    /// `force` already means "skip the archive hook" and bypasses the status
+    /// check for cascade flows; folding this into it would make confirming a
+    /// dev-server prompt silently skip the repo's archive hook, which nobody
+    /// asked for, and would make every cascade flow skip this check.
+    ///
+    /// Only `running` records prompt. A record whose process is definitively gone
+    /// describes nothing an archive could strand, and one that cannot be read is
+    /// not evidence either; prompting on those would train people to click
+    /// through the prompt, which costs more than it saves.
+    func archiveWorktree(
+        id: UUID, force: Bool = false, devServersConfirmed: Bool = false
+    ) async {
         let worktree = findWorktree(id: id)
         if worktree?.isScratch == true {
             await archiveScratch(id: id)
             return
+        }
+        // `localPath` is a filesystem path only for a LOCAL row. On a remote row
+        // it is the synthetic `remote://…` URI that exists to satisfy a NOT NULL
+        // UNIQUE column, and a dev-server registry on this machine can say
+        // nothing about a worktree that lives on another one. Skipping is the
+        // honest answer; comparing would silently never match and read as
+        // "nothing running" for a reason that has nothing to do with the facts.
+        if !devServersConfirmed, let worktree, worktree.localPath.hasPrefix("/") {
+            let running = devServerRegistry.running(inWorktree: worktree.localPath)
+            if !running.isEmpty {
+                pendingArchiveWithDevServers = PendingArchive(
+                    worktreeID: id,
+                    worktreeName: worktree.displayName,
+                    servers: running.map(\.label),
+                    force: force
+                )
+                return
+            }
         }
         let worktreeName = worktree?.displayName ?? "worktree"
         do {

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -611,10 +611,11 @@ extension AppState {
         id: UUID, force: Bool = false, devServersConfirmed: Bool = false
     ) async {
         let worktree = findWorktree(id: id)
-        if worktree?.isScratch == true {
-            await archiveScratch(id: id)
-            return
-        }
+        // The gate runs BEFORE the scratch delegation. A scratch space is a real
+        // directory on disk that can host a dev server exactly like a repo
+        // worktree, and archiving one closes its terminals just the same — so
+        // routing it past the check would leave the feature's guarantee true
+        // only for rows that happen to belong to a repo.
         if let held = Self.devServerArchiveGate(
             worktree: worktree,
             devServersConfirmed: devServersConfirmed,
@@ -622,6 +623,10 @@ extension AppState {
             runningServers: { path in devServerRegistry.running(inWorktree: path).map(\.label) }
         ) {
             pendingArchiveWithDevServers = held
+            return
+        }
+        if worktree?.isScratch == true {
+            await archiveScratch(id: id)
             return
         }
         let worktreeName = worktree?.displayName ?? "worktree"
@@ -1598,6 +1603,19 @@ extension AppState {
     /// - the selected repo worktree is the main branch or still creating
     ///   (those refuse the archive shortcut; scratch rows always proceed —
     ///   the daemon creates them `.active`, never `.main`/`.creating`).
+    /// Declared dev servers still running anywhere in `repoID`'s worktrees.
+    ///
+    /// Removing a repo cascade-archives every active worktree in it — server
+    /// side, in one RPC, without going through `archiveWorktree` — so the
+    /// per-worktree gate cannot see it. This is what the removal confirmation
+    /// asks instead, so that path tells the same truth.
+    func runningDevServers(inRepo repoID: UUID) -> [String] {
+        (worktrees[repoID] ?? [])
+            .filter { $0.status == .active || $0.status == .creating }
+            .filter { $0.localPath.hasPrefix("/") }
+            .flatMap { devServerRegistry.running(inWorktree: $0.localPath).map(\.label) }
+    }
+
     /// Decide whether an archive should be held back for still-running dev
     /// servers. Returns the prompt to show, or `nil` to proceed.
     ///

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -615,23 +615,14 @@ extension AppState {
             await archiveScratch(id: id)
             return
         }
-        // `localPath` is a filesystem path only for a LOCAL row. On a remote row
-        // it is the synthetic `remote://…` URI that exists to satisfy a NOT NULL
-        // UNIQUE column, and a dev-server registry on this machine can say
-        // nothing about a worktree that lives on another one. Skipping is the
-        // honest answer; comparing would silently never match and read as
-        // "nothing running" for a reason that has nothing to do with the facts.
-        if !devServersConfirmed, let worktree, worktree.localPath.hasPrefix("/") {
-            let running = devServerRegistry.running(inWorktree: worktree.localPath)
-            if !running.isEmpty {
-                pendingArchiveWithDevServers = PendingArchive(
-                    worktreeID: id,
-                    worktreeName: worktree.displayName,
-                    servers: running.map(\.label),
-                    force: force
-                )
-                return
-            }
+        if let held = Self.devServerArchiveGate(
+            worktree: worktree,
+            devServersConfirmed: devServersConfirmed,
+            force: force,
+            runningServers: { path in devServerRegistry.running(inWorktree: path).map(\.label) }
+        ) {
+            pendingArchiveWithDevServers = held
+            return
         }
         let worktreeName = worktree?.displayName ?? "worktree"
         do {
@@ -1607,6 +1598,45 @@ extension AppState {
     /// - the selected repo worktree is the main branch or still creating
     ///   (those refuse the archive shortcut; scratch rows always proceed —
     ///   the daemon creates them `.active`, never `.main`/`.creating`).
+    /// Decide whether an archive should be held back for still-running dev
+    /// servers. Returns the prompt to show, or `nil` to proceed.
+    ///
+    /// Pure, and separated from `archiveWorktree` for the same reason
+    /// `archiveShortcutRoute` below is: this is the branch that decides whether
+    /// a destructive action happens, and it should be testable without standing
+    /// up a daemon. `runningServers` is passed in rather than read from the
+    /// registry here so a test can supply the answer directly.
+    ///
+    /// Three ways to proceed without asking, and each is a deliberate choice:
+    ///
+    /// - **Already confirmed.** The question has been answered; re-asking would
+    ///   make the second click appear to do nothing.
+    /// - **No worktree, or a remote one.** `localPath` is a filesystem path only
+    ///   for a local row — on a remote row it is the synthetic `remote://…` URI
+    ///   that exists to satisfy a NOT NULL UNIQUE column. A registry on this
+    ///   machine cannot speak for a worktree on another, and comparing anyway
+    ///   would silently never match, reading as "nothing running" for a reason
+    ///   that has nothing to do with the facts.
+    /// - **Nothing running.** Only `running` records reach here; a definitively
+    ///   dead record describes nothing an archive could strand.
+    nonisolated static func devServerArchiveGate(
+        worktree: Worktree?,
+        devServersConfirmed: Bool,
+        force: Bool,
+        runningServers: (String) -> [String]
+    ) -> PendingArchive? {
+        guard !devServersConfirmed else { return nil }
+        guard let worktree, worktree.localPath.hasPrefix("/") else { return nil }
+        let running = runningServers(worktree.localPath)
+        guard !running.isEmpty else { return nil }
+        return PendingArchive(
+            worktreeID: worktree.id,
+            worktreeName: worktree.displayName,
+            servers: running,
+            force: force
+        )
+    }
+
     nonisolated static func archiveShortcutRoute(
         selectedWorktree: Worktree?
     ) -> UUID? {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -103,6 +103,15 @@ final class AppState: ObservableObject {
     /// Subscription to themeStore.$userThemes changes for reconciling the active scheme.
     private var themeStoreSubscription: AnyCancellable?
 
+    /// Reads the machine-global dev-server registry. Read-only — TBD never
+    /// writes a record; it only asks what a worktree would strand.
+    let devServerRegistry = DevServerRegistry()
+
+    /// Set when an archive was held back because the worktree still has declared
+    /// dev servers running. Confirming re-issues the archive with the same
+    /// `force` it carried, plus `devServersConfirmed: true`.
+    @Published var pendingArchiveWithDevServers: PendingArchive?
+
     @Published var repos: [Repo] = []
     @Published var worktrees: [UUID: [Worktree]] = [:] {
         didSet {

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -317,6 +317,37 @@ struct ContentView: View {
             }
         }
         .alert(
+            "Still running in this worktree",
+            isPresented: Binding(
+                get: { appState.pendingArchiveWithDevServers != nil },
+                set: { if !$0 { appState.pendingArchiveWithDevServers = nil } }
+            ),
+            presenting: appState.pendingArchiveWithDevServers
+        ) { pending in
+            Button("Archive Anyway", role: .destructive) {
+                appState.pendingArchiveWithDevServers = nil
+                Task {
+                    await appState.archiveWorktree(
+                        id: pending.worktreeID,
+                        force: pending.force,
+                        devServersConfirmed: true
+                    )
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                appState.pendingArchiveWithDevServers = nil
+            }
+        } message: { pending in
+            // Names what is running, because "a dev server is running" is not
+            // actionable and "storybook is running" is. Archiving does not stop
+            // them — say so, rather than implying the archive cleans up.
+            Text(
+                "\(pending.worktreeName) still has \(pending.serverList) running. "
+                    + "Archiving removes the worktree but does not stop them, so they "
+                    + "keep running with nothing pointing at them."
+            )
+        }
+        .alert(
             appState.alertIsError ? "Error" : "Success",
             isPresented: Binding(
                 get: { appState.alertMessage != nil },

--- a/Sources/TBDApp/PendingArchive.swift
+++ b/Sources/TBDApp/PendingArchive.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// An archive that was held back because the worktree still has declared dev
+/// servers running.
+///
+/// Carries the names rather than the records: the prompt needs to say what is
+/// running, and nothing downstream of the prompt acts on a record. Keeping the
+/// records out of the app's published state also keeps the confirmation from
+/// going stale in a way the user cannot see — by the time they answer, the
+/// servers may have exited, and the answer is about intent rather than about a
+/// snapshot.
+struct PendingArchive: Identifiable, Equatable {
+    let worktreeID: UUID
+    let worktreeName: String
+    let servers: [String]
+    /// The `force` the held-back call carried, so confirming re-issues the SAME
+    /// archive rather than a subtly different one. `force` means "skip the
+    /// archive hook"; a confirmation must not silently turn that on or off.
+    let force: Bool
+
+    var id: UUID { worktreeID }
+
+    /// "storybook and dev", "a, b, and c" — the prompt reads as a sentence.
+    var serverList: String {
+        switch servers.count {
+        case 0: return ""
+        case 1: return servers[0]
+        case 2: return "\(servers[0]) and \(servers[1])"
+        default:
+            return servers.dropLast().joined(separator: ", ") + ", and " + (servers.last ?? "")
+        }
+    }
+}

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -96,9 +96,34 @@ struct RepoSectionView: View {
         let base = "This unregisters the repo from TBD. Your git repository and files on disk are not touched."
         if activeWorktreeCount > 0 {
             let plural = activeWorktreeCount == 1 ? "worktree" : "worktrees"
-            return "\(activeWorktreeCount) active \(plural) will be archived first.\n\n\(base)"
+            // Removing a repo cascade-archives its worktrees server-side, in one
+            // RPC that never passes through the per-worktree dev-server gate. So
+            // this message carries the same warning, rather than letting the one
+            // path that archives SEVERAL worktrees at once be the one that says
+            // nothing about stranding their servers.
+            let running = appState.runningDevServers(inRepo: repo.id)
+            let serverNote =
+                running.isEmpty
+                ? ""
+                : "\n\n\(Self.serverSentence(running)) still running. Archiving does not stop them."
+            return
+                "\(activeWorktreeCount) active \(plural) will be archived first.\(serverNote)\n\n\(base)"
         }
         return base
+    }
+
+    /// "storybook is", "storybook and dev are" — the sentence has to agree with
+    /// itself or the warning reads as broken and gets dismissed.
+    private static func serverSentence(_ servers: [String]) -> String {
+        let unique = Array(Set(servers)).sorted()
+        let verb = unique.count == 1 ? "is" : "are"
+        let names: String
+        switch unique.count {
+        case 1: names = unique[0]
+        case 2: names = "\(unique[0]) and \(unique[1])"
+        default: names = unique.dropLast().joined(separator: ", ") + ", and " + (unique.last ?? "")
+        }
+        return "\(names) \(verb)"
     }
 
     /// Hoisted out of the chevron `Image`'s `.foregroundStyle` so the type

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -164,7 +164,10 @@ struct RowActionMenuActions {
 
         case .archiveScratch:
             let wtID = worktree.id
-            Task { await appState.archiveScratch(id: wtID) }
+            // Through `archiveWorktree`, not `archiveScratch` directly: it
+            // self-routes scratch rows to the same RPC, and going straight to
+            // the RPC skips the dev-server gate that lives one level up.
+            Task { await appState.archiveWorktree(id: wtID) }
 
         case .deleteScratch:
             let wtID = worktree.id

--- a/Sources/TBDShared/DevServerRegistry.swift
+++ b/Sources/TBDShared/DevServerRegistry.swift
@@ -1,0 +1,250 @@
+import Darwin
+import Foundation
+
+/// Reads the machine-global dev-server registry: a small cross-app convention
+/// for declaring long-lived development servers so that "what is running, for
+/// which worktree, and how do I stop it" is a lookup rather than a guess.
+///
+/// ## Why TBD reads this
+///
+/// Archiving a worktree removes its checkout and kills the terminal windows its
+/// sessions live in. A development server started inside that worktree does not
+/// necessarily die with them — a detached supervisor, or a process whose parent
+/// exited, is reparented to `launchd` and keeps running with nothing left
+/// pointing at it. The directory it was started from can be gone while the
+/// process is still holding memory and a port.
+///
+/// So before an archive removes the last thing that would have told you the
+/// server existed, TBD can say: this worktree still has something running.
+///
+/// ## What this is not
+///
+/// **Read-only.** TBD never writes a record. Records are written by whatever
+/// launcher started the process; a reader that also wrote would have to agree
+/// with every writer about fields it does not own.
+///
+/// **Not a census.** Only a launcher that opts in declares anything. A server
+/// started by hand from a shell declares nothing, so an empty result means "no
+/// declarations", never "nothing is running".
+///
+/// **Never a command interpreter.** A record's `command` field is display text.
+/// Records are written at runtime by any process, with no review, while this app
+/// is trusted and long-running — so executing a string out of one would let a
+/// process that cannot run arbitrary commands itself get one run on its behalf.
+/// The stop vocabulary is a closed set of typed methods for the same reason.
+public enum DevServerLiveness: String, Sendable {
+    /// A process with the recorded identity is alive.
+    case running
+    /// The recorded process is definitively gone.
+    case stale
+    /// The record could not be read, or the process table could not be. This is
+    /// deliberately distinct from `stale`: "cannot tell" must never be treated
+    /// as "safe to act on".
+    case indeterminate
+}
+
+/// One declared server.
+public struct DevServerRecord: Sendable, Equatable {
+    /// The schema version this reader understands. An unrecognised version
+    /// reads `indeterminate` — a future record's fields cannot be interpreted,
+    /// so nothing may be concluded from them.
+    public static let supportedVersion = 1
+
+    /// Implementations may differ on truncate-vs-round when converting a process
+    /// start time to whole seconds. One second of slack costs nothing and
+    /// prevents a cross-implementation disagreement from reporting every live
+    /// server as dead.
+    public static let startEpochToleranceSeconds = 1
+
+    public let version: Int
+    public let label: String
+    /// Absolute path of the worktree this server belongs to.
+    public let root: String
+    /// Display text. Never executed.
+    public let command: String
+    public let pid: Int32?
+    public let startEpoch: Int?
+
+    public init(
+        version: Int, label: String, root: String, command: String,
+        pid: Int32?, startEpoch: Int?
+    ) {
+        self.version = version
+        self.label = label
+        self.root = root
+        self.command = command
+        self.pid = pid
+        self.startEpoch = startEpoch
+    }
+
+    /// Parse one record, or `nil` when it cannot be read.
+    ///
+    /// `nil` means indeterminate, never stale.
+    public static func decode(from data: Data) -> DevServerRecord? {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let json = object as? [String: Any],
+            let version = json["version"] as? Int,
+            let label = json["label"] as? String,
+            let root = json["root"] as? String
+        else { return nil }
+        let proc = json["proc"] as? [String: Any]
+        return DevServerRecord(
+            version: version,
+            label: label,
+            root: root,
+            command: json["command"] as? String ?? "",
+            pid: (proc?["pid"] as? Int).map(Int32.init),
+            startEpoch: proc?["start_epoch"] as? Int
+        )
+    }
+}
+
+/// Answers the kernel questions a record's liveness depends on.
+///
+/// A protocol because the states that matter — a reused pid, a process that
+/// exited without being reaped — cannot be produced on demand from a test.
+public protocol DevServerProcessProbe: Sendable {
+    /// Unix epoch seconds at which `pid` started, or `nil` if no such process.
+    func startEpoch(pid: Int32) -> Int?
+    /// Has `pid` exited without being reaped?
+    func isZombie(pid: Int32) -> Bool
+}
+
+/// `sysctl(KERN_PROC_PID)`, which answers both questions from one struct.
+public struct SysctlDevServerProbe: DevServerProcessProbe {
+    public init() {}
+
+    /// `SZOMB` from `<sys/proc.h>`; a C `#define`, so it does not come across in
+    /// the Darwin module.
+    private static let zombieState: Int32 = 5
+
+    private func info(pid: Int32) -> kinfo_proc? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        var record = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        let result = sysctl(&mib, UInt32(mib.count), &record, &size, nil, 0)
+        // A missing pid is not an error: sysctl returns 0 and sets size to 0.
+        // Checking only the return value reads "no such process" as a valid
+        // all-zero record, i.e. a process that started at the epoch.
+        guard result == 0, size > 0 else { return nil }
+        return record
+    }
+
+    public func startEpoch(pid: Int32) -> Int? {
+        guard pid > 0, let record = info(pid: pid) else { return nil }
+        return Int(record.kp_proc.p_starttime.tv_sec)
+    }
+
+    public func isZombie(pid: Int32) -> Bool {
+        guard pid > 0, let record = info(pid: pid) else { return false }
+        return record.kp_proc.p_stat == Self.zombieState
+    }
+}
+
+/// A record plus the verdict derived from the kernel.
+public struct DevServerEntry: Sendable, Equatable {
+    public let label: String
+    public let root: String
+    /// Display text. Never executed.
+    public let command: String
+    public let liveness: DevServerLiveness
+
+    public init(label: String, root: String, command: String, liveness: DevServerLiveness) {
+        self.label = label
+        self.root = root
+        self.command = command
+        self.liveness = liveness
+    }
+}
+
+public struct DevServerRegistry: Sendable {
+    private let probe: DevServerProcessProbe
+
+    public init(probe: DevServerProcessProbe = SysctlDevServerProbe()) {
+        self.probe = probe
+    }
+
+    /// `${XDG_STATE_HOME:-~/.local/state}/dev-servers/`.
+    ///
+    /// No vendor segment: the directory is a shared surface that several
+    /// unrelated applications write to, and a name owned by one of them gives
+    /// the next adopter a reason to invent a second directory instead.
+    public static func directory(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        if let state = environment["XDG_STATE_HOME"], !state.isEmpty {
+            return URL(fileURLWithPath: state).appendingPathComponent("dev-servers")
+        }
+        return home.appendingPathComponent(".local/state/dev-servers")
+    }
+
+    /// Liveness of `(pid, startEpoch)`, asked of the kernel.
+    ///
+    /// The identity is the pair, not the pid: a pid alone is reused, and a
+    /// record naming a recycled pid would otherwise describe a stranger.
+    static func liveness(
+        pid: Int32?, startEpoch: Int?, probe: DevServerProcessProbe
+    ) -> DevServerLiveness {
+        guard let pid, let startEpoch, pid > 0 else { return .indeterminate }
+        guard let actual = probe.startEpoch(pid: pid) else { return .stale }
+        guard abs(actual - startEpoch) <= DevServerRecord.startEpochToleranceSeconds else {
+            return .stale
+        }
+        // A process that exited without being reaped still reports its original
+        // start time, so the pair alone reads a dead server as running forever.
+        return probe.isZombie(pid: pid) ? .stale : .running
+    }
+
+    static func liveness(of record: DevServerRecord, probe: DevServerProcessProbe) -> DevServerLiveness {
+        guard record.version == DevServerRecord.supportedVersion else { return .indeterminate }
+        return liveness(pid: record.pid, startEpoch: record.startEpoch, probe: probe)
+    }
+
+    /// Every declared server, whatever its state.
+    public func all(directory: URL? = nil) -> [DevServerEntry] {
+        let dir = directory ?? Self.directory()
+        let files =
+            (try? FileManager.default.contentsOfDirectory(
+                at: dir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+            )) ?? []
+
+        return files.filter { $0.pathExtension == "json" }.map { url in
+            guard
+                let data = try? Data(contentsOf: url),
+                let record = DevServerRecord.decode(from: data)
+            else {
+                // An unreadable file is surfaced rather than dropped: skipping it
+                // would make a malformed record indistinguishable from no record.
+                return DevServerEntry(
+                    label: url.deletingPathExtension().lastPathComponent,
+                    root: "", command: "", liveness: .indeterminate
+                )
+            }
+            return DevServerEntry(
+                label: record.label,
+                root: record.root,
+                command: record.command,
+                liveness: Self.liveness(of: record, probe: probe)
+            )
+        }
+    }
+
+    /// Servers still running in `worktreePath`.
+    ///
+    /// Only `running` — the question this answers is "will archiving this strand
+    /// something", and neither a definitively-dead record nor one that cannot be
+    /// read is evidence that it will.
+    ///
+    /// Paths are compared after symlink resolution: a record is written with a
+    /// fully-resolved root, while a worktree path can arrive through a symlinked
+    /// ancestor, and the two would otherwise never match.
+    public func running(inWorktree worktreePath: String, directory: URL? = nil) -> [DevServerEntry] {
+        let target = URL(fileURLWithPath: worktreePath).resolvingSymlinksInPath().path
+        return all(directory: directory).filter { entry in
+            guard entry.liveness == .running, !entry.root.isEmpty else { return false }
+            return URL(fileURLWithPath: entry.root).resolvingSymlinksInPath().path == target
+        }
+    }
+}

--- a/Tests/TBDAppTests/DevServerArchiveGateTests.swift
+++ b/Tests/TBDAppTests/DevServerArchiveGateTests.swift
@@ -109,6 +109,31 @@ struct DevServerArchiveGateTests {
         #expect(asked == "/tmp/some-worktree")
     }
 
+    /// A scratch space is a real directory that can host a dev server, and
+    /// archiving one closes its terminals just the same. The gate must see it —
+    /// `archiveWorktree` used to delegate scratch rows before running the check,
+    /// which made the guarantee true only for rows belonging to a repo.
+    @Test func aScratchRowIsGatedLikeAnyOther() {
+        let scratch = Worktree(
+            id: UUID(),
+            repoID: nil,
+            name: "scratch",
+            displayName: "Scratch",
+            branch: "main",
+            path: "/tmp/scratch-wt",
+            status: .active,
+            tmuxServer: "test-server"
+        )
+        #expect(scratch.isScratch)
+        let held = AppState.devServerArchiveGate(
+            worktree: scratch,
+            devServersConfirmed: false,
+            force: false,
+            runningServers: { _ in ["dev"] }
+        )
+        #expect(held?.servers == ["dev"])
+    }
+
     /// `force` means "skip the archive hook". It has to survive the round trip
     /// so confirming re-issues the SAME archive; flipping it here would run, or
     /// skip, a repo's hook against the user's intent.

--- a/Tests/TBDAppTests/DevServerArchiveGateTests.swift
+++ b/Tests/TBDAppTests/DevServerArchiveGateTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import TBDShared
+import Testing
+
+@testable import TBDApp
+
+private func makeWorktree(
+    id: UUID = UUID(),
+    displayName: String = "my-feature",
+    localPath: String = "/tmp/wt"
+) -> Worktree {
+    Worktree(
+        id: id,
+        repoID: UUID(),
+        name: "wt",
+        displayName: displayName,
+        branch: "main",
+        path: localPath,
+        status: .active,
+        tmuxServer: "test-server"
+    )
+}
+
+/// The branch that decides whether a destructive action happens.
+///
+/// Separated from `archiveWorktree` so each arm is reachable without standing up
+/// a daemon — the same reason `archiveShortcutRoute` is a pure seam. Every arm
+/// below is a way the archive can proceed *without* asking, and each one is a
+/// decision rather than a default, so each gets its own case.
+@Suite("dev-server archive gate")
+struct DevServerArchiveGateTests {
+
+    @Test func holdsTheArchiveWhenAServerIsRunning() {
+        let id = UUID()
+        let held = AppState.devServerArchiveGate(
+            worktree: makeWorktree(id: id, displayName: "my-feature"),
+            devServersConfirmed: false,
+            force: false,
+            runningServers: { _ in ["storybook", "dev"] }
+        )
+        #expect(held?.worktreeID == id)
+        #expect(held?.worktreeName == "my-feature")
+        #expect(held?.servers == ["storybook", "dev"])
+    }
+
+    @Test func proceedsWhenNothingIsRunning() {
+        let held = AppState.devServerArchiveGate(
+            worktree: makeWorktree(),
+            devServersConfirmed: false,
+            force: false,
+            runningServers: { _ in [] }
+        )
+        #expect(held == nil)
+    }
+
+    /// The question has been answered. Re-asking would make the second click
+    /// appear to do nothing, and the prompt would be unescapable.
+    @Test func proceedsOnceConfirmedEvenWithServersStillRunning() {
+        let held = AppState.devServerArchiveGate(
+            worktree: makeWorktree(),
+            devServersConfirmed: true,
+            force: false,
+            runningServers: { _ in ["dev"] }
+        )
+        #expect(held == nil)
+    }
+
+    /// A remote row's `localPath` is the synthetic `remote://…` URI, not a
+    /// filesystem path. A registry on this machine cannot speak for a worktree
+    /// on another one, so the gate does not consult it at all — rather than
+    /// consulting it and relying on the comparison never matching.
+    @Test func proceedsForARemoteRowWithoutConsultingTheRegistry() {
+        var consulted = false
+        let held = AppState.devServerArchiveGate(
+            worktree: makeWorktree(localPath: "remote://provider/session-id"),
+            devServersConfirmed: false,
+            force: false,
+            runningServers: { _ in
+                consulted = true
+                return ["dev"]
+            }
+        )
+        #expect(held == nil)
+        #expect(consulted == false, "a remote row must not be looked up in a local registry")
+    }
+
+    @Test func proceedsWhenThereIsNoWorktree() {
+        let held = AppState.devServerArchiveGate(
+            worktree: nil,
+            devServersConfirmed: false,
+            force: false,
+            runningServers: { _ in ["dev"] }
+        )
+        #expect(held == nil)
+    }
+
+    /// The gate asks about the worktree it was given, not some other path.
+    @Test func looksUpTheWorktreesOwnPath() {
+        var asked: String?
+        _ = AppState.devServerArchiveGate(
+            worktree: makeWorktree(localPath: "/tmp/some-worktree"),
+            devServersConfirmed: false,
+            force: false,
+            runningServers: { path in
+                asked = path
+                return []
+            }
+        )
+        #expect(asked == "/tmp/some-worktree")
+    }
+
+    /// `force` means "skip the archive hook". It has to survive the round trip
+    /// so confirming re-issues the SAME archive; flipping it here would run, or
+    /// skip, a repo's hook against the user's intent.
+    @Test func forceIsCarriedIntoTheHeldArchive() {
+        for force in [true, false] {
+            let held = AppState.devServerArchiveGate(
+                worktree: makeWorktree(),
+                devServersConfirmed: false,
+                force: force,
+                runningServers: { _ in ["dev"] }
+            )
+            #expect(held?.force == force)
+        }
+    }
+}

--- a/Tests/TBDAppTests/PendingArchiveTests.swift
+++ b/Tests/TBDAppTests/PendingArchiveTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+/// The prompt has to read as a sentence. "storybook, dev running" is a list
+/// pasted into prose; "storybook and dev" is English, and the difference is
+/// whether the person reads the warning or dismisses it.
+@Test func serverListReadsAsASentence() {
+    #expect(makePending(servers: []).serverList == "")
+    #expect(makePending(servers: ["dev"]).serverList == "dev")
+    #expect(makePending(servers: ["storybook", "dev"]).serverList == "storybook and dev")
+    #expect(
+        makePending(servers: ["a", "b", "c"]).serverList == "a, b, and c")
+    #expect(
+        makePending(servers: ["a", "b", "c", "d"]).serverList == "a, b, c, and d")
+}
+
+/// Identity is the worktree, so SwiftUI replaces rather than stacks a prompt if
+/// a second archive attempt arrives for the same worktree.
+@Test func identityIsTheWorktree() {
+    let id = UUID()
+    #expect(makePending(id: id, servers: ["a"]).id == id)
+}
+
+/// `force` round-trips so a confirmation re-issues the SAME archive. It means
+/// "skip the archive hook" — a confirmation that silently flipped it would run,
+/// or skip, a repo's hook against the user's intent.
+@Test func forceRoundTripsThroughTheConfirmation() {
+    #expect(makePending(servers: ["dev"], force: true).force == true)
+    #expect(makePending(servers: ["dev"], force: false).force == false)
+}
+
+private func makePending(
+    id: UUID = UUID(), name: String = "worktree", servers: [String], force: Bool = false
+) -> PendingArchive {
+    PendingArchive(worktreeID: id, worktreeName: name, servers: servers, force: force)
+}

--- a/Tests/TBDSharedTests/DevServerRegistryTests.swift
+++ b/Tests/TBDSharedTests/DevServerRegistryTests.swift
@@ -195,22 +195,22 @@ private func makeDirectory() throws -> URL {
 @Test func directoryHonoursXDGStateHome() {
     let url = DevServerRegistry.directory(
         environment: ["XDG_STATE_HOME": "/tmp/state"],
-        home: URL(fileURLWithPath: "/Users/someone"))
+        home: URL(fileURLWithPath: "/tmp/test-home"))
     #expect(url.path == "/tmp/state/dev-servers")
 }
 
 @Test func directoryFallsBackToTheHomeDefault() {
     let url = DevServerRegistry.directory(
-        environment: [:], home: URL(fileURLWithPath: "/Users/someone"))
-    #expect(url.path == "/Users/someone/.local/state/dev-servers")
+        environment: [:], home: URL(fileURLWithPath: "/tmp/test-home"))
+    #expect(url.path == "/tmp/test-home/.local/state/dev-servers")
 }
 
 /// An empty value is not a value. Treating it as one yields `/dev-servers` at
 /// the filesystem root, which silently reads nothing forever.
 @Test func directoryIgnoresAnEmptyXDGStateHome() {
     let url = DevServerRegistry.directory(
-        environment: ["XDG_STATE_HOME": ""], home: URL(fileURLWithPath: "/Users/someone"))
-    #expect(url.path == "/Users/someone/.local/state/dev-servers")
+        environment: ["XDG_STATE_HOME": ""], home: URL(fileURLWithPath: "/tmp/test-home"))
+    #expect(url.path == "/tmp/test-home/.local/state/dev-servers")
 }
 
 // MARK: - The real probe is wired to the kernel

--- a/Tests/TBDSharedTests/DevServerRegistryTests.swift
+++ b/Tests/TBDSharedTests/DevServerRegistryTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+
+@testable import TBDShared
+
+/// A probe whose answers the test chooses.
+///
+/// The states that decide this feature — a reused pid, a process that exited
+/// without being reaped — cannot be produced on demand from a test process, and
+/// getting them wrong means telling someone their worktree is safe to archive
+/// when it is not (or nagging them when it is).
+private struct StubProbe: DevServerProcessProbe {
+    var starts: [Int32: Int] = [:]
+    var zombies: Set<Int32> = []
+
+    func startEpoch(pid: Int32) -> Int? { starts[pid] }
+    func isZombie(pid: Int32) -> Bool { zombies.contains(pid) }
+}
+
+private func writeRecord(
+    in directory: URL,
+    name: String,
+    version: Int = 1,
+    label: String = "dev",
+    root: String,
+    command: String = "start the dev server",
+    pid: Int = 4242,
+    startEpoch: Int = 1_700_000_000
+) throws {
+    let json = """
+        {
+          "version": \(version),
+          "label": "\(label)",
+          "root": "\(root)",
+          "command": "\(command)",
+          "proc": { "pid": \(pid), "start_epoch": \(startEpoch) },
+          "stop": []
+        }
+        """
+    try json.write(
+        to: directory.appendingPathComponent("\(name).json"), atomically: true, encoding: .utf8)
+}
+
+private func makeDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("dev-servers-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+// MARK: - Liveness
+
+@Test func matchingPidAndStartTimeIsRunning() {
+    let probe = StubProbe(starts: [4242: 1_700_000_000])
+    #expect(
+        DevServerRegistry.liveness(pid: 4242, startEpoch: 1_700_000_000, probe: probe) == .running)
+}
+
+@Test func absentPidIsStale() {
+    #expect(
+        DevServerRegistry.liveness(pid: 4242, startEpoch: 1_700_000_000, probe: StubProbe())
+            == .stale)
+}
+
+/// The identity is the pair, not the pid. A live pid that started at a different
+/// time is a different process, and treating it as the recorded one is how a
+/// `.pid`-file scheme ends up pointing at a stranger.
+@Test func reusedPidIsStaleNotRunning() {
+    let probe = StubProbe(starts: [4242: 1_700_000_000 + 86_400])
+    #expect(
+        DevServerRegistry.liveness(pid: 4242, startEpoch: 1_700_000_000, probe: probe) == .stale)
+}
+
+/// A zombie still reports its original start time, so the pair alone reads a
+/// dead server as running forever.
+@Test func zombieIsStale() {
+    let probe = StubProbe(starts: [4242: 1_700_000_000], zombies: [4242])
+    #expect(
+        DevServerRegistry.liveness(pid: 4242, startEpoch: 1_700_000_000, probe: probe) == .stale)
+}
+
+/// Implementations may truncate or round when deriving whole seconds. A
+/// one-second disagreement must not report every live server as dead.
+@Test func oneSecondOfSkewIsStillRunning() {
+    let probe = StubProbe(starts: [4242: 1_700_000_001])
+    #expect(
+        DevServerRegistry.liveness(pid: 4242, startEpoch: 1_700_000_000, probe: probe) == .running)
+}
+
+@Test func missingIdentityIsIndeterminate() {
+    let probe = StubProbe(starts: [4242: 1_700_000_000])
+    #expect(DevServerRegistry.liveness(pid: nil, startEpoch: 1, probe: probe) == .indeterminate)
+    #expect(DevServerRegistry.liveness(pid: 4242, startEpoch: nil, probe: probe) == .indeterminate)
+}
+
+/// A future record's fields cannot be interpreted, so nothing may be concluded
+/// from them — least of all that the thing it describes is gone.
+@Test func unknownSchemaVersionIsIndeterminateNotStale() {
+    let record = DevServerRecord(
+        version: 99, label: "dev", root: "/tmp/x", command: "", pid: 4242,
+        startEpoch: 1_700_000_000)
+    #expect(DevServerRegistry.liveness(of: record, probe: StubProbe()) == .indeterminate)
+}
+
+// MARK: - Decoding
+
+@Test func malformedRecordsDoNotDecode() {
+    #expect(DevServerRecord.decode(from: Data("not json".utf8)) == nil)
+    #expect(DevServerRecord.decode(from: Data(#"{"version": 1}"#.utf8)) == nil)
+}
+
+@Test func recordDecodesItsFields() throws {
+    let json = """
+        {"version":1,"label":"dev","root":"/tmp/wt","command":"display only",
+         "proc":{"pid":7,"start_epoch":123}}
+        """
+    let record = try #require(DevServerRecord.decode(from: Data(json.utf8)))
+    #expect(record.label == "dev")
+    #expect(record.root == "/tmp/wt")
+    #expect(record.command == "display only")
+    #expect(record.pid == 7)
+    #expect(record.startEpoch == 123)
+}
+
+// MARK: - Selecting what would be stranded by an archive
+
+@Test func runningInWorktreeFindsOnlyThatWorktree() throws {
+    let dir = try makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeRecord(in: dir, name: "a", label: "mine", root: "/tmp/wt-a")
+    try writeRecord(in: dir, name: "b", label: "theirs", root: "/tmp/wt-b", pid: 5151)
+
+    let registry = DevServerRegistry(
+        probe: StubProbe(starts: [4242: 1_700_000_000, 5151: 1_700_000_000]))
+    let running = registry.running(inWorktree: "/tmp/wt-a", directory: dir)
+
+    #expect(running.map(\.label) == ["mine"])
+}
+
+/// Only `running` counts. A definitively-dead record describes nothing that an
+/// archive could strand, and one that cannot be read is not evidence either —
+/// warning on those trains people to click through the warning.
+@Test func staleAndIndeterminateRecordsAreNotReportedAsRunning() throws {
+    let dir = try makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeRecord(in: dir, name: "gone", label: "gone", root: "/tmp/wt", pid: 1111)
+    try writeRecord(
+        in: dir, name: "future", version: 99, label: "future", root: "/tmp/wt", pid: 2222)
+    try "not json".write(
+        to: dir.appendingPathComponent("broken.json"), atomically: true, encoding: .utf8)
+
+    // No pid is alive.
+    let registry = DevServerRegistry(probe: StubProbe())
+    #expect(registry.running(inWorktree: "/tmp/wt", directory: dir).isEmpty)
+
+    // …but all three are still visible in the full listing, so a malformed
+    // record is never silently indistinguishable from no record at all.
+    #expect(registry.all(directory: dir).count == 3)
+}
+
+/// A record is written with a fully-resolved root while a worktree path can
+/// arrive through a symlinked ancestor. Comparing the raw strings would report
+/// "nothing running" for every worktree under such a path — the failure would
+/// look exactly like the feature working.
+@Test func worktreePathsAreComparedAfterResolvingSymlinks() throws {
+    let dir = try makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let real = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wt-real-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: real) }
+
+    let link = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wt-link-\(UUID().uuidString)")
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+    defer { try? FileManager.default.removeItem(at: link) }
+
+    try writeRecord(in: dir, name: "a", label: "dev", root: real.resolvingSymlinksInPath().path)
+
+    let registry = DevServerRegistry(probe: StubProbe(starts: [4242: 1_700_000_000]))
+    #expect(registry.running(inWorktree: link.path, directory: dir).map(\.label) == ["dev"])
+}
+
+@Test func anAbsentRegistryDirectoryIsEmptyNotAnError() {
+    let registry = DevServerRegistry(probe: StubProbe())
+    let missing = FileManager.default.temporaryDirectory
+        .appendingPathComponent("definitely-absent-\(UUID().uuidString)")
+    #expect(registry.all(directory: missing).isEmpty)
+    #expect(registry.running(inWorktree: "/tmp/wt", directory: missing).isEmpty)
+}
+
+// MARK: - Location
+
+@Test func directoryHonoursXDGStateHome() {
+    let url = DevServerRegistry.directory(
+        environment: ["XDG_STATE_HOME": "/tmp/state"],
+        home: URL(fileURLWithPath: "/Users/someone"))
+    #expect(url.path == "/tmp/state/dev-servers")
+}
+
+@Test func directoryFallsBackToTheHomeDefault() {
+    let url = DevServerRegistry.directory(
+        environment: [:], home: URL(fileURLWithPath: "/Users/someone"))
+    #expect(url.path == "/Users/someone/.local/state/dev-servers")
+}
+
+/// An empty value is not a value. Treating it as one yields `/dev-servers` at
+/// the filesystem root, which silently reads nothing forever.
+@Test func directoryIgnoresAnEmptyXDGStateHome() {
+    let url = DevServerRegistry.directory(
+        environment: ["XDG_STATE_HOME": ""], home: URL(fileURLWithPath: "/Users/someone"))
+    #expect(url.path == "/Users/someone/.local/state/dev-servers")
+}
+
+// MARK: - The real probe is wired to the kernel
+
+/// The stub above is what makes the interesting cases reachable; this is what
+/// stops the suite passing against a probe that answers `nil` for everything.
+@Test func realProbeAnswersForThisProcessAndNotForAnUnallocatablePid() {
+    let probe = SysctlDevServerProbe()
+    let mine = probe.startEpoch(pid: ProcessInfo.processInfo.processIdentifier)
+    #expect(mine != nil)
+    if let mine {
+        #expect(mine <= Int(Date().timeIntervalSince1970))
+    }
+    #expect(probe.isZombie(pid: ProcessInfo.processInfo.processIdentifier) == false)
+    #expect(probe.startEpoch(pid: 4_194_303) == nil)
+}

--- a/docs/specs/2026-08-20-dev-server-registry-design.md
+++ b/docs/specs/2026-08-20-dev-server-registry-design.md
@@ -1,0 +1,166 @@
+# Dev-server registry — design
+
+TBD reads a machine-global registry of running development servers so it can
+warn, before archiving a worktree, that archiving will strand something.
+
+This document specifies the on-disk convention TBD reads, the liveness rule it
+applies, and the boundaries it deliberately does not cross. It is written for a
+reader implementing a *writer* — a launcher that starts dev servers and wants TBD
+(and other consumers) to know about them.
+
+## The problem
+
+Archiving a worktree removes its checkout and closes the terminals its sessions
+live in. A development server started inside that worktree does not necessarily
+go with them. A supervisor started detached, or a process whose parent has
+already exited, is reparented to `launchd` and keeps running — holding memory and
+a port, with a working directory that no longer exists.
+
+Nothing surfaces this. The row disappears from the sidebar and the process
+carries on, discoverable only by reading `ps` by eye and recognising the argv.
+
+Detection cannot close this. Inferring "is a dev server running for this
+worktree" from the process table means matching argv patterns against a set of
+server names, and the process that survives is usually the *supervisor* — a task
+runner, a process manager, a package-manager wrapper — whose argv contains none
+of them, while the recognisable server is its child and no longer a candidate
+because its parent is gone. Whoever *starts* the process is the only party that
+reliably knows what it is.
+
+So the convention is declaration: the launcher writes a record.
+
+## The convention
+
+A record is a JSON file in:
+
+```
+${XDG_STATE_HOME:-~/.local/state}/dev-servers/
+```
+
+- **Machine-global, not inside the worktree.** A record placed in the worktree
+  would be deleted with the worktree — destroying the only pointer to the process
+  at the exact moment that process becomes an orphan. The registry's lifetime
+  must be at least the process's, and the process's is unbounded.
+- **No vendor segment in the path.** The directory is a surface several unrelated
+  applications write to and read. A segment owned by one of them gives the next
+  adopter a reason to create a second directory rather than join the first, and
+  a convention with two directories is not a convention.
+- **Not `$XDG_RUNTIME_DIR`,** which looks like the natural home and is wrong: it
+  is cleared when the login session ends, and surviving the session is the entire
+  problem.
+
+### Record shape
+
+The fields TBD reads:
+
+- **`version`** — schema version, currently `1`. A version this build does not
+  recognise reads *indeterminate*: its fields cannot be interpreted, so nothing
+  may be concluded from them.
+- **`label`** — a short name shown to the user, e.g. `dev`, `storybook`.
+- **`root`** — absolute, symlink-resolved path of the worktree the server belongs
+  to.
+- **`command`** — display text describing what was started. **Never executed.**
+- **`proc.pid`** and **`proc.start_epoch`** — the process identity: its pid, and
+  its start time in whole Unix epoch seconds.
+
+Records carry more than this — endpoints, an owning session, typed stop methods.
+TBD ignores what it does not need; a reader must tolerate fields it does not
+know, and a writer may add them.
+
+Writers should create the file atomically (write a temporary file in the same
+directory, then rename over the destination) so a reader never observes a partial
+record.
+
+## Liveness
+
+**The record is not trusted to be current.** The common case is a writer that
+died without cleaning up — that is the failure this whole feature exists for — so
+a design that depends on the writer removing its own record, or refreshing a
+heartbeat, reproduces the original problem inside the registry. A stale record is
+the expected state, not an error.
+
+Liveness is therefore asked of the kernel, using `(pid, start_epoch)` as the
+identity:
+
+- **running** — a process with that pid exists and its start time matches.
+- **stale** — no process has that pid, *or* one does but started at a different
+  time. Definitively gone.
+- **indeterminate** — the record could not be read, or its version is not
+  understood.
+
+Two failure modes this specifically defeats:
+
+- **Pid reuse.** A pid alone is recycled, so a record naming one would eventually
+  describe a stranger — the flaw every `.pid` file scheme has. Pairing it with
+  the start time makes the identity unforgeable by accident.
+- **Unreaped exits.** A process that has exited but has not been waited for still
+  appears in the process table and still reports its original start time, so the
+  pair check alone would read a dead server as running forever. Whether one
+  lingers is a property of the reaping parent, not of the OS, which is why it
+  cannot be assumed away.
+
+Comparison allows one second of slack, because implementations may differ on
+truncating versus rounding when deriving whole seconds, and a cross-implementation
+disagreement would otherwise report every live server as dead.
+
+### Three states, not two
+
+`stale` and `indeterminate` are different answers and only the first is evidence.
+Collapsing them into "not running" would be harmless here — TBD only warns — but
+the distinction is part of the convention rather than of this feature, because a
+consumer that *acts* (stopping a process, reclaiming a resource) must never treat
+"cannot tell" as "safe to act on".
+
+## What TBD does with it
+
+Before archiving a local worktree, TBD asks the registry which declared servers
+in that worktree read `running`. If any do, it holds the archive and asks:
+
+> `my-feature` still has storybook and dev running. Archiving removes the
+> worktree but does not stop them, so they keep running with nothing pointing at
+> them.
+
+Confirming re-issues the archive; cancelling does nothing.
+
+Only `running` prompts. A `stale` record describes nothing an archive could
+strand, and an `indeterminate` one is not evidence either — prompting on those
+teaches people to click through the prompt, which costs more than the warning
+saves.
+
+Remote rows are skipped without consulting the registry at all: their
+`localPath` is a synthetic `remote://` URI rather than a filesystem path, and a
+registry on this machine cannot speak for a worktree on another one.
+
+## Boundaries
+
+- **TBD never writes a record.** Writers own fields a reader would otherwise have
+  to agree with them about, and a reader that writes becomes a second source of
+  truth for a file it does not own.
+- **TBD never stops anything through this.** Stopping belongs to whoever owns the
+  process. This feature answers one question — *would archiving strand
+  something?* — and leaves the rest alone.
+- **No string from a record is ever executed.** `command` is display text.
+  Records are written at runtime by any process, with no review, while TBD is
+  long-running and trusted; executing a record-supplied string would let a
+  process that cannot run arbitrary commands itself get one run on its behalf.
+  A "path to an executable" field is the same hole with one level of indirection
+  and is equally excluded. Where a consumer acts on a record at all, the
+  vocabulary is a closed set of typed methods and the consumer supplies the
+  executable.
+- **Declaration is never complete, and the design says so.** Only a launcher that
+  opts in declares anything; a server started by hand from a shell declares
+  nothing. An empty result means "nothing declared", never "nothing running", and
+  a consumer that reads it as a census has misread it.
+
+## Rejected alternatives
+
+- **A daemon or broker owning the registry.** The directory is the coordination
+  point precisely so that adopting the convention costs a file write. A shared
+  runtime dependency between unrelated applications is a reason not to adopt it.
+- **Heartbeats or a TTL.** Both require the writer to keep behaving after the
+  moment it stops behaving, which is the failure being modelled.
+- **Health or readiness in the record.** Stale the instant it is written; ask the
+  endpoint.
+- **Detection instead of declaration.** Covered above: the surviving process is
+  usually the one whose argv identifies nothing.
+- **A per-worktree file.** Deleted with the worktree, at exactly the wrong moment.


### PR DESCRIPTION
## Summary

Archiving a worktree closes the terminals its sessions live in, and a dev server started inside it does not necessarily go with them. #681 now reclaims those — its sweep kills processes whose cwd is inside an archived worktree, at daemon start and hourly after.

So the process no longer leaks. What is still missing is that **you are not told**, and the decision is made for you: you archive, nothing appears to happen, and within the hour a server you may have wanted is gone. The reverse is just as opaque — a server you forgot about is reclaimed silently and you never learn it was running.

This asks first: *"`my-feature` still has storybook and dev running. Archiving removes the worktree, and its servers will be reclaimed."* Archive Anyway, or Cancel.

**This is the prevent half of #681's clean-up half, not a second cleaner.** It does not kill anything, and it does not change what the sweep reclaims. It adds the moment of choice ahead of an action that is otherwise irreversible-by-schedule, and it can name what is running — `storybook and dev` — which a cwd-keyed sweep structurally cannot, because it identifies processes by where they live rather than by what they are.

It knows because of a small cross-app convention: whatever starts a long-lived dev server writes a record describing it under `${XDG_STATE_HOME:-~/.local/state}/dev-servers/`. TBD only reads.

## Why this shape

**Read-only, and not a second reclaimer.** TBD never writes a record, and this path never stops anything — reclamation is #681's, and duplicating it would put two mechanisms with different identification rules in charge of killing the same process. This PR answers one question — *is there something here you would rather not lose?* — and leaves the rest alone.

**Declaration, where #681 uses detection, and the two answer different questions.** A cwd-keyed sweep can find a process without being able to say what it is; a record carries a label. That is also why this does not simply reuse #681's collector: it needs a name to put in a sentence, and the sweep deliberately identifies by location.

**No vendor segment in the path.** The directory is a surface several unrelated applications write to. A name owned by one of them gives the next adopter a reason to invent a second directory instead of joining the first, so the convention has to be neutral to be worth adopting.

**Liveness is asked of the kernel, never of the record.** A record cannot be trusted to be current: the common case is the writer dying without cleaning up, which is the whole reason the feature exists. So the identity is `(pid, start time)`, checked through `sysctl`:

- a **reused pid** reads stale rather than pointing at a stranger — the flaw every `.pid` file scheme has;
- a **process that exited without being reaped** reads stale rather than running forever, because a zombie still reports its original start time and would otherwise satisfy the pair check indefinitely.

**Three states, not two.** `running`, `stale`, and `indeterminate` — the last meaning the record could not be read or its schema version is not one this build understands. Only `running` prompts. A definitively dead record describes nothing an archive could strand, and one that cannot be read is not evidence either; prompting on those teaches people to click through the prompt, which costs more than the warning saves.

**A separate flag from `force`.** `force` already means "skip the archive hook" and bypasses a status check for cascade flows. Confirming the dev-server prompt passes `devServersConfirmed: true` and re-issues the *original* `force`. Folding the two together would make confirming a prompt silently skip a repo's archive hook, and would make every cascade flow skip this check.

**The record's `command` is display text and nothing reads it as an instruction.** Records are written at runtime by any process, with no review, while TBD is long-running and trusted. Executing a string out of one would let a process that cannot run arbitrary commands itself get one run on its behalf.

Spec: [`docs/specs/2026-08-20-dev-server-registry-design.md`](docs/specs/2026-08-20-dev-server-registry-design.md), written for someone implementing a *writer*. This PR originally shipped without one on the grounds that it was a single read plus a dialog; that undersold it — it commits TBD to a versioned on-disk protocol other applications write into, with a liveness rule carrying several judgment calls, which is a change to the system's theory rather than a UI addition.

## What this PR does

- `TBDShared/DevServerRegistry.swift` — the reader. Record decoding, the three-state liveness rule, a `sysctl` probe behind a protocol, and `running(inWorktree:)` for the one question the app asks.
- `TBDApp/PendingArchive.swift` — the held-back archive: which worktree, which servers, and the original `force` so confirming re-issues the same call.
- `AppState.devServerArchiveGate` — a pure seam deciding hold-vs-proceed, alongside `archiveShortcutRoute`, so every arm is testable without a daemon.
- `AppState.archiveWorktree` — runs the gate, ahead of the scratch delegation.
- `RowActionMenuActions` — the sidebar's scratch archive routes through `archiveWorktree` rather than straight to the RPC.
- `RepoSectionView` — the existing Remove-Repo confirmation now also names running servers, because that path cascade-archives every worktree in the repo server-side and never reaches the per-worktree gate.
- `ContentView` — the confirmation, naming what is running.

## Assumptions

- **Assumes records are written by the launchers that start dev servers.** Nothing here creates them, so on a machine where nothing declares anything this feature is silently inert — correctly, but invisibly. It is a warning about *declared* servers, never a census: a server started by hand from a shell declares nothing, and gets archived with no prompt (and then reclaimed by #681's sweep, which does not need a declaration to find it).
- **Assumes #681's sweep remains the thing that reclaims.** If teardown-time reaping later lands — explicitly deferred in #681's spec — this warning should be revisited alongside it rather than left to describe a sequence that changed.
- **Assumes `localPath` is a real filesystem path for local rows.** Remote rows are skipped explicitly — their `localPath` is the synthetic `remote://` URI, and a registry on this machine cannot speak for a worktree on another one.
- **Assumes the answer is about intent, not a snapshot.** Between the prompt appearing and the click, the servers may exit. Confirming archives regardless rather than re-checking; re-asking on a second click would make the button appear broken.

## Evidence & verification

28 tests (17 reader, 8 gate, 3 prompt), and the ones that matter are about refusing to be confident:

- a reused pid reads stale, not running
- a zombie reads stale, not running
- an unrecognised schema version reads indeterminate, never stale
- one second of clock skew still reads running, so a truncate-vs-round disagreement between implementations does not report every live server as dead
- stale and indeterminate records are excluded from the prompt but still visible in the full listing, so a malformed record is never indistinguishable from no record
- worktree paths are compared after resolving symlinks — comparing raw strings would report "nothing running" for every worktree reached through a symlinked ancestor, and that failure looks exactly like the feature working
- an absent registry directory is empty, not an error
- `force` round-trips through the confirmation, so confirming cannot silently turn a repo's archive hook on or off
- a scratch row is gated like any other — it is a real directory that can host a server, and it used to be delegated past the check
- a remote row is not merely excluded from the result but never *looked up*, so the exclusion cannot silently become "the comparison happened not to match"

The liveness cases run against an injected probe, because a reused pid and an unreaped zombie cannot be produced on demand from a test process. One case exercises the real `sysctl` probe against this process and an unallocatable pid, so the suite cannot pass against a probe that answers `nil` for everything.
