### PR TITLE
Fix: Stop a malformed escape sequence being half-stripped

### DIFF
--- a/Sources/TBDShared/ANSIEscape.swift
+++ b/Sources/TBDShared/ANSIEscape.swift
@@ -20,10 +20,31 @@ public enum ANSIEscape {
     /// 2. OSC (`ESC ] … BEL|ST`).
     /// 3. Generic two-byte-or-more escape sequences with no `[` or `]`:
     ///    `ESC` + zero or more intermediate bytes (0x20-0x2F, e.g. the `(`
-    ///    / `)` charset-selector introducer) + one final byte (0x30-0x7E).
-    ///    Covers `ESC 7` / `ESC 8` (save/restore cursor) and `ESC ( B` /
-    ///    `ESC ) 0` (charset designation) — none of which start with `[` or
-    ///    `]`, so alternatives 1 and 2 never see them.
+    ///    / `)` charset-selector introducer) + one final byte. The final-byte
+    ///    class excludes `[` and `]` (0x30-0x5A, 0x5C, 0x5E-0x7E, skipping
+    ///    0x5B and 0x5D) even though both fall inside the raw 0x30-0x7E
+    ///    final-byte range: those two bytes are precisely what introduces CSI
+    ///    and OSC, so a genuine bracket-less escape's final byte is never one
+    ///    of them. Without the exclusion, a malformed or truncated CSI/OSC
+    ///    run — one that never reaches a valid final byte, so alternatives 1
+    ///    and 2 fail — would fall through to this alternative and match only
+    ///    the two-byte `ESC [` / `ESC ]` lead-in, leaving the truncated
+    ///    remainder behind as literal text: worse than leaving the whole
+    ///    malformed run untouched. With the exclusion, a malformed run falls
+    ///    through all three alternatives and survives whole. Covers
+    ///    `ESC 7` / `ESC 8` (save/restore cursor) and `ESC ( B` / `ESC ) 0`
+    ///    (charset designation) — none of which start with, or ever end in,
+    ///    `[` or `]`, so alternatives 1 and 2 never see them and excluding
+    ///    those bytes from the final-byte class costs them nothing.
+    ///
+    /// Accepted consequence: a stray literal `ESC` that isn't part of any
+    /// real sequence consumes the one character immediately after it (e.g.
+    /// `ESC` + `A` strips to nothing), where the old CSI/OSC-only pattern
+    /// left both untouched. This is inherent to recognizing two-byte escapes
+    /// at all — `ESC A` is a well-formed escape sequence, and a stripper
+    /// cannot distinguish it from a stray `ESC` followed by an unrelated
+    /// letter. Stripping it is the correct reading; this is not a bug to
+    /// "fix" with heuristics that guess intent.
     ///
     /// Mirrors the scrubber pattern used elsewhere in TBD, widened against a
     /// real `claude --cloud` capture whose first line survived stripping
@@ -31,7 +52,7 @@ public enum ANSIEscape {
     private static let regex = try! NSRegularExpression(
         pattern: "\u{1B}\\[[0-9:;<=>?]*[ -/]*[@-~]"
             + "|\u{1B}\\][^\u{07}\u{1B}]*(?:\u{07}|\u{1B}\\\\)"
-            + "|\u{1B}[ -/]*[0-~]"
+            + "|\u{1B}[ -/]*[0-Z\\\\^-~]"
     )
 
     /// Remove all ANSI/OSC escape sequences, leaving the visible text.

--- a/Tests/TBDSharedTests/ANSIEscapeTests.swift
+++ b/Tests/TBDSharedTests/ANSIEscapeTests.swift
@@ -64,4 +64,54 @@ import Foundation
             + "Created cloud session: Probe reply OK then stop"
         #expect(ANSIEscape.strip(raw) == "^D\u{08}\u{08}Created cloud session: Probe reply OK then stop")
     }
+
+    // MARK: - Malformed/truncated runs (finding 2) and the accepted stray-ESC consequence (finding 3)
+
+    /// A CSI run truncated before any valid final byte (parameter bytes then
+    /// end-of-string) must survive intact. Before the final-byte class
+    /// excluded `[`/`]`, the generic fallback alternative matched just the
+    /// two-byte `ESC [` lead-in here, leaving the truncated parameter bytes
+    /// behind as literal text — worse than leaving the whole run untouched.
+    /// Ends at end-of-string rather than trailing more text: a letter right
+    /// after the parameter bytes would itself be a legal ECMA-48 CSI final
+    /// byte (0x40-0x7E includes lowercase letters), so alternative 1 would
+    /// legitimately consume it as the sequence's real terminator — that
+    /// would not be a truncated run at all, just a CSI ending in a letter.
+    @Test func leavesTruncatedCSIIntact() {
+        let raw = "before" + "\u{1B}[" + "1;2"
+        #expect(ANSIEscape.strip(raw) == raw)
+    }
+
+    /// Same failure mode for OSC: a run with no BEL/ST terminator must
+    /// survive whole rather than being partially eaten down to `ESC ]`.
+    @Test func leavesTruncatedOSCIntact() {
+        let raw = "before" + "\u{1B}]" + "0;untitled" + "after"
+        #expect(ANSIEscape.strip(raw) == raw)
+    }
+
+    /// The bracket-less generic fallback must still catch its intended
+    /// forms after `[`/`]` are excluded from the final-byte class — the
+    /// exclusion should cost these nothing since none of them end in `[`
+    /// or `]`.
+    @Test func stripsBracketlessFormsAfterFinalByteExclusion() {
+        let raw = "\u{1B}7" + "\u{1B}8" + "\u{1B}(B" + "kept"
+        #expect(ANSIEscape.strip(raw) == "kept")
+    }
+
+    /// A well-formed CSI immediately following a malformed/truncated one
+    /// is still stripped — the fallback alternative must not swallow past
+    /// the boundary between the two runs.
+    @Test func stripsWellFormedCSIFollowingTruncatedRun() {
+        let raw = "\u{1B}[" + "1;2" + "\u{1B}[0m" + "after"
+        #expect(ANSIEscape.strip(raw) == "\u{1B}[1;2after")
+    }
+
+    /// Pins the accepted finding-3 consequence: a stray `ESC` not part of
+    /// any real sequence consumes the single character after it, because
+    /// `ESC` + letter is indistinguishable from a genuine two-byte escape.
+    /// Recorded here as intended behavior, not a bug to be rediscovered.
+    @Test func strayEscapeConsumesFollowingCharacter() {
+        let raw = "before" + "\u{1B}" + "Xafter"
+        #expect(ANSIEscape.strip(raw) == "beforeafter")
+    }
 }


### PR DESCRIPTION
## What's broken

`ANSIEscape.strip` half-eats a malformed escape sequence. Given a CSI or OSC run that never reaches a valid terminator — a capture truncated mid-sequence, say — it removes the two leading bytes and leaves the remainder behind as literal text. A viewer showing that output gets `1;2` where it previously got the whole sequence intact.

It reaches a user through the read-only closed-terminal history viewer, which strips arbitrary captured scrollback for display. Truncated runs are unusual, which is why this is small — but scrollback is exactly the place arbitrary bytes turn up.

## Why it happens

The stripper matches three alternatives in order: CSI, OSC, then a generic fallback for the bracket-less forms (`ESC 7`, `ESC 8`, `ESC ( B`). That fallback is `ESC` + intermediates + one final byte drawn from `[0-~]` — and `[` (0x5B) and `]` (0x5D) both sit inside that range.

So when a CSI run is malformed, the first alternative fails to match, and the fallback then matches the two bytes `ESC [` on their own. The sequence is neither stripped nor preserved; it is cut in half.

## When it broke

It arrived with the widening in #683, which added the generic fallback to catch the escape forms a real pty emits. The fallback was correct about the forms it targeted and too permissive about its final byte. It was reported as a Minor finding on that PR and is fixed here rather than there, so the title-parse fix could ship on its own.

## What this PR does

Excludes `[` and `]` from the fallback's final-byte class. That is principled rather than a patch: those two bytes are precisely what introduce CSI and OSC, so a genuine bracket-less escape's final byte is never one of them. With them excluded a malformed run matches no alternative at all and survives whole, exactly as before the widening, while `ESC 7`, `ESC 8` and the charset selectors keep stripping.

A stray `ESC` still consumes the character after it, and this PR deliberately leaves that alone. `ESC A` is a well-formed two-byte escape; nothing can distinguish it from an accidental `ESC` before a letter, and stripping it is the correct reading. It is documented in the source and pinned by a test so the decision is visible rather than rediscovered as a bug — a heuristic that guessed intent would be worse than the behaviour it replaced.

## Evidence & verification

- **Mutation-checked.** Reverting the character class to `[0-~]` fails three of the twelve tests, each showing the partial-strip artifact — `before[1;2` reduced to `before1;2`, the `ESC` and `[` eaten and the rest surviving. Restored within the same command and re-confirmed green.
- **Tests cover both directions**, because a class that excluded too much would pass a "leave it intact" test while breaking real stripping: truncated CSI and truncated OSC survive whole; `ESC 7`, `ESC 8` and `ESC ( B` still strip; and a well-formed CSI immediately following a malformed run is still stripped, proving the boundary was not swallowed.
- One test in drafting was found to prove nothing and was rebuilt: a truncated run followed by prose terminated legitimately, because the `a` of the following word is itself a legal CSI final byte (0x61). The fixture now ends the truncated run at end-of-string.
- Full suite: 7818 tests in 761 suites. Three failures, none from this change and all checked rather than assumed — `OrphanProcessCollectorTests.parseLiveCWDs` reproduces identically on pristine `origin/main` with none of this branch applied (it expects `/tmp/…` where this machine resolves `/tmp` to `/private/tmp`), and a `TerminalActivityEventHandlerTests` case that passes in isolation under load. `swiftlint --strict` clean.

[20260815-icy-yak](https://cheapsteak.github.io/tbd/open/?worktree=BBA22690-7E4E-4F7F-A4F8-A71351FA5FD5)
