### PR TITLE
Feat: Move the project disclosure chevron to the right of the name

### DIFF
--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -195,6 +195,12 @@ struct RepoSectionView: View {
     /// `newWorktreePlusButton`) so the two hover affordances appear and vanish
     /// together. The hidden branch keeps the 18pt square so the "missing" badge
     /// doesn't slide sideways as the chevron comes and goes.
+    ///
+    /// Hover-gating a disclosure control is deliberate, not incidental: it
+    /// trades the at-a-glance expanded/collapsed read for a quieter sidebar,
+    /// and it is the choice the `+` on this same row already made. The
+    /// always-available path to the same action is the header's context-menu
+    /// Collapse/Expand item, which is not gated on hover.
     @ViewBuilder
     private var chevronButton: some View {
         Group {
@@ -212,6 +218,9 @@ struct RepoSectionView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(HoverPressButtonStyle())
+                // The glyph carries no text, so VoiceOver has nothing to
+                // announce without this — parity with the `+`'s label.
+                .accessibilityLabel(repo.expanded ? "Collapse \(repo.displayName)" : "Expand \(repo.displayName)")
                 .onHover { isChevronHovered = $0 }
                 .help(repo.expanded ? "Collapse" : "Expand")
             } else {

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -55,6 +55,10 @@ struct RepoSectionView: View {
                 // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try await Task.sleep(nanoseconds: 80_000_000)
                 isSectionHovered = false
+                // The chevron is torn down by this same gate, so its
+                // `onHover(false)` may never arrive — without this the
+                // worktree rows would stay dimmed at 0.7 forever.
+                isChevronHovered = false
             }
         }
     }
@@ -130,7 +134,7 @@ struct RepoSectionView: View {
         }
     }
 
-    /// The section header row (chevron + name + `+`) and every modifier
+    /// The section header row (name + chevron + `+`) and every modifier
     /// attached to it — extracted out of `body` alongside `expandedContent`,
     /// and further split into `headerHStack` + its own sub-pieces below, so
     /// the type checker sees several smaller expressions instead of one
@@ -171,14 +175,14 @@ struct RepoSectionView: View {
         .tag(repo.id)
     }
 
-    /// The header row's actual content (chevron + name + optional "missing"
+    /// The header row's actual content (name + chevron + optional "missing"
     /// badge + `+`), with none of `headerRow`'s trailing modifiers — see
     /// `headerRow`'s doc comment.
     @ViewBuilder
     private var headerHStack: some View {
         HStack(spacing: 4) {
-            chevronButton
             nameLabel
+            chevronButton
             if repo.status == .missing {
                 missingBadge
             }
@@ -187,20 +191,42 @@ struct RepoSectionView: View {
         }
     }
 
+    /// The disclosure chevron, revealed on the same hover gate as the `+` (see
+    /// `newWorktreePlusButton`) so the two hover affordances appear and vanish
+    /// together. The hidden branch keeps the 18pt square so the "missing" badge
+    /// doesn't slide sideways as the chevron comes and goes.
     @ViewBuilder
     private var chevronButton: some View {
-        Button {
-            Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
-        } label: {
-            Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
-                .font(.system(size: 11))
-                .foregroundStyle(chevronForegroundStyle)
-                .frame(width: 18, height: 18)
-                .contentShape(Rectangle())
+        Group {
+            if HoverMenuModel.shouldShowPlus(hovered: isSectionHovered, menuOpen: newWorktreeMenu.isOpen) {
+                Button {
+                    Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
+                } label: {
+                    Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 10))
+                        // Applied to the glyph, not the button, so it wins over
+                        // `HoverPressButtonStyle`'s blanket `.secondary` and a
+                        // missing repo still renders dimmed.
+                        .foregroundStyle(chevronForegroundStyle)
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(HoverPressButtonStyle())
+                .onHover { isChevronHovered = $0 }
+                .help(repo.expanded ? "Collapse" : "Expand")
+            } else {
+                Color.clear
+            }
         }
-        .buttonStyle(.plain)
-        .onHover { isChevronHovered = $0 }
-        .help(repo.expanded ? "Collapse" : "Expand")
+        .frame(width: 18, height: 18)
+        // The 18pt-square hit target centers the 10pt glyph, leaving ~4pt of
+        // slack on each side. Trim the leading slack so the chevron reads as
+        // attached to the name rather than floating after it.
+        .padding(.leading, -3)
+        // Nudge down so the chevron sits on the name's optical baseline
+        // rather than its cap-height center. Layout-neutral by design — the
+        // hit target rides along with the glyph.
+        .offset(y: 2)
     }
 
     @ViewBuilder
@@ -220,7 +246,6 @@ struct RepoSectionView: View {
                 .truncationMode(.tail)
                 .foregroundStyle(nameForegroundStyle)
         }
-        .padding(.leading, -2)
     }
 
     @ViewBuilder

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -196,11 +196,20 @@ struct RepoSectionView: View {
     /// together. The hidden branch keeps the 18pt square so the "missing" badge
     /// doesn't slide sideways as the chevron comes and goes.
     ///
-    /// Hover-gating a disclosure control is deliberate, not incidental: it
-    /// trades the at-a-glance expanded/collapsed read for a quieter sidebar,
-    /// and it is the choice the `+` on this same row already made. The
-    /// always-available path to the same action is the header's context-menu
-    /// Collapse/Expand item, which is not gated on hover.
+    /// Hover-gating a disclosure control is deliberate, not incidental, and
+    /// was signed off by the maintainer. It trades two things for a quieter
+    /// sidebar: the at-a-glance expanded/collapsed read, and pointer-free
+    /// reachability — `isSectionHovered` is driven only by `.onHover`, so the
+    /// button is absent from the focus tree entirely until a pointer enters
+    /// the section, and Tab/Full Keyboard Access skips it. The accepted answer
+    /// for keyboard-only users is the header's context-menu Collapse/Expand
+    /// item (below), which is not gated on hover and performs the same action.
+    /// The `+` on this same row already made this exact trade.
+    ///
+    /// So do not "fix" this by always-mounting the button — that reverses a
+    /// decision someone made on purpose. The `.accessibilityLabel` below is
+    /// worth keeping regardless: it serves VoiceOver whenever the button is
+    /// mounted, which it never did before.
     @ViewBuilder
     private var chevronButton: some View {
         Group {


### PR DESCRIPTION
## Summary

In the sidebar, each project (repo) section header carried its expand/collapse
chevron on the far left, ahead of the project name. That put a piece of chrome
in the position the eye scans first, and it indented every project name 18pt
further right than the Scratch and remote-provider headers directly above and
below it — three section headers, three different left edges.

This moves the chevron to sit immediately after the project name, so the name
claims the leading edge and the control follows what it acts on. Project names
now start flush with every other sidebar section header. The chevron also
becomes a hover affordance rather than persistent chrome, appearing and
vanishing in step with the `+` already on that row.

## Why this shape

The chevron trails the name directly rather than being pushed to the row's
trailing edge: it is a control *on the name*, and parking it against the far
right would divorce it from what it collapses and crowd it against the `+`.

**The hover gate is an interaction-model change, and was chosen on purpose.**
Before this PR the chevron was unconditional — always rendered, always
clickable, its glyph a persistent at-a-glance read of whether the section was
expanded. It is now absent from the view tree (`Color.clear`) unless the
pointer is inside the project header or one of its worktree rows. The trade-off
is real and goes both ways:

- **Cost.** You can no longer tell a collapsed project from an expanded one
  without moving the pointer there, and the control cannot be reached by
  pointer-free navigation while hidden.
- **Benefit.** The sidebar is quieter at rest, and the two hover affordances on
  the row now behave identically instead of one being chrome and one being
  hover-revealed.
- **Cost, precisely.** `isSectionHovered` is driven only by `.onHover`, so the
  button is absent from the focus tree — not merely invisible — until a
  pointer enters the section. Tab and Full Keyboard Access skip it, and the
  `.accessibilityLabel` added here only serves a VoiceOver user who has
  already hovered with a pointer. This is a real reduction in pointer-free
  reachability of this specific control.
- **What backstops it.** Collapse/Expand is also a header context-menu item
  (`RepoSectionView.swift:475`), which is not gated on hover — so the
  capability itself stays reachable without a pointer; what is hover-gated is
  its dedicated single-press control.

**Maintainer sign-off.** The repo owner asked for the hover gate in these terms
("hide the collapse chevron along with the + button if the user isn't hovered
into the project or its worktrees"), and, when the keyboard-reachability cost
above was put to them explicitly alongside the alternative of always-mounting
the chevron in a low-emphasis idle style, chose to keep the hover gate with the
context menu as the accepted keyboard-only path. That decision is recorded at
the call site in `chevronButton`'s doc comment so it isn't silently reverted.

This mirrors the choice the `+` on this same row already made, so the header no
longer mixes two conventions. A human weighed the discoverability cost against
the quieter sidebar and asked for the hover gate; the rationale is recorded in
the `chevronButton` doc comment so a future reader doesn't "fix" it back.

No spec: this changes the visibility rule of one existing control on one row
and adds no new capability, state, flag, or persisted data.

## What this PR does

All in `Sources/TBDApp/Sidebar/RepoSectionView.swift`:

- `headerHStack` orders `nameLabel` before `chevronButton`. The name's old
  `.padding(.leading, -2)` — which existed to close the gap to a *leading*
  chevron — is dropped, aligning project names with the Scratch and remote
  headers.
- `chevronButton` gains `HoverPressButtonStyle` (the `+`'s hover/press wash)
  and the same visibility predicate the `+` uses,
  `HoverMenuModel.shouldShowPlus(hovered:menuOpen:)`. Every worktree and
  remote-session row in the section already reports into
  `onSectionHoverChange`, so hovering a child keeps both controls up.
- The glyph goes from 11pt to 10pt so it doesn't visually outweigh the 12pt
  semibold name it now trails, with `-3` leading padding to trim the hit
  target's slack and a layout-neutral `.offset(y: 2)` to drop it onto the
  name's optical baseline.
- New `.accessibilityLabel` ("Collapse/Expand <project>") — the glyph is
  text-free, so a hidden-until-hover button would otherwise announce nothing.
- The hidden branch renders a `Color.clear` at the same 18x18, so the
  `[missing]` badge that follows the chevron doesn't slide sideways as the
  chevron comes and goes.
- The hover debounce in `onSectionHoverChange` now also clears
  `isChevronHovered`.

## Assumptions

The chevron's `foregroundStyle` is applied to the `Image`, not the `Button`,
because `HoverPressButtonStyle` sets a blanket `.secondary` on its label and
the innermost style wins — this is what keeps a `missing` repo's chevron
rendering dimmed. If that style stops applying `foregroundStyle`, the missing
state still renders correctly; if the chevron's own modifier is ever hoisted
out to the button, it stops.

## Evidence & verification

Verified live in the running app across the iterations that produced the final
values (`scripts/restart.sh --app` after each): the chevron reads as attached
to the name, its hover wash matches the `+`, and both controls appear and
disappear together whether the pointer is over the header or over one of the
project's worktree rows.

One behavior needed a guard rather than an observation. The chevron is torn
down by the same hover gate that would deliver its `onHover(false)`, so that
event can be lost — which would strand `isChevronHovered` at `true` and leave
every worktree row in the section dimmed to 0.7 opacity permanently. The
debounce that clears `isSectionHovered` now clears `isChevronHovered` alongside
it.

`scripts/swift-safe build` and `swiftlint --strict` are clean. No daemon or
shared code changed, so `scripts/test.sh` was not run.

[▸ Chevron Right Of Project](https://cheapsteak.github.io/tbd/open/?worktree=74B2B340-FF9C-4938-85CF-90ACB8BC1422)