### PR TITLE
fix: prevent scratch terminal pane aliasing

### DIFF
--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -198,7 +198,8 @@ struct ActuationTarget: Codable, Sendable, Equatable {
     /// live row references it any more, and an orphaned window is swept
     /// precisely because no terminal row claims it — so neither has a worktree
     /// or terminal to name, and the coordinates that DO identify them are the
-    /// server name, the window id, and the repo whose sweep found them.
+    /// server name and the window id. Repo-initiated sweeps also name the repo
+    /// that found them; scratch-only sweeps have no repo to record.
     var server: String?
     var window: String?
     var repo: String?
@@ -211,10 +212,10 @@ struct ActuationTarget: Codable, Sendable, Equatable {
         ActuationTarget(provider: provider, session: session)
     }
 
-    /// A whole tmux server, or one untracked window on it, found by the
-    /// reconcile sweep of `repo`.
-    static func tmux(server: String, window: String? = nil, repo: UUID) -> ActuationTarget {
-        ActuationTarget(server: server, window: window, repo: repo.uuidString)
+    /// A whole tmux server, or one untracked window on it, found by a reconcile
+    /// sweep. `repo` is absent when the scratch-only startup sweep found it.
+    static func tmux(server: String, window: String? = nil, repo: UUID?) -> ActuationTarget {
+        ActuationTarget(server: server, window: window, repo: repo?.uuidString)
     }
 }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -419,7 +419,7 @@ public final class Daemon: Sendable {
     }
 
     /// Start the daemon: create config directory, clean up stale state,
-    /// initialize database and all managers, start servers, reconcile worktrees.
+    /// initialize database and all managers, reconcile worktrees, then start servers.
     public func start() async throws {
         // 0. Raise the file-descriptor limit before any tmux server is spawned.
         Self.raiseFileDescriptorLimit()
@@ -789,6 +789,18 @@ public final class Daemon: Sendable {
         // migration or marker is needed. Best-effort, never blocks startup.
         await database.notes.exportContentColumnToFiles()
 
+        // 8d. Reconcile parked state and durable tmux ownership before any
+        // listener accepts an RPC. Full startup recovery may destructively
+        // reap shared scratch servers; once serving begins, a terminal-create
+        // RPC can have created and stamped a window whose DB row has not yet
+        // landed, so that full sweep is no longer safe.
+        if mockMode == nil {
+            await rpcRouter.hibernationCoordinator.reconcileOnStartup()
+        }
+        await performStartupReconciliation(
+            mockMode: mockMode, database: database, git: git, lifecycle: lifecycle,
+            actuationLog: actuationLog)
+
         // 9. Start socket server
         let sock = SocketServer(router: rpcRouter)
         self.socketServer = sock
@@ -824,17 +836,6 @@ public final class Daemon: Sendable {
         let http = HTTPServer(router: rpcRouter)
         self.httpServer = http
         try await http.start()
-
-        if mockMode == nil {
-            // 11. Reconcile parked (hibernated / legacy-suspended) state: clear a
-            // stale parked timestamp for any terminal whose Claude is still alive.
-            await rpcRouter.hibernationCoordinator.reconcileOnStartup()
-        }
-
-        // 11. Perform DB-mutating reconciliation (skipped in mock mode so fixtures render as authored)
-        await performStartupReconciliation(
-            mockMode: mockMode, database: database, git: git, lifecycle: lifecycle,
-            actuationLog: actuationLog)
 
         // 11b. Delivery acknowledgement (design §12): wire the verifier and
         // replay the observations the last daemon's timers died owing.

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -265,8 +265,14 @@ public final class Daemon: Sendable {
     static func performOrphanMaintenance(
         orphanGC: OrphanGC,
         lifecycle: WorktreeLifecycle,
+        configStore: ConfigStore,
         actuationLog: ActuationLog
     ) async {
+        // This entire hourly cadence answers to the GC master switch. Read it
+        // before either action so disabling GC also disables the scratch
+        // ownership mutation that shares its timer. OrphanGC keeps its own
+        // gate as defense in depth for direct/manual callers.
+        guard (try? await configStore.get())?.gcEnabled == true else { return }
         _ = await orphanGC.sweep()
         do {
             try await lifecycle.reconcileScratchTerminals(
@@ -875,6 +881,7 @@ public final class Daemon: Sendable {
                     await Self.performOrphanMaintenance(
                         orphanGC: orphanGC,
                         lifecycle: maintenanceLifecycle,
+                        configStore: database.config,
                         actuationLog: actuationLog)
                     while !Task.isCancelled {
                         // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
@@ -883,6 +890,7 @@ public final class Daemon: Sendable {
                         await Self.performOrphanMaintenance(
                             orphanGC: orphanGC,
                             lifecycle: maintenanceLifecycle,
+                            configStore: database.config,
                             actuationLog: actuationLog)
                     }
                 }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -238,7 +238,9 @@ public final class Daemon: Sendable {
         // server. Reconcile them independently so this still runs when there
         // are zero registered repos and catches recycled pane coordinates.
         do {
-            try await lifecycle.reconcileScratchTerminals(actuationLog: actuationLog)
+            try await lifecycle.reconcileScratchTerminals(
+                actuationLog: actuationLog,
+                reapOrphanTmuxResources: true)
         } catch {
             reconcileLogger.warning("Failed to reconcile scratch terminals: \(error.localizedDescription, privacy: .public)")
         }
@@ -264,7 +266,9 @@ public final class Daemon: Sendable {
     ) async {
         _ = await orphanGC.sweep()
         do {
-            try await lifecycle.reconcileScratchTerminals(actuationLog: actuationLog)
+            try await lifecycle.reconcileScratchTerminals(
+                actuationLog: actuationLog,
+                reapOrphanTmuxResources: false)
         } catch {
             reconcileLogger.warning("Failed to reconcile scratch terminals during orphan maintenance: \(error.localizedDescription, privacy: .public)")
         }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -226,7 +226,10 @@ public final class Daemon: Sendable {
             let repos = try await database.repos.list()
             for repo in repos {
                 do {
-                    try await lifecycle.reconcile(repoID: repo.id, actuationLog: actuationLog)
+                    try await lifecycle.reconcile(
+                        repoID: repo.id,
+                        actuationLog: actuationLog,
+                        reapSharedScratchTmuxResources: true)
                 } catch {
                     reconcileLogger.warning("Failed to reconcile repo \(repo.displayName, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -68,8 +68,9 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var gitStatusTask: Task<Void, Never>?
     public nonisolated(unsafe) var reaperTask: Task<Void, Never>?
     public nonisolated(unsafe) var hibernationSweepTask: Task<Void, Never>?
-    /// Orphan-GC hourly sweep task (agent worktrees + scratchpads). `nil` in
-    /// mock mode. See `orphanGC` for the actor it drives.
+    /// Hourly orphan-maintenance task (orphan GC + scratch terminal
+    /// reconciliation). `nil` in mock mode. See `orphanGC` for the actor it
+    /// drives.
     public nonisolated(unsafe) var gcTask: Task<Void, Never>?
     /// Orphan-GC actor. Owned here so `gc.*` RPC handlers (Task 9) can reach
     /// it the same way they reach `rpcRouter.hibernationCoordinator`. `nil`
@@ -251,6 +252,22 @@ public final class Daemon: Sendable {
         // [missing] tags as soon as the daemon is up.
         let healthValidator = RepoHealthValidator(git: git)
         await healthValidator.validateAll(db: database)
+    }
+
+    /// Run one pass of the hourly orphan-maintenance cadence. Scratch terminal
+    /// reconciliation shares this pass so tmux coordinate reuse is repaired
+    /// while the daemon remains alive, not only at startup.
+    static func performOrphanMaintenance(
+        orphanGC: OrphanGC,
+        lifecycle: WorktreeLifecycle,
+        actuationLog: ActuationLog
+    ) async {
+        _ = await orphanGC.sweep()
+        do {
+            try await lifecycle.reconcileScratchTerminals(actuationLog: actuationLog)
+        } catch {
+            reconcileLogger.warning("Failed to reconcile scratch terminals during orphan maintenance: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     /// Wire the delivery verifier and perform the startup replay, gated on
@@ -836,21 +853,29 @@ public final class Daemon: Sendable {
                 }
             }
 
-            // 11a-gc. Orphan-GC: reap abandoned agent worktrees + scratchpads
+            // 11a-gc. Orphan maintenance: reap abandoned agent worktrees + scratchpads
+            // and reconcile scratch terminals against their shared tmux server
             // (event-driven cleanup already runs via `lifecycle.onWorktreeRemoved`
             // above; this periodic sweep catches everything else — worktrees
             // orphaned outside a TBD-initiated remove, e.g. manual `rm -rf`).
             // Constructed above (guarded the same `mockMode == nil` check), so
             // `orphanGC` is always non-nil here.
             if let orphanGC {
-                self.gcTask = Task {
+                let maintenanceLifecycle = lifecycle
+                self.gcTask = Task { [orphanGC, maintenanceLifecycle, actuationLog] in
                     // Sweep once immediately (cold recovery), then every hour.
-                    _ = await orphanGC.sweep()
+                    await Self.performOrphanMaintenance(
+                        orphanGC: orphanGC,
+                        lifecycle: maintenanceLifecycle,
+                        actuationLog: actuationLog)
                     while !Task.isCancelled {
                         // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                         try? await Task.sleep(for: .seconds(3600))
                         guard !Task.isCancelled else { break }
-                        _ = await orphanGC.sweep()
+                        await Self.performOrphanMaintenance(
+                            orphanGC: orphanGC,
+                            lifecycle: maintenanceLifecycle,
+                            actuationLog: actuationLog)
                     }
                 }
             }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -233,6 +233,14 @@ public final class Daemon: Sendable {
         } catch {
             reconcileLogger.warning("Failed to list repos for reconciliation: \(error.localizedDescription, privacy: .public)")
         }
+        // Scratch spaces have no repo row and deliberately share one tmux
+        // server. Reconcile them independently so this still runs when there
+        // are zero registered repos and catches recycled pane coordinates.
+        do {
+            try await lifecycle.reconcileScratchTerminals(actuationLog: actuationLog)
+        } catch {
+            reconcileLogger.warning("Failed to reconcile scratch terminals: \(error.localizedDescription, privacy: .public)")
+        }
         // Backfill archived worktrees whose branch is missing — repairs
         // rows whose branch was renamed before archive captured the new name.
         // Idempotent and best-effort; never throws.

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -128,6 +128,16 @@ public final class TBDDatabase: Sendable {
         try Self.buildMigrator().migrate(queue)
     }
 
+    /// Delete a terminal and its sparse tab metadata in one transaction. The
+    /// tab table has no foreign key, so callers must not commit one deletion
+    /// without the other and leave an undiscoverable metadata row behind.
+    func deleteTerminalAndTab(id: UUID) async throws {
+        try await writer.write { db in
+            _ = try TerminalRecord.deleteOne(db, key: id.uuidString)
+            _ = try TabRecord.deleteOne(db, key: id.uuidString)
+        }
+    }
+
     /// Best-effort pre-migration snapshot. Failures are logged, not thrown —
     /// the migration must still be allowed to proceed even if e.g. the disk
     /// is full or the parent directory isn't writable.

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -114,15 +114,6 @@ public actor HibernationCoordinator {
     /// spawn two `claude --resume` processes into the same window.
     private var wakesInFlight: Set<UUID> = []
 
-    /// Tmux servers whose wake tmux-section currently holds the per-server
-    /// lock (see `withServerLock`). `wakesInFlight` only dedupes SAME-terminal
-    /// wakes; this serializes DIFFERENT terminals on the same server.
-    private var lockedServers: Set<String> = []
-
-    /// FIFO waiters per server, resumed one at a time on release so lock
-    /// ownership transfers in arrival order (no starvation, no thundering herd).
-    private var serverLockWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
-
     /// Invoked after EVERY `ensureServer` on the wake-recreate path (whether or
     /// not a server was actually created — the downstream control-mode
     /// `enableIfGated` is idempotent, so firing on an existing server is a
@@ -782,26 +773,42 @@ public actor HibernationCoordinator {
         // when the window survived, or the recreated window's fresh ones.
         let livePaneID: String
         let liveWindowID: String
+        let liveServer: String
 
         // The whole decide-then-mutate tmux section (ownership check +
         // windowExists + respawn/create/kill/persist) runs under the
         // per-server lock: `wakesInFlight` above only dedupes wakes for the
         // SAME terminal, while this closes the cross-terminal TOCTOU on a
-        // shared server (see `withServerLock`). The lock is NOT held around
-        // the delayed session-recapture Task below.
-        let outcome = await withServerLock(server) {
-            await self.wakeTmuxSection(
-                terminal: terminal, worktree: worktree.worktree, server: server,
-                windowID: windowID, paneID: paneID, spawnCommand: spawn.command,
-                env: env, sensitiveEnv: sensitiveEnv, cols: cols, rows: rows
-            )
+        // shared server (see `TmuxManager.withWorktreeServerLock`). The lock
+        // is NOT held around the delayed session-recapture Task below.
+        let outcome: WakeTmuxOutcome
+        do {
+            outcome = try await tmux.withWorktreeServerLock(
+                db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
+            ) { currentWorktree in
+                await self.wakeTmuxSection(
+                    terminal: terminal,
+                    worktree: currentWorktree.worktree,
+                    server: currentWorktree.tmuxServer,
+                    windowID: windowID,
+                    paneID: paneID,
+                    spawnCommand: spawn.command,
+                    env: env,
+                    sensitiveEnv: sensitiveEnv,
+                    cols: cols,
+                    rows: rows
+                )
+            }
+        } catch {
+            return .notFound
         }
         switch outcome {
         case .failed(let result):
             return result
-        case .respawned(let newPaneID, let newWindowID):
+        case .respawned(let newPaneID, let newWindowID, let currentServer):
             livePaneID = newPaneID
             liveWindowID = newWindowID
+            liveServer = currentServer
         }
 
         do {
@@ -825,7 +832,9 @@ public actor HibernationCoordinator {
         Task {
             // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(5))
-            if let newID = await self.detector.captureSessionID(server: server, paneID: livePaneID) {
+            if let newID = await self.detector.captureSessionID(
+                server: liveServer, paneID: livePaneID
+            ) {
                 try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
             }
         }
@@ -836,14 +845,14 @@ public actor HibernationCoordinator {
     /// Outcome of `wakeTmuxSection`: the live pane/window ids the rest of
     /// `wake()` should reference, or the `WakeResult` to return verbatim.
     private enum WakeTmuxOutcome {
-        case respawned(paneID: String, windowID: String)
+        case respawned(paneID: String, windowID: String, server: String)
         case failed(WakeResult)
     }
 
     /// The decide-then-mutate tmux section of `wake()` — ownership check,
     /// `windowExists`, and the in-place respawn OR recreate mutations. Must
-    /// only be entered under `withServerLock(server:)` (see the call site in
-    /// `wake()`), otherwise two concurrent wakes on the same server can
+    /// only be entered under `TmuxManager.withWorktreeServerLock` (see the call
+    /// site in `wake()`), otherwise two concurrent wakes on the same server can
     /// interleave across the awaits below and hijack each other's windows.
     private func wakeTmuxSection(
         terminal: Terminal,
@@ -883,7 +892,7 @@ public actor HibernationCoordinator {
                     cols: cols,
                     rows: rows
                 )
-                return .respawned(paneID: paneID, windowID: windowID)
+                return .respawned(paneID: paneID, windowID: windowID, server: server)
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
                 logger.warning("wake: respawn-to-claude failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -952,7 +961,8 @@ public actor HibernationCoordinator {
                     return .failed(.respawnFailed(reason: "recreated tmux window \(window.windowID), but persisting the new tmux ids failed: \(error.localizedDescription)"))
                 }
                 logger.info("wake: window \(windowID, privacy: .public) was gone for terminal \(terminal.id, privacy: .public); recreated as \(window.windowID, privacy: .public) (pane \(window.paneID, privacy: .public))")
-                return .respawned(paneID: window.paneID, windowID: window.windowID)
+                return .respawned(
+                    paneID: window.paneID, windowID: window.windowID, server: server)
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
                 logger.warning("wake: recreate-window failed for terminal \(terminal.id, privacy: .public) (old window \(windowID, privacy: .public)): \(error.localizedDescription, privacy: .public)")
@@ -1167,52 +1177,7 @@ public actor HibernationCoordinator {
     /// reissues window ids from @1, so a stale parked row can collide with a
     /// window a different terminal's wake just created — and the other row's
     /// claim is necessarily the fresher one. Worktrees can share a per-repo
-    /// server, so ownership is resolved across all worktrees with the same
-    /// `tmuxServer` string, not just this terminal's worktree.
-    /// Run `body` while holding an exclusive async lock keyed by tmux server.
-    ///
-    /// Actors are reentrant across `await` points, and SocketServer dispatches
-    /// each RPC as its own Task (up to 8 in flight), so two concurrent wakes
-    /// for DIFFERENT terminals on the SAME server can interleave between the
-    /// ownership check, `windowExists`, and the respawn/create mutations —
-    /// e.g. terminal B's recreate mints a fresh post-reboot id equal to A's
-    /// stale one, then A's `windowExists` sees B's just-spawned window as
-    /// alive and the in-place respawn hijacks B's live session. A bare Set
-    /// could only REJECT a concurrent entrant; the FIFO waiter queue makes
-    /// this a true mutex that SERIALIZES them. Different servers never
-    /// serialize against each other.
-    ///
-    /// Release is structural (defer), so every path — success, error return,
-    /// or a throw out of `body` — unlocks. On release, ownership transfers to
-    /// the first waiter WITHOUT clearing `lockedServers`, so no third task can
-    /// barge in between resume and the waiter actually running.
-    ///
-    /// Package-internal (not `private`) so tests can drive the FIFO
-    /// mutual-exclusion semantics directly (mirrors `runExternalCommand`).
-    func withServerLock<T>(_ server: String, _ body: () async -> T) async -> T {
-        if lockedServers.contains(server) {
-            await withCheckedContinuation { continuation in
-                serverLockWaiters[server, default: []].append(continuation)
-            }
-            // Resumed by releaseServerLock: we now OWN the lock.
-        } else {
-            lockedServers.insert(server)
-        }
-        defer { releaseServerLock(server) }
-        return await body()
-    }
-
-    /// Hand the lock to the oldest waiter, or unlock if none are queued.
-    private func releaseServerLock(_ server: String) {
-        if var waiters = serverLockWaiters[server], !waiters.isEmpty {
-            let next = waiters.removeFirst()
-            serverLockWaiters[server] = waiters.isEmpty ? nil : waiters
-            next.resume() // lock ownership transfers; lockedServers stays set
-        } else {
-            lockedServers.remove(server)
-        }
-    }
-
+    /// server, so ownership is resolved across every worktree on that server.
     private func windowClaimedByAnotherTerminal(
         server: String, windowID: String, excluding terminalID: UUID
     ) async -> Bool {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1219,6 +1219,51 @@ extension WorktreeLifecycle {
         /// it nil and gets exactly the overlay it got before the tee existed.
         watchDeskRole: WatchDeskRole? = nil
     ) async throws -> [(id: UUID, label: String)] {
+        try await tmux.withWorktreeServerLock(
+            db: db,
+            worktreeID: worktree.id,
+            allowedStatuses: [worktree.status, .creating]
+        ) { currentWorktree in
+            try await spawnPrimaryTerminalsWhileLocked(
+                worktree: currentWorktree.worktree,
+                repo: repo,
+                worktreePath: worktreePath,
+                skipClaude: skipClaude,
+                archivedClaudeSessions: archivedClaudeSessions,
+                initialPrompt: initialPrompt,
+                cols: cols,
+                rows: rows,
+                preSessionTerminalID: preSessionTerminalID,
+                overrideProfileID: overrideProfileID,
+                modelOverride: modelOverride,
+                primaryAgentPreference: primaryAgentPreference,
+                claudeSettingsOverlay: claudeSettingsOverlay,
+                carryover: carryover,
+                preparedCodexLaunch: preparedCodexLaunch,
+                watchDeskRole: watchDeskRole)
+        }
+    }
+
+    /// Implementation of `spawnPrimaryTerminals` while the worktree's current
+    /// tmux server is exclusively locked through every terminal-row commit.
+    private func spawnPrimaryTerminalsWhileLocked(
+        worktree: Worktree,
+        repo: Repo?,
+        worktreePath: String?,
+        skipClaude: Bool,
+        archivedClaudeSessions: [String]?,
+        initialPrompt: String?,
+        cols: Int?,
+        rows: Int?,
+        preSessionTerminalID: UUID?,
+        overrideProfileID: UUID?,
+        modelOverride: String?,
+        primaryAgentPreference: PrimaryAgentPreference?,
+        claudeSettingsOverlay: String?,
+        carryover: ConversationCarryover?,
+        preparedCodexLaunch: CodexLaunchPreparation?,
+        watchDeskRole: WatchDeskRole?
+    ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
         let worktreePath = worktreePath ?? worktree.localPath
@@ -1447,20 +1492,26 @@ extension WorktreeLifecycle {
             cols: resolvedCols,
             rows: resolvedRows
         )
-        _ = try await db.terminals.create(
-            id: plannedTerminalID1,
-            worktreeID: worktreeID,
-            tmuxWindowID: window1.windowID,
-            tmuxPaneID: window1.paneID,
-            label: primaryLabel,
-            claudeSessionID: primarySessionID,
-            profileID: primaryProfileID,
-            kind: primaryTerminalKind,
-            // Same value the overlay above was built from, written to the row
-            // so the fact outlives this call. A desk woken from hibernation
-            // reuses this row, and the wake site has nothing else to read.
-            watchDeskRole: watchDeskRole
-        )
+        do {
+            _ = try await db.terminals.create(
+                id: plannedTerminalID1,
+                worktreeID: worktreeID,
+                tmuxWindowID: window1.windowID,
+                tmuxPaneID: window1.paneID,
+                label: primaryLabel,
+                claudeSessionID: primarySessionID,
+                profileID: primaryProfileID,
+                kind: primaryTerminalKind,
+                // Same value the overlay above was built from, written to the
+                // row so the fact outlives this call. A desk woken from
+                // hibernation reuses this row, and the wake site has nothing
+                // else to read.
+                watchDeskRole: watchDeskRole
+            )
+        } catch {
+            try? await tmux.killWindow(server: tmuxServer, windowID: window1.windowID)
+            throw error
+        }
         if carryover != nil {
             SessionRecaptureScheduler(db: db, tmux: tmux).schedule(
                 terminalID: plannedTerminalID1,
@@ -1541,14 +1592,19 @@ extension WorktreeLifecycle {
                 cols: resolvedCols,
                 rows: resolvedRows
             )
-            _ = try await db.terminals.create(
-                id: plannedTerminalID2,
-                worktreeID: worktreeID,
-                tmuxWindowID: window2.windowID,
-                tmuxPaneID: window2.paneID,
-                label: TerminalLabel.setup,
-                kind: .shell
-            )
+            do {
+                _ = try await db.terminals.create(
+                    id: plannedTerminalID2,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: window2.windowID,
+                    tmuxPaneID: window2.paneID,
+                    label: TerminalLabel.setup,
+                    kind: .shell
+                )
+            } catch {
+                try? await tmux.killWindow(server: tmuxServer, windowID: window2.windowID)
+                throw error
+            }
             createdTerminals.append((id: plannedTerminalID2, label: TerminalLabel.setup))
             if let setupMarkerPath, let setupHookPath {
                 // The auto-close wrapper lets the pane EXIT on hook success,
@@ -1564,6 +1620,7 @@ extension WorktreeLifecycle {
                 }
                 setupAutoCloseSpawn = PreSessionSpawn(
                     terminalID: plannedTerminalID2,
+                    tmuxServer: tmuxServer,
                     windowID: window2.windowID,
                     paneID: window2.paneID,
                     markerPath: setupMarkerPath,
@@ -1644,16 +1701,22 @@ extension WorktreeLifecycle {
                     cols: resolvedCols,
                     rows: resolvedRows
                 )
-                _ = try await db.terminals.create(
-                    id: plannedID,
-                    worktreeID: worktreeID,
-                    tmuxWindowID: window.windowID,
-                    tmuxPaneID: window.paneID,
-                    label: TerminalLabel.claudeCode,
-                    claudeSessionID: sessionID,
-                    profileID: resolvedProfile?.profileID,
-                    kind: .claude
-                )
+                do {
+                    _ = try await db.terminals.create(
+                        id: plannedID,
+                        worktreeID: worktreeID,
+                        tmuxWindowID: window.windowID,
+                        tmuxPaneID: window.paneID,
+                        label: TerminalLabel.claudeCode,
+                        claudeSessionID: sessionID,
+                        profileID: resolvedProfile?.profileID,
+                        kind: .claude
+                    )
+                } catch {
+                    try? await tmux.killWindow(
+                        server: tmuxServer, windowID: window.windowID)
+                    throw error
+                }
                 createdTerminals.append((id: plannedID, label: TerminalLabel.claudeCode))
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -8,6 +8,7 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "worktreeLife
 /// wait + primary terminal spawn) consumes it.
 struct PreSessionSpawn: Sendable {
     let terminalID: UUID
+    let tmuxServer: String
     let windowID: String
     let paneID: String
     let markerPath: String
@@ -122,19 +123,8 @@ extension WorktreeLifecycle {
         }
 
         let worktreeID = worktree.id
-        let tmuxServer = worktree.tmuxServer
         let resolvedCols = cols ?? TmuxManager.defaultCols
         let resolvedRows = rows ?? TmuxManager.defaultRows
-
-        // Ensure tmux server exists — capture initial window ID to kill once
-        // the first real window (the pre-session one) exists.
-        let initialWindowID = try await tmux.ensureServer(
-            server: tmuxServer,
-            session: "main",
-            cwd: worktreePath,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
 
         let terminalID = UUID()
         let markerPath = Self.preSessionMarkerPath(worktreeID: worktreeID)
@@ -147,36 +137,57 @@ extension WorktreeLifecycle {
             markerPath: markerPath,
             shell: defaultShell
         )
-        // Full hook environment per docs/worktree-hooks.md. TBD_WORKTREE_NAME
-        // uses `worktree.name` to match the archive hook's env (the display
-        // name can be renamed later; the folder name is the stable identity).
-        let env: [String: String] = [
-            "TBD_WORKTREE_ID": worktreeID.uuidString,
-            "TBD_TERMINAL_ID": terminalID.uuidString,
-            "TBD_EVENT": HookEvent.preSession.rawValue,
-            "TBD_WORKTREE_NAME": worktree.name,
-            "TBD_WORKTREE_PATH": worktreePath,
-            "TBD_REPO_PATH": repo?.path ?? worktreePath,
-            "TBD_BRANCH": worktree.branch,
-        ]
-        let window = try await tmux.createWindow(
-            server: tmuxServer,
-            session: "main",
-            cwd: worktreePath,
-            shellCommand: command,
-            env: env,
-            sensitiveEnv: Self.hookPaneEnv,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
-        _ = try await db.terminals.create(
-            id: terminalID,
-            worktreeID: worktreeID,
-            tmuxWindowID: window.windowID,
-            tmuxPaneID: window.paneID,
-            label: TerminalLabel.preSession,
-            kind: .shell
-        )
+        let (window, tmuxServer) = try await tmux.withWorktreeServerLock(
+            db: db, worktreeID: worktreeID, allowedStatuses: [worktree.status]
+        ) { currentWorktree in
+            let currentPath = currentWorktree.path
+            let env: [String: String] = [
+                "TBD_WORKTREE_ID": worktreeID.uuidString,
+                "TBD_TERMINAL_ID": terminalID.uuidString,
+                "TBD_EVENT": HookEvent.preSession.rawValue,
+                "TBD_WORKTREE_NAME": currentWorktree.name,
+                "TBD_WORKTREE_PATH": currentPath,
+                "TBD_REPO_PATH": repo?.path ?? currentPath,
+                "TBD_BRANCH": currentWorktree.branch,
+            ]
+            let initialWindowID = try await tmux.ensureServer(
+                server: currentWorktree.tmuxServer,
+                session: "main",
+                cwd: currentPath,
+                cols: resolvedCols,
+                rows: resolvedRows)
+            let window = try await tmux.createWindow(
+                server: currentWorktree.tmuxServer,
+                session: "main",
+                cwd: currentPath,
+                shellCommand: command,
+                env: env,
+                sensitiveEnv: Self.hookPaneEnv,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+            do {
+                _ = try await db.terminals.create(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: window.windowID,
+                    tmuxPaneID: window.paneID,
+                    label: TerminalLabel.preSession,
+                    kind: .shell
+                )
+            } catch {
+                try? await tmux.killWindow(
+                    server: currentWorktree.tmuxServer,
+                    windowID: window.windowID)
+                throw error
+            }
+            if let initialWindowID {
+                try? await tmux.killWindow(
+                    server: currentWorktree.tmuxServer,
+                    windowID: initialWindowID)
+            }
+            return (window, currentWorktree.tmuxServer)
+        }
         if claimsFocus {
             // The pre-session terminal is the only tab until phase 3 runs.
             try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: [terminalID])
@@ -197,17 +208,10 @@ extension WorktreeLifecycle {
             )))
         }
 
-        // Kill the untracked initial window now that a real window exists.
-        // Only the focus-claiming (create/revive) path can have created it —
-        // `ensureServer` returns nil when the server already exists, so this
-        // stays correct for the re-run path without a `claimsFocus` check.
-        if let initialWindowID {
-            try? await tmux.killWindow(server: tmuxServer, windowID: initialWindowID)
-        }
-
         logger.info("preSession hook \(hookPath, privacy: .public) spawned for worktree \(worktreeID, privacy: .public); gating primary terminals on marker")
         return PreSessionSpawn(
             terminalID: terminalID,
+            tmuxServer: tmuxServer,
             windowID: window.windowID,
             paneID: window.paneID,
             markerPath: markerPath,
@@ -290,7 +294,7 @@ extension WorktreeLifecycle {
         preparedCodexLaunch: CodexLaunchPreparation? = nil
     ) async {
         let outcome = await waitForPreSessionCompletion(
-            preSession: preSession, tmuxServer: worktree.tmuxServer
+            preSession: preSession, tmuxServer: preSession.tmuxServer
         )
         // The marker must never outlive the wait, whatever the outcome —
         // `.completed` consumes it inside the wait; this catches any straggler
@@ -320,7 +324,7 @@ extension WorktreeLifecycle {
         guard rowExists else {
             logger.warning("phase-3: worktree \(worktree.id, privacy: .public) row disappeared mid-wait — skipping primary spawn and cleaning up")
             try? await tmux.killWindow(
-                server: worktree.tmuxServer, windowID: preSession.windowID
+                server: preSession.tmuxServer, windowID: preSession.windowID
             )
             return
         }
@@ -434,6 +438,7 @@ extension WorktreeLifecycle {
     func closePreSessionTerminal(worktree: Worktree, preSession: PreSessionSpawn) async {
         await closeHookTerminal(
             worktree: worktree,
+            tmuxServer: preSession.tmuxServer,
             terminalID: preSession.terminalID,
             windowID: preSession.windowID
         )
@@ -445,7 +450,9 @@ extension WorktreeLifecycle {
     /// is a no-op on the create-success path (the primary spawn already set
     /// an order without the hook tab) and keeps the stored order consistent
     /// on the paths that appended the tab (manual re-run, setup auto-close).
-    func closeHookTerminal(worktree: Worktree, terminalID: UUID, windowID: String) async {
+    func closeHookTerminal(
+        worktree: Worktree, tmuxServer: String, terminalID: UUID, windowID: String
+    ) async {
         // Preserve the hook tab's output before the window dies so a user can
         // read an auto-closed setup/pre-session run later (Session History →
         // Closed Terminals). Best-effort: captureOnClose logs failures and
@@ -453,10 +460,10 @@ extension WorktreeLifecycle {
         if let terminal = try? await db.terminals.get(id: terminalID) {
             await db.terminalHistory.captureOnClose(terminal: terminal) {
                 try await tmux.capturePaneScrollback(
-                    server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
+                    server: tmuxServer, paneID: terminal.tmuxPaneID)
             }
         }
-        try? await tmux.killWindow(server: worktree.tmuxServer, windowID: windowID)
+        try? await tmux.killWindow(server: tmuxServer, windowID: windowID)
         do {
             try await db.terminals.delete(id: terminalID)
             try await db.tabs.delete(tabID: terminalID)
@@ -585,7 +592,7 @@ extension WorktreeLifecycle {
         worktree: Worktree, preSession: PreSessionSpawn
     ) async {
         let outcome = await waitForPreSessionCompletion(
-            preSession: preSession, tmuxServer: worktree.tmuxServer
+            preSession: preSession, tmuxServer: preSession.tmuxServer
         )
         // The marker must never outlive the wait, whatever the outcome.
         try? FileManager.default.removeItem(atPath: preSession.markerPath)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -459,13 +459,20 @@ extension WorktreeLifecycle {
                             logger.warning("reconcile: skipped sweeping orphan window \(window.windowID, privacy: .public) on \(server, privacy: .public) — the actuation record is unwritable")
                             continue
                         }
-                        await killWindowAndReap(
+                        let killFailure = await killWindowAndReap(
                             server: server,
                             windowID: window.windowID,
                             paneID: window.paneID
                         )
-                        await actuationLog.appendOutcome(
-                            confirms: actuationID, result: .dispatched)
+                        if let killFailure {
+                            await actuationLog.appendOutcome(
+                                confirms: actuationID,
+                                result: .transportFailed,
+                                error: killFailure)
+                        } else {
+                            await actuationLog.appendOutcome(
+                                confirms: actuationID, result: .dispatched)
+                        }
                     }
                 } catch {
                     logger.warning("reconcile: failed to list tmux windows for server \(server, privacy: .public): \(error, privacy: .public)")

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -190,14 +190,21 @@ extension WorktreeLifecycle {
         // was built for.
         let mainWorktrees = try await db.worktrees.listLocal(repoID: repoID, status: .main)
         for wt in (dbWorktrees + mainWorktrees) where wt.tmuxServer != correctTmuxServer {
-            if await hasLiveWindow(server: wt.tmuxServer, worktreeID: wt.id) {
-                logger.info("reconcile: keeping non-canonical tmux server \(wt.tmuxServer, privacy: .public) for worktree \(wt.id, privacy: .public) — it has live windows (promoted-scratch inheritance)")
-                continue
-            }
-            do {
-                try await db.worktrees.updateTmuxServer(id: wt.id, tmuxServer: correctTmuxServer)
-            } catch {
-                logger.warning("reconcile: failed to update tmux server for worktree \(wt.id, privacy: .public): \(error, privacy: .public)")
+            try await tmux.withServerResourceLock(server: wt.tmuxServer) {
+                // A concurrent reconciliation may have already moved this row
+                // while we waited. Only judge the server whose lock we hold.
+                guard let current = try await db.worktrees.getLocal(id: wt.id),
+                      current.tmuxServer == wt.tmuxServer else { return }
+                if await hasLiveWindow(server: current.tmuxServer, worktreeID: current.id) {
+                    logger.info("reconcile: keeping non-canonical tmux server \(current.tmuxServer, privacy: .public) for worktree \(current.id, privacy: .public) — it has live windows (promoted-scratch inheritance)")
+                    return
+                }
+                do {
+                    try await db.worktrees.updateTmuxServer(
+                        id: current.id, tmuxServer: correctTmuxServer)
+                } catch {
+                    logger.warning("reconcile: failed to update tmux server for worktree \(current.id, privacy: .public): \(error, privacy: .public)")
+                }
             }
         }
         // Re-fetch with corrected names
@@ -239,36 +246,39 @@ extension WorktreeLifecycle {
         // is best-effort (a dead window/pane just logs and skips). The archived
         // row and its history rows survive, so the output stays readable.
         for wt in dbWorktrees where !gitPaths.contains(wt.path) {
-            let terminals = try await db.terminals.list(worktreeID: wt.id)
-            var recordedEveryKill = true
-            for terminal in terminals {
-                var row = ActuationRow(
-                    actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
-                row.target = .local(worktree: wt.id, terminal: terminal.id)
-                guard let actuationID = try? await actuationLog.appendRequest(row) else {
-                    recordedEveryKill = false
-                    continue
+            try await tmux.withWorktreeServerLock(
+                db: db, worktreeID: wt.id, allowedStatuses: [wt.status]
+            ) { current in
+                let terminals = try await db.terminals.list(worktreeID: current.id)
+                var recordedEveryKill = true
+                for terminal in terminals {
+                    var row = ActuationRow(
+                        actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                    row.target = .local(worktree: current.id, terminal: terminal.id)
+                    guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                        recordedEveryKill = false
+                        continue
+                    }
+                    await captureThenKillWindow(
+                        terminal: terminal, server: current.tmuxServer)
+                    await actuationLog.appendOutcome(
+                        confirms: actuationID, result: .dispatched)
                 }
-                await captureThenKillWindow(terminal: terminal, server: wt.tmuxServer)
-                await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
+                // A kill that could not be recorded did not happen, so the
+                // rows still pointing at those windows must survive too.
+                guard recordedEveryKill else {
+                    logger.warning("reconcile: leaving \(current.id, privacy: .public) for the next sweep — the actuation record is unwritable, so its windows were not killed")
+                    return
+                }
+                try await db.terminals.deleteForWorktree(worktreeID: current.id)
+                try await db.tabs.deleteForWorktree(worktreeID: current.id)
+                for terminal in terminals {
+                    await pendingQuestions.clear(terminalID: terminal.id)
+                    ClaudeHookOverlay.removePerSessionOverlay(
+                        sessionKey: terminal.id.uuidString)
+                }
+                try await db.worktrees.archive(id: current.id)
             }
-            // A kill that could not be recorded did not happen, so the rows that
-            // still point at those windows must not be torn down either — that
-            // would archive the worktree and leave its live windows unreachable.
-            // Leave the whole worktree for the next sweep instead.
-            guard recordedEveryKill else {
-                logger.warning("reconcile: leaving \(wt.id, privacy: .public) for the next sweep — the actuation record is unwritable, so its windows were not killed")
-                continue
-            }
-            try await db.terminals.deleteForWorktree(worktreeID: wt.id)
-            try await db.tabs.deleteForWorktree(worktreeID: wt.id)
-            for terminal in terminals {
-                await pendingQuestions.clear(terminalID: terminal.id)
-                // Reclaim any per-session fallbackModel overlay (keyed by terminal
-                // id), mirroring handleTerminalDelete. No-op when none was written.
-                ClaudeHookOverlay.removePerSessionOverlay(sessionKey: terminal.id.uuidString)
-            }
-            try await db.worktrees.archive(id: wt.id)
         }
 
         // Add unknown worktrees (skip the main repo worktree).
@@ -356,18 +366,15 @@ extension WorktreeLifecycle {
         // hard-deletes its main worktree row (deleteForRepo) — the only repo
         // row referencing the inherited scratch server — leaving that server,
         // and the removed repo's still-running windows on it, reachable by no
-        // repo reconcile at all (#325-class leak). The live cleanup path skips
-        // those servers until startup recovery because a scratch create can be
-        // in flight before its terminal row exists.
+        // repo reconcile at all (#325-class leak). Callers that are not a full
+        // recovery pass can exclude those shared servers explicitly.
         let scratchRows = try await db.worktrees.listLocal(scratchOnly: true)
         let scratchServers = Set(scratchRows.map(\.tmuxServer))
         if reapSharedScratchTmuxResources {
             referencedServers.formUnion(scratchServers)
         } else {
-            // A live cleanup can overlap scratch terminal creation after its
-            // tmux window exists but before its terminal row lands. Protect
-            // both current scratch pointers and the deterministic scratch
-            // server, plus inherited noncanonical repo servers whose retired
+            // Protect current scratch pointers, the deterministic scratch
+            // server, and inherited noncanonical repo servers whose retired
             // scratch source row may already be gone. Reinsert the repo's
             // canonical server last so its ordinary orphan cleanup still runs.
             let canonicalScratchServer = TmuxManager.serverName(
@@ -410,11 +417,9 @@ extension WorktreeLifecycle {
             status: .active, scratchOnly: true)
         try await reconcileTerminals(in: scratchWorktrees, actuationLog: actuationLog)
 
-        // Live maintenance may race a terminal spawn between tmux window
-        // creation and terminal-row insertion. Ownership pruning is safe in
-        // that gap because the pane's identity proves stale aliases, but an
-        // orphan sweep would mistake the new window for untracked and kill it.
-        // Full resource reaping therefore remains a startup-only recovery pass.
+        // Hourly maintenance requests ownership repair only. Startup and
+        // explicit cleanup also request external-resource recovery; that
+        // destructive pass serializes with terminal creation per server.
         guard reapOrphanTmuxResources else { return }
 
         // Scratch rows have no repo, so the per-repo pass cannot be relied on
@@ -435,78 +440,90 @@ extension WorktreeLifecycle {
     private func reconcileTmuxResources(
         servers: Set<String>, sweepingRepoID: UUID?, actuationLog: ActuationLog
     ) async throws {
-        let globalLiveRows = try await db.worktrees.listLocal(excludeArchived: true)
-
         for server in servers.sorted() {
-            let liveRowsOnServer = globalLiveRows.filter { $0.tmuxServer == server }
-            if liveRowsOnServer.isEmpty {
-                // Nothing references this server anymore. Skip silently when
-                // it isn't running (nothing to reap or kill — and archived
-                // rows keep pointing here forever, so this is the steady
-                // state on every later reconcile).
-                guard await tmux.serverExists(server: server) else { continue }
-                // Nothing left names this server — that is why it is being
-                // killed — so the row is identified by what IS known: the
-                // server, and the repo whose sweep found it when there is one.
-                // The child reap is part of this disposal, not a second act.
-                var row = ActuationRow(
-                    actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
-                row.target = .tmux(server: server, repo: sweepingRepoID)
-                guard let actuationID = try? await actuationLog.appendRequest(row) else {
-                    logger.warning("reconcile: skipped killing tmux server \(server, privacy: .public) — the actuation record is unwritable")
-                    continue
-                }
-                await reaper.reapServerChildren(server: server)
-                do {
-                    try await tmux.killServer(server: server)
-                    await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
-                } catch {
-                    await actuationLog.appendOutcome(
-                        confirms: actuationID, result: .transportFailed, error: "\(error)")
-                    logger.warning("reconcile: failed to kill tmux server \(server, privacy: .public): \(error, privacy: .public)")
-                }
-            } else {
-                // Collect window IDs tracked by ANY live worktree row on this
-                // server (all repos + scratch), then kill the untracked rest.
-                var trackedWindowIDs: Set<String> = []
-                for wt in liveRowsOnServer {
-                    let terminals = try await db.terminals.list(worktreeID: wt.id)
-                    for terminal in terminals {
-                        trackedWindowIDs.insert(terminal.tmuxWindowID)
+            try await tmux.withServerResourceLock(server: server) {
+                // Ownership must be read only after acquiring the same lock a
+                // creator holds through its terminal-row commit.
+                let globalLiveRows = try await db.worktrees.listLocal(excludeArchived: true)
+                let liveRowsOnServer = globalLiveRows.filter { $0.tmuxServer == server }
+                if liveRowsOnServer.isEmpty {
+                    // Nothing references this server anymore. Skip silently
+                    // when it isn't running (nothing to reap or kill — and
+                    // archived rows keep pointing here forever, so this is
+                    // the steady state on every later reconcile).
+                    guard await tmux.serverExists(server: server) else { return }
+                    // Nothing left names this server — that is why it is being
+                    // killed — so the row is identified by what IS known: the
+                    // server, and the repo whose sweep found it when there is
+                    // one. The child reap is part of this disposal, not a
+                    // second act.
+                    var row = ActuationRow(
+                        actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                    row.target = .tmux(server: server, repo: sweepingRepoID)
+                    guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                        logger.warning("reconcile: skipped killing tmux server \(server, privacy: .public) — the actuation record is unwritable")
+                        return
                     }
-                }
+                    await reaper.reapServerChildren(server: server)
+                    do {
+                        try await tmux.killServer(server: server)
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID, result: .dispatched)
+                    } catch {
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID,
+                            result: .transportFailed,
+                            error: "\(error)")
+                        logger.warning("reconcile: failed to kill tmux server \(server, privacy: .public): \(error, privacy: .public)")
+                    }
+                } else {
+                    // Collect window IDs tracked by ANY live worktree row on
+                    // this server (all repos + scratch), then kill the
+                    // untracked rest.
+                    var trackedWindowIDs: Set<String> = []
+                    for wt in liveRowsOnServer {
+                        let terminals = try await db.terminals.list(worktreeID: wt.id)
+                        for terminal in terminals {
+                            trackedWindowIDs.insert(terminal.tmuxWindowID)
+                        }
+                    }
 
-                do {
-                    let tmuxWindows = try await tmux.listWindows(server: server, session: "main")
-                    for window in tmuxWindows where !trackedWindowIDs.contains(window.windowID) {
-                        // No terminal row claims this window — that is what
-                        // makes it an orphan — so the row names the server,
-                        // window, and sweeping repo when there is one.
-                        var row = ActuationRow(
-                            actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
-                        row.target = .tmux(
-                            server: server, window: window.windowID, repo: sweepingRepoID)
-                        guard let actuationID = try? await actuationLog.appendRequest(row) else {
-                            logger.warning("reconcile: skipped sweeping orphan window \(window.windowID, privacy: .public) on \(server, privacy: .public) — the actuation record is unwritable")
-                            continue
+                    do {
+                        let tmuxWindows = try await tmux.listWindows(
+                            server: server, session: "main")
+                        for window in tmuxWindows
+                        where !trackedWindowIDs.contains(window.windowID) {
+                            // No terminal row claims this window — that is what
+                            // makes it an orphan — so the row names the server,
+                            // window, and sweeping repo when there is one.
+                            var row = ActuationRow(
+                                actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                            row.target = .tmux(
+                                server: server,
+                                window: window.windowID,
+                                repo: sweepingRepoID)
+                            guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                                logger.warning("reconcile: skipped sweeping orphan window \(window.windowID, privacy: .public) on \(server, privacy: .public) — the actuation record is unwritable")
+                                continue
+                            }
+                            let killFailure = await killWindowAndReap(
+                                server: server,
+                                windowID: window.windowID,
+                                paneID: window.paneID
+                            )
+                            if let killFailure {
+                                await actuationLog.appendOutcome(
+                                    confirms: actuationID,
+                                    result: .transportFailed,
+                                    error: killFailure)
+                            } else {
+                                await actuationLog.appendOutcome(
+                                    confirms: actuationID, result: .dispatched)
+                            }
                         }
-                        let killFailure = await killWindowAndReap(
-                            server: server,
-                            windowID: window.windowID,
-                            paneID: window.paneID
-                        )
-                        if let killFailure {
-                            await actuationLog.appendOutcome(
-                                confirms: actuationID,
-                                result: .transportFailed,
-                                error: killFailure)
-                        } else {
-                            await actuationLog.appendOutcome(
-                                confirms: actuationID, result: .dispatched)
-                        }
+                    } catch {
+                        logger.warning("reconcile: failed to list tmux windows for server \(server, privacy: .public): \(error, privacy: .public)")
                     }
-                } catch {
-                    logger.warning("reconcile: failed to list tmux windows for server \(server, privacy: .public): \(error, privacy: .public)")
                 }
             }
         }
@@ -521,6 +538,26 @@ extension WorktreeLifecycle {
     /// --resume` processes (~0.5-1.5 GB each) and OOM'd the machine (#284).
     /// Lazy recreate-on-demand keeps idle worktrees as cheap suspended rows.
     private func reconcileTerminals(
+        in worktrees: [LocalWorktree], actuationLog: ActuationLog
+    ) async throws {
+        let grouped = Dictionary(grouping: worktrees, by: \.tmuxServer)
+        for server in grouped.keys.sorted() {
+            let candidates = grouped[server] ?? []
+            try await tmux.withServerResourceLock(server: server) {
+                var currentWorktrees: [LocalWorktree] = []
+                for candidate in candidates {
+                    guard let current = try await db.worktrees.getLocal(id: candidate.id),
+                          current.tmuxServer == server else { continue }
+                    currentWorktrees.append(current)
+                }
+                try await reconcileTerminalsWhileLocked(
+                    in: currentWorktrees, actuationLog: actuationLog)
+            }
+        }
+    }
+
+    /// Ownership probing while the caller holds the server resource lock.
+    private func reconcileTerminalsWhileLocked(
         in worktrees: [LocalWorktree], actuationLog: ActuationLog
     ) async throws {
         // Probe the server each worktree row actually stores, not a canonical

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -302,97 +302,9 @@ extension WorktreeLifecycle {
             )
         }
 
-        // Reconcile terminals whose tmux window is gone. A window can vanish two
-        // ways: its specific window died while the server is still up, or the
-        // whole server is gone after a reboot/long sleep. BOTH are handled the
-        // same way — park resumable Claude sessions and let the user bring them
-        // back on demand via wake (HibernationCoordinator.wake, the single
-        // unified resume path; see #285 for the dead-server bootstrap history).
-        //
-        // We deliberately do NOT eagerly recreate terminals on reboot: on a
-        // machine with many worktrees that spawned N simultaneous `claude
-        // --resume` processes (~0.5-1.5 GB each) and OOM'd the machine (#284).
-        // Lazy recreate-on-demand keeps idle worktrees as cheap suspended rows.
         let allLiveWorktrees = try await db.worktrees.listLocal(repoID: repoID, status: .active)
             + (try await db.worktrees.listLocal(repoID: repoID, status: .main))
-        // Probe the server each worktree row actually STORES, not the
-        // canonical name: after a scratch promote the main worktree's windows
-        // live on the inherited scratch server, and probing the canonical
-        // (empty) server would declare every live window dead. Cached per
-        // server name — rows overwhelmingly share one server.
-        var serverAliveByName: [String: Bool] = [:]
-        for wt in allLiveWorktrees {
-            let serverAlive: Bool
-            if let cached = serverAliveByName[wt.tmuxServer] {
-                serverAlive = cached
-            } else {
-                serverAlive = await tmux.serverExists(server: wt.tmuxServer)
-                serverAliveByName[wt.tmuxServer] = serverAlive
-            }
-            let terminals = try await db.terminals.list(worktreeID: wt.id)
-            // Parked rows (`hibernatedAt` OR legacy `suspendedAt` — see
-            // `isParked`) are skipped: a parked terminal's window being gone
-            // is expected (post-reboot), the row is already exactly what this
-            // pass would produce, and re-evaluating it would refresh the park
-            // timestamp or, worse, DELETE a parked non-Claude-resumable row.
-            for terminal in terminals where !terminal.isParked {
-                // After a reboot the server is gone, so every window is dead;
-                // otherwise probe the specific window. (Split across statements
-                // because `&&` builds an autoclosure that can't contain `await`.)
-                var windowAlive = false
-                if serverAlive {
-                    windowAlive = await tmux.windowExists(server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
-                }
-                guard !windowAlive else { continue }
-
-                // Extra safety: If this is a Claude-resumable terminal, double-check
-                // that the process is truly gone before parking. If Claude is still
-                // running, leave the terminal active — the next reconcile can reassess.
-                if terminal.isClaudeResumable {
-                    if let cmd = try? await tmux.paneCurrentCommand(server: wt.tmuxServer, paneID: terminal.tmuxPaneID),
-                       ClaudeStateDetector.isClaudeProcess(cmd) {
-                        // Claude is still running in this pane despite windowExists returning false.
-                        // This shouldn't happen, but don't park if it's true.
-                        logger.warning("reconcile: terminal \(terminal.id, privacy: .public) window marked dead but claude process still running — skipping park")
-                        continue
-                    }
-                }
-
-                if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
-                    // Resumable Claude session: park it. The unified park/wake
-                    // machinery rebuilds a window from the session ID on demand.
-                    // Deleting here would orphan the transcript and the session
-                    // would vanish from TBD. Write the authoritative `hibernatedAt`
-                    // column so `wake()` (which un-parks any parked row) can resume it.
-                    //
-                    // This park bypasses `HibernationCoordinator` entirely, so it
-                    // is this sweep's own act and carries this sweep's own row.
-                    // Fail-closed: an unrecordable park is skipped and the row
-                    // stays as it is for the next sweep.
-                    var row = ActuationRow(
-                        actor: .daemon(rail: ActuationRail.reconcile), kind: .hibernate)
-                    row.target = .local(worktree: wt.id, terminal: terminal.id)
-                    guard let actuationID = try? await actuationLog.appendRequest(row) else {
-                        logger.warning("reconcile: skipped parking terminal \(terminal.id, privacy: .public) — the actuation record is unwritable")
-                        continue
-                    }
-                    do {
-                        try await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID, reason: .recovery)
-                        await actuationLog.appendOutcome(
-                            confirms: actuationID, result: .dispatched)
-                    } catch {
-                        await actuationLog.appendOutcome(
-                            confirms: actuationID, result: .transportFailed, error: "\(error)")
-                    }
-                    logger.info("reconcile: parked terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved, wakeable via the unified resume path")
-                } else {
-                    // Plain shell / Codex: nothing resumable to preserve, delete.
-                    try? await db.terminals.delete(id: terminal.id)
-                    logger.info("reconcile: deleted terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone, no session to preserve")
-                }
-                await pendingQuestions.clear(terminalID: terminal.id)
-            }
-        }
+        try await reconcileTerminals(in: allLiveWorktrees, actuationLog: actuationLog)
 
         // Clean up orphaned tmux windows and dead servers. This must cover
         // every server actually referenced by the repo's worktree rows, not
@@ -529,6 +441,122 @@ extension WorktreeLifecycle {
             subscriptions?.broadcast(delta: .repoAdded(RepoDelta(
                 repoID: repo.id, path: repo.path, displayName: repo.displayName
             )))
+        }
+    }
+
+    /// Reconcile active scratch-space terminals independently of registered
+    /// repositories. Scratch spaces deliberately share a tmux server, so tmux
+    /// may recycle one pane coordinate after an older scratch row survives.
+    public func reconcileScratchTerminals(actuationLog: ActuationLog) async throws {
+        let scratchWorktrees = try await db.worktrees.listLocal(
+            status: .active, scratchOnly: true)
+        try await reconcileTerminals(in: scratchWorktrees, actuationLog: actuationLog)
+    }
+
+    /// Reconcile terminals whose tmux window is gone or no longer belongs to
+    /// their database row. Both cases use the same established outcomes: park
+    /// resumable Claude sessions and delete non-resumable Codex/shell rows.
+    ///
+    /// We deliberately do NOT eagerly recreate terminals on reboot: on a
+    /// machine with many worktrees that spawned N simultaneous `claude
+    /// --resume` processes (~0.5-1.5 GB each) and OOM'd the machine (#284).
+    /// Lazy recreate-on-demand keeps idle worktrees as cheap suspended rows.
+    private func reconcileTerminals(
+        in worktrees: [LocalWorktree], actuationLog: ActuationLog
+    ) async throws {
+        // Probe the server each worktree row actually stores, not a canonical
+        // name. Promoted scratch worktrees keep their inherited scratch server.
+        // Cached per server name — rows overwhelmingly share one server.
+        var serverAliveByName: [String: Bool] = [:]
+        for wt in worktrees {
+            let serverAlive: Bool
+            if let cached = serverAliveByName[wt.tmuxServer] {
+                serverAlive = cached
+            } else {
+                serverAlive = await tmux.serverExists(server: wt.tmuxServer)
+                serverAliveByName[wt.tmuxServer] = serverAlive
+            }
+            let terminals = try await db.terminals.list(worktreeID: wt.id)
+            // Parked rows (`hibernatedAt` OR legacy `suspendedAt` — see
+            // `isParked`) are skipped: a parked terminal's window being gone
+            // is expected, and the row is already exactly what this pass would
+            // produce.
+            for terminal in terminals where !terminal.isParked {
+                var windowAlive = false
+                if serverAlive {
+                    windowAlive = await tmux.windowExists(
+                        server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
+                }
+
+                var paneBelongsToDifferentTerminal = false
+                if windowAlive {
+                    do {
+                        switch try await tmux.paneSendTarget(
+                            server: wt.tmuxServer, paneID: terminal.tmuxPaneID)
+                        {
+                        case .live(let paneTerminalID):
+                            if let paneTerminalID {
+                                paneBelongsToDifferentTerminal =
+                                    paneTerminalID.caseInsensitiveCompare(
+                                        terminal.id.uuidString) != .orderedSame
+                            } else {
+                                // Panes predating the identity stamp remain
+                                // live for backward compatibility.
+                                continue
+                            }
+                            if !paneBelongsToDifferentTerminal { continue }
+                        case .missing, .dead:
+                            break
+                        }
+                    } catch {
+                        // An unreadable identity is not evidence of staleness.
+                        // Keep the row and let a later sweep retry the probe.
+                        logger.warning("reconcile: failed to inspect pane ownership for terminal \(terminal.id, privacy: .public): \(error, privacy: .public)")
+                        continue
+                    }
+                }
+
+                // Preserve the existing extra safety when the window probe
+                // itself says a Claude window is gone: if Claude is still
+                // running, retain the row. A pane that answered `.dead`,
+                // `.missing`, or with another terminal's identity is already
+                // definitive, so never inspect its current command.
+                if terminal.isClaudeResumable && !windowAlive {
+                    if let cmd = try? await tmux.paneCurrentCommand(
+                        server: wt.tmuxServer, paneID: terminal.tmuxPaneID),
+                       ClaudeStateDetector.isClaudeProcess(cmd) {
+                        logger.warning("reconcile: terminal \(terminal.id, privacy: .public) window marked dead but claude process still running — skipping park")
+                        continue
+                    }
+                }
+
+                if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
+                    // This park bypasses `HibernationCoordinator`, so the
+                    // reconcile rail records its own independent actuation.
+                    // Fail closed if that authoritative record cannot be made.
+                    var row = ActuationRow(
+                        actor: .daemon(rail: ActuationRail.reconcile), kind: .hibernate)
+                    row.target = .local(worktree: wt.id, terminal: terminal.id)
+                    guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                        logger.warning("reconcile: skipped parking terminal \(terminal.id, privacy: .public) — the actuation record is unwritable")
+                        continue
+                    }
+                    do {
+                        try await db.terminals.setHibernated(
+                            id: terminal.id, sessionID: sessionID, reason: .recovery)
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID, result: .dispatched)
+                    } catch {
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID, result: .transportFailed, error: "\(error)")
+                    }
+                    logger.info("reconcile: parked terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone or reassigned, session \(sessionID, privacy: .public) preserved, wakeable via the unified resume path")
+                } else {
+                    try? await db.terminals.delete(id: terminal.id)
+                    logger.info("reconcile: deleted terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone or reassigned, no session to preserve")
+                }
+                await pendingQuestions.clear(terminalID: terminal.id)
+            }
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -352,80 +352,14 @@ extension WorktreeLifecycle {
         // hard-deletes its main worktree row (deleteForRepo) — the only repo
         // row referencing the inherited scratch server — leaving that
         // server, and the removed repo's still-running windows on it,
-        // reachable by no reconcile at all (#325-class leak). Folding scratch
-        // servers into every repo's reconcile makes whichever repo reconciles
-        // next sweep those orphans; the live-row checks below already span
-        // all repos + scratch spaces, so live scratch windows stay safe.
+        // reachable by no repo reconcile at all (#325-class leak). Both this
+        // repo pass and the independent scratch pass visit those servers; the
+        // live-row checks below span all repos + scratch spaces, so live
+        // scratch windows stay safe.
         let scratchRows = try await db.worktrees.listLocal(scratchOnly: true)
         referencedServers.formUnion(scratchRows.map(\.tmuxServer))
-        let globalLiveRows = try await db.worktrees.listLocal(excludeArchived: true)
-
-        for server in referencedServers.sorted() {
-            let liveRowsOnServer = globalLiveRows.filter { $0.tmuxServer == server }
-            if liveRowsOnServer.isEmpty {
-                // Nothing references this server anymore. Skip silently when
-                // it isn't running (nothing to reap or kill — and archived
-                // rows keep pointing here forever, so this is the steady
-                // state on every later reconcile).
-                guard await tmux.serverExists(server: server) else { continue }
-                // Nothing left names this server — that is why it is being
-                // killed — so the row is identified by what IS known: the
-                // server, and the repo whose sweep found it. The child reap is
-                // part of this one disposal, not a second act.
-                var row = ActuationRow(
-                    actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
-                row.target = .tmux(server: server, repo: repoID)
-                guard let actuationID = try? await actuationLog.appendRequest(row) else {
-                    logger.warning("reconcile: skipped killing tmux server \(server, privacy: .public) — the actuation record is unwritable")
-                    continue
-                }
-                await reaper.reapServerChildren(server: server)
-                do {
-                    try await tmux.killServer(server: server)
-                    await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
-                } catch {
-                    await actuationLog.appendOutcome(
-                        confirms: actuationID, result: .transportFailed, error: "\(error)")
-                    logger.warning("reconcile: failed to kill tmux server \(server, privacy: .public): \(error, privacy: .public)")
-                }
-            } else {
-                // Collect window IDs tracked by ANY live worktree row on this
-                // server (all repos + scratch), then kill the untracked rest.
-                var trackedWindowIDs: Set<String> = []
-                for wt in liveRowsOnServer {
-                    let terminals = try await db.terminals.list(worktreeID: wt.id)
-                    for t in terminals {
-                        trackedWindowIDs.insert(t.tmuxWindowID)
-                    }
-                }
-
-                do {
-                    let tmuxWindows = try await tmux.listWindows(server: server, session: "main")
-                    for window in tmuxWindows where !trackedWindowIDs.contains(window.windowID) {
-                        // No terminal row claims this window — that is what
-                        // makes it an orphan — so the row names the server, the
-                        // window and the sweeping repo.
-                        var row = ActuationRow(
-                            actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
-                        row.target = .tmux(
-                            server: server, window: window.windowID, repo: repoID)
-                        guard let actuationID = try? await actuationLog.appendRequest(row) else {
-                            logger.warning("reconcile: skipped sweeping orphan window \(window.windowID, privacy: .public) on \(server, privacy: .public) — the actuation record is unwritable")
-                            continue
-                        }
-                        await killWindowAndReap(
-                            server: server,
-                            windowID: window.windowID,
-                            paneID: window.paneID
-                        )
-                        await actuationLog.appendOutcome(
-                            confirms: actuationID, result: .dispatched)
-                    }
-                } catch {
-                    logger.warning("reconcile: failed to list tmux windows for server \(server, privacy: .public): \(error, privacy: .public)")
-                }
-            }
-        }
+        try await reconcileTmuxResources(
+            servers: referencedServers, sweepingRepoID: repoID, actuationLog: actuationLog)
 
         // Recompute health so the next call sees the right status. A repo that
         // just transitioned ok→missing here would otherwise stay ok in memory
@@ -451,6 +385,93 @@ extension WorktreeLifecycle {
         let scratchWorktrees = try await db.worktrees.listLocal(
             status: .active, scratchOnly: true)
         try await reconcileTerminals(in: scratchWorktrees, actuationLog: actuationLog)
+
+        // Scratch rows have no repo, so the per-repo pass cannot be relied on
+        // to visit their servers — particularly on installations with zero
+        // registered repos. Prune stale terminal owners first, then let the
+        // shared global-row sweep reclaim only windows nobody still owns.
+        let allScratchWorktrees = try await db.worktrees.listLocal(scratchOnly: true)
+        try await reconcileTmuxResources(
+            servers: Set(allScratchWorktrees.map(\.tmuxServer)),
+            sweepingRepoID: nil,
+            actuationLog: actuationLog
+        )
+    }
+
+    /// Reclaim tmux resources on the requested servers using ownership from
+    /// every live local worktree row. A repo-initiated sweep records that repo;
+    /// a scratch-only sweep has no repo to name and leaves it absent.
+    private func reconcileTmuxResources(
+        servers: Set<String>, sweepingRepoID: UUID?, actuationLog: ActuationLog
+    ) async throws {
+        let globalLiveRows = try await db.worktrees.listLocal(excludeArchived: true)
+
+        for server in servers.sorted() {
+            let liveRowsOnServer = globalLiveRows.filter { $0.tmuxServer == server }
+            if liveRowsOnServer.isEmpty {
+                // Nothing references this server anymore. Skip silently when
+                // it isn't running (nothing to reap or kill — and archived
+                // rows keep pointing here forever, so this is the steady
+                // state on every later reconcile).
+                guard await tmux.serverExists(server: server) else { continue }
+                // Nothing left names this server — that is why it is being
+                // killed — so the row is identified by what IS known: the
+                // server, and the repo whose sweep found it when there is one.
+                // The child reap is part of this disposal, not a second act.
+                var row = ActuationRow(
+                    actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                row.target = .tmux(server: server, repo: sweepingRepoID)
+                guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                    logger.warning("reconcile: skipped killing tmux server \(server, privacy: .public) — the actuation record is unwritable")
+                    continue
+                }
+                await reaper.reapServerChildren(server: server)
+                do {
+                    try await tmux.killServer(server: server)
+                    await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
+                } catch {
+                    await actuationLog.appendOutcome(
+                        confirms: actuationID, result: .transportFailed, error: "\(error)")
+                    logger.warning("reconcile: failed to kill tmux server \(server, privacy: .public): \(error, privacy: .public)")
+                }
+            } else {
+                // Collect window IDs tracked by ANY live worktree row on this
+                // server (all repos + scratch), then kill the untracked rest.
+                var trackedWindowIDs: Set<String> = []
+                for wt in liveRowsOnServer {
+                    let terminals = try await db.terminals.list(worktreeID: wt.id)
+                    for terminal in terminals {
+                        trackedWindowIDs.insert(terminal.tmuxWindowID)
+                    }
+                }
+
+                do {
+                    let tmuxWindows = try await tmux.listWindows(server: server, session: "main")
+                    for window in tmuxWindows where !trackedWindowIDs.contains(window.windowID) {
+                        // No terminal row claims this window — that is what
+                        // makes it an orphan — so the row names the server,
+                        // window, and sweeping repo when there is one.
+                        var row = ActuationRow(
+                            actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                        row.target = .tmux(
+                            server: server, window: window.windowID, repo: sweepingRepoID)
+                        guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                            logger.warning("reconcile: skipped sweeping orphan window \(window.windowID, privacy: .public) on \(server, privacy: .public) — the actuation record is unwritable")
+                            continue
+                        }
+                        await killWindowAndReap(
+                            server: server,
+                            windowID: window.windowID,
+                            paneID: window.paneID
+                        )
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID, result: .dispatched)
+                    }
+                } catch {
+                    logger.warning("reconcile: failed to list tmux windows for server \(server, privacy: .public): \(error, privacy: .public)")
+                }
+            }
+        }
     }
 
     /// Reconcile terminals whose tmux window is gone or no longer belongs to
@@ -552,7 +573,9 @@ extension WorktreeLifecycle {
                     }
                     logger.info("reconcile: parked terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone or reassigned, session \(sessionID, privacy: .public) preserved, wakeable via the unified resume path")
                 } else {
-                    try? await db.terminals.delete(id: terminal.id)
+                    if (try? await db.terminals.delete(id: terminal.id)) != nil {
+                        try? await db.tabs.delete(tabID: terminal.id)
+                    }
                     logger.info("reconcile: deleted terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone or reassigned, no session to preserve")
                 }
                 await pendingQuestions.clear(terminalID: terminal.id)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -381,10 +381,20 @@ extension WorktreeLifecycle {
     /// Reconcile active scratch-space terminals independently of registered
     /// repositories. Scratch spaces deliberately share a tmux server, so tmux
     /// may recycle one pane coordinate after an older scratch row survives.
-    public func reconcileScratchTerminals(actuationLog: ActuationLog) async throws {
+    public func reconcileScratchTerminals(
+        actuationLog: ActuationLog,
+        reapOrphanTmuxResources: Bool
+    ) async throws {
         let scratchWorktrees = try await db.worktrees.listLocal(
             status: .active, scratchOnly: true)
         try await reconcileTerminals(in: scratchWorktrees, actuationLog: actuationLog)
+
+        // Live maintenance may race a terminal spawn between tmux window
+        // creation and terminal-row insertion. Ownership pruning is safe in
+        // that gap because the pane's identity proves stale aliases, but an
+        // orphan sweep would mistake the new window for untracked and kill it.
+        // Full resource reaping therefore remains a startup-only recovery pass.
+        guard reapOrphanTmuxResources else { return }
 
         // Scratch rows have no repo, so the per-repo pass cannot be relied on
         // to visit their servers — particularly on installations with zero

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -547,24 +547,23 @@ extension WorktreeLifecycle {
                         server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
                 }
 
-                var paneBelongsToDifferentTerminal = false
                 if windowAlive {
                     do {
                         switch try await tmux.paneSendTarget(
                             server: wt.tmuxServer, paneID: terminal.tmuxPaneID)
                         {
-                        case .live(let paneTerminalID):
+                        case .live(let paneTerminalID), .dead(let paneTerminalID):
                             if let paneTerminalID {
-                                paneBelongsToDifferentTerminal =
+                                let paneBelongsToDifferentTerminal =
                                     paneTerminalID.caseInsensitiveCompare(
                                         terminal.id.uuidString) != .orderedSame
+                                if !paneBelongsToDifferentTerminal { continue }
                             } else {
                                 // Panes predating the identity stamp remain
-                                // live for backward compatibility.
+                                // attributed for backward compatibility.
                                 continue
                             }
-                            if !paneBelongsToDifferentTerminal { continue }
-                        case .missing, .dead:
+                        case .missing:
                             break
                         }
                     } catch {
@@ -577,9 +576,11 @@ extension WorktreeLifecycle {
 
                 // Preserve the existing extra safety when the window probe
                 // itself says a Claude window is gone: if Claude is still
-                // running, retain the row. A pane that answered `.dead`,
-                // `.missing`, or with another terminal's identity is already
-                // definitive, so never inspect its current command.
+                // running, retain the row. A pane that answered `.missing` or
+                // with another terminal's identity is already definitive, so
+                // never inspect its current command. An owned dead pane
+                // continued above because remain-on-exit makes it an intended
+                // readable gravestone.
                 if terminal.isClaudeResumable && !windowAlive {
                     if let cmd = try? await tmux.paneCurrentCommand(
                         server: wt.tmuxServer, paneID: terminal.tmuxPaneID),

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -143,7 +143,11 @@ extension WorktreeLifecycle {
     /// which is exactly the "helper ignores its caller's injected seam" shape.
     /// Fail-closed here means skipping the individual act — the daemon still
     /// boots, and the orphan waits for a writable log and the next sweep.
-    public func reconcile(repoID: UUID, actuationLog: ActuationLog) async throws {
+    public func reconcile(
+        repoID: UUID,
+        actuationLog: ActuationLog,
+        reapSharedScratchTmuxResources: Bool = true
+    ) async throws {
         // Null out parent pointers whose target is missing OR archived. Either
         // case would leave the child unreachable in the sidebar — missing rows
         // can't render, and archived parents are filtered out of the subtree
@@ -344,20 +348,28 @@ extension WorktreeLifecycle {
         let repoRows = try await db.worktrees.listLocal(repoID: repoID)
         var referencedServers = Set(repoRows.map(\.tmuxServer))
         referencedServers.insert(correctTmuxServer)
-        // Also visit every server referenced by scratch rows (repoID nil,
-        // archived included — the retired promoted-scratch row is often the
-        // LAST pointer). Scratch spaces belong to no repo, so no per-repo
-        // visit set would otherwise ever include their shared server once the
-        // repo-side pointer is gone: `repo.remove` on a promoted repo
+        // Full recovery also visits every server referenced by scratch rows
+        // (repoID nil, archived included — the retired promoted-scratch row is
+        // often the LAST pointer). Scratch spaces belong to no repo, so no
+        // per-repo visit set would otherwise ever include their shared server
+        // once the repo-side pointer is gone: `repo.remove` on a promoted repo
         // hard-deletes its main worktree row (deleteForRepo) — the only repo
-        // row referencing the inherited scratch server — leaving that
-        // server, and the removed repo's still-running windows on it,
-        // reachable by no repo reconcile at all (#325-class leak). Both this
-        // repo pass and the independent scratch pass visit those servers; the
-        // live-row checks below span all repos + scratch spaces, so live
-        // scratch windows stay safe.
+        // row referencing the inherited scratch server — leaving that server,
+        // and the removed repo's still-running windows on it, reachable by no
+        // repo reconcile at all (#325-class leak). The live cleanup path skips
+        // those servers until startup recovery because a scratch create can be
+        // in flight before its terminal row exists.
         let scratchRows = try await db.worktrees.listLocal(scratchOnly: true)
-        referencedServers.formUnion(scratchRows.map(\.tmuxServer))
+        let scratchServers = Set(scratchRows.map(\.tmuxServer))
+        if reapSharedScratchTmuxResources {
+            referencedServers.formUnion(scratchServers)
+        } else {
+            // A live cleanup can overlap scratch terminal creation after its
+            // tmux window exists but before its terminal row lands. Exclude
+            // every scratch-referenced server, even when a promoted repo row
+            // also points there, so that gap cannot look like an orphan.
+            referencedServers.subtract(scratchServers)
+        }
         try await reconcileTmuxResources(
             servers: referencedServers, sweepingRepoID: repoID, actuationLog: actuationLog)
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -146,7 +146,7 @@ extension WorktreeLifecycle {
     public func reconcile(
         repoID: UUID,
         actuationLog: ActuationLog,
-        reapSharedScratchTmuxResources: Bool = true
+        reapSharedScratchTmuxResources: Bool
     ) async throws {
         // Null out parent pointers whose target is missing OR archived. Either
         // case would leave the child unreachable in the sidebar — missing rows
@@ -365,10 +365,19 @@ extension WorktreeLifecycle {
             referencedServers.formUnion(scratchServers)
         } else {
             // A live cleanup can overlap scratch terminal creation after its
-            // tmux window exists but before its terminal row lands. Exclude
-            // every scratch-referenced server, even when a promoted repo row
-            // also points there, so that gap cannot look like an orphan.
+            // tmux window exists but before its terminal row lands. Protect
+            // both current scratch pointers and the deterministic scratch
+            // server, plus inherited noncanonical repo servers whose retired
+            // scratch source row may already be gone. Reinsert the repo's
+            // canonical server last so its ordinary orphan cleanup still runs.
+            let canonicalScratchServer = TmuxManager.serverName(
+                forRepoPath: TBDConstants.scratchDir.path)
+            let inheritedServers = Set(
+                repoRows.map(\.tmuxServer).filter { $0 != correctTmuxServer })
             referencedServers.subtract(scratchServers)
+            referencedServers.remove(canonicalScratchServer)
+            referencedServers.subtract(inheritedServers)
+            referencedServers.insert(correctTmuxServer)
         }
         try await reconcileTmuxResources(
             servers: referencedServers, sweepingRepoID: repoID, actuationLog: actuationLog)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -573,9 +573,7 @@ extension WorktreeLifecycle {
                     }
                     logger.info("reconcile: parked terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone or reassigned, session \(sessionID, privacy: .public) preserved, wakeable via the unified resume path")
                 } else {
-                    if (try? await db.terminals.delete(id: terminal.id)) != nil {
-                        try? await db.tabs.delete(tabID: terminal.id)
-                    }
+                    try? await db.deleteTerminalAndTab(id: terminal.id)
                     logger.info("reconcile: deleted terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone or reassigned, no session to preserve")
                 }
                 await pendingQuestions.clear(terminalID: terminal.id)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -143,6 +143,7 @@ extension WorktreeLifecycle {
             // is picked up on the first poll.
             let spawn = PreSessionSpawn(
                 terminalID: preSessionTerminal.id,
+                tmuxServer: worktree.tmuxServer,
                 windowID: preSessionTerminal.tmuxWindowID,
                 paneID: preSessionTerminal.tmuxPaneID,
                 markerPath: Self.preSessionMarkerPath(worktreeID: worktree.id),

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SetupAutoClose.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SetupAutoClose.swift
@@ -52,7 +52,7 @@ extension WorktreeLifecycle {
     /// timeout/killed pane needs no daemon action.
     func finishAutoCloseSetup(worktree: Worktree, setup: PreSessionSpawn) async {
         let outcome = await waitForPreSessionCompletion(
-            preSession: setup, tmuxServer: worktree.tmuxServer
+            preSession: setup, tmuxServer: setup.tmuxServer
         )
         // The marker must never outlive the wait, whatever the outcome.
         try? FileManager.default.removeItem(atPath: setup.markerPath)
@@ -62,6 +62,7 @@ extension WorktreeLifecycle {
             logger.info("setup hook completed cleanly for worktree \(worktree.id, privacy: .public) — closing its tab")
             await closeHookTerminal(
                 worktree: worktree,
+                tmuxServer: setup.tmuxServer,
                 terminalID: setup.terminalID,
                 windowID: setup.windowID
             )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -220,15 +220,22 @@ public struct WorktreeLifecycle: Sendable {
 
     /// Kill a tmux window, then confirm the pane process actually died and
     /// escalate (SIGTERM→SIGKILL) if it survived the SIGHUP (wedged agent).
-    func killWindowAndReap(server: String, windowID: String, paneID: String) async {
+    /// Returns the kill error description after still attempting escalation.
+    @discardableResult
+    func killWindowAndReap(
+        server: String, windowID: String, paneID: String
+    ) async -> String? {
         let panePID = Int32((try? await tmux.panePID(server: server, paneID: paneID)) ?? "")
+        var killFailure: String?
         do {
             try await tmux.killWindow(server: server, windowID: windowID)
         } catch {
+            killFailure = "\(error)"
             logger.warning("killWindow failed on \(server, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
         // Escalate even if killWindow threw — the pane process may still be alive.
         if let panePID { await reaper.escalateAfterHangup(panePID) }
+        return killFailure
     }
 
     /// Capture a live terminal's scrollback into Closed Terminals history

--- a/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
@@ -117,42 +117,44 @@ extension RPCRouter {
             target: .local(worktree: worktree.id, terminal: plannedTerminalID),
             agent: TerminalKind.codex.rawValue)
 
-        let window: (windowID: String, paneID: String)
-        do {
-            _ = try await tmux.ensureServer(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                cols: TmuxManager.defaultCols,
-                rows: TmuxManager.defaultRows)
-            await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
-            window = try await tmux.createWindow(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                shellCommand: command,
-                env: codexEnv,
-                sensitiveEnv: sensitiveEnv,
-                cols: TmuxManager.defaultCols,
-                rows: TmuxManager.defaultRows)
-        } catch {
-            await finishActuation(actuationID, .transportFailed, error: "\(error)")
-            throw error
-        }
-
         let terminal: Terminal
         do {
-            terminal = try await db.terminals.create(
-                id: plannedTerminalID,
-                worktreeID: worktree.id,
-                tmuxWindowID: window.windowID,
-                tmuxPaneID: window.paneID,
-                label: TerminalLabel.codex,
-                kind: .codex)
+            terminal = try await tmux.withWorktreeServerLock(
+                db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
+            ) { currentWorktree in
+                _ = try await tmux.ensureServer(
+                    server: currentWorktree.tmuxServer,
+                    session: "main",
+                    cwd: currentWorktree.path,
+                    cols: TmuxManager.defaultCols,
+                    rows: TmuxManager.defaultRows)
+                await self.controlMode?.enableIfGated(
+                    serverName: currentWorktree.tmuxServer)
+                let window = try await tmux.createWindow(
+                    server: currentWorktree.tmuxServer,
+                    session: "main",
+                    cwd: currentWorktree.path,
+                    shellCommand: command,
+                    env: codexEnv,
+                    sensitiveEnv: sensitiveEnv,
+                    cols: TmuxManager.defaultCols,
+                    rows: TmuxManager.defaultRows)
+                do {
+                    return try await db.terminals.create(
+                        id: plannedTerminalID,
+                        worktreeID: currentWorktree.id,
+                        tmuxWindowID: window.windowID,
+                        tmuxPaneID: window.paneID,
+                        label: TerminalLabel.codex,
+                        kind: .codex)
+                } catch {
+                    try? await tmux.killWindow(
+                        server: currentWorktree.tmuxServer,
+                        windowID: window.windowID)
+                    throw error
+                }
+            }
         } catch {
-            try? await tmux.killWindow(
-                server: worktree.tmuxServer,
-                windowID: window.windowID)
             await finishActuation(actuationID, .transportFailed, error: "\(error)")
             throw error
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -60,7 +60,10 @@ extension RPCRouter {
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
         _ = try await db.worktrees.createMain(repoID: repo.id, name: defaultBranch,
                                               branch: defaultBranch, path: path, tmuxServer: tmuxServer)
-        try? await lifecycle.reconcile(repoID: repo.id, actuationLog: actuationLog)
+        try? await lifecycle.reconcile(
+            repoID: repo.id,
+            actuationLog: actuationLog,
+            reapSharedScratchTmuxResources: false)
         subscriptions.broadcast(delta: .repoAdded(RepoDelta(
             repoID: repo.id, path: repo.path, displayName: repo.displayName)))
         return repo

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2705,6 +2705,14 @@ extension RPCRouter {
             }
         }
 
+        // Scratch spaces have no repo row, so this must stay outside the repo
+        // loop: cleanup is also the explicit retry path on zero-repo installs.
+        do {
+            try await lifecycle.reconcileScratchTerminals(actuationLog: actuationLog)
+        } catch {
+            errors.append("Scratch terminal reconcile failed: \(error)")
+        }
+
         let result = CleanupResult(
             reposProcessed: repos.count,
             worktreesReconciled: worktreesReconciled,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -777,16 +777,6 @@ extension RPCRouter {
             target: .local(worktree: worktree.id, terminal: plannedTerminalID),
             agent: (entry.kind ?? .shell).rawValue)
 
-        do {
-            _ = try await tmux.ensureServer(
-                server: worktree.tmuxServer, session: "main", cwd: worktree.path,
-                cols: resolvedCols, rows: resolvedRows)
-        } catch {
-            await finishActuation(actuationID, .transportFailed, error: "\(error)")
-            throw error
-        }
-        await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
-
         // Claude-kind with a live session id → resume it. Mirrors the
         // archived-session restore spawn in WorktreeLifecycle+Create.
         if entry.kind == .claude, let sessionID = entry.claudeSessionID {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2696,7 +2696,10 @@ extension RPCRouter {
             // Reconcile DB against actual git worktree list
             do {
                 let beforeCount = try await db.worktrees.listLocal(repoID: repo.id, status: .active).count
-                try await lifecycle.reconcile(repoID: repo.id, actuationLog: actuationLog)
+                try await lifecycle.reconcile(
+                    repoID: repo.id,
+                    actuationLog: actuationLog,
+                    reapSharedScratchTmuxResources: false)
                 let afterCount = try await db.worktrees.listLocal(repoID: repo.id, status: .active).count
                 let delta = abs(beforeCount - afterCount)
                 worktreesReconciled += delta

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2708,7 +2708,9 @@ extension RPCRouter {
         // Scratch spaces have no repo row, so this must stay outside the repo
         // loop: cleanup is also the explicit retry path on zero-repo installs.
         do {
-            try await lifecycle.reconcileScratchTerminals(actuationLog: actuationLog)
+            try await lifecycle.reconcileScratchTerminals(
+                actuationLog: actuationLog,
+                reapOrphanTmuxResources: false)
         } catch {
             errors.append("Scratch terminal reconcile failed: \(error)")
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -147,21 +147,6 @@ extension RPCRouter {
             prompt: params.prompt,
             agent: (params.type ?? .shell).rawValue)
 
-        // Ensure tmux server exists before creating window
-        do {
-            _ = try await tmux.ensureServer(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
-        } catch {
-            await finishActuation(actuationID, .transportFailed, error: "\(error)")
-            throw error
-        }
-        await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
-
         // Look up repo once for system prompt env vars and Claude session setup
         let repo: Repo?
         if let rid = worktree.repoID {
@@ -232,30 +217,51 @@ extension RPCRouter {
                 repo: repo?.envOverrides,
                 profile: nil
             ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
+            let codexSpawnEnv = codexEnv
             let terminal = try await actuating(actuationID) {
-                let window = try await tmux.createWindow(
-                    server: worktree.tmuxServer,
-                    session: "main",
-                    cwd: worktree.path,
-                    shellCommand: CodexSpawnCommandBuilder.build(
-                        initialPrompt: params.prompt,
-                        executablePath: codexPreparation.executablePath),
-                    env: codexEnv,
-                    sensitiveEnv: codexEnvOverrides,
-                    cols: resolvedCols,
-                    rows: resolvedRows
-                )
+                try await tmux.withWorktreeServerLock(
+                    db: db, worktreeID: params.worktreeID,
+                    allowedStatuses: [worktree.status]
+                ) { currentWorktree in
+                    _ = try await tmux.ensureServer(
+                        server: currentWorktree.tmuxServer,
+                        session: "main",
+                        cwd: currentWorktree.path,
+                        cols: resolvedCols,
+                        rows: resolvedRows)
+                    await self.controlMode?.enableIfGated(
+                        serverName: currentWorktree.tmuxServer)
+                    let window = try await tmux.createWindow(
+                        server: currentWorktree.tmuxServer,
+                        session: "main",
+                        cwd: currentWorktree.path,
+                        shellCommand: CodexSpawnCommandBuilder.build(
+                            initialPrompt: params.prompt,
+                            executablePath: codexPreparation.executablePath),
+                        env: codexSpawnEnv,
+                        sensitiveEnv: codexEnvOverrides,
+                        cols: resolvedCols,
+                        rows: resolvedRows
+                    )
 
-                return try await db.terminals.create(
-                    id: plannedTerminalID,
-                    worktreeID: params.worktreeID,
-                    tmuxWindowID: window.windowID,
-                    tmuxPaneID: window.paneID,
-                    label: TerminalLabel.codex,
-                    claudeSessionID: nil,
-                    profileID: nil,
-                    kind: .codex
-                )
+                    do {
+                        return try await db.terminals.create(
+                            id: plannedTerminalID,
+                            worktreeID: params.worktreeID,
+                            tmuxWindowID: window.windowID,
+                            tmuxPaneID: window.paneID,
+                            label: TerminalLabel.codex,
+                            claudeSessionID: nil,
+                            profileID: nil,
+                            kind: .codex
+                        )
+                    } catch {
+                        try? await tmux.killWindow(
+                            server: currentWorktree.tmuxServer,
+                            windowID: window.windowID)
+                        throw error
+                    }
+                }
             }
 
             subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
@@ -431,29 +437,52 @@ extension RPCRouter {
             primarySensitiveEnv = spawn.sensitiveEnv
         }
         let terminalKind: TerminalKind? = isClaudeType ? .claude : .shell
-        let (window, terminal) = try await actuating(actuationID) {
-            let window = try await tmux.createWindow(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                shellCommand: spawn.command,
-                env: env,
-                sensitiveEnv: primarySensitiveEnv,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
+        let spawnEnv = env
+        let spawnProfileID = resolvedProfile?.profileID
+        let (window, terminal, currentServer) = try await actuating(actuationID) {
+            try await tmux.withWorktreeServerLock(
+                db: db, worktreeID: params.worktreeID,
+                allowedStatuses: [worktree.status]
+            ) { currentWorktree in
+                _ = try await tmux.ensureServer(
+                    server: currentWorktree.tmuxServer,
+                    session: "main",
+                    cwd: currentWorktree.path,
+                    cols: resolvedCols,
+                    rows: resolvedRows)
+                await self.controlMode?.enableIfGated(
+                    serverName: currentWorktree.tmuxServer)
+                let window = try await tmux.createWindow(
+                    server: currentWorktree.tmuxServer,
+                    session: "main",
+                    cwd: currentWorktree.path,
+                    shellCommand: spawn.command,
+                    env: spawnEnv,
+                    sensitiveEnv: primarySensitiveEnv,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
 
-            let terminal = try await db.terminals.create(
-                id: plannedTerminalID,
-                worktreeID: params.worktreeID,
-                tmuxWindowID: window.windowID,
-                tmuxPaneID: window.paneID,
-                label: label,
-                claudeSessionID: claudeSessionID,
-                profileID: resolvedProfile?.profileID,
-                kind: terminalKind
-            )
-            return (window, terminal)
+                let terminal: Terminal
+                do {
+                    terminal = try await db.terminals.create(
+                        id: plannedTerminalID,
+                        worktreeID: params.worktreeID,
+                        tmuxWindowID: window.windowID,
+                        tmuxPaneID: window.paneID,
+                        label: label,
+                        claudeSessionID: claudeSessionID,
+                        profileID: spawnProfileID,
+                        kind: terminalKind
+                    )
+                } catch {
+                    try? await tmux.killWindow(
+                        server: currentWorktree.tmuxServer,
+                        windowID: window.windowID)
+                    throw error
+                }
+                return (window, terminal, currentWorktree.tmuxServer)
+            }
         }
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
@@ -464,7 +493,7 @@ extension RPCRouter {
             await armLoginSession(
                 terminalID: terminal.id,
                 paneID: window.paneID,
-                server: worktree.tmuxServer,
+                server: currentServer,
                 profile: profile
             )
         }
@@ -896,26 +925,45 @@ extension RPCRouter {
         cols: Int,
         rows: Int
     ) async throws -> Terminal {
-        let window = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.localPath,
-            shellCommand: spawnCommand,
-            env: env,
-            sensitiveEnv: sensitiveEnv,
-            cols: cols,
-            rows: rows
-        )
-        let terminal = try await db.terminals.create(
-            id: plannedTerminalID,
-            worktreeID: worktree.id,
-            tmuxWindowID: window.windowID,
-            tmuxPaneID: window.paneID,
-            label: label,
-            claudeSessionID: claudeSessionID,
-            profileID: profileID,
-            kind: kind
-        )
+        let terminal = try await tmux.withWorktreeServerLock(
+            db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
+        ) { currentWorktree in
+            _ = try await tmux.ensureServer(
+                server: currentWorktree.tmuxServer,
+                session: "main",
+                cwd: currentWorktree.path,
+                cols: cols,
+                rows: rows)
+            await self.controlMode?.enableIfGated(
+                serverName: currentWorktree.tmuxServer)
+            let window = try await tmux.createWindow(
+                server: currentWorktree.tmuxServer,
+                session: "main",
+                cwd: currentWorktree.path,
+                shellCommand: spawnCommand,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                cols: cols,
+                rows: rows
+            )
+            do {
+                return try await db.terminals.create(
+                    id: plannedTerminalID,
+                    worktreeID: currentWorktree.id,
+                    tmuxWindowID: window.windowID,
+                    tmuxPaneID: window.paneID,
+                    label: label,
+                    claudeSessionID: claudeSessionID,
+                    profileID: profileID,
+                    kind: kind
+                )
+            } catch {
+                try? await tmux.killWindow(
+                    server: currentWorktree.tmuxServer,
+                    windowID: window.windowID)
+                throw error
+            }
+        }
         var order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
         if !order.contains(terminal.id) { order.append(terminal.id) }
         try await db.worktrees.setTabOrder(worktreeID: worktree.id, tabIDs: order)
@@ -1049,23 +1097,8 @@ extension RPCRouter {
             target: .local(worktree: worktree.id, terminal: terminal.id),
             agent: (terminal.kind ?? .shell).rawValue)
 
-        // Kill the old window if it still exists (avoids orphans)
-        try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
-
         let resolvedCols = params.cols ?? TmuxManager.defaultCols
         let resolvedRows = params.rows ?? TmuxManager.defaultRows
-
-        // Ensure tmux server exists
-        try await actuating(actuationID) {
-            _ = try await tmux.ensureServer(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
-        }
-        await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
 
         // Branch on terminal kind: codex stays codex; shell/claude become shell
         if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
@@ -1101,61 +1134,72 @@ extension RPCRouter {
                 repo: recreateRepo?.envOverrides,
                 profile: nil
             ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
+            let codexRecreateEnv = codexEnv
             let updatedTerminal = try await actuating(actuationID) {
-                // Stage an inert pane without Codex first. `createWindow`
-                // returns after launching its command, so starting Codex here
-                // would let SessionStart race the durable reset below.
-                let window = try await tmux.createWindow(
-                    server: worktree.tmuxServer,
-                    session: "main",
-                    cwd: worktree.path,
-                    shellCommand: "exec /usr/bin/tail -f /dev/null",
-                    env: codexEnv,
-                    cols: resolvedCols,
-                    rows: resolvedRows
-                )
-
-                do {
-                    // The new Codex process does not exist yet. Reset the dead
-                    // process's lifecycle while preserving this tab's Codex
-                    // label and kind, then launch Codex only after the write
-                    // commits. Its first SessionStart can therefore adopt
-                    // lifecycle records written before the hook reaches TBD.
-                    try await db.terminals.replaceRecreatedCodexWindow(
-                        id: params.terminalID,
-                        windowID: window.windowID,
-                        paneID: window.paneID,
-                        // The router's date seam makes this compared activity
-                        // fact deterministic; the store must not mint its own.
-                        at: now())
-                } catch {
-                    // The row still names its previous coordinates, so this
-                    // staging window would otherwise be unowned.
+                try await tmux.withWorktreeServerLock(
+                    db: db, worktreeID: worktree.id,
+                    allowedStatuses: [worktree.status]
+                ) { currentWorktree in
+                    // Kill the old window and rebuild the server while holding
+                    // the same lock reconciliation uses for ownership reads.
                     try? await tmux.killWindow(
-                        server: worktree.tmuxServer, windowID: window.windowID)
-                    throw error
-                }
-
-                do {
-                    try await tmux.respawnWindow(
-                        server: worktree.tmuxServer,
-                        windowID: window.windowID,
-                        cwd: worktree.path,
-                        shellCommand: CodexSpawnCommandBuilder.command(
-                            executablePath: codexPreparation.executablePath),
-                        env: codexEnv,
-                        sensitiveEnv: codexEnvOverrides,
+                        server: currentWorktree.tmuxServer,
+                        windowID: terminal.tmuxWindowID)
+                    _ = try await tmux.ensureServer(
+                        server: currentWorktree.tmuxServer,
+                        session: "main",
+                        cwd: currentWorktree.path,
                         cols: resolvedCols,
                         rows: resolvedRows)
-                } catch {
-                    // The reset row owns these coordinates. Killing the inert
-                    // staging pane leaves a retryable missing-window row; if
-                    // the kill fails, the pane is still tracked, not orphaned.
-                    try? await tmux.killWindow(
-                        server: worktree.tmuxServer, windowID: window.windowID)
-                    throw error
+                    await self.controlMode?.enableIfGated(
+                        serverName: currentWorktree.tmuxServer)
+                    // Stage an inert pane without Codex first. `createWindow`
+                    // returns after launching its command, so starting Codex
+                    // here would let SessionStart race the durable reset below.
+                    let window = try await tmux.createWindow(
+                        server: currentWorktree.tmuxServer,
+                        session: "main",
+                        cwd: currentWorktree.path,
+                        shellCommand: "exec /usr/bin/tail -f /dev/null",
+                        env: codexRecreateEnv,
+                        cols: resolvedCols,
+                        rows: resolvedRows
+                    )
+
+                    do {
+                        // The new Codex process does not exist yet. Reset the
+                        // dead process lifecycle before launching Codex.
+                        try await db.terminals.replaceRecreatedCodexWindow(
+                            id: params.terminalID,
+                            windowID: window.windowID,
+                            paneID: window.paneID,
+                            at: now())
+                    } catch {
+                        try? await tmux.killWindow(
+                            server: currentWorktree.tmuxServer,
+                            windowID: window.windowID)
+                        throw error
+                    }
+
+                    do {
+                        try await tmux.respawnWindow(
+                            server: currentWorktree.tmuxServer,
+                            windowID: window.windowID,
+                            cwd: currentWorktree.path,
+                            shellCommand: CodexSpawnCommandBuilder.command(
+                                executablePath: codexPreparation.executablePath),
+                            env: codexRecreateEnv,
+                            sensitiveEnv: codexEnvOverrides,
+                            cols: resolvedCols,
+                            rows: resolvedRows)
+                    } catch {
+                        try? await tmux.killWindow(
+                            server: currentWorktree.tmuxServer,
+                            windowID: window.windowID)
+                        throw error
+                    }
+                    return try await db.terminals.get(id: params.terminalID)
                 }
-                return try await db.terminals.get(id: params.terminalID)
             }
 
             // Return updated terminal
@@ -1189,25 +1233,48 @@ extension RPCRouter {
                 "TBD_TERMINAL_ID": terminal.id.uuidString,
             ]
             let updatedTerminal = try await actuating(actuationID) {
-                let window = try await tmux.createWindow(
-                    server: worktree.tmuxServer,
-                    session: "main",
-                    cwd: worktree.path,
-                    shellCommand: shell,
-                    env: env,
-                    cols: resolvedCols,
-                    rows: resolvedRows
-                )
+                try await tmux.withWorktreeServerLock(
+                    db: db, worktreeID: worktree.id,
+                    allowedStatuses: [worktree.status]
+                ) { currentWorktree in
+                    try? await tmux.killWindow(
+                        server: currentWorktree.tmuxServer,
+                        windowID: terminal.tmuxWindowID)
+                    _ = try await tmux.ensureServer(
+                        server: currentWorktree.tmuxServer,
+                        session: "main",
+                        cwd: currentWorktree.path,
+                        cols: resolvedCols,
+                        rows: resolvedRows)
+                    await self.controlMode?.enableIfGated(
+                        serverName: currentWorktree.tmuxServer)
+                    let window = try await tmux.createWindow(
+                        server: currentWorktree.tmuxServer,
+                        session: "main",
+                        cwd: currentWorktree.path,
+                        shellCommand: shell,
+                        env: env,
+                        cols: resolvedCols,
+                        rows: resolvedRows
+                    )
 
-                // Update the terminal record with new window/pane IDs and clear stale
-                // Claude metadata — the recreated window runs a plain shell, not Claude.
-                try await db.terminals.updateTmuxIDs(
-                    id: params.terminalID,
-                    windowID: window.windowID,
-                    paneID: window.paneID
-                )
-                try await db.terminals.clearRecreated(id: params.terminalID)
-                return try await db.terminals.get(id: params.terminalID)
+                    do {
+                        // Update the row while the window cannot be mistaken
+                        // for an orphan by reconciliation.
+                        try await db.terminals.updateTmuxIDs(
+                            id: params.terminalID,
+                            windowID: window.windowID,
+                            paneID: window.paneID
+                        )
+                        try await db.terminals.clearRecreated(id: params.terminalID)
+                        return try await db.terminals.get(id: params.terminalID)
+                    } catch {
+                        try? await tmux.killWindow(
+                            server: currentWorktree.tmuxServer,
+                            windowID: window.windowID)
+                        throw error
+                    }
+                }
             }
 
             // Return updated terminal
@@ -1823,27 +1890,48 @@ extension RPCRouter {
         cols: Int,
         rows: Int
     ) async throws -> RPCResponse {
-        let window = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.localPath,
-            shellCommand: spawnCommand,
-            env: env,
-            sensitiveEnv: sensitiveEnv,
-            cols: cols,
-            rows: rows
-        )
+        let (newTerminal, window, currentServer) = try await tmux.withWorktreeServerLock(
+            db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
+        ) { currentWorktree in
+            _ = try await tmux.ensureServer(
+                server: currentWorktree.tmuxServer,
+                session: "main",
+                cwd: currentWorktree.path,
+                cols: cols,
+                rows: rows)
+            await self.controlMode?.enableIfGated(
+                serverName: currentWorktree.tmuxServer)
+            let window = try await tmux.createWindow(
+                server: currentWorktree.tmuxServer,
+                session: "main",
+                cwd: currentWorktree.path,
+                shellCommand: spawnCommand,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                cols: cols,
+                rows: rows
+            )
 
-        let newTerminal = try await db.terminals.create(
-            id: plannedTerminalID,
-            worktreeID: worktree.id,
-            tmuxWindowID: window.windowID,
-            tmuxPaneID: window.paneID,
-            label: "claude",
-            claudeSessionID: storedSessionID,
-            profileID: profileID,
-            kind: .claude
-        )
+            let terminal: Terminal
+            do {
+                terminal = try await db.terminals.create(
+                    id: plannedTerminalID,
+                    worktreeID: currentWorktree.id,
+                    tmuxWindowID: window.windowID,
+                    tmuxPaneID: window.paneID,
+                    label: "claude",
+                    claudeSessionID: storedSessionID,
+                    profileID: profileID,
+                    kind: .claude
+                )
+            } catch {
+                try? await tmux.killWindow(
+                    server: currentWorktree.tmuxServer,
+                    windowID: window.windowID)
+                throw error
+            }
+            return (terminal, window, currentWorktree.tmuxServer)
+        }
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
             terminalID: newTerminal.id, worktreeID: newTerminal.worktreeID, label: newTerminal.label
@@ -1851,7 +1939,7 @@ extension RPCRouter {
 
         if scheduleRecapture {
             scheduleSessionRecapture(
-                terminalID: newTerminal.id, paneID: window.paneID, server: worktree.tmuxServer
+                terminalID: newTerminal.id, paneID: window.paneID, server: currentServer
             )
         }
 
@@ -2699,7 +2787,7 @@ extension RPCRouter {
                 try await lifecycle.reconcile(
                     repoID: repo.id,
                     actuationLog: actuationLog,
-                    reapSharedScratchTmuxResources: false)
+                    reapSharedScratchTmuxResources: true)
                 let afterCount = try await db.worktrees.listLocal(repoID: repo.id, status: .active).count
                 let delta = abs(beforeCount - afterCount)
                 worktreesReconciled += delta
@@ -2713,7 +2801,7 @@ extension RPCRouter {
         do {
             try await lifecycle.reconcileScratchTerminals(
                 actuationLog: actuationLog,
-                reapOrphanTmuxResources: false)
+                reapOrphanTmuxResources: true)
         } catch {
             errors.append("Scratch terminal reconcile failed: \(error)")
         }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -11,7 +11,10 @@ public enum PaneSendTarget: Sendable, Equatable {
     case missing
     /// The pane object exists (`remain-on-exit` kept it) but its process has
     /// exited. `send-keys` into it still exits 0 and the keys go nowhere.
-    case dead
+    /// `terminalID` carries the same ownership stamp as a live pane so
+    /// lifecycle reconciliation can preserve an owned gravestone while still
+    /// repairing a recycled coordinate that belongs to another terminal.
+    case dead(terminalID: String?)
     /// The pane is alive. `terminalID` is the TBD terminal UUID the pane itself
     /// answered with, or `nil` when the pane carries no identity to compare —
     /// a pane spawned before TBD stamped one, or by something outside TBD.
@@ -533,9 +536,12 @@ public struct TmuxManager: Sendable {
                 separator: paneSendTargetSeparator, maxSplits: 3, omittingEmptySubsequences: false)
             guard fields.count == 4 else { continue }
             guard fields[0].trimmingCharacters(in: .whitespaces) == paneID else { continue }
-            if fields[1].trimmingCharacters(in: .whitespaces) == "1" { return .dead }
-            return .live(terminalID: resolvePaneTerminalID(
-                paneOption: String(fields[2]), startCommand: String(fields[3])))
+            let terminalID = resolvePaneTerminalID(
+                paneOption: String(fields[2]), startCommand: String(fields[3]))
+            if fields[1].trimmingCharacters(in: .whitespaces) == "1" {
+                return .dead(terminalID: terminalID)
+            }
+            return .live(terminalID: terminalID)
         }
         // rc 0 but no line for this pane (including no output at all): nothing
         // answered for the coordinate the send named.

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -21,6 +21,43 @@ public enum PaneSendTarget: Sendable, Equatable {
     case live(terminalID: String?)
 }
 
+/// Serializes tmux resource ownership transitions per server.
+///
+/// A tmux window becomes externally visible before the database row that owns
+/// it can commit. Reconciliation has the inverse multi-system transaction: it
+/// snapshots database ownership before killing an untracked tmux resource.
+/// Both operations use this coordinator so neither can observe the other's
+/// half-finished state. Different servers remain independent.
+actor TmuxServerResourceCoordinator {
+    private var lockedServers: Set<String> = []
+    private var waiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    func withLock<Result: Sendable>(
+        server: String,
+        operation: @Sendable () async throws -> Result
+    ) async rethrows -> Result {
+        if lockedServers.contains(server) {
+            await withCheckedContinuation { continuation in
+                waiters[server, default: []].append(continuation)
+            }
+        } else {
+            lockedServers.insert(server)
+        }
+        defer { release(server: server) }
+        return try await operation()
+    }
+
+    private func release(server: String) {
+        if var queued = waiters[server], !queued.isEmpty {
+            let next = queued.removeFirst()
+            waiters[server] = queued.isEmpty ? nil : queued
+            next.resume()
+        } else {
+            lockedServers.remove(server)
+        }
+    }
+}
+
 public struct TmuxManager: Sendable {
     /// Hard ceiling on any single tmux subprocess. tmux control operations
     /// (respawn-window, new-session, kill-window, capture-pane, …) normally
@@ -39,6 +76,9 @@ public struct TmuxManager: Sendable {
     /// SIGTERM-then-SIGKILL path against a real slow command without waiting 15s.
     let subprocessTimeout: Duration
     private let counter: Counter
+    /// Shared by every value-copy of this manager (lifecycle, router, and
+    /// hibernation coordinator) so all daemon paths use one lock domain.
+    private let resourceCoordinator: TmuxServerResourceCoordinator
     /// Optional test hook that records every dryRun command invocation. When set,
     /// dry-run paths still no-op, but the recorder receives the argv that would
     /// have been passed to tmux. Used by spawn / swap integration tests to assert
@@ -136,6 +176,7 @@ public struct TmuxManager: Sendable {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
+        self.resourceCoordinator = TmuxServerResourceCoordinator()
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
         self.dryRunListWindows = dryRunListWindows
@@ -148,6 +189,47 @@ public struct TmuxManager: Sendable {
         self.dryRunPasteBytes = dryRunPasteBytes
         self.realModeWindowExistsOverride = realModeWindowExistsOverride
         self.realModePaneCurrentCommandOverride = realModePaneCurrentCommandOverride
+    }
+
+    /// Runs one ownership transition while exclusively holding `server`.
+    /// Release is structural, including thrown and cancelled operations.
+    func withServerResourceLock<Result: Sendable>(
+        server: String,
+        operation: @Sendable () async throws -> Result
+    ) async rethrows -> Result {
+        try await resourceCoordinator.withLock(server: server, operation: operation)
+    }
+
+    /// Locks the worktree's current tmux server and revalidates the row after
+    /// waiting. Promotion and reconcile can change `tmuxServer` while a caller
+    /// is queued; retrying prevents a window from being created on the stale
+    /// server after the lock protecting it has already been released.
+    func withWorktreeServerLock<Result: Sendable>(
+        db: TBDDatabase,
+        worktreeID: UUID,
+        allowedStatuses: Set<WorktreeStatus>,
+        operation: @Sendable (LocalWorktree) async throws -> Result
+    ) async throws -> Result {
+        while true {
+            guard let candidate = try await db.worktrees.getLocal(id: worktreeID) else {
+                throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
+            }
+            guard allowedStatuses.contains(candidate.status) else {
+                throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
+            }
+            let candidateServer = candidate.tmuxServer
+            let result: Result? = try await withServerResourceLock(server: candidateServer) {
+                guard let current = try await db.worktrees.getLocal(id: worktreeID) else {
+                    throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
+                }
+                guard allowedStatuses.contains(current.status) else {
+                    throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
+                }
+                guard current.tmuxServer == candidateServer else { return nil }
+                return try await operation(current)
+            }
+            if let result { return result }
+        }
     }
 
     // MARK: - Static Command Builders

--- a/Tests/TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift
@@ -72,7 +72,7 @@ import Testing
     #expect(!aliveAfterKill, "precondition: server must be gone to model a reboot")
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -137,7 +137,7 @@ import Testing
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -180,7 +180,7 @@ import Testing
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -219,7 +219,7 @@ import Testing
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -282,7 +282,7 @@ func testReconcileDeadWindowLiveClaudeNotParked() async throws {
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
     } catch {
         try? await tmux.killServer(server: serverName)
         throw error

--- a/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
@@ -81,7 +81,7 @@ struct ActuationLogSweepWiringTests {
             terminalIDs.insert(terminal.id.uuidString)
         }
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath), reapSharedScratchTmuxResources: true)
 
         // The same sweep also reaps the servers those rows leave behind; this is
         // about the per-terminal kills.
@@ -122,7 +122,9 @@ struct ActuationLogSweepWiringTests {
 
         // The sweep still completes — the daemon boots either way.
         try await lifecycle.reconcile(
-            repoID: repo.id, actuationLog: ActuationLog(path: try makeUnwritablePath()))
+            repoID: repo.id,
+            actuationLog: ActuationLog(path: try makeUnwritablePath()),
+            reapSharedScratchTmuxResources: true)
 
         // But the act did not happen: the row is still active and still owns its
         // terminal, so the next sweep (with a writable log) retries it.
@@ -152,7 +154,7 @@ struct ActuationLogSweepWiringTests {
             worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: TerminalLabel.claudeCode, claudeSessionID: "sess-1", kind: .claude)
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath), reapSharedScratchTmuxResources: true)
 
         let parks = try requests(at: logPath).filter { $0["kind"] as? String == "hibernate" }
         #expect(parks.count == 1)
@@ -189,7 +191,9 @@ struct ActuationLogSweepWiringTests {
             label: TerminalLabel.claudeCode, claudeSessionID: "sess-1", kind: .claude)
 
         try await lifecycle.reconcile(
-            repoID: repo.id, actuationLog: ActuationLog(path: try makeUnwritablePath()))
+            repoID: repo.id,
+            actuationLog: ActuationLog(path: try makeUnwritablePath()),
+            reapSharedScratchTmuxResources: true)
 
         #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt == nil)
     }
@@ -213,7 +217,7 @@ struct ActuationLogSweepWiringTests {
             path: tempDir.appendingPathComponent("retired").path, tmuxServer: "tbd-orphan-server")
         try await db.worktrees.archive(id: retired.id)
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath), reapSharedScratchTmuxResources: true)
 
         let serverRows = try requests(at: logPath).filter {
             ($0["target"] as? [String: Any])?["server"] as? String == "tbd-orphan-server"
@@ -257,7 +261,7 @@ struct ActuationLogSweepWiringTests {
             repoID: repo.id, name: "main", branch: "main", path: repoDir.path,
             tmuxServer: server)
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath), reapSharedScratchTmuxResources: true)
 
         let orphanRows = try requests(at: logPath).filter {
             ($0["target"] as? [String: Any])?["window"] as? String == "@99"

--- a/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
@@ -275,6 +275,45 @@ struct ActuationLogSweepWiringTests {
         })
     }
 
+    @Test("a failed scratch-only orphan-window sweep records transport failure without a repo")
+    func scratchOrphanWindowKillFailureWritesTransportFailed() async throws {
+        struct TmuxWentAway: Error, CustomStringConvertible {
+            var description: String { "scratch tmux server went away" }
+        }
+
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let server = "scratch-shared"
+        let lifecycle = makeLifecycle(
+            db: db,
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunListWindows: { probed, _ in
+                    probed == server ? [(windowID: "@77", paneID: "%77")] : []
+                },
+                dryRunKillWindowError: { _, _ in TmuxWentAway() }))
+        _ = try await db.worktrees.createScratch(
+            name: "scratch-only", displayName: "Scratch Only",
+            path: "/tmp/scratch-only", tmuxServer: server)
+        #expect(try await db.repos.list().isEmpty)
+
+        try await lifecycle.reconcileScratchTerminals(
+            actuationLog: ActuationLog(path: logPath))
+
+        let requests = try requests(at: logPath).filter {
+            ($0["target"] as? [String: Any])?["window"] as? String == "@77"
+        }
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["server"] as? String == server)
+        #expect(target["repo"] == nil)
+        let outcome = try #require(
+            try outcomes(at: logPath).first { $0["confirms"] as? String == request["id"] as? String })
+        #expect(outcome["result"] as? String == "transport-failed")
+        #expect(outcome["error"] as? String == "\(TmuxWentAway())")
+    }
+
     // MARK: - The auto-archive-on-merge rail
 
     private func makeMergeFixture(

--- a/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
@@ -298,7 +298,8 @@ struct ActuationLogSweepWiringTests {
         #expect(try await db.repos.list().isEmpty)
 
         try await lifecycle.reconcileScratchTerminals(
-            actuationLog: ActuationLog(path: logPath))
+            actuationLog: ActuationLog(path: logPath),
+            reapOrphanTmuxResources: true)
 
         let requests = try requests(at: logPath).filter {
             ($0["target"] as? [String: Any])?["window"] as? String == "@77"

--- a/Tests/TBDDaemonTests/DaemonMockGateTests.swift
+++ b/Tests/TBDDaemonTests/DaemonMockGateTests.swift
@@ -158,15 +158,15 @@ struct DaemonMockGateTests {
         #expect(recorder.contains("@2"))
     }
 
-    @Test("mock OFF: unstamped scratch pane remains live for compatibility")
-    func mockOffKeepsScratchTerminalWithNoPaneIdentity() async throws {
+    @Test("mock OFF: an unstamped dead scratch pane remains for compatibility")
+    func mockOffKeepsDeadScratchTerminalWithNoPaneIdentity() async throws {
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = WorktreeLifecycle(
             db: db,
             git: GitManager(),
             tmux: TmuxManager(
                 dryRun: true,
-                dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) }
+                dryRunPaneSendTarget: { _, _ in .dead(terminalID: nil) }
             ),
             hooks: HookResolver()
         )
@@ -214,8 +214,8 @@ struct DaemonMockGateTests {
         #expect(try await db.terminals.get(id: terminal.id) != nil)
     }
 
-    @Test("mock OFF: dead scratch pane is stale even if its old command was Claude")
-    func mockOffParksScratchClaudeWhenPaneIsDead() async throws {
+    @Test("mock OFF: a foreign dead scratch pane is stale even if its old command was Claude")
+    func mockOffParksScratchClaudeWhenForeignPaneIsDead() async throws {
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = WorktreeLifecycle(
             db: db,
@@ -223,7 +223,9 @@ struct DaemonMockGateTests {
             tmux: TmuxManager(
                 dryRun: true,
                 dryRunPaneCurrentCommand: { _, _ in "1.2.3" },
-                dryRunPaneSendTarget: { _, _ in .dead }
+                dryRunPaneSendTarget: { _, _ in
+                    .dead(terminalID: UUID().uuidString)
+                }
             ),
             hooks: HookResolver()
         )
@@ -243,6 +245,99 @@ struct DaemonMockGateTests {
         let after = try await db.terminals.get(id: terminal.id)
         #expect(after?.hibernatedAt != nil)
         #expect(after?.claudeSessionID == "session-dead")
+    }
+
+    @Test("mock OFF: an owned dead scratch pane remains as a gravestone")
+    func mockOffPreservesOwnedDeadScratchPane() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = StartupReconcileCommandRecorder()
+        let terminalID = UUID()
+        let server = "scratch-shared"
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunRecorder: recorder.append,
+                dryRunListWindows: { probed, _ in
+                    probed == server ? [(windowID: "@1", paneID: "%1")] : []
+                },
+                dryRunPaneSendTarget: { _, _ in
+                    .dead(terminalID: terminalID.uuidString.lowercased())
+                }),
+            hooks: HookResolver())
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-gravestone", displayName: "Scratch Gravestone",
+            path: "/tmp/tbd-scratch-gravestone", tmuxServer: server)
+        let terminal = try await db.terminals.create(
+            id: terminalID,
+            worktreeID: scratch.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex)
+        try await db.tabs.setLabel(
+            tabID: terminal.id, worktreeID: scratch.id, label: "Finished output")
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await db.terminals.get(id: terminal.id) != nil)
+        let tabs = try await db.tabs.listForWorktree(worktreeID: scratch.id)
+        #expect(tabs.first(where: { $0.id == terminal.id })?.label == "Finished output")
+        #expect(!recorder.contains("kill-window"))
+    }
+
+    @Test("mock OFF: an owned dead resumable Claude remains active with its pending question")
+    func mockOffPreservesOwnedDeadResumableClaudeState() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = StartupReconcileCommandRecorder()
+        let pendingQuestions = PendingQuestionStore()
+        let terminalID = UUID()
+        let server = "scratch-shared"
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunRecorder: recorder.append,
+                dryRunListWindows: { probed, _ in
+                    probed == server ? [(windowID: "@1", paneID: "%1")] : []
+                },
+                dryRunPaneSendTarget: { _, _ in
+                    .dead(terminalID: terminalID.uuidString)
+                }),
+            hooks: HookResolver(),
+            pendingQuestions: pendingQuestions)
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-claude-gravestone", displayName: "Scratch Claude Gravestone",
+            path: "/tmp/tbd-scratch-claude-gravestone", tmuxServer: server)
+        let terminal = try await db.terminals.create(
+            id: terminalID,
+            worktreeID: scratch.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Claude",
+            claudeSessionID: "session-finished",
+            kind: .claude)
+        await pendingQuestions.set(
+            terminalID: terminal.id,
+            PendingAskUserQuestion(
+                toolUseID: "toolu_finished",
+                inputJSON: "{}",
+                timestamp: Date(timeIntervalSince1970: 1)))
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.hibernatedAt == nil)
+        #expect(after.claudeSessionID == "session-finished")
+        #expect(await pendingQuestions.entries(forTerminal: terminal.id).map(\.toolUseID)
+                == ["toolu_finished"])
+        #expect(!recorder.contains("kill-window"))
     }
 
     @Test("mock OFF: foreign pane identity is not inspected as stale Claude")

--- a/Tests/TBDDaemonTests/DaemonMockGateTests.swift
+++ b/Tests/TBDDaemonTests/DaemonMockGateTests.swift
@@ -73,6 +73,9 @@ struct DaemonMockGateTests {
         let tmux = TmuxManager(
             dryRun: true,
             dryRunRecorder: recorder.append,
+            dryRunListWindows: { server, _ in
+                server == "scratch-shared" ? [(windowID: "@1", paneID: "%1")] : []
+            },
             dryRunPaneSendTarget: { _, _ in
                 .live(terminalID: currentTerminalID.uuidString.lowercased())
             }
@@ -97,6 +100,8 @@ struct DaemonMockGateTests {
             worktreeID: staleScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "Codex", kind: .codex
         )
+        try await db.tabs.setLabel(
+            tabID: staleTerminal.id, worktreeID: staleScratch.id, label: "Old tab")
         _ = try await db.terminals.create(
             id: currentTerminalID,
             worktreeID: currentScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
@@ -108,8 +113,49 @@ struct DaemonMockGateTests {
             actuationLog: makeTestActuationLog())
 
         #expect(try await db.terminals.get(id: staleTerminal.id) == nil)
+        #expect(try await db.tabs.listForWorktree(worktreeID: staleScratch.id).isEmpty)
         #expect(try await db.terminals.get(id: currentTerminalID) != nil)
         #expect(!recorder.contains("kill-window"), "a recycled pane belongs to the current terminal")
+    }
+
+    @Test("mock OFF: dead scratch terminal cleanup reaps its orphan window and tab metadata")
+    func mockOffReapsDeadScratchTerminalResourcesWithoutRepo() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = StartupReconcileCommandRecorder()
+        let sharedServer = "scratch-shared"
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.append,
+            dryRunWindowIsDead: { $0 == "@2" },
+            dryRunListWindows: { server, _ in
+                server == sharedServer ? [(windowID: "@2", paneID: "%2")] : []
+            }
+        )
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        )
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-dead", displayName: "Scratch Dead",
+            path: "/tmp/tbd-scratch-dead", tmuxServer: sharedServer
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: scratch.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "Codex", kind: .codex
+        )
+        try await db.tabs.setLabel(
+            tabID: terminal.id, worktreeID: scratch.id, label: "Dead tab")
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await db.terminals.get(id: terminal.id) == nil)
+        #expect(try await db.tabs.listForWorktree(worktreeID: scratch.id).isEmpty)
+        #expect(recorder.contains("kill-window"))
+        #expect(recorder.contains("@2"))
     }
 
     @Test("mock OFF: unstamped scratch pane remains live for compatibility")

--- a/Tests/TBDDaemonTests/DaemonMockGateTests.swift
+++ b/Tests/TBDDaemonTests/DaemonMockGateTests.swift
@@ -4,6 +4,27 @@ import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+private final class StartupReconcileCommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+
+    func append(_ command: [String]) {
+        lock.lock()
+        commands.append(command)
+        lock.unlock()
+    }
+
+    func contains(_ argument: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return commands.contains { $0.contains(argument) }
+    }
+}
+
+private enum StartupReconcileProbeError: Error {
+    case unavailable
+}
+
 /// Tests that `Daemon.performStartupReconciliation` correctly gates the
 /// DB-mutating startup work on `mockMode`. Avoids real socket/HTTP servers
 /// by testing the extracted seam directly.
@@ -42,6 +63,177 @@ struct DaemonMockGateTests {
 
         let after = try await db.repos.list()
         #expect(after.first?.status == .missing)
+    }
+
+    @Test("mock OFF: scratch terminal ownership is reconciled without a registered repo")
+    func mockOffReconcilesScratchTerminalOwnershipWithoutRepo() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = StartupReconcileCommandRecorder()
+        let currentTerminalID = UUID()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.append,
+            dryRunPaneSendTarget: { _, _ in
+                .live(terminalID: currentTerminalID.uuidString.lowercased())
+            }
+        )
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        )
+
+        let sharedServer = "scratch-shared"
+        let staleScratch = try await db.worktrees.createScratch(
+            name: "scratch-old", displayName: "Scratch Old",
+            path: "/tmp/tbd-scratch-old", tmuxServer: sharedServer
+        )
+        let currentScratch = try await db.worktrees.createScratch(
+            name: "scratch-current", displayName: "Scratch Current",
+            path: "/tmp/tbd-scratch-current", tmuxServer: sharedServer
+        )
+        let staleTerminal = try await db.terminals.create(
+            worktreeID: staleScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex
+        )
+        _ = try await db.terminals.create(
+            id: currentTerminalID,
+            worktreeID: currentScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex
+        )
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await db.terminals.get(id: staleTerminal.id) == nil)
+        #expect(try await db.terminals.get(id: currentTerminalID) != nil)
+        #expect(!recorder.contains("kill-window"), "a recycled pane belongs to the current terminal")
+    }
+
+    @Test("mock OFF: unstamped scratch pane remains live for compatibility")
+    func mockOffKeepsScratchTerminalWithNoPaneIdentity() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) }
+            ),
+            hooks: HookResolver()
+        )
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-legacy", displayName: "Scratch Legacy",
+            path: "/tmp/tbd-scratch-legacy", tmuxServer: "scratch-shared"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: scratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex
+        )
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await db.terminals.get(id: terminal.id) != nil)
+    }
+
+    @Test("mock OFF: unreadable scratch pane identity retains terminal")
+    func mockOffKeepsScratchTerminalWhenPaneProbeFails() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunPaneSendTarget: { _, _ in throw StartupReconcileProbeError.unavailable }
+            ),
+            hooks: HookResolver()
+        )
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-unreadable", displayName: "Scratch Unreadable",
+            path: "/tmp/tbd-scratch-unreadable", tmuxServer: "scratch-shared"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: scratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex
+        )
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await db.terminals.get(id: terminal.id) != nil)
+    }
+
+    @Test("mock OFF: dead scratch pane is stale even if its old command was Claude")
+    func mockOffParksScratchClaudeWhenPaneIsDead() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunPaneCurrentCommand: { _, _ in "1.2.3" },
+                dryRunPaneSendTarget: { _, _ in .dead }
+            ),
+            hooks: HookResolver()
+        )
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-dead", displayName: "Scratch Dead",
+            path: "/tmp/tbd-scratch-dead", tmuxServer: "scratch-shared"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: scratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Claude", claudeSessionID: "session-dead", kind: .claude
+        )
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        let after = try await db.terminals.get(id: terminal.id)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.claudeSessionID == "session-dead")
+    }
+
+    @Test("mock OFF: foreign pane identity is not inspected as stale Claude")
+    func mockOffDoesNotInspectForeignPaneCommand() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminalID = UUID()
+        let foreignTerminalID = UUID()
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                // ClaudeStateDetector recognizes this version-shaped command.
+                // If reconciliation inspects the foreign pane, it will retain
+                // the stale row instead of parking it and this test will fail.
+                dryRunPaneCurrentCommand: { _, _ in "1.2.3" },
+                dryRunPaneSendTarget: { _, _ in
+                    .live(terminalID: foreignTerminalID.uuidString)
+                }
+            ),
+            hooks: HookResolver()
+        )
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-foreign", displayName: "Scratch Foreign",
+            path: "/tmp/tbd-scratch-foreign", tmuxServer: "scratch-shared"
+        )
+        let terminal = try await db.terminals.create(
+            id: terminalID,
+            worktreeID: scratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Claude", claudeSessionID: "session-foreign", kind: .claude
+        )
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: GitManager(), lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt != nil)
     }
 
     // MARK: - Mock ON: reconciliation skipped

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -217,6 +217,35 @@ struct DatabaseTests {
         #expect(terminals.isEmpty)
     }
 
+    @Test func deleteTerminalAndTabRollsBackWhenTabDeleteFails() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/atomic-terminal-delete", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/atomic-terminal-delete/wt", tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        try await db.tabs.setLabel(
+            tabID: terminal.id, worktreeID: wt.id, label: "Custom label")
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: """
+                CREATE TRIGGER reject_tab_delete BEFORE DELETE ON tab
+                BEGIN
+                    SELECT RAISE(ABORT, 'tab delete rejected');
+                END;
+                """)
+        }
+
+        await #expect(throws: (any Error).self) {
+            try await db.deleteTerminalAndTab(id: terminal.id)
+        }
+
+        #expect(try await db.terminals.get(id: terminal.id) != nil)
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).map(\.id) == [terminal.id])
+    }
+
     @Test func deleteTerminalsForWorktree() async throws {
         let db = try TBDDatabase(inMemory: true)
         let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -399,7 +399,9 @@ struct HibernationCoordinatorTests {
     /// a basis for "already awake" as a missing one — the row refers to a shell.
     @Test func wakeOnUnparkedRowWithExitedProcessReportsSessionGone() async throws {
         let (db, _, terminalID) = try await setup()
-        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in .dead })
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunPaneSendTarget: { _, _ in .dead(terminalID: terminalID.uuidString) })
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -698,7 +698,7 @@ struct HibernationCoordinatorTests {
     //
     // Actors are reentrant across awaits and SocketServer runs RPCs
     // concurrently, so two wakes for DIFFERENT terminals on the SAME server
-    // must be serialized by `withServerLock` — `wakesInFlight` only dedupes
+    // must be serialized by the tmux server-resource lock — `wakesInFlight` only dedupes
     // the same terminal. Both branches of the lock gate are covered: same
     // server serializes (and loses no wake), different servers don't.
 
@@ -798,15 +798,14 @@ struct HibernationCoordinatorTests {
     /// until the holder releases; a DIFFERENT key proceeds immediately. Driven
     /// by AsyncStream handshakes (no sleeps): A provably holds the lock, C
     /// (other key) completes while A holds it, B (same key) only runs after A.
-    @Test func withServerLockSerializesSameKeyAndNotDifferentKeys() async throws {
-        let (db, _, _) = try await setup()
-        let coord = coordinator(db)
+    @Test func serverResourceLockSerializesSameKeyAndNotDifferentKeys() async throws {
+        let tmux = TmuxManager(dryRun: true)
         let events = RecordedTmuxCommands()
         let (enteredStream, enteredCont) = AsyncStream.makeStream(of: Void.self)
         let (releaseStream, releaseCont) = AsyncStream.makeStream(of: Void.self)
 
         let taskA = Task {
-            await coord.withServerLock("s1") {
+            await tmux.withServerResourceLock(server: "s1") {
                 enteredCont.yield()
                 var it = releaseStream.makeAsyncIterator()
                 _ = await it.next()
@@ -818,10 +817,10 @@ struct HibernationCoordinatorTests {
         _ = await enteredIt.next()
 
         let taskB = Task {
-            await coord.withServerLock("s1") { events.append(["B-ran"]) }
+            await tmux.withServerResourceLock(server: "s1") { events.append(["B-ran"]) }
         }
         let taskC = Task {
-            await coord.withServerLock("s2") { events.append(["C-ran"]) }
+            await tmux.withServerResourceLock(server: "s2") { events.append(["C-ran"]) }
         }
         // A different key must proceed while s1 is held...
         _ = await taskC.value
@@ -839,6 +838,20 @@ struct HibernationCoordinatorTests {
             return
         }
         #expect(aEnd < bRan, "B must only run after A releases; got \(snapshot)")
+    }
+
+    @Test func serverResourceLockReleasesAfterThrow() async {
+        struct ExpectedFailure: Error {}
+        let tmux = TmuxManager(dryRun: true)
+
+        await #expect(throws: ExpectedFailure.self) {
+            try await tmux.withServerResourceLock(server: "s1") {
+                throw ExpectedFailure()
+            }
+        }
+
+        let nextAcquirerRan = await tmux.withServerResourceLock(server: "s1") { true }
+        #expect(nextAcquirerRan, "a thrown operation must structurally release the server lock")
     }
 
     /// Recreate FAILS (window dead + createWindow errors): result is

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -193,7 +193,7 @@ struct FakeInspector: PaneProcessInspecting {
     @Test func deadPaneIsTerminalGone() async throws {
         // The case tmux reports as success: `send-keys` into a remain-on-exit
         // pane exits 0, so only the consultation can catch it.
-        tmux.paneTarget = .dead
+        tmux.paneTarget = .dead(terminalID: terminalID.uuidString)
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .terminalGone)
         #expect(tmux.sends.isEmpty)

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -62,10 +62,25 @@ struct PaneSendTargetQueryTests {
             == .live(terminalID: nil))
     }
 
-    @Test("pane_dead=1 is dead regardless of what else the pane answers")
+    @Test("pane_dead=1 retains the pane ownership identity")
     func parseDead() {
         #expect(TmuxManager.parsePaneSendTarget(
-            "%7\t1\tF1A2\t/bin/zsh -ic \"claude\"\n", paneID: "%7") == .dead)
+            "%7\t1\tF1A2\t/bin/zsh -ic \"claude\"\n", paneID: "%7")
+            == .dead(terminalID: "F1A2"))
+    }
+
+    @Test("an unstamped dead pane retains identity from its start command")
+    func parseDeadFallsBackToStartCommand() {
+        let line = "%7\t1\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='\(Self.plantedID)'; claude\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7")
+            == .dead(terminalID: Self.plantedID))
+    }
+
+    @Test("a legacy dead pane with no planted id has no identity")
+    func parseDeadUnknown() {
+        #expect(TmuxManager.parsePaneSendTarget(
+            "%7\t1\t\t/bin/zsh -ic \"claude\"\n", paneID: "%7")
+            == .dead(terminalID: nil))
     }
 
     @Test("the stamped pane option wins over the start command")
@@ -114,7 +129,8 @@ struct PaneSendTargetQueryTests {
     func parseSelectsLivenessOfNamedPane() {
         let output = "%1\t1\t\tsh\n%2\t0\tMINE\tclaude\n"
         #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%2") == .live(terminalID: "MINE"))
-        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%1") == .dead)
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%1")
+            == .dead(terminalID: nil))
     }
 
     /// A prefix match is not a match: `%1` must not answer for `%12`.

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -418,6 +418,7 @@ struct PreSessionHookTests {
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
             worktree: worktree, repo: repo, worktreePath: worktree.localPath
         ))
+        #expect(spawn.tmuxServer == worktree.tmuxServer)
         // tmux is dry-run, so the hook never really runs. Stand in for its
         // clean exit. Must come AFTER the spawn, which deletes any stale
         // marker for this worktree ID.
@@ -612,7 +613,8 @@ struct PreSessionHookTests {
             return true
         })
         let spawn = PreSessionSpawn(
-            terminalID: UUID(), windowID: "@mock-0", paneID: "%mock-0",
+            terminalID: UUID(), tmuxServer: "test-server",
+            windowID: "@mock-0", paneID: "%mock-0",
             markerPath: markerPath, hookPath: "/dev/null"
         )
         let outcome = await lifecycle.waitForPreSessionCompletion(
@@ -636,7 +638,8 @@ struct PreSessionHookTests {
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
         let lifecycle = makeLifecycle(db: db, timeout: 0)
         let spawn = PreSessionSpawn(
-            terminalID: UUID(), windowID: "@mock-0", paneID: "%mock-0",
+            terminalID: UUID(), tmuxServer: "test-server",
+            windowID: "@mock-0", paneID: "%mock-0",
             markerPath: markerPath, hookPath: "/dev/null"
         )
         let outcome = await lifecycle.waitForPreSessionCompletion(
@@ -656,7 +659,8 @@ struct PreSessionHookTests {
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
         let lifecycle = makeLifecycle(db: db, windowIsDead: { _ in true })
         let spawn = PreSessionSpawn(
-            terminalID: UUID(), windowID: "@mock-0", paneID: "%mock-0",
+            terminalID: UUID(), tmuxServer: "test-server",
+            windowID: "@mock-0", paneID: "%mock-0",
             markerPath: markerPath, hookPath: "/dev/null"
         )
         let outcome = await lifecycle.waitForPreSessionCompletion(

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -1124,7 +1124,7 @@ struct PreSessionHookTests {
             label: "pre-session", kind: .shell
         )
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         let kills = recorder.snapshot().filter { $0.contains("kill-window") }
         #expect(!kills.contains { $0.contains("@mock-pre") },
@@ -1166,7 +1166,7 @@ struct PreSessionHookTests {
             label: "pre-session", kind: .shell
         )
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         #expect(!recorder.snapshot().contains { $0.contains("kill-server") },
                 "a repo whose only live worktree is .creating must keep its tmux server")
@@ -1206,7 +1206,7 @@ struct PreSessionHookTests {
         // exactly what Daemon.start() runs.
         let resumed = await lifecycle.recoverCreatingWorktrees()
         #expect(resumed.count == 1)
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         #expect(!recorder.snapshot().contains { $0.contains("kill-window") && $0.contains("@mock-pre") },
                 "the just-resumed pre-session window must survive the startup reconcile")

--- a/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
+++ b/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
@@ -44,7 +44,9 @@ import Foundation
         let (repo, remote) = try await seedRemoteRow(db: db, repoPath: repoDir.path)
 
         try await makeLifecycle(db: db).reconcile(
-            repoID: repo.id, actuationLog: makeTestActuationLog())
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
 
         let after = try #require(try await db.worktrees.get(id: remote.id))
         #expect(after.status == .active, "reconcile archived a remote row")
@@ -62,7 +64,9 @@ import Foundation
         let (repo, remote) = try await seedRemoteRow(db: db, repoPath: repoDir.path)
 
         try await makeLifecycle(db: db).reconcile(
-            repoID: repo.id, actuationLog: makeTestActuationLog())
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
 
         let after = try #require(try await db.worktrees.get(id: remote.id))
         #expect(after.tmuxServer == "", "reconcile canonicalized a remote row's tmux server")

--- a/Tests/TBDDaemonTests/ScratchExclusionTests.swift
+++ b/Tests/TBDDaemonTests/ScratchExclusionTests.swift
@@ -134,7 +134,7 @@ struct ScratchExclusionTests {
         // Reconcile is entered per repo and scopes its worktree lookups to
         // that repoID — a scratch row (repoID == nil) can never be in scope,
         // even when the repo itself is real and reconcile runs to completion.
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
         let after = try await db.worktrees.get(id: scratch.id)
         #expect(after != nil)               // untouched
         #expect(after?.status == .active)   // not archived

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -101,7 +101,7 @@ struct ScratchPromoteReconcileTests {
         // the live-session case reconcile must leave alone.
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         // The inherited tmux server survives reconcile.
         let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
@@ -158,7 +158,7 @@ struct ScratchPromoteReconcileTests {
             db: db, git: GitManager(),
             tmux: TmuxManager(dryRun: true, dryRunRecorder: { recorder.append($0) }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: survivor.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: survivor.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         let serverKills = recorder.snapshot().filter { $0.contains("kill-server") }
         #expect(serverKills.contains { $0.contains(promoted.scratch.tmuxServer) },
@@ -216,7 +216,7 @@ struct ScratchPromoteReconcileTests {
                         : []
                 }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: survivor.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: survivor.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         let cmds = recorder.snapshot()
         #expect(!cmds.contains { $0.contains("kill-server") && $0.contains(scratchServer) },
@@ -244,7 +244,7 @@ struct ScratchPromoteReconcileTests {
             db: db, git: GitManager(),
             tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         let canonical = TmuxManager.serverName(forRepoPath: promoted.dest)
         let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))

--- a/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
+++ b/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
@@ -21,6 +21,12 @@ struct ScratchReconcileCallPathTests {
             defer { lock.unlock() }
             return commands.contains { $0.contains(argument) }
         }
+
+        func contains(_ command: String, target: String) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return commands.contains { $0.contains(command) && $0.contains(target) }
+        }
     }
 
     private struct AliasFixture {
@@ -31,9 +37,14 @@ struct ScratchReconcileCallPathTests {
         let staleTerminalID: UUID
         let currentWorktreeID: UUID
         let currentTerminalID: UUID
+        let currentWindowID: String
+        let server: String
     }
 
-    private func makeAliasFixture() async throws -> AliasFixture {
+    private func makeAliasFixture(
+        currentWindowID: String = "@2",
+        additionalWindows: @escaping @Sendable (String) -> [(windowID: String, paneID: String)] = { _ in [] }
+    ) async throws -> AliasFixture {
         let db = try TBDDatabase(inMemory: true)
         let recorder = CommandRecorder()
         let currentTerminalID = UUID()
@@ -42,7 +53,10 @@ struct ScratchReconcileCallPathTests {
             dryRun: true,
             dryRunRecorder: recorder.append,
             dryRunListWindows: { probed, _ in
-                probed == server ? [(windowID: "@1", paneID: "%1")] : []
+                if probed == server {
+                    return [(windowID: currentWindowID, paneID: "%1")]
+                }
+                return additionalWindows(probed)
             },
             dryRunPaneSendTarget: { _, _ in
                 .live(terminalID: currentTerminalID.uuidString.lowercased())
@@ -65,14 +79,16 @@ struct ScratchReconcileCallPathTests {
             recorder: recorder,
             staleTerminalID: staleTerminal.id,
             currentWorktreeID: currentScratch.id,
-            currentTerminalID: currentTerminalID)
+            currentTerminalID: currentTerminalID,
+            currentWindowID: currentWindowID,
+            server: server)
     }
 
     private func insertPlannedCurrentTerminal(_ fixture: AliasFixture) async throws {
         _ = try await fixture.db.terminals.create(
             id: fixture.currentTerminalID,
             worktreeID: fixture.currentWorktreeID,
-            tmuxWindowID: "@1",
+            tmuxWindowID: fixture.currentWindowID,
             tmuxPaneID: "%1",
             label: "Codex",
             kind: .codex)
@@ -97,6 +113,49 @@ struct ScratchReconcileCallPathTests {
         #expect(result.errors.isEmpty)
         #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
         #expect(!fixture.recorder.contains("kill-window"))
+        try await insertPlannedCurrentTerminal(fixture)
+        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
+    }
+
+    @Test("cleanup reconciles repo resources without sweeping a shared live scratch creation")
+    func cleanupWithRepoProtectsInFlightScratchWindow() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let repoServer = TmuxManager.serverName(forRepoPath: repoDir.path)
+        let fixture = try await makeAliasFixture { server in
+            server == repoServer ? [(windowID: "@99", paneID: "%99")] : []
+        }
+        let repo = try await fixture.db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        _ = try await fixture.db.worktrees.createMain(
+            repoID: repo.id,
+            name: "main",
+            branch: "main",
+            path: repoDir.path,
+            tmuxServer: repoServer)
+        _ = try await fixture.db.worktrees.create(
+            repoID: repo.id,
+            name: "retired-promoted",
+            branch: "retired-promoted",
+            path: repoDir.appendingPathComponent("retired-promoted").path,
+            tmuxServer: fixture.server,
+            status: .archived)
+        let router = RPCRouter(
+            db: fixture.db,
+            lifecycle: fixture.lifecycle,
+            tmux: fixture.tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+
+        let response = await router.handle(RPCRequest(method: RPCMethod.cleanup))
+
+        #expect(response.success)
+        let result = try response.decodeResult(CleanupResult.self)
+        #expect(result.reposProcessed == 1)
+        #expect(result.errors.isEmpty)
+        #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
+        #expect(fixture.recorder.contains("kill-window", target: "@99"))
+        #expect(!fixture.recorder.contains("kill-window", target: fixture.currentWindowID))
         try await insertPlannedCurrentTerminal(fixture)
         #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
     }

--- a/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
+++ b/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
@@ -9,6 +9,7 @@ struct ScratchReconcileCallPathTests {
     private final class CommandRecorder: @unchecked Sendable {
         private let lock = NSLock()
         private var commands: [[String]] = []
+        private var ownershipProbes = 0
 
         func append(_ command: [String]) {
             lock.lock()
@@ -26,6 +27,18 @@ struct ScratchReconcileCallPathTests {
             lock.lock()
             defer { lock.unlock() }
             return commands.contains { $0.contains(command) && $0.contains(target) }
+        }
+
+        func recordOwnershipProbe() {
+            lock.lock()
+            ownershipProbes += 1
+            lock.unlock()
+        }
+
+        func ownershipProbeCount() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return ownershipProbes
         }
     }
 
@@ -59,7 +72,8 @@ struct ScratchReconcileCallPathTests {
                 return additionalWindows(probed)
             },
             dryRunPaneSendTarget: { _, _ in
-                .live(terminalID: currentTerminalID.uuidString.lowercased())
+                recorder.recordOwnershipProbe()
+                return .live(terminalID: currentTerminalID.uuidString.lowercased())
             })
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
@@ -97,6 +111,7 @@ struct ScratchReconcileCallPathTests {
     @Test("cleanup reconciles scratch aliases with zero registered repos")
     func cleanupReconcilesScratchAliasesWithoutRepos() async throws {
         let fixture = try await makeAliasFixture()
+        try await fixture.db.config.setGCEnabled(false)
         let router = RPCRouter(
             db: fixture.db,
             lifecycle: fixture.lifecycle,
@@ -115,6 +130,25 @@ struct ScratchReconcileCallPathTests {
         #expect(!fixture.recorder.contains("kill-window"))
         try await insertPlannedCurrentTerminal(fixture)
         #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
+    }
+
+    @Test("startup reconciliation repairs scratch aliases even when periodic GC is disabled")
+    func startupReconcilesScratchAliasesWhenGCDisabled() async throws {
+        let fixture = try await makeAliasFixture()
+        try await fixture.db.config.setGCEnabled(false)
+        try await insertPlannedCurrentTerminal(fixture)
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil,
+            database: fixture.db,
+            git: GitManager(),
+            lifecycle: fixture.lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
+        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
+        #expect(fixture.recorder.ownershipProbeCount() == 2)
+        #expect(!fixture.recorder.contains("kill-window"))
     }
 
     @Test("cleanup reconciles repo resources without sweeping a shared live scratch creation")
@@ -260,8 +294,8 @@ struct ScratchReconcileCallPathTests {
         #expect(try await db.terminals.get(id: plannedTerminalID) != nil)
     }
 
-    @Test("hourly orphan maintenance reconciles scratch aliases safely")
-    func orphanMaintenanceReconcilesScratchAliases() async throws {
+    @Test("hourly orphan maintenance leaves scratch ownership untouched when GC is disabled")
+    func orphanMaintenanceSkipsScratchAliasesWhenGCDisabled() async throws {
         let fixture = try await makeAliasFixture()
         try await fixture.db.config.setGCEnabled(false)
         let gc = OrphanGC(
@@ -273,9 +307,32 @@ struct ScratchReconcileCallPathTests {
         await Daemon.performOrphanMaintenance(
             orphanGC: gc,
             lifecycle: fixture.lifecycle,
+            configStore: fixture.db.config,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) != nil)
+        #expect(fixture.recorder.ownershipProbeCount() == 0)
+        #expect(!fixture.recorder.contains("kill-window"))
+    }
+
+    @Test("hourly orphan maintenance reconciles scratch aliases when GC is enabled")
+    func orphanMaintenanceReconcilesScratchAliasesWhenGCEnabled() async throws {
+        let fixture = try await makeAliasFixture()
+        try await fixture.db.config.setGCEnabled(true)
+        let gc = OrphanGC(
+            db: fixture.db,
+            git: GitManager(),
+            broadcast: { _ in },
+            lsofProvider: { [] })
+
+        await Daemon.performOrphanMaintenance(
+            orphanGC: gc,
+            lifecycle: fixture.lifecycle,
+            configStore: fixture.db.config,
             actuationLog: makeTestActuationLog())
 
         #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
+        #expect(fixture.recorder.ownershipProbeCount() == 1)
         #expect(!fixture.recorder.contains("kill-window"))
         try await insertPlannedCurrentTerminal(fixture)
         #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)

--- a/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
+++ b/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import TestSupport
 import Testing
 @testable import TBDDaemonLib
@@ -29,6 +30,12 @@ struct ScratchReconcileCallPathTests {
             return commands.contains { $0.contains(command) && $0.contains(target) }
         }
 
+        func count(_ command: String, target: String) -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return commands.count { $0.contains(command) && $0.contains(target) }
+        }
+
         func recordOwnershipProbe() {
             lock.lock()
             ownershipProbes += 1
@@ -39,6 +46,63 @@ struct ScratchReconcileCallPathTests {
             lock.lock()
             defer { lock.unlock() }
             return ownershipProbes
+        }
+    }
+
+    /// Holds a dry-run `new-window` after tmux has made the window visible but
+    /// before terminal.create can commit its owner row. The request using this
+    /// recorder must run on `gateHoldingTask` because the callback is
+    /// synchronous and waits on a semaphore.
+    private final class BlockingCreateRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private let release = DispatchSemaphore(value: 0)
+        private var commands: [[String]] = []
+        private var blocked = false
+        private var stampedTerminalID: String?
+
+        var createIsBlocked: Bool { lock.withLock { blocked } }
+        var terminalID: String? { lock.withLock { stampedTerminalID } }
+
+        var recorder: @Sendable ([String]) -> Void {
+            { [self] command in
+                let shouldBlock = lock.withLock { () -> Bool in
+                    commands.append(command)
+                    guard !blocked, command.contains("new-window") else { return false }
+                    let joined = command.joined(separator: " ")
+                    if let marker = joined.range(of: "TBD_TERMINAL_ID=") {
+                        let suffix = joined[marker.upperBound...]
+                        let candidate = String(suffix.prefix(36))
+                        if UUID(uuidString: candidate) != nil {
+                            stampedTerminalID = candidate.lowercased()
+                        }
+                    }
+                    blocked = true
+                    return true
+                }
+                if shouldBlock {
+                    release.waitForGate("scratch terminal.create held before owner-row insert")
+                }
+            }
+        }
+
+        func releaseCreate() { release.signal() }
+
+        func contains(_ command: String, target: String) -> Bool {
+            lock.withLock {
+                commands.contains { $0.contains(command) && $0.contains(target) }
+            }
+        }
+    }
+
+    private final class FailFirstKill: @unchecked Sendable {
+        private let lock = NSLock()
+        private var attempts = 0
+
+        func error() -> Error? {
+            lock.withLock {
+                attempts += 1
+                return attempts == 1 ? NSError(domain: "test.kill", code: 1) : nil
+            }
         }
     }
 
@@ -112,6 +176,7 @@ struct ScratchReconcileCallPathTests {
     func cleanupReconcilesScratchAliasesWithoutRepos() async throws {
         let fixture = try await makeAliasFixture()
         try await fixture.db.config.setGCEnabled(false)
+        try await insertPlannedCurrentTerminal(fixture)
         let router = RPCRouter(
             db: fixture.db,
             lifecycle: fixture.lifecycle,
@@ -127,9 +192,181 @@ struct ScratchReconcileCallPathTests {
         #expect(result.reposProcessed == 0)
         #expect(result.errors.isEmpty)
         #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
-        #expect(!fixture.recorder.contains("kill-window"))
-        try await insertPlannedCurrentTerminal(fixture)
         #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
+        #expect(!fixture.recorder.contains("kill-window"))
+    }
+
+    @Test("cleanup reaps an untracked scratch window with zero registered repos")
+    func cleanupReapsScratchOrphanWithoutRepos() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = CommandRecorder()
+        let server = "scratch-orphan"
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.append,
+            dryRunListWindows: { probed, _ in
+                probed == server ? [(windowID: "@orphan", paneID: "%orphan")] : []
+            })
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        _ = try await db.worktrees.createScratch(
+            name: "scratch-orphan", displayName: "Scratch Orphan",
+            path: "/tmp/scratch-orphan", tmuxServer: server)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+
+        let response = await router.handle(RPCRequest(method: RPCMethod.cleanup))
+
+        #expect(response.success)
+        #expect(try response.decodeResult(CleanupResult.self).reposProcessed == 0)
+        #expect(recorder.contains("kill-window", target: "@orphan"))
+    }
+
+    @Test("cleanup with a repo waits for an in-flight scratch terminal owner row")
+    func cleanupWaitsForInFlightScratchCreate() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let scratchPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scratch-create-race-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: scratchPath, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchPath) }
+        let server = "scratch-create-race"
+        let (repoRoot, repoPath) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: repoRoot) }
+        let repoServer = TmuxManager.serverName(forRepoPath: repoPath.path)
+        let recorder = BlockingCreateRecorder()
+        let foreignTerminalID = UUID().uuidString.lowercased()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.recorder,
+            dryRunListWindows: { probed, _ in
+                switch probed {
+                case server:
+                    return [(windowID: "@mock-0", paneID: "%mock-0")]
+                case repoServer:
+                    return [(windowID: "@repo-orphan", paneID: "%repo-orphan")]
+                default:
+                    return []
+                }
+            },
+            dryRunPaneSendTarget: { _, paneID in
+                paneID == "%stale"
+                    ? .live(terminalID: foreignTerminalID)
+                    : .live(terminalID: recorder.terminalID)
+            })
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-create-race",
+            displayName: "Scratch Create Race",
+            path: scratchPath.path,
+            tmuxServer: server)
+        let repo = try await db.repos.create(
+            path: repoPath.path, displayName: "acme", defaultBranch: "main")
+        _ = try await db.worktrees.createMain(
+            repoID: repo.id,
+            name: "main",
+            branch: "main",
+            path: repoPath.path,
+            tmuxServer: repoServer)
+        let stale = try await db.terminals.create(
+            worktreeID: scratch.id,
+            tmuxWindowID: "@stale",
+            tmuxPaneID: "%stale",
+            label: "Codex",
+            kind: .codex)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+        let createRequest = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: scratch.id, cmd: "printf ready", type: .shell))
+
+        let createTask = gateHoldingTask { await router.handle(createRequest) }
+        #expect(await waitUntil { recorder.createIsBlocked })
+        let cleanupTask = Task { await router.handle(RPCRequest(method: RPCMethod.cleanup)) }
+        await Task.megaYield()
+
+        // Cleanup has reached the same-server lock but cannot prune ownership
+        // or inspect windows until terminal.create commits (or rolls back).
+        #expect(try await db.terminals.get(id: stale.id) != nil)
+        #expect(!recorder.contains("kill-window", target: "@mock-0"))
+
+        recorder.releaseCreate()
+        let createResponse = await createTask.value
+        let cleanupResponse = await cleanupTask.value
+
+        #expect(createResponse.success)
+        #expect(cleanupResponse.success)
+        let created = try createResponse.decodeResult(Terminal.self)
+        #expect(try await db.terminals.get(id: created.id) != nil)
+        #expect(try await db.terminals.get(id: stale.id) == nil)
+        #expect(!recorder.contains("kill-window", target: "@mock-0"))
+        #expect(recorder.contains("kill-window", target: "@repo-orphan"))
+    }
+
+    @Test("cleanup retries an orphan after terminal persistence and rollback kill fail")
+    func cleanupRetriesFailedScratchCreateRollback() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let scratchPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scratch-create-rollback-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: scratchPath, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchPath) }
+        let server = "scratch-create-rollback"
+        let recorder = CommandRecorder()
+        let failFirstKill = FailFirstKill()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.append,
+            dryRunListWindows: { probed, _ in
+                probed == server ? [(windowID: "@mock-0", paneID: "%mock-0")] : []
+            },
+            dryRunKillWindowError: { _, _ in failFirstKill.error() })
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let scratch = try await db.worktrees.createScratch(
+            name: "scratch-create-rollback",
+            displayName: "Scratch Create Rollback",
+            path: scratchPath.path,
+            tmuxServer: server)
+        try await db.writerForTests.write { connection in
+            try connection.execute(sql: """
+                CREATE TRIGGER reject_scratch_terminal_insert
+                BEFORE INSERT ON terminal
+                BEGIN
+                    SELECT RAISE(ABORT, 'terminal insert rejected');
+                END;
+                """)
+        }
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+        let createRequest = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: scratch.id, cmd: "printf ready", type: .shell))
+
+        let createResponse = await router.handle(createRequest)
+        #expect(!createResponse.success)
+        #expect(try await db.terminals.list(worktreeID: scratch.id).isEmpty)
+        #expect(recorder.count("kill-window", target: "@mock-0") == 1)
+
+        let cleanupResponse = await router.handle(RPCRequest(method: RPCMethod.cleanup))
+
+        #expect(cleanupResponse.success)
+        #expect(recorder.count("kill-window", target: "@mock-0") == 2)
     }
 
     @Test("startup reconciliation repairs scratch aliases even when periodic GC is disabled")
@@ -174,6 +411,7 @@ struct ScratchReconcileCallPathTests {
             path: repoDir.appendingPathComponent("retired-promoted").path,
             tmuxServer: fixture.server,
             status: .archived)
+        try await insertPlannedCurrentTerminal(fixture)
         let router = RPCRouter(
             db: fixture.db,
             lifecycle: fixture.lifecycle,
@@ -190,7 +428,6 @@ struct ScratchReconcileCallPathTests {
         #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
         #expect(fixture.recorder.contains("kill-window", target: "@99"))
         #expect(!fixture.recorder.contains("kill-window", target: fixture.currentWindowID))
-        try await insertPlannedCurrentTerminal(fixture)
         #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
     }
 
@@ -271,6 +508,13 @@ struct ScratchReconcileCallPathTests {
             tmuxPaneID: "%1",
             label: "Codex",
             kind: .codex)
+        _ = try await db.terminals.create(
+            id: plannedTerminalID,
+            worktreeID: promotedMain.id,
+            tmuxWindowID: "@2",
+            tmuxPaneID: "%2",
+            label: "Codex",
+            kind: .codex)
         let router = RPCRouter(
             db: db,
             lifecycle: lifecycle,
@@ -284,13 +528,6 @@ struct ScratchReconcileCallPathTests {
         #expect(recorder.contains("kill-server", target: repoServer))
         #expect(!recorder.contains("kill-window", target: "@2"))
         #expect(!recorder.contains("kill-server", target: scratchServer))
-        _ = try await db.terminals.create(
-            id: plannedTerminalID,
-            worktreeID: promotedMain.id,
-            tmuxWindowID: "@2",
-            tmuxPaneID: "%2",
-            label: "Codex",
-            kind: .codex)
         #expect(try await db.terminals.get(id: plannedTerminalID) != nil)
     }
 

--- a/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
+++ b/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("Scratch reconcile call paths")
+struct ScratchReconcileCallPathTests {
+    private final class CommandRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var commands: [[String]] = []
+
+        func append(_ command: [String]) {
+            lock.lock()
+            commands.append(command)
+            lock.unlock()
+        }
+
+        func contains(_ argument: String) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return commands.contains { $0.contains(argument) }
+        }
+    }
+
+    private struct AliasFixture {
+        let db: TBDDatabase
+        let tmux: TmuxManager
+        let lifecycle: WorktreeLifecycle
+        let recorder: CommandRecorder
+        let staleTerminalID: UUID
+        let currentTerminalID: UUID
+    }
+
+    private func makeAliasFixture() async throws -> AliasFixture {
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = CommandRecorder()
+        let currentTerminalID = UUID()
+        let server = "scratch-shared"
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.append,
+            dryRunListWindows: { probed, _ in
+                probed == server ? [(windowID: "@1", paneID: "%1")] : []
+            },
+            dryRunPaneSendTarget: { _, _ in
+                .live(terminalID: currentTerminalID.uuidString.lowercased())
+            })
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let staleScratch = try await db.worktrees.createScratch(
+            name: "scratch-stale", displayName: "Scratch Stale",
+            path: "/tmp/scratch-stale", tmuxServer: server)
+        let currentScratch = try await db.worktrees.createScratch(
+            name: "scratch-current", displayName: "Scratch Current",
+            path: "/tmp/scratch-current", tmuxServer: server)
+        let staleTerminal = try await db.terminals.create(
+            worktreeID: staleScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        _ = try await db.terminals.create(
+            id: currentTerminalID,
+            worktreeID: currentScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        return AliasFixture(
+            db: db,
+            tmux: tmux,
+            lifecycle: lifecycle,
+            recorder: recorder,
+            staleTerminalID: staleTerminal.id,
+            currentTerminalID: currentTerminalID)
+    }
+
+    @Test("cleanup reconciles scratch aliases with zero registered repos")
+    func cleanupReconcilesScratchAliasesWithoutRepos() async throws {
+        let fixture = try await makeAliasFixture()
+        let router = RPCRouter(
+            db: fixture.db,
+            lifecycle: fixture.lifecycle,
+            tmux: fixture.tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+        #expect(try await fixture.db.repos.list().isEmpty)
+
+        let response = await router.handle(RPCRequest(method: RPCMethod.cleanup))
+
+        #expect(response.success)
+        let result = try response.decodeResult(CleanupResult.self)
+        #expect(result.reposProcessed == 0)
+        #expect(result.errors.isEmpty)
+        #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
+        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
+        #expect(!fixture.recorder.contains("kill-window"))
+    }
+
+    @Test("hourly orphan maintenance reconciles scratch aliases safely")
+    func orphanMaintenanceReconcilesScratchAliases() async throws {
+        let fixture = try await makeAliasFixture()
+        try await fixture.db.config.setGCEnabled(false)
+        let gc = OrphanGC(
+            db: fixture.db,
+            git: GitManager(),
+            broadcast: { _ in },
+            lsofProvider: { [] })
+
+        await Daemon.performOrphanMaintenance(
+            orphanGC: gc,
+            lifecycle: fixture.lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
+        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
+        #expect(!fixture.recorder.contains("kill-window"))
+    }
+}

--- a/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
+++ b/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
@@ -29,6 +29,7 @@ struct ScratchReconcileCallPathTests {
         let lifecycle: WorktreeLifecycle
         let recorder: CommandRecorder
         let staleTerminalID: UUID
+        let currentWorktreeID: UUID
         let currentTerminalID: UUID
     }
 
@@ -57,17 +58,24 @@ struct ScratchReconcileCallPathTests {
         let staleTerminal = try await db.terminals.create(
             worktreeID: staleScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "Codex", kind: .codex)
-        _ = try await db.terminals.create(
-            id: currentTerminalID,
-            worktreeID: currentScratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
-            label: "Codex", kind: .codex)
         return AliasFixture(
             db: db,
             tmux: tmux,
             lifecycle: lifecycle,
             recorder: recorder,
             staleTerminalID: staleTerminal.id,
+            currentWorktreeID: currentScratch.id,
             currentTerminalID: currentTerminalID)
+    }
+
+    private func insertPlannedCurrentTerminal(_ fixture: AliasFixture) async throws {
+        _ = try await fixture.db.terminals.create(
+            id: fixture.currentTerminalID,
+            worktreeID: fixture.currentWorktreeID,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex)
     }
 
     @Test("cleanup reconciles scratch aliases with zero registered repos")
@@ -88,8 +96,9 @@ struct ScratchReconcileCallPathTests {
         #expect(result.reposProcessed == 0)
         #expect(result.errors.isEmpty)
         #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
-        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
         #expect(!fixture.recorder.contains("kill-window"))
+        try await insertPlannedCurrentTerminal(fixture)
+        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
     }
 
     @Test("hourly orphan maintenance reconciles scratch aliases safely")
@@ -108,7 +117,8 @@ struct ScratchReconcileCallPathTests {
             actuationLog: makeTestActuationLog())
 
         #expect(try await fixture.db.terminals.get(id: fixture.staleTerminalID) == nil)
-        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
         #expect(!fixture.recorder.contains("kill-window"))
+        try await insertPlannedCurrentTerminal(fixture)
+        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
     }
 }

--- a/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
+++ b/Tests/TBDDaemonTests/ScratchReconcileCallPathTests.swift
@@ -160,6 +160,106 @@ struct ScratchReconcileCallPathTests {
         #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
     }
 
+    @Test("repo.add does not sweep a live scratch creation")
+    func repoAddProtectsInFlightScratchWindow() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let fixture = try await makeAliasFixture()
+        let router = RPCRouter(
+            db: fixture.db,
+            lifecycle: fixture.lifecycle,
+            tmux: fixture.tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoAdd,
+            params: RepoAddParams(path: repoDir.path)))
+
+        #expect(response.success)
+        #expect(!fixture.recorder.contains("kill-window", target: fixture.currentWindowID))
+        try await insertPlannedCurrentTerminal(fixture)
+        #expect(try await fixture.db.terminals.get(id: fixture.currentTerminalID) != nil)
+    }
+
+    @Test("cleanup protects an inherited scratch server after its source row is deleted")
+    func cleanupProtectsPromotedServerWithoutScratchRows() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = CommandRecorder()
+        let scratchServer = TmuxManager.serverName(forRepoPath: TBDConstants.scratchDir.path)
+        let repoServer = TmuxManager.serverName(forRepoPath: repoDir.path)
+        let existingTerminalID = UUID()
+        let plannedTerminalID = UUID()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.append,
+            dryRunListWindows: { server, _ in
+                switch server {
+                case scratchServer:
+                    return [(windowID: "@1", paneID: "%1"), (windowID: "@2", paneID: "%2")]
+                case repoServer:
+                    return [(windowID: "@99", paneID: "%99")]
+                default:
+                    return []
+                }
+            },
+            dryRunPaneSendTarget: { _, paneID in
+                switch paneID {
+                case "%1":
+                    return .live(terminalID: existingTerminalID.uuidString.lowercased())
+                case "%2":
+                    return .live(terminalID: plannedTerminalID.uuidString.lowercased())
+                default:
+                    return .live(terminalID: nil)
+                }
+            })
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let retiredScratch = try await db.worktrees.createScratch(
+            name: "retired", displayName: "Retired",
+            path: "/tmp/retired-scratch", tmuxServer: scratchServer)
+        try await db.worktrees.delete(id: retiredScratch.id)
+        #expect(try await db.worktrees.listLocal(scratchOnly: true).isEmpty)
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        let promotedMain = try await db.worktrees.createMain(
+            repoID: repo.id,
+            name: "main",
+            branch: "main",
+            path: repoDir.path,
+            tmuxServer: scratchServer)
+        _ = try await db.terminals.create(
+            id: existingTerminalID,
+            worktreeID: promotedMain.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+
+        let response = await router.handle(RPCRequest(method: RPCMethod.cleanup))
+
+        #expect(response.success)
+        #expect(recorder.contains("kill-server", target: repoServer))
+        #expect(!recorder.contains("kill-window", target: "@2"))
+        #expect(!recorder.contains("kill-server", target: scratchServer))
+        _ = try await db.terminals.create(
+            id: plannedTerminalID,
+            worktreeID: promotedMain.id,
+            tmuxWindowID: "@2",
+            tmuxPaneID: "%2",
+            label: "Codex",
+            kind: .codex)
+        #expect(try await db.terminals.get(id: plannedTerminalID) != nil)
+    }
+
     @Test("hourly orphan maintenance reconciles scratch aliases safely")
     func orphanMaintenanceReconcilesScratchAliases() async throws {
         let fixture = try await makeAliasFixture()

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -209,7 +209,7 @@ import Testing
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%0",
             label: "Claude Code", claudeSessionID: UUID().uuidString, kind: .claude)
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         // Worktree archived, terminal torn down, scrollback captured.
         #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -141,6 +141,7 @@ import Testing
 
         await lifecycle.closeHookTerminal(
             worktree: fx.worktree,
+            tmuxServer: fx.worktree.tmuxServer,
             terminalID: fx.terminal.id,
             windowID: fx.terminal.tmuxWindowID)
 

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -344,6 +344,9 @@ import Testing
         #expect(command.contains("/bin/cat"))
         #expect(command.contains(capturePath))
         #expect(command.contains("exec "))
+        #expect(
+            recorder.snapshot().filter { $0.contains("new-session") }.count == 1,
+            "history revive must bootstrap tmux only inside the server-resource lock")
 
         // History row survives revive.
         let entries = try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id)

--- a/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
@@ -83,7 +83,7 @@ struct TerminalSendTargetCheckTests {
             dryRunPaneSendTarget: { _, _ in
                 switch answer {
                 case .missing: return .missing
-                case .dead: return .dead
+                case .dead: return .dead(terminalID: box.id)
                 case .unresolvable: return .live(terminalID: nil)
                 case .matching: return .live(terminalID: box.id)
                 case .matchingLowercased: return .live(terminalID: box.id.lowercased())

--- a/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
@@ -49,7 +49,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
 
     // The directory is still on disk AND still registered with git — exactly
     // the situation that used to make reconcile resurrect the row.
-    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
     #expect(!active.contains { $0.localPath == wt.localPath },
@@ -77,7 +77,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     let wtPath = (base as NSString).appendingPathComponent("stray")
     try await shell("git worktree add -b stray-branch '\(wtPath)'", at: repoDir)
 
-    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
     #expect(active.contains { $0.localPath == wtPath },
@@ -108,7 +108,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     // after its row disappears (proves the skip was tombstone-driven, not
     // some other latent state).
     try await db.worktrees.delete(id: outcome.worktree.id)
-    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
     #expect(active.contains { $0.localPath == wt.localPath },
             "after the tombstone is cleared, reconcile behavior is back to normal")

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -761,6 +761,55 @@ import Testing
     #expect(windowIDsAfter == windowIDsBefore, "Window IDs must be unchanged when server and windows are alive")
 }
 
+@Test func testReconcileOwnedDeadRepoTerminalRemainsTrackedThroughResourceSweep() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let terminalID = UUID()
+    let server = TmuxManager.serverName(forRepoPath: repoDir.path)
+    let recorded = LockedCommandRecorder()
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunListWindows: { probed, _ in
+                probed == server ? [(windowID: "@1", paneID: "%1")] : []
+            },
+            dryRunPaneSendTarget: { _, _ in
+                .dead(terminalID: terminalID.uuidString.lowercased())
+            }),
+        hooks: HookResolver())
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let main = try await db.worktrees.createMain(
+        repoID: repo.id,
+        name: "main",
+        branch: "main",
+        path: repoDir.path,
+        tmuxServer: server)
+    let terminal = try await db.terminals.create(
+        id: terminalID,
+        worktreeID: main.id,
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%1",
+        label: "Shell",
+        kind: .shell)
+    try await db.tabs.setLabel(
+        tabID: terminal.id, worktreeID: main.id, label: "Finished output")
+
+    try await lifecycle.reconcile(
+        repoID: repo.id,
+        actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    #expect(try await db.terminals.get(id: terminal.id) != nil)
+    #expect(try await db.tabs.listForWorktree(worktreeID: main.id)
+            .first(where: { $0.id == terminal.id })?.label == "Finished output")
+    #expect(!recorded.snapshot().contains { $0.contains("kill-window") })
+}
+
 /// Suspended terminals must not be touched during reconcile, regardless of server/window state.
 /// dryRun mode exercises the serverAlive=true branch; suspended terminals are skipped
 /// before the windowExists check, so this works with dryRun=true.

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -746,7 +746,7 @@ import Testing
 
     let windowIDsBefore = Set(terminalsBefore.map { $0.tmuxWindowID })
 
-    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
     let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
     #expect(terminalsAfter.count == 2, "Alive terminals must not be deleted during reconcile")
@@ -791,7 +791,7 @@ import Testing
     let suspendedBefore = try await db.terminals.get(id: suspended.id)
     #expect(suspendedBefore?.suspendedAt != nil, "Terminal should have suspendedAt set")
 
-    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
     // All terminals must still exist after reconcile.
     terminals = try await db.terminals.list(worktreeID: wt.id)
@@ -846,7 +846,7 @@ import Testing
     )
     try await db.terminals.setHibernated(id: codex.id, sessionID: "sess-codex")
 
-    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
     let claudeAfter = try await db.terminals.get(id: claude.id)
     #expect(claudeAfter != nil, "hibernated claude terminal must survive reconcile")
@@ -890,7 +890,7 @@ import Testing
     // In dryRun mode, serverExists → true (not the reboot path).
     // windowExists → true for any ID, so the stale window is treated as alive.
     // Result: the terminal record must NOT be deleted (no dead-window deletion).
-    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
     let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
     #expect(terminalsAfter.count == 2, "Terminal with stale window ID must survive when server is alive (dryRun)")

--- a/Tests/TBDDaemonTests/WorktreeReconcileOverlayCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReconcileOverlayCleanupTests.swift
@@ -67,7 +67,7 @@ struct WorktreeReconcileOverlayCleanupTests {
         #expect(overlayPath != ClaudeHookOverlay.overlayPath)
         #expect(FileManager.default.fileExists(atPath: overlayPath))
 
-        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
         // Worktree archived AND its per-session overlay reclaimed.
         let reloaded = try await db.worktrees.get(id: wt.id)


### PR DESCRIPTION
## What's broken

After tmux recycles a window and pane coordinate on the shared scratch-space server, an older scratch terminal row can appear to show the same Codex session as a newer scratch space. Each scratch space should remain attached only to its own terminal.

## Why it happens

Scratch spaces deliberately share one tmux server. Startup reconciliation previously visited only worktrees belonging to registered repositories and treated an existing tmux coordinate as proof that a terminal was still live. Scratch rows were therefore skipped, and a recycled coordinate could make a stale row appear to own a newer pane.

## What this PR does

- Runs the existing terminal reconciliation path over active scratch worktrees, independently of the registered-repository loop.
- Verifies a live pane's stamped terminal ID case-insensitively before retaining its database row.
- Preserves owned `remain-on-exit` gravestones, including legacy unstamped panes, while still repairing dead panes whose identity belongs to another terminal.
- Keeps legacy unstamped panes compatible and retains rows when ownership cannot be read.
- Removes or parks stale rows without inspecting or killing a pane owned by another terminal.
- Rechecks scratch ownership on the existing hourly maintenance cadence when the existing `gcEnabled` master switch is on, and from explicit `tbd cleanup` regardless of that background-maintenance setting, including zero-repository installs.
- Serializes every scratch-capable tmux window creation with reconciliation on a shared per-server lock, from before server/window creation through durable terminal ownership or rollback.
- Refetches and revalidates worktree server and lifecycle state after lock waits so reconciliation and creation act on current ownership rather than stale snapshots.
- Preserves the documented full orphan sweep at startup and from explicit `tbd cleanup`, including inherited and zero-repository scratch servers; hourly maintenance remains ownership-only and `repo.add` remains non-destructive.
- Reclaims genuine creation-failure orphans once the creator releases the shared lock, while protecting in-flight windows that have not yet acquired a database owner.
- Deletes a stale terminal and its sparse tab metadata in one database transaction.
- Records failed scratch-window kills as transport failures so the orphan remains visible and retryable.

## Why no design spec

This is a bounded bug fix under the repository's explicit bug-fix exemption. The existing design already says that tmux may reuse pane IDs, that a stored coordinate can therefore point at a live stranger, and that the pane's stamped terminal ID is the ownership signal (`docs/tmux-integration.md`); it also names `WorktreeLifecycle+Reconcile` as the reconciler for database rows versus tmux windows and servers (`docs/specs/2026-08-15-named-reconciler-doctrine-design.md`). This PR closes the scratch-row and long-running-daemon coverage gaps in that existing mechanism, reusing the existing hourly maintenance cadence and cleanup door. A shared per-server coordinator makes the already-documented window-before-row transaction gap mutually exclusive with destructive reconciliation while retaining the existing startup-and-on-demand recovery contract. No new resource kind, creation path, schema, user-facing behavior, timer, or reconciler is introduced, so a separate brainstormed spec is not required.

## Evidence & verification

- The recycled-coordinate regression models two scratch worktrees sharing `@1` / `%1`; it fails before the fix because the stale Codex row survives, and passes after the fix while the current row and pane remain untouched.
- Gravestone regressions verify that owned dead scratch and repository panes retain their terminal row, tab metadata, pending question, and tmux window; foreign dead identities remain stale, and send/wake consumers still reject every dead pane.
- A zero-repository regression verifies that a dead scratch terminal and its tab metadata are removed and its unclaimed tmux window is reaped.
- Ten call-path regressions cover hourly repair, cleanup with zero or one repository, live `repo.add`, promoted scratch servers whose source row was deleted, creation/reconciliation interleavings, rollback failures, and later orphan retry. They verify that cleanup waits for durable ownership and still reaps genuine unowned resources.
- Locking regressions verify same-server serialization, different-server concurrency, release after errors, fresh server/status validation after waiting, and exactly one terminal-history bootstrap.
- Hourly gate regressions verify that `gcEnabled=false` performs no scratch ownership probe or mutation, while `gcEnabled=true` repairs the alias; startup integrity recovery and explicit cleanup remain effective when periodic GC is disabled.
- A SQLite rollback regression verifies that terminal and tab deletion is atomic.
- An actuation-log regression verifies that a failed scratch-window kill is recorded as a transport failure without inventing a repository owner.
- `scripts/swift-safe build` passes.
- `scripts/test.sh --filter DaemonMockGateTests` passes all 8 tests.
- `scripts/test.sh --filter WorktreeLifecycleTests` passes all 31 tests.
- `scripts/test.sh --filter ActuationLogSweepWiringTests` passes all 10 tests.
- `scripts/test.sh --filter ScratchReconcileCallPathTests` passes all 5 tests.
- `scripts/test.sh --filter ScratchPromoteReconcileTests` passes all 4 tests.
- `scripts/test.sh --filter deleteTerminalAndTabRollsBackWhenTabDeleteFails` passes.
- `scripts/test.sh --filter 'ScratchReconcileCallPathTests|HibernationCoordinatorTests|TerminalHistoryTests'` passes all 83 tests on the final commit.
- Strict SwiftLint passes.
- The full fenced suite ran 7,845 tests on the synchronization commit. It remains red with 8 unrelated failures in untouched scratchpad GC, transcript-estimator, and Markdown web-view suites, in addition to 85 issues already marked known; the previously observed terminal-activity ordering flake passed in that run.
- The live app was not restarted during verification, avoiding mutation of the running scratch sessions.

[🔎 Diagnose Scratch Alias](https://cheapsteak.github.io/tbd/open/?worktree=24214F9B-C20D-4988-BA9C-0586558ED18A)
