### PR TITLE
Fix: A first message typed while the pre-session hook runs was thrown away

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -233,6 +233,13 @@ extension AppState {
     /// on `worktree.create`: it may be sent long after creation finished, and
     /// creation must never wait for it. Blank text parks nothing — that is the
     /// same outcome as dismissing the sheet.
+    ///
+    /// **Nothing that fails here may swallow what the operator wrote.** The
+    /// modal is gone by the time any of these answers arrives, and there is no
+    /// draft store behind it — an alert alone would leave a message that exists
+    /// nowhere. So every path that ends without the text parked puts it on the
+    /// pasteboard first and says so, which is the same recovery the read-back's
+    /// Copy offers for text that was parked and cannot be delivered.
     func submitQueuedPrompt(_ target: QueuedPromptTarget, text: String, submit: Bool) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -243,19 +250,37 @@ extension AppState {
                 // the prompt silently; the text is still on screen behind the
                 // alert only if the sheet is up, so name what happened.
                 logger.error("Queued prompt not sent: worktree creation failed")
-                showAlert("Worktree creation failed — your first message was not sent.", isError: true)
+                keepUnqueuedFirstMessage(
+                    trimmed,
+                    "Worktree creation failed — your first message was not sent.")
             case .created(let worktreeID):
                 do {
                     let result = try await pendingPromptSetter(worktreeID, trimmed, submit)
                     if case .refused(let reason) = result {
-                        showAlert("First message was not queued: \(reason)", isError: true)
+                        keepUnqueuedFirstMessage(
+                            trimmed, "First message was not queued: \(reason)")
                     }
                 } catch {
                     logger.error("Failed to queue prompt: \(error, privacy: .public)")
-                    showAlert("Failed to queue your first message: \(error.localizedDescription)", isError: true)
+                    keepUnqueuedFirstMessage(
+                        trimmed,
+                        "Failed to queue your first message: \(error.localizedDescription)")
                 }
             }
         }
+    }
+
+    /// Hand a composed first message back to the operator after it failed to
+    /// park, and tell them where it went.
+    ///
+    /// The pasteboard because it is the one place text can be put that survives
+    /// the alert, needs no new surface, and is where they would paste from
+    /// anyway. `reason` is a sentence — the alert appends where the text is, so
+    /// the two facts arrive together and neither can be shown without the
+    /// other.
+    private func keepUnqueuedFirstMessage(_ text: String, _ reason: String) {
+        pasteboardWriter(text)
+        showAlert("\(reason) It has been copied to your clipboard.", isError: true)
     }
 
     /// Close whichever prompt sheet is on screen — the write half of the single

--- a/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
+++ b/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
@@ -78,22 +78,22 @@ struct ParkedPromptReadback: Identifiable, Equatable {
     /// Whether this worktree's primary terminal is a plain shell — one of the
     /// spec's named undeliverable causes, and the one the app can see.
     ///
-    /// Mirrors the daemon's `PendingPromptCoordinator.primaryAgentTerminal`:
-    /// terminals list oldest-first and the primary is created before the setup
-    /// tab, so "no agent-kind terminal at all" is "the primary is a shell".
-    /// The distinction matters because `park` answers `.parkedForSpawn` in both
-    /// this case and the pre-spawn one, and only the pre-spawn one is a promise
-    /// that can be kept — here the spawn has already happened and no later one
-    /// is coming.
+    /// Both halves are `PrimaryTerminal`'s, which is also what the daemon's
+    /// `park` decides on: there is no agent-kind row, AND no spawn is still
+    /// coming that could produce one. Asking the second half is what keeps the
+    /// app from calling a message undeliverable while the daemon is holding it
+    /// for a spawn — the two would then be describing the same text in
+    /// opposite terms.
     ///
-    /// An EMPTY list is not a shell primary: nothing has spawned yet (or the
-    /// app has not loaded this worktree's terminals), which is exactly the case
-    /// where a parked prompt still rides the next spawn's argv. The ambiguity
-    /// resolves toward offering delivery, because being wrong that way costs a
-    /// re-park and being wrong the other way withholds a working action.
+    /// A worktree whose only row is the blocking `preSession` hook's tab, and
+    /// one with no rows at all, are therefore NOT a shell primary: both have
+    /// their primary agent still ahead of them, and a prompt parked now reaches
+    /// it. The residual ambiguity — terminals the app has not loaded — resolves
+    /// toward offering delivery, because being wrong that way costs a re-park
+    /// and being wrong the other way withholds a working action.
     static func primaryIsPlainShell(terminals: [Terminal]) -> Bool {
-        guard !terminals.isEmpty else { return false }
-        return !terminals.contains { ($0.kind ?? .shell) != .shell }
+        guard PrimaryTerminal.agent(in: terminals) == nil else { return false }
+        return !PrimaryTerminal.spawnIsStillComing(terminals: terminals)
     }
 }
 
@@ -145,6 +145,12 @@ enum ParkedPromptPhase: Equatable {
     /// cannot see reads as pending, which is both the truth most of the time
     /// and the failure mode worth having: a message described as still coming
     /// costs a glance, one described as failed costs trust.
+    ///
+    /// A worktree still waiting on its primary agent is pending — whether it
+    /// has no terminals yet or is sitting behind a blocking `preSession` hook,
+    /// which is the wait this feature exists for and the one where the pane
+    /// banner has the most to say. `.undeliverable(.noAgent)` belongs only to a
+    /// worktree whose spawn already produced a shell.
     static func resolve(isArchived: Bool, terminals: [Terminal]) -> ParkedPromptPhase {
         if isArchived { return .undeliverable(.archived) }
         if ParkedPromptReadback.primaryIsPlainShell(terminals: terminals) {

--- a/Sources/TBDDaemon/Lifecycle/PendingPromptCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/PendingPromptCoordinator.swift
@@ -224,13 +224,17 @@ actor PendingPromptCoordinator {
         }
 
         // "Not yet" and "not ever" look the same from here, and only the first
-        // may answer `.parkedForSpawn`. A worktree whose terminals already
-        // exist has had its primary spawn: whatever it produced is not an
-        // agent, so there is nothing to park for.
+        // may answer `.parkedForSpawn`. `PrimaryTerminal.spawnIsStillComing` is
+        // what tells them apart: a worktree with no rows at all, or with none
+        // but the blocking `preSession` hook's tab, still has its primary spawn
+        // ahead of it. A worktree holding any other terminal has had that spawn
+        // already, and whatever it produced is not an agent — so there is
+        // nothing to park for, and saying so now is better than a promise the
+        // daemon cannot keep.
         let primary = await primaryAgentTerminal(worktreeID: worktreeID)
         if primary == nil {
             let terminals = (try? await db.terminals.list(worktreeID: worktreeID)) ?? []
-            guard terminals.isEmpty else {
+            guard PrimaryTerminal.spawnIsStillComing(terminals: terminals) else {
                 return .refused(reason: """
                     this worktree's primary terminal is not an agent, so a prompt cannot be \
                     delivered to it — nothing was parked.
@@ -646,11 +650,10 @@ actor PendingPromptCoordinator {
     }
 
     /// The worktree's primary agent terminal, or `nil` when none has spawned.
-    /// Terminals list oldest-first and `spawnPrimaryTerminals` creates the
-    /// primary before the setup tab, so the first agent-kind row is it.
+    /// The rule itself is `PrimaryTerminal.agent(in:)`, shared with the app so
+    /// the two cannot end up describing different rows as the primary.
     private func primaryAgentTerminal(worktreeID: UUID) async -> Terminal? {
-        let terminals = (try? await db.terminals.list(worktreeID: worktreeID)) ?? []
-        return terminals.first { ($0.kind ?? .shell) != .shell }
+        PrimaryTerminal.agent(in: (try? await db.terminals.list(worktreeID: worktreeID)) ?? [])
     }
 
     /// Records a daemon notification and broadcasts it — the pattern

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -71,7 +71,11 @@ extension WorktreeLifecycle {
 
             let terminals = (try? await db.terminals.list(worktreeID: row.id)) ?? []
             let preSessionTerminal = terminals.first { $0.label == TerminalLabel.preSession }
-            let hasPrimaries = terminals.contains { $0.label != TerminalLabel.preSession }
+            // "Has phase 3 already spawned the primaries?" is the same question
+            // `park` asks before it promises a first message to a spawn, so it
+            // is asked through the same rule — a second copy here would be free
+            // to drift into disagreeing with the promise the operator was made.
+            let hasPrimaries = !PrimaryTerminal.spawnIsStillComing(terminals: terminals)
 
             // Everything past here needs a directory, so convert once. The
             // conversion also covers a local row with no path at all — the

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -333,7 +333,13 @@ extension RPCRouter {
             claudeSessionID = nil
             freshSessionID = nil
             appendSystemPrompt = nil
-            label = cmd
+            // The command doubles as the tab's title, but it is caller text and
+            // may not claim one of the daemon's own identities: a row labelled
+            // `pre-session` reads as a spawn still on its way, `Codex` reads as
+            // a codex session, `login` as a profile login tab. A colliding
+            // command still spawns; it just gets the generic title a labelless
+            // shell gets.
+            label = TerminalLabel.userSupplied(cmd)
         } else {
             claudeSessionID = nil
             freshSessionID = nil

--- a/Sources/TBDShared/PrimaryTerminal.swift
+++ b/Sources/TBDShared/PrimaryTerminal.swift
@@ -13,9 +13,11 @@ import Foundation
 public enum PrimaryTerminal {
     /// The worktree's primary agent terminal, or `nil` when none has spawned.
     ///
-    /// Terminals list oldest-first and the spawn path creates the primary
-    /// before the setup tab, so the first agent-kind row is it. A row with no
-    /// kind recorded reads as a shell, which is what such a row is.
+    /// `TerminalStore.list` returns rows oldest-first and the spawn path
+    /// creates the primary before the setup tab, so the first agent-kind row is
+    /// it. That ordering is the store's, not a property of any `[Terminal]` —
+    /// pass a list in creation order, never one sorted into tab order. A row
+    /// with no kind recorded reads as a shell, which is what such a row is.
     public static func agent(in terminals: [Terminal]) -> Terminal? {
         terminals.first { ($0.kind ?? .shell) != .shell }
     }
@@ -25,12 +27,20 @@ public enum PrimaryTerminal {
     /// hook's tab.
     ///
     /// "Not yet" and "not ever" are opposite answers that look alike from a
-    /// list of terminals, and this label is what separates them. A worktree
-    /// whose `preSession` hook is still running has exactly one row — that
-    /// hook's tab, created before `worktree.create` returns — and its primary
-    /// agent spawns the moment the hook exits. A worktree whose spawn already
-    /// happened and produced a plain shell has a row carrying no such label,
-    /// and no later spawn is coming for it.
+    /// list of terminals, and this label is what separates them. A create or a
+    /// revive gated on a `preSession` hook holds exactly one row for as long as
+    /// that hook runs — the hook's tab, made before the RPC returns — and its
+    /// primary agent spawns the moment the hook exits. A worktree whose spawn
+    /// already happened and produced a plain shell has a row carrying no such
+    /// label, and no later spawn is coming for it.
+    ///
+    /// **Every row, not merely some row.** A hook tab can also sit *beside*
+    /// live ones: a manual re-run (`worktree.rerunPreSession`) appends one to a
+    /// worktree that already has its primaries, and a hook that failed or timed
+    /// out keeps its tab next to the primary phase 3 then spawns anyway. Those
+    /// worktrees have had their spawn — only a worktree holding nothing *but*
+    /// hook tabs still has one ahead of it, which is why this reads every row
+    /// rather than asking whether a hook tab is present.
     ///
     /// An empty list is vacuously still-coming, and that is the point: it is
     /// the pre-spawn shape (and, in the app, a worktree whose terminals have
@@ -39,10 +49,8 @@ public enum PrimaryTerminal {
     ///
     /// Keyed on the label rather than on `worktree.status == .creating`
     /// deliberately: the status is a coarser fact that also covers moments this
-    /// rule should not speak about, while the label names the actual cause. The
-    /// label also covers the revive path for free — a revive spawns the same
-    /// hook tab ahead of the same primaries, and is still-coming for exactly
-    /// the reason a create is.
+    /// rule should not speak about, while the label names the actual cause —
+    /// and it is the same fact whether a create or a revive spawned the tab.
     public static func spawnIsStillComing(terminals: [Terminal]) -> Bool {
         terminals.allSatisfy { $0.label == TerminalLabel.preSession }
     }

--- a/Sources/TBDShared/PrimaryTerminal.swift
+++ b/Sources/TBDShared/PrimaryTerminal.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Which of a worktree's terminal rows is its primary agent, and whether one is
+/// still on its way.
+///
+/// Both questions are asked on both sides of the socket: the daemon decides
+/// whether a first message can be parked for a spawn that has not happened yet,
+/// and the app decides whether to tell the operator that message is still
+/// coming. Two copies of the rule would eventually disagree, and the shape that
+/// disagreement takes is a banner promising delivery over a refusal that
+/// already threw the text away — so the rule lives here, once, beside the
+/// labels it reads.
+public enum PrimaryTerminal {
+    /// The worktree's primary agent terminal, or `nil` when none has spawned.
+    ///
+    /// Terminals list oldest-first and the spawn path creates the primary
+    /// before the setup tab, so the first agent-kind row is it. A row with no
+    /// kind recorded reads as a shell, which is what such a row is.
+    public static func agent(in terminals: [Terminal]) -> Terminal? {
+        terminals.first { ($0.kind ?? .shell) != .shell }
+    }
+
+    /// Whether this worktree has no primary agent **yet** and a spawn is still
+    /// coming — true exactly when every row it has is the blocking `preSession`
+    /// hook's tab.
+    ///
+    /// "Not yet" and "not ever" are opposite answers that look alike from a
+    /// list of terminals, and this label is what separates them. A worktree
+    /// whose `preSession` hook is still running has exactly one row — that
+    /// hook's tab, created before `worktree.create` returns — and its primary
+    /// agent spawns the moment the hook exits. A worktree whose spawn already
+    /// happened and produced a plain shell has a row carrying no such label,
+    /// and no later spawn is coming for it.
+    ///
+    /// An empty list is vacuously still-coming, and that is the point: it is
+    /// the pre-spawn shape (and, in the app, a worktree whose terminals have
+    /// not loaded yet), which wants the same answer for the same reason rather
+    /// than a second rule beside this one.
+    ///
+    /// Keyed on the label rather than on `worktree.status == .creating`
+    /// deliberately: the status is a coarser fact that also covers moments this
+    /// rule should not speak about, while the label names the actual cause. The
+    /// label also covers the revive path for free — a revive spawns the same
+    /// hook tab ahead of the same primaries, and is still-coming for exactly
+    /// the reason a create is.
+    public static func spawnIsStillComing(terminals: [Terminal]) -> Bool {
+        terminals.allSatisfy { $0.label == TerminalLabel.preSession }
+    }
+}

--- a/Sources/TBDShared/PrimaryTerminal.swift
+++ b/Sources/TBDShared/PrimaryTerminal.swift
@@ -47,6 +47,13 @@ public enum PrimaryTerminal {
     /// not loaded yet), which wants the same answer for the same reason rather
     /// than a second rule beside this one.
     ///
+    /// The label carries that much weight because nothing outside the daemon
+    /// can write it: caller text reaches a row only through
+    /// `TerminalLabel.userSupplied(_:)`, which drops any claim to a reserved
+    /// identity. That boundary is the whole guarantee — this reads the label
+    /// alone, with no second condition standing behind it, so which check is
+    /// load-bearing stays plain.
+    ///
     /// Keyed on the label rather than on `worktree.status == .creating`
     /// deliberately: the status is a coarser fact that also covers moments this
     /// rule should not speak about, while the label names the actual cause —

--- a/Sources/TBDShared/TerminalLabel.swift
+++ b/Sources/TBDShared/TerminalLabel.swift
@@ -1,6 +1,12 @@
 /// Canonical labels the daemon assigns to terminals it creates. The app keys
 /// classification decisions (pre-session banner, primary-terminal detection,
 /// startup recovery) off these labels, so daemon and app must agree.
+///
+/// These are **identities the daemon assigns**, never text a caller supplies.
+/// A row wearing one is a claim about how it was spawned, and consumers on both
+/// sides of the socket read it as such — so free text arriving over RPC (a
+/// `terminal.create` `cmd`, say) must pass through `userSupplied(_:)` before it
+/// can become a row's label.
 public enum TerminalLabel {
     /// Blocking `preSession` hook terminal (WorktreeLifecycle+PreSession).
     public static let preSession = "pre-session"
@@ -14,8 +20,29 @@ public enum TerminalLabel {
     public static let codex = "Codex"
     /// Profile login-session terminal (Settings → "Open login session"):
     /// a Claude session pinned to an OAuth profile, spawned so the user can
-    /// run `/login` into the profile's isolated config dir. The daemon
-    /// auto-types `/login` into terminals carrying this label, and the app
-    /// dedupes "Open login session" clicks against it.
+    /// run `/login` into the profile's isolated config dir. The daemon spawns
+    /// it with an auto-`/login` pump attached and the app dedupes "Open login
+    /// session" clicks against this label.
     public static let login = "login"
+
+    /// Every identity above, as one set: the labels a caller may not claim.
+    ///
+    /// Membership is exact — these strings *are* the identities, and every
+    /// consumer compares them with `==`. A command that merely resembles one
+    /// (`codex` beside `Codex`) is a different string and stays a plain label.
+    public static let reserved: Set<String> = [
+        preSession, setup, shell, claudeCode, codex, login,
+    ]
+
+    /// A caller-supplied label, or `nil` when it claims one of the identities
+    /// above.
+    ///
+    /// The trade is deliberate: a colliding label is dropped rather than
+    /// refused, because the label is a tab title and turning away an otherwise
+    /// valid spawn over the wording of its command would cost more than the
+    /// generic title the row falls back to.
+    public static func userSupplied(_ candidate: String?) -> String? {
+        guard let candidate, !reserved.contains(candidate) else { return nil }
+        return candidate
+    }
 }

--- a/Tests/TBDAppTests/ParkedPromptReadbackTests.swift
+++ b/Tests/TBDAppTests/ParkedPromptReadbackTests.swift
@@ -75,12 +75,14 @@ struct ParkedPromptReadbackTests {
 
     private func terminal(
         worktreeID: UUID, kind: TerminalKind?,
+        label: String? = nil,
         transcriptPath: String? = nil,
         activityState: TerminalActivityState = .unknown
     ) -> Terminal {
         Terminal(
             worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
-            transcriptPath: transcriptPath, kind: kind, activityState: activityState)
+            label: label, transcriptPath: transcriptPath, kind: kind,
+            activityState: activityState)
     }
 
     /// The single sheet slot both prompt surfaces share.
@@ -301,6 +303,39 @@ struct ParkedPromptReadbackTests {
             terminals: [terminal(worktreeID: wtID, kind: nil)]) == true)
     }
 
+    /// The `preSession` hook tab is a shell-kind row like any other, and for
+    /// as long as it is the worktree's only tab the primary agent has not
+    /// spawned yet. Reading it as "the spawn produced a shell" hides the pane
+    /// banner and greys Deliver-now for a message that is about to be typed in
+    /// normally.
+    @Test("A worktree behind its preSession hook is still waiting, not undeliverable")
+    func preSessionHookTabIsStillPending() {
+        let repoID = UUID()
+        let wt = worktree(repoID: repoID, prompt: "say this first")
+        let hookTab = terminal(
+            worktreeID: wt.id, kind: .shell, label: TerminalLabel.preSession)
+        let plainShell = terminal(worktreeID: wt.id, kind: .shell)
+
+        #expect(ParkedPromptReadback.primaryIsPlainShell(terminals: [hookTab]) == false)
+        #expect(ParkedPromptReadback(worktree: wt, terminals: [hookTab])?.phase == .pending)
+        // Which is what puts the pane footer up for the whole hook wait — the
+        // one surface that says the message is still coming.
+        #expect(QueuedPromptBannerModel.shows(
+            phase: ParkedPromptReadback(worktree: wt, terminals: [hookTab])?.phase,
+            footer: nil))
+
+        // A spawn that already happened and produced a shell is the other
+        // answer, with or without the hook tab still beside it.
+        #expect(ParkedPromptReadback(worktree: wt, terminals: [plainShell])?
+            .phase == .undeliverable(.noAgent))
+        #expect(ParkedPromptReadback(worktree: wt, terminals: [hookTab, plainShell])?
+            .phase == .undeliverable(.noAgent))
+        // And archiving still outranks both: nothing is coming for that row.
+        #expect(ParkedPromptReadback(
+            worktree: worktree(repoID: repoID, prompt: "x", status: .archived),
+            terminals: [hookTab])?.phase == .undeliverable(.archived))
+    }
+
     @Test("Deliver now is inert while its own RPC is outstanding")
     func doubleClickParksOnce() async throws {
         try await withAppState { state, harness in
@@ -411,6 +446,7 @@ struct ParkedPromptReadbackTests {
         let wt = worktree(repoID: repoID, prompt: "one message")
         let cases: [[Terminal]] = [
             [],
+            [terminal(worktreeID: wt.id, kind: .shell, label: TerminalLabel.preSession)],
             [terminal(worktreeID: wt.id, kind: .claude)],
             [terminal(worktreeID: wt.id, kind: .claude, activityState: .working)],
             [terminal(worktreeID: wt.id, kind: .shell)]

--- a/Tests/TBDAppTests/QueuedPromptOnCreateTests.swift
+++ b/Tests/TBDAppTests/QueuedPromptOnCreateTests.swift
@@ -40,6 +40,9 @@ struct QueuedPromptOnCreateTests {
         var parkResult: WorktreeSetPendingPromptResult = .parkedForSpawn
         var createError: Error?
         var flagWrites: [Bool] = []
+        /// Everything written to the pasteboard. Stubbed on every state this
+        /// suite builds, so no test can reach the developer's real one.
+        var copied: [String] = []
     }
 
     private struct StubError: Error {}
@@ -104,6 +107,7 @@ struct QueuedPromptOnCreateTests {
         state.queuedPromptFlagSetter = { @MainActor enabled in
             harness.flagWrites.append(enabled)
         }
+        state.pasteboardWriter = { @MainActor text in harness.copied.append(text) }
     }
 
     // MARK: - The gate, both branches
@@ -299,6 +303,9 @@ struct QueuedPromptOnCreateTests {
             await waitUntil("alert") { state.alertMessage != nil }
             #expect(harness.parked == nil)
             #expect(state.alertIsError)
+            // The row never existed, so the text has nowhere to be recovered
+            // from but the pasteboard.
+            #expect(harness.copied == ["never lands"])
         }
     }
 
@@ -318,6 +325,35 @@ struct QueuedPromptOnCreateTests {
 
             await waitUntil("alert") { state.alertMessage != nil }
             #expect(state.alertMessage?.contains("queued prompts are disabled") == true)
+        }
+    }
+
+    /// The modal is dismissed by the time a refusal comes back and there is no
+    /// draft store behind it, so an alert on its own would leave the operator's
+    /// message existing nowhere at all.
+    @Test("A refused first message is handed back on the clipboard")
+    func refusalKeepsTheComposedTextRecoverable() async throws {
+        try await withAppState { state in
+            let repoID = UUID()
+            let created = daemonWorktree(repoID: repoID)
+            let harness = Harness()
+            harness.parkResult = .refused(
+                reason: "this worktree's primary terminal is not an agent")
+            arm(state, harness, created: created)
+            state.daemonCapabilities = capabilities(queuedPrompt: true)
+
+            state.createWorktree(repoID: repoID)
+            let target = try #require(state.queuedPromptTarget)
+            state.submitQueuedPrompt(target, text: "  the thing I typed  ", submit: true)
+
+            await waitUntil("alert") { state.alertMessage != nil }
+            // Trimmed exactly as the parking RPC would have carried it.
+            #expect(harness.copied == ["the thing I typed"])
+            // The alert names the reason AND where the text went, so neither
+            // fact can arrive without the other.
+            #expect(state.alertMessage?.contains("not an agent") == true)
+            #expect(state.alertMessage?.contains("copied to your clipboard") == true)
+            #expect(state.alertIsError)
         }
     }
 

--- a/Tests/TBDAppTests/QueuedPromptOnCreateTests.swift
+++ b/Tests/TBDAppTests/QueuedPromptOnCreateTests.swift
@@ -38,6 +38,11 @@ struct QueuedPromptOnCreateTests {
         /// needs to see both.
         var parkedAll: [(worktreeID: UUID, text: String?, submit: Bool)] = []
         var parkResult: WorktreeSetPendingPromptResult = .parkedForSpawn
+        /// Makes the parking RPC itself fail — a dropped socket rather than a
+        /// refusal the daemon composed. Thrown after the call is recorded, so
+        /// "the RPC went out and nothing came back parked" is what the test
+        /// sees.
+        var parkError: Error?
         var createError: Error?
         var flagWrites: [Bool] = []
         /// Everything written to the pasteboard. Stubbed on every state this
@@ -100,6 +105,7 @@ struct QueuedPromptOnCreateTests {
         }
         state.pendingPromptSetter = { @MainActor worktreeID, text, submit in
             harness.calls.append(RPCMethod.worktreeSetPendingPrompt)
+            if let parkError = harness.parkError { throw parkError }
             harness.parked = (worktreeID, text, submit)
             harness.parkedAll.append((worktreeID, text, submit))
             return harness.parkResult
@@ -352,6 +358,33 @@ struct QueuedPromptOnCreateTests {
             // The alert names the reason AND where the text went, so neither
             // fact can arrive without the other.
             #expect(state.alertMessage?.contains("not an agent") == true)
+            #expect(state.alertMessage?.contains("copied to your clipboard") == true)
+            #expect(state.alertIsError)
+        }
+    }
+
+    /// The third way parking can end without the text in the column, and the
+    /// likeliest one in the field: the RPC never completed. A refusal at least
+    /// proves the daemon read the message; a dropped socket does not, so the
+    /// hand-back matters here most.
+    @Test("A parking RPC that throws hands the composed text back too")
+    func transportFailureKeepsTheComposedTextRecoverable() async throws {
+        try await withAppState { state in
+            let repoID = UUID()
+            let created = daemonWorktree(repoID: repoID)
+            let harness = Harness()
+            harness.parkError = StubError()
+            arm(state, harness, created: created)
+            state.daemonCapabilities = capabilities(queuedPrompt: true)
+
+            state.createWorktree(repoID: repoID)
+            let target = try #require(state.queuedPromptTarget)
+            state.submitQueuedPrompt(target, text: "the socket died", submit: true)
+
+            await waitUntil("alert") { state.alertMessage != nil }
+            #expect(harness.calls.contains(RPCMethod.worktreeSetPendingPrompt))
+            #expect(harness.parked == nil)
+            #expect(harness.copied == ["the socket died"])
             #expect(state.alertMessage?.contains("copied to your clipboard") == true)
             #expect(state.alertIsError)
         }

--- a/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
@@ -997,6 +997,93 @@ struct QueuedPromptDeliveryTests {
         #expect(try await pendingPrompt(fixture.db, fixture.worktree.id) == nil)
     }
 
+    // MARK: - Behind a blocking preSession hook
+
+    /// Installs a `preSession` hook where `spawnPreSessionTerminal` resolves
+    /// it, so the hook tab under test is made by the path that makes the live
+    /// one rather than hand-written into the terminals table.
+    private func installPreSessionHook(at worktreePath: String) throws {
+        let hooksDir = URL(fileURLWithPath: worktreePath)
+            .appendingPathComponent(".worktree-hooks", isDirectory: true)
+        try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+        let hook = hooksDir.appendingPathComponent(HookEvent.preSession.rawValue)
+        try "#!/bin/sh\nexit 0\n".write(to: hook, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: hook.path)
+    }
+
+    /// The wait this feature exists for. A blocking `preSession` hook owns the
+    /// worktree's only tab for as long as it runs — ten minutes is a normal
+    /// hook — and the primary agent spawns after it exits. A park during that
+    /// window is "not yet", and answering "not ever" throws away the message
+    /// the operator composed on the creation modal.
+    @Test("a prompt parked behind a running preSession hook rides the spawn")
+    func parkedBehindPreSessionHookIsDelivered() async throws {
+        let clock = TestClock()
+        let fixture = try await makeSpawnFixture(clock: clock)
+        try await fixture.db.config.setQueuedPrompt(true)
+        try installPreSessionHook(at: fixture.worktree.localPath)
+
+        let preSession = try #require(try await fixture.lifecycle.spawnPreSessionTerminal(
+            worktree: fixture.worktree, repo: fixture.repo,
+            worktreePath: fixture.worktree.localPath))
+        let hookTab = try #require(try await fixture.db.terminals.get(id: preSession.terminalID))
+        // The shape the refusal used to read as "the spawn already happened":
+        // one shell-kind row, and only its label says otherwise.
+        #expect(hookTab.label == TerminalLabel.preSession)
+        #expect((hookTab.kind ?? .shell) == .shell)
+
+        #expect(await fixture.coordinator.park(
+            worktreeID: fixture.worktree.id, text: Self.multiLinePrompt,
+            submit: true) == .parkedForSpawn)
+        #expect(try await pendingPrompt(fixture.db, fixture.worktree.id) == Self.multiLinePrompt)
+
+        // The hook exits; phase 3 spawns the primary and tells the coordinator.
+        let created = try await fixture.lifecycle.spawnPrimaryTerminals(
+            worktree: fixture.worktree, repo: fixture.repo, skipClaude: false,
+            preSessionTerminalID: preSession.terminalID)
+        let primary = try #require(created.first?.id)
+        #expect(fixture.sends.calls.isEmpty)
+
+        await fixture.coordinator.noteSessionReady(
+            worktreeID: fixture.worktree.id, terminalID: primary)
+        await advancePastSettle(clock, fixture)
+        await awaitDeliveries(fixture.coordinator)
+
+        #expect(fixture.sends.calls == [SendRecorder.Call(
+            terminalID: primary, text: Self.multiLinePrompt, submit: true)])
+        #expect(try await pendingPrompt(fixture.db, fixture.worktree.id) == nil)
+        #expect(try await fixture.db.notifications.unread(
+            worktreeID: fixture.worktree.id).isEmpty)
+    }
+
+    /// A hook tab present does not make a worktree pre-spawn: a manual hook
+    /// re-run appends one beside live tabs, and a spawn that produced a shell
+    /// keeps its hook tab when the hook failed. The refusal is owed to every
+    /// row, not to the absence of one.
+    @Test("undeliverable: a shell beside the hook tab is a spawn that already happened")
+    func parkingOnAShellPrimaryBesideTheHookTabIsRefused() async throws {
+        let fixture = try await makeSpawnFixture()
+        try await fixture.db.config.setQueuedPrompt(true)
+        try installPreSessionHook(at: fixture.worktree.localPath)
+        _ = try #require(try await fixture.lifecycle.spawnPreSessionTerminal(
+            worktree: fixture.worktree, repo: fixture.repo,
+            worktreePath: fixture.worktree.localPath))
+        _ = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+            kind: .shell)
+
+        let result = await fixture.coordinator.park(
+            worktreeID: fixture.worktree.id, text: "no composer here either", submit: true)
+
+        guard case .refused(let reason) = result else {
+            Issue.record("expected a refusal, got \(result)")
+            return
+        }
+        #expect(reason.contains("not an agent"))
+        #expect(try await pendingPrompt(fixture.db, fixture.worktree.id) == nil)
+    }
+
     /// Park a real hibernated row — written through `TerminalStore`'s own park
     /// choke point, not hand-set fields — and check what it actually looks like
     /// before parking against it. A hibernated agent keeps `kind == .claude`

--- a/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
@@ -236,6 +236,86 @@ extension RPCRouterTests {
         #expect(terminal.claudeSessionID != nil)
     }
 
+    // MARK: - Caller-supplied labels
+
+    /// A `terminal.create` command doubles as the tab's title, so it is the one
+    /// place caller text reaches a row's label. `TerminalLabel` names identities
+    /// the daemon assigns and both sides of the socket read as such, so a
+    /// command that spells one must not become one.
+    private func makeLabelGuardWorktree() async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        // terminal.create refuses to spawn into a missing directory, so the
+        // worktree path must actually exist on disk.
+        let wtPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-wt-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(atPath: wtPath, withIntermediateDirectories: true)
+        return try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: wtPath,
+            tmuxServer: "tbd-test"
+        )
+    }
+
+    private func createTerminal(worktreeID: UUID, cmd: String) async throws -> Terminal {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        return try response.decodeResult(Terminal.self)
+    }
+
+    @Test("terminal.create with a command naming the preSession hook does not read as a spawn still coming")
+    func terminalCreateCmdCannotClaimPreSession() async throws {
+        let wt = try await makeLabelGuardWorktree()
+        let terminal = try await createTerminal(worktreeID: wt.id, cmd: TerminalLabel.preSession)
+        #expect(terminal.label != TerminalLabel.preSession)
+        #expect(terminal.label == nil)
+
+        // Read the rows back the way every consumer does: this worktree's only
+        // terminal is a shell somebody spawned, not a hook tab with an agent
+        // still behind it, and a message parked on it would never be delivered.
+        let listResponse = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id)
+        ))
+        let rows = try listResponse.decodeResult([Terminal].self)
+        #expect(rows.count == 1)
+        #expect(PrimaryTerminal.spawnIsStillComing(terminals: rows) == false)
+    }
+
+    @Test("terminal.create with a command naming a login or agent identity does not claim it")
+    func terminalCreateCmdCannotClaimOtherIdentities() async throws {
+        let wt = try await makeLabelGuardWorktree()
+
+        let login = try await createTerminal(worktreeID: wt.id, cmd: TerminalLabel.login)
+        #expect(login.label == nil)
+
+        let codex = try await createTerminal(worktreeID: wt.id, cmd: TerminalLabel.codex)
+        #expect(codex.label == nil)
+        #expect(codex.isCodexTerminal == false)
+
+        let setup = try await createTerminal(worktreeID: wt.id, cmd: TerminalLabel.setup)
+        #expect(setup.label == nil)
+    }
+
+    @Test("terminal.create keeps an ordinary command as the tab's label")
+    func terminalCreateOrdinaryCmdKeepsItsLabel() async throws {
+        let wt = try await makeLabelGuardWorktree()
+        let terminal = try await createTerminal(worktreeID: wt.id, cmd: "vim")
+        #expect(terminal.label == "vim")
+        // Exact match, so a command that merely resembles an identity keeps it.
+        let lowercased = try await createTerminal(worktreeID: wt.id, cmd: "codex")
+        #expect(lowercased.label == "codex")
+    }
+
     // MARK: - Terminal Output
 
     @Test("terminal.output returns error when terminal not found")

--- a/Tests/TBDSharedTests/PrimaryTerminalTests.swift
+++ b/Tests/TBDSharedTests/PrimaryTerminalTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// The one rule the daemon and the app both read to answer "is this worktree's
+/// primary agent still coming?" — the question a first message parked at
+/// creation time turns on.
+///
+/// The pairs below are the whole point: `[preSession hook tab]` and
+/// `[plain shell]` are both lists of shell-kind rows, and they want opposite
+/// answers. Only the label separates them.
+@Suite("PrimaryTerminal")
+struct PrimaryTerminalTests {
+
+    private func terminal(kind: TerminalKind?, label: String? = nil) -> Terminal {
+        Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: label, kind: kind)
+    }
+
+    private var preSessionTab: Terminal {
+        terminal(kind: .shell, label: TerminalLabel.preSession)
+    }
+
+    @Test("Nothing spawned yet: the primary is still coming")
+    func emptyListIsStillComing() {
+        #expect(PrimaryTerminal.spawnIsStillComing(terminals: []))
+        #expect(PrimaryTerminal.agent(in: []) == nil)
+    }
+
+    @Test("A worktree behind its preSession hook is still coming")
+    func preSessionHookTabIsStillComing() {
+        // The hook tab exists before `worktree.create` returns and is the only
+        // row until the hook exits; the primary agent spawns after it.
+        #expect(PrimaryTerminal.spawnIsStillComing(terminals: [preSessionTab]))
+        #expect(PrimaryTerminal.agent(in: [preSessionTab]) == nil)
+    }
+
+    @Test("A spawn that produced a plain shell is not still coming")
+    func plainShellPrimaryIsNotStillComing() {
+        #expect(PrimaryTerminal.spawnIsStillComing(terminals: [terminal(kind: .shell)]) == false)
+        // A row with no kind recorded reads as a shell, and carries no label
+        // either, so it is a spawn that happened.
+        #expect(PrimaryTerminal.spawnIsStillComing(terminals: [terminal(kind: nil)]) == false)
+    }
+
+    @Test("A shell beside the hook tab means the spawn already happened")
+    func hookTabPlusShellIsNotStillComing() {
+        let terminals = [preSessionTab, terminal(kind: .shell)]
+        #expect(PrimaryTerminal.spawnIsStillComing(terminals: terminals) == false)
+        #expect(PrimaryTerminal.agent(in: terminals) == nil)
+    }
+
+    @Test("An agent row is an agent that arrived, not one still coming")
+    func agentRowIsNotStillComing() {
+        let terminals = [preSessionTab, terminal(kind: .claude)]
+        #expect(PrimaryTerminal.spawnIsStillComing(terminals: terminals) == false)
+        #expect(PrimaryTerminal.agent(in: terminals)?.kind == .claude)
+    }
+
+    @Test("The primary is the first agent-kind row, oldest-first")
+    func primaryIsTheFirstAgentRow() {
+        let shell = terminal(kind: .shell)
+        let claude = terminal(kind: .claude)
+        let codex = terminal(kind: .codex)
+        // Shell tabs ahead of it do not make a worktree agentless: the daemon
+        // picks the first non-shell row, not row zero.
+        #expect(PrimaryTerminal.agent(in: [shell, claude, codex])?.id == claude.id)
+        #expect(PrimaryTerminal.agent(in: [codex, claude])?.id == codex.id)
+    }
+}

--- a/Tests/TBDSharedTests/TerminalLabelTests.swift
+++ b/Tests/TBDSharedTests/TerminalLabelTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// `TerminalLabel` names identities the daemon assigns, and consumers on both
+/// sides of the socket read a row's label as a claim about how it was spawned.
+/// `userSupplied` is the boundary that keeps caller text from making that claim.
+@Suite("TerminalLabel")
+struct TerminalLabelTests {
+
+    @Test("Every reserved identity is refused as a caller-supplied label")
+    func reservedLabelsAreRefused() {
+        for reserved in TerminalLabel.reserved {
+            #expect(
+                TerminalLabel.userSupplied(reserved) == nil,
+                "\(reserved) is a daemon-assigned identity and must not survive as a caller label")
+        }
+        // Named individually too, so deleting a value from `reserved` fails
+        // here rather than shrinking the loop above into a vacuous pass.
+        #expect(TerminalLabel.userSupplied(TerminalLabel.preSession) == nil)
+        #expect(TerminalLabel.userSupplied(TerminalLabel.setup) == nil)
+        #expect(TerminalLabel.userSupplied(TerminalLabel.shell) == nil)
+        #expect(TerminalLabel.userSupplied(TerminalLabel.claudeCode) == nil)
+        #expect(TerminalLabel.userSupplied(TerminalLabel.codex) == nil)
+        #expect(TerminalLabel.userSupplied(TerminalLabel.login) == nil)
+    }
+
+    @Test("An ordinary command passes through unchanged")
+    func ordinaryLabelsPassThrough() {
+        #expect(TerminalLabel.userSupplied("vim") == "vim")
+        #expect(TerminalLabel.userSupplied("npm run dev") == "npm run dev")
+        // Nothing here is a claim on an identity, so nothing is dropped: the
+        // match is exact, and these are all different strings from the values
+        // every consumer compares against.
+        #expect(TerminalLabel.userSupplied("codex") == "codex")
+        #expect(TerminalLabel.userSupplied("Pre-Session") == "Pre-Session")
+        #expect(TerminalLabel.userSupplied("pre-session-check") == "pre-session-check")
+    }
+
+    @Test("No label supplied stays no label")
+    func nilPassesThrough() {
+        #expect(TerminalLabel.userSupplied(nil) == nil)
+    }
+}

--- a/docs/specs/2026-08-10-queued-prompt-on-create-design.md
+++ b/docs/specs/2026-08-10-queued-prompt-on-create-design.md
@@ -372,9 +372,12 @@ Three are answered at `park` rather than at delivery, because the app must never
 promise something the daemon will refuse. An **archived** worktree has no
 terminal rows — archive deletes them — so it looks exactly like a worktree still
 being created, and the honest answer for the two is opposite; parking there
-would leave text nothing will ever read. A worktree whose terminals already
-exist and whose primary is a **shell** has had its spawn, and nothing is coming.
-A **hibernated** primary is a pane with no composer in it. All three are
+would leave text nothing will ever read. A worktree whose spawn has already
+happened and produced a **shell** primary has nothing coming either — and the
+tell is the labels on its rows, not their number: a worktree holding nothing but
+the blocking `preSession` hook's tab (or no rows at all) still has its primary
+ahead of it, and parking there is the promise this feature is for. A
+**hibernated** primary is a pane with no composer in it. All three are
 refused, with the reason, and nothing is parked.
 
 **A hibernated primary is asked about twice — at `park` and again immediately

--- a/docs/specs/2026-08-10-queued-prompt-on-create-design.md
+++ b/docs/specs/2026-08-10-queued-prompt-on-create-design.md
@@ -134,6 +134,16 @@ While the modal is on, `createWorktree` no longer sets `editingWorktreeID`.
 Rename-on-create and the modal cannot both own focus, and the prompt is the
 reason the modal exists; renaming stays available from the sidebar.
 
+**A first message that does not park is handed back on the pasteboard.** The
+modal dismisses on submit and there is no draft store behind it, so by the time
+a creation failure, a refusal, or a transport error comes back there is nowhere
+the operator could go looking for what they wrote — an alert on its own would
+leave the message existing nowhere at all. Every one of those paths therefore
+copies the text first and says so in the same sentence as the reason, which is
+the recovery the read-back's Copy already offers for text that was parked and
+cannot be delivered. It costs the operator's clipboard, and that is the trade:
+the clipboard is replaceable and the composed message is not.
+
 **Two surfaces for a parked message, split by one rule.** Text in the column
 means one of two things, and the app names them separately:
 


### PR DESCRIPTION
## What's broken

You create a worktree in a repo with a blocking `preSession` hook, the "First message" composer opens, you type what you want the agent to work on, and press Queue. The modal closes. A moment later an alert says:

> First message was not queued: this worktree's primary terminal is not an agent, so a prompt cannot be delivered to it — nothing was parked.

The message is gone. Not parked, not on the clipboard, not in the column the read-back composer reads from — the modal that held the only copy already dismissed. The agent then spawns normally a minute or two later, into an empty composer, and you retype what you wrote.

It happens on every create where a `preSession` hook is configured and you compose fast enough to beat the hook, which is most of them: the composer opens immediately and the hook can run for minutes.

## Why it happens

A blocking `preSession` hook owns the worktree's only tab while it runs. That tab is a real terminal row, and because it is running a hook rather than an agent it is recorded as a shell.

`park` has to tell two situations apart that look identical from a list of terminals: the primary agent has not spawned **yet**, and the spawn already happened and produced something that is not an agent. Only the first may promise delivery. It drew the line at "does this worktree have any terminal rows at all" — no rows meant not-yet, any row meant the spawn had happened. The hook's tab is a row, so a worktree whose agent was still minutes away read as one whose spawn had already come and gone, and the refusal fired.

The app carried the same rule and so made the same mistake, one layer up: it classified that worktree as undeliverable, which hides the pane footer that says "First message queued — TBD types it into the agent's composer when it is ready. Click to edit." and greys out Deliver-now. So the surface built to reassure you the message is coming was suppressed by the same misreading that discarded it.

Both were then compounded by the composer being fire-and-forget: `submitQueuedPrompt` dismisses the modal before the answer arrives, so any refusal that reaches it has nowhere to put the text.

## When it broke

Present since #624, which shipped the feature. The `terminals.isEmpty` test was correct for the create path it was written against — without a hook, `worktree.create` returns only after the primary exists, so a park either finds no rows or finds the agent. The pre-session path breaks that: the hook tab is created and broadcast *before* `create` returns, so the park lands in a window the rule did not model. Nothing failed loudly enough to catch it — the refusal is a well-formed message about a real state, just the wrong one, and no test constructed a worktree holding only a hook tab.

## What this PR does

Moves the rule into `PrimaryTerminal` in `TBDShared`, which answers both questions once for both sides of the socket: which row is the primary agent, and whether a spawn is still coming. A spawn is still coming when **every** row the worktree has is the hook's tab — an empty list is vacuously true, so the pre-spawn case the old code handled is now the same rule rather than a second one beside it.

Keyed on the hook tab's label rather than on `worktree.status == .creating`. The status is a coarser fact that also covers moments this rule should not speak about; the label names the actual cause, and it covers the revive path for free, since a revive spawns the same hook tab ahead of the same primaries.

- **Daemon** — `park` answers `.parkedForSpawn` behind a running hook, and delivery proceeds normally when the agent spawns. A worktree whose spawn really did produce a plain shell still refuses, with the same message.
- **App** — the same list resolves to `.pending`, so the footer banner appears during the hook wait and Deliver-now stays live.
- **Recovery** — `WorktreeLifecycle+Recovery` was asking this same question with its own hand-rolled copy of the test. It now reads the shared rule, so there is one definition rather than three.
- **Labels** — `TerminalLabel` now names the reserved set alongside the identities themselves, and caller text passes through `TerminalLabel.userSupplied(_:)` on its way to a row. A `terminal.create` whose `cmd` spells `pre-session`, `login`, `Codex`, or any other reserved value still spawns its terminal; it just gets the generic tab title a labelless shell gets rather than the identity it named. That is what lets the rule above read the label alone, with no second condition behind it.
- **Hand-back** — every path in `submitQueuedPrompt` that ends without the text parked now puts it on the pasteboard and says so. The remaining refusals are real (a genuine shell primary, an archived worktree, the flag switched off mid-flight, a dropped socket), and none of them may swallow what you wrote.

One consequence worth knowing: parking during a hook on a worktree that will spawn a *shell* primary used to be refused instantly, and now parks, with the existing "primary terminal is a plain shell" notification firing when the spawn happens. That is the honest sequence — the daemon cannot know what the spawn produces until it does — and the text stays recoverable either way.

## Assumptions

- A terminal's label is an identity the daemon assigns, never text a caller supplies, so only `spawnPreSessionTerminal` writes `pre-session`. Of the ten `db.terminals.create` sites, nine pass a constant; the tenth is the mock seeder, which materializes an authored fixture whose whole job is to reproduce labelled states. Caller text reaches a label at exactly one place — `terminal.create`'s `cmd`, which doubles as the tab title — and it crosses `TerminalLabel.userSupplied(_:)` first. If a future site starts writing `pre-session` for a tab that is not a blocking hook, a worktree holding that tab would read as still-coming.
- An install whose database already holds a row that claimed a reserved label from outside the daemon's own paths keeps it. Such a row makes its worktree read as still-coming, so a first message parks and waits instead of delivering; the text stays recoverable through the row's prompt glyph, and nothing can write another one, so this is left to age out rather than migrated.
- A worktree left holding only a hook tab with no spawn ever coming — phase 3's spawn threw, or every primary was closed and the hook re-run by hand — reads as still-coming indefinitely, so a park is accepted for a delivery that never arrives. This is a pre-existing class (a worktree with *zero* rows already parks forever on the same branch) and the text stays recoverable, but it is wider now.
- Window recreation rewrites a row's label to `shell`, which is the safe direction: such a row reads as not-still-coming.

## Evidence & verification

**The repro**, before the fix: create a worktree in a repo with a `preSession` hook, type a first message, press Queue. Alert, text gone. Confirmed in the code path — the hook tab is created at `WorktreeLifecycle+PreSession.swift:172` and broadcast at `WorktreeLifecycle+Create.swift:501`, both before `create` returns the result the app parks against.

**Discriminating tests.** Each was mutation-checked rather than assumed: the fix was reverted to `terminals.isEmpty` and the suites re-run, producing 8 failures across 3 suites, then restored.

- `parkedBehindPreSessionHookIsDelivered` — 4 failures before the fix (refusal instead of `.parkedForSpawn`, empty column, no send). Builds the hook tab through `spawnPreSessionTerminal` against a real `.worktree-hooks/preSession` rather than hand-writing the row, then drives `spawnPrimaryTerminals` → `noteSessionReady` → paste.
- `preSessionHookTabIsStillPending` — 3 failures before (`primaryIsPlainShell` true, phase `.undeliverable(.noAgent)`, banner hidden). Also pins `[plain shell]` and `[hook tab, plain shell]` to `.noAgent`, and archived outranking both.
- `parkingOnAShellPrimaryBesideTheHookTabIsRefused` — passes before and after by design; it is the over-fire guard against a naive "any hook tab present" implementation.
- `refusalKeepsTheComposedTextRecoverable`, `transportFailureKeepsTheComposedTextRecoverable`, `creationFailureDoesNotPark` — cover all three refusal paths; each fails with the pasteboard write removed.
- `PrimaryTerminalTests` (6) pin the shared rule, including the `[pre-session]` vs `[plain shell]` pair that is indistinguishable by kind.
- `terminalCreateCmdCannotClaimPreSession` — the discriminating test for the label boundary: a `terminal.create` with `cmd: "pre-session"` produces the worktree's only row, and that worktree does not read as still-coming. With the boundary removed it fails 3 ways, including `spawnIsStillComing → true`. Its siblings cover `login`, `Codex` (which also fails `isCodexTerminal` unguarded) and `setup`, and `terminalCreateOrdinaryCmdKeepsItsLabel` holds the pass-through branch — it passes with the boundary removed, which is the point.
- `TerminalLabelTests` (3) pin the helper itself: every reserved value coerces to `nil`, ordinary commands and near-misses (`codex` beside `Codex`) pass through unchanged. All 12 expectations in the reserved case fail with the guard reverted to an identity function.

**Suites**: 222 tests in 8 suites pass (`PrimaryTerminalTests`, `TerminalLabelTests`, `RPCRouterTests`, `QueuedPromptDeliveryTests`, `ParkedPromptReadbackTests`, `QueuedPromptOnCreateTests`, `PreSessionHookTests`). Full suite: 7,656 tests, 14 failures, all in the load-sensitive timing families (PTY teardown, subprocess timeouts, debounce, file watcher) — none touch this code, all pass on re-run in isolation, and the run took 475s against a ~15–20s baseline on a machine at load 69. Build and `swiftlint --strict` clean.

**Live verification not done.** Exercising this end-to-end means `scripts/restart.sh`, which would restart the daemon underneath the sessions currently running on this machine. Happy to run it on request.

## Known gap, not addressed here

`park` has four suspension points before it writes the column. If the hook exits inside that window, phase 3's `notePrimaryTerminalExists` can run early, see no parked prompt, and return — leaving the `awaitingPane` licence granted to nobody, so the text sits in the column undelivered until you press Deliver-now. This PR opens that window (previously a park behind a hook was refused outright), and the outcome is the recoverable state the design already commits to. Closing it properly needs a second place that spends the licence, which contradicts the coordinator's documented "granted here and nowhere else" invariant — a spec'd change rather than a fix smuggled into this one. Filed separately.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E1687244-AD8B-4AD2-84EE-1477EC701039)

https://claude.ai/code/session_013M8QmfEYzagCH3NDTtqJ3B
