### PR TITLE
fix: keep test gate holds off the cooperative pool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
       # is what decides how many blocked threads it takes to wedge the whole
       # test process. It was inferred, not measured, the one time that mattered.
       - name: Record runner CPU width
-        run: echo "runner cores: $(sysctl -n hw.ncpu)"
+        run: 'echo "runner cores: $(sysctl -n hw.ncpu)"'
 
       - name: Cache SwiftPM build artifacts and dependencies
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,12 @@ jobs:
       - name: Capture Swift toolchain version
         run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> $GITHUB_ENV
 
+      # Swift's cooperative pool is one thread per core, so the runner's width
+      # is what decides how many blocked threads it takes to wedge the whole
+      # test process. It was inferred, not measured, the one time that mattered.
+      - name: Record runner CPU width
+        run: echo "runner cores: $(sysctl -n hw.ncpu)"
+
       - name: Cache SwiftPM build artifacts and dependencies
         uses: actions/cache@v4
         with:

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -349,6 +349,33 @@ New tests should state their tier. Tier-1 tests put no real sleep in the
 time. The scheduling handshake that observes it may still sleep; see "Clock and
 date seams" below for why that is not a tier violation.
 
+## Thread-blocking gates run off the cooperative pool
+
+Some seams can only be held still by blocking the thread that reaches them —
+a synchronous date provider, a sink called from a receive loop, a teardown
+closure. `DispatchSemaphore` is the right primitive there; **which thread it
+blocks is the safety question.**
+
+Swift's cooperative pool is only as wide as the machine has cores, and CI's
+`macos-26-arm64` runner has 3. Every suspended task in the process draws on
+that pool, including the statement that would release the gate. Park as many
+gates as the pool is wide and nothing can reach a `signal()`: the run goes
+silent and dies on the step's `timeout-minutes` with zero failing tests, and no
+per-test `.timeLimit` fires, because a blocked thread is where cooperative
+cancellation cannot reach. Bounding the wait converts the wedge into
+starvation, not into health — a bounded holder still owns its thread for the
+whole deadline, and innocent suites blow their own 90 s and 120 s
+hang-catchers first.
+
+So start the side that will be held with `gateHoldingTask`
+(`Tests/TestSupport/BoundedGateSupport.swift`), which pins it and every
+default-actor hop it makes to threads the tests own. A gate already reached
+from a dedicated `Thread` or a `DispatchQueue` needs nothing. Bound every wait
+with `waitForGate` regardless: it is the net under the rule, naming the gate
+instead of leaving an anonymous job timeout. `BoundedGateWaitTests` reproduces
+the wedge on any machine by deriving its holder count from
+`activeProcessorCount`.
+
 ## Quarantine — `.flaky(issue:)`
 
 There is no blanket retry policy, in any tier, and there will not be one:

--- a/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
+++ b/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import TestSupport
+import Testing
+
+/// Harness for `waitForGate` (`Tests/TestSupport/BoundedGateSupport.swift`).
+///
+/// The expiry branch runs on no healthy machine, so without these it would be
+/// code nobody ever executes — and the whole point of the bound is that it
+/// behaves correctly on the one day it fires. Both halves are asserted: a
+/// satisfied gate must still be a plain ordering primitive that records
+/// nothing, and an unsatisfied one must return rather than park forever, with
+/// a named issue.
+@Suite("bounded gate waits")
+struct BoundedGateWaitTests {
+
+    @Test("a signalled gate succeeds and records nothing")
+    func signalledGatePasses() {
+        let gate = DispatchSemaphore(value: 0)
+        gate.signal()
+        #expect(gate.waitForGate("self-test: pre-signalled", timeout: .seconds(5)))
+    }
+
+    @Test("a gate signalled from another thread still orders the two sides")
+    func gateOrdersConcurrentSignal() {
+        let gate = DispatchSemaphore(value: 0)
+        let released = NSLock()
+        nonisolated(unsafe) var didRelease = false
+        DispatchQueue.global().async {
+            released.withLock { didRelease = true }
+            gate.signal()
+        }
+        #expect(gate.waitForGate("self-test: cross-thread", timeout: .seconds(30)))
+        #expect(released.withLock { didRelease }, "the wait must not return before the signal")
+    }
+
+    @Test("an unsignalled gate gives up and records a named issue")
+    func unsignalledGateReportsItself() {
+        let gate = DispatchSemaphore(value: 0)
+        var gaveUp = false
+        // The recorded issue IS the expected outcome here; `withKnownIssue`
+        // also fails if no issue is recorded, so this pins that the expiry
+        // branch reports rather than failing silently.
+        withKnownIssue("the gate is deliberately never signalled") {
+            gaveUp = gate.waitForGate("self-test: never signalled", timeout: .milliseconds(50))
+                == false
+        }
+        #expect(gaveUp, "an expired gate must return false, not park the thread")
+        // Leave the semaphore at its initial value: an expired `wait(timeout:)`
+        // consumes nothing, so no balancing `signal()` is owed, and an extra
+        // one would mask a regression here.
+    }
+
+    @Test("the timeout diagnostic names the gate and the deadline")
+    func timeoutDescriptionCarriesTheDiagnostic() {
+        let description = String(
+            describing: TestGateTimeout(gate: "some gate", after: .seconds(3)))
+        #expect(description.contains("some gate"))
+        #expect(description.contains("3"))
+    }
+}

--- a/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
+++ b/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
@@ -29,7 +29,11 @@ struct BoundedGateWaitTests {
             released.withLock { didRelease = true }
             gate.signal()
         }
-        #expect(gate.waitForGate("self-test: cross-thread", timeout: .seconds(30)))
+        // Default deadline, not a snappier number of its own: this is a
+        // hang-catcher on a `DispatchQueue.global()` hop, and 30 s was not
+        // enough for one on a saturated 3-core runner — it went red there
+        // while asserting nothing about time.
+        #expect(gate.waitForGate("self-test: cross-thread"))
         #expect(released.withLock { didRelease }, "the wait must not return before the signal")
     }
 
@@ -50,6 +54,40 @@ struct BoundedGateWaitTests {
         // one would mask a regression here.
     }
 
+    @Test("gate holders block their own threads, leaving the cooperative pool free")
+    func gateHoldersDoNotStarveTheCooperativePool() async throws {
+        // More simultaneous holders than Swift's cooperative pool is wide, so
+        // the count reproduces CI's 3-thread runner on any machine. Started
+        // with a plain `Task` these park every pool thread; the `await` below
+        // then cannot get one until a holder gives up, and the giving-up is
+        // what reds this test. Enqueueing them needs no thread, so all of them
+        // are pending before the first suspension point.
+        let holders = ProcessInfo.processInfo.activeProcessorCount + 2
+        let gate = DispatchSemaphore(value: 0)
+        let parked = Counter()
+        let tasks = (0..<holders).map { index in
+            gateHoldingTask {
+                parked.increment()
+                return gate.waitForGate("self-test: pool-starvation holder \(index)")
+            }
+        }
+        defer { for _ in 0..<holders { gate.signal() } }
+
+        // Ordinary cooperative work still gets a thread while every gate is
+        // held. Deliberately not timed: scheduling latency in the parallel
+        // pass is tens of seconds under load, so a wall-clock bound here would
+        // go red on a merely busy machine. The default gate deadline clears
+        // that latency with room to spare, which is what keeps the discrimination
+        // one-sided — a healthy run always releases first.
+        #expect(await Task { true }.value)
+
+        for _ in 0..<holders { gate.signal() }
+        var released = 0
+        for task in tasks where await task.value { released += 1 }
+        #expect(released == holders, "every holder must be released, not expire")
+        #expect(parked.value == holders, "every holder must have reached its gate")
+    }
+
     @Test("the timeout diagnostic names the gate and the deadline")
     func timeoutDescriptionCarriesTheDiagnostic() {
         let description = String(
@@ -57,4 +95,14 @@ struct BoundedGateWaitTests {
         #expect(description.contains("some gate"))
         #expect(description.contains("3"))
     }
+}
+
+
+/// Minimal thread-safe counter — the holders increment from threads that are
+/// about to block, so this cannot be an actor.
+private final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    var value: Int { lock.withLock { count } }
+    func increment() { lock.withLock { count += 1 } }
 }

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -149,7 +149,7 @@ struct CodexActivityReconciliationTests {
                 terminalID: terminal.id,
                 activityState: .working))
 
-        let inFlightList = Task { await raceRouter.handle(list) }
+        let inFlightList = gateHoldingTask { await raceRouter.handle(list) }
         guard await waitUntil(
             { dates.firstCallIsBlocked }, timeout: Self.raceRendezvousTimeout
         ) else {
@@ -474,7 +474,7 @@ struct CodexActivityReconciliationTests {
                 transcriptPath: currentTranscript.path,
                 source: "SessionStart"))
 
-        let staleList = Task { await router.handle(list) }
+        let staleList = gateHoldingTask { await router.handle(list) }
         guard await waitUntil(
             { dates.firstCallIsBlocked }, timeout: Self.raceRendezvousTimeout
         ) else {
@@ -563,7 +563,7 @@ struct CodexActivityReconciliationTests {
                 terminalID: terminal.id, sessionID: "same-session",
                 transcriptPath: transcript.path, source: "SessionStart"))
 
-        let staleList = Task { await raceRouter.handle(list) }
+        let staleList = gateHoldingTask { await raceRouter.handle(list) }
         guard await waitUntil(
             { dates.firstCallIsBlocked }, timeout: Self.raceRendezvousTimeout
         ) else {
@@ -863,6 +863,12 @@ private func waitUntilAsync(
     return false
 }
 
+/// Holds the first `now()` call until the test releases it, so "the earlier
+/// request is mid-flight" is a deterministic state rather than a timing window.
+///
+/// The held request MUST be started with `gateHoldingTask`: this blocks the
+/// thread it runs on, and a blocked cooperative-pool thread starves every
+/// other test in the process. See `Tests/TestSupport/BoundedGateSupport.swift`.
 private final class BlockingListDates: @unchecked Sendable {
     private let lock = NSLock()
     private let first: Date

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -889,7 +889,7 @@ private final class BlockingListDates: @unchecked Sendable {
                 return call
             }
             guard call == 0 else { return subsequent }
-            release.wait()
+            release.waitForGate("codex activity reconciliation first date-provider call")
             return first
         }
     }

--- a/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
@@ -84,7 +84,7 @@ private final class BlockingPresentationDates: @unchecked Sendable {
                 return call
             }
             guard call == 0 else { return subsequent }
-            release.wait()
+            release.waitForGate("codex transcript presentation first date-provider call")
             return first
         }
     }

--- a/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
@@ -27,7 +27,10 @@ struct CodexPresentationObservationTests {
             worktreeID: UUID()
         )]
 
-        let first = Task {
+        // `observeStamped` is a synchronous actor method, so the gate below
+        // holds the tracker actor itself. Off the cooperative pool, that costs
+        // one thread this test owns; on it, it would cost a shared one.
+        let first = gateHoldingTask {
             await tracker.observeStamped(transcripts: targets, now: dates.provider)
         }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
@@ -58,6 +61,12 @@ struct CodexPresentationObservationTests {
     }
 }
 
+/// Holds the first `now()` call until the test releases it, so "the earlier
+/// request is mid-flight" is a deterministic state rather than a timing window.
+///
+/// The held request MUST be started with `gateHoldingTask`: this blocks the
+/// thread it runs on, and a blocked cooperative-pool thread starves every
+/// other test in the process. See `Tests/TestSupport/BoundedGateSupport.swift`.
 private final class BlockingPresentationDates: @unchecked Sendable {
     private let lock = NSLock()
     private let first: Date

--- a/Tests/TBDDaemonTests/FDVendingServerTests.swift
+++ b/Tests/TBDDaemonTests/FDVendingServerTests.swift
@@ -393,6 +393,8 @@ struct FDVendingServerTests {
         // decoded but undelivered) while the NEW connection is adopted — the
         // exact interleave that would break wire order == stream order.
         let sequence = TaggedFrameSequence()
+        // Blocks the server's dedicated receive `Thread`, never a
+        // cooperative-pool thread, so this gate needs no `gateHoldingTask`.
         let releaseSink = DispatchSemaphore(value: 0)
         let exits = TaggedFrameSequence()
         let server = FDVendingServer()

--- a/Tests/TBDDaemonTests/FDVendingServerTests.swift
+++ b/Tests/TBDDaemonTests/FDVendingServerTests.swift
@@ -398,7 +398,9 @@ struct FDVendingServerTests {
         let server = FDVendingServer()
         await server.setOnInput { header, _ in
             sequence.record(kind: "input", pane: header.paneID)
-            if header.paneID == "%old-1" { releaseSink.wait() }
+            if header.paneID == "%old-1" {
+                releaseSink.waitForGate("FDVendingServer superseded receive thread held mid-loop")
+            }
         }
         await server.setOnReceiveLoopExit { exits.record(kind: "exit", pane: "") }
         await server.adoptConnection(fd: oldServerFD)

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -856,7 +856,7 @@ private final class BlockingDateSequence: @unchecked Sendable {
                 return call
             }
             guard call == 0 else { return subsequent }
-            release.wait()
+            release.waitForGate("terminal.activityEvent first date-provider call")
             return first
         }
     }

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -457,7 +457,7 @@ struct TerminalActivityEventHandlerTests {
             params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
         )
 
-        let earlier = Task { await router.handle(idle) }
+        let earlier = gateHoldingTask { await router.handle(idle) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -490,7 +490,7 @@ struct TerminalActivityEventHandlerTests {
             params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .working)
         )
 
-        let earlier = Task { await router.handle(interrupt) }
+        let earlier = gateHoldingTask { await router.handle(interrupt) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -536,7 +536,7 @@ struct TerminalActivityEventHandlerTests {
             params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .working)
         )
 
-        let earlier = Task { await router.handle(idle) }
+        let earlier = gateHoldingTask { await router.handle(idle) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -633,7 +633,7 @@ struct TerminalActivityEventHandlerTests {
             )
         )
 
-        let earlier = Task { await router.handle(activity) }
+        let earlier = gateHoldingTask { await router.handle(activity) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -710,7 +710,7 @@ struct TerminalActivityEventHandlerTests {
             params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
         )
 
-        let earlier = Task { await router.handle(working) }
+        let earlier = gateHoldingTask { await router.handle(working) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -742,7 +742,7 @@ struct TerminalActivityEventHandlerTests {
             params: TerminalActivityEventParams(terminalID: terminal.id, activityState: .idle)
         )
 
-        let earlier = Task { await router.handle(working) }
+        let earlier = gateHoldingTask { await router.handle(working) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -812,7 +812,7 @@ struct TerminalActivityEventHandlerTests {
             params: #"{"terminalID":"\#(terminal.id.uuidString)","activityState":"idle","origin":"user_interrupt"}"#
         )
 
-        let earlier = Task { await router.handle(sessionStart) }
+        let earlier = gateHoldingTask { await router.handle(sessionStart) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -830,6 +830,12 @@ struct TerminalActivityEventHandlerTests {
     }
 }
 
+/// Holds the first `now()` call until the test releases it, so "the earlier
+/// request is mid-flight" is a deterministic state rather than a timing window.
+///
+/// The held request MUST be started with `gateHoldingTask`: this blocks the
+/// thread it runs on, and a blocked cooperative-pool thread starves every
+/// other test in the process. See `Tests/TestSupport/BoundedGateSupport.swift`.
 private final class BlockingDateSequence: @unchecked Sendable {
     private let lock = NSLock()
     private let first: Date

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -665,7 +665,7 @@ private final class BlockingSessionDates: @unchecked Sendable {
                 return call
             }
             guard call == 0 else { return subsequent }
-            release.wait()
+            release.waitForGate("terminal.sessionEvent first date-provider call")
             return first
         }
     }

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -314,7 +314,7 @@ struct TerminalSessionEventHandlerTests {
                 notificationType: "permission_prompt",
                 message: "The old session needs permission"))
 
-        let sessionUpdate = Task { await raceRouter.handle(sessionStart) }
+        let sessionUpdate = gateHoldingTask { await raceRouter.handle(sessionStart) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await sessionUpdate.value
@@ -387,7 +387,7 @@ struct TerminalSessionEventHandlerTests {
                 notificationType: "permission_prompt",
                 message: "Codex needs permission"))
 
-        let earlier = Task { await raceRouter.handle(staleSession) }
+        let earlier = gateHoldingTask { await raceRouter.handle(staleSession) }
         guard await waitUntil({ dates.firstCallIsBlocked }) else {
             dates.releaseFirstCall()
             _ = await earlier.value
@@ -639,6 +639,12 @@ private final class SessionDeltaCapture: @unchecked Sendable {
     }
 }
 
+/// Holds the first `now()` call until the test releases it, so "the earlier
+/// request is mid-flight" is a deterministic state rather than a timing window.
+///
+/// The held request MUST be started with `gateHoldingTask`: this blocks the
+/// thread it runs on, and a blocked cooperative-pool thread starves every
+/// other test in the process. See `Tests/TestSupport/BoundedGateSupport.swift`.
 private final class BlockingSessionDates: @unchecked Sendable {
     private let lock = NSLock()
     private let first: Date

--- a/Tests/TBDDaemonTests/TmuxControlSupervisorTeardownTests.swift
+++ b/Tests/TBDDaemonTests/TmuxControlSupervisorTeardownTests.swift
@@ -31,6 +31,10 @@ struct TmuxControlSupervisorTeardownTests {
         // The stop seam blocks until the TEST releases it, so "teardown is
         // mid-stop" is a deterministic state, not a timing window.
         let stopStarted = EventCounter()
+        // `stopConnection` runs on `DispatchQueue.global(qos: .utility)` — the
+        // production code puts blocking stops off the actor deliberately — so
+        // this gate never parks a cooperative-pool thread and needs no
+        // `gateHoldingTask`. The same holds for the other two gates below.
         let stopGate = DispatchSemaphore(value: 0)
         let supervisor = TmuxControlSupervisor(
             makeConnection: { TmuxControlConnection(serverName: $0, tmuxBinary: stub) },

--- a/Tests/TBDDaemonTests/TmuxControlSupervisorTeardownTests.swift
+++ b/Tests/TBDDaemonTests/TmuxControlSupervisorTeardownTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import TestSupport
 import Testing
 
 @testable import TBDDaemonLib
@@ -40,7 +41,9 @@ struct TmuxControlSupervisorTeardownTests {
                 // connection; gating that call too would deadlock the test
                 // against its own semaphore (the defer below can't run while
                 // the body is awaiting stopAll).
-                if stopStarted.count == 1 { stopGate.wait() }
+                if stopStarted.count == 1 {
+                    stopGate.waitForGate("TmuxControlSupervisor slow-stop teardown held mid-stop")
+                }
                 connection.stop()
             })
         defer { stopGate.signal() }  // never leave the stop thread parked on failure
@@ -105,7 +108,9 @@ struct TmuxControlSupervisorTeardownTests {
                 // Gate ONLY the teardown under test — see
                 // slowStopDoesNotBlockActor for why the closing stopAll()
                 // cleanup must pass through ungated.
-                if stopStarted.count == 1 { stopGate.wait() }
+                if stopStarted.count == 1 {
+                    stopGate.waitForGate("TmuxControlSupervisor in-flight-stop teardown held mid-stop")
+                }
                 connection.stop()
                 stopFinished.increment()
             })
@@ -158,7 +163,8 @@ struct TmuxControlSupervisorTeardownTests {
             makeConnection: { TmuxControlConnection(serverName: $0, tmuxBinary: stub) },
             stopConnection: { connection in
                 stopStarted.increment()
-                stopGate.wait()  // held open until the test signals
+                // Held open until the test signals.
+                stopGate.waitForGate("TmuxControlSupervisor stopAll() stop() held mid-stop")
                 connection.stop()
             })
         // Never leave stop threads parked on failure (one per connection below).

--- a/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
@@ -182,6 +182,9 @@ struct WorktreeDeletionQueueTests {
 
         // Signalled in a `defer` so a failure anywhere below cannot leave the
         // process-wide drain queue blocked for other suites.
+        // Blocks `WorktreeDeletionQueue.drainQueue` — a plain dispatch
+        // queue, not a cooperative-pool thread — so this gate needs no
+        // `gateHoldingTask`.
         let gate = DispatchSemaphore(value: 0)
         defer { gate.signal() }
         let occupied = Flag()

--- a/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
@@ -1,3 +1,4 @@
+import TestSupport
 import Testing
 import Foundation
 @testable import TBDDaemonLib
@@ -186,7 +187,7 @@ struct WorktreeDeletionQueueTests {
         let occupied = Flag()
         WorktreeDeletionQueue.drainQueue.async {
             occupied.set()
-            gate.wait()
+            gate.waitForGate("WorktreeDeletionQueue drain-queue occupancy")
         }
         try await waitUntil(occupied.isSet, "drain queue never picked up the gate item")
 

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -2,35 +2,103 @@ import Dispatch
 import Foundation
 import Testing
 
-// Bounded waits for the `DispatchSemaphore` gates tests use to hold a piece of
-// production work at a chosen instant while the test observes the world around
-// it.
+// Thread-blocking gates in tests, and the two things they need to be safe.
 //
-// WHY THE BOUND EXISTS — do not "simplify" `waitForGate` back to a bare
-// `wait()`.
+// Several suites hold a piece of production work still at a chosen instant —
+// freeze a date provider on its first call, hold a receive loop mid-loop, hold
+// a teardown mid-stop — while the test observes the world around it. The seam
+// they reach is a *synchronous* closure, so the only way to hold it is to
+// block the thread running it: `DispatchSemaphore.wait()`, released by the
+// test.
 //
-// A `DispatchSemaphore.wait()` with no deadline parks the *thread* it runs on.
-// These gates are reached from inside async work — a date provider called
-// under an `await`, a sink invoked from a receive loop, a teardown seam — so
-// the parked thread is usually one of Swift's cooperative pool threads, and
-// the pool is only as wide as the machine has cores. CI's `macos-26-arm64`
-// runner has 3. The statement that would release the gate is itself async work
-// needing a thread from that same pool, so once as many gates are parked as
-// the pool is wide, nothing can reach a `signal()` and the whole test process
-// wedges — permanently, and invisibly.
+// WHICH THREAD gets blocked is the whole safety question, and it is decided by
+// the caller, not by the gate.
+//
+// ## 1. Never block a cooperative-pool thread — `gateHoldingTask`
+//
+// A blocked thread is gone until the gate is released. When that thread
+// belongs to Swift's cooperative pool the loss is shared: the pool is only as
+// wide as the machine has cores (CI's `macos-26-arm64` runner has 3), every
+// suspended task in the process needs a thread from it, and the statement that
+// would release the gate is itself async work needing one. Park as many gates
+// as the pool is wide and no thread can reach any `signal()`; the process
+// stops making progress permanently.
 //
 // That is not hypothetical: it turned `main` red. All ~4050 tests run in one
-// process with no concurrency cap, seven suites held unbounded gates, and on
-// the 3-vCPU runner all seven parked and none finished. The job died on its
-// 30-minute `timeout-minutes` after ~23 minutes of total silence, with zero
-// test failures reported. No per-test `.timeLimit` fired either: a blocked
-// thread is exactly where cooperative cancellation cannot reach.
+// process with no concurrency cap, and on the 3-thread runner the pass went
+// silent for ~23 minutes and died on the step's 30-minute `timeout-minutes`
+// having reported zero test failures. No per-test `.timeLimit` fired either —
+// a blocked thread is exactly where cooperative cancellation cannot reach.
 //
-// A bounded wait cannot prevent the starvation, but it converts it from an
-// anonymous job timeout into a named failing test — the same reason
-// `test.yml`'s own `timeout-minutes` comment gives for existing. Every gate in
-// this repo goes through here so there is one seam to find and one deadline to
-// re-derive.
+// Bounding the wait does not fix that. A bounded wait still owns its thread
+// for the whole deadline, so the gates stop wedging the process and instead
+// starve it: on the first bounded run the four date-seam suites held pool
+// threads for their full 120 s while ~43 innocent tests in suites with no gate
+// of their own blew their own 90 s and 120 s hang-catchers. The cure is to
+// keep the blocking OFF the pool entirely — start the task that will hold a
+// gate with `gateHoldingTask`, which pins it (and every default-actor hop it
+// makes) to threads these tests own.
+//
+// Gates reached from a dedicated `Thread` or a `DispatchQueue` never had the
+// problem and need nothing: `FDVendingServer` delivers to its sinks from a
+// dedicated receive `Thread`, `WorktreeDeletionQueue`'s gate sits on its own
+// `drainQueue`, and `TmuxControlSupervisor` runs `stopConnection` on
+// `DispatchQueue.global(qos:.utility)` precisely so a blocking stop stays off
+// the actor. Those three keep a plain bounded `waitForGate` and no executor.
+//
+// ## 2. Bound every wait anyway — `waitForGate`
+//
+// The bound is the safety net under the rule above, not a substitute for it.
+// An author who adds a gate and starts it with a plain `Task` gets a named
+// failing test naming the gate instead of an anonymous 30-minute job timeout —
+// the same reason `test.yml`'s own `timeout-minutes` comment gives for
+// existing. Every gate in this repo goes through `waitForGate` so there is one
+// seam to find and one deadline to re-derive.
+
+/// Runs jobs on threads the test process owns rather than on Swift's
+/// cooperative pool, so a task that blocks inside a gate cannot starve
+/// unrelated tests.
+///
+/// Task executor preference is inherited by child tasks and — per SE-0417 —
+/// also carries into *default* actors, so a handler that hops through
+/// `RPCRouter`, a store actor and `CodexTranscriptActivityTracker` keeps
+/// running here for the whole call. TBD declares no custom `unownedExecutor`
+/// anywhere in `Sources/`, so there is no actor along these paths that would
+/// pull the job back onto the pool.
+///
+/// The queue is concurrent: gates are held one per task, and a blocked worker
+/// must not stall an unrelated job that happens to be queued behind it.
+public final class GateExecutor: TaskExecutor, @unchecked Sendable {
+    /// One per process. The executor holds no state; the shared instance
+    /// exists so `gateHoldingTask` does not mint a queue per call site.
+    public static let shared = GateExecutor()
+
+    private let queue = DispatchQueue(
+        label: "com.tbd.tests.gate-executor",
+        qos: .userInitiated,
+        attributes: .concurrent)
+
+    private init() {}
+
+    public func enqueue(_ job: consuming ExecutorJob) {
+        let job = UnownedJob(job)
+        let executor = asUnownedTaskExecutor()
+        queue.async { job.runSynchronously(on: executor) }
+    }
+}
+
+/// Starts a task that is expected to block on a `waitForGate`, on threads that
+/// are not Swift's cooperative pool.
+///
+/// Use this for the ONE side that gets held. The other side — the work the
+/// test runs while the gate is closed, and the `signal()` that releases it —
+/// stays on the pool, which is the point: it needs a thread, and this call is
+/// what guarantees one is left.
+public func gateHoldingTask<Success: Sendable>(
+    _ operation: @escaping @Sendable () async -> Success
+) -> Task<Success, Never> {
+    Task(executorPreference: GateExecutor.shared) { await operation() }
+}
 
 /// How long a bounded gate wait tolerates before it reports itself.
 ///
@@ -71,9 +139,10 @@ public struct TestGateTimeout: Error, CustomStringConvertible {
     public var description: String {
         """
         test gate "\(gate)" was never signalled within \(after) — the releasing \
-        statement never ran. On a narrow runner this is cooperative-pool \
-        starvation: too many gates parked at once for any of them to be \
-        released. See Tests/TestSupport/BoundedGateSupport.swift.
+        statement never ran. If the holding side was started with a plain \
+        `Task` rather than `gateHoldingTask`, it blocked a cooperative-pool \
+        thread and starved the work that would have released it. See \
+        Tests/TestSupport/BoundedGateSupport.swift.
         """
     }
 }

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -1,0 +1,119 @@
+import Dispatch
+import Foundation
+import Testing
+
+// Bounded waits for the `DispatchSemaphore` gates tests use to hold a piece of
+// production work at a chosen instant while the test observes the world around
+// it.
+//
+// WHY THE BOUND EXISTS — do not "simplify" `waitForGate` back to a bare
+// `wait()`.
+//
+// A `DispatchSemaphore.wait()` with no deadline parks the *thread* it runs on.
+// These gates are reached from inside async work — a date provider called
+// under an `await`, a sink invoked from a receive loop, a teardown seam — so
+// the parked thread is usually one of Swift's cooperative pool threads, and
+// the pool is only as wide as the machine has cores. CI's `macos-26-arm64`
+// runner has 3. The statement that would release the gate is itself async work
+// needing a thread from that same pool, so once as many gates are parked as
+// the pool is wide, nothing can reach a `signal()` and the whole test process
+// wedges — permanently, and invisibly.
+//
+// That is not hypothetical: it turned `main` red. All ~4050 tests run in one
+// process with no concurrency cap, seven suites held unbounded gates, and on
+// the 3-vCPU runner all seven parked and none finished. The job died on its
+// 30-minute `timeout-minutes` after ~23 minutes of total silence, with zero
+// test failures reported. No per-test `.timeLimit` fired either: a blocked
+// thread is exactly where cooperative cancellation cannot reach.
+//
+// A bounded wait cannot prevent the starvation, but it converts it from an
+// anonymous job timeout into a named failing test — the same reason
+// `test.yml`'s own `timeout-minutes` comment gives for existing. Every gate in
+// this repo goes through here so there is one seam to find and one deadline to
+// re-derive.
+
+/// How long a bounded gate wait tolerates before it reports itself.
+///
+/// **Sized to dominate the longest legitimate hold, not to be snappy.** A gate
+/// is held for as long as the test's own observation takes, and the outer
+/// observations are themselves hang-catchers sized against a loaded runner:
+/// the `TmuxControlSupervisor` teardown gates are held across a `waitUntil`
+/// bounded by `ciSafeDeadline` (90 s). A gate deadline below that would go red
+/// on a merely slow machine, and a spuriously red CI is worse than the bug
+/// this bound exists to report. 120 s clears 90 s with margin while staying a
+/// small fraction of the 30-minute step budget, so a wedge reports in minutes
+/// instead of consuming the job.
+///
+/// It also stays inside `.clockDriven`'s `.timeLimit(.minutes(4))`, leaving
+/// room for the rest of an ordinary test after one full gate timeout — the
+/// same invariant `Tests/CLAUDE.md` derives for `ciSafeDeadline` and
+/// `waitForSuspension`. Re-derive it together with those two when the test
+/// population moves materially.
+public enum TestGate {
+    public static let deadline: Duration = .seconds(120)
+}
+
+/// Thrown-shaped diagnostic for an expired gate.
+///
+/// `Issue.record(_: some Error)` is the only form that puts this text on the
+/// **primary** failure line; `Issue.record(String)` and `#expect(_, "…")`
+/// demote it to a trailing `↳` line that CI summaries drop. See
+/// `Tests/CLAUDE.md`, "Timeout errors must report observed state".
+public struct TestGateTimeout: Error, CustomStringConvertible {
+    public let gate: String
+    public let after: Duration
+
+    public init(gate: String, after: Duration) {
+        self.gate = gate
+        self.after = after
+    }
+
+    public var description: String {
+        """
+        test gate "\(gate)" was never signalled within \(after) — the releasing \
+        statement never ran. On a narrow runner this is cooperative-pool \
+        starvation: too many gates parked at once for any of them to be \
+        released. See Tests/TestSupport/BoundedGateSupport.swift.
+        """
+    }
+}
+
+extension DispatchSemaphore {
+    /// Waits for this gate, giving up after `timeout` and recording a named
+    /// test issue instead of parking the thread forever.
+    ///
+    /// On a healthy machine the gate is signalled long before the deadline, so
+    /// the ordering guarantee the gate provides is exactly what it was with a
+    /// bare `wait()` — nothing this call does weakens it. The deadline is a
+    /// hang-catcher: it asserts nothing and costs a passing run nothing.
+    ///
+    /// - Parameters:
+    ///   - name: What is being held, in enough detail to identify the site
+    ///     from a CI log alone.
+    ///   - timeout: Defaults to ``TestGate/deadline``; override only with a
+    ///     reason.
+    /// - Returns: `true` if the gate was signalled, `false` if it expired.
+    ///   Ignorable — the recorded issue is the report — but returned so a
+    ///   caller that can act on the distinction may.
+    ///
+    /// Note: a gate reached from a plain dispatch queue or `Thread` has no
+    /// task-local test context, so its issue may be reported against the run
+    /// rather than attributed to one test. The process unwedging is the point;
+    /// the test's own downstream assertions then fail with their own names.
+    @discardableResult
+    public func waitForGate(
+        _ name: String,
+        timeout: Duration = TestGate.deadline,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) -> Bool {
+        let seconds = Double(timeout.components.seconds)
+            + Double(timeout.components.attoseconds) / 1e18
+        guard wait(timeout: .now() + seconds) == .success else {
+            Issue.record(
+                TestGateTimeout(gate: name, after: timeout),
+                sourceLocation: sourceLocation)
+            return false
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## What's broken

`main` is red for every PR. The `Test (fast parallel pass 1/2 — TBDDaemonTests)`
step dies on its 30-minute `timeout-minutes` having reported **zero test
failures**. The log shows the run going quiet — roughly 23 minutes of total
silence, no test events at all, with ~1400 tests and ~198 suites still marked
in flight. For scale, the last green run finished the whole pass in 127
seconds.

It reproduces deterministically: two separate commits and an explicit job
re-run all died the same way. Anyone opening a PR faces a failing required
check they cannot fix from their own diff.

## Why it happens

The test process is wedged, not slow, and it is wedged on a thread shortage.

Four suites need to hold a piece of production work still at a chosen instant —
freeze a date provider on its first call, so that "the earlier request is
mid-flight" is a deterministic state rather than a timing window — while the
test observes the world around it. The seam they reach is a *synchronous*
closure, so the only way to hold it is to block the thread running it: the
production side calls `DispatchSemaphore.wait()`, the test does its checks,
then the test calls `signal()`.

**Which thread gets blocked is the whole safety question, and it is decided by
the caller, not by the gate.** Each of these holds is started with a plain
`Task`, so the blocked thread belongs to Swift's cooperative pool — and that
pool is only as wide as the machine has cores. The CI runner is
`macos-26-arm64`: **3 cores, so a 3-thread pool**. All ~4050 tests run in one
process with no concurrency cap, so many suites are in flight at once.

The statement that would release a gate is itself async work needing a thread
from that same pool. So once as many gates are parked as the pool is wide, no
remaining thread can reach any `signal()` — and none ever will. The process
stops making progress permanently.

Two consequences worth naming, because they are why this was invisible:

- **No per-test `.timeLimit` fired.** A time limit cancels cooperatively, and a
  thread blocked in `wait()` is precisely where cancellation cannot reach.
- **Nothing was reported as failing.** The only signal was the job clock
  running out, which says nothing about where.

On a developer machine this does not happen by accident: 12 cores means a
12-wide pool, and a handful of parked gates leave threads to spare. It happens
on purpose — see the regression test below, which reproduces it here.

## When it broke

All four gates are new, from #684 and #686 — `git grep -l DispatchSemaphore --
Tests/` goes from 6 files to 10 between the last green commit and the first red
one. `CodexActivityReconciliation`, `CodexTranscriptPresentationObservation`,
`TerminalActivityEventHandler` and `TerminalSessionEventHandler` are copies of
one another and of a shape already in the tree, so nothing about them looked new
or risky in review.

Three older gates (`FDVendingServer`, `WorktreeDeletionQueue`,
`TmuxControlSupervisor` teardown) look identical at the call site but are not
the same hazard, and reading them was what made the mechanism precise: each is
already reached from a thread nobody else needs. `FDVendingServer` delivers to
its sinks from a dedicated receive `Thread`; `WorktreeDeletionQueue`'s gate sits
on its own `drainQueue`; `TmuxControlSupervisor` invokes `stopConnection` on
`DispatchQueue.global(qos: .utility)` precisely so a blocking stop stays off the
actor. None of them can take a thread the pool needs.

It slipped through because the failure mode is invisible to every guard we
have. It needs a narrow machine to appear at all, it produces no failing test,
and the per-test time limits that would normally bound a hang are structurally
unable to interrupt it.

## What this PR does

**Takes the blocking off the cooperative pool, and bounds it as a net.**

- Adds `gateHoldingTask` to `Tests/TestSupport/BoundedGateSupport.swift`: a
  `TaskExecutor` backed by a queue the tests own, and a `Task` factory that
  prefers it. Task executor preference is inherited by child tasks and, per
  SE-0417, carries into *default* actors — so a handler that hops through
  `RPCRouter`, a store actor and `CodexTranscriptActivityTracker` keeps running
  off-pool for the whole call. TBD declares no custom `unownedExecutor`
  anywhere in `Sources/`, so nothing pulls the job back.
- Starts all thirteen gate-holding tasks in the four suites through it. The
  three older gates keep a plain bounded wait, with a line at each site saying
  which thread they block so nobody "fixes" them later.
- Keeps `DispatchSemaphore.waitForGate(_:timeout:)` on every wait. It waits with
  a deadline; on expiry it records a test issue naming the gate and returns
  instead of parking forever. That is the net under the rule, not the rule: an
  author who adds an eighth gate and starts it with a plain `Task` gets a named
  failing test instead of a mystery.
- Records `sysctl -n hw.ncpu` in the test job. The runner's width is the
  quantity that decides how many blocked threads it takes to wedge the process,
  and it was inferred here, not measured.
- Writes the rule into `Tests/CLAUDE.md`.

**Bounding alone was not enough, and the first CI run of this branch is the
evidence.** With every wait bounded at 120 s the pass stopped wedging — it
completed in 265.9 s with 4054 tests instead of dying silent at 30 minutes —
but it was still red with ~43 real failures, overwhelmingly in suites with no
gate of their own. A bounded holder still owns its thread for the whole
deadline, so the wedge became starvation: the innocent suites blew their own
90 s `ciSafeDeadline` polls and 120 s suite limits *before* the gates gave up.
Lowering the deadline is not the fix either — the `TmuxControlSupervisor` gates
are legitimately held across a `waitUntil` bounded by `ciSafeDeadline` (90 s),
so any shorter bound trades starvation for spurious redness.

**No assertion changed.** `gateHoldingTask` changes only which threads a task
runs on. Every gate is signalled by the same statement in the same place, so
the ordering each one provides is exactly what it was, and the deadline still
asserts nothing and costs a passing run nothing.

**On the deadline: 120 seconds, and it is deliberately not "a few seconds".**
A gate is held for as long as the test's own observation takes, and those
observations are themselves hang-catchers sized against a loaded runner — the
`TmuxControlSupervisor` gates are held across `ciSafeDeadline`, which is 90 s.
Any gate deadline below that goes red on a merely slow machine, and a
spuriously red CI is strictly worse than the bug this bound exists to report.
120 s clears 90 s with margin, stays inside `.clockDriven`'s 4-minute limit with
room for the rest of a test after one full timeout, and is a small fraction of
the 30-minute step budget. That is the same invariant `Tests/CLAUDE.md` derives
for `ciSafeDeadline` and `waitForSuspension`, and the new constant is documented
to be re-derived alongside them.

Per repo convention this is a bug fix and ships without a spec: it restores the
suite to its existing theory rather than revising one.

## Assumptions

- **The runner is 3 cores.** The mechanism needs the pool to be narrower than
  the number of simultaneously parked gates. A wider runner hides it; a
  1-2 core runner makes it worse. The new `hw.ncpu` line means the next person
  reads this instead of inferring it.
- **90 s remains the ceiling on a legitimate hold.** If `ciSafeDeadline` is
  raised past 120 s, or a new gate is held across something slower, this
  deadline must move with it or it will go spuriously red.
- **Gates reached from a plain dispatch queue or `Thread`** have no task-local
  test context, so an expiry issue may be attributed to the run rather than to
  one test. The test's own downstream assertions then fail under their own
  names.

## Evidence & verification

**Be clear about the limit up front: the CI wedge cannot be reproduced on this
machine, and a green local run does not prove the fix.** The development box has
12 cores, so the 3-wide pool that starves the runner never occurs here, and a
green run says nothing about a narrow one. What *can* be shown here is the
mechanism, and the regression test below shows it.

*Discriminating evidence for the rule.*
`BoundedGateWaitTests.gateHoldersDoNotStarveTheCooperativePool` starts
`activeProcessorCount + 2` gate holders — a count derived from the pool's width,
so it saturates whatever machine runs it — and then requires ordinary
cooperative work to make progress and every holder to be *released* rather than
expire. Mutated back to a plain `Task` (and a 5 s deadline so the mutation run
does not take two minutes) it reds exactly as CI did, with the diagnostic on the
primary failure line:

```
Test "gate holders block their own threads, leaving the cooperative pool free"
recorded an issue at BoundedGateWaitTests.swift:71:40: Caught error: test gate
"self-test: pool-starvation holder 4" was never signalled within 5.0 seconds —
the releasing statement never ran. …
```

*Discriminating evidence for the bound.* The expiry branch runs on no healthy
machine, so `BoundedGateWaitTests` pins both halves: a satisfied gate still
orders its two sides and records nothing; an unsignalled gate returns rather
than parking, via `withKnownIssue`, which also fails if no issue is recorded —
so the test fails if the expiry path ever goes silent.

*The four suites.* `scripts/test.sh --filter` over all four plus the new
harness: **59 tests in 5 suites passed** in 1.6 s, 1 known issue (the deliberate
expiry self-test).

*No regression.* `scripts/test.sh --filter '^TBDDaemonTests\.'`: **4055 tests in
360 suites passed in 118.0 s**, 71 known issues — the pre-existing 70 plus the
one this PR adds. Against the 127 s green baseline and the 265.9 s the
bounded-only run took.

*Lint.* `swiftlint --strict`: 0 violations, 0 serious across 792 files.

*Not verified, and CI is the only place it can be.* That a 3-core runner now
finishes the pass green. The first green run of this branch is itself that
evidence.

## The ~43 failures on the bounded-only run

Reading them is what identified the starvation, and all of them are consistent
with it — every one is a hang-catcher expiring, and not one is a logic
assertion about behavior:

- **`RemoteFilingSyncTests`, 20 tests** — the whole suite, each "Time limit was
  exceeded: 120.000 seconds". Its `.timeLimit(.minutes(2))` is the same 120 s as
  the gate bound, so it was the first thing to die once gates started holding
  threads for their full deadline. That suite's own doc comment already records
  a *previous* round of this bug in the same file.
- **`TmuxControlSupervisorTeardownTests` (5) and
  `TmuxControlConnectionWedgedWriteTests` (1)** — `waitUntil(…, ciSafeDeadline)`
  expiring at 90 s. Their own gates are off-pool; their *polls* are not.
- **`ControlModeInputRouterTests:160`, `PRStatusManagerBindingTests:899`,
  `PRPollReconcileTests`** — bystanders with no gate of their own, dying on 90 s
  polls.
- **`BoundedGateWaitTests`' own cross-thread self-test** — a
  `DispatchQueue.global()` hop that did not run within 30 s, which is its own
  small piece of evidence about how saturated that runner was. Its deadline was
  an arbitrary number and is now the shared default; it asserts nothing about
  time.
- **`TerminalSessionEventHandlerTests:668`, 2 cases** — the gate itself
  reporting that it was never released within 120 s. This is the bound doing its
  job, and direct confirmation of the mechanism.

Nothing in that set looks independently broken, so no deadline was widened to
absorb one. If any of them survives on a green pool it is a separate bug and
gets its own fix.
