### PR TITLE
fix: stop worktree branches tracking the default branch

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -392,10 +392,11 @@ public struct GitManager: Sendable {
         }
     }
 
-    /// Creates a new worktree at `worktreePath` on a new branch based on `baseBranch`.
+    /// Creates a new worktree at `worktreePath` on a new branch based on `baseBranch`
+    /// without configuring that base as the new branch's upstream.
     /// Enables parallel checkout for faster working-tree setup.
     public func worktreeAdd(repoPath: String, worktreePath: String, branch: String, baseBranch: String) async throws {
-        _ = try await run(arguments: ["-c", "checkout.workers=0", "worktree", "add", worktreePath, "-b", branch, baseBranch], at: repoPath)
+        _ = try await run(arguments: ["-c", "checkout.workers=0", "worktree", "add", "--no-track", worktreePath, "-b", branch, baseBranch], at: repoPath)
     }
 
     /// Adds a worktree at `worktreePath` using an existing branch (no -b flag).

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -826,10 +826,11 @@ extension WorktreeLifecycle {
             }
         }
 
-        // Mirrors the first loop: `.repoLevel` is worth the other base, whose
-        // plain local ref skips the upstream-config write the remote base
-        // performs, but is never worth a further name. "Spent" here means this
-        // loop's bases — the first loop already spent its own.
+        // Mirrors the first loop: `.repoLevel` is worth the other base because
+        // the remote and local refs resolve independently — a local branch named
+        // `origin/main`, for example, can make the remote spelling ambiguous
+        // while local `main` still resolves. It is never worth a further name.
+        // "Spent" here means this loop's bases — the first loop spent its own.
         if lastKind == .repoLevel, let lastError {
             throw WorktreeLifecycleError.createFailed(
                 "git worktree add failed\(repoLevelHint(lastError))\(formatErrorForMessage(lastError))"

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -292,11 +292,11 @@ extension WorktreeLifecycle {
                 // `--track -b <localName> <path> origin/<name>` to create a
                 // local tracking branch.
                 //
-                // Two of the three legs below CREATE a local branch before the
-                // step that can fail, and git fails *after* creating it in the
-                // ordinary case — a stale `.git/config.lock` makes the upstream
-                // config write fail while the branch stands (verified against
-                // git 2.50). Those two record what they made here so the `catch`
+                // Two of the three legs below CREATE a local branch before a
+                // later step can fail. A stale `.git/config.lock` can fail the
+                // remote-tracking leg's config write after its branch exists;
+                // the fork-PR leg creates its branch in the fetch before the
+                // checkout. Those two record what they made here so the `catch`
                 // can hand it to the same `cleanUpFailedWorktreeAdd` the
                 // fresh-create path uses, with the same gates.
                 //
@@ -719,16 +719,11 @@ extension WorktreeLifecycle {
 
         // A repo-level cause that survived both bases. `.repoLevel` deliberately
         // does NOT break out of the loop above, because the two bases are not
-        // interchangeable: base 1 is a remote-tracking ref, so `-b` writes
-        // upstream configuration, while base 2 is a plain local ref and writes
-        // none. Verified against git 2.50, the local base recovers from causes
-        // the remote base cannot survive — a stale `.git/config.lock` fails only
-        // the config write (and the cleanup above clears the branch it left, so
-        // the second attempt starts clean), and a local branch literally named
-        // `origin/main` makes base 1 fatal on `ambiguous object name` while base
-        // 2 resolves. A *fresh name* still cannot help, though, so this throws
-        // rather than falling through to the rename retry. Surface git's own
-        // words instead of guessing.
+        // interchangeable: a local branch literally named `origin/main` makes
+        // base 1 fatal on `ambiguous object name` while base 2 resolves. A
+        // *fresh name* still cannot help, though, so this throws rather than
+        // falling through to the rename retry. Surface git's own words instead
+        // of guessing.
         if lastKind == .repoLevel, let lastError {
             throw WorktreeLifecycleError.createFailed(
                 "git worktree add failed\(repoLevelHint(lastError))\(formatErrorForMessage(lastError))"
@@ -862,12 +857,11 @@ extension WorktreeLifecycle {
         /// The branch name, the folder path, or the checkout is already taken.
         /// Every base fails identically; only a *fresh name* can help.
         case nameCollision
-        /// Anything else git reported: a stale `.git/config.lock`, a corrupt
-        /// repo, a full disk, a local branch shadowing `origin/<default>`.
-        /// No *name* changes the outcome, but the *other base* still can —
-        /// the two are not interchangeable, since only the remote-tracking one
-        /// makes `-b` write upstream configuration. So the loop continues and
-        /// this only becomes fatal once both bases are spent.
+        /// Anything else git reported: a corrupt repo, a full disk, or a local
+        /// branch shadowing `origin/<default>`. No *name* changes the outcome,
+        /// but the *other base* still can because the refs resolve independently.
+        /// So the loop continues and this only becomes fatal once both bases are
+        /// spent.
         case repoLevel
         /// git returned no verdict at all — the subprocess timed out or could
         /// not be spawned. Nothing was learned about the base or the name, and
@@ -1020,10 +1014,9 @@ extension WorktreeLifecycle {
     /// Cleans up whatever a single failed `worktreeAdd` attempt left behind:
     /// the partially-written directory always, and — only when this attempt is
     /// the one that can have created it — the branch `-b` made. Git can fail
-    /// *after* creating the branch (a stale `.git/config.lock` makes the
-    /// upstream-config write fail while the branch stands), which is how a
-    /// failed create used to leak a `tbd/<name>` branch and then mask the real
-    /// cause behind "a branch named … already exists" on the next attempt.
+    /// *after* creating the branch. For example, the explicit remote-tracking
+    /// path can hit a stale `.git/config.lock` while recording its upstream,
+    /// leaving the branch standing.
     ///
     /// **Four independent gates stand between a failure and `branch -D`, and
     /// deleting a branch the user owns is the worst outcome this path has.

--- a/Tests/TBDDaemonTests/GitManagerTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTests.swift
@@ -55,6 +55,7 @@ struct GitManagerTests {
         let base = try await addBareRemoteAndPushDefault()
         let wtPath = tempDir.appendingPathComponent("wt-remote-default").path
         let branch = "tbd/no-upstream"
+        try await GitManagerTests.shell("git config branch.autoSetupMerge true", at: repoDir)
 
         try await git.worktreeAdd(
             repoPath: repoDir.path,
@@ -65,6 +66,15 @@ struct GitManagerTests {
 
         let upstream = await git.upstreamBranchName(worktreePath: wtPath, branch: branch)
         #expect(upstream == nil)
+        let wtDir = URL(fileURLWithPath: wtPath)
+        try await GitManagerTests.shell(
+            "git config --get 'branch.\(branch).remote' >/dev/null; test $? -eq 1",
+            at: wtDir
+        )
+        try await GitManagerTests.shell(
+            "git config --get 'branch.\(branch).merge' >/dev/null; test $? -eq 1",
+            at: wtDir
+        )
         cleanup()
     }
 

--- a/Tests/TBDDaemonTests/GitManagerTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTests.swift
@@ -51,6 +51,23 @@ struct GitManagerTests {
         cleanup()
     }
 
+    @Test func worktreeAddFromRemoteDefaultDoesNotConfigureUpstream() async throws {
+        let base = try await addBareRemoteAndPushDefault()
+        let wtPath = tempDir.appendingPathComponent("wt-remote-default").path
+        let branch = "tbd/no-upstream"
+
+        try await git.worktreeAdd(
+            repoPath: repoDir.path,
+            worktreePath: wtPath,
+            branch: branch,
+            baseBranch: "origin/\(base)"
+        )
+
+        let upstream = await git.upstreamBranchName(worktreePath: wtPath, branch: branch)
+        #expect(upstream == nil)
+        cleanup()
+    }
+
     @Test func worktreeRemove() async throws {
         let wtPath = tempDir.appendingPathComponent("wt1").path
         let branch = try await git.detectDefaultBranch(repoPath: repoDir.path)
@@ -92,10 +109,10 @@ struct GitManagerTests {
     }
 
     @Test func pushBranchNameReportsNoDestinationForABranchTrackingItsBase() async throws {
-        // The shape every worktree branch cut from the base branch has: it
-        // TRACKS the base, and git refuses to derive a push destination from
-        // that. This is the discriminator the PR matcher relies on — the
-        // tracking config alone cannot tell a head ref from a base ref.
+        // A legacy or externally configured branch may track its base. Git
+        // refuses to derive a push destination from that shape, which is the
+        // discriminator the PR matcher relies on — tracking config alone cannot
+        // tell a head ref from a base ref.
         let base = try await addBareRemoteAndPushDefault()
         try await GitManagerTests.shell("git checkout -b tbd/my-branch", at: repoDir)
         try await GitManagerTests.shell("git config branch.tbd/my-branch.remote origin", at: repoDir)

--- a/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
@@ -102,6 +102,7 @@ import Testing
 
     // Clone into the test repo (mirrors what a user would do).
     try await shell("git clone '\(remoteDir.path)' '\(cloneRepoDir.path)'", at: cloneTempDir)
+    try await shell("git config branch.autoSetupMerge false", at: cloneRepoDir)
 
     let db = try TBDDatabase(inMemory: true)
     let lifecycle = WorktreeLifecycle(
@@ -139,6 +140,15 @@ import Testing
         branch: wt.branch
     )
     #expect(upstream == "remote-feature")
+    let worktreeDir = URL(fileURLWithPath: wt.localPath)
+    try await shell(
+        "test \"$(git config --get 'branch.remote-feature.remote')\" = origin",
+        at: worktreeDir
+    )
+    try await shell(
+        "test \"$(git config --get 'branch.remote-feature.merge')\" = refs/heads/remote-feature",
+        at: worktreeDir
+    )
 }
 
 @Test func testCreateWorktreeForExistingBranchDeDupesAgainstArchivedRowPath() async throws {

--- a/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
@@ -134,6 +134,11 @@ import Testing
     #expect(listed.contains { entry in
         entry.branch == "remote-feature" && entry.path.hasSuffix("/remote-feature")
     })
+    let upstream = await GitManager().upstreamBranchName(
+        worktreePath: wt.localPath,
+        branch: wt.branch
+    )
+    #expect(upstream == "remote-feature")
 }
 
 @Test func testCreateWorktreeForExistingBranchDeDupesAgainstArchivedRowPath() async throws {

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -7,21 +7,13 @@ import Testing
 /// Tier 2 (real git subprocesses, real filesystem, no tmux — `dryRun: true`).
 ///
 /// Covers what a *failed* `git worktree add` leaves behind, and how the create
-/// path decides whether retrying can help.
-///
-/// The failure is induced with a stale `.git/config.lock`, which is a faithful
-/// reproduction rather than a contrivance: `git worktree add -b <branch>
-/// origin/<default>` creates the branch, then writes upstream tracking
-/// configuration, and a lock file left by a crashed git makes only the second
-/// half fail. Git rolls back the directory and the worktree registration but
-/// keeps the branch — so the create fails with a `tbd/<name>` branch standing.
-/// `GitManager` is a concrete struct, so real git is also the only way to drive
-/// these paths.
+/// path decides whether retrying can help. `GitManager` is a concrete struct,
+/// so real git is also the only way to drive these paths.
 @Suite struct WorktreeCreateFailureCleanupTests {
 
     /// A bare remote plus a clone with `main` pushed, so `origin/main` resolves
-    /// and the upstream-config write is actually attempted. Returns the clone's
-    /// host directory (the caller's `tempDir`) and the clone itself.
+    /// during fresh-branch creation. Returns the clone's host directory (the
+    /// caller's `tempDir`) and the clone itself.
     ///
     /// `remoteOnlyBranches` are pushed to the remote and then deleted from the
     /// source, so the clone sees `origin/<name>` with no local counterpart —
@@ -76,23 +68,10 @@ import Testing
         )
     }
 
-    /// Jams the repo so `git worktree add -b … origin/main` fails *after*
-    /// creating the branch. No process holds this lock; it is exactly the
-    /// residue a crashed git leaves.
-    ///
-    /// It jams only the *remote* base by default, and that asymmetry is the
-    /// point: `-b <new> origin/main` writes upstream tracking configuration,
-    /// while `-b <new> main` writes none and therefore never touches
-    /// `.git/config`. Pass `includingTheLocalBase: true` to set
-    /// `branch.autoSetupMerge = always`, which makes a local base configure
-    /// upstream too — the way to build one cause that both bases hit. Both
-    /// halves verified against git 2.50.
-    private func jamConfigLock(
-        _ repoDir: URL, includingTheLocalBase: Bool = false
-    ) async throws {
-        if includingTheLocalBase {
-            try await shell("git config branch.autoSetupMerge always", at: repoDir)
-        }
+    /// Jams repository config writes with the residue a crashed git can leave.
+    /// The explicit remote-tracking checkout uses this to fail after creating
+    /// its local branch but before recording the upstream.
+    private func jamConfigLock(_ repoDir: URL) throws {
         try Data().write(to: repoDir.appendingPathComponent(".git/config.lock"))
     }
 
@@ -119,89 +98,17 @@ import Testing
         try await GitManager().headSHA(repoPath: repoDir.path, ref: "refs/heads/\(branch)")
     }
 
-    // MARK: - Bug 1: a failed create must not leak the branch it just made
+    // MARK: - A repo-level failure earns the other base, but never a name
 
-    /// Jammed for BOTH bases: a lock that stops only the remote base is now
-    /// recovered by the local one (see `remoteBaseFailureRecoversOnTheLocalBase`),
-    /// so making the create fail at all takes a cause neither base escapes.
-    @Test func failedCreateLeavesNothingBehind() async throws {
-        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
-        defer { try? FileManager.default.removeItem(at: parentDir) }
-        try await jamConfigLock(repoDir, includingTheLocalBase: true)
-
-        let db = try TBDDatabase(inMemory: true)
-        let lifecycle = makeLifecycle(db: db)
-        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
-
-        await #expect(throws: WorktreeLifecycleError.self) {
-            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-        }
-
-        // The whole point: git created `tbd/<name>` before failing, and nothing
-        // cleaned it up. Against the unfixed tree this listed one branch per
-        // generated name — e.g. ["tbd/…-thirsty-marmoset", "tbd/…-underlying-vole"].
-        let branches = try await localBranches(repoDir)
-        let leaked = branches.filter { $0.hasPrefix("tbd/") }
-        #expect(leaked.isEmpty, "failed create leaked branches: \(leaked)")
-
-        // Registration and directory, checked in the same run so the sweep is
-        // whole. Git rolls both back by itself for this particular failure, so
-        // these two are a guard against a future failure mode that doesn't —
-        // which is why `worktreePrune` is part of the cleanup.
-        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
-        #expect(listed.count == 1, "stray worktree registrations: \(listed.map(\.path))")
-
-        let base = WorktreeLayout().basePath(for: repo)
-        let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []
-        #expect(survivors.isEmpty, "failed create left worktree directories: \(survivors)")
-    }
-
-    // MARK: - Bug 2: a repo-level failure earns the other base, but never a name
-
-    /// The two bases are not interchangeable, so a repo-level failure on the
-    /// remote one is not the end of the road: `origin/main` makes `-b` write
-    /// upstream configuration, and a stale `.git/config.lock` fails exactly that
-    /// write, while the plain local `main` writes no configuration at all and
-    /// succeeds with the lock still sitting there.
+    /// A local branch literally named `origin/main` makes base 1 fatal on
+    /// `fatal: ambiguous object name: 'origin/main'` — creating nothing at all,
+    /// so there is not even a branch to clean up — while base 2 resolves the
+    /// unambiguous local `main` and succeeds.
     ///
-    /// What makes continuing safe is the branch cleanup this suite's first test
-    /// covers: attempt 1 leaves `tbd/<name>` standing, cleanup removes it, and
-    /// attempt 2 finds the name free. Failing fast here spent that cleanup for
-    /// nothing.
-    @Test func remoteBaseFailureRecoversOnTheLocalBase() async throws {
-        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
-        defer { try? FileManager.default.removeItem(at: parentDir) }
-        try await jamConfigLock(repoDir)
-
-        let db = try TBDDatabase(inMemory: true)
-        let lifecycle = makeLifecycle(db: db)
-        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
-
-        let created = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-
-        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
-        #expect(listed.contains { $0.branch == created.branch },
-                "the local base did not recover the create: \(listed)")
-        #expect(FileManager.default.fileExists(atPath: created.localPath),
-                "the create reported success without a checkout at \(created.localPath)")
-
-        // Exactly the branch the create started with — a fresh name would show
-        // up here as a second `tbd/…`, and an uncleaned attempt 1 as a leftover.
-        let branches = try await localBranches(repoDir)
-        #expect(branches.filter { $0.hasPrefix("tbd/") } == [created.branch],
-                "the recovery burned a second name or leaked a branch: \(branches)")
-    }
-
-    /// The second verified shape of the same thing, and the one that regressed
-    /// outright: a local branch literally named `origin/main` makes base 1 fatal
-    /// on `fatal: ambiguous object name: 'origin/main'` — creating nothing at
-    /// all, so there is not even a branch to clean up — while base 2 resolves
-    /// the unambiguous local `main` and succeeds.
-    ///
-    /// Distinct from the config-lock shape above because its stderr is a
-    /// *reference* complaint that the base-unresolvable whitelist deliberately
-    /// does not match ("ambiguous object name" is not "not a valid object
-    /// name"), so it lands in `.repoLevel` and depends on that case continuing.
+    /// Its stderr is a *reference* complaint that the base-unresolvable
+    /// whitelist deliberately does not match ("ambiguous object name" is not
+    /// "not a valid object name"), so it lands in `.repoLevel` and depends on
+    /// that case continuing.
     @Test func aShadowingLocalBranchStillResolvesOnTheLocalBase() async throws {
         let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
         defer { try? FileManager.default.removeItem(at: parentDir) }
@@ -221,48 +128,12 @@ import Testing
                 "the recovery burned a second name or leaked a branch: \(branches)")
     }
 
-    /// Once BOTH bases hit the same repo-level cause the create is over: git's
-    /// own words reach the user, with the one hint they can act on.
-    ///
-    /// Asserts preserved behavior, so it is mutation-checked: deleting the
-    /// `.repoLevel` fast-exit from both loops drops the create through to the
-    /// generic "after all attempts" message, which carries no
-    /// `.git/config.lock` hint.
-    @Test func repoLevelFailureOnBothBasesSurfacesGitStderr() async throws {
-        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
-        defer { try? FileManager.default.removeItem(at: parentDir) }
-        try await jamConfigLock(repoDir, includingTheLocalBase: true)
-
-        let db = try TBDDatabase(inMemory: true)
-        let lifecycle = makeLifecycle(db: db)
-        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
-
-        do {
-            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-            Issue.record("expected the jammed config lock to fail the create")
-        } catch {
-            let text = String(describing: error)
-            // Before the fix, the surfaced stderr came from the LAST attempt —
-            // "a branch named 'tbd/…' already exists", an artifact of the leak
-            // in bug 1 — and the real cause never reached the user.
-            #expect(text.contains("could not lock config file"),
-                    "the real cause was masked: \(text)")
-            #expect(!text.contains("the folder or branch may already exist"),
-                    "repo-level failure reported as a collision guess: \(text)")
-            #expect(text.contains(".git/config.lock"),
-                    "no actionable hint for a stale lock: \(text)")
-        }
-    }
-
     /// A fresh name genuinely cannot help a repo-level cause, so spending the
     /// other base must not turn into spending a second name too.
     ///
-    /// The read-only worktree base is chosen over a jammed config lock because
-    /// it makes the answer *directly* observable: git names the path it could
-    /// not create, so the surfaced message says which folder the create died
-    /// on. A jammed lock cannot settle this — its stderr names no folder, and
-    /// the retry leg's own `.repoLevel` exit produces a byte-identical message,
-    /// so both outcomes read the same.
+    /// The read-only worktree base makes the answer directly observable: git
+    /// names the path it could not create, so the surfaced message says which
+    /// folder the create died on.
     ///
     /// Preserved behavior, so it is mutation-checked: deleting the FIRST loop's
     /// post-loop `.repoLevel` throw makes the create generate a second folder
@@ -749,12 +620,11 @@ import Testing
                 "cleanup deleted the pre-existing colliding branch: \(branches)")
     }
 
-    // MARK: - The existing-branch flow leaks the same way
+    // MARK: - Existing-branch creation cleanup
 
-    /// `--track -b <local> <path> origin/<name>` has the same shape as the
-    /// fresh-create path: git creates the local branch, then writes upstream
-    /// tracking configuration, and a jammed `.git/config.lock` fails only the
-    /// second half. Reproduced by hand against git 2.50:
+    /// `--track -b <local> <path> origin/<name>` creates the local branch, then
+    /// writes upstream tracking configuration, and a jammed `.git/config.lock`
+    /// fails only the second half. Reproduced by hand against git 2.50:
     /// `git worktree add --track -b tracked ../wt origin/tracked` leaves
     /// `tracked` standing and creates no directory.
     @Test func failedTrackingCheckoutLeavesNoBranchBehind() async throws {
@@ -762,7 +632,7 @@ import Testing
             remoteOnlyBranches: ["feature"]
         )
         defer { try? FileManager.default.removeItem(at: parentDir) }
-        try await jamConfigLock(repoDir)
+        try jamConfigLock(repoDir)
 
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = makeLifecycle(db: db)

--- a/docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md
+++ b/docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md
@@ -31,11 +31,11 @@ help:
   may; the two-base loop exists for exactly this.
 - **`nameCollision`** — the branch name, the path, or the checkout is taken.
   Base-independent, so further bases are pointless and only a fresh name helps.
-- **`repoLevel`** — a stale lock, a corrupt repo, no disk. A fresh name cannot
-  help, so that leg is skipped. The *other base* is still tried: the two are not
-  interchangeable, because `origin/<default>` is a remote-tracking ref whose
-  `-b` triggers an upstream-config write while a plain local ref writes none.
-  With a jammed config lock, the remote base fails and the local base succeeds.
+- **`repoLevel`** — a corrupt repo, no disk, or an ambiguous base ref. A fresh
+  name cannot help, so that leg is skipped. The *other base* is still tried
+  because the refs resolve independently. For example, a local branch literally
+  named `origin/<default>` can make the remote spelling ambiguous while the
+  plain local `<default>` ref still resolves.
 - **`gitUnusable`** — a timeout or spawn failure, i.e. not a `GitError` at all.
   Fails immediately. This is the one cause where a further attempt has a real
   cost — another full `GitManager.commandTimeout` — rather than a real chance.


### PR DESCRIPTION
## What's broken

A newly created TBD feature worktree can report itself ahead of the repository's default branch even after its matching remote feature branch has been pushed. Git status is comparing the feature branch with `origin/main`, so the output makes a successful push look missing.

## Why it happens

Fresh worktrees were created with `git worktree add -b <feature> <path> origin/<default>`. With Git's normal automatic merge setup, branching from that remote-tracking ref configures the new feature branch to track the default branch. A later push to the matching remote feature branch does not replace that existing upstream configuration.

## What this PR does

- Passes `--no-track` when TBD creates a fresh feature branch, leaving it without an upstream until the first upstream-setting push.
- Preserves explicit matching upstream configuration when checking out an existing remote feature branch.
- Makes both regression paths independent of host Git configuration and checks the raw `branch.*.remote` and `branch.*.merge` values.
- Removes fresh-create config-lock cases made unreachable by `--no-track` while retaining cleanup and fallback coverage for remaining failure paths.

## Assumptions

A fresh feature branch intentionally begins without an upstream. `git push -u` or Git's `push.autoSetupRemote` can then establish the matching remote feature branch; until that happens, status shows no upstream comparison instead of comparing against the default branch.

## Evidence & verification

- Reproduced the original command against a bare remote: the new feature branch received `remote = origin` and `merge = refs/heads/<default>`.
- The focused regression failed before the production change because the observed upstream was the default branch, then passed after `--no-track` was added.
- `scripts/test.sh --filter GitManagerTests`: 18 tests passed.
- `scripts/test.sh --filter WorktreeCreateExistingBranchTests`: 8 tests passed, including explicit `origin/<feature>` tracking.
- `scripts/test.sh --filter WorktreeCreateFailureCleanupTests`: 24 tests passed.
- `scripts/swift-safe build`: passed.
- The full fenced suite ran 7,819 tests in 762 suites and retained the pre-change baseline of 95 issues, including 85 known issues; the remaining transcript-estimator and terminal-activity failures are unrelated and were reproduced before this change.

[Fix worktree upstream](https://cheapsteak.github.io/tbd/open/?worktree=0C1E5747-1C9E-4E07-B1BD-3CD4B0E91334)
