### PR TITLE
Fix: `tbd worktree archive` couldn't archive a scratch space

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -581,9 +581,14 @@ extension AppState {
     }
 
     /// Archive a worktree. Scratch-aware by construction: repo-less scratch
-    /// spaces are delegated to `archiveScratch(id:)` — the repo-worktree
-    /// `worktree.archive` RPC rejects them with `repoNotFound` — so callers
-    /// don't have to route per collection.
+    /// spaces are delegated to `archiveScratch(id:)` so callers don't have to
+    /// route per collection.
+    ///
+    /// The daemon routes them too now (`worktree.archive` dispatches a scratch
+    /// row to the same `scratch.archive` body), so this branch is no longer
+    /// what keeps the call from failing. It stays because the two client-side
+    /// settlements differ: `archiveScratch` also refreshes the Scratch
+    /// section's Archived tab, which the repo-worktree leg has no reason to do.
     func archiveWorktree(id: UUID, force: Bool = false) async {
         let worktree = findWorktree(id: id)
         if worktree?.isScratch == true {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2057,6 +2057,14 @@ final class AppState: ObservableObject {
             applyWorktreeArchivedDelta(d)
         case .worktreeRevived(let d):
             recentlyArchivedWorktreeIDs.removeValue(forKey: d.worktreeID)
+            // A revived row must leave the Scratch section's Archived tab, not
+            // just rejoin the sidebar. `refreshWorktrees` fetches with
+            // `excludeArchived: true` and never touches
+            // `archivedScratchWorktrees`, so without this a row revived from
+            // the CLI stays listed there while also showing as active, and
+            // that stale row's Delete button trashes the folder of a scratch
+            // space that is now live.
+            archivedScratchWorktrees.removeAll { $0.id == d.worktreeID }
             Task { [weak self] in await self?.refreshWorktrees() }
         case .controlModeInputHealthChanged(let d):
             applyControlModeInputHealthDelta(d)
@@ -2173,6 +2181,15 @@ final class AppState: ObservableObject {
         let failureMessage = Self.creationFailureMessage(worktree, creationFailed: delta.creationFailed)
 
         removeArchivedWorktreeFromState(id: delta.worktreeID)
+
+        // The mirror of the `.worktreeRevived` case: an archive that originated
+        // elsewhere (the CLI, a hook, a script) must ADD the row to the Scratch
+        // section's Archived tab, or an archived scratch space looks deleted:
+        // gone from the sidebar and absent from the only view that lists it.
+        // Cheap because the listing is small and unpaginated.
+        if worktree?.isScratch == true {
+            Task { [weak self] in await self?.refreshArchivedScratch() }
+        }
 
         // The daemon tells us whether creation actually failed; we never infer
         // it from `.creating` status. A deliberate archive of a still-creating

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -373,8 +373,18 @@ enum RowActionMenu {
                 .action(Action(kind: .rename, title: "Rename...")),
                 // `.destructive` for consistency with the repo-worktree Archive
                 // even though scratch archive is recoverable and leaves the
-                // folder on disk.
-                .action(Action(kind: .archiveScratch, title: "Archive", role: .destructive)),
+                // folder on disk. Gated on active children for the same reason
+                // and with the same copy as the repo-worktree Archive: a scratch
+                // space can be a parent (`tbd worktree new` run from inside one
+                // parents the new worktree on it), and the daemon refuses that
+                // archive, so the item must not look available.
+                .action(Action(
+                    kind: .archiveScratch,
+                    title: context.hasActiveChildren ? archiveHasChildrenLabel : "Archive",
+                    role: .destructive,
+                    isEnabled: !context.hasActiveChildren,
+                    disabledHelp: context.hasActiveChildren ? archiveNeedsChildrenGoneHelp : nil
+                )),
             ],
             pinActions(context: context).map(Item.action),
             hibernationActions(context: context).map(Item.action),

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -60,8 +60,17 @@ extension WorktreeLifecycle {
             try await db.worktrees.assertArchivable(id: worktreeID)
         }
 
-        guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
-            throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
+        // Split deliberately: a repo-less row and a row naming a missing repo
+        // are different failures, and the combined guard reported the first as
+        // the second with the worktree's own id substituted for the repo's.
+        // Repo-less rows are scratch spaces; the router routes those to the
+        // `scratch.*` path, so reaching this throw means an internal
+        // inconsistency and the message should say which one.
+        guard let rid = worktree.repoID else {
+            throw WorktreeLifecycleError.worktreeHasNoRepo(worktreeID)
+        }
+        guard let repo = try await db.repos.get(id: rid) else {
+            throw WorktreeLifecycleError.repoNotFound(rid)
         }
 
         // Collect Claude session IDs before archiving so they survive terminal deletion
@@ -298,8 +307,17 @@ extension WorktreeLifecycle {
             throw WorktreeLifecycleError.worktreeAlreadyActive(worktreeID)
         }
 
-        guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
-            throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
+        // Split deliberately: a repo-less row and a row naming a missing repo
+        // are different failures, and the combined guard reported the first as
+        // the second with the worktree's own id substituted for the repo's.
+        // Repo-less rows are scratch spaces; the router routes those to the
+        // `scratch.*` path, so reaching this throw means an internal
+        // inconsistency and the message should say which one.
+        guard let rid = worktree.repoID else {
+            throw WorktreeLifecycleError.worktreeHasNoRepo(worktreeID)
+        }
+        guard let repo = try await db.repos.get(id: rid) else {
+            throw WorktreeLifecycleError.repoNotFound(rid)
         }
 
         // Create parent directory if needed

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -232,9 +232,17 @@ extension WorktreeLifecycle {
         guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
-        guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
+        // Same split as archive/revive: name the condition that actually held.
+        // A scratch space never reaches the create lifecycle (scratch rows are
+        // minted by `handleScratchCreate`), so the repo-less arm here is an
+        // internal-inconsistency report, not a routing decision.
+        guard let rid = worktree.repoID else {
             try? await db.worktrees.delete(id: worktreeID)
-            throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
+            throw WorktreeLifecycleError.worktreeHasNoRepo(worktreeID)
+        }
+        guard let repo = try await db.repos.get(id: rid) else {
+            try? await db.worktrees.delete(id: worktreeID)
+            throw WorktreeLifecycleError.repoNotFound(rid)
         }
 
         do {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -8,6 +8,13 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "reaper")
 public enum WorktreeLifecycleError: LocalizedError, CustomStringConvertible {
     case repoNotFound(UUID)
     case worktreeNotFound(UUID)
+    /// The worktree row carries no `repoID` at all, so an operation that needs
+    /// a repository cannot run against it. Distinct from `repoNotFound`, which
+    /// means the row named a repo that is missing: conflating the two produced
+    /// a "Repository not found: <worktree id>" message that named an object
+    /// nothing had looked up. Repo-less rows are scratch spaces, and the
+    /// router routes those to the `scratch.*` path before this can fire.
+    case worktreeHasNoRepo(UUID)
     case worktreeNotArchived(UUID)
     case worktreeAlreadyActive(UUID)
     case createFailed(String)
@@ -24,6 +31,8 @@ public enum WorktreeLifecycleError: LocalizedError, CustomStringConvertible {
             return "Repository not found: \(id)"
         case .worktreeNotFound(let id):
             return "Worktree not found: \(id)"
+        case .worktreeHasNoRepo(let id):
+            return "Worktree \(id) has no repository (it is a scratch space), and this operation requires one."
         case .worktreeNotArchived(let id):
             return "Worktree is not archived: \(id)"
         case .worktreeAlreadyActive(let id):

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -177,16 +177,24 @@ extension RPCRouter {
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchArchiveParams.self, from: paramsData)
-        return try await archiveScratchSpace(worktreeID: params.worktreeID, actor: actor)
+        return try await archiveScratchSpace(
+            worktreeID: params.worktreeID, surface: .scratchArchive, force: false, actor: actor)
     }
 
-    /// The body of `scratch.archive`, shared with `worktree.archive`'s
-    /// scratch branch (`handleWorktreeArchive`). Extracted rather than
-    /// duplicated so there stays exactly one implementation of "archive a
-    /// scratch space": the repo-worktree archive path must never run against
-    /// one, because its phase 2 removes the directory.
+    /// The body of `scratch.archive`, shared with `worktree.archive`'s scratch
+    /// branch (`handleWorktreeArchive`). Extracted rather than duplicated so
+    /// the two RPC doors share one implementation: the repo-worktree archive
+    /// path must never run against a scratch space, because its phase 2
+    /// removes the directory. (`DeskSessionManager.closeDeskSession` still
+    /// carries a third, drifted copy of this teardown; folding it in is
+    /// tracked separately.)
+    ///
+    /// `surface` is the door the request came through, so the actuation row
+    /// records the method the caller actually called. Both surfaces carry the
+    /// same `kind` (`.dispose`), so this needs no `ActuationBranch`: the act is
+    /// identical and only the door differs.
     func archiveScratchSpace(
-        worktreeID: UUID, actor: ActuationActor?
+        worktreeID: UUID, surface: ActuationSurface, force: Bool, actor: ActuationActor?
     ) async throws -> RPCResponse {
         guard let wt = try await db.worktrees.getLocal(id: worktreeID) else {
             return RPCResponse(error: "Scratch space not found: \(worktreeID)")
@@ -195,10 +203,37 @@ extension RPCRouter {
             return RPCResponse(error: "Not a scratch space: \(worktreeID)")
         }
 
+        // Idempotent on an already-archived row, and deliberately not a
+        // re-archive: `WorktreeStore.archive` re-stamps `archivedAt`
+        // unconditionally, and that timestamp is the GC grace clock
+        // `OrphanProcessCollector` reaps from. A retry (a socket timeout, a
+        // hook firing twice, a sweep re-issuing the call) would otherwise push
+        // the reap of a wedged agent out by another `gcGraceSeconds` each time,
+        // and re-broadcast an archive delta for a row every client has already
+        // filed away.
+        guard wt.status != .archived else {
+            scratchLogger.info(
+                "\(surface.method, privacy: .public): \(wt.id, privacy: .public) is already archived; no-op")
+            return .ok()
+        }
+
+        // The same refusal the repo path gives, and for the same reason: a
+        // scratch space CAN be a parent. `ParentResolver`'s `caller` arm
+        // rejects only `.main` and `.archived`, so `tbd worktree new` run from
+        // inside a scratch space mints a repo worktree whose
+        // `parentWorktreeID` is this row, and `worktree.move` permits the same
+        // by hand. Archiving the parent out from under a live child leaves the
+        // child rendering nowhere until reconcile nulls the pointer, so it is
+        // refused unless the caller passed `force`. The cascade flows
+        // (`repo.remove`) are the ones that legitimately bypass it.
+        if !force {
+            try await db.worktrees.assertArchivable(id: worktreeID)
+        }
+
         // Same teardown as `scratch.delete`, so the same row: one per call,
         // worktree-named, written before the first kill.
         let actuationID = try await beginActuation(
-            .scratchArchive, actor: actor,
+            surface, actor: actor,
             target: ActuationTarget(worktree: wt.id.uuidString))
         try await actuating(actuationID) { try await closeScratchTerminals(wt.worktree) }
         await finishActuation(actuationID, .dispatched)
@@ -250,22 +285,37 @@ extension RPCRouter {
         guard wt.status == .archived else {
             return .refused("Scratch space is already active: \(wt.id)")
         }
+        // A promoted row is retired, not archived-and-revivable: promotion sets
+        // `promotedToRepoID` and leaves `repoID` NULL, so `isScratch` and the
+        // status check both still pass and only the stale `wt.path` (whose
+        // folder promotion moved away) incidentally stops this today. Both
+        // sibling verbs guard on it explicitly (`scratch.promote` refuses a
+        // second promotion, `scratch.delete` skips the trash), so revive does
+        // too, rather than resting on a filesystem coincidence that anything
+        // recreating the old directory would undo.
+        guard wt.promotedToRepoID == nil else {
+            return .refused("Scratch space was promoted to a repo and cannot be revived: \(wt.id)")
+        }
         guard FileManager.default.fileExists(atPath: wt.path) else {
             return .refused("Scratch directory missing on disk: \(wt.path)")
         }
 
         try await db.worktrees.revive(id: wt.id)
 
-        subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
-            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path)))
-        scratchLogger.info("scratch.revive: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
-
-        // Re-read rather than mutate the snapshot: the caller that returns a
-        // row must return the post-revive `status`/`archivedAt`, and the
-        // store owns how those are cleared.
+        // Re-read BEFORE broadcasting, and return the stored row rather than a
+        // mutated snapshot: the caller that answers with a row must answer with
+        // the post-revive `status`/`archivedAt`, and the store owns how those
+        // are cleared. Ordering it ahead of the broadcast keeps the one
+        // mutating failure honest: if a concurrent delete removed the row, no
+        // subscriber is told the revive happened before the caller is told it
+        // did not.
         guard let revived = try await db.worktrees.get(id: wt.id) else {
             return .refused("Scratch space vanished while reviving: \(wt.id)")
         }
+
+        subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
+            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path)))
+        scratchLogger.info("scratch.revive: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
         return .revived(revived)
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -310,6 +310,23 @@ extension RPCRouter {
         guard wt.isScratch else {
             return .refused("Not a scratch space: \(worktreeID)")
         }
+        // The mirror of the archive guard, and the reason it has to exist
+        // separately: `DeskSessionManager.closeDeskSession` archives the desk's
+        // row through `db.worktrees.archive` directly, changing neither
+        // `repoID` nor the display name, so the archived row still satisfies
+        // `isNightwatchDesk` and passes every other guard below. Reviving it
+        // here would flip it `.active` and broadcast a revive while the desk
+        // actor's in-memory pointer, judge lease row, lease credential file and
+        // terminals stay gone: an active desk with nothing behind it.
+        //
+        // Refusing costs nothing, because nothing legitimately revives a desk
+        // row. `ensureDeskSession`'s recovery path excludes archived worktrees
+        // deliberately, so the desk mints a fresh session instead.
+        guard !wt.isNightwatchDesk else {
+            return .refused(
+                "This is the Nightwatch Watch Desk; it is not revived by hand. The desk opens a "
+                    + "fresh session itself when it next runs.")
+        }
         guard wt.status == .archived else {
             return .refused("Scratch space is already active: \(wt.id)")
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -178,7 +178,7 @@ extension RPCRouter {
     ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchArchiveParams.self, from: paramsData)
         return try await archiveScratchSpace(
-            worktreeID: params.worktreeID, surface: .scratchArchive, force: false, actor: actor)
+            worktreeID: params.worktreeID, surface: .scratchArchive, actor: actor)
     }
 
     /// The body of `scratch.archive`, shared with `worktree.archive`'s scratch
@@ -194,7 +194,7 @@ extension RPCRouter {
     /// same `kind` (`.dispose`), so this needs no `ActuationBranch`: the act is
     /// identical and only the door differs.
     func archiveScratchSpace(
-        worktreeID: UUID, surface: ActuationSurface, force: Bool, actor: ActuationActor?
+        worktreeID: UUID, surface: ActuationSurface, actor: ActuationActor?
     ) async throws -> RPCResponse {
         guard let wt = try await db.worktrees.getLocal(id: worktreeID) else {
             return RPCResponse(error: "Scratch space not found: \(worktreeID)")
@@ -203,14 +203,34 @@ extension RPCRouter {
             return RPCResponse(error: "Not a scratch space: \(worktreeID)")
         }
 
+        // The Watch Desk is a scratch row (`isNightwatchDesk` is `isScratch`
+        // plus its display name), so the routing above reaches it. Its teardown
+        // is not this one: `DeskSessionManager.closeDeskSession` also clears the
+        // in-memory desk pointer and is paired with `releaseJudgeLease`, which
+        // drops the lease row and unlinks the lease credential file. Neither
+        // resource has a reconciler, so retiring the desk through the generic
+        // body would leak both with nothing to reclaim them. Refused rather
+        // than half-torn-down.
+        guard !wt.isNightwatchDesk else {
+            return RPCResponse(
+                error: "This is the Nightwatch Watch Desk; it is retired by the desk's own "
+                    + "teardown, not by archiving. Stop the desk instead.")
+        }
+
         // Idempotent on an already-archived row, and deliberately not a
         // re-archive: `WorktreeStore.archive` re-stamps `archivedAt`
         // unconditionally, and that timestamp is the GC grace clock
-        // `OrphanProcessCollector` reaps from. A retry (a socket timeout, a
-        // hook firing twice, a sweep re-issuing the call) would otherwise push
-        // the reap of a wedged agent out by another `gcGraceSeconds` each time,
-        // and re-broadcast an archive delta for a row every client has already
-        // filed away.
+        // `OrphanProcessCollector` reaps from. A *sequential* retry (a hook
+        // firing twice, a sweep re-issuing the call, a user repeating it) would
+        // otherwise push the reap of a wedged agent out by another
+        // `gcGraceSeconds` each time, and re-broadcast an archive delta for a
+        // row every client has already filed away.
+        //
+        // This is a read in its own transaction, so it does not close the
+        // window where two calls overlap in flight; the durable fix is a status
+        // check inside `WorktreeStore.archive`'s write block beside the
+        // `.main`/`.creating` refusals, which would cover the repo path and the
+        // direct callers (reconcile, the Watch Desk) at the same time.
         guard wt.status != .archived else {
             scratchLogger.info(
                 "\(surface.method, privacy: .public): \(wt.id, privacy: .public) is already archived; no-op")
@@ -223,12 +243,17 @@ extension RPCRouter {
         // inside a scratch space mints a repo worktree whose
         // `parentWorktreeID` is this row, and `worktree.move` permits the same
         // by hand. Archiving the parent out from under a live child leaves the
-        // child rendering nowhere until reconcile nulls the pointer, so it is
-        // refused unless the caller passed `force`. The cascade flows
-        // (`repo.remove`) are the ones that legitimately bypass it.
-        if !force {
-            try await db.worktrees.assertArchivable(id: worktreeID)
-        }
+        // child rendering nowhere until reconcile nulls the pointer.
+        //
+        // Unconditional, and deliberately NOT gated on the caller's `force`:
+        // `handleWorktreeArchive` does not forward `force` to
+        // `beginArchiveWorktree` either, so this assertion always runs for a
+        // repo worktree arriving through the same door. `force` bypasses it
+        // only for the in-process cascade flows that call the lifecycle
+        // directly (`repo.remove`), and no cascade reaches a repo-less row.
+        // Honouring `force` here would have made one flag mean opposite things
+        // on the two branches of one RPC.
+        try await db.worktrees.assertArchivable(id: worktreeID)
 
         // Same teardown as `scratch.delete`, so the same row: one per call,
         // worktree-named, written before the first kill.
@@ -243,7 +268,8 @@ extension RPCRouter {
         // client's perspective the row leaves the active section identically
         // whether archived or deleted.
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
-        scratchLogger.info("scratch.archive: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
+        scratchLogger.info(
+            "\(surface.method, privacy: .public): \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
         return .ok()
     }
 
@@ -275,7 +301,9 @@ extension RPCRouter {
 
     /// The body of `scratch.revive`, shared with `worktree.revive`'s scratch
     /// branch (`handleWorktreeRevive`).
-    func reviveScratchSpace(worktreeID: UUID) async throws -> ScratchReviveOutcome {
+    func reviveScratchSpace(
+        worktreeID: UUID, method: String = RPCMethod.scratchRevive
+    ) async throws -> ScratchReviveOutcome {
         guard let wt = try await db.worktrees.getLocal(id: worktreeID) else {
             return .refused("Scratch space not found: \(worktreeID)")
         }
@@ -315,7 +343,8 @@ extension RPCRouter {
 
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path)))
-        scratchLogger.info("scratch.revive: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
+        scratchLogger.info(
+            "\(method, privacy: .public): \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
         return .revived(revived)
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -177,11 +177,22 @@ extension RPCRouter {
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchArchiveParams.self, from: paramsData)
-        guard let wt = try await db.worktrees.getLocal(id: params.worktreeID) else {
-            return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
+        return try await archiveScratchSpace(worktreeID: params.worktreeID, actor: actor)
+    }
+
+    /// The body of `scratch.archive`, shared with `worktree.archive`'s
+    /// scratch branch (`handleWorktreeArchive`). Extracted rather than
+    /// duplicated so there stays exactly one implementation of "archive a
+    /// scratch space": the repo-worktree archive path must never run against
+    /// one, because its phase 2 removes the directory.
+    func archiveScratchSpace(
+        worktreeID: UUID, actor: ActuationActor?
+    ) async throws -> RPCResponse {
+        guard let wt = try await db.worktrees.getLocal(id: worktreeID) else {
+            return RPCResponse(error: "Scratch space not found: \(worktreeID)")
         }
         guard wt.isScratch else {
-            return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
+            return RPCResponse(error: "Not a scratch space: \(worktreeID)")
         }
 
         // Same teardown as `scratch.delete`, so the same row: one per call,
@@ -207,17 +218,40 @@ extension RPCRouter {
     /// repo-scoped revive.
     func handleScratchRevive(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchReviveParams.self, from: paramsData)
-        guard let wt = try await db.worktrees.getLocal(id: params.worktreeID) else {
-            return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
+        switch try await reviveScratchSpace(worktreeID: params.worktreeID) {
+        case .revived:
+            // `scratch.revive`'s result shape is unchanged: its GUI caller
+            // refreshes from the delta rather than reading a returned row.
+            return .ok()
+        case .refused(let message):
+            return RPCResponse(error: message)
+        }
+    }
+
+    /// Outcome of `reviveScratchSpace`. The two callers disagree on the
+    /// success payload: `scratch.revive` answers `.ok()`, while
+    /// `worktree.revive` must answer with the row, because both its CLI and
+    /// its app client decode a `Worktree` from the result. So the shared
+    /// helper hands back the row and lets each caller shape its response.
+    enum ScratchReviveOutcome {
+        case revived(Worktree)
+        case refused(String)
+    }
+
+    /// The body of `scratch.revive`, shared with `worktree.revive`'s scratch
+    /// branch (`handleWorktreeRevive`).
+    func reviveScratchSpace(worktreeID: UUID) async throws -> ScratchReviveOutcome {
+        guard let wt = try await db.worktrees.getLocal(id: worktreeID) else {
+            return .refused("Scratch space not found: \(worktreeID)")
         }
         guard wt.isScratch else {
-            return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
+            return .refused("Not a scratch space: \(worktreeID)")
         }
         guard wt.status == .archived else {
-            return RPCResponse(error: "Scratch space is already active: \(wt.id)")
+            return .refused("Scratch space is already active: \(wt.id)")
         }
         guard FileManager.default.fileExists(atPath: wt.path) else {
-            return RPCResponse(error: "Scratch directory missing on disk: \(wt.path)")
+            return .refused("Scratch directory missing on disk: \(wt.path)")
         }
 
         try await db.worktrees.revive(id: wt.id)
@@ -225,7 +259,14 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path)))
         scratchLogger.info("scratch.revive: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
-        return .ok()
+
+        // Re-read rather than mutate the snapshot: the caller that returns a
+        // row must return the post-revive `status`/`archivedAt`, and the
+        // store owns how those are cleared.
+        guard let revived = try await db.worktrees.get(id: wt.id) else {
+            return .refused("Scratch space vanished while reviving: \(wt.id)")
+        }
+        return .revived(revived)
     }
 
     func handleScratchPromote(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -226,15 +226,22 @@ extension RPCRouter {
         // instead. The GUI has been routing this client-side all along
         // (`AppState.archiveWorktree`); doing it here means the CLI, hooks,
         // scripts, and every future client get it without repeating the check.
-        // `force` is accepted and inert on this path: a scratch space has
-        // neither an archive hook (hooks resolve per repo) nor children.
+        // `force` is forwarded, not dropped: it still bypasses the
+        // active-children refusal, which a scratch space is subject to (it can
+        // be a parent). What it does NOT reach on this path is an archive hook,
+        // because the scratch body runs none at all, so a scratch space
+        // carrying `.worktree-hooks/archive`, or a user with a global
+        // `~/tbd/hooks/default/archive`, gets no archive hook and no
+        // diagnostic. Hook resolution is not repo-scoped, so that is a real
+        // gap, recorded in the design doc rather than papered over here.
         if let existing = try await db.worktrees.get(id: params.worktreeID) {
             if !existing.location.isLocal {
                 return try await archiveRemoteLane(existing, force: params.force, actor: actor)
             }
             if existing.isScratch {
                 return try await archiveScratchSpace(
-                    worktreeID: params.worktreeID, actor: actor)
+                    worktreeID: params.worktreeID, surface: .worktreeArchive,
+                    force: params.force, actor: actor)
             }
         }
 
@@ -506,13 +513,29 @@ extension RPCRouter {
                 return try await reviveRemoteLane(existing, actor: actor)
             }
             if existing.isScratch {
-                switch try await reviveScratchSpace(worktreeID: params.worktreeID) {
+                // Recorded like every other branch of this door. `beginActuation`
+                // is fail-closed, so a repo-less row must not be the one shape
+                // that flips `.archived` -> `.active` with an unwritable log and
+                // no row naming the actor who asked for it.
+                let actuationID = try await beginActuation(
+                    .worktreeRevive, actor: actor,
+                    target: ActuationTarget(worktree: params.worktreeID.uuidString))
+                let outcome: ScratchReviveOutcome
+                do {
+                    outcome = try await reviveScratchSpace(worktreeID: params.worktreeID)
+                } catch {
+                    await finishActuation(actuationID, .transportFailed, error: "\(error)")
+                    throw error
+                }
+                switch outcome {
                 case .revived(let revived):
+                    await finishActuation(actuationID, .dispatched)
                     // The row, not `.ok()`: `worktree.revive`'s clients decode
                     // a `Worktree` from the result. The delta is broadcast
                     // inside the helper, so this returns without repeating it.
                     return try RPCResponse(result: revived)
                 case .refused(let message):
+                    await finishActuation(actuationID, .transportFailed, error: message)
                     return RPCResponse(error: message)
                 }
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -217,9 +217,25 @@ extension RPCRouter {
         // handlers. A *missing* row is deliberately not handled here: that
         // stays `beginArchiveWorktree`'s throw, recorded as transport-failed,
         // unchanged.
-        if let existing = try await db.worktrees.get(id: params.worktreeID),
-           !existing.location.isLocal {
-            return try await archiveRemoteLane(existing, force: params.force, actor: actor)
+        //
+        // A repo-less scratch space is the second such row-shaped fact, read
+        // from the same DB row. `beginArchiveWorktree` needs a repo for the
+        // archive hook, and `completeArchiveWorktree` uses it to remove the
+        // directory (a scratch space has no repo, and its folder must SURVIVE
+        // archiving), so it routes to the dedicated `scratch.archive` body
+        // instead. The GUI has been routing this client-side all along
+        // (`AppState.archiveWorktree`); doing it here means the CLI, hooks,
+        // scripts, and every future client get it without repeating the check.
+        // `force` is accepted and inert on this path: a scratch space has
+        // neither an archive hook (hooks resolve per repo) nor children.
+        if let existing = try await db.worktrees.get(id: params.worktreeID) {
+            if !existing.location.isLocal {
+                return try await archiveRemoteLane(existing, force: params.force, actor: actor)
+            }
+            if existing.isScratch {
+                return try await archiveScratchSpace(
+                    worktreeID: params.worktreeID, actor: actor)
+            }
         }
 
         // One row per call, naming the worktree and no terminal: the caller
@@ -480,9 +496,26 @@ extension RPCRouter {
         // `getLocal` and would throw for it. Pre-row validation, like
         // archive's branch above; a *missing* row still falls through to the
         // lifecycle's own throw.
-        if let existing = try await db.worktrees.get(id: params.worktreeID),
-           !existing.location.isLocal {
-            return try await reviveRemoteLane(existing, actor: actor)
+        //
+        // A repo-less scratch space likewise: revive's git-worktree recreation
+        // has nothing to recreate for it (the folder never left disk), so it
+        // routes to the `scratch.revive` body, which re-checks the folder is
+        // still there and flips the row back. Mirror of archive's branch above.
+        if let existing = try await db.worktrees.get(id: params.worktreeID) {
+            if !existing.location.isLocal {
+                return try await reviveRemoteLane(existing, actor: actor)
+            }
+            if existing.isScratch {
+                switch try await reviveScratchSpace(worktreeID: params.worktreeID) {
+                case .revived(let revived):
+                    // The row, not `.ok()`: `worktree.revive`'s clients decode
+                    // a `Worktree` from the result. The delta is broadcast
+                    // inside the helper, so this returns without repeating it.
+                    return try RPCResponse(result: revived)
+                case .refused(let message):
+                    return RPCResponse(error: message)
+                }
+            }
         }
 
         // The row names the worktree, not a terminal: revive spawns its

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -219,29 +219,36 @@ extension RPCRouter {
         // unchanged.
         //
         // A repo-less scratch space is the second such row-shaped fact, read
-        // from the same DB row. `beginArchiveWorktree` needs a repo for the
-        // archive hook, and `completeArchiveWorktree` uses it to remove the
-        // directory (a scratch space has no repo, and its folder must SURVIVE
-        // archiving), so it routes to the dedicated `scratch.archive` body
-        // instead. The GUI has been routing this client-side all along
-        // (`AppState.archiveWorktree`); doing it here means the CLI, hooks,
-        // scripts, and every future client get it without repeating the check.
-        // `force` is forwarded, not dropped: it still bypasses the
-        // active-children refusal, which a scratch space is subject to (it can
-        // be a parent). What it does NOT reach on this path is an archive hook,
-        // because the scratch body runs none at all, so a scratch space
-        // carrying `.worktree-hooks/archive`, or a user with a global
-        // `~/tbd/hooks/default/archive`, gets no archive hook and no
-        // diagnostic. Hook resolution is not repo-scoped, so that is a real
-        // gap, recorded in the design doc rather than papered over here.
+        // from the same DB row. Phase 1 needs a repo to sync the branch from
+        // `git worktree list`, and phase 2 needs one to run the archive hook
+        // and to remove the directory (a scratch space has no repo, and its
+        // folder must SURVIVE archiving), so it routes to the dedicated
+        // `scratch.archive` body instead. The GUI has been routing this
+        // client-side all along (`AppState.archiveWorktree`); doing it here
+        // means the CLI, hooks, scripts, and every future client get it
+        // without repeating the check.
+        //
+        // `params.force` is deliberately not forwarded: the repo branch below
+        // does not forward it to `beginArchiveWorktree` either, so on this door
+        // it governs only phase 2's hook skip, and the scratch body runs no
+        // phase 2. Passing it through would have made one flag bypass the
+        // active-children refusal for a scratch row while leaving it in force
+        // for a repo worktree through the same door.
+        //
+        // What the scratch body does not do, all pre-existing and all recorded
+        // in the design doc: it runs no archive hook (only the highest-priority
+        // hook leg is repo-scoped, so `<worktree>/.worktree-hooks/archive` and
+        // the global `~/tbd/hooks/default/archive` would otherwise apply), it
+        // captures no scrollback into Closed Terminals, it does not escalate to
+        // SIGKILL for a pane surviving SIGHUP, and it records no resumable
+        // Claude session ids.
         if let existing = try await db.worktrees.get(id: params.worktreeID) {
             if !existing.location.isLocal {
                 return try await archiveRemoteLane(existing, force: params.force, actor: actor)
             }
             if existing.isScratch {
                 return try await archiveScratchSpace(
-                    worktreeID: params.worktreeID, surface: .worktreeArchive,
-                    force: params.force, actor: actor)
+                    worktreeID: params.worktreeID, surface: .worktreeArchive, actor: actor)
             }
         }
 
@@ -513,29 +520,30 @@ extension RPCRouter {
                 return try await reviveRemoteLane(existing, actor: actor)
             }
             if existing.isScratch {
-                // Recorded like every other branch of this door. `beginActuation`
-                // is fail-closed, so a repo-less row must not be the one shape
-                // that flips `.archived` -> `.active` with an unwritable log and
-                // no row naming the actor who asked for it.
-                let actuationID = try await beginActuation(
-                    .worktreeRevive, actor: actor,
-                    target: ActuationTarget(worktree: params.worktreeID.uuidString))
-                let outcome: ScratchReviveOutcome
-                do {
-                    outcome = try await reviveScratchSpace(worktreeID: params.worktreeID)
-                } catch {
-                    await finishActuation(actuationID, .transportFailed, error: "\(error)")
-                    throw error
-                }
-                switch outcome {
+                // No actuation row, and that asymmetry with the repo branch is
+                // the correct one rather than a gap. `ActuationSurface`'s
+                // boundary rule puts DB-only mutations OUT ("nothing there
+                // reaches a process, so nothing there is an actuation"), and
+                // this branch is exactly that: a status flip, a re-read and a
+                // delta. The repo branch records because it really does spawn
+                // the worktree's primary terminals, which is why
+                // `.worktreeRevive` carries `kind: .spawn`, a kind this branch
+                // would be lying about, and one a fleet reader querying
+                // "spawned but no session appeared" would flag forever.
+                //
+                // Consequence to know: `cols`, `rows` and `preferredSessionID`
+                // are accepted and unused here, because there is no terminal to
+                // size and no session to resume. Archive deleted every terminal
+                // row and this spawns none.
+                switch try await reviveScratchSpace(
+                    worktreeID: params.worktreeID, method: RPCMethod.worktreeRevive
+                ) {
                 case .revived(let revived):
-                    await finishActuation(actuationID, .dispatched)
                     // The row, not `.ok()`: `worktree.revive`'s clients decode
                     // a `Worktree` from the result. The delta is broadcast
                     // inside the helper, so this returns without repeating it.
                     return try RPCResponse(result: revived)
                 case .refused(let message):
-                    await finishActuation(actuationID, .transportFailed, error: message)
                     return RPCResponse(error: message)
                 }
             }

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -104,10 +104,10 @@ struct FindWorktreeScratchTests {
     }
 }
 
-/// Cmd+Shift+A routing: the route seam only decides refuse-vs-proceed —
+/// Cmd+Shift+A routing: the route seam only decides refuse-vs-proceed.
 /// `archiveWorktree(id:)` is scratch-aware and self-routes scratch rows to
-/// the `scratch.archive` RPC (the repo-worktree `worktree.archive` RPC would
-/// reject them with `repoNotFound`). `archiveShortcutRoute` takes the
+/// the `scratch.archive` RPC; the daemon routes them too, so either door
+/// reaches the same body. `archiveShortcutRoute` takes the
 /// caller-resolved selection (`selectedWorktreeIDs.first.flatMap(findWorktree)`),
 /// so a stale/unknown selected ID resolves to nil and routes nowhere.
 @MainActor
@@ -115,8 +115,10 @@ struct FindWorktreeScratchTests {
 struct ArchiveShortcutRouteTests {
 
     @Test func scratchSelectionProceeds() {
-        // Scratch rows always proceed: the daemon creates them `.active`,
-        // never `.main`/`.creating`, so the repo-worktree refusals can't apply.
+        // Scratch rows proceed through this seam: the daemon creates them
+        // `.active`, never `.main`/`.creating`. The one repo-worktree refusal
+        // that DOES apply to them, active children, is enforced daemon-side and
+        // pre-disabled in the row menu rather than here.
         let scratchID = UUID()
         let target = AppState.archiveShortcutRoute(
             selectedWorktree: makeWorktree(id: scratchID, repoID: nil)

--- a/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
@@ -279,6 +279,61 @@ struct ActuationLogTeardownWiringTests {
         #expect(try await db.worktrees.get(id: scratch.id)?.status == .archived)
     }
 
+    @Test("a scratch archive routed from worktree.archive is filed under that door")
+    func routedScratchArchiveRecordsTheWorktreeArchiveMethod() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let scratch = try await makeScratch(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: scratch.id),
+            actor: .app))
+        #expect(response.success)
+
+        // `method` names the door the request came through, `kind` the act, so
+        // the same body reached from the other door must not file the request
+        // under a verb only the GUI ever sends. Both surfaces carry `dispose`,
+        // which is why this needs no `ActuationBranch`.
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["method"] as? String == "worktree.archive")
+        #expect(written.first?["kind"] as? String == "dispose")
+        #expect(written.last?["result"] as? String == "dispatched")
+        #expect(try await db.worktrees.get(id: scratch.id)?.status == .archived)
+    }
+
+    @Test("a scratch revive routed from worktree.revive writes no row: it reaches no process")
+    func routedScratchReviveWritesNothing() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let scratch = try await makeScratch(in: db)
+        // Revive requires the folder to still be there, and this suite's
+        // fixture only writes the row.
+        try FileManager.default.createDirectory(
+            atPath: scratch.localPath, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scratch.localPath) }
+        #expect(await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: scratch.id), actor: .app)).success)
+        let afterArchive = try rows(at: logPath).count
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: scratch.id), actor: .app))
+        #expect(response.success)
+
+        // The actuation boundary puts DB-only mutations OUT, and this branch is
+        // a status flip plus a delta: no tmux, no pty, no process. The repo
+        // branch records because it spawns the worktree's primary terminals,
+        // which is what `.worktreeRevive`'s `spawn` kind names. Recording here
+        // would post a phantom spawn against a worktree with zero terminals.
+        #expect(try rows(at: logPath).count == afterArchive)
+        #expect(try await db.worktrees.get(id: scratch.id)?.status == .active)
+    }
+
     @Test("a scratch space that does not exist is declined before any row exists")
     func scratchDeleteOfAbsentRowWritesNothing() async throws {
         let logPath = try makeLogPath()

--- a/Tests/TBDDaemonTests/LocalizedErrorPayloadTests.swift
+++ b/Tests/TBDDaemonTests/LocalizedErrorPayloadTests.swift
@@ -245,6 +245,11 @@ struct LocalizedErrorPayloadTests {
             "WorktreeLifecycleError.repoNotFound"
         )
         assertRenders(
+            WorktreeLifecycleError.worktreeHasNoRepo(Self.worktreeID),
+            [Self.worktreeID.uuidString],
+            "WorktreeLifecycleError.worktreeHasNoRepo"
+        )
+        assertRenders(
             OrphanGCError.recordNotFound(Self.recordID),
             [Self.recordID.uuidString],
             "OrphanGCError.recordNotFound"

--- a/Tests/TBDDaemonTests/LocalizedErrorPayloadTests.swift
+++ b/Tests/TBDDaemonTests/LocalizedErrorPayloadTests.swift
@@ -114,6 +114,10 @@ struct LocalizedErrorPayloadTests {
             ),
             ("WorktreeLifecycleError.repoNotFound", WorktreeLifecycleError.repoNotFound(Self.repoID)),
             ("WorktreeLifecycleError.worktreeNotFound", WorktreeLifecycleError.worktreeNotFound(Self.worktreeID)),
+            (
+                "WorktreeLifecycleError.worktreeHasNoRepo",
+                WorktreeLifecycleError.worktreeHasNoRepo(Self.worktreeID)
+            ),
             ("WorktreeLifecycleError.worktreeNotArchived", WorktreeLifecycleError.worktreeNotArchived(Self.worktreeID)),
             ("WorktreeLifecycleError.createFailed", WorktreeLifecycleError.createFailed("branch already checked out")),
             (

--- a/Tests/TBDDaemonTests/PreSessionTestSupport.swift
+++ b/Tests/TBDDaemonTests/PreSessionTestSupport.swift
@@ -6,7 +6,8 @@ import Testing
 @testable import TBDShared
 
 // Shared fixtures for the pre-session hook suites (`PreSessionHookTests`,
-// `PreSessionRerunTests`). Both are nested under `extension TBDHomeSerialized`
+// `PreSessionRerunTests`); `isolateTBDHome()` is target-wide and other suites
+// use it too. Every caller is nested under `extension TBDHomeSerialized`
 // because `isolateTBDHome()` mutates the process-global `TBD_HOME` env var —
 // see TBDHomeSerializedSuites.swift for why that requires serialization.
 //

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -192,8 +192,6 @@ struct WorktreeArchiveScratchRoutingRPCTests {
             method: RPCMethod.worktreeArchive,
             params: WorktreeArchiveParams(worktreeID: wt.id)))
         #expect(archive.success)
-        // The old failure's exact wording, asserted so a regression that
-        // reinstates the repo guard fails loudly rather than just unsuccessfully.
         #expect(archive.error == nil)
 
         let reloaded = try await db.worktrees.get(id: wt.id)
@@ -316,30 +314,148 @@ struct WorktreeArchiveScratchRoutingRPCTests {
         #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)
     }
 
-    @Test func aRepoWorktreeStillTakesTheRepoPath() async throws {
+    /// The false arm of `if existing.isScratch` on the archive door. Driven
+    /// through a `.main` row so `beginArchiveWorktree` refuses at its very
+    /// first guard: that proves the repo path ran (the scratch body's own
+    /// refusal reads "Not a scratch space") while touching no tmux, no git and
+    /// no disk, and above all never reaching the detached phase 2 whose
+    /// deletion-queue rename would outlive this test's `TBD_HOME` isolation.
+    @Test func archiveDoesNotDivertARepoWorktreeIntoTheScratchBody() async throws {
         let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
         let db = try TBDDatabase(inMemory: true)
         let (router, _) = makeRouter(db: db)
-        // The routing keys on `repoID == nil`. A row that HAS a repo must not
-        // reach the scratch body: it would leave the directory and the git
-        // registration behind while reporting success.
         let repo = try await db.repos.create(
             path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("wt-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: dir) }
         let wt = try await db.worktrees.create(
-            repoID: repo.id, name: "w", branch: "b", path: dir.path, tmuxServer: "tbd-x")
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x")
         #expect(!wt.isScratch)
+        try await db.worktrees.updateStatus(id: wt.id, status: .main)
 
         let archive = await router.handle(try RPCRequest(
             method: RPCMethod.worktreeArchive,
             params: WorktreeArchiveParams(worktreeID: wt.id)))
-        // Phase 1 succeeds against a real repo row; the point is that it went
-        // through the lifecycle at all, which the scratch body would have
-        // refused with "Not a scratch space".
-        #expect(archive.error != "Not a scratch space: \(wt.id)")
+        #expect(!archive.success)
+        #expect(archive.error?.contains("Cannot archive the main branch worktree") == true)
+        #expect(archive.error?.contains("Not a scratch space") == false)
+    }
+
+    /// The false arm of `if existing.isScratch` on the revive door. An `.active`
+    /// repo worktree makes `beginReviveWorktree` refuse at its status guard,
+    /// before the repo lookup and before any git work; the scratch body would
+    /// have answered "Not a scratch space" instead. Without this, a future
+    /// refactor that widened the predicate could route repo worktrees into
+    /// `reviveScratchSpace` (flipping a row `.active` with no git worktree
+    /// recreated) with the whole suite green.
+    @Test func reviveDoesNotDivertARepoWorktreeIntoTheScratchBody() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x")
+
+        let revive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: wt.id)))
+        #expect(!revive.success)
+        #expect(revive.error?.contains("Worktree is already active") == true)
+        #expect(revive.error?.contains("Not a scratch space") == false)
+        #expect(revive.error?.contains("Scratch space") == false)
+    }
+
+    /// A scratch space can be a parent: `ParentResolver`'s `caller` arm returns
+    /// the caller id after rejecting only `.main`/`.archived`, so
+    /// `tbd worktree new` run from inside a scratch space sets that row as the
+    /// new worktree's parent. Archiving it out from under a live child is the
+    /// refusal `assertArchivable` exists for, and the routed path must give it
+    /// rather than behaving as though `--force` were always passed.
+    @Test func archiveRefusesAScratchSpaceWithAnActiveChild() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let parent = try await makeScratch(router, name: "wt-scratch-parent")
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "child", branch: "b",
+            path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x",
+            parentWorktreeID: parent.id)
+
+        let archive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: parent.id)))
+        #expect(!archive.success)
+        #expect(archive.error?.contains("Archive nested worktrees first") == true)
+        #expect(try await db.worktrees.get(id: parent.id)?.status == .active)
+
+        // `--force` is the documented bypass for cascade flows, and it must
+        // still reach the scratch body rather than being swallowed as inert.
+        let forced = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: parent.id, force: true)))
+        #expect(forced.success)
+        #expect(try await db.worktrees.get(id: parent.id)?.status == .archived)
+    }
+
+    /// `archivedAt` is the GC grace clock `OrphanProcessCollector` reaps from,
+    /// so a retry must not re-stamp it and push the reap of a wedged agent out
+    /// by another grace window.
+    @Test func archivingAnAlreadyArchivedScratchRowIsAnIdempotentNoOp() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-archive-twice")
+        #expect(await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id))).success)
+        let firstStamp = try await db.worktrees.get(id: wt.id)?.archivedAt
+        #expect(firstStamp != nil)
+
+        let again = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id)))
+        #expect(again.success)
+        #expect(try await db.worktrees.get(id: wt.id)?.archivedAt == firstStamp)
+        // And no second delta for a row every client already filed away.
+        let archived = deltas.snapshot().filter {
+            if case .worktreeArchived(let d) = $0 { return d.worktreeID == wt.id }
+            return false
+        }
+        #expect(archived.count == 1)
+    }
+
+    /// A promoted scratch row is retired, not archived-and-revivable. Promotion
+    /// leaves `repoID` NULL, so `isScratch` still holds and only the moved
+    /// folder incidentally blocked this before the explicit guard.
+    @Test func reviveRefusesAPromotedScratchRow() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-promoted")
+        // The production retirement path: it archives the scratch row and sets
+        // `promotedToRepoID` while leaving `repoID` NULL, which is exactly the
+        // shape that keeps `isScratch` true for a row that must not revive.
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let main = try await db.worktrees.create(
+            repoID: repo.id, name: "main", branch: "main",
+            path: "/tmp/main-\(UUID().uuidString)", tmuxServer: "tbd-y", status: .main)
+        try await db.worktrees.promoteScratchMigration(
+            scratchID: wt.id, mainWorktreeID: main.id, repoID: repo.id, tmuxServer: "tbd-y")
+        // Recreate a directory at the stale scratch path, so the fileExists
+        // check cannot be what refuses this.
+        try FileManager.default.createDirectory(
+            atPath: wt.localPath, withIntermediateDirectories: true)
+
+        let revive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: wt.id)))
+        #expect(!revive.success)
+        #expect(revive.error?.contains("promoted") == true)
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)
     }
 }
 }

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -494,6 +494,49 @@ struct WorktreeArchiveScratchRoutingRPCTests {
         #expect(archived.count == 1)
     }
 
+    /// The desk needs its own revive guard, not archive's: `closeDeskSession`
+    /// archives the desk row through the store directly and changes neither
+    /// `repoID` nor the display name, so the archived row still reads as the
+    /// desk and would otherwise pass every guard revive has. Reviving it would
+    /// report an active desk with no lease, no credential file and no terminals
+    /// behind it. Reachable from any client only because of this PR's routing.
+    @Test func reviveRefusesAnArchivedNightwatchWatchDesk() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("desk-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let desk = try await db.worktrees.createScratch(
+            name: "watch-desk", displayName: NightwatchDeskPrompts.deskDisplayName,
+            path: dir.path, tmuxServer: "tbd-x")
+        // Exactly what `closeDeskSession` does: archive the row through the
+        // store, touching neither `repoID` nor the display name.
+        try await db.worktrees.archive(id: desk.id)
+        let archived = try await db.worktrees.get(id: desk.id)
+        #expect(archived?.isNightwatchDesk == true)
+        // The folder is present, so the fileExists guard is not what refuses.
+        #expect(FileManager.default.fileExists(atPath: dir.path))
+
+        for method in [RPCMethod.worktreeRevive, RPCMethod.scratchRevive] {
+            let revive = await router.handle(
+                method == RPCMethod.worktreeRevive
+                    ? try RPCRequest(method: method,
+                                     params: WorktreeReviveParams(worktreeID: desk.id))
+                    : try RPCRequest(method: method,
+                                     params: ScratchReviveParams(worktreeID: desk.id)))
+            #expect(!revive.success)
+            #expect(revive.error?.contains("Watch Desk") == true)
+            #expect(try await db.worktrees.get(id: desk.id)?.status == .archived)
+        }
+        // And no revive delta told any client the desk came back.
+        #expect(!deltas.snapshot().contains {
+            if case .worktreeRevived(let d) = $0 { return d.worktreeID == desk.id }
+            return false
+        })
+    }
+
     /// A promoted scratch row is retired, not archived-and-revivable. Promotion
     /// leaves `repoID` NULL, so `isScratch` still holds and only the moved
     /// folder incidentally blocked this before the explicit guard.

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -537,6 +537,46 @@ struct WorktreeArchiveScratchRoutingRPCTests {
         })
     }
 
+    /// The one refusal that can follow a committed write. Forced deterministically
+    /// with a trigger rather than raced: the in-memory store is a single-connection
+    /// `DatabaseQueue`, so an AFTER UPDATE trigger that deletes the row as the
+    /// status flips reproduces exactly what a concurrent `scratch.delete` would do
+    /// between `revive()` and the re-read.
+    ///
+    /// The property under test is the ORDERING: the re-read sits ahead of the
+    /// broadcast, so this failure must not have told every subscriber the revive
+    /// happened while telling the caller it did not.
+    @Test func reviveRefusesAndBroadcastsNothingIfTheRowVanishesMidWrite() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-vanish-mid-revive")
+        #expect(await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id))).success)
+
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: """
+                CREATE TRIGGER vanish_on_revive AFTER UPDATE ON worktree
+                WHEN new.status = '\(WorktreeStatus.active.rawValue)'
+                BEGIN
+                    DELETE FROM worktree WHERE id = new.id;
+                END;
+                """)
+        }
+
+        let revive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: wt.id)))
+        #expect(!revive.success)
+        #expect(revive.error?.contains("vanished while reviving") == true)
+        #expect(try await db.worktrees.get(id: wt.id) == nil)
+        #expect(!deltas.snapshot().contains {
+            if case .worktreeRevived(let d) = $0 { return d.worktreeID == wt.id }
+            return false
+        })
+    }
+
     /// A promoted scratch row is retired, not archived-and-revivable. Promotion
     /// leaves `repoID` NULL, so `isScratch` still holds and only the moved
     /// folder incidentally blocked this before the explicit guard.

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -4,35 +4,28 @@ import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+/// Router whose lifecycle and handlers share one StateSubscriptionManager,
+/// with every broadcast delta captured in `deltas`.
+private func makeRouter(db: TBDDatabase) -> (router: RPCRouter, deltas: BroadcastDeltas) {
+    let deltas = BroadcastDeltas()
+    let subs = StateSubscriptionManager()
+    subs.addSubscriber { data in
+        if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+            deltas.append(delta)
+        }
+        return true
+    }
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+        tmux: TmuxManager(dryRun: true),
+        subscriptions: subs, actuationLog: makeTestActuationLog())
+    return (router, deltas)
+}
+
 extension TBDHomeSerialized {
 @Suite("scratch.archive / scratch.revive RPC")
 struct ScratchArchiveReviveRPCTests {
-    private func isolateTBDHome() -> (URL, () -> Void) {
-        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-scratcharch-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
-        let priorTBDHome = setTBDHome(home.path)
-        return (home, { restoreTBDHome(priorTBDHome); try? FileManager.default.removeItem(at: home) })
-    }
-
-    /// Router whose lifecycle and handlers share one StateSubscriptionManager,
-    /// with every broadcast delta captured in `deltas`.
-    private func makeRouter(db: TBDDatabase) -> (router: RPCRouter, deltas: BroadcastDeltas) {
-        let deltas = BroadcastDeltas()
-        let subs = StateSubscriptionManager()
-        subs.addSubscriber { data in
-            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
-                deltas.append(delta)
-            }
-            return true
-        }
-        let router = RPCRouter(
-            db: db,
-            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true),
-            subscriptions: subs, actuationLog: makeTestActuationLog())
-        return (router, deltas)
-    }
-
     @Test func archiveFlipsStatusSetsArchivedAtAndLeavesFolder() async throws {
         let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
         let db = try TBDDatabase(inMemory: true)
@@ -168,5 +161,205 @@ private final class BroadcastDeltas: @unchecked Sendable {
     func snapshot() -> [StateDelta] {
         lock.lock(); defer { lock.unlock() }
         return deltas
+    }
+}
+
+/// `tbd worktree archive <scratch>` used to fail with "Repository not found:
+/// <worktree id>": the repo-worktree archive path resolves a repo before doing
+/// anything, and a scratch row has none. `worktree.archive` and
+/// `worktree.revive` now route a repo-less row to the `scratch.*` body.
+/// See `docs/specs/2026-08-20-scratch-archive-routing-design.md`.
+extension TBDHomeSerialized {
+@Suite("worktree.archive / worktree.revive on a scratch space")
+struct WorktreeArchiveScratchRoutingRPCTests {
+
+    private func makeScratch(
+        _ router: RPCRouter, name: String
+    ) async throws -> Worktree {
+        let created = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: name)))
+        return try created.decodeResult(Worktree.self)
+    }
+
+    @Test func archiveSucceedsFlipsStatusAndLeavesFolderOnDisk() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-archive-me")
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
+
+        let archive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id)))
+        #expect(archive.success)
+        // The old failure's exact wording, asserted so a regression that
+        // reinstates the repo guard fails loudly rather than just unsuccessfully.
+        #expect(archive.error == nil)
+
+        let reloaded = try await db.worktrees.get(id: wt.id)
+        #expect(reloaded?.status == .archived)
+        #expect(reloaded?.archivedAt != nil)
+        // Archived, not forgotten and not deleted: the row survives...
+        #expect(reloaded != nil)
+        // ...and so does the folder. `worktree.archive`'s phase 2 hands the
+        // directory to the deletion queue; the scratch path must never do that.
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
+
+        let archived = deltas.snapshot().filter {
+            if case .worktreeArchived(let d) = $0 { return d.worktreeID == wt.id }
+            return false
+        }
+        #expect(archived.count == 1)
+    }
+
+    @Test func archivedScratchRowAppearsInTheArchivedListing() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-archive-listing")
+
+        let archive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id)))
+        #expect(archive.success)
+
+        let listed = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(status: .archived)))
+        let rows = try listed.decodeResult([Worktree].self)
+        #expect(rows.contains { $0.id == wt.id })
+    }
+
+    @Test func reviveBringsTheArchivedScratchRowBackAndReturnsTheRow() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-revive-me")
+        #expect(await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id))).success)
+
+        let revive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: wt.id)))
+        #expect(revive.success)
+        // Both the CLI and the app client decode a `Worktree` from
+        // `worktree.revive`'s result, so `.ok()` would break them.
+        let returned = try revive.decodeResult(Worktree.self)
+        #expect(returned.id == wt.id)
+        #expect(returned.status == .active)
+        #expect(returned.archivedAt == nil)
+
+        let reloaded = try await db.worktrees.get(id: wt.id)
+        #expect(reloaded?.status == .active)
+        #expect(reloaded?.archivedAt == nil)
+
+        let revived = deltas.snapshot().filter {
+            if case .worktreeRevived(let d) = $0 { return d.worktreeID == wt.id }
+            return false
+        }
+        // Exactly one: the helper broadcasts, and the routed branch returns
+        // before the repo path's own broadcast.
+        #expect(revived.count == 1)
+    }
+
+    @Test func archiveTearsDownTerminalsAndTabs() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-archive-terminals")
+        // scratch.create auto-spawns a primary agent terminal; clear it so this
+        // test owns its fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        try await db.tabs.setLabel(tabID: terminal.id, worktreeID: wt.id, label: "my tab")
+
+        #expect(await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id))).success)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func forceIsAcceptedAndInertOnAScratchSpace() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-archive-forced")
+
+        let archive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id, force: true)))
+        #expect(archive.success)
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)
+        // Still on disk: `force` skips the archive hook on the repo path, and
+        // must not be read as license to remove anything here.
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
+    }
+
+    @Test func reviveRefusesWhenTheFolderVanishedAndKeepsTheRowArchived() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let wt = try await makeScratch(router, name: "wt-revive-vanished")
+        #expect(await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id))).success)
+        try FileManager.default.removeItem(atPath: wt.localPath)
+
+        let revive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRevive,
+            params: WorktreeReviveParams(worktreeID: wt.id)))
+        #expect(!revive.success)
+        #expect(revive.error?.contains("missing on disk") == true)
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)
+    }
+
+    @Test func aRepoWorktreeStillTakesTheRepoPath() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        // The routing keys on `repoID == nil`. A row that HAS a repo must not
+        // reach the scratch body: it would leave the directory and the git
+        // registration behind while reporting success.
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b", path: dir.path, tmuxServer: "tbd-x")
+        #expect(!wt.isScratch)
+
+        let archive = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: wt.id)))
+        // Phase 1 succeeds against a real repo row; the point is that it went
+        // through the lifecycle at all, which the scratch body would have
+        // refused with "Not a scratch space".
+        #expect(archive.error != "Not a scratch space: \(wt.id)")
+    }
+}
+}
+
+/// The message that shipped the bug read "Repository not found: <worktree id>":
+/// one guard covered two different failures, and the `?? worktreeID` fallback
+/// named an object nothing had looked up.
+@Suite("WorktreeLifecycleError repo-less rendering")
+struct WorktreeLifecycleRepoErrorMessageTests {
+    @Test func aRepoLessRowRendersAsSuchAndNamesTheWorktree() {
+        let worktreeID = UUID()
+        let message = WorktreeLifecycleError.worktreeHasNoRepo(worktreeID).description
+        #expect(message.contains(worktreeID.uuidString))
+        #expect(message.lowercased().contains("no repository"))
+        #expect(!message.contains("Repository not found"))
+    }
+
+    @Test func repoNotFoundStillMeansAMissingRepoRow() {
+        let repoID = UUID()
+        #expect(WorktreeLifecycleError.repoNotFound(repoID).description
+            == "Repository not found: \(repoID)")
     }
 }

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -280,7 +280,11 @@ struct WorktreeArchiveScratchRoutingRPCTests {
         #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty)
     }
 
-    @Test func forceIsAcceptedAndInertOnAScratchSpace() async throws {
+    /// `--force` is accepted and changes nothing on this path. What it governs
+    /// on the repo branch is phase 2's hook skip, and the scratch body has no
+    /// phase 2; the children refusal it does NOT govern is asserted in
+    /// `archiveRefusesAScratchSpaceWithAnActiveChild`.
+    @Test func forceIsAcceptedAndChangesNothingOnAScratchSpace() async throws {
         let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
         let db = try TBDDatabase(inMemory: true)
         let (router, _) = makeRouter(db: db)
@@ -291,8 +295,8 @@ struct WorktreeArchiveScratchRoutingRPCTests {
             params: WorktreeArchiveParams(worktreeID: wt.id, force: true)))
         #expect(archive.success)
         #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)
-        // Still on disk: `force` skips the archive hook on the repo path, and
-        // must not be read as license to remove anything here.
+        // Still on disk: `force` must never be read as license to remove
+        // anything here, which is what phase 2 would have done.
         #expect(FileManager.default.fileExists(atPath: wt.localPath))
     }
 
@@ -379,7 +383,7 @@ struct WorktreeArchiveScratchRoutingRPCTests {
         let parent = try await makeScratch(router, name: "wt-scratch-parent")
         let repo = try await db.repos.create(
             path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
-        _ = try await db.worktrees.create(
+        let child = try await db.worktrees.create(
             repoID: repo.id, name: "child", branch: "b",
             path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x",
             parentWorktreeID: parent.id)
@@ -391,13 +395,76 @@ struct WorktreeArchiveScratchRoutingRPCTests {
         #expect(archive.error?.contains("Archive nested worktrees first") == true)
         #expect(try await db.worktrees.get(id: parent.id)?.status == .active)
 
-        // `--force` is the documented bypass for cascade flows, and it must
-        // still reach the scratch body rather than being swallowed as inert.
+        // `--force` must NOT bypass it, because it does not bypass it for a
+        // repo worktree arriving through this same door either:
+        // `handleWorktreeArchive` never forwards `force` to
+        // `beginArchiveWorktree`, so that assertion always runs there too. One
+        // flag meaning opposite things on the two branches of one RPC is the
+        // divergence this asserts against.
         let forced = await router.handle(try RPCRequest(
             method: RPCMethod.worktreeArchive,
             params: WorktreeArchiveParams(worktreeID: parent.id, force: true)))
-        #expect(forced.success)
+        #expect(!forced.success)
+        #expect(forced.error?.contains("Archive nested worktrees first") == true)
+        #expect(try await db.worktrees.get(id: parent.id)?.status == .active)
+
+        // Once the child is out of the way, the archive goes through.
+        try await db.worktrees.archive(id: child.id)
+        let after = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: parent.id)))
+        #expect(after.success)
         #expect(try await db.worktrees.get(id: parent.id)?.status == .archived)
+    }
+
+    /// The refusal reaches the pre-existing `scratch.archive` door too, since
+    /// both doors share the body. That door is the GUI's, and it carries no
+    /// `force` on the wire at all, which is the other half of why the children
+    /// assertion is unconditional rather than `force`-gated.
+    @Test func theScratchArchiveDoorRefusesAnActiveChildToo() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let parent = try await makeScratch(router, name: "wt-scratch-parent-door")
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "child", branch: "b",
+            path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x",
+            parentWorktreeID: parent.id)
+
+        let archive = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchArchive,
+            params: ScratchArchiveParams(worktreeID: parent.id)))
+        #expect(!archive.success)
+        #expect(archive.error?.contains("Archive nested worktrees first") == true)
+        #expect(try await db.worktrees.get(id: parent.id)?.status == .active)
+    }
+
+    /// The Watch Desk is a scratch row, so the routing reaches it. Its lease row
+    /// and lease credential file have no reconciler, and only
+    /// `DeskSessionManager.closeDeskSession` releases them, so the generic body
+    /// must refuse rather than half-retire the desk.
+    @Test func archiveRefusesTheNightwatchWatchDesk() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let desk = try await db.worktrees.createScratch(
+            name: "watch-desk", displayName: NightwatchDeskPrompts.deskDisplayName,
+            path: "/tmp/desk-\(UUID().uuidString)", tmuxServer: "tbd-x")
+        #expect(desk.isNightwatchDesk)
+
+        for method in [RPCMethod.worktreeArchive, RPCMethod.scratchArchive] {
+            let archive = await router.handle(
+                method == RPCMethod.worktreeArchive
+                    ? try RPCRequest(method: method,
+                                     params: WorktreeArchiveParams(worktreeID: desk.id))
+                    : try RPCRequest(method: method,
+                                     params: ScratchArchiveParams(worktreeID: desk.id)))
+            #expect(!archive.success)
+            #expect(archive.error?.contains("Watch Desk") == true)
+            #expect(try await db.worktrees.get(id: desk.id)?.status == .active)
+        }
     }
 
     /// `archivedAt` is the GC grace clock `OrphanProcessCollector` reaps from,

--- a/docs/specs/2026-08-20-scratch-archive-routing-design.md
+++ b/docs/specs/2026-08-20-scratch-archive-routing-design.md
@@ -298,8 +298,8 @@ body, testable on its own, and none is a refusal the routing removes:
   since only the GUI could archive one.
 
 The `?? worktreeID` shape appears once more, in `completeCreateWorktree`. That
-path is unreachable for a scratch space (scratch rows are minted by
-`handleScratchCreate`, never by the create lifecycle), but it is the same
+path is unreachable for a scratch space (repo-less rows are minted through
+`WorktreeStore.createScratch`, never by the create lifecycle), but it is the same
 defect, so it moves to the new error case too rather than being left as a
 second copy of a message the reader has just learned not to trust.
 
@@ -310,8 +310,14 @@ second copy of a message the reader has just learned not to trust.
 were nil would be routed to a path that leaves its directory and git
 registration in place, an under-cleanup rather than a data-loss failure, and
 would then be reported as archived. `repoID` is non-null for every row the
-create lifecycle writes, and `handleScratchCreate` is the only writer of a null
-one, so this requires the DB to already be inconsistent.
+create lifecycle writes, and the only two writers of a null one both go through
+`WorktreeStore.createScratch`: `handleScratchCreate`, whose rows are the
+intended target of this routing, and the Watch Desk's session creation, whose
+row is refused explicitly by the `isNightwatchDesk` guard in both shared bodies.
+So a row reaching the scratch teardown by way of a nil `repoID` it should not
+have had requires the DB to already be inconsistent. That premise is worth
+re-checking rather than inheriting: a third `createScratch` caller would widen
+this routing silently, and its rows would need their own answer here.
 
 **A scratch row misclassified as a repo worktree.** The inverse is the dangerous
 direction, since it reaches the phase-2 deletion path, and it is exactly what

--- a/docs/specs/2026-08-20-scratch-archive-routing-design.md
+++ b/docs/specs/2026-08-20-scratch-archive-routing-design.md
@@ -52,9 +52,9 @@ implementation inside the daemon, before any repo resolution is attempted. The
 routing sits in `handleWorktreeArchive` / `handleWorktreeRevive`, immediately
 alongside the remote-lane branch those handlers already carry, and reuses the
 exact code path `scratch.archive` / `scratch.revive` run. The bodies of those
-two handlers move into `archiveScratchSpace(worktreeID:actor:)` and
-`reviveScratchSpace(worktreeID:)`, called from both entry points, so there stays
-one implementation of "archive a scratch space" in the tree.
+two handlers move into `archiveScratchSpace(worktreeID:surface:force:actor:)`
+and `reviveScratchSpace(worktreeID:)`, called from both entry points, so the two
+RPC doors share one implementation.
 
 Separately, the guard stops lying. `WorktreeLifecycleError` gains a case for the
 condition that actually held:
@@ -131,32 +131,119 @@ path's `captureThenKillWindow` does. That gap is pre-existing behavior of
 Closing it means changing `closeScratchTerminals`, which improves both callers
 at once; it is a separate change with its own testable surface.
 
-**Actuation kind.** A routed call records `.scratchArchive`, not
-`.worktreeArchive`. The record names what was actually done, which is the
-property the actuation log exists to hold. `scratch.revive` records no actuation
-today and the routed revive matches it, so `worktree.revive` on a scratch row
-writes no actuation row where the repo path writes one. Both are consistent with
-"the record reflects the path taken"; giving scratch revive an actuation record
-is a change to the scratch path, not to the routing.
+**Actuation records name the door, not the destination.** `ActuationSurface`'s
+own rule is that `method` names the door a request came through and `kind` names
+the act, so a request that arrived on `worktree.archive` records
+`method: "worktree.archive"` even though the scratch body carries it out. The
+surface is therefore a parameter of `archiveScratchSpace`, passed as
+`.scratchArchive` by its own door and `.worktreeArchive` by the routed one. This
+needs no `ActuationBranch`: both surfaces already map to `kind: .dispose`, so
+the act is identical and only the door differs. Filing routed archives under a
+verb only the GUI sends would have made a door-based audit under-report
+`worktree.archive` and report `scratch.archive` calls nobody made.
 
-**`force` is inert.** `worktree.archive`'s `force` flag skips the archive hook
-and the archivable-children assertion. A scratch space has neither a hook
-(hooks resolve per repo) nor children (nothing creates a scratch row with a
-parent), so the flag is accepted and ignored on the routed path rather than
-rejected. Rejecting it would break `tbd worktree archive --force <scratch>` for
-no gain.
+The routed revive records too, against `.worktreeRevive`. `scratch.revive`
+itself still records nothing, which is its pre-existing shape, but
+`worktree.revive` must not have one branch that skips the log: `beginActuation`
+is fail-closed, so with the log unwritable the repo and remote branches refuse
+while a repo-less row would otherwise flip `.archived` to `.active` with no
+record of who asked.
+
+**`force` is forwarded, and it governs one of its two jobs.**
+`worktree.archive`'s `force` flag skips two things: the archive hook and the
+archivable-children assertion. The assertion applies to a scratch space and is
+enforced (see "The refusals the routed path keeps" below), so `force` is passed
+through rather than swallowed. The hook does not apply, because the scratch body
+runs none.
+
+That second half is a real gap, not an absence. Hook resolution is **not**
+repo-scoped: `HookResolver.resolve` checks `<worktreePath>/.worktree-hooks/<event>`
+using the worktree's own directory, and falls back to a global
+`~/tbd/hooks/default/<event>` that applies to every worktree regardless of repo.
+A scratch space is routinely a git repo (promotion requires `git init` plus
+commits), so `.worktree-hooks/archive` inside one is an ordinary shape. Neither
+that hook nor the global default runs when a scratch space is archived, through
+either door, and the user gets no diagnostic. This is pre-existing
+`scratch.archive` behavior that the routing now exposes to every client;
+closing it means giving the scratch body a hook call, which is a change to that
+body with its own testable surface.
+
+### The refusals the routed path keeps
+
+Routing must not turn `worktree.archive` into a quieter verb than it was, so the
+scratch body enforces the guards that matter for a repo-less row. Three were
+missing from `scratch.archive` and are added here, because the routing is what
+makes them reachable without a user gesture:
+
+- **Active children.** `assertArchivable` asks whether the row *is* a parent
+  (`SELECT ... WHERE parentWorktreeID = ?`), and a scratch space can be one:
+  `ParentResolver`'s `caller` arm returns the caller id after rejecting only
+  `.main` and `.archived`, so `tbd worktree new` run from inside a scratch space
+  mints a repo worktree parented to it, and `worktree.move` permits the same by
+  hand. Archiving the parent out from under a live child leaves the child
+  rendering nowhere until reconcile nulls the pointer. Refused unless `force`,
+  exactly as on the repo path.
+- **Already archived.** `WorktreeStore.archive` re-stamps `archivedAt`
+  unconditionally, and that timestamp is the grace clock
+  `OrphanProcessCollector` reaps orphaned agents from. A retried call would push
+  the reap of a wedged agent out by another `gcGraceSeconds` every time, and
+  re-broadcast an archive delta for a row every client has already filed away.
+  So an already-archived row is an idempotent no-op that re-stamps nothing,
+  rather than either a re-archive or a new user-visible refusal.
+- **Promoted.** Promotion retires the row as archived with `promotedToRepoID`
+  set and leaves `repoID` NULL, so `isScratch` and revive's status check both
+  still pass. Only the stale path, whose folder promotion moved away,
+  incidentally blocked revive; anything that recreates a directory there would
+  resurrect a retired row as active. Both sibling verbs guard on the pointer
+  explicitly, so revive does too.
+
+Revive also re-reads the row **before** broadcasting `.worktreeRevived`. The
+re-read exists because the caller that answers with a row must answer with the
+stored post-revive `status`; ordering it ahead of the broadcast means the one
+failure that can occur after the write commits (a concurrent delete removing the
+row) does not tell every subscriber the revive happened and the caller that it
+did not.
 
 ### What this does not touch
 
 The shared scratch tmux server is not killed. `TmuxManager.serverName(forRepoPath:)`
-hashes the path, so every scratch space under `~/tbd/scratch` resolves to the
-same server (`tbd-7ec3bd20`); killing it on a single-row archive would take out
-every other scratch space. Both the repo path and the scratch path only ever
-kill individual windows, and the routing changes nothing here.
+is a djb2 hash of the directory's absolute path, so every scratch space under
+`~/tbd/scratch` resolves to one server name; killing it on a single-row archive
+would take out every other scratch space. Both the repo path and the scratch
+path only ever kill individual windows, and the routing changes nothing here.
 
 Reconcile cannot resurrect the archived row. Scratch paths are absent from
 `WorktreeLayout.legacyAndCanonicalPrefixes`, so the re-adopt sweep does not scan
 `TBDConstants.scratchDir`.
+
+`DeskSessionManager.closeDeskSession` carries a third, hand-rolled copy of this
+teardown against a row of the same kind, and it has already drifted: it omits
+the `pendingQuestions.clear` and per-session overlay removal that
+`closeScratchTerminals` performs, so overlay files accumulate until the next
+daemon restart. Folding it onto the shared body is deferred, so the extraction
+here unifies the two RPC doors rather than every caller.
+
+Four further properties of the scratch body are pre-existing, unchanged by the
+routing, and deliberately left for separate changes. Each is a change to that
+body, testable on its own, and none is a refusal the routing removes:
+
+- **Teardown ordering.** The scratch body kills panes and deletes terminal and
+  tab rows *before* the status flip, and stamps its actuation `.dispatched`
+  before a write that can throw. The repo path documents the opposite ordering
+  as load bearing ("a crash mid-archive can't leave the row half-updated").
+- **No terminals after revive.** Archive deletes every terminal row and revive
+  spawns none, so a revived scratch space comes back active with nothing to
+  attach to. `scratch.create` auto-spawns a primary agent; revive does not. The
+  GUI's Archived tab has always behaved this way, and the CLI now does too.
+- **Claude session ids.** The repo path captures resumable session ids before
+  deleting terminals and preserves them across a revive that spawns no agent.
+  The scratch body does neither; the two halves currently mask each other, so
+  fixing either alone would clear ids that nothing had recorded.
+- **Client-side settlement.** No delta handler updates the app's
+  `archivedScratchWorktrees`, so a daemon-originated archive or revive leaves
+  the Scratch section's Archived tab stale until the user navigates away and
+  back. Related: a `tbd://` deep link to an archived scratch space returns
+  without navigating and without a diagnostic.
 
 The `?? worktreeID` shape appears once more, in `completeCreateWorktree`. That
 path is unreachable for a scratch space (scratch rows are minted by
@@ -200,6 +287,20 @@ properties that distinguish archive from both the old failure and from delete:
 - `worktree.revive` on that archived row succeeds, returns the decodable
   `Worktree` result its clients expect, and flips the row back to `.active`.
 - Terminals and tabs are torn down, matching what `scratch.archive` does.
-- A repo worktree whose `repoID` names no repo row still fails, and with a
-  message naming the repo id rather than the worktree id, so the guard split
-  did not turn a real inconsistency into a silent success.
+- The false arm of each `isScratch` gate: a `.main` repo worktree is refused by
+  `beginArchiveWorktree`'s first guard, and an `.active` repo worktree by
+  revive's status guard. Both prove the repo path ran, since the scratch body
+  refuses with "Not a scratch space", and both stop before any tmux, git, or
+  disk work, in particular before archive's detached phase 2, whose
+  deletion-queue rename would outlive the test's `TBD_HOME` isolation.
+- The three kept refusals: a scratch space with an active child is refused and
+  `--force` still bypasses it; a second archive re-stamps no `archivedAt` and
+  broadcasts no second delta; a promoted row is refused even with a directory
+  recreated at its stale path, so the guard and not the filesystem is what
+  refuses it.
+- `worktreeHasNoRepo` renders through the `LocalizedError` bridge, alongside
+  the other daemon errors, so the worktree id survives into log lines.
+
+A dangling `repoID` is not constructible through the store (the column is
+`REFERENCES repo(id) ON DELETE CASCADE`), so `repoNotFound(rid)`'s new argument
+is covered by the error-rendering test rather than by a router-level fixture.

--- a/docs/specs/2026-08-20-scratch-archive-routing-design.md
+++ b/docs/specs/2026-08-20-scratch-archive-routing-design.md
@@ -136,37 +136,55 @@ own rule is that `method` names the door a request came through and `kind` names
 the act, so a request that arrived on `worktree.archive` records
 `method: "worktree.archive"` even though the scratch body carries it out. The
 surface is therefore a parameter of `archiveScratchSpace`, passed as
-`.scratchArchive` by its own door and `.worktreeArchive` by the routed one. This
+`.scratchArchive` by its own door and `.worktreeArchive` by the routed one, and
+both shared bodies interpolate the caller's method into their success log lines
+for the same reason. This
 needs no `ActuationBranch`: both surfaces already map to `kind: .dispose`, so
 the act is identical and only the door differs. Filing routed archives under a
 verb only the GUI sends would have made a door-based audit under-report
 `worktree.archive` and report `scratch.archive` calls nobody made.
 
-The routed revive records too, against `.worktreeRevive`. `scratch.revive`
-itself still records nothing, which is its pre-existing shape, but
-`worktree.revive` must not have one branch that skips the log: `beginActuation`
-is fail-closed, so with the log unwritable the repo and remote branches refuse
-while a repo-less row would otherwise flip `.archived` to `.active` with no
-record of who asked.
+The routed **revive**, by contrast, records nothing, and the asymmetry with the
+repo branch is the correct one. `ActuationSurface`'s boundary rule puts DB-only
+mutations out of the record ("nothing there reaches a process, so nothing there
+is an actuation"), and this branch is exactly that: a status flip, a re-read and
+a delta. The repo branch records because it really does spawn the worktree's
+primary terminals, which is what `.worktreeRevive`'s `spawn` kind names, and a
+row claiming a spawn against a worktree with zero terminals is a phantom a fleet
+reader querying "spawned but no session appeared" would flag forever. Archive is
+the opposite case and does record: killing panes disposes of sessions, which is
+squarely inside the boundary.
 
-**`force` is forwarded, and it governs one of its two jobs.**
-`worktree.archive`'s `force` flag skips two things: the archive hook and the
-archivable-children assertion. The assertion applies to a scratch space and is
-enforced (see "The refusals the routed path keeps" below), so `force` is passed
-through rather than swallowed. The hook does not apply, because the scratch body
-runs none.
+The same reasoning is why `cols`, `rows` and `preferredSessionID` are accepted
+and unused on the routed revive: there is no terminal to size and no session to
+resume, because archive deleted every terminal row and revive spawns none.
 
-That second half is a real gap, not an absence. Hook resolution is **not**
-repo-scoped: `HookResolver.resolve` checks `<worktreePath>/.worktree-hooks/<event>`
-using the worktree's own directory, and falls back to a global
+**`force` is not forwarded, and that is parity rather than a shortfall.**
+`worktree.archive`'s `force` flag has two jobs in the lifecycle: skipping the
+archive hook and skipping the archivable-children assertion. But
+`handleWorktreeArchive` does not pass it to `beginArchiveWorktree` at all, so on
+this door it reaches only phase 2's hook skip, and the children assertion always
+runs for a repo worktree too. `force` bypasses that assertion only for the
+in-process cascade flows that call the lifecycle directly (`repo.remove`), and no
+cascade reaches a repo-less row.
+
+So the scratch body asserts unconditionally. Forwarding `force` would have made
+one flag bypass the children refusal for a scratch row while leaving it in force
+for a repo worktree through the same door: a flag whose meaning depends on the
+row shape is worse than one that is simply inert here.
+
+The hook half is a real gap, not an absence. Hook resolution is only *partly*
+repo-scoped: the highest-priority leg is the app's per-repo hook path, which a
+repo-less row can never have, but the remaining legs are repo-independent,
+including `<worktreePath>/.worktree-hooks/<event>` and a global
 `~/tbd/hooks/default/<event>` that applies to every worktree regardless of repo.
 A scratch space is routinely a git repo (promotion requires `git init` plus
 commits), so `.worktree-hooks/archive` inside one is an ordinary shape. Neither
 that hook nor the global default runs when a scratch space is archived, through
 either door, and the user gets no diagnostic. This is pre-existing
-`scratch.archive` behavior that the routing now exposes to every client;
-closing it means giving the scratch body a hook call, which is a change to that
-body with its own testable surface.
+`scratch.archive` behavior that the routing now exposes to every client; closing
+it means giving the scratch body a hook call, and deciding first what the
+per-repo leg means for a row with no repo.
 
 ### The refusals the routed path keeps
 
@@ -181,21 +199,47 @@ makes them reachable without a user gesture:
   `.main` and `.archived`, so `tbd worktree new` run from inside a scratch space
   mints a repo worktree parented to it, and `worktree.move` permits the same by
   hand. Archiving the parent out from under a live child leaves the child
-  rendering nowhere until reconcile nulls the pointer. Refused unless `force`,
-  exactly as on the repo path.
+  rendering nowhere until reconcile nulls the pointer. Refused unconditionally,
+  which is what a repo worktree arriving through this same door gets. The GUI's
+  row menu pre-disables its scratch Archive item on active children, with the
+  same copy the repo-worktree Archive already uses, so the refusal is not first
+  met as an alert from an enabled control.
 - **Already archived.** `WorktreeStore.archive` re-stamps `archivedAt`
   unconditionally, and that timestamp is the grace clock
   `OrphanProcessCollector` reaps orphaned agents from. A retried call would push
   the reap of a wedged agent out by another `gcGraceSeconds` every time, and
   re-broadcast an archive delta for a row every client has already filed away.
   So an already-archived row is an idempotent no-op that re-stamps nothing,
-  rather than either a re-archive or a new user-visible refusal.
+  rather than either a re-archive or a new user-visible refusal. This guard is a
+  read in its own transaction, so it closes sequential retries and not two calls
+  overlapping in flight; the durable fix is a status check inside
+  `WorktreeStore.archive`'s write block beside the `.main`/`.creating` refusals,
+  which would cover the repo path and the direct callers at once.
 - **Promoted.** Promotion retires the row as archived with `promotedToRepoID`
   set and leaves `repoID` NULL, so `isScratch` and revive's status check both
   still pass. Only the stale path, whose folder promotion moved away,
   incidentally blocked revive; anything that recreates a directory there would
   resurrect a retired row as active. Both sibling verbs guard on the pointer
   explicitly, so revive does too.
+
+**The Watch Desk is refused.** `isNightwatchDesk` is `isScratch` plus the desk's
+display name, so the routing reaches the Nightwatch desk row. Its teardown is
+`DeskSessionManager.closeDeskSession`, which also clears the in-memory desk
+pointer and is paired with `releaseJudgeLease` to drop the lease row and unlink
+the lease credential file. Neither resource has a named reconciler, so retiring
+the desk through the generic body would leak both with nothing to reclaim them.
+Both doors refuse it and say so, which is the honest answer to the reconciler
+question this new destruction path would otherwise have to answer.
+
+The app keeps its own listings honest on daemon-originated transitions: the
+`.worktreeRevived` handler drops the row from `archivedScratchWorktrees`, and the
+archived handler refreshes that listing for a scratch row. Without the first
+half, a revive from the CLI left the row in the Scratch section's open Archived
+tab while it was live again, and that stale row's Delete button trashes the
+folder: `scratch.delete` has no status guard, deliberately, because the sidebar
+deletes active scratch spaces through it. Without the second half, an archived
+scratch space looked deleted: gone from the sidebar and absent from the only view
+that lists it.
 
 Revive also re-reads the row **before** broadcasting `.worktreeRevived`. The
 re-read exists because the caller that answers with a row must answer with the
@@ -239,11 +283,9 @@ body, testable on its own, and none is a refusal the routing removes:
   deleting terminals and preserves them across a revive that spawns no agent.
   The scratch body does neither; the two halves currently mask each other, so
   fixing either alone would clear ids that nothing had recorded.
-- **Client-side settlement.** No delta handler updates the app's
-  `archivedScratchWorktrees`, so a daemon-originated archive or revive leaves
-  the Scratch section's Archived tab stale until the user navigates away and
-  back. Related: a `tbd://` deep link to an archived scratch space returns
-  without navigating and without a diagnostic.
+- **Deep links.** A `tbd://` deep link to an archived scratch space returns
+  without navigating and without a diagnostic. Previously near-unreachable,
+  since only the GUI could archive one.
 
 The `?? worktreeID` shape appears once more, in `completeCreateWorktree`. That
 path is unreachable for a scratch space (scratch rows are minted by

--- a/docs/specs/2026-08-20-scratch-archive-routing-design.md
+++ b/docs/specs/2026-08-20-scratch-archive-routing-design.md
@@ -1,0 +1,205 @@
+# Archiving a scratch space through `worktree.archive`: design
+
+Status: **implemented**.
+
+## Problem
+
+`tbd worktree archive <name-or-id>` fails on every scratch space, and the
+failure message names the wrong object:
+
+```
+$ tbd worktree archive 20260814-zygomorphic-ant
+Error: Repository not found: E3DB7381-2215-4B1A-B7A2-DEB42E4CE4A5
+```
+
+The UUID printed there is the *worktree* id. Nothing looked up a repo.
+
+A scratch space is a repo-less TBD workspace under `~/tbd/scratch/<name>`
+(`docs/superpowers/specs/2026-07-02-scratch-spaces-design.md`); `Worktree.isScratch`
+is defined as `repoID == nil` (`Sources/TBDShared/Models.swift`). Archive's phase 1
+resolves a repo before it does anything else:
+
+```swift
+guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
+    throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
+}
+```
+
+For a scratch row the *first* clause fails, so `worktree.repoID` is nil and the
+`?? worktreeID` fallback substitutes the worktree id into a message about
+repositories. Revive carries the identical guard, so an archived scratch space
+could not be brought back through `worktree.revive` either.
+
+The daemon is perfectly capable of archiving a scratch space: `scratch.archive`
+does it, and the GUI reaches it by routing client-side in
+`AppState.archiveWorktree(id:force:)`, whose doc comment records the workaround
+("the repo-worktree `worktree.archive` RPC rejects them with `repoNotFound`").
+Only the GUI knows to route. Every other client, the CLI included, sends
+`worktree.archive` and gets the misleading error. The CLI has no scratch
+lifecycle commands at all: `tbd scratch` exposes `new`, `list`, and `promote`,
+and the `scratchArchive`/`scratchDelete`/`scratchRevive` client methods have
+exactly one caller, the GUI.
+
+The user-visible consequence is that the only CLI verb that appears to apply
+(`tbd worktree forget`) is the wrong one. `forget` hard-deletes the worktree row
+and its closed-terminal history and has no inverse, so reaching for it as a
+substitute for archiving loses the row and its history permanently.
+
+## Design
+
+`worktree.archive` and `worktree.revive` route a repo-less row to the scratch
+implementation inside the daemon, before any repo resolution is attempted. The
+routing sits in `handleWorktreeArchive` / `handleWorktreeRevive`, immediately
+alongside the remote-lane branch those handlers already carry, and reuses the
+exact code path `scratch.archive` / `scratch.revive` run. The bodies of those
+two handlers move into `archiveScratchSpace(worktreeID:actor:)` and
+`reviveScratchSpace(worktreeID:)`, called from both entry points, so there stays
+one implementation of "archive a scratch space" in the tree.
+
+Separately, the guard stops lying. `WorktreeLifecycleError` gains a case for the
+condition that actually held:
+
+```swift
+guard let rid = worktree.repoID else {
+    throw WorktreeLifecycleError.worktreeHasNoRepo(worktreeID)
+}
+guard let repo = try await db.repos.get(id: rid) else {
+    throw WorktreeLifecycleError.repoNotFound(rid)
+}
+```
+
+`repoNotFound` now only ever carries a repo id, and a repo-less row gets a
+message that says so and names what to do about it. The routing above means no
+supported client reaches the new error through archive or revive, but three
+call paths still enter `beginArchiveWorktree` without passing the router
+(the synchronous `archiveWorktree(worktreeID:force:)` wrapper, the `repo.remove`
+cascade, and auto-archive on merge), and an internal invariant violation should
+report itself accurately rather than as a fictional repo lookup.
+
+### Why route in the daemon rather than add `tbd scratch archive`
+
+`worktree.archive` is already the general verb, not the repo-worktree verb. The
+same handler dispatches remote lanes to `archiveRemoteLane` because "the files
+are on another machine" makes the local teardown meaningless for them. "The
+worktree has no repo" is the same kind of fact about the row, discovered the
+same way (one DB read before any work), and it deserves the same treatment. The
+CLI's `worktree` noun already covers scratch spaces everywhere else:
+`resolveWorktreeNameOrID` resolves them by name, and `tbd worktree list` prints
+them. `worktree archive` refusing them was the odd one out.
+
+Routing in the daemon also fixes every client at once, including the ones that
+do not exist yet: the CLI, `tbd` skill invocations, hooks, scripts, and the
+nightwatch desk. Fixing it in the CLI instead would have reproduced the GUI's
+client-side check a second time and left the next client to discover the trap a
+third time.
+
+The contract question is whether silently redirecting an RPC is honest. It is,
+because the redirect preserves the caller's intent exactly: the caller asked for
+this worktree to be archived, and afterwards it is archived, its folder is
+intact, and it appears in the archived listing. The alternative reading, that
+`worktree.archive` promises specifically the git-worktree teardown, is not a
+promise any client relies on: the same method already means something
+structurally different for a remote lane.
+
+A dedicated `tbd scratch archive|delete|revive` CLI surface is deliberately
+**not** part of this change. With the routing in place those commands would be
+aliases for verbs that already work, so they add naming surface and no
+capability. They remain a reasonable follow-up for discoverability, and the
+argument for them is not weakened by shipping this first.
+
+### Why delegate rather than teach the repo path to skip its repo work
+
+The alternative was to make `beginArchiveWorktree` tolerate `repoID == nil`,
+returning `(Worktree, Repo?)`, and have `completeArchiveWorktree` skip the parts
+that need a repo. That was rejected on blast radius and on risk asymmetry. It
+changes the signature of two public lifecycle methods and every caller and test
+that touches them, and the phase-2 body it would newly become responsible for
+gating is the destructive one: the archive hook, `deletionQueue.enqueue`, the
+directory rename, `git worktree prune`, and the fallback `git worktree remove`.
+A missed gate there deletes the user's scratch folder, which is the one outcome
+archive exists to avoid. Delegating to a path that never had a phase 2 makes
+that failure mode unreachable rather than merely guarded.
+
+### Consequences of delegating, accepted
+
+**Teardown fidelity.** The scratch path (`closeScratchTerminals`) kills each
+tmux window and clears the terminal, tab, and pending-question rows. It does not
+capture scrollback into Closed Terminals history, and it does not escalate to
+SIGKILL for a pane that survives `kill-window`'s SIGHUP, both of which the repo
+path's `captureThenKillWindow` does. That gap is pre-existing behavior of
+`scratch.archive`, which the GUI has always used, and is not introduced here.
+Closing it means changing `closeScratchTerminals`, which improves both callers
+at once; it is a separate change with its own testable surface.
+
+**Actuation kind.** A routed call records `.scratchArchive`, not
+`.worktreeArchive`. The record names what was actually done, which is the
+property the actuation log exists to hold. `scratch.revive` records no actuation
+today and the routed revive matches it, so `worktree.revive` on a scratch row
+writes no actuation row where the repo path writes one. Both are consistent with
+"the record reflects the path taken"; giving scratch revive an actuation record
+is a change to the scratch path, not to the routing.
+
+**`force` is inert.** `worktree.archive`'s `force` flag skips the archive hook
+and the archivable-children assertion. A scratch space has neither a hook
+(hooks resolve per repo) nor children (nothing creates a scratch row with a
+parent), so the flag is accepted and ignored on the routed path rather than
+rejected. Rejecting it would break `tbd worktree archive --force <scratch>` for
+no gain.
+
+### What this does not touch
+
+The shared scratch tmux server is not killed. `TmuxManager.serverName(forRepoPath:)`
+hashes the path, so every scratch space under `~/tbd/scratch` resolves to the
+same server (`tbd-7ec3bd20`); killing it on a single-row archive would take out
+every other scratch space. Both the repo path and the scratch path only ever
+kill individual windows, and the routing changes nothing here.
+
+Reconcile cannot resurrect the archived row. Scratch paths are absent from
+`WorktreeLayout.legacyAndCanonicalPrefixes`, so the re-adopt sweep does not scan
+`TBDConstants.scratchDir`.
+
+The `?? worktreeID` shape appears once more, in `completeCreateWorktree`. That
+path is unreachable for a scratch space (scratch rows are minted by
+`handleScratchCreate`, never by the create lifecycle), but it is the same
+defect, so it moves to the new error case too rather than being left as a
+second copy of a message the reader has just learned not to trust.
+
+## Risks
+
+**A non-scratch row misclassified as scratch.** The branch keys on
+`Worktree.isScratch`, that is `repoID == nil`. A repo worktree whose `repoID`
+were nil would be routed to a path that leaves its directory and git
+registration in place, an under-cleanup rather than a data-loss failure, and
+would then be reported as archived. `repoID` is non-null for every row the
+create lifecycle writes, and `handleScratchCreate` is the only writer of a null
+one, so this requires the DB to already be inconsistent.
+
+**A scratch row misclassified as a repo worktree.** The inverse is the dangerous
+direction, since it reaches the phase-2 deletion path, and it is exactly what
+the routing prevents. It is unreachable through the router after this change,
+and the `worktreeHasNoRepo` guard is what stops it in the three non-router
+entry points.
+
+**Ordering against the remote-lane branch.** Both branches read the same row.
+The remote check runs first and is unchanged; a remote lane is never scratch
+(remote rows carry a repo), so the two conditions cannot both hold, and the
+order is not load bearing. It stays first to keep the existing branch's diff
+empty.
+
+## Testing
+
+`Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift` covers the
+`scratch.*` methods already. The new coverage exercises the routed `worktree.*`
+methods against a scratch row created through `scratch.create`, asserting the
+properties that distinguish archive from both the old failure and from delete:
+
+- `worktree.archive` on a scratch row succeeds, flips `status` to `.archived`,
+  sets `archivedAt`, and broadcasts one `.worktreeArchived` delta.
+- The folder is still on disk afterwards, and the row is still present (not
+  deleted), so it appears in the archived listing.
+- `worktree.revive` on that archived row succeeds, returns the decodable
+  `Worktree` result its clients expect, and flips the row back to `.active`.
+- Terminals and tabs are torn down, matching what `scratch.archive` does.
+- A repo worktree whose `repoID` names no repo row still fails, and with a
+  message naming the repo id rather than the worktree id, so the guard split
+  did not turn a real inconsistency into a silent success.

--- a/docs/specs/2026-08-20-scratch-archive-routing-design.md
+++ b/docs/specs/2026-08-20-scratch-archive-routing-design.md
@@ -52,9 +52,9 @@ implementation inside the daemon, before any repo resolution is attempted. The
 routing sits in `handleWorktreeArchive` / `handleWorktreeRevive`, immediately
 alongside the remote-lane branch those handlers already carry, and reuses the
 exact code path `scratch.archive` / `scratch.revive` run. The bodies of those
-two handlers move into `archiveScratchSpace(worktreeID:surface:force:actor:)`
-and `reviveScratchSpace(worktreeID:)`, called from both entry points, so the two
-RPC doors share one implementation.
+two handlers move into `archiveScratchSpace(worktreeID:surface:actor:)` and
+`reviveScratchSpace(worktreeID:method:)`, called from both entry points, so the
+two RPC doors share one implementation.
 
 Separately, the guard stops lying. `WorktreeLifecycleError` gains a case for the
 condition that actually held:
@@ -231,6 +231,16 @@ the desk through the generic body would leak both with nothing to reclaim them.
 Both doors refuse it and say so, which is the honest answer to the reconciler
 question this new destruction path would otherwise have to answer.
 
+Revive refuses it as well, and needs its own guard rather than inheriting
+archive's. `closeDeskSession` archives the desk row through
+`db.worktrees.archive` directly and changes neither `repoID` nor the display
+name, so the archived row still reads as the desk and satisfies every other
+revive guard. Bringing it back by hand would flip the row `.active` and
+broadcast a revive while the desk actor's pointer, lease row, lease credential
+file and terminals stay gone. Nothing legitimately revives a desk row:
+`ensureDeskSession`'s recovery path excludes archived worktrees deliberately, so
+the desk opens a fresh session instead.
+
 The app keeps its own listings honest on daemon-originated transitions: the
 `.worktreeRevived` handler drops the row from `archivedScratchWorktrees`, and the
 archived handler refreshes that listing for a scratch row. Without the first
@@ -336,7 +346,7 @@ properties that distinguish archive from both the old failure and from delete:
   disk work, in particular before archive's detached phase 2, whose
   deletion-queue rename would outlive the test's `TBD_HOME` isolation.
 - The three kept refusals: a scratch space with an active child is refused and
-  `--force` still bypasses it; a second archive re-stamps no `archivedAt` and
+  `--force` does not bypass it, through either door; a second archive re-stamps no `archivedAt` and
   broadcasts no second delta; a promoted row is refused even with a directory
   recreated at its stale path, so the guard and not the filesystem is what
   refuses it.


### PR DESCRIPTION
## What's broken

Archiving a scratch space from the CLI fails, and the error names the wrong
object:

```
$ tbd worktree archive 20260814-zygomorphic-ant
Error: Repository not found: E3DB7381-2215-4B1A-B7A2-DEB42E4CE4A5
```

That UUID is the *worktree* id. Nothing looked up a repo.

Anyone who works in a scratch space (a repo-less workspace under
`~/tbd/scratch/<name>`) and wants to put it away from the terminal hits this
every time. The sidebar's Archive item works, so the failure looks like a CLI
bug rather than a missing capability, and the only CLI verb that appears to
apply is the wrong one: `tbd worktree forget` hard-deletes the row and its
closed-terminal history with no inverse. `tbd worktree revive` was broken the
same way, so even a successfully archived scratch space could not be brought
back from the CLI.

## Why it happens

A scratch space is defined by having no repository (`Worktree.isScratch` is
`repoID == nil`). Archive's phase 1 resolves a repo before it does anything
else, in one guard that covered two different failures:

```swift
guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
    throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
}
```

For a scratch row the *first* clause fails, so `worktree.repoID` is nil and the
`?? worktreeID` fallback puts the worktree id into a message about
repositories. `beginReviveWorktree` carried the identical guard.

The daemon has always been able to archive a scratch space: `scratch.archive`
does it, and the app reached that path by routing client-side in
`AppState.archiveWorktree`, whose doc comment recorded the workaround. Only the
app knew to route. Everything else, the CLI included, sent `worktree.archive`
and got the misleading error.

## What this PR does

`worktree.archive` and `worktree.revive` route a repo-less row to the
`scratch.*` body, in the same pre-row branch those handlers already use for
remote lanes:

- `handleWorktreeArchive` dispatches a scratch row to the new
  `archiveScratchSpace(worktreeID:surface:force:actor:)`, and
  `handleWorktreeRevive` to `reviveScratchSpace(worktreeID:)`. Both are the
  extracted bodies of the existing `scratch.archive` / `scratch.revive`
  handlers, so the two RPC doors share one implementation.
- `WorktreeLifecycleError.worktreeHasNoRepo` names the repo-less case, and the
  guard splits in three places so `repoNotFound` only ever carries a repo id.
- The app's client-side branch stays (its state settlement differs: it also
  refreshes the Scratch section's Archived tab), with its comment corrected.

Routing in the daemon rather than adding `tbd scratch archive` was the design
call. `worktree.archive` is already the general verb, not the repo-worktree
verb: the same handler dispatches a remote lane to `archiveRemoteLane` because
"the files are on another machine" makes the local teardown meaningless for it,
and "the worktree has no repo" is the same kind of row-shaped fact discovered
the same way. The CLI's `worktree` noun already covers scratch spaces
everywhere else (`tbd worktree list` prints them, name resolution finds them);
`archive` refusing them was the odd one out. And one daemon-side branch covers
the CLI, hooks, scripts, and clients that do not exist yet, instead of leaving
each to rediscover the trap.

The alternative of teaching `beginArchiveWorktree` to tolerate a nil `repoID`
was rejected on risk asymmetry: the phase-2 body it would newly have to gate is
the destructive one (archive hook, deletion-queue enqueue, directory rename,
`git worktree prune`), and a missed gate there deletes the user's scratch
folder. Delegating to a path that never had a phase 2 makes that unreachable
rather than merely guarded.

A dedicated `tbd scratch archive|delete|revive` surface is deliberately not
here: with the routing in place those would be aliases for verbs that already
work. Reasonable follow-up for discoverability.

Design, including the accepted trade-offs (teardown fidelity, actuation kind,
inert `force`) and the risks:
[`docs/specs/2026-08-20-scratch-archive-routing-design.md`](docs/specs/2026-08-20-scratch-archive-routing-design.md).

### Refusals the routed path keeps

Routing must not make `worktree.archive` a quieter verb than it was, so three
guards `scratch.archive` never had are added to the scratch body (both doors get
them):

- **Active children.** `assertArchivable` asks whether a row *is* a parent, and
  a scratch space can be one: `ParentResolver`'s `caller` arm returns the caller
  id after rejecting only `.main`/`.archived`, so `tbd worktree new` run from
  inside a scratch space parents the new worktree to it. Refused unless `force`,
  which is now forwarded rather than swallowed as inert.
- **Already archived.** An idempotent no-op instead of a re-archive.
  `WorktreeStore.archive` re-stamps `archivedAt` unconditionally, and that is
  the grace clock `OrphanProcessCollector` reaps orphaned agents from, so a
  retry pushed the reap out by another grace window and re-broadcast a delta for
  a row clients had already filed away.
- **Promoted.** Promotion leaves `repoID` NULL, so `isScratch` and revive's
  status check both still pass; only the moved folder incidentally blocked
  revive. Both sibling verbs guard the pointer explicitly, so revive does too.

Revive also re-reads the row *before* broadcasting, so the one failure that can
follow the committed write (a concurrent delete) no longer tells subscribers the
revive happened while telling the caller it did not.

Actuation records the door, not the destination: `archiveScratchSpace` takes the
surface, so a routed call is filed under `worktree.archive` per
`ActuationSurface`'s own rule that "`method` names the door a request came
through and `kind` names the act". No `ActuationBranch` is needed because both
surfaces already map to `kind: .dispose`. The routed revive records against
`.worktreeRevive` rather than being the one branch of that door to skip a
fail-closed log gate.

## Known gaps, deliberately not in this PR

Pre-existing properties of the scratch body and the app, unchanged by the
routing but newly reachable from every client. All recorded in the spec:

- No archive hook runs for a scratch space through either door. Hook resolution
  is **not** repo-scoped (`<worktreePath>/.worktree-hooks/<event>` and a global
  `~/tbd/hooks/default/<event>` both apply, and a scratch space is routinely a
  git repo), so this is a real gap rather than an absence.
- The scratch body tears terminals down before the status flip and stamps
  `.dispatched` before a throwable write, the inverse of the ordering the repo
  path documents as load bearing.
- Revive spawns no terminals, so a revived scratch space comes back with nothing
  to attach to. The GUI's Archived tab has always behaved this way.
- Claude session ids are neither captured at archive nor preserved across
  revive. The two halves mask each other, so fixing either alone would clear ids
  nothing recorded.
- No delta handler updates the app's `archivedScratchWorktrees`, so a
  daemon-originated archive or revive leaves the Scratch Archived tab stale; and
  a `tbd://` deep link to an archived scratch space is a silent no-op.
- `DeskSessionManager.closeDeskSession` is a third, drifted copy of this
  teardown (it leaks per-session overlay files).

## Assumptions

- **`repoID == nil` means "scratch space", not "inconsistent row".** The
  routing keys on it. There are exactly two writers of a null `repoID`, both
  through `WorktreeStore.createScratch`: `handleScratchCreate`, whose rows are
  the intended target, and the Watch Desk's session creation, whose row both
  shared bodies refuse explicitly. A third caller would widen this routing
  silently, and its rows would need their own answer.
- **A dangling `repoID` is not constructible through the store** (the column is
  `REFERENCES repo(id) ON DELETE CASCADE`), so `repoNotFound(rid)`'s new
  argument is covered by the error-rendering test rather than a router fixture.

## Evidence & verification

**Repro, then the fix, end to end through the CLI** against a daemon on an
isolated `TBD_HOME` (the live daemon was not restarted). Before, on the same
build with only the error-message half applied:

```
$ TBDCLI scratch new --name repro-scratch
Created scratch space: repro-scratch
$ TBDCLI worktree archive repro-scratch
Error: Worktree 0F170262-... has no repository (it is a scratch space), and this operation requires one.
$ TBDCLI worktree list --status archived
No worktrees found.
```

After:

```
$ TBDCLI worktree archive repro-scratch
Worktree archived.
$ TBDCLI worktree list --status archived
1E1F6A30-46B1-4380-A7A8-7AA284504302  repro-scratch  archived
$ ls -d $TBD_HOME/scratch/repro-scratch    # folder survived
$ TBDCLI worktree revive repro-scratch
Worktree revived: repro-scratch
```

**Discriminating tests.** `WorktreeArchiveScratchRoutingRPCTests` (11 tests) and
`WorktreeLifecycleRepoErrorMessageTests` (2) are new. Reverting only
`RPCRouter+WorktreeHandlers.swift` and re-running reds the routing tests with 18
issues, including the archive returning `success: false`, the row staying
`.active`, and the archived listing not containing it.

Both false arms of `if existing.isScratch` are covered, per CLAUDE.md's
test-per-branch rule, and both are driven through guards that refuse before any
tmux, git, or disk work: a `.main` row for archive, an `.active` row for revive.
That placement is deliberate. An earlier version of the archive-side test drove
the real repo path, whose phase 2 is an unawaited `Task.detached` that outlived
the test's own `TBD_HOME` cleanup and would have renamed directories in the
unfenced real `$TMPDIR`; it also asserted only that the error was not one
specific string, so it would have stayed green with the repo path fully
broken.

Covered properties: archive succeeds and sets `archivedAt`; the folder is still
on disk afterwards; the row survives (archived, not forgotten) and appears in
`worktree.list --status archived`; revive returns a decodable `Worktree` (its
CLI and app clients both decode one, so `.ok()` would break them) and flips
back to `.active`; terminals and tabs are torn down; `--force` is inert;
revive still refuses when the folder vanished; a scratch space with an active
child is refused while `--force` still bypasses it; a second archive re-stamps
no `archivedAt` and broadcasts no second delta; and a promoted row is refused
even with a directory recreated at its stale path, so the guard rather than the
filesystem is what refuses it.

**Suite and lint.** `scripts/test.sh --filter '^TBDDaemonTests\.'`: 4068 tests
in 362 suites passed (58.1 s). `scripts/test.sh --skip
'^(TBDDaemonTests|TBDDaemonLiveTests)\.'`: 3515 tests in 366 suites passed
(43.3 s). `swiftlint --strict`: 0 violations in 792 files.
`scripts/swift-safe build`: clean.
