### PR TITLE
Fix: Stop the first-message composer yanking your cursor to the end mid-sentence

### DIFF
--- a/Sources/TBDApp/Components/SubmittingTextEditor.swift
+++ b/Sources/TBDApp/Components/SubmittingTextEditor.swift
@@ -48,6 +48,37 @@ enum ComposerReturnKey {
 /// A scrolling multi-line text editor with chat-box Return semantics: Return
 /// sends, Shift+Return and Option+Return insert a line break.
 ///
+/// **The text flows one way only.** `initialText` seeds the view once, when it
+/// is made; from then on the `NSTextView` owns what it holds and SwiftUI is
+/// merely told about it, through `onTextChange` and through the string handed
+/// to `onSubmit`. Nothing writes the editor's contents from outside, and
+/// `updateNSView` touches neither the text nor the selection.
+///
+/// That is what makes the caret safe, structurally rather than by policing. A
+/// SwiftUI update pass is not ordered against the operator's typing: the parent
+/// republishes for its own reasons — a poll tick, a subscription event — and
+/// such a pass can be evaluated with a text snapshot taken BEFORE the keystroke
+/// the text view has already applied. Writing that snapshot back shows the
+/// operator a character they just typed disappearing, and, because assigning
+/// `NSTextView.string` slams the insertion point to the end of the document, it
+/// strands the caret at the end even after the following pass restores the
+/// text — worst of all when they had moved back to edit an earlier sentence.
+/// A view that never accepts text cannot be told anything stale.
+///
+/// The same reasoning decides where a submit reads its text: `onSubmit` is
+/// handed the TEXT VIEW's current string, not anything held on this struct. The
+/// coordinator's `parent` is itself refreshed by an update pass and can be one
+/// behind; the text view cannot.
+///
+/// The tradeoff, stated plainly: there is no way to set the text from outside
+/// after the view exists. Restoring a draft, filling in a template, or clearing
+/// the box would need an explicit imperative path — a coordinator method driven
+/// by an identity token, say — and that path does not exist. It is deliberately
+/// absent rather than provisionally missing: no call site needs it, and adding
+/// a write-back door reopens the ambiguity the one-way flow removes. Add it
+/// when something genuinely needs it, as an explicit command rather than as
+/// state SwiftUI can resend at a moment of its own choosing.
+///
 /// An `NSTextView` rather than SwiftUI's `TextEditor` (which never submits) or
 /// `TextField(axis: .vertical)` (which does, for free, but grows with its
 /// content instead of scrolling). A first message is a task brief — the whole
@@ -59,10 +90,17 @@ enum ComposerReturnKey {
 /// agent verbatim, and silently turning `"` into `"` corrupts a prompt that
 /// quotes code.
 struct SubmittingTextEditor: NSViewRepresentable {
-    @Binding var text: String
-    /// Return, when the text is submittable. The caller applies its own
-    /// enablement rules — a Return must not do what a disabled button cannot.
-    var onSubmit: () -> Void
+    /// What the box starts with. Read once, in `makeNSView`; later changes to
+    /// it are ignored by design.
+    var initialText: String = ""
+    /// Every edit, as the text view now holds it. The caller's own state
+    /// follows the view rather than driving it.
+    var onTextChange: (String) -> Void
+    /// Return, when the text is submittable, carrying the text view's current
+    /// string. The caller applies its own enablement rules — a Return must not
+    /// do what a disabled button cannot — and judges blankness on the string it
+    /// is given, which is the one value guaranteed not to lag.
+    var onSubmit: (String) -> Void
     /// Escape. Forwarded explicitly because an `NSTextView` answers
     /// `cancelOperation:` itself, and a sheet's Cancel button would otherwise
     /// never see the key.
@@ -77,7 +115,7 @@ struct SubmittingTextEditor: NSViewRepresentable {
 
         guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
         textView.delegate = context.coordinator
-        textView.string = text
+        textView.string = initialText
         textView.isRichText = false
         textView.allowsUndo = true
         textView.drawsBackground = false
@@ -97,14 +135,14 @@ struct SubmittingTextEditor: NSViewRepresentable {
         return scrollView
     }
 
+    /// Refreshing the coordinator's parent is the whole job — and it is
+    /// load-bearing, not vestigial: `self` is a fresh struct each pass, so this
+    /// is what keeps `onTextChange`, `onSubmit` and `onCancel` pointing at the
+    /// current body's closures rather than at the ones captured when the view
+    /// was made. Deliberately nothing else: this pass must not touch the text
+    /// view's contents or its selection, which is the entire contract above.
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         context.coordinator.parent = self
-        guard let textView = scrollView.documentView as? NSTextView else { return }
-        // Only when they differ: assigning `string` collapses the selection, so
-        // an unconditional write would fight the cursor on every keystroke.
-        if textView.string != text {
-            textView.string = text
-        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
@@ -118,7 +156,7 @@ struct SubmittingTextEditor: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
-            parent.text = textView.string
+            parent.onTextChange(textView.string)
         }
 
         func textView(
@@ -136,7 +174,8 @@ struct SubmittingTextEditor: NSViewRepresentable {
             )
             switch action {
             case .submit:
-                parent.onSubmit()
+                // The text view, never `parent` — see the type's doc comment.
+                parent.onSubmit(textView.string)
                 return true
             case .newline:
                 textView.insertNewlineIgnoringFieldEditor(nil)

--- a/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
+++ b/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
@@ -219,8 +219,8 @@ struct ParkedPromptReadbackView: View {
         _sendImmediately = State(initialValue: readback.submit)
     }
 
-    private var isBlank: Bool {
-        draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    private func isBlank(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var isEdited: Bool { draft != readback.text }
@@ -234,8 +234,9 @@ struct ParkedPromptReadbackView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             SubmittingTextEditor(
-                text: $draft,
-                onSubmit: { submitIfAllowed() },
+                initialText: readback.text,
+                onTextChange: { draft = $0 },
+                onSubmit: { submitIfAllowed($0) },
                 onCancel: { dismiss() }
             )
             .frame(minHeight: 140, maxHeight: 300)
@@ -262,7 +263,7 @@ struct ParkedPromptReadbackView: View {
                 Spacer()
                 Button("Close") { dismiss() }
                     .keyboardShortcut(.cancelAction)
-                Button(isEdited ? "Deliver Edited" : "Deliver Now") { submitIfAllowed() }
+                Button(isEdited ? "Deliver Edited" : "Deliver Now") { submitIfAllowed(draft) }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.return, modifiers: [.command])
                 // Disabled rather than offered-and-refused where nothing can be
@@ -270,7 +271,11 @@ struct ParkedPromptReadbackView: View {
                 // button, and Copy is the action that works here. Blank is
                 // disabled too — empty text is the UNPARK signal, and Discard
                 // is the deliberate way to ask for that.
-                .disabled(!canSubmit)
+                // `draft` here, the editor's own string on the Return path —
+                // safe because this closure and this modifier are rebuilt on
+                // every body evaluation, so `draft` already carries the edit
+                // that enabled the button by the time it can be clicked.
+                .disabled(!canSubmit(draft))
                 .help(undeliverable?.help ?? "")
             }
         }
@@ -279,16 +284,20 @@ struct ParkedPromptReadbackView: View {
     }
 
     /// The one enablement rule, read by both the button and the Return key —
-    /// a keystroke must never do what the disabled button cannot.
-    private var canSubmit: Bool {
-        undeliverable == nil && !isBlank && !appState.parkedPromptDeliveryInFlight
+    /// a keystroke must never do what the disabled button cannot. Every reason
+    /// but blankness is the app's own state, and blankness is judged on the
+    /// text passed in: the Return path passes what the editor holds, which
+    /// `draft` follows by one SwiftUI pass, so reading `draft` there would
+    /// refuse a Return pressed straight after the first keystroke.
+    private func canSubmit(_ text: String) -> Bool {
+        undeliverable == nil && !isBlank(text) && !appState.parkedPromptDeliveryInFlight
     }
 
-    private func submitIfAllowed() {
-        guard canSubmit else { return }
+    private func submitIfAllowed(_ text: String) {
+        guard canSubmit(text) else { return }
         Task {
             await appState.deliverParkedPromptNow(
-                readback, text: draft, submit: sendImmediately)
+                readback, text: text, submit: sendImmediately)
         }
     }
 

--- a/Sources/TBDApp/Worktree/QueuedPromptModal.swift
+++ b/Sources/TBDApp/Worktree/QueuedPromptModal.swift
@@ -147,8 +147,13 @@ struct QueuedPromptModal: View {
     @AppStorage(QueuedPromptComposer.sendImmediatelyKey)
     private var sendImmediately = QueuedPromptComposer.sendImmediatelyDefault
 
-    private var isBlank: Bool {
-        draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    /// Blankness of a specific string. Taken as an argument rather than read
+    /// off `draft`, because the Return path must be judged on the text the
+    /// editor just handed over: `draft` follows the view by one SwiftUI pass,
+    /// and a Return pressed straight after the first keystroke would otherwise
+    /// be refused as blank while the box plainly holds text.
+    private func isBlank(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     var body: some View {
@@ -160,8 +165,9 @@ struct QueuedPromptModal: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             SubmittingTextEditor(
-                text: $draft,
-                onSubmit: { submit() },
+                initialText: draft,
+                onTextChange: { draft = $0 },
+                onSubmit: { submit($0) },
                 onCancel: { dismiss() }
             )
             .frame(minHeight: 140)
@@ -178,19 +184,23 @@ struct QueuedPromptModal: View {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
-                Button(sendImmediately ? "Send" : "Queue") { submit() }
+                // `draft`, not the editor's own string, and safe for the same
+                // reason the disabled state is: this closure is rebuilt on
+                // every body evaluation, so by the time the button can be
+                // clicked `draft` already carries the edit that enabled it.
+                Button(sendImmediately ? "Send" : "Queue") { submit(draft) }
                     .keyboardShortcut(.return, modifiers: [.command])
                     .buttonStyle(.borderedProminent)
-                    .disabled(isBlank)
+                    .disabled(isBlank(draft))
             }
         }
         .padding(20)
         .frame(width: 480)
     }
 
-    private func submit() {
-        guard !isBlank else { return }
-        appState.submitQueuedPrompt(target, text: draft, submit: sendImmediately)
+    private func submit(_ text: String) {
+        guard !isBlank(text) else { return }
+        appState.submitQueuedPrompt(target, text: text, submit: sendImmediately)
         dismiss()
     }
 }

--- a/Tests/TBDAppTests/ComposerTextOwnershipTests.swift
+++ b/Tests/TBDAppTests/ComposerTextOwnershipTests.swift
@@ -1,0 +1,137 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import TBDApp
+
+/// Who owns the composer's text, and where a submit reads it from.
+///
+/// Tier 1: deterministic, in-process state only — a real but off-screen
+/// `NSTextView` driven through a real `Coordinator`. No sleeps, no
+/// subprocesses, no filesystem, no `~/tbd`.
+///
+/// `SubmittingTextEditor` takes text in exactly once, at `makeNSView`, and
+/// never again: the view owns what it holds while it is on screen, and SwiftUI
+/// only ever hears about it. That is what makes a lagging update pass unable to
+/// move the caret — there is no write for it to carry. These cases pin the two
+/// halves of that contract a test can reach: every edit is reported outward in
+/// order, and a submit reads the TEXT VIEW rather than the coordinator's
+/// `parent`, which an update pass can leave a beat behind.
+///
+/// `updateNSView` itself is not callable from a test — there is no way to
+/// construct a `Context` — so the staleness case constructs the same condition
+/// directly, by driving a coordinator whose `parent` is the one it was built
+/// with.
+@MainActor
+@Suite("ComposerTextOwnership")
+struct ComposerTextOwnershipTests {
+
+    /// What the editor reported outward, in the order it reported it.
+    private final class Reports {
+        var changes: [String] = []
+        var submitted: [String] = []
+        var cancels = 0
+    }
+
+    /// A real off-screen `NSTextView` delegating to a real `Coordinator`.
+    private struct Probe {
+        let window: NSWindow
+        let textView: NSTextView
+        let coordinator: SubmittingTextEditor.Coordinator
+        let reports: Reports
+
+        /// Insert at the caret the way a keystroke does, so the delegate fires
+        /// and the coordinator reports the edit.
+        @MainActor
+        func type(_ text: String) {
+            textView.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        /// Hand the coordinator a resolved command the way AppKit's
+        /// `interpretKeyEvents` would.
+        @MainActor
+        @discardableResult
+        func command(_ selector: Selector) -> Bool {
+            coordinator.textView(textView, doCommandBy: selector)
+        }
+    }
+
+    /// `initialText` seeds the coordinator's `parent`, which is the value a
+    /// wrong implementation would submit. `seedTextView` is what the view
+    /// actually ends up holding — passed separately so a test can make the two
+    /// disagree, which is the whole point of the staleness case.
+    private func makeProbe(initialText: String = "", seedTextView: String? = nil) -> Probe {
+        // `doCommandBy` reads `NSApp.currentEvent` for the Shift modifier, and
+        // `NSApp` is nil until an application object exists.
+        _ = NSApplication.shared
+
+        let reports = Reports()
+        let editor = SubmittingTextEditor(
+            initialText: initialText,
+            onTextChange: { reports.changes.append($0) },
+            onSubmit: { reports.submitted.append($0) },
+            onCancel: { reports.cancels += 1 },
+            focusOnAppear: false)
+        let coordinator = SubmittingTextEditor.Coordinator(editor)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.titled], backing: .buffered, defer: true)
+        let textView = NSTextView(frame: window.contentLayoutRect)
+        textView.delegate = coordinator
+        // Mirror the `makeNSView` settings this suite is answerable to.
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.font = .systemFont(ofSize: NSFont.systemFontSize)
+        // Straight onto the storage, bypassing the delegate: this stands in for
+        // the seeding `makeNSView` does, which reports nothing outward either.
+        textView.string = seedTextView ?? initialText
+        window.contentView?.addSubview(textView)
+        window.makeFirstResponder(textView)
+        return Probe(
+            window: window, textView: textView, coordinator: coordinator, reports: reports)
+    }
+
+    @Test("Every keystroke is reported outward, in order, as the view now holds it")
+    func typingForwardsEachValue() {
+        let probe = makeProbe()
+        probe.type("d")
+        probe.type("r")
+        probe.type("aft")
+
+        #expect(probe.reports.changes == ["d", "dr", "draft"])
+        #expect(probe.textView.string == "draft")
+        // Reporting is one-way: nothing flowed back into the view.
+        #expect(probe.reports.submitted.isEmpty)
+    }
+
+    @Test("Return submits what the text view holds, not what the parent was handed")
+    func submitReadsTheTextViewNotTheStaleParent() {
+        // The staleness, constructed: the coordinator's `parent` still carries
+        // the text the view was made with, while the view has moved on. This is
+        // exactly the shape an update pass evaluated before the last keystroke
+        // leaves behind, and submitting `parent.initialText` here would send a
+        // message missing everything typed since.
+        let probe = makeProbe(initialText: "stale seed", seedTextView: "stale seed")
+        probe.type(" plus the last word")
+        #expect(probe.coordinator.parent.initialText == "stale seed")
+
+        probe.command(#selector(NSResponder.insertNewline(_:)))
+
+        #expect(probe.reports.submitted == ["stale seed plus the last word"])
+        // Return sends rather than breaking the line, so the text is untouched.
+        #expect(probe.textView.string == "stale seed plus the last word")
+    }
+
+    @Test("Escape forwards cancel and swallows the key")
+    func escapeForwardsCancel() {
+        let probe = makeProbe()
+        probe.type("half a thought")
+
+        let handled = probe.command(#selector(NSResponder.cancelOperation(_:)))
+
+        #expect(handled)
+        #expect(probe.reports.cancels == 1)
+        #expect(probe.reports.submitted.isEmpty)
+    }
+}


### PR DESCRIPTION
## What's broken

While typing the first message for a new session — the modal TBD opens as a worktree is being created — the caret occasionally jumps to the end of the text. It bites hardest mid-edit: you move back to fix an earlier sentence, type a word or two, and the rest of what you type lands at the end instead. Nothing is lost, which is what makes it hard to catch; the text stays intact and only the caret moves, so the first sign is words appearing where you didn't put them. Both first-message composers are affected — the creation modal and the read-back sheet for a message parked on a worktree.

## Why it happens

Confirmed, not hypothesised.

A SwiftUI update pass is not ordered against typing. Each keystroke reaches the composer's `NSTextView` first; the delegate then pushes the new text up through the binding. But the parent republishes for its own reasons — the app polls the daemon every two seconds and streams subscription events — and one of those passes can be evaluated with a `text` snapshot taken *before* a keystroke the text view has already applied.

`updateNSView` wrote that snapshot back whenever it differed from the view, and assigning `NSTextView.string` collapses the selection to the end of the document. So a pass arriving a keystroke late reverted the text and slammed the caret to the end; the next pass restored the text and left the caret where it had been dumped. Instrumented in the running app, one occurrence looked like this:

```
46.921  textDidChange len=10 sel={10,0}            keystroke lands, "pleasefixt" pushed up
46.936  mismatch viewLen=10 bindingLen=9           a pass carrying the PRE-keystroke value
46.936  afterWrite sel={9,0}                       stale write -> caret at the end
46.937  mismatch viewLen=9 bindingLen=10           the next pass, with the current value
46.937  afterWrite sel={10,0}                      text restored, caret still at the end
```

It is occasional because it needs an unrelated re-render to land in the same runloop turn as a keystroke.

This is the same failure React documents for controlled inputs whose value takes an asynchronous round trip: the control cannot tell that one character changed, so it resets the caret. React's own remedy for the synchronous case is precisely the guard we had — don't touch the control when the value is unchanged — and it is exactly what a stale value defeats.

## When it broke

Present since #624 introduced the composer — the file has only ever had one prior commit. It slipped through because the guard reads as obviously correct (write only when they differ), and the failure needs an unrelated re-render to land in the same runloop turn as a keystroke, so it never showed up in a deliberate test of the composer.

## What this PR does

Removes the write rather than policing it. The editor's text now flows one way:

- `SubmittingTextEditor` takes `initialText`, which seeds the text view once when it is made, and reports every edit upward through `onTextChange`. Nothing sets its contents afterwards, and `updateNSView` does one thing: refresh the coordinator's closures so they point at the current body's. A view that never accepts text cannot be told anything stale, so there is no pass to classify and no caret to preserve.
- `onSubmit` is handed the **text view's own string** rather than anything held on the view struct, for the same reason the bug existed: the coordinator's `parent` is refreshed by an update pass and can lag by one; the text view cannot. Both composers judge blankness on that string, so a Return pressed straight after the first keystroke is no longer refused as blank.

The alternative was to keep the binding and detect stale passes at runtime — classify each one against a record of values already pushed up, and preserve the selection when writing anyway. That version was built, reviewed, and works, but it manages a race that this version cannot have, and every defect three review rounds found lived in that machinery rather than in the part that fixes the bug.

No spec: this restores the composer to its existing intended behavior rather than revising it.

## Assumptions

- **Nothing needs to set the composer's text from outside.** True today — both call sites seed a local `@State` once and dismiss rather than clearing in place. If that stops holding (restoring a draft, filling a template, a Clear button), it needs an explicit imperative path, which deliberately does not exist: adding a write-back door reopens exactly the ambiguity the one-way flow removes. The type's doc comment says so, so the next reader meets the constraint rather than discovering it.

## Evidence & verification

- **Repro:** instrumented the composer, drove the real app, and typed into an actual first-message modal. A stale-echo write appeared within 15 keystrokes — the log above. Separately confirmed the mechanism's second half in isolation: assigning `NSTextView.string` moves a caret at offset 5 to offset 37.
- **Live verification after the fix:** typed `hello world`, moved the caret back six characters, then typed twenty characters one key at a time over ~25 seconds of ordinary app churn. All twenty landed contiguously at the caret — the message delivered as `helloabcdefghijklmnopqrst world`. Separately, a single character followed immediately by Return delivered that character rather than being refused as blank.
- **Discriminating test:** `ComposerTextOwnershipTests` drives a real `NSTextView` through a real `Coordinator` and pins the source-of-truth decision — Return submits the view's current string while the coordinator's `parent` still carries an older seed. Mutation-checked: pointing `onSubmit` at the parent's value instead reds that case and only that case.
- **Suites:** composer suites pass; the full suite shows only failures present on the base commit and unrelated to this change (a daemon-side `/tmp` vs `/private/tmp` assertion that fails identically in isolation, plus two load-dependent flakes that pass on their own). `swiftlint --strict` clean.

[⌨️ Fix First Message Cursor Jump](https://cheapsteak.github.io/tbd/open/?worktree=730FA204-57D7-4867-8C70-7610A8D3C7B4)
