### PR TITLE
fix: surface permission prompts as attention instead of thinking dots

### DIFF
--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3078,10 +3078,13 @@ extension RPCRouter {
     /// policy decision TBD could not depend on, while a fork here is compiled
     /// and testable.
     ///
-    /// The handler records a fact and changes nothing else. There is no
-    /// broadcast: no delta shape carries a wait reason, and inventing one to
-    /// carry a fact no surface renders yet would ship app behavior this slice
-    /// deliberately does not have.
+    /// The handler records the reason columns, and for a prompt-on-screen
+    /// classification additionally raises an `.attentionNeeded` notification
+    /// so the sidebar swaps the thinking dots for the attention indicator and
+    /// bolds the name (the app's `RowStatusIndicator` already ranks attention
+    /// above working). There is still no delta carrying the wait reason
+    /// itself: the notification row is the fact the app renders, and focusing
+    /// the worktree clears it through `notifications.markRead`.
     func handleTerminalNotificationEvent(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalNotificationEventParams.self, from: paramsData)
 
@@ -3123,6 +3126,30 @@ extension RPCRouter {
         // seam rather than a `Clock`.
         try await db.terminals.recordAwaitingInputReason(
             id: terminal.id, reason: reason, observedAt: now())
+
+        // A prompt on screen is the one class a human has to act on now, so
+        // it, and only it, raises the attention notification the sidebar
+        // renders (same pattern as the AskUserQuestion pending path). A
+        // failed insert must not fail a fire-and-forget hook.
+        if reason.classification == .promptOnScreen {
+            let bannerMessage = params.message.isEmpty
+                ? "Claude needs your input" : params.message
+            do {
+                let notification = try await db.notifications.create(
+                    worktreeID: terminal.worktreeID,
+                    type: .attentionNeeded,
+                    message: bannerMessage
+                )
+                subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
+                    notificationID: notification.id,
+                    worktreeID: notification.worktreeID,
+                    type: notification.type,
+                    message: notification.message
+                )))
+            } catch {
+                logger.debug("notificationEvent: failed to create attentionNeeded notification: \(String(describing: error), privacy: .public)")
+            }
+        }
 
         // `message` may quote repo content, so it is `.private`; the type and
         // the class are TBD's own closed vocabulary and stay public.

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -4,8 +4,9 @@ import Testing
 @testable import TBDShared
 import TestSupport
 
-/// Tier 1. `terminal.notificationEvent` records one fact and changes nothing
-/// else. Two properties carry most of the weight here:
+/// Tier 1. `terminal.notificationEvent` records one fact, and for a
+/// prompt-on-screen classification raises the attention notification the
+/// sidebar renders. Two properties carry most of the weight here:
 ///
 /// 1. Every classification branch records the message verbatim beside the label
 ///    TBD put on it, and an unrecognized type stays unrecognized.
@@ -20,6 +21,10 @@ import TestSupport
     let terminalID: UUID
     let worktreeID: UUID
     let worktreePath: String
+    /// Every delta the handler broadcasts, captured through a real subscriber
+    /// on the router's own `StateSubscriptionManager` (`broadcast` fans out
+    /// synchronously, so the capture is complete once the handler returns).
+    fileprivate let broadcasts: BroadcastDeltas
 
     /// Pinned through the router's date seam, so the stored observed-at is an
     /// exact assertion rather than a freshness window.
@@ -28,6 +33,15 @@ import TestSupport
     init() async throws {
         let db = try TBDDatabase(inMemory: true)
         self.db = db
+        let broadcasts = BroadcastDeltas()
+        self.broadcasts = broadcasts
+        let subscriptions = StateSubscriptionManager()
+        subscriptions.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                broadcasts.append(delta)
+            }
+            return true
+        }
         self.router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
@@ -35,6 +49,7 @@ import TestSupport
                 tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
+            subscriptions: subscriptions,
             now: { Self.observedAt },
             actuationLog: makeTestActuationLog())
         let repo = try await db.repos.create(
@@ -166,6 +181,62 @@ import TestSupport
         #expect(parkDecision(after) == parkDecision(before))
         #expect(parkDecision(after) == .eligible)
         #expect(HibernationGate.blockingRail(terminal: after) == nil)
+
+        // A prompt on screen is the one class a human has to act on now, so
+        // it, and only it, raises the attention notification the sidebar
+        // renders in place of the thinking dots. Every other class leaves the
+        // notification ledger and the delta stream untouched.
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        let received = broadcasts.snapshot().filter {
+            if case .notificationReceived = $0 { return true }
+            return false
+        }
+        if branch.expected == .promptOnScreen {
+            #expect(unread.count == 1)
+            #expect(unread.first?.type == .attentionNeeded)
+            #expect(received.count == 1)
+        } else {
+            #expect(unread.isEmpty)
+            #expect(received.isEmpty)
+        }
+    }
+
+    /// The delta the app renders from: it must carry the created row's own
+    /// identity and message, so the sidebar's unread state and the row agree.
+    @Test func aPromptOnScreenBroadcastsTheNotificationItCreated() async throws {
+        let message = "Claude needs your permission to use Bash"
+        #expect(await notify(type: "permission_prompt", message: message).success)
+
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        let row = try #require(unread.first)
+        #expect(unread.count == 1)
+        #expect(row.type == .attentionNeeded)
+        #expect(row.worktreeID == worktreeID)
+        #expect(row.message == message)
+
+        let delta = try #require(broadcasts.snapshot().compactMap { delta -> NotificationDelta? in
+            if case .notificationReceived(let d) = delta { return d }
+            return nil
+        }.first)
+        #expect(delta.notificationID == row.id)
+        #expect(delta.worktreeID == worktreeID)
+        #expect(delta.type == .attentionNeeded)
+        #expect(delta.message == message)
+    }
+
+    /// A notification hook can arrive with an empty message; the banner still
+    /// has to say something a human can act on.
+    @Test func anEmptyMessageFallsBackToTheGenericBanner() async throws {
+        #expect(await notify(type: "permission_prompt", message: "").success)
+
+        let row = try #require(try await db.notifications.unread(worktreeID: worktreeID).first)
+        #expect(row.message == "Claude needs your input")
+
+        let delta = try #require(broadcasts.snapshot().compactMap { delta -> NotificationDelta? in
+            if case .notificationReceived(let d) = delta { return d }
+            return nil
+        }.first)
+        #expect(delta.message == "Claude needs your input")
     }
 
     /// A near-miss spelling of a known type is the case a "helpful" matcher
@@ -348,5 +419,22 @@ import TestSupport
         let after = try await terminal()
         #expect(after.activityStateObservedAt == Self.observedAt)
         #expect(after.observedActivity?.observedAt == Self.observedAt)
+    }
+}
+
+/// Thread-safe collector for broadcast StateDeltas (same shape as the one in
+/// `RPCRouterWorktreeCreateBroadcastTests`).
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
     }
 }


### PR DESCRIPTION
## What's broken

A Claude session that stops on a tool-approval prompt (a permission ask, an MCP elicitation) keeps showing the animated thinking dots in the sidebar, with a regular-weight name. It looks like the agent is making progress when it is actually blocked waiting for a human. Anyone running a fleet hits this whenever a session raises a permission prompt: the one row that most needs a glance is indistinguishable from rows that are genuinely working.

## Why it happens

The signal already reaches the daemon. Claude Code's `Notification` hook fires with `notification_type: "permission_prompt"`, and `handleTerminalNotificationEvent` classifies it as prompt-on-screen and persists it to the terminal's awaiting-input columns. But that was the end of the line: nothing was broadcast, and no app surface read those columns (only the supervision resolver does). Meanwhile `activityState` still holds `working` from the last `UserPromptSubmit` hook, and the sidebar renders `working` as the thinking dots. Deliberately so on the activity side: `activityState` is a gating field (hibernation rails read it), and the Notification hook only reports that a prompt was raised, never that it went away, so writing `waiting_for_user` from it would latch sessions un-parkable.

Observed live before the fix: a terminal with `activityState: "working"` observed at 15:09 and an `awaitingInputReason` of `permission_prompt` observed at 15:20, rendering as thinking dots.

## What this PR does

When the classification is prompt-on-screen, the handler now additionally creates an `.attentionNeeded` notification row and broadcasts the existing `.notificationReceived` delta, the same pattern the `PreToolUse:AskUserQuestion` path already uses. Everything downstream already exists: `RowStatusIndicator.shouldBoldName` bolds the name for `.attentionNeeded`, the suffix slot ranks attention above working (so the amber hand replaces the dots), and focusing the worktree clears it through the existing `notifications.markRead` path.

Alternatives rejected:

- Writing `activityState = .waitingForUser` from the hook: it is a gating field for hibernation, and `.waitingForUser` is sticky by design, so a raise-only signal would latch sessions un-parkable.
- Plumbing `awaitingInputReason` into the sidebar: needs a new delta shape plus a precedence rule against `activityState`, a much larger change for the same rendered outcome.

`activityState` is untouched, so hibernation gating and interrupt behavior are unchanged.

## Evidence & verification

- TDD red run: the new assertions in `NotificationHookRPCTests` failed 11 ways before the handler change (no notification row, no delta), then passed after it.
- The parametrized classification-branch test now asserts, per branch: the three prompt-on-screen types each create exactly one unread `.attentionNeeded` row and one `.notificationReceived` delta; every other classification (including informational `agent_completed`) creates zero rows and zero deltas; and the pre-existing assertions still hold for all branches (reason recorded verbatim, activity triple unchanged, hibernation decision unchanged).
- New tests: the broadcast delta carries the created row's id, worktree, type, and message; an empty hook message falls back to "Claude needs your input".
- `scripts/test.sh --filter 'NotificationHookRPCTests'` (16 tests), `--filter 'askUserQuestion'` (7 tests), and `--filter 'Notification'` (113 tests, 29 suites) all pass; `scripts/swift-safe build` clean; `swiftlint --strict` clean on touched files.
- Live verification is pending: exercising it end to end requires restarting the daemon, which would disrupt the running fleet, so it was not done from this session.

[🛎 Fix Tool Approval State](https://cheapsteak.github.io/tbd/open/?worktree=1AB96221-AABD-435B-AE8F-86754E6D749B)
