### PR TITLE
Fix: A test-listing run could come back green having listed nothing

### DIFF
--- a/docs/specs/2026-08-16-remote-verification-valve-design.md
+++ b/docs/specs/2026-08-16-remote-verification-valve-design.md
@@ -215,11 +215,27 @@ directions cost differently. A false positive costs one lane an optimisation. A
 false negative adopts a whole-suite failure as a narrowed run's result, naming
 tests the caller excluded — so anything that might select a subset is treated as
 if it does: `--filter` and `--skip`, the deprecated `--specifier` and its `-s`
-spelling, `--disable-xctest` and `--disable-swift-testing`, `--test-product`, and
-`--list-tests` and the bare `list` subcommand, which run no tests at all. Both the
-`--flag value` and `--flag=value` spellings are recognised. Options that widen or
-merely configure a run — `--enable-xctest`, `--num-workers`, `--xunit-output` —
-are deliberately absent.
+spelling, `--disable-xctest` and `--disable-swift-testing`, and `--test-product`.
+Both the `--flag value` and `--flag=value` spellings are recognised. Options that
+widen or merely configure a run — `--enable-xctest`, `--num-workers`,
+`--xunit-output` — are deliberately absent.
+
+**A listing invocation is its own category, and it never routes at all.**
+`--list-tests`, and the bare `list` subcommand that spells the same thing, ask for
+output rather than a verdict: they run nothing and print method names, and those
+names are the answer. The remote path returns a verdict, and no verdict answers
+that question in either direction — green would exit 0 having printed nothing the
+caller asked for, and red would report failures for a run that was never going to
+run a test. So the valve is left disarmed for such an invocation: no routing is
+armed, the yield bound is cleared exactly as it is on the valve-off path, and the
+run queues locally with one line on stderr saying why. Gating the arming rather
+than the verdict is what keeps a whole dispatch from being spent on a question CI
+cannot answer and then run locally anyway. Both names stay on the narrowing list
+as well, as defence in depth: were the gate ever bypassed, a red whole-suite
+verdict still would not be adopted as a listing run's result. A malformed
+`TBD_REMOTE_VERIFY_YIELD_SECONDS` is still refused for a listing run — it is a
+property of the caller's environment rather than of this invocation's arguments,
+and it will strand the next run just as badly.
 
 Passing the caller's narrowing arguments through to the dispatch would remove the
 mismatch and make a red verdict directly usable. That input must be allowlisted

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -204,6 +204,14 @@
 #      it deliberately excluded. The narrowed suite is re-run locally instead and
 #      the LOCAL verdict is reported.
 #
+# A LISTING RUN IS THE ONE THING THAT DOES NOT ROUTE, and it is not an exception
+# to the asymmetry so much as a different question. `--list-tests`, and the bare
+# `list` subcommand that spells the same thing, ask for OUTPUT — the test names —
+# and a verdict is not output. Green would exit 0 having printed nothing the
+# caller asked for; red would report failures for a run that was never going to
+# run a test. So the valve is left DISARMED for those invocations rather than
+# armed and then interpreted; see `asks_for_a_listing` below.
+#
 # WHY NOT JUST REFUSE TO ROUTE A NARROWED RUN, which would need no interpretation
 # at all: because it turns the valve off for every real caller. `pre-push`
 # narrows both of its passes, the nightly stress harness forwards a filter, and
@@ -376,14 +384,19 @@ valid_yield_bound() {
 #                               available. The binary names it itself: "found
 #                               multiple test products: …; use --test-product to
 #                               select one".
-#   --list-tests                the extreme case — it runs NOTHING and only
-#                               prints method names. A whole-suite verdict is not
-#                               an answer to that question in either direction.
+#   --list-tests                DEFENCE IN DEPTH, NOT THE MECHANISM. A listing
+#                               invocation never routes at all — the valve is
+#                               left disarmed for it by `asks_for_a_listing`
+#                               below, because a whole-suite verdict answers a
+#                               listing question in neither direction. It stays
+#                               on this list so that were that gate ever
+#                               bypassed, a red whole-suite verdict still would
+#                               not be adopted as a listing run's result.
 #   list                        `swift test list` is the same thing as a
 #                               subcommand. It is a bare word rather than a
 #                               flag, so it matches a `--filter list` value too;
-#                               that is a false positive, and false positives
-#                               are the cheap direction.
+#                               a false positive there now costs the run only
+#                               the valve, which is still the cheap direction.
 SUITE_NARROWING_ARGS=(
   --filter --skip
   --specifier -s
@@ -397,6 +410,36 @@ narrows_the_suite() {
   for arg in "$@"; do
     for known in "${SUITE_NARROWING_ARGS[@]}"; do
       # Both spellings: `--filter X` and `--filter=X`.
+      case "$arg" in
+        "$known"|"$known"=*) return 0 ;;
+      esac
+    done
+  done
+  return 1
+}
+
+# THE ARGUMENTS THAT ASK FOR OUTPUT RATHER THAN A VERDICT — the one question
+# that decides whether to route AT ALL. `swift test --list-tests`, and `swift test
+# list` which is the same thing spelled as a subcommand, run nothing: they
+# print method names, and those names are the answer. The remote path computes
+# a verdict, and no verdict answers that question in either direction — green
+# names no test, and red names none either.
+#
+# SO A LISTING INVOCATION MUST NEVER ARM THE VALVE, rather than route and then
+# be salvaged when the answer comes back. Salvaging it would spend a whole CI
+# dispatch on a question CI cannot answer and then run locally anyway; not
+# arming costs one lane an optimisation it could never have used.
+#
+# The matching is `narrows_the_suite`'s, for the same reasons: both the
+# `--flag value` and `--flag=value` spellings, wherever in the argument list
+# they appear, and a VALUE that merely looks like one of these names — a filter
+# regex, say — does not match.
+SUITE_LISTING_ARGS=(--list-tests list)
+
+asks_for_a_listing() {
+  local arg known
+  for arg in "$@"; do
+    for known in "${SUITE_LISTING_ARGS[@]}"; do
       case "$arg" in
         "$known"|"$known"=*) return 0 ;;
       esac
@@ -461,7 +504,6 @@ caller_narrowed=0
 # yield"), which is the pre-valve behavior "unset" is supposed to mean.
 fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS=)
 if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
-  remote_verify_enabled=1
   # `:-`, SO AN EMPTY VALUE MEANS "NOT SET" RATHER THAN FAILING THE RUN. The
   # alternative — a bare `-`, which substitutes only for an UNSET variable — sends
   # the empty string to the validator, which refuses it and exits 64. That is the
@@ -492,15 +534,42 @@ if [ "${TBD_REMOTE_VERIFY:-}" = "1" ]; then
     echo "         indistinguishable from a failing test suite." >&2
     exit 64
   fi
-  # ASKED ONCE, HERE, WHILE THE ARGUMENTS ARE IN FRONT OF US, and consulted
-  # later when the remote answer arrives. It gates nothing: a narrowed run
-  # forwards the bound and routes exactly like any other, because a green
-  # whole-suite verdict is sound for it. What this decides is how a RED answer is
-  # read — see the `case` on `$remote_status` below.
-  if narrows_the_suite ${swift_test_args[@]+"${swift_test_args[@]}"}; then
-    caller_narrowed=1
+  # THE BOUND IS VALIDATED ABOVE THIS GATE, NOT BELOW IT, AND THAT ORDER IS
+  # DELIBERATE. A malformed `TBD_REMOTE_VERIFY_YIELD_SECONDS` is a property of
+  # the caller's environment rather than of this invocation's arguments: it
+  # will strand the next run just as badly, and it is cheapest to hear about
+  # while the person who exported it is still looking. So it is refused for a
+  # listing run exactly as for any other, and only the ARMING below is gated.
+  #
+  # NOT ARMING MEANS THE PRE-VALVE STATE EXACTLY — `remote_verify_enabled` left
+  # at 0 AND the yield bound CLEARED, which this branch achieves by leaving
+  # `fenced_env` at the explicit empty assignment it was initialised with
+  # above. Merely declining to SET the bound would not do: an inherited
+  # `TBD_SWIFT_QUEUE_YIELD_SECONDS` passes straight through `env`, `swift-safe`
+  # gates the yield on the subcommand alone and knows nothing about
+  # `TBD_REMOTE_VERIFY`, so the run would yield 76 with no routing armed — the
+  # wrapper exiting 76 having tested nothing and having printed no test names
+  # either. See "THE BOUND IS CLEARED, NOT LEFT ALONE" above.
+  #
+  # THE LINE GOES TO STDERR BECAUSE STDOUT CARRIES THE LISTING, and it is worth
+  # saying at all: a developer who turned the valve on and is now watching a
+  # queue is owed the reason the run is waiting.
+  if asks_for_a_listing ${swift_test_args[@]+"${swift_test_args[@]}"}; then
+    echo "test.sh: this run asks for a test LISTING, which the remote path" >&2
+    echo "         cannot answer — it returns a verdict, and no verdict names" >&2
+    echo "         a test. Queueing locally, with the valve left disarmed." >&2
+  else
+    remote_verify_enabled=1
+    # ASKED ONCE, HERE, WHILE THE ARGUMENTS ARE IN FRONT OF US, and consulted
+    # later when the remote answer arrives. It gates nothing: a narrowed run
+    # forwards the bound and routes exactly like any other, because a green
+    # whole-suite verdict is sound for it. What this decides is how a RED
+    # answer is read — see the `case` on `$remote_status` below.
+    if narrows_the_suite ${swift_test_args[@]+"${swift_test_args[@]}"}; then
+      caller_narrowed=1
+    fi
+    fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$yield_seconds")
   fi
-  fenced_env=(TBD_SWIFT_QUEUE_YIELD_SECONDS="$yield_seconds")
 fi
 
 # Resolved HERE, while `$HOME` and `$TBD_HOME` still hold the caller's real

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -1761,6 +1761,177 @@ test_a_narrowed_run_falls_back_on_a_refusal_like_any_other() {
 }
 
 # ---------------------------------------------------------------------------
+# 7d. A listing invocation never arms the valve at all
+#
+# `--list-tests`, and the bare `list` subcommand that spells the same thing, ask
+# for OUTPUT rather than a verdict: they run nothing and print method names, and
+# those names are the whole answer. The remote path produces a verdict, and a
+# verdict answers that question in NEITHER direction — green would exit 0 having
+# printed no name the caller asked for, red would report failures for a run that
+# was never going to run a test.
+#
+# SO THE GATE IS AT THE ARMING, NOT AT THE VERDICT. Routing a listing run and
+# salvaging it on the way back would spend a whole CI dispatch on a question CI
+# cannot answer and then run locally anyway. Not arming has to leave the run in
+# the PRE-VALVE state exactly — no routing AND the yield bound cleared — which is
+# what the inherited-bound case below is for: `env` passes an inherited
+# `TBD_SWIFT_QUEUE_YIELD_SECONDS` straight through, so merely declining to set it
+# would strand a listing run at 76 with nothing printed and nothing routed.
+#
+# The bound is still VALIDATED for a listing run, because a malformed one is a
+# property of the caller's environment rather than of these arguments.
+# ---------------------------------------------------------------------------
+
+# The line the wrapper prints when it declines to arm. On stderr, because stdout
+# is where the listing itself goes.
+LISTING_NOTICE="asks for a test LISTING"
+
+test_a_list_tests_run_never_arms_the_valve() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --list-tests
+  RUN_ENV=()
+  assert_ok "a listing run is green" "$RUN_RC"
+  assert_eq "and nothing is dispatched, whatever the remote would have said" \
+    "0" "$(remote_verify_dispatches "$fix")"
+  assert_eq "the listing really ran locally" "1" "$(swift_invocations "$fix")"
+  assert_contains "with the request intact" "$(dump_of "$fix")" "argv: test --list-tests"
+  assert_contains "and no yield bound to give the queue up with" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  assert_contains "the reason is stated" "$RUN_OUT" "$LISTING_NOTICE"
+  rmfix "$fix"
+}
+
+# THE SUBCOMMAND SPELLING IS THE SAME REQUEST, and it is a bare word rather than
+# a flag, so nothing about the matching can be flag-shaped.
+test_the_bare_list_subcommand_never_arms_the_valve() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" list
+  RUN_ENV=()
+  assert_ok "a bare-subcommand listing run is green" "$RUN_RC"
+  assert_eq "and nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
+  assert_eq "the listing really ran locally" "1" "$(swift_invocations "$fix")"
+  assert_contains "with the subcommand intact" "$(dump_of "$fix")" "argv: test list"
+  assert_contains "and no yield bound" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  assert_contains "the reason is stated" "$RUN_OUT" "$LISTING_NOTICE"
+  rmfix "$fix"
+}
+
+# CLEARED, NOT MERELY UNSET — the distinction the whole gate turns on. `env` ADDS
+# assignments rather than clearing inherited ones, so a gate that only declined
+# to SET the bound would let a caller's exported `TBD_SWIFT_QUEUE_YIELD_SECONDS`
+# ride into a listing run: `swift-safe` gates the yield on the subcommand alone,
+# would yield 76 with no routing armed, and the wrapper would exit 76 having
+# printed no test names at all. The assignment below reaches the run because
+# `env` applies assignments after its options, past `run_script`'s `-u` list.
+test_an_inherited_yield_bound_does_not_bound_a_listing_run() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_SWIFT_QUEUE_YIELD_SECONDS=10
+           FAKE_REMOTE_VERIFY_RC=0 FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --list-tests
+  RUN_ENV=()
+  assert_ok "the listing run is green" "$RUN_RC"
+  assert_contains "the inherited bound is cleared, not passed through" \
+    "$(dump_of "$fix")" "TBD_SWIFT_QUEUE_YIELD_SECONDS=<unset>"
+  assert_eq "and nothing is dispatched" "0" "$(remote_verify_dispatches "$fix")"
+  assert_eq "the listing ran" "1" "$(swift_invocations "$fix")"
+  rmfix "$fix"
+}
+
+# A MALFORMED BOUND IS STILL REFUSED, LISTING OR NOT. It is a misconfiguration in
+# the environment rather than a property of these arguments — it will strand the
+# next run just as badly — and `swift-safe` would answer it with a bare 1, which
+# reads as a failing suite. The gate skips the ARMING, never the validation.
+test_a_bad_bound_still_fails_a_listing_run_loudly() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 TBD_REMOTE_VERIFY_YIELD_SECONDS=0
+           FAKE_REMOTE_VERIFY_RC=0 FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --list-tests
+  RUN_ENV=()
+  assert_eq "a listing run with a bad bound exits 64, not 1" "64" "$RUN_RC"
+  assert_contains "and names the variable" "$RUN_OUT" "TBD_REMOTE_VERIFY_YIELD_SECONDS"
+  assert_contains "and says what it must be" "$RUN_OUT" "must be a positive number"
+  assert_eq "with no listing started" "0" "$(swift_invocations "$fix")"
+  assert_eq "and nothing dispatched" "0" "$(remote_verify_dispatches "$fix")"
+  rmfix "$fix"
+}
+
+# The classifier on its own, sourced. It matches exactly as `narrows_the_suite`
+# does — both spellings, wherever the argument appears — and, crucially, it must
+# not fire on a run that merely selects a subset: those still route.
+test_asks_for_a_listing_recognises_both_spellings() {
+  local arg
+  for arg in --list-tests list; do
+    asks_for_a_listing "$arg"
+    assert_ok "[$arg] asks for a listing" "$?"
+    asks_for_a_listing "$arg=Foo"
+    assert_ok "[$arg=Foo] asks for a listing" "$?"
+    asks_for_a_listing --parallel -j 2 "$arg"
+    assert_ok "[$arg] is recognised wherever it appears" "$?"
+  done
+  for arg in --filter --skip --specifier -s --test-product --disable-xctest \
+             --disable-swift-testing --parallel --no-parallel -j --verbose; do
+    asks_for_a_listing "$arg"
+    assert_nonzero "[$arg] does not ask for a listing" "$?"
+  done
+  asks_for_a_listing
+  assert_nonzero "no arguments at all does not ask for a listing" "$?"
+  # A regex that merely mentions the flag's name is a VALUE, not the flag.
+  asks_for_a_listing --filter '^--list-testsTests\.'
+  assert_nonzero "a regex mentioning the flag name does not ask for a listing" "$?"
+  # And every listing name is on the narrowing list too, as defence in depth: if
+  # this gate were ever bypassed, a red whole-suite verdict still must not be
+  # adopted as a listing run's result.
+  for arg in --list-tests list; do
+    narrows_the_suite "$arg"
+    assert_ok "[$arg] is on the narrowing list as well" "$?"
+  done
+}
+
+# MUTATION, AND THE ONE THIS SECTION EXISTS FOR. Disable the gate and the bug
+# comes straight back: a `--list-tests` run bounds its queueing, yields 76,
+# dispatches a whole-suite CI run, and adopts its GREEN verdict — exiting 0
+# having never listed a single test name. The caller asked for output and got a
+# verdict instead.
+test_the_listing_gate_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  mutant="$(mutant_of "$SCRIPT" 's/if asks_for_a_listing .*; then/if false; then/')"
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$mutant" --list-tests
+  RUN_ENV=()
+  assert_eq "without the gate a listing run dispatches" "1" \
+    "$(remote_verify_dispatches "$fix")"
+  assert_ok "and adopts the green whole-suite verdict" "$RUN_RC"
+  assert_eq "having yielded before listing anything" "1" "$(swift_invocations "$fix")"
+  assert_contains "because the bound was armed after all" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=$DEFAULT_YIELD_SECONDS"
+  assert_missing "and nothing was said about listings" "$RUN_OUT" "$LISTING_NOTICE"
+  rmfix "$fix"
+}
+
+# THE OTHER DIRECTION: the gate must not be over-broad. A run that merely selects
+# a subset still routes, still forwards the bound, and still adopts a green
+# whole-suite verdict — see section 7b, whose reading depends on it.
+test_the_listing_gate_does_not_catch_a_filtered_run() {
+  local fix; fix="$(mkfix)"; mk_repo_fixture "$fix" >/dev/null
+  RUN_ENV=(TBD_REMOTE_VERIFY=1 FAKE_SWIFT_RC=76 FAKE_REMOTE_VERIFY_RC=0
+           FAKE_REMOTE_VERIFY_LOG="$fix/remote-verify-log")
+  run_with_valve "$fix" "$SCRIPT" --filter '^FooTests\.'
+  RUN_ENV=()
+  assert_ok "a filtered run still adopts a green remote verdict" "$RUN_RC"
+  assert_eq "and it really was dispatched" "1" "$(remote_verify_dispatches "$fix")"
+  assert_contains "with the bound armed" "$(dump_of "$fix")" \
+    "TBD_SWIFT_QUEUE_YIELD_SECONDS=$DEFAULT_YIELD_SECONDS"
+  assert_missing "and no listing notice" "$RUN_OUT" "$LISTING_NOTICE"
+  rmfix "$fix"
+}
+
+# ---------------------------------------------------------------------------
 # 7c. The count in the log has to describe the run being reported
 #
 # Six consumers decide whether a run is trustworthy by grepping its log for


### PR DESCRIPTION
## What's broken

Ask `scripts/test.sh` for a list of test names with the remote-verification valve
switched on, and it can answer with silence and a success exit code.

The invocation is `scripts/test.sh --list-tests` (or the bare `list` subcommand,
which spells the same thing). With `TBD_REMOTE_VERIFY=1`, if that run waits out
the yield threshold on the machine-global build slot, it gives up its place in
the queue, a whole-suite run is dispatched to CI, and the verdict that comes back
is adopted as this run's result. When that verdict is green, the wrapper exits 0
having never listed anything: no test names on stdout, nothing locally run, and
no indication that the question went unanswered.

Reaching it takes the flag on, a queue wait past the threshold, and a listing
invocation — so it is uncommon rather than routine. What makes it worth fixing
anyway is the failure mode: the caller is told "success" for a question that was
never asked, and the output they wanted simply is not there.

## Why it happens

The valve exists because a whole-suite CI verdict is a sound substitute for a
local run. That substitution is what the wrapper reasons carefully about
everywhere else: a caller who narrowed its run with `--filter` or `--skip` did
not ask the question CI answered, so the code treats the two directions
differently. A green whole suite genuinely implies every subset of it passed, and
is adopted. A red one says nothing about the caller's subset — those failures may
lie entirely outside it — so the narrowed suite is re-run locally and the local
verdict reported.

A listing invocation does not fit that frame at all, because it is not asking for
a verdict. It runs no tests; it prints method names, and those names *are* the
answer. No verdict answers that question in either direction — green names no
test, and red names none either.

The code already said so. The entry for `--list-tests` in the narrowing list read
"a whole-suite verdict is not an answer to that question in either direction".
But only the red branch of the routing ever consulted the narrowing flag; the
green branch adopted the remote verdict unconditionally. So the stated rule held
in one direction and quietly did not hold in the other.

## When it broke

Introduced with the valve itself in #676, and known at the time — it was filed as
a MINOR finding on that PR and deliberately deferred rather than expanding the
change under review. This is that follow-up.

## What this PR does

A listing invocation now never arms the valve. `asks_for_a_listing` is consulted
while the arguments are still in hand, and when it matches, the run is left in
exactly the pre-valve state: no routing armed, and the yield bound cleared.

**The gate is at the arming, not at the verdict.** The alternative — route it and
salvage the green case on the way back — would spend a whole CI dispatch on a
question CI cannot answer and then run locally anyway. If the remote path can
never answer, the right move is never to ask.

Two details carry more weight than their size suggests:

- **The bound is cleared, not merely left unset.** An inherited
  `TBD_SWIFT_QUEUE_YIELD_SECONDS` passes straight through `env`, and `swift-safe`
  gates the yield on the subcommand alone — it knows nothing about
  `TBD_REMOTE_VERIFY`. Declining to *set* the bound would leave such a run
  yielding the queue with no routing armed, and the wrapper would exit 76 having
  tested nothing and listed nothing. This mirrors the reasoning already spelled
  out on the valve-off path.
- **A malformed `TBD_REMOTE_VERIFY_YIELD_SECONDS` is still refused.** Validation
  sits above the gate rather than below it: a bad value belongs to the caller's
  environment, not to this invocation's arguments, and it will strand the next
  run just as badly. Skipping it here would make one invocation shape silently
  tolerant of a typo every other shape rejects.

`--list-tests` and `list` stay on the narrowing list as defence in depth — were
the arming gate ever bypassed, a red whole-suite verdict still would not be
adopted as a listing run's result.

No new spec: this restores the system to its existing theory rather than revising
it, the code's own stated rule being the thing that was not implemented. The
committed valve spec is updated to match, with listing split out as its own
category instead of folded into the over-broad narrowing list.

## Assumptions

- Assumes `--list-tests` and `list` remain the only ways to ask this toolchain
  for names without running tests. A future listing spelling would need adding to
  `SUITE_LISTING_ARGS`; until then it would route and hit the original bug.
- The matcher is deliberately over-broad in the same direction as the narrowing
  one: `--filter list` matches, so such a run forgoes the valve. That costs one
  lane an optimisation, never a wrong answer.

## Evidence & verification

**The repro, as a discriminating test.** The seven new cases in
`scripts/test.test.sh` were run against `origin/main`'s `scripts/test.sh` — the
unfixed file — and **12 assertions fail** there, exit 1. The behavioural ones are
the proof, not the function-missing ones:

```
FAIL - and no yield bound to give the queue up with: [argv: test --list-tests …
FAIL - the inherited bound is cleared, not passed through: [argv: test --list-tests …
FAIL - the reason is stated: [] lacks [asks for a test LISTING]
```

The first shows the unfixed wrapper forwarding the yield bound on a listing run —
the arming that leads to the silent green adoption.

**A mutation check, per this harness's convention.**
`test_the_listing_gate_is_load_bearing` rewrites the gate's condition to `false`
and asserts the mutant *does* dispatch, adopts the green verdict, and forwards
the bound — the original bug, reproduced on demand. Without it the gate could be
deleted and every other new case would still pass.

**Suite family, all green after the change:**

- `scripts/test.test.sh` — 412 assertions, 0 failures (361 on main; 86 cases → 93)
- `scripts/remote-verify.test.sh` — 93 assertions, 0 failures
- `scripts/test-remote-verify.py` — 114 tests OK
- `scripts/test-swift-safe.py` — 68 tests OK

`bash -n` clean, and `shellcheck` reports an identical finding set to
`origin/main` for both touched scripts — no new findings.

**One thing deliberately not asserted.** That the new notice goes to stderr rather
than stdout is not covered by a test: the harness merges `2>&1` for all 93 cases,
and adding a stderr seam would touch shared infrastructure every case depends on.
Stdout carries the listing, so the redirection matters; it is stated at the call
site, but a future change moving it to stdout would not be caught here.

[20260816-neat-gorilla](https://cheapsteak.github.io/tbd/open/?worktree=68C0F549-84E5-44B9-A1CF-6642C94CAC12)
