### PR TITLE
fix: keep the thinking dots off a row whose session has a prompt on screen

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2332,11 +2332,15 @@ final class AppState: ObservableObject {
     private func applyTerminalAwaitingInputDelta(_ delta: TerminalAwaitingInputDelta) {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(
             where: { $0.id == delta.terminalID }) else { return }
-        guard terminals[delta.worktreeID]![idx].awaitingInputReason != delta.reason
-            || terminals[delta.worktreeID]![idx].awaitingInputObservedAt != delta.observedAt
-        else { return }
-        terminals[delta.worktreeID]?[idx].awaitingInputReason = delta.reason
-        terminals[delta.worktreeID]?[idx].awaitingInputObservedAt = delta.observedAt
+        var terminal = terminals[delta.worktreeID]![idx]
+        guard terminal.awaitingInputReason != delta.reason
+            || terminal.awaitingInputObservedAt != delta.observedAt else { return }
+        terminal.awaitingInputReason = delta.reason
+        terminal.awaitingInputObservedAt = delta.observedAt
+        // One write-back through the `@Published` dictionary, not two: each
+        // assignment is a full copy-on-write plus an `objectWillChange`, and
+        // this delta arrives on every `Notification` hook of every class.
+        terminals[delta.worktreeID]?[idx] = terminal
     }
 
     /// Seamless in-place "Switch account": the terminal row is unchanged except

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2045,6 +2045,8 @@ final class AppState: ObservableObject {
             applyTerminalRemovedDelta(d)
         case .terminalActivityUpdated(let d):
             applyTerminalActivityDelta(d)
+        case .terminalAwaitingInputChanged(let d):
+            applyTerminalAwaitingInputDelta(d)
         case .terminalProfileChanged(let d):
             applyTerminalProfileDelta(d)
         case .watchDeskRolesChanged(let d):
@@ -2317,6 +2319,24 @@ final class AppState: ObservableObject {
             terminalPresentationOrderObservedAt.removeValue(forKey: delta.terminalID)
         }
         terminals[delta.worktreeID]?[idx] = terminal
+    }
+
+    /// Mirror the daemon's awaiting-input columns onto the cached terminal.
+    ///
+    /// Deliberately writes ONLY those two fields: a recorded wait reason says
+    /// nothing about `activityState`, and the daemon does not assert one from
+    /// the `Notification` hook either. The sidebar reads this instead of the
+    /// `.attentionNeeded` notification because notifications are unread mail —
+    /// they are marked read as soon as the worktree is selected, so the row
+    /// the user is looking at is exactly the one that would lose the signal.
+    private func applyTerminalAwaitingInputDelta(_ delta: TerminalAwaitingInputDelta) {
+        guard let idx = terminals[delta.worktreeID]?.firstIndex(
+            where: { $0.id == delta.terminalID }) else { return }
+        guard terminals[delta.worktreeID]![idx].awaitingInputReason != delta.reason
+            || terminals[delta.worktreeID]![idx].awaitingInputObservedAt != delta.observedAt
+        else { return }
+        terminals[delta.worktreeID]?[idx].awaitingInputReason = delta.reason
+        terminals[delta.worktreeID]?[idx].awaitingInputObservedAt = delta.observedAt
     }
 
     /// Seamless in-place "Switch account": the terminal row is unchanged except

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2393,6 +2393,15 @@ final class AppState: ObservableObject {
             // Resume" item keep advertising a resume that won't happen for
             // the delta-to-refetch window. No delta field needed.
             terminals[delta.worktreeID]?[idx].pendingResumeAt = nil
+            // Parking also implies retraction, for the same reason and by the
+            // same write: `setHibernated` nils the awaiting-input columns
+            // because a parked session's agent is dead and is waiting for
+            // nothing. Mirroring it here is what makes that true on WAKE too —
+            // `Terminal.hasPromptOnScreen` masks a stale reason only while the
+            // row is parked, so a reason left cached through a park would
+            // resurface as a raised hand on a woken session with no prompt.
+            terminals[delta.worktreeID]?[idx].awaitingInputReason = nil
+            terminals[delta.worktreeID]?[idx].awaitingInputObservedAt = nil
         } else {
             // Woken: clear the reason, keep the snapshot (clearHibernated
             // semantics — reconnect backdrop, overwritten on the next park).

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -35,11 +35,11 @@ final class JumpMenuController {
     }
 
     /// Worktrees holding at least one terminal with a prompt on screen, read
-    /// through the same predicate the sidebar row uses so the two surfaces
-    /// cannot disagree about which worktree is blocked.
-    static func promptOnScreenWorktreeIDs(appState: AppState) -> Set<UUID> {
-        Set(appState.terminals.compactMap { worktreeID, terminals in
-            WorktreeRowView.hasPromptOnScreen(in: terminals) ? worktreeID : nil
+    /// through the same `Terminal.hasPromptOnScreen` the sidebar row uses so
+    /// the two surfaces cannot disagree about which worktree is blocked.
+    static func promptOnScreenWorktreeIDs(terminals: [UUID: [Terminal]]) -> Set<UUID> {
+        Set(terminals.compactMap { worktreeID, rows in
+            rows.contains { $0.hasPromptOnScreen } ? worktreeID : nil
         })
     }
 
@@ -58,7 +58,7 @@ final class JumpMenuController {
             worktrees: snapshots,
             unread: appState.unreadByWorktree,
             recentIDs: appState.recentWorktreeIDs,
-            promptOnScreenIDs: Self.promptOnScreenWorktreeIDs(appState: appState)
+            promptOnScreenIDs: Self.promptOnScreenWorktreeIDs(terminals: appState.terminals)
         )
         self.viewModel = vm
 

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -34,6 +34,15 @@ final class JumpMenuController {
         }
     }
 
+    /// Worktrees holding at least one terminal with a prompt on screen, read
+    /// through the same predicate the sidebar row uses so the two surfaces
+    /// cannot disagree about which worktree is blocked.
+    static func promptOnScreenWorktreeIDs(appState: AppState) -> Set<UUID> {
+        Set(appState.terminals.compactMap { worktreeID, terminals in
+            WorktreeRowView.hasPromptOnScreen(in: terminals) ? worktreeID : nil
+        })
+    }
+
     private func open() {
         guard let appState else {
             logger.warning("toggle() called before configure(appState:)")
@@ -48,7 +57,8 @@ final class JumpMenuController {
         let vm = JumpMenuViewModel(
             worktrees: snapshots,
             unread: appState.unreadByWorktree,
-            recentIDs: appState.recentWorktreeIDs
+            recentIDs: appState.recentWorktreeIDs,
+            promptOnScreenIDs: Self.promptOnScreenWorktreeIDs(appState: appState)
         )
         self.viewModel = vm
 

--- a/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
@@ -15,6 +15,28 @@ struct JumpMenuRow: Identifiable, Equatable {
     let repoName: String
     let severity: NotificationType?   // nil for recent / match-without-unread
     let section: Section
+    /// One of the worktree's terminals has a prompt on screen. Independent of
+    /// `severity`: the `.attentionNeeded` notification reporting the same thing
+    /// is marked read the moment the worktree is selected, and the switcher's
+    /// whole job is finding the worktree that needs you — including the one you
+    /// last looked at.
+    let hasPromptOnScreen: Bool
+
+    init(
+        id: UUID,
+        displayName: String,
+        repoName: String,
+        severity: NotificationType?,
+        section: Section,
+        hasPromptOnScreen: Bool = false
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.repoName = repoName
+        self.severity = severity
+        self.section = section
+        self.hasPromptOnScreen = hasPromptOnScreen
+    }
 }
 
 struct JumpMenuRowView: View {
@@ -22,14 +44,19 @@ struct JumpMenuRowView: View {
     let isSelected: Bool
 
     private var suffix: SuffixRowIndicator? {
-        RowStatusIndicator.suffix(notification: row.severity, isWorking: false, isSuspended: false)
+        RowStatusIndicator.suffix(
+            notification: row.severity,
+            isWorking: false,
+            isSuspended: false,
+            hasPromptOnScreen: row.hasPromptOnScreen)
     }
 
     var body: some View {
         HStack(spacing: 8) {
             Text(row.displayName)
                 .font(.system(size: 13))
-                .fontWeight(RowStatusIndicator.shouldBoldName(row.severity) ? .bold : .regular)
+                .fontWeight(RowStatusIndicator.shouldBoldName(
+                    row.severity, hasPromptOnScreen: row.hasPromptOnScreen) ? .bold : .regular)
                 .lineLimit(1)
                 .truncationMode(.tail)
             Text(row.repoName)

--- a/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
@@ -22,17 +22,23 @@ final class JumpMenuViewModel: ObservableObject {
     private let allWorktrees: [JumpMenuWorktreeSnapshot]
     private let unread: [UUID: UnreadSummary]
     private let recentIDs: [UUID]
+    /// Worktrees with a prompt on screen, snapshotted at open time like the
+    /// rest. Defaulted empty so a caller that has no terminal state (tests,
+    /// and any future surface) keeps the notification-only behavior.
+    private let promptOnScreenIDs: Set<UUID>
 
     static let rowCap = 20
 
     init(
         worktrees: [JumpMenuWorktreeSnapshot],
         unread: [UUID: UnreadSummary],
-        recentIDs: [UUID]
+        recentIDs: [UUID],
+        promptOnScreenIDs: Set<UUID> = []
     ) {
         self.allWorktrees = worktrees
         self.unread = unread
         self.recentIDs = recentIDs
+        self.promptOnScreenIDs = promptOnScreenIDs
     }
 
     /// Currently-displayed rows, recomputed when `query` changes.
@@ -90,7 +96,8 @@ final class JumpMenuViewModel: ObservableObject {
                     displayName: snap.displayName,
                     repoName: snap.repoName,
                     severity: summary.type,
-                    section: .unread
+                    section: .unread,
+                    hasPromptOnScreen: promptOnScreenIDs.contains(id)
                 )
             }
 
@@ -110,7 +117,8 @@ final class JumpMenuViewModel: ObservableObject {
                     displayName: pair.1.displayName,
                     repoName: pair.1.repoName,
                     severity: nil,
-                    section: .recent
+                    section: .recent,
+                    hasPromptOnScreen: promptOnScreenIDs.contains(pair.0)
                 )
             }
 
@@ -139,7 +147,8 @@ final class JumpMenuViewModel: ObservableObject {
                     displayName: snap.displayName,
                     repoName: snap.repoName,
                     severity: unread[snap.id]?.type,
-                    section: .match
+                    section: .match,
+                    hasPromptOnScreen: promptOnScreenIDs.contains(snap.id)
                 )
             }
             // Order: unread rows first (severity desc), then recency

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -108,7 +108,18 @@ enum RowStatusIndicator {
     /// notification. Bold tracks "you should look here" — a completed response
     /// or an attention request. Shared by the sidebar row and the jump menu so
     /// they stay consistent.
-    static func shouldBoldName(_ notification: NotificationType?) -> Bool {
+    ///
+    /// `hasPromptOnScreen` bolds on the same input that gives the suffix slot
+    /// its attention glyph, and for the same reason: the notification saying
+    /// the same thing is marked read the moment its worktree is selected, so
+    /// without it the row this fix targets would show the raised hand beside a
+    /// regular-weight name — half-escalated, a state the notification-only
+    /// design could never produce.
+    static func shouldBoldName(
+        _ notification: NotificationType?,
+        hasPromptOnScreen: Bool = false
+    ) -> Bool {
+        if hasPromptOnScreen { return true }
         switch notification {
         case .responseComplete, .attentionNeeded, .focusRequest, .limitReached:
             return true

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -122,15 +122,36 @@ enum RowStatusIndicator {
     /// `responseComplete` is surfaced as a bold name in the view, not as a
     /// suffix. Hibernated is lowest — it's the calmest, safest state, so any
     /// louder signal wins the slot.
+    ///
+    /// `hasPromptOnScreen` shares the `.attention` rank with the notification
+    /// that reports the same thing, and is the input that survives a glance.
+    /// The two carriers are not interchangeable: a notification is unread mail
+    /// and is marked read the moment its worktree is selected, so the selected
+    /// (or pinned) row — the one the user is actually looking at — fell through
+    /// to `isWorking` and animated the thinking dots at a session that was
+    /// sitting on a permission prompt. This flag comes from the terminal's own
+    /// `awaitingInputReason` and is independent of read state and of selection.
+    ///
+    /// It ranks above `isWorking` deliberately, and `activityState` is left
+    /// alone: Claude Code raises a prompt in the middle of a turn, so the
+    /// session genuinely IS working — that fact gates hibernation and must not
+    /// be rewritten. The slot shows the louder of the two, which is the prompt.
+    ///
+    /// Only `.promptOnScreen` reaches this parameter. `.doneWaiting`,
+    /// `.informational` and `.unrecognized` are no signal here — see
+    /// `AwaitingInputClass`, where an unknown class is never guessed into a
+    /// neighbouring one.
     static func suffix(
         notification: NotificationType?,
         isWorking: Bool,
         isSuspended: Bool,
-        isHibernated: Bool = false
+        isHibernated: Bool = false,
+        hasPromptOnScreen: Bool = false
     ) -> SuffixRowIndicator? {
         if notification == .error {
             return .error
-        } else if notification == .attentionNeeded || notification == .focusRequest {
+        } else if notification == .attentionNeeded || notification == .focusRequest
+                    || hasPromptOnScreen {
             return .attention
         } else if isWorking {
             return .working

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -115,11 +115,16 @@ enum RowStatusIndicator {
     /// without it the row this fix targets would show the raised hand beside a
     /// regular-weight name — half-escalated, a state the notification-only
     /// design could never produce.
+    ///
+    /// It does not outrank `.error`, because `suffix` does not either: an error
+    /// takes the slot over a prompt, and `.error` deliberately does not bold.
+    /// Bolding here regardless would put a bold name beside an error glyph —
+    /// two severities at once, the same half-escalation in the other direction.
     static func shouldBoldName(
         _ notification: NotificationType?,
         hasPromptOnScreen: Bool = false
     ) -> Bool {
-        if hasPromptOnScreen { return true }
+        if hasPromptOnScreen, notification != .error { return true }
         switch notification {
         case .responseComplete, .attentionNeeded, .focusRequest, .limitReached:
             return true

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -95,6 +95,30 @@ struct WorktreeRowView: View {
         return Self.hasForegroundWork(in: terminals)
     }
 
+    /// One of the row's terminals has a prompt on screen right now.
+    ///
+    /// Read from the terminal's own `awaitingInputReason`, not from the
+    /// `.attentionNeeded` notification the daemon raises alongside it: that
+    /// notification is auto-marked-read for every visible worktree, so the
+    /// selected or pinned row — the one being looked at — lost it and animated
+    /// the thinking dots at a session waiting on a permission prompt.
+    private var hasPromptOnScreenTerminal: Bool {
+        let terminals = appState.terminals[worktree.id] ?? []
+        return Self.hasPromptOnScreen(in: terminals)
+    }
+
+    /// Whether a terminal's recorded wait reason says a prompt is on screen.
+    /// Only `.promptOnScreen` counts — every other class, `.unrecognized`
+    /// included, is no signal here.
+    nonisolated static func isPromptOnScreen(_ terminal: Terminal) -> Bool {
+        terminal.awaitingInputReason?.classification == .promptOnScreen
+    }
+
+    /// The collection form used by the row and by pure presentation tests.
+    nonisolated static func hasPromptOnScreen(in terminals: [Terminal]) -> Bool {
+        terminals.contains(where: isPromptOnScreen)
+    }
+
     /// Whether one terminal has trustworthy foreground work to animate in the
     /// sidebar. Codex's hook state can remain latched after a turn ends, so its
     /// transcript-derived presentation state is authoritative here unless the
@@ -317,7 +341,8 @@ struct WorktreeRowView: View {
             isWorking: hasWorkingTerminal,
             // Suspend retired: every parked session funnels to the moon.
             isSuspended: false,
-            isHibernated: hasParkedTerminal
+            isHibernated: hasParkedTerminal,
+            hasPromptOnScreen: hasPromptOnScreenTerminal
         ) {
         case .working:
             TypingDotsView(color: SuffixRowIndicator.working.color)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -107,22 +107,10 @@ struct WorktreeRowView: View {
         return Self.hasPromptOnScreen(in: terminals)
     }
 
-    /// Whether a terminal's recorded wait reason says a prompt is on screen.
-    /// Only `.promptOnScreen` counts — every other class, `.unrecognized`
-    /// included, is no signal here.
-    ///
-    /// A parked terminal never counts, whatever its columns say. Parking kills
-    /// the agent process, so whatever prompt was on screen went with it; the
-    /// daemon clears the columns at the same moment, and this guard keeps the
-    /// row calm through the window before that retraction lands rather than
-    /// advertising "needs your attention" on a session that no longer exists.
-    nonisolated static func isPromptOnScreen(_ terminal: Terminal) -> Bool {
-        !terminal.isParked && terminal.awaitingInputReason?.classification == .promptOnScreen
-    }
-
-    /// The collection form used by the row and by pure presentation tests.
+    /// The collection form of `Terminal.hasPromptOnScreen`, used by the row,
+    /// by the jump menu, and by pure presentation tests.
     nonisolated static func hasPromptOnScreen(in terminals: [Terminal]) -> Bool {
-        terminals.contains(where: isPromptOnScreen)
+        terminals.contains { $0.hasPromptOnScreen }
     }
 
     /// Whether one terminal has trustworthy foreground work to animate in the

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -52,7 +52,7 @@ struct WorktreeRowView: View {
     }
 
     private var hasBoldNotification: Bool {
-        RowStatusIndicator.shouldBoldName(notification)
+        RowStatusIndicator.shouldBoldName(notification, hasPromptOnScreen: hasPromptOnScreenTerminal)
     }
 
     private var prObservation: PRObservation? {
@@ -110,8 +110,14 @@ struct WorktreeRowView: View {
     /// Whether a terminal's recorded wait reason says a prompt is on screen.
     /// Only `.promptOnScreen` counts — every other class, `.unrecognized`
     /// included, is no signal here.
+    ///
+    /// A parked terminal never counts, whatever its columns say. Parking kills
+    /// the agent process, so whatever prompt was on screen went with it; the
+    /// daemon clears the columns at the same moment, and this guard keeps the
+    /// row calm through the window before that retraction lands rather than
+    /// advertising "needs your attention" on a session that no longer exists.
     nonisolated static func isPromptOnScreen(_ terminal: Terminal) -> Bool {
-        terminal.awaitingInputReason?.classification == .promptOnScreen
+        !terminal.isParked && terminal.awaitingInputReason?.classification == .promptOnScreen
     }
 
     /// The collection form used by the row and by pure presentation tests.

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -173,6 +173,11 @@ struct AppliedTerminalSessionStart: Sendable {
     let orderObservedAt: Date?
     let isInitialAttachment: Bool
     let activityObservation: AppliedTerminalActivityObservation?
+    /// True when applying this SessionStart retracted a standing awaiting-input
+    /// reason. Reported separately from `activityObservation` because the
+    /// Claude/shell branch retracts one while returning no activity observation
+    /// at all — a retraction read off that field alone would be missed there.
+    let clearedAwaitingInput: Bool
 }
 
 private func preservesStoredActivityAtEqualOrder(
@@ -470,6 +475,8 @@ public struct TerminalStore: Sendable {
                     record.transcriptPath = transcriptPath
                 }
                 record.sessionOrderObservedAt = nil
+                let hadReason = record.awaitingInputReason != nil
+                    || record.awaitingInputObservedAt != nil
                 record.awaitingInputReason = nil
                 record.awaitingInputObservedAt = nil
                 try record.update(db)
@@ -478,7 +485,8 @@ public struct TerminalStore: Sendable {
                     transcriptPath: record.transcriptPath,
                     orderObservedAt: nil,
                     isInitialAttachment: false,
-                    activityObservation: nil)
+                    activityObservation: nil,
+                    clearedAwaitingInput: hadReason)
             }
             let isInitialAttachment = record.claudeSessionID == nil
                 && record.transcriptPath == nil
@@ -504,7 +512,7 @@ public struct TerminalStore: Sendable {
             // The activity helper performs this when it accepts Codex's idle
             // fact. Keep the independent call so a rejected stale activity
             // transition still retracts only a prompt known to be older.
-            clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
+            let clearedHere = clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
             try record.update(db)
             guard let persistedRecord = try TerminalRecord.fetchOne(
                 db, key: id.uuidString
@@ -518,7 +526,9 @@ public struct TerminalStore: Sendable {
                 // terminal-list read will reload.
                 orderObservedAt: persistedRecord.sessionOrderObservedAt,
                 isInitialAttachment: isInitialAttachment,
-                activityObservation: activityObservation)
+                activityObservation: activityObservation,
+                clearedAwaitingInput: clearedHere
+                    || (activityObservation?.clearedAwaitingInput ?? false))
         }
     }
 
@@ -623,8 +633,11 @@ public struct TerminalStore: Sendable {
     /// reason, so the stored reason always describes the state stored beside
     /// it, never a wait that has since ended.
     ///
-    /// Returns whether the awaiting-input columns changed, so a caller can
-    /// broadcast the retraction (or the replacement) without re-reading the row.
+    /// Returns whether a standing wait reason was RETRACTED — a reason stood
+    /// before and none stands now — so a caller can announce the retraction
+    /// without re-reading the row. A call that installs a reason returns false:
+    /// there is nothing retracted to announce, and a caller that passes one is
+    /// responsible for broadcasting what it wrote.
     @discardableResult
     public func setActivityState(
         id: UUID,
@@ -652,7 +665,7 @@ public struct TerminalStore: Sendable {
             record.awaitingInputReason = FactColumnJSON.encode(awaitingInputReason)
             record.awaitingInputObservedAt = awaitingInputReason == nil ? nil : observedAt
             try record.update(db)
-            return hadReason || awaitingInputReason != nil
+            return hadReason && awaitingInputReason == nil
         }
     }
 
@@ -810,13 +823,18 @@ public struct TerminalStore: Sendable {
     /// `handleTerminalActivityEvent`'s unchanged-state guard drops. Without
     /// this entry point the reason would stay pinned to the row until the turn
     /// ended, long after the prompt it describes went away.
+    ///
+    /// A terminal that vanished between the caller's read and this write
+    /// reports `false` rather than throwing: the only callers are
+    /// fire-and-forget hooks, whose handlers soft-succeed on an unknown
+    /// terminal, and there is nothing to retract on a row that is gone.
     public func clearAwaitingInputReasonIfNotNewer(
         id: UUID,
         observedAt: Date
     ) async throws -> Bool {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
-                throw DatabaseError(message: "Terminal not found")
+                return false
             }
             guard clearAwaitingInputIfNotNewer(record: &record, than: observedAt) else {
                 return false
@@ -841,12 +859,13 @@ public struct TerminalStore: Sendable {
     /// no turn boundary.
     ///
     /// The activity rail is **not** a sufficient retraction on its own here,
-    /// which is why this writer is not just a `setActivityState` call.
-    /// `handleTerminalActivityEvent` returns early when the state is unchanged,
-    /// so the SessionStart overlay's own `tbd terminal-activity idle` clears
-    /// nothing when the row already reads idle — and it is a second, separate,
-    /// best-effort CLI invocation that a stale `tbd` on `PATH` can lose while
-    /// the first one lands.
+    /// which is why this writer is not just a `setActivityState` call. It is
+    /// unconditional where the rail is ordered: the rail retracts only a reason
+    /// not newer than the observation superseding it, and these two callers
+    /// know the process the prompt was raised on is gone regardless of when it
+    /// was recorded. The rail is also a second, separate, best-effort CLI
+    /// invocation that a stale `tbd` on `PATH` can lose while the first one
+    /// lands.
     ///
     /// Idempotent: clearing columns that are already nil is a no-op write.
     public func clearAwaitingInputReason(id: UUID) async throws {

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -148,6 +148,23 @@ public struct AppliedTerminalActivityObservation: Sendable {
     public let source: FactSource
     public let observedAt: Date
     public let orderObservedAt: Date
+    /// True when applying this observation retracted a standing awaiting-input
+    /// reason, so the caller knows there is a retraction worth broadcasting.
+    public let clearedAwaitingInput: Bool
+
+    public init(
+        activityState: TerminalActivityState,
+        source: FactSource,
+        observedAt: Date,
+        orderObservedAt: Date,
+        clearedAwaitingInput: Bool = false
+    ) {
+        self.activityState = activityState
+        self.source = source
+        self.observedAt = observedAt
+        self.orderObservedAt = orderObservedAt
+        self.clearedAwaitingInput = clearedAwaitingInput
+    }
 }
 
 struct AppliedTerminalSessionStart: Sendable {
@@ -170,13 +187,20 @@ private func preservesStoredActivityAtEqualOrder(
     return storedState != .working && incomingState == .working
 }
 
+/// Retract a standing awaiting-input reason unless it is newer than the
+/// observation superseding it. Returns whether a standing reason was actually
+/// retracted, so a caller can broadcast the retraction without re-reading the
+/// row.
+@discardableResult
 private func clearAwaitingInputIfNotNewer(
     record: inout TerminalRecord,
     than observedAt: Date
-) {
-    guard record.awaitingInputObservedAt.map({ $0 >= observedAt }) != true else { return }
+) -> Bool {
+    guard record.awaitingInputObservedAt.map({ $0 >= observedAt }) != true else { return false }
+    let hadReason = record.awaitingInputReason != nil || record.awaitingInputObservedAt != nil
     record.awaitingInputReason = nil
     record.awaitingInputObservedAt = nil
+    return hadReason
 }
 
 private func applyActivityObservationToRecord(
@@ -212,12 +236,13 @@ private func applyActivityObservationToRecord(
        let storedSource,
        let storedObservedAt = record.activityStateObservedAt {
         record.activityStateOrderObservedAt = observedAt
-        clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
+        let cleared = clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
         return AppliedTerminalActivityObservation(
             activityState: activityState,
             source: storedSource,
             observedAt: storedObservedAt,
-            orderObservedAt: observedAt
+            orderObservedAt: observedAt,
+            clearedAwaitingInput: cleared
         )
     }
 
@@ -225,12 +250,13 @@ private func applyActivityObservationToRecord(
     record.activityStateSource = FactColumnJSON.encode(source)
     record.activityStateObservedAt = observedAt
     record.activityStateOrderObservedAt = observedAt
-    clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
+    let cleared = clearAwaitingInputIfNotNewer(record: &record, than: observedAt)
     return AppliedTerminalActivityObservation(
         activityState: activityState,
         source: source,
         observedAt: observedAt,
-        orderObservedAt: observedAt
+        orderObservedAt: observedAt,
+        clearedAwaitingInput: cleared
     )
 }
 
@@ -596,17 +622,23 @@ public struct TerminalStore: Sendable {
     /// is superseded by the next: passing nil (the default) clears any previous
     /// reason, so the stored reason always describes the state stored beside
     /// it, never a wait that has since ended.
+    ///
+    /// Returns whether the awaiting-input columns changed, so a caller can
+    /// broadcast the retraction (or the replacement) without re-reading the row.
+    @discardableResult
     public func setActivityState(
         id: UUID,
         activityState: TerminalActivityState,
         source: FactSource,
         observedAt: Date = Date(),
         awaitingInputReason: AwaitingInputReason? = nil
-    ) async throws {
+    ) async throws -> Bool {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
+            let hadReason = record.awaitingInputReason != nil
+                || record.awaitingInputObservedAt != nil
             record.activityState = activityState.rawValue
             record.activityStateSource = FactColumnJSON.encode(source)
             record.activityStateObservedAt = observedAt
@@ -620,6 +652,7 @@ public struct TerminalStore: Sendable {
             record.awaitingInputReason = FactColumnJSON.encode(awaitingInputReason)
             record.awaitingInputObservedAt = awaitingInputReason == nil ? nil : observedAt
             try record.update(db)
+            return hadReason || awaitingInputReason != nil
         }
     }
 
@@ -664,6 +697,8 @@ public struct TerminalStore: Sendable {
                 // non-Codex caller must retain the pre-existing changed-value
                 // replacement and same-value no-op behavior.
                 guard record.activityState != activityState.rawValue else { return nil }
+                let hadReason = record.awaitingInputReason != nil
+                    || record.awaitingInputObservedAt != nil
                 record.activityState = activityState.rawValue
                 record.activityStateSource = FactColumnJSON.encode(source)
                 record.activityStateObservedAt = observedAt
@@ -675,7 +710,8 @@ public struct TerminalStore: Sendable {
                     activityState: activityState,
                     source: source,
                     observedAt: observedAt,
-                    orderObservedAt: observedAt)
+                    orderObservedAt: observedAt,
+                    clearedAwaitingInput: hadReason)
             }
             // Codex writes session identity into every supported hook payload.
             // Check it in this transaction, rather than against the terminal
@@ -735,11 +771,16 @@ public struct TerminalStore: Sendable {
     /// always has: `setActivityState` clears both columns, so a genuine
     /// observation of the session moving on still retracts the reason. This
     /// guard only refuses to let a report that observed nothing do it.
+    ///
+    /// Returns whether the reason was written. `false` means the guard above
+    /// declined it and the standing reason is unchanged — nothing for a caller
+    /// to announce.
+    @discardableResult
     public func recordAwaitingInputReason(
         id: UUID,
         reason: AwaitingInputReason,
         observedAt: Date
-    ) async throws {
+    ) async throws -> Bool {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
@@ -750,11 +791,38 @@ public struct TerminalStore: Sendable {
                let standing = FactColumnJSON.decode(
                     AwaitingInputReason.self, from: record.awaitingInputReason),
                standing.classification == .promptOnScreen {
-                return
+                return false
             }
             record.awaitingInputReason = FactColumnJSON.encode(reason)
             record.awaitingInputObservedAt = observedAt
             try record.update(db)
+            return true
+        }
+    }
+
+    /// Retract a standing wait reason that is not newer than `observedAt`,
+    /// WITHOUT asserting an activity state. Returns whether one was retracted.
+    ///
+    /// The activity rail is what supersedes a recorded reason, and it has to be
+    /// able to do so on an observation that repeats the state the row already
+    /// held. A permission prompt is raised in the middle of a turn: the hook
+    /// that fires once the human answers reports `working` again, which
+    /// `handleTerminalActivityEvent`'s unchanged-state guard drops. Without
+    /// this entry point the reason would stay pinned to the row until the turn
+    /// ended, long after the prompt it describes went away.
+    public func clearAwaitingInputReasonIfNotNewer(
+        id: UUID,
+        observedAt: Date
+    ) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard clearAwaitingInputIfNotNewer(record: &record, than: observedAt) else {
+                return false
+            }
+            try record.update(db)
+            return true
         }
     }
 

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -143,6 +143,17 @@ enum FactColumnJSON {
     }
 }
 
+/// What a `recordAwaitingInputReason` call did to the record.
+public enum AwaitingInputWrite: Sendable, Equatable {
+    /// The guard refused the report; the standing reason is unchanged.
+    case declined
+    /// The reason columns now hold the reported reason.
+    /// `displacedPromptOnScreen` says whether a prompt-on-screen reason was
+    /// standing before — the case a display consumer has to hear about even
+    /// when the new class is one it does not render.
+    case written(displacedPromptOnScreen: Bool)
+}
+
 public struct AppliedTerminalActivityObservation: Sendable {
     public let activityState: TerminalActivityState
     public let source: FactSource
@@ -785,31 +796,30 @@ public struct TerminalStore: Sendable {
     /// observation of the session moving on still retracts the reason. This
     /// guard only refuses to let a report that observed nothing do it.
     ///
-    /// Returns whether the reason was written. `false` means the guard above
-    /// declined it and the standing reason is unchanged — nothing for a caller
-    /// to announce.
+    /// Reports what the write did, so a caller can decide whether it is worth
+    /// announcing. `.declined` means the guard above refused and the standing
+    /// reason is unchanged.
     @discardableResult
     public func recordAwaitingInputReason(
         id: UUID,
         reason: AwaitingInputReason,
         observedAt: Date
-    ) async throws -> Bool {
+    ) async throws -> AwaitingInputWrite {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
+            let standing = FactColumnJSON.decode(
+                AwaitingInputReason.self, from: record.awaitingInputReason)
             let establishesNothing = reason.classification == .informational
                 || reason.classification == .unrecognized
-            if establishesNothing,
-               let standing = FactColumnJSON.decode(
-                    AwaitingInputReason.self, from: record.awaitingInputReason),
-               standing.classification == .promptOnScreen {
-                return false
+            if establishesNothing, standing?.classification == .promptOnScreen {
+                return .declined
             }
             record.awaitingInputReason = FactColumnJSON.encode(reason)
             record.awaitingInputObservedAt = observedAt
             try record.update(db)
-            return true
+            return .written(displacedPromptOnScreen: standing?.classification == .promptOnScreen)
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1990,6 +1990,7 @@ extension RPCRouter {
         // hooks to arrive — they may be seconds away, or lost to a stale `tbd`
         // on the pane's PATH.
         try await db.terminals.clearAwaitingInputReason(id: oldTerminal.id)
+        broadcastAwaitingInputRetraction(terminal: oldTerminal)
 
         // 3. Respawn IN PLACE — same window id / pane id → the tab and terminal
         //    row survive.
@@ -3065,6 +3066,11 @@ extension RPCRouter {
                 activityStateOrderObservedAt: application.orderObservedAt
             )))
         }
+        // A `/clear`, a resume, or a hand relaunch replaces the process the
+        // prompt was raised on, and the store retracts the reason with it.
+        if sessionApplication.clearedAwaitingInput {
+            broadcastAwaitingInputRetraction(terminal: terminal)
+        }
         return .ok()
     }
 
@@ -3089,6 +3095,12 @@ extension RPCRouter {
     /// the prompt was still on screen.
     func handleTerminalNotificationEvent(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalNotificationEventParams.self, from: paramsData)
+        // Timestamp receipt before any actor or database suspension, exactly as
+        // `handleTerminalActivityEvent` and `handleTerminalSessionEvent` do.
+        // The stamp is one end of an ordering comparison the activity rail makes
+        // when it retracts this reason, so a busy daemon must not be able to
+        // date a prompt later than the answer to it.
+        let observedAt = now()
 
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
             // Soft success — the caller is a fire-and-forget hook, and the
@@ -3098,7 +3110,7 @@ extension RPCRouter {
             logger.debug("notificationEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
             return .ok()
         }
-        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: now())
+        await sessionCounters.recordHookEvent(terminalID: terminal.id, at: observedAt)
 
         if let cwd = params.cwd, !cwd.isEmpty {
             guard try await hookCWDBelongsToTerminal(cwd, terminal: terminal, event: "notificationEvent")
@@ -3126,7 +3138,6 @@ extension RPCRouter {
         // `observedAt` comes from the router's date seam, never a bare `Date()`
         // at the write site: a persisted observed-at is data, so it is the date
         // seam rather than a `Clock`.
-        let observedAt = now()
         let recorded = try await db.terminals.recordAwaitingInputReason(
             id: terminal.id, reason: reason, observedAt: observedAt)
 
@@ -3258,37 +3269,36 @@ extension RPCRouter {
                     await limitResumeScheduler?.wake()
                 }
             }
-            // Retract a not-newer wait reason BEFORE the unchanged-state guard.
-            // A permission prompt is raised mid-turn, so the hook that fires
-            // once the human answers reports `working` again — the very
-            // observation the guard drops. Clearing only on a *changed* state
-            // would pin the reason to the row until the turn ended.
-            var retractedAwaitingInput = try await db.terminals
-                .clearAwaitingInputReasonIfNotNewer(
-                    id: terminal.id, observedAt: observedAt)
-            if terminal.activityState != params.activityState {
-                // `setActivityState` nils the reason columns unconditionally —
-                // it IS the superseding rail — so take its answer over the
-                // conditional retraction above.
-                retractedAwaitingInput = try await db.terminals.setActivityState(
-                    id: terminal.id,
-                    activityState: params.activityState,
-                    source: .hookEvent(RPCMethod.terminalActivityEvent),
-                    observedAt: observedAt) || retractedAwaitingInput
-                subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
-                    terminalID: terminal.id,
-                    worktreeID: terminal.worktreeID,
-                    activityState: params.activityState
-                )))
+            guard terminal.activityState != params.activityState else {
+                // Previously a pure no-op. A same-state observation still
+                // supersedes a not-newer wait reason, and it is the only
+                // observation some prompts ever get: a permission prompt is
+                // raised mid-turn, so the row already reads `working` and the
+                // next hook reports `working` again. Gated on the row already
+                // in hand, so the overwhelmingly common case — no standing
+                // reason — still costs no database write.
+                if terminal.awaitingInputReason != nil || terminal.awaitingInputObservedAt != nil,
+                   try await db.terminals.clearAwaitingInputReasonIfNotNewer(
+                       id: terminal.id, observedAt: observedAt) {
+                    broadcastAwaitingInputRetraction(terminal: terminal)
+                }
+                return .ok()
             }
-            if retractedAwaitingInput {
-                subscriptions.broadcast(delta: .terminalAwaitingInputChanged(
-                    TerminalAwaitingInputDelta(
-                        terminalID: terminal.id,
-                        worktreeID: terminal.worktreeID,
-                        reason: nil,
-                        observedAt: nil)))
-            }
+            // `setActivityState` nils the reason columns unconditionally — it
+            // IS the superseding rail — and reports whether a standing reason
+            // went with them, so the retraction is announced from what the
+            // write actually did rather than from the row read before it.
+            let retracted = try await db.terminals.setActivityState(
+                id: terminal.id,
+                activityState: params.activityState,
+                source: .hookEvent(RPCMethod.terminalActivityEvent),
+                observedAt: observedAt)
+            subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+                terminalID: terminal.id,
+                worktreeID: terminal.worktreeID,
+                activityState: params.activityState
+            )))
+            if retracted { broadcastAwaitingInputRetraction(terminal: terminal) }
             return .ok()
         }
         let source: FactSource = params.origin == .userInterrupt
@@ -3321,14 +3331,24 @@ extension RPCRouter {
             activityStateOrderObservedAt: activityApplication.orderObservedAt
         )))
         if activityApplication.clearedAwaitingInput {
-            subscriptions.broadcast(delta: .terminalAwaitingInputChanged(
-                TerminalAwaitingInputDelta(
-                    terminalID: terminal.id,
-                    worktreeID: terminal.worktreeID,
-                    reason: nil,
-                    observedAt: nil)))
+            broadcastAwaitingInputRetraction(terminal: terminal)
         }
         return .ok()
+    }
+
+    /// Announce that a terminal's recorded wait reason is gone.
+    ///
+    /// Every daemon site that nils those columns owes the app one of these:
+    /// the app mirrors the record rather than deriving it, so a column cleared
+    /// without a retraction leaves a "needs your attention" indicator standing
+    /// on a session that is no longer waiting, until the next `terminal.list`.
+    func broadcastAwaitingInputRetraction(terminal: Terminal) {
+        subscriptions.broadcast(delta: .terminalAwaitingInputChanged(
+            TerminalAwaitingInputDelta(
+                terminalID: terminal.id,
+                worktreeID: terminal.worktreeID,
+                reason: nil,
+                observedAt: nil)))
     }
     func handleTerminalTranscript(_ paramsData: Data) async throws -> RPCResponse {
         perfTranscriptLog.debug("rpc.handle.start method=terminalTranscript")

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3138,7 +3138,7 @@ extension RPCRouter {
         // `observedAt` comes from the router's date seam, never a bare `Date()`
         // at the write site: a persisted observed-at is data, so it is the date
         // seam rather than a `Clock`.
-        let recorded = try await db.terminals.recordAwaitingInputReason(
+        let write = try await db.terminals.recordAwaitingInputReason(
             id: terminal.id, reason: reason, observedAt: observedAt)
 
         // The reason columns are what the sidebar reads for "a prompt is on
@@ -3146,7 +3146,16 @@ extension RPCRouter {
         // notification row would not do: notifications model unread mail and
         // are marked read the moment the worktree is selected, which is
         // exactly the worktree whose prompt the user most needs to see.
-        if recorded {
+        //
+        // Only writes that change whether a prompt is on screen are pushed.
+        // This hook carries no matcher, so it also fires for every
+        // `agent_completed` a parallel subagent produces and every 60-second
+        // `idle_prompt` across the fleet; announcing those would republish the
+        // app's whole terminal collection for a sidebar that cannot change by
+        // a pixel. A write that DISPLACES a standing prompt still goes out —
+        // that one takes the indicator down.
+        if case .written(let displacedPromptOnScreen) = write,
+           reason.classification == .promptOnScreen || displacedPromptOnScreen {
             subscriptions.broadcast(delta: .terminalAwaitingInputChanged(
                 TerminalAwaitingInputDelta(
                     terminalID: terminal.id,
@@ -3271,15 +3280,25 @@ extension RPCRouter {
             }
             guard terminal.activityState != params.activityState else {
                 // Previously a pure no-op. A same-state observation still
-                // supersedes a not-newer wait reason, and it is the only
-                // observation some prompts ever get: a permission prompt is
-                // raised mid-turn, so the row already reads `working` and the
-                // next hook reports `working` again. Gated on the row already
-                // in hand, so the overwhelmingly common case — no standing
-                // reason — still costs no database write.
-                if terminal.awaitingInputReason != nil || terminal.awaitingInputObservedAt != nil,
-                   try await db.terminals.clearAwaitingInputReasonIfNotNewer(
-                       id: terminal.id, observedAt: observedAt) {
+                // supersedes a not-newer wait reason: this is the only rail
+                // that speaks when an activity value repeats, and the reason
+                // column moves independently of the activity stamp.
+                //
+                // Deliberately NOT gated on `terminal`'s reason columns. That
+                // row was read before an unbounded stretch of async work (a
+                // counter actor hop, a worktree read, and on an idle event a
+                // transcript file copy), and `handleTerminalNotificationEvent`
+                // runs concurrently on its own connection — a prompt recorded
+                // inside that window is invisible here, and skipping the call
+                // would leave the database holding a reason older than the
+                // newest activity observation, which is the one state the
+                // ordering rule exists to prevent. The store re-reads inside
+                // its own transaction and returns false without writing when
+                // there is nothing to retract, and a repeated activity value
+                // is a rare event on this rail (a queued prompt mid-turn, a
+                // second Stop), so the saved write was worth little anyway.
+                if try await db.terminals.clearAwaitingInputReasonIfNotNewer(
+                    id: terminal.id, observedAt: observedAt) {
                     broadcastAwaitingInputRetraction(terminal: terminal)
                 }
                 return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3080,11 +3080,13 @@ extension RPCRouter {
     ///
     /// The handler records the reason columns, and for a prompt-on-screen
     /// classification additionally raises an `.attentionNeeded` notification
-    /// so the sidebar swaps the thinking dots for the attention indicator and
-    /// bolds the name (the app's `RowStatusIndicator` already ranks attention
-    /// above working). There is still no delta carrying the wait reason
-    /// itself: the notification row is the fact the app renders, and focusing
-    /// the worktree clears it through `notifications.markRead`.
+    /// so the macOS banner fires and the name bolds.
+    ///
+    /// The recorded reason is ALSO pushed as `.terminalAwaitingInputChanged`,
+    /// and that — not the notification — is what the sidebar's suffix slot
+    /// reads. The notification is unread mail: selecting the worktree marks it
+    /// read, so the row the user is looking at would lose the indicator while
+    /// the prompt was still on screen.
     func handleTerminalNotificationEvent(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalNotificationEventParams.self, from: paramsData)
 
@@ -3124,8 +3126,23 @@ extension RPCRouter {
         // `observedAt` comes from the router's date seam, never a bare `Date()`
         // at the write site: a persisted observed-at is data, so it is the date
         // seam rather than a `Clock`.
-        try await db.terminals.recordAwaitingInputReason(
-            id: terminal.id, reason: reason, observedAt: now())
+        let observedAt = now()
+        let recorded = try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id, reason: reason, observedAt: observedAt)
+
+        // The reason columns are what the sidebar reads for "a prompt is on
+        // screen right now", so the app has to learn about them by push. A
+        // notification row would not do: notifications model unread mail and
+        // are marked read the moment the worktree is selected, which is
+        // exactly the worktree whose prompt the user most needs to see.
+        if recorded {
+            subscriptions.broadcast(delta: .terminalAwaitingInputChanged(
+                TerminalAwaitingInputDelta(
+                    terminalID: terminal.id,
+                    worktreeID: terminal.worktreeID,
+                    reason: reason,
+                    observedAt: observedAt)))
+        }
 
         // A prompt on screen is the one class a human has to act on now, so
         // it, and only it, raises the attention notification the sidebar
@@ -3241,17 +3258,37 @@ extension RPCRouter {
                     await limitResumeScheduler?.wake()
                 }
             }
-            guard terminal.activityState != params.activityState else { return .ok() }
-            try await db.terminals.setActivityState(
-                id: terminal.id,
-                activityState: params.activityState,
-                source: .hookEvent(RPCMethod.terminalActivityEvent),
-                observedAt: observedAt)
-            subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
-                terminalID: terminal.id,
-                worktreeID: terminal.worktreeID,
-                activityState: params.activityState
-            )))
+            // Retract a not-newer wait reason BEFORE the unchanged-state guard.
+            // A permission prompt is raised mid-turn, so the hook that fires
+            // once the human answers reports `working` again — the very
+            // observation the guard drops. Clearing only on a *changed* state
+            // would pin the reason to the row until the turn ended.
+            var retractedAwaitingInput = try await db.terminals
+                .clearAwaitingInputReasonIfNotNewer(
+                    id: terminal.id, observedAt: observedAt)
+            if terminal.activityState != params.activityState {
+                // `setActivityState` nils the reason columns unconditionally —
+                // it IS the superseding rail — so take its answer over the
+                // conditional retraction above.
+                retractedAwaitingInput = try await db.terminals.setActivityState(
+                    id: terminal.id,
+                    activityState: params.activityState,
+                    source: .hookEvent(RPCMethod.terminalActivityEvent),
+                    observedAt: observedAt) || retractedAwaitingInput
+                subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+                    terminalID: terminal.id,
+                    worktreeID: terminal.worktreeID,
+                    activityState: params.activityState
+                )))
+            }
+            if retractedAwaitingInput {
+                subscriptions.broadcast(delta: .terminalAwaitingInputChanged(
+                    TerminalAwaitingInputDelta(
+                        terminalID: terminal.id,
+                        worktreeID: terminal.worktreeID,
+                        reason: nil,
+                        observedAt: nil)))
+            }
             return .ok()
         }
         let source: FactSource = params.origin == .userInterrupt
@@ -3283,6 +3320,14 @@ extension RPCRouter {
             activityStateObservedAt: activityApplication.observedAt,
             activityStateOrderObservedAt: activityApplication.orderObservedAt
         )))
+        if activityApplication.clearedAwaitingInput {
+            subscriptions.broadcast(delta: .terminalAwaitingInputChanged(
+                TerminalAwaitingInputDelta(
+                    terminalID: terminal.id,
+                    worktreeID: terminal.worktreeID,
+                    reason: nil,
+                    observedAt: nil)))
+        }
         return .ok()
     }
     func handleTerminalTranscript(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Supervision/SessionStateResolver.swift
+++ b/Sources/TBDDaemon/Supervision/SessionStateResolver.swift
@@ -106,8 +106,10 @@ struct SessionStateFacts: Sendable, Equatable {
 /// `handleTerminalNotificationEvent` records a reason without touching
 /// `activityState` (deliberately — `activityState` gates hibernation), and
 /// `handleTerminalActivityEvent` returns early when the state is unchanged, so
-/// a repeated same-state event does **not** rewrite the activity stamp and does
-/// **not** supersede a recorded reason.
+/// a repeated same-state event does **not** rewrite the activity stamp. It does
+/// retract a not-newer reason, on the same ordering rule a changed state
+/// follows — but the retraction and the activity stamp move independently, and
+/// only the reason column is touched.
 ///
 /// So neither fact may be given a standing rank, and observed-at decides
 /// between them. A reason older than the newest activity observation is a
@@ -125,7 +127,16 @@ struct SessionStateFacts: Sendable, Equatable {
 /// provenance. So a `permission_prompt` recorded a second *after* the turn's
 /// `working` stamp keeps outranking it for the rest of the turn — ten minutes
 /// of reporting `.awaitingInput` for a prompt answered seconds after it
-/// appeared. Nothing on the hook rail ever retracts the reason.
+/// appeared.
+///
+/// A same-state event does now retract a not-newer reason, and that is what
+/// closes this window for an `AskUserQuestion` prompt (whose post-hook fires a
+/// `working` event the moment it is answered). It closes nothing for the
+/// ordinary tool-permission prompt, because **no hook fires when a human
+/// approves a Bash or an Edit**: the overlay's only `PostToolUse` entries are
+/// matched to `AskUserQuestion` and to `Bash`-for-PR-binding, so between the
+/// approval and the turn's `Stop` the hook rail says nothing at all. The
+/// transcript check below is still the only thing that speaks in that window.
 ///
 /// The transcript is the only other interface that speaks during a turn, and it
 /// **cannot settle this either — so growth is evidence of ambiguity, not of an

--- a/Sources/TBDDaemon/Supervision/SessionStateResolver.swift
+++ b/Sources/TBDDaemon/Supervision/SessionStateResolver.swift
@@ -129,14 +129,20 @@ struct SessionStateFacts: Sendable, Equatable {
 /// of reporting `.awaitingInput` for a prompt answered seconds after it
 /// appeared.
 ///
-/// A same-state event does now retract a not-newer reason, and that is what
-/// closes this window for an `AskUserQuestion` prompt (whose post-hook fires a
-/// `working` event the moment it is answered). It closes nothing for the
-/// ordinary tool-permission prompt, because **no hook fires when a human
-/// approves a Bash or an Edit**: the overlay's only `PostToolUse` entries are
-/// matched to `AskUserQuestion` and to `Bash`-for-PR-binding, so between the
-/// approval and the turn's `Stop` the hook rail says nothing at all. The
-/// transcript check below is still the only thing that speaks in that window.
+/// A same-state event does now retract a not-newer reason, which is what the
+/// rail could not do before. It does not close this window, and it is worth
+/// being exact about how narrow it is. An `AskUserQuestion` prompt was never in
+/// the window: its pre-hook writes `waiting_for_user` and its post-hook writes
+/// `working`, a *changed* state that has always retracted. And **no hook fires
+/// at all when a human approves a Bash or an Edit** — the overlay's only
+/// `PostToolUse` entries are matched to `AskUserQuestion` and to
+/// `Bash`-for-PR-binding — so between that approval and the turn's `Stop` there
+/// is nothing to retract on. What the same-state retraction reaches is a
+/// repeated value: a queued `UserPromptSubmit` mid-turn, a second `Stop`, or a
+/// post-hook whose paired pre-hook was lost to a stale `tbd` on `PATH`.
+///
+/// So the transcript check below is still the only thing that speaks during a
+/// turn, and it is still what this doctrine rests on.
 ///
 /// The transcript is the only other interface that speaks during a turn, and it
 /// **cannot settle this either — so growth is evidence of ambiguity, not of an

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -793,6 +793,20 @@ public extension Terminal {
         kind == .codex || label == TerminalLabel.codex
     }
 
+    /// The recorded wait reason says a prompt is on screen right now.
+    ///
+    /// Only `.promptOnScreen` counts. `.doneWaiting`, `.informational` and
+    /// `.unrecognized` are no signal, and an unknown class is never guessed
+    /// into the prompt class — see `AwaitingInputClass`.
+    ///
+    /// A parked terminal never counts, whatever its columns say. Parking kills
+    /// the agent process, so whatever prompt was on screen went with it; the
+    /// park clears the columns in the same write, and this guard keeps a row
+    /// calm through the window before the app learns that.
+    var hasPromptOnScreen: Bool {
+        !isParked && awaitingInputReason?.classification == .promptOnScreen
+    }
+
     /// True only for Claude terminals whose session can be resumed through
     /// Claude-specific lifecycle flows like suspend/resume and dead-window
     /// preservation.

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -215,6 +215,14 @@ public struct TerminalActivityDelta: Codable, Sendable {
 /// was retracted — the app mirrors the columns rather than deriving them, so
 /// there is exactly one place that decides what the record says.
 ///
+/// **What it promises is narrower than "every write":** a reason is pushed when
+/// it installs a prompt-on-screen or displaces one, and every retraction is
+/// pushed. The `Notification` hook carries no matcher, so it also records
+/// classes that cannot change whether a prompt is up — an `agent_completed`
+/// per finished subagent, an `idle_prompt` per idle minute — and pushing those
+/// would republish every subscriber's terminal collection for no visible
+/// change. A consumer that needs the other classes must read `terminal.list`.
+///
 /// This is a *recorded reason*, not a claim about activity: nothing here
 /// asserts `activityState`, and the app must not write one from it.
 public struct TerminalAwaitingInputDelta: Codable, Sendable {

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -23,6 +23,12 @@ public enum StateDelta: Codable, Sendable {
     case modelProfilesChanged
     case terminalSessionUpdated(TerminalSessionDelta)
     case terminalActivityUpdated(TerminalActivityDelta)
+    /// A terminal's recorded awaiting-input reason was written or retracted.
+    /// Separate from `.terminalActivityUpdated` on purpose: a `Notification`
+    /// hook records that a prompt was raised without asserting what the
+    /// session is doing, and an activity event that repeats the state it
+    /// already had retracts a reason while broadcasting no activity change.
+    case terminalAwaitingInputChanged(TerminalAwaitingInputDelta)
     case terminalProfileChanged(TerminalProfileDelta)
     /// Explicit Watch Desk Judge/Read-only role markers changed. The app
     /// refetches that worktree's terminal rows; lease credentials stay daemon-side.
@@ -200,6 +206,34 @@ public struct TerminalActivityDelta: Codable, Sendable {
         self.activityStateSource = activityStateSource
         self.activityStateObservedAt = activityStateObservedAt
         self.activityStateOrderObservedAt = activityStateOrderObservedAt
+    }
+}
+
+/// Delta payload for a terminal's awaiting-input reason.
+///
+/// Carries the reason the daemon just persisted, or `nil` when a standing one
+/// was retracted — the app mirrors the columns rather than deriving them, so
+/// there is exactly one place that decides what the record says.
+///
+/// This is a *recorded reason*, not a claim about activity: nothing here
+/// asserts `activityState`, and the app must not write one from it.
+public struct TerminalAwaitingInputDelta: Codable, Sendable {
+    public let terminalID: UUID
+    public let worktreeID: UUID
+    /// The persisted reason, or nil when it was retracted.
+    public let reason: AwaitingInputReason?
+    /// When the reason was observed. Nil whenever `reason` is nil.
+    public let observedAt: Date?
+    public init(
+        terminalID: UUID,
+        worktreeID: UUID,
+        reason: AwaitingInputReason?,
+        observedAt: Date?
+    ) {
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.reason = reason
+        self.observedAt = observedAt
     }
 }
 

--- a/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
+++ b/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
@@ -336,6 +336,34 @@ struct DeltaIngestionTests {
         }
     }
 
+    /// Parking retracts the reason in the same daemon write that sets
+    /// `hibernatedAt`, and the app mirrors both from the one delta — so the
+    /// park costs one publish, not two, and the row wakes with no stale prompt.
+    @Test("terminalHibernationChanged: a park retracts the cached reason")
+    func parkingClearsTheCachedAwaitingInputReason() {
+        withEmissionState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            var terminal = makeTerminal(
+                id: terminalID, worktreeID: worktreeID, activityState: .idle)
+            terminal.awaitingInputReason = AwaitingInputReason(
+                message: "needs your permission",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt")
+            terminal.awaitingInputObservedAt = Date(timeIntervalSince1970: 20)
+            seatOneTerminal(state, worktreeID: worktreeID, terminal: terminal)
+
+            state.handleDelta(.terminalHibernationChanged(TerminalHibernationDelta(
+                terminalID: terminalID, worktreeID: worktreeID,
+                hibernated: true, keepWarm: false
+            )))
+
+            let parked = state.terminals[worktreeID]?.first
+            #expect(parked?.awaitingInputReason == nil)
+            #expect(parked?.hasPromptOnScreen == false)
+        }
+    }
+
     /// A session rollover delta re-sent with the same session identity is a
     /// semantic no-op and must not republish the terminal collection.
     @Test("terminalSessionUpdated: the same session and transcript path")

--- a/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
+++ b/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
@@ -280,6 +280,62 @@ struct DeltaIngestionTests {
         }
     }
 
+    /// Broadcast on every `Notification` hook of every class, plus every
+    /// activity-rail retraction, so its publish cost is worth a ratchet.
+    @Test("terminalAwaitingInputChanged: the same reason")
+    func identicalAwaitingInputDelta() {
+        withEmissionState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            let reason = AwaitingInputReason(
+                message: "needs your permission",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt")
+            let observedAt = Date(timeIntervalSince1970: 20)
+            var terminal = makeTerminal(
+                id: terminalID, worktreeID: worktreeID, activityState: .working)
+            terminal.awaitingInputReason = reason
+            terminal.awaitingInputObservedAt = observedAt
+            seatOneTerminal(state, worktreeID: worktreeID, terminal: terminal)
+
+            let count = countEmissions(of: state) {
+                state.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
+                    terminalID: terminalID, worktreeID: worktreeID,
+                    reason: reason, observedAt: observedAt
+                )))
+            }
+
+            #expect(count == 0)
+        }
+    }
+
+    @Test("terminalAwaitingInputChanged: a retraction")
+    func retractingAwaitingInputDelta() {
+        withEmissionState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            var terminal = makeTerminal(
+                id: terminalID, worktreeID: worktreeID, activityState: .working)
+            terminal.awaitingInputReason = AwaitingInputReason(
+                message: "needs your permission",
+                hookEventName: "Notification",
+                notificationType: "permission_prompt")
+            terminal.awaitingInputObservedAt = Date(timeIntervalSince1970: 20)
+            seatOneTerminal(state, worktreeID: worktreeID, terminal: terminal)
+
+            let count = countEmissions(of: state) {
+                state.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
+                    terminalID: terminalID, worktreeID: worktreeID,
+                    reason: nil, observedAt: nil
+                )))
+            }
+
+            // One write-back, not one per column.
+            #expect(count == 1)
+            #expect(state.terminals[worktreeID]?.first?.awaitingInputReason == nil)
+        }
+    }
+
     /// A session rollover delta re-sent with the same session identity is a
     /// semantic no-op and must not republish the terminal collection.
     @Test("terminalSessionUpdated: the same session and transcript path")

--- a/Tests/TBDAppTests/JumpMenuViewModelTests.swift
+++ b/Tests/TBDAppTests/JumpMenuViewModelTests.swift
@@ -18,7 +18,7 @@ struct JumpMenuViewModelTests {
     /// The switcher's job is finding the worktree that needs you, and the
     /// `.attentionNeeded` notification that would have said so is marked read
     /// the moment its worktree is selected. Every section carries the flag.
-    @Test func promptOnScreenReachesEverySection() {
+    @Test func promptOnScreenReachesEverySection() throws {
         let unreadID = UUID(); let recentID = UUID(); let matchID = UUID()
         let vm = JumpMenuViewModel(
             worktrees: [
@@ -36,9 +36,39 @@ struct JumpMenuViewModelTests {
         #expect(defaults.first { $0.id == recentID }?.hasPromptOnScreen == true)
 
         vm.query = "alpha-three"
-        let match = try! #require(vm.rows.first { $0.id == matchID })
+        let match = try #require(vm.rows.first { $0.id == matchID })
         #expect(match.section == .match)
         #expect(match.hasPromptOnScreen)
+    }
+
+    /// The producer between `AppState.terminals` and the view model. Without a
+    /// test the argument could be dropped at the call site and every row would
+    /// silently revert to notification-only behavior — both sides default.
+    @Test func promptOnScreenWorktreeIDsReadsTheTerminals() {
+        let prompting = UUID(); let quiet = UUID(); let parked = UUID()
+        func terminal(worktreeID: UUID, notificationType: String?) -> Terminal {
+            var t = Terminal(
+                worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+                kind: .claude, activityState: .working)
+            if let notificationType {
+                t.awaitingInputReason = AwaitingInputReason(
+                    message: "needs your permission",
+                    hookEventName: "Notification",
+                    notificationType: notificationType)
+                t.awaitingInputObservedAt = Date(timeIntervalSince1970: 1)
+            }
+            return t
+        }
+        var parkedTerminal = terminal(worktreeID: parked, notificationType: "permission_prompt")
+        parkedTerminal.hibernatedAt = Date(timeIntervalSince1970: 2)
+
+        let ids = JumpMenuController.promptOnScreenWorktreeIDs(terminals: [
+            prompting: [terminal(worktreeID: prompting, notificationType: "permission_prompt")],
+            quiet: [terminal(worktreeID: quiet, notificationType: nil)],
+            parked: [parkedTerminal],
+        ])
+
+        #expect(ids == [prompting])
     }
 
     @Test func noPromptOnScreenByDefault() {

--- a/Tests/TBDAppTests/JumpMenuViewModelTests.swift
+++ b/Tests/TBDAppTests/JumpMenuViewModelTests.swift
@@ -13,6 +13,44 @@ struct JumpMenuViewModelTests {
         JumpMenuWorktreeSnapshot(id: id, displayName: name, repoName: repo)
     }
 
+    // MARK: - Prompt on screen
+
+    /// The switcher's job is finding the worktree that needs you, and the
+    /// `.attentionNeeded` notification that would have said so is marked read
+    /// the moment its worktree is selected. Every section carries the flag.
+    @Test func promptOnScreenReachesEverySection() {
+        let unreadID = UUID(); let recentID = UUID(); let matchID = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(unreadID, name: "alpha"),
+                snap(recentID, name: "alpha-two"),
+                snap(matchID, name: "alpha-three"),
+            ],
+            unread: [unreadID: UnreadSummary(type: .responseComplete, mostRecentAt: Date())],
+            recentIDs: [recentID],
+            promptOnScreenIDs: [unreadID, recentID, matchID]
+        )
+
+        let defaults = vm.rows
+        #expect(defaults.first { $0.id == unreadID }?.hasPromptOnScreen == true)
+        #expect(defaults.first { $0.id == recentID }?.hasPromptOnScreen == true)
+
+        vm.query = "alpha-three"
+        let match = try! #require(vm.rows.first { $0.id == matchID })
+        #expect(match.section == .match)
+        #expect(match.hasPromptOnScreen)
+    }
+
+    @Test func noPromptOnScreenByDefault() {
+        let id = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(id)],
+            unread: [:],
+            recentIDs: [id]
+        )
+        #expect(vm.rows.first?.hasPromptOnScreen == false)
+    }
+
     // MARK: - Tests
 
     @Test func emptyState() {

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -175,4 +175,13 @@ struct ShouldBoldNameTests {
     @Test func doesNotBoldWhenThereIsNoPromptAndNoNotification() {
         #expect(RowStatusIndicator.shouldBoldName(nil, hasPromptOnScreen: false) == false)
     }
+
+    /// `suffix` ranks `.error` above a prompt on screen, so the name must not
+    /// bold: a bold name beside an error octagon shows two severities at once.
+    @Test func aPromptOnScreenDoesNotBoldOverAnError() {
+        #expect(RowStatusIndicator.suffix(
+            notification: .error, isWorking: true, isSuspended: false,
+            hasPromptOnScreen: true) == .error)
+        #expect(RowStatusIndicator.shouldBoldName(.error, hasPromptOnScreen: true) == false)
+    }
 }

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -81,6 +81,61 @@ struct SuffixRowIndicatorTests {
             notification: .attentionNeeded, isWorking: false, isSuspended: false, isHibernated: true) == .attention)
     }
 
+    // MARK: - Prompt on screen
+
+    @Test func promptOnScreenOutranksWorking() {
+        // The reported bug: the session IS working (a permission prompt is
+        // raised mid-turn), the notification has been auto-marked-read because
+        // the worktree is selected, and the row animated the thinking dots.
+        #expect(RowStatusIndicator.suffix(
+            notification: nil,
+            isWorking: true,
+            isSuspended: false,
+            hasPromptOnScreen: true) == .attention)
+    }
+
+    @Test func workingWithoutPromptStillAnimates() {
+        #expect(RowStatusIndicator.suffix(
+            notification: nil,
+            isWorking: true,
+            isSuspended: false,
+            hasPromptOnScreen: false) == .working)
+    }
+
+    @Test func promptOnScreenWithoutWorking() {
+        #expect(RowStatusIndicator.suffix(
+            notification: nil,
+            isWorking: false,
+            isSuspended: false,
+            hasPromptOnScreen: true) == .attention)
+    }
+
+    @Test func errorStillOutranksPromptOnScreen() {
+        #expect(RowStatusIndicator.suffix(
+            notification: .error,
+            isWorking: true,
+            isSuspended: false,
+            hasPromptOnScreen: true) == .error)
+    }
+
+    @Test func promptOnScreenOutranksParked() {
+        #expect(RowStatusIndicator.suffix(
+            notification: nil,
+            isWorking: false,
+            isSuspended: false,
+            isHibernated: true,
+            hasPromptOnScreen: true) == .attention)
+    }
+
+    @Test func attentionNotificationStillWorksWithoutPrompt() {
+        // The non-selected worktree keeps the pre-existing notification path.
+        #expect(RowStatusIndicator.suffix(
+            notification: .attentionNeeded,
+            isWorking: true,
+            isSuspended: false,
+            hasPromptOnScreen: false) == .attention)
+    }
+
     @Test func glyphMapping() {
         #expect(SuffixRowIndicator.error.systemImage == "exclamationmark.octagon.fill")
         #expect(SuffixRowIndicator.attention.systemImage == "hand.raised.fill")

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -160,4 +160,19 @@ struct ShouldBoldNameTests {
     @Test func doesNotBoldForNoNotification() {
         #expect(RowStatusIndicator.shouldBoldName(nil) == false)
     }
+
+    /// The row this fix targets has no unread notification left — it was
+    /// auto-marked-read on selection — so without this the raised hand would
+    /// sit beside a regular-weight name.
+    @Test func boldsForAPromptOnScreenWithNoNotification() {
+        #expect(RowStatusIndicator.shouldBoldName(nil, hasPromptOnScreen: true) == true)
+    }
+
+    @Test func aPromptOnScreenBoldsEvenOverANonBoldingNotification() {
+        #expect(RowStatusIndicator.shouldBoldName(.taskComplete, hasPromptOnScreen: true) == true)
+    }
+
+    @Test func doesNotBoldWhenThereIsNoPromptAndNoNotification() {
+        #expect(RowStatusIndicator.shouldBoldName(nil, hasPromptOnScreen: false) == false)
+    }
 }

--- a/Tests/TBDAppTests/TerminalAwaitingInputDeltaTests.swift
+++ b/Tests/TBDAppTests/TerminalAwaitingInputDeltaTests.swift
@@ -11,8 +11,14 @@ import TBDShared
 @Suite("AppState — terminalAwaitingInputChanged")
 @MainActor
 struct TerminalAwaitingInputDeltaTests {
-    private func state() -> (AppState, worktreeID: UUID, terminalID: UUID) {
-        let state = AppState()
+    /// `UserDefaults.standard` on this unbundled executable is the developer's
+    /// real `TBDApp.plist`, so each `AppState` gets its own suite and the
+    /// caller tears it down.
+    private func state() -> (
+        state: AppState, worktreeID: UUID, terminalID: UUID, suiteName: String
+    ) {
+        let suiteName = "TerminalAwaitingInputDeltaTests-\(UUID().uuidString)"
+        let state = AppState(userDefaults: UserDefaults(suiteName: suiteName)!)
         let worktreeID = UUID()
         let terminalID = UUID()
         state.terminals = [
@@ -30,7 +36,7 @@ struct TerminalAwaitingInputDeltaTests {
                 )
             ]
         ]
-        return (state, worktreeID, terminalID)
+        return (state, worktreeID, terminalID, suiteName)
     }
 
     private static let prompt = AwaitingInputReason(
@@ -39,7 +45,8 @@ struct TerminalAwaitingInputDeltaTests {
         notificationType: "permission_prompt")
 
     @Test func recordsTheReasonOnTheCachedTerminal() throws {
-        let (app, worktreeID, terminalID) = state()
+        let (app, worktreeID, terminalID, suiteName) = state()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
         let observedAt = Date(timeIntervalSince1970: 20)
 
         app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
@@ -58,7 +65,8 @@ struct TerminalAwaitingInputDeltaTests {
     /// deliberately does not move `activityState` from the `Notification` hook
     /// either — it gates hibernation.
     @Test func leavesTheActivityFactAlone() throws {
-        let (app, worktreeID, terminalID) = state()
+        let (app, worktreeID, terminalID, suiteName) = state()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
         let before = app.terminals[worktreeID]!.first!
 
         app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
@@ -74,7 +82,8 @@ struct TerminalAwaitingInputDeltaTests {
     }
 
     @Test func retractionClearsBothColumns() throws {
-        let (app, worktreeID, terminalID) = state()
+        let (app, worktreeID, terminalID, suiteName) = state()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
         app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
             terminalID: terminalID,
             worktreeID: worktreeID,
@@ -94,7 +103,8 @@ struct TerminalAwaitingInputDeltaTests {
     }
 
     @Test func aDeltaForAnUnknownTerminalIsANoOp() {
-        let (app, worktreeID, _) = state()
+        let (app, worktreeID, _, suiteName) = state()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
 
         app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
             terminalID: UUID(),

--- a/Tests/TBDAppTests/TerminalAwaitingInputDeltaTests.swift
+++ b/Tests/TBDAppTests/TerminalAwaitingInputDeltaTests.swift
@@ -58,7 +58,7 @@ struct TerminalAwaitingInputDeltaTests {
         let terminal = try #require(app.terminals[worktreeID]?.first)
         #expect(terminal.awaitingInputReason == Self.prompt)
         #expect(terminal.awaitingInputObservedAt == observedAt)
-        #expect(WorktreeRowView.isPromptOnScreen(terminal))
+        #expect(terminal.hasPromptOnScreen)
     }
 
     /// The delta says nothing about what the session is doing, and the daemon
@@ -99,7 +99,7 @@ struct TerminalAwaitingInputDeltaTests {
         let terminal = try #require(app.terminals[worktreeID]?.first)
         #expect(terminal.awaitingInputReason == nil)
         #expect(terminal.awaitingInputObservedAt == nil)
-        #expect(!WorktreeRowView.isPromptOnScreen(terminal))
+        #expect(!terminal.hasPromptOnScreen)
     }
 
     @Test func aDeltaForAnUnknownTerminalIsANoOp() {

--- a/Tests/TBDAppTests/TerminalAwaitingInputDeltaTests.swift
+++ b/Tests/TBDAppTests/TerminalAwaitingInputDeltaTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The app mirrors the daemon's awaiting-input columns from a push, rather than
+/// deriving them or waiting for the next `terminal.list` refresh. This is what
+/// lets the sidebar show "a prompt is on screen" on the worktree the user is
+/// looking at: the `.attentionNeeded` notification that reports the same thing
+/// is auto-marked-read for every visible worktree.
+@Suite("AppState — terminalAwaitingInputChanged")
+@MainActor
+struct TerminalAwaitingInputDeltaTests {
+    private func state() -> (AppState, worktreeID: UUID, terminalID: UUID) {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        state.terminals = [
+            worktreeID: [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "@1",
+                    tmuxPaneID: "%1",
+                    label: "claude",
+                    kind: .claude,
+                    activityState: .working,
+                    activityStateSource: .hookEvent("PreToolUse"),
+                    activityStateObservedAt: Date(timeIntervalSince1970: 10)
+                )
+            ]
+        ]
+        return (state, worktreeID, terminalID)
+    }
+
+    private static let prompt = AwaitingInputReason(
+        message: "Claude needs your permission to use Bash",
+        hookEventName: "Notification",
+        notificationType: "permission_prompt")
+
+    @Test func recordsTheReasonOnTheCachedTerminal() throws {
+        let (app, worktreeID, terminalID) = state()
+        let observedAt = Date(timeIntervalSince1970: 20)
+
+        app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
+            terminalID: terminalID,
+            worktreeID: worktreeID,
+            reason: Self.prompt,
+            observedAt: observedAt)))
+
+        let terminal = try #require(app.terminals[worktreeID]?.first)
+        #expect(terminal.awaitingInputReason == Self.prompt)
+        #expect(terminal.awaitingInputObservedAt == observedAt)
+        #expect(WorktreeRowView.isPromptOnScreen(terminal))
+    }
+
+    /// The delta says nothing about what the session is doing, and the daemon
+    /// deliberately does not move `activityState` from the `Notification` hook
+    /// either — it gates hibernation.
+    @Test func leavesTheActivityFactAlone() throws {
+        let (app, worktreeID, terminalID) = state()
+        let before = app.terminals[worktreeID]!.first!
+
+        app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
+            terminalID: terminalID,
+            worktreeID: worktreeID,
+            reason: Self.prompt,
+            observedAt: Date(timeIntervalSince1970: 20))))
+
+        let after = try #require(app.terminals[worktreeID]?.first)
+        #expect(after.activityState == before.activityState)
+        #expect(after.activityStateSource == before.activityStateSource)
+        #expect(after.activityStateObservedAt == before.activityStateObservedAt)
+    }
+
+    @Test func retractionClearsBothColumns() throws {
+        let (app, worktreeID, terminalID) = state()
+        app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
+            terminalID: terminalID,
+            worktreeID: worktreeID,
+            reason: Self.prompt,
+            observedAt: Date(timeIntervalSince1970: 20))))
+
+        app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
+            terminalID: terminalID,
+            worktreeID: worktreeID,
+            reason: nil,
+            observedAt: nil)))
+
+        let terminal = try #require(app.terminals[worktreeID]?.first)
+        #expect(terminal.awaitingInputReason == nil)
+        #expect(terminal.awaitingInputObservedAt == nil)
+        #expect(!WorktreeRowView.isPromptOnScreen(terminal))
+    }
+
+    @Test func aDeltaForAnUnknownTerminalIsANoOp() {
+        let (app, worktreeID, _) = state()
+
+        app.handleDelta(.terminalAwaitingInputChanged(TerminalAwaitingInputDelta(
+            terminalID: UUID(),
+            worktreeID: worktreeID,
+            reason: Self.prompt,
+            observedAt: Date(timeIntervalSince1970: 20))))
+
+        #expect(app.terminals[worktreeID]?.first?.awaitingInputReason == nil)
+    }
+}

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -122,7 +122,7 @@ struct WorktreeRowPromptOnScreenTests {
 
     @Test(arguments: ["permission_prompt", "elicitation_dialog", "agent_needs_input"])
     func promptClassesAreRecognized(notificationType: String) {
-        #expect(WorktreeRowView.isPromptOnScreen(terminal(notificationType: notificationType)))
+        #expect(terminal(notificationType: notificationType).hasPromptOnScreen)
     }
 
     @Test func noReasonIsNoSignal() {
@@ -133,7 +133,7 @@ struct WorktreeRowPromptOnScreenTests {
             kind: .claude,
             activityState: .working)
 
-        #expect(!WorktreeRowView.isPromptOnScreen(working))
+        #expect(!working.hasPromptOnScreen)
     }
 
     /// `.doneWaiting`, `.informational`, and `.unrecognized` are not prompts.
@@ -143,11 +143,11 @@ struct WorktreeRowPromptOnScreenTests {
         "idle_prompt", "auth_success", "agent_completed", "a_brand_new_prompt_type",
     ])
     func otherClassesAreNoSignal(notificationType: String) {
-        #expect(!WorktreeRowView.isPromptOnScreen(terminal(notificationType: notificationType)))
+        #expect(!terminal(notificationType: notificationType).hasPromptOnScreen)
     }
 
     @Test func absentNotificationTypeIsNoSignal() {
-        #expect(!WorktreeRowView.isPromptOnScreen(terminal(notificationType: nil)))
+        #expect(!terminal(notificationType: nil).hasPromptOnScreen)
     }
 
     /// Parking kills the agent process, so whatever prompt was on screen went
@@ -156,12 +156,12 @@ struct WorktreeRowPromptOnScreenTests {
     /// as long as the stale columns survived.
     @Test func aParkedTerminalIsNeverPrompting() {
         var parked = terminal(notificationType: "permission_prompt")
-        #expect(WorktreeRowView.isPromptOnScreen(parked))
+        #expect(parked.hasPromptOnScreen)
 
         parked.hibernatedAt = Date(timeIntervalSince1970: 100)
 
         #expect(parked.isParked)
-        #expect(!WorktreeRowView.isPromptOnScreen(parked))
+        #expect(!parked.hasPromptOnScreen)
         #expect(!WorktreeRowView.hasPromptOnScreen(in: [parked]))
     }
 

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -150,6 +150,21 @@ struct WorktreeRowPromptOnScreenTests {
         #expect(!WorktreeRowView.isPromptOnScreen(terminal(notificationType: nil)))
     }
 
+    /// Parking kills the agent process, so whatever prompt was on screen went
+    /// with it. `.attention` outranks `.hibernated`, so without this the calm
+    /// moon would be replaced by "needs your attention" on a dead session for
+    /// as long as the stale columns survived.
+    @Test func aParkedTerminalIsNeverPrompting() {
+        var parked = terminal(notificationType: "permission_prompt")
+        #expect(WorktreeRowView.isPromptOnScreen(parked))
+
+        parked.hibernatedAt = Date(timeIntervalSince1970: 100)
+
+        #expect(parked.isParked)
+        #expect(!WorktreeRowView.isPromptOnScreen(parked))
+        #expect(!WorktreeRowView.hasPromptOnScreen(in: [parked]))
+    }
+
     @Test func collectionReportsAnyPromptOnScreen() {
         let prompt = terminal(notificationType: "permission_prompt")
         let idlePrompt = terminal(notificationType: "idle_prompt")

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -101,3 +101,61 @@ struct WorktreeRowActivityTests {
         #expect(!WorktreeRowView.hasForegroundWork(in: []))
     }
 }
+
+@Suite("WorktreeRowView — prompt on screen")
+struct WorktreeRowPromptOnScreenTests {
+    private func terminal(notificationType: String?) -> Terminal {
+        var terminal = Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            kind: .claude,
+            activityState: .working
+        )
+        terminal.awaitingInputReason = AwaitingInputReason(
+            message: "Claude needs your permission to use Bash",
+            hookEventName: "Notification",
+            notificationType: notificationType)
+        terminal.awaitingInputObservedAt = Date(timeIntervalSince1970: 1)
+        return terminal
+    }
+
+    @Test(arguments: ["permission_prompt", "elicitation_dialog", "agent_needs_input"])
+    func promptClassesAreRecognized(notificationType: String) {
+        #expect(WorktreeRowView.isPromptOnScreen(terminal(notificationType: notificationType)))
+    }
+
+    @Test func noReasonIsNoSignal() {
+        let working = Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            kind: .claude,
+            activityState: .working)
+
+        #expect(!WorktreeRowView.isPromptOnScreen(working))
+    }
+
+    /// `.doneWaiting`, `.informational`, and `.unrecognized` are not prompts.
+    /// A type this build has never heard of must NOT be guessed into the
+    /// prompt class on the strength of its spelling.
+    @Test(arguments: [
+        "idle_prompt", "auth_success", "agent_completed", "a_brand_new_prompt_type",
+    ])
+    func otherClassesAreNoSignal(notificationType: String) {
+        #expect(!WorktreeRowView.isPromptOnScreen(terminal(notificationType: notificationType)))
+    }
+
+    @Test func absentNotificationTypeIsNoSignal() {
+        #expect(!WorktreeRowView.isPromptOnScreen(terminal(notificationType: nil)))
+    }
+
+    @Test func collectionReportsAnyPromptOnScreen() {
+        let prompt = terminal(notificationType: "permission_prompt")
+        let idlePrompt = terminal(notificationType: "idle_prompt")
+
+        #expect(WorktreeRowView.hasPromptOnScreen(in: [idlePrompt, prompt]))
+        #expect(!WorktreeRowView.hasPromptOnScreen(in: [idlePrompt]))
+        #expect(!WorktreeRowView.hasPromptOnScreen(in: []))
+    }
+}

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -25,6 +25,9 @@ import TestSupport
     /// on the router's own `StateSubscriptionManager` (`broadcast` fans out
     /// synchronously, so the capture is complete once the handler returns).
     fileprivate let broadcasts: BroadcastDeltas
+    /// Shared with `activityRouter` so the retraction broadcast the activity
+    /// rail emits lands in the same collector as the notification's.
+    private let subscriptions: StateSubscriptionManager
 
     /// Pinned through the router's date seam, so the stored observed-at is an
     /// exact assertion rather than a freshness window.
@@ -36,6 +39,7 @@ import TestSupport
         let broadcasts = BroadcastDeltas()
         self.broadcasts = broadcasts
         let subscriptions = StateSubscriptionManager()
+        self.subscriptions = subscriptions
         subscriptions.addSubscriber { data in
             if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
                 broadcasts.append(delta)
@@ -104,8 +108,27 @@ import TestSupport
                 tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
+            subscriptions: subscriptions,
             now: { observedAt },
             actuationLog: makeTestActuationLog())
+    }
+
+    /// Every awaiting-input delta the collector saw, in order.
+    private func awaitingInputDeltas() -> [TerminalAwaitingInputDelta] {
+        broadcasts.snapshot().compactMap { delta in
+            if case .terminalAwaitingInputChanged(let d) = delta { return d }
+            return nil
+        }
+    }
+
+    private func sendActivity(
+        _ activityState: TerminalActivityState, at observedAt: Date
+    ) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminalID, activityState: activityState))
+        #expect(await activityRouter(observedAt: observedAt).handle(request).success)
     }
 
     /// The park decision for the current row, plus the raw activity triple —
@@ -404,6 +427,109 @@ import TestSupport
             observedAt: Self.observedAt.addingTimeInterval(1)).handle(request).success)
 
         #expect(try await terminal().awaitingInputReason == nil)
+    }
+
+    // MARK: - The awaiting-input delta
+
+    /// The sidebar reads the reason columns, not the notification row, so the
+    /// record has to reach the app by push. The notification is unread mail —
+    /// selecting a worktree marks it read, which is why the row the user was
+    /// looking at kept animating the thinking dots at a session sitting on a
+    /// permission prompt.
+    @Test func aRecordedPromptIsBroadcastAlongsideTheNotification() async throws {
+        let message = "Claude needs your permission to use Bash"
+        #expect(await notify(type: "permission_prompt", message: message).success)
+
+        let delta = try #require(awaitingInputDeltas().first)
+        #expect(awaitingInputDeltas().count == 1)
+        #expect(delta.terminalID == terminalID)
+        #expect(delta.worktreeID == worktreeID)
+        #expect(delta.observedAt == Self.observedAt)
+        #expect(delta.reason?.message == message)
+        #expect(delta.reason?.notificationType == "permission_prompt")
+        #expect(delta.reason?.classification == .promptOnScreen)
+    }
+
+    /// Every class is broadcast, not only the one the sidebar renders: the app
+    /// mirrors the columns rather than deriving them, so a `doneWaiting` that
+    /// replaces a standing prompt has to reach it too.
+    @Test func aNonPromptClassIsBroadcastToo() async throws {
+        #expect(await notify(type: "idle_prompt", message: "back at the prompt").success)
+
+        let delta = try #require(awaitingInputDeltas().first)
+        #expect(delta.reason?.classification == .doneWaiting)
+    }
+
+    /// The mirror of the write guard: a report that establishes nothing does
+    /// not change the record, so there is nothing to announce.
+    @Test func aRefusedReportBroadcastsNothing() async throws {
+        #expect(await notify(type: "permission_prompt", message: "needs permission").success)
+        #expect(awaitingInputDeltas().count == 1)
+
+        #expect(await notify(type: "agent_completed", message: "a subagent finished").success)
+
+        #expect(awaitingInputDeltas().count == 1, "the standing prompt is unchanged")
+    }
+
+    /// **The staleness case, and the reason the retraction cannot ride the
+    /// activity delta.** A permission prompt is raised in the MIDDLE of a turn,
+    /// so the session already reads `working`; the hook that fires once the
+    /// human answers reports `working` again. The handler's unchanged-state
+    /// guard drops that observation, so a reason retracted only on a *changed*
+    /// state would stay pinned to the row until the turn ended — minutes of
+    /// attention indicator for a prompt nobody is looking at.
+    @Test func aSameStateActivityObservationStillRetractsAStandingPrompt() async throws {
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(-1))
+        #expect(await notify(type: "permission_prompt").success)
+        #expect(try await terminal().awaitingInputReason != nil)
+
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(1))
+
+        let after = try await terminal()
+        #expect(after.awaitingInputReason == nil)
+        #expect(after.awaitingInputObservedAt == nil)
+        #expect(after.activityState == .working, "activityState is left exactly as it was")
+
+        let retraction = try #require(awaitingInputDeltas().last)
+        #expect(retraction.reason == nil)
+        #expect(retraction.observedAt == nil)
+        #expect(retraction.terminalID == terminalID)
+        #expect(retraction.worktreeID == worktreeID)
+    }
+
+    /// The changed-state path announces its retraction as well — the app must
+    /// not need a `terminal.list` refresh to stop showing the indicator.
+    @Test func aChangedStateActivityObservationBroadcastsTheRetraction() async throws {
+        #expect(await notify(type: "permission_prompt").success)
+
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(1))
+
+        #expect(try await terminal().awaitingInputReason == nil)
+        let retraction = try #require(awaitingInputDeltas().last)
+        #expect(retraction.reason == nil)
+    }
+
+    /// No standing reason means no retraction to announce, so an ordinary turn
+    /// boundary does not add a delta per hook event.
+    @Test func anActivityObservationWithNoStandingReasonBroadcastsNothing() async throws {
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(1))
+        try await sendActivity(.idle, at: Self.observedAt.addingTimeInterval(2))
+
+        #expect(awaitingInputDeltas().isEmpty)
+    }
+
+    /// A reason recorded AFTER the activity event was stamped is newer than the
+    /// observation superseding it, so it survives — the ordering rule
+    /// `clearAwaitingInputIfNotNewer` has always applied, now reachable on a
+    /// same-state event too.
+    @Test func aNewerReasonSurvivesAnOlderSameStateObservation() async throws {
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(-2))
+        #expect(await notify(type: "permission_prompt").success)
+
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(-1))
+
+        #expect(try await terminal().awaitingInputReason?.classification == .promptOnScreen)
+        #expect(awaitingInputDeltas().allSatisfy { $0.reason != nil })
     }
 
     /// The router's date seam reaches BOTH stamps the resolver's rung-4 decision

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -206,9 +206,10 @@ import TestSupport
         #expect(HibernationGate.blockingRail(terminal: after) == nil)
 
         // A prompt on screen is the one class a human has to act on now, so
-        // it, and only it, raises the attention notification the sidebar
-        // renders in place of the thinking dots. Every other class leaves the
-        // notification ledger and the delta stream untouched.
+        // it, and only it, raises the attention notification behind the macOS
+        // banner. Every other class leaves the notification ledger untouched.
+        // (The awaiting-input delta is broadcast for every class that is
+        // written — the app mirrors the columns — and is asserted separately.)
         let unread = try await db.notifications.unread(worktreeID: worktreeID)
         let received = broadcasts.snapshot().filter {
             if case .notificationReceived = $0 { return true }
@@ -518,18 +519,74 @@ import TestSupport
         #expect(awaitingInputDeltas().isEmpty)
     }
 
-    /// A reason recorded AFTER the activity event was stamped is newer than the
-    /// observation superseding it, so it survives — the ordering rule
-    /// `clearAwaitingInputIfNotNewer` has always applied, now reachable on a
-    /// same-state event too.
-    @Test func aNewerReasonSurvivesAnOlderSameStateObservation() async throws {
+    /// The ordering rule survives the move onto the same-state path: a reason
+    /// recorded AFTER the activity event was stamped is newer than the
+    /// observation superseding it, so it stands.
+    ///
+    /// Paired with its control, because the refusal on its own is satisfied by
+    /// simply never running the retraction at all — the shape this test had
+    /// before the control was added, which passed against a tree with no
+    /// same-state retraction in it.
+    @Test(arguments: [(-1.0, true), (1.0, false)])
+    func aSameStateObservationRetractsOnlyANotNewerReason(
+        offset: Double, survives: Bool
+    ) async throws {
         try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(-2))
         #expect(await notify(type: "permission_prompt").success)
+        #expect(awaitingInputDeltas().count == 1)
 
-        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(-1))
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(offset))
 
-        #expect(try await terminal().awaitingInputReason?.classification == .promptOnScreen)
-        #expect(awaitingInputDeltas().allSatisfy { $0.reason != nil })
+        let reason = try await terminal().awaitingInputReason
+        #expect((reason?.classification == .promptOnScreen) == survives)
+        // The retraction is announced exactly when it happened, so a tree that
+        // stopped retracting on the same-state path fails the control half
+        // rather than passing both.
+        let retractions = awaitingInputDeltas().filter { $0.reason == nil }
+        #expect(retractions.count == (survives ? 0 : 1))
+    }
+
+    /// The Codex rail retracts through `applyActivityObservation` rather than
+    /// the same-state branch, and owes the app the same announcement.
+    @Test func theCodexRailAlsoAnnouncesItsRetraction() async throws {
+        let codex = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "codex", claudeSessionID: "s-2", kind: .codex)
+        #expect(await notify(type: "permission_prompt", terminalID: codex.id).success)
+        #expect(try await db.terminals.get(id: codex.id)?.awaitingInputReason != nil)
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: codex.id, activityState: .working, sessionID: "s-2"))
+        #expect(await activityRouter(
+            observedAt: Self.observedAt.addingTimeInterval(1)).handle(request).success)
+
+        #expect(try await db.terminals.get(id: codex.id)?.awaitingInputReason == nil)
+        let retraction = try #require(awaitingInputDeltas().last)
+        #expect(retraction.reason == nil)
+        #expect(retraction.terminalID == codex.id)
+    }
+
+    /// A `/clear`, a resume, or a hand relaunch replaces the process the prompt
+    /// was raised on. The store retracts the reason; the app has to be told, or
+    /// its cached row keeps the indicator up on a session that no longer holds
+    /// the prompt.
+    @Test func aSessionStartAnnouncesItsRetraction() async throws {
+        #expect(await notify(type: "permission_prompt").success)
+        #expect(try await terminal().awaitingInputReason != nil)
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID, sessionID: "s-2",
+                transcriptPath: nil, source: "clear"))
+        #expect(await router.handle(request).success)
+
+        #expect(try await terminal().awaitingInputReason == nil)
+        let retraction = try #require(awaitingInputDeltas().last)
+        #expect(retraction.reason == nil)
+        #expect(retraction.terminalID == terminalID)
     }
 
     /// The router's date seam reaches BOTH stamps the resolver's rung-4 decision

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -451,14 +451,30 @@ import TestSupport
         #expect(delta.reason?.classification == .promptOnScreen)
     }
 
-    /// Every class is broadcast, not only the one the sidebar renders: the app
-    /// mirrors the columns rather than deriving them, so a `doneWaiting` that
-    /// replaces a standing prompt has to reach it too.
-    @Test func aNonPromptClassIsBroadcastToo() async throws {
+    /// A class that cannot change whether a prompt is up, recorded over
+    /// nothing, is not announced. This hook carries no matcher, so it fires for
+    /// every `agent_completed` a parallel subagent produces and every
+    /// 60-second `idle_prompt` across the fleet; pushing those would republish
+    /// every subscriber's terminal collection for a sidebar that cannot change.
+    @Test(arguments: ["idle_prompt", "agent_completed", "auth_success", "some_future_type"])
+    func aClassThatChangesNoPromptIsNotBroadcast(type: String) async throws {
+        #expect(await notify(type: type, message: "nothing to see").success)
+
+        #expect(try await terminal().awaitingInputReason != nil, "still recorded")
+        #expect(awaitingInputDeltas().isEmpty, "but not announced")
+    }
+
+    /// The other half: a write that DISPLACES a standing prompt takes the
+    /// indicator down, so it must be announced even though its own class is one
+    /// the sidebar never renders.
+    @Test func aClassThatDisplacesAStandingPromptIsBroadcast() async throws {
+        #expect(await notify(type: "permission_prompt").success)
+        #expect(awaitingInputDeltas().count == 1)
+
         #expect(await notify(type: "idle_prompt", message: "back at the prompt").success)
 
-        let delta = try #require(awaitingInputDeltas().first)
-        #expect(delta.reason?.classification == .doneWaiting)
+        #expect(awaitingInputDeltas().count == 2)
+        #expect(awaitingInputDeltas().last?.reason?.classification == .doneWaiting)
     }
 
     /// The mirror of the write guard: a report that establishes nothing does
@@ -510,13 +526,37 @@ import TestSupport
         #expect(retraction.reason == nil)
     }
 
-    /// No standing reason means no retraction to announce, so an ordinary turn
-    /// boundary does not add a delta per hook event.
+    /// No standing reason means no retraction to announce — on both paths.
+    /// The second pair repeats a value the row already holds, so it enters the
+    /// same-state branch rather than passing on the changed-state one.
     @Test func anActivityObservationWithNoStandingReasonBroadcastsNothing() async throws {
         try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(1))
         try await sendActivity(.idle, at: Self.observedAt.addingTimeInterval(2))
+        #expect(awaitingInputDeltas().isEmpty, "changed-state path")
 
-        #expect(awaitingInputDeltas().isEmpty)
+        #expect(try await terminal().activityState == .idle)
+        try await sendActivity(.idle, at: Self.observedAt.addingTimeInterval(3))
+        try await sendActivity(.idle, at: Self.observedAt.addingTimeInterval(4))
+
+        #expect(awaitingInputDeltas().isEmpty, "same-state path")
+    }
+
+    /// The same-state retraction must not be gated on a row read before the
+    /// handler's async work: `handleTerminalNotificationEvent` runs on its own
+    /// connection, so a prompt can commit inside that window. A gate on the
+    /// stale snapshot would skip the retraction and leave the DATABASE holding
+    /// a reason older than the newest activity observation — which no client
+    /// refresh can repair, because the database itself is then wrong.
+    @Test func aReasonRecordedAfterTheRowWasReadIsStillRetracted() async throws {
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(-2))
+        // Stands in for the concurrent commit: the row the activity handler
+        // reads has no reason, and one lands before its write.
+        #expect(await notify(type: "permission_prompt").success)
+
+        try await sendActivity(.working, at: Self.observedAt.addingTimeInterval(1))
+
+        #expect(try await terminal().awaitingInputReason == nil)
+        #expect(awaitingInputDeltas().last?.reason == nil)
     }
 
     /// The ordering rule survives the move onto the same-state path: a reason


### PR DESCRIPTION
## What's broken

A Claude session stops mid-turn and asks for permission to run a tool. In the
sidebar, that worktree's row should stop animating and show the amber "needs
your attention" hand, so a glance down the fleet finds the row that is blocked.

It does, unless the worktree is the one you have selected, or one you have
pinned. Those rows keep animating the thinking dots for as long as the prompt
is up, which is exactly backwards: the row you are looking at is the one whose
question you can answer. Field evidence was three consecutive `attention_needed`
rows for one worktree, minutes apart, all already marked read. Deterministic,
not a race.

## Why it happens

The daemon does record the fact. A `prompt_on_screen` classification writes the
terminal's awaiting-input reason and raises an `.attentionNeeded` notification
alongside it, and the sidebar's suffix slot ranks attention above working.

But a notification is unread mail, and the sidebar was reading the mail. The app
auto-marks-read every unread summary belonging to a visible worktree (selection
plus pinned terminals), and then filters visible worktrees out of the unread map
entirely; selecting a worktree fires `notifications.markRead` on top of that. So
the row got `notification: nil`, fell through to the "is any terminal working?"
branch, and drew the dots. Nothing contradicted them: `activityState` stays
`working` while a prompt is up, deliberately, because it gates hibernation.

The per-terminal fact that does describe the current wait, `awaitingInputReason`,
already rode in every `terminal.list` response and had no readers in the app.

## When it broke

Not a regression. https://github.com/cheapsteak/tbd/pull/705 added the
notification path and made the indicator correct for every worktree except the
visible ones; this finishes that work by moving the sidebar off the notification
and onto the fact.

## What this PR does

**The sidebar reads the terminal, not the mail.** `RowStatusIndicator.suffix`
takes a `hasPromptOnScreen` input that shares the `.attention` rank with the
notification reporting the same thing, and the row feeds it from its own
terminals' `awaitingInputReason`. That input is independent of notification read
state and of selection, so it survives the glance that clears the mail. Only
`.promptOnScreen` takes the slot: `.doneWaiting`, `.informational` and
`.unrecognized` are no signal, and an unknown class is never guessed into the
prompt class.

`activityState` is untouched, and the notification path is untouched: the macOS
banner, the bold name, and the unfocused row all keep working exactly as they
do today. A prompt is raised in the middle of a turn, so the session genuinely
*is* working; the slot just shows the louder of the two facts.

**Two supporting changes were needed to make the fact trustworthy.** Both are
about the reason reaching the app and then leaving again:

- **It had no push channel.** The reason columns only reached the app on a full
  `terminal.list` refresh, so a prompt could sit unannounced for as long as it
  took one to happen. New `.terminalAwaitingInputChanged` delta, broadcast from
  the `Notification` hook when a reason is written and from the activity rail
  when one is retracted. The app mirrors the two columns and writes nothing
  else, because a recorded reason says nothing about `activityState`, and the
  daemon does not assert one from that hook either.

- **Retraction could only happen on a state CHANGE.** A permission prompt is
  raised *mid-turn*, so by the time it appears the row already reads `working`,
  and any later hook reporting `working` again was dropped by
  `handleTerminalActivityEvent`'s unchanged-state guard without touching the
  reason. The conditional retraction now runs on this side of that guard, so a
  repeated activity value can retract too. It stays conditional
  (`clearAwaitingInputIfNotNewer`), so a reason newer than the observation
  superseding it still survives, and it still asserts nothing about activity.
  Read the next section before assuming this clears on the answer: for an
  ordinary permission prompt, no hook fires then at all.

## Known limitation: when the indicator goes down

**Answering an ordinary tool-permission prompt fires no hook, so the indicator
stands until the turn's `Stop`.** This is worth stating plainly because the
obvious reading of the retraction above is that it clears on the answer, and for
most prompts it does not.

`ClaudeHookOverlay.generateBody` wires `tbd terminal-activity` to exactly five
places: SessionStart, Stop, StopFailure, UserPromptSubmit, and the
PreToolUse/PostToolUse pair matched to `AskUserQuestion` (the `PostToolUse:Bash`
entry runs the PR-binding command and sends no activity). So:

- **AskUserQuestion**: its pre-hook writes `waiting_for_user` and its post-hook
  writes `working`. That is a *changed* state, which the rail has always
  retracted on, so this prompt was never in the window.
- **Bash / Edit / Write permission prompts**: nothing fires between the approval
  and the turn's `Stop`. The reason stands for the rest of the turn, and with
  `.attention` outranking `working` the row shows the raised hand rather than
  the thinking dots for that stretch.

So the same-state retraction this PR adds is narrower than it first looks: what
it reaches is a *repeated* activity value, such as a queued `UserPromptSubmit`
mid-turn, a second `Stop`, or a post-hook whose paired pre-hook was lost to a
stale `tbd` on `PATH`. It is still the only retraction available on those paths,
but it does not close the permission-prompt window.

There is also a dismissibility change worth naming. Before, `markRead` on
selection cleared the `.attentionNeeded` row, so looking at the worktree ended
the signal. `hasPromptOnScreen` is deliberately independent of read state and
of selection, so during that window the user has no gesture that dismisses it.
The window is bounded by the turn, and the alternative it replaces (dots at a
session blocked on a human, with no bound at all) is worse, but the trade is
real.

Closing it properly needs a hook that fires on a permission decision, which is
a fleet-wide per-tool-call cost and a design change: a follow-up with a spec,
not a line in a bug fix.

`SessionStateResolver`'s staleness doctrine asserted the old mechanics as fact
("a repeated same-state event does not supersede a recorded reason", "nothing on
the hook rail ever retracts the reason"), so it is corrected here too, including
the AskUserQuestion detail above.

## Why no spec

Per CLAUDE.md this is a bug fix: it restores the system to its existing theory
rather than revising it. The theory already held that a terminal's recorded wait
reason describes the current wait and that the sidebar shows the louder of a
row's facts; what was missing was transport for a fact the model already had,
and a sidebar reading the wrong carrier for it. The wire case and the two store
entry points exist to carry that fact, not to introduce a new one. The parts
that WOULD revise the theory are named above as follow-ups and deliberately not
taken: a hook on permission decisions, ranking `waitingForUser` in the suffix
slot, and widening the switcher's membership rule.

## Assumptions

- The `Notification` hook is the only writer of a `promptOnScreen` reason.
  Codex has no such hook (`CodexHomeManager` registers `PermissionRequest`,
  which writes `activityState = waiting_for_user` and no reason), so a Codex
  session on a permission prompt still shows no suffix at all. Neither does a
  Claude session on `AskUserQuestion`, whose pre-hook writes the same value.
  `waitingForUser` is the strongest machine fact TBD has for "a human is being
  waited on", and no suffix rank reads it. A real gap, but a different bug from
  this one and a wider behavior change than a fix belongs in.
- A `.doneWaiting` report (`idle_prompt`) still displaces a standing
  `.promptOnScreen`, which is pre-existing store behavior with its own test and
  rationale. If Claude Code emits `idle_prompt` while a modal permission prompt
  is up, that would take the indicator down early. Worth confirming in the
  field; changing it is a supervision-semantics decision, not a bug fix.
- Activity RPCs carry no `cwd`, so unlike the notification and session hooks
  they are not checked against the terminal's worktree. A nested process in the
  pane that inherited `TBD_TERMINAL_ID` and fires its own activity hook can now
  retract a not-newer reason where before an unchanged-state event was a no-op.
  If that becomes real, the fix is a `cwd` on `TerminalActivityEventParams` and
  the same `hookCWDBelongsToTerminal` guard the other two handlers use.
- A row is "prompting" if *any* of its non-parked terminals is, matching how
  `hasWorkingTerminal` already collapses a multi-terminal worktree onto one
  suffix glyph.
- The jump menu shows the indicator and bolds, but the flag does not affect row
  inclusion or ordering: membership comes from the unread map and the in-memory
  recents list, and the first sort key is unread severity. A pinned,
  never-selected, prompting worktree after an app relaunch is in neither map and
  produces no row at all. Worth a follow-up; widening the switcher's membership
  rule is more than this fix should carry.

## Evidence & verification

The discriminating tests, each failing before this change:

- `RowStatusIndicatorTests`: a `promptOnScreen` row with `isWorking: true` and
  `notification: nil` (the bug's exact state, post-auto-mark-read) resolves to
  `.attention`, not `.working`; a working row *without* a prompt still resolves
  to `.working`; error still outranks the prompt; and the plain
  `.attentionNeeded` notification path still resolves to `.attention` on its
  own, so the non-selected row is unchanged.
- `WorktreeRowActivityTests`: all three prompt-class `notification_type`s are
  recognized; `idle_prompt`, `auth_success`, `agent_completed`, an absent type,
  and a type this build has never heard of are all no signal.
- `NotificationHookRPCTests`, through the real router, real database and a real
  broadcast subscriber: the recorded reason is broadcast; a report the write
  guard refuses broadcasts nothing; **a same-state `working` observation retracts
  a standing prompt and announces it, while leaving `activityState` exactly as it
  was** (the retraction-was-too-late case above); a reason newer than the
  observation survives; and an activity event with no standing reason adds no
  delta.
- `TerminalAwaitingInputDeltaTests`: the app mirrors both columns from the
  delta, clears them on a retraction, leaves the activity triple untouched, and
  ignores a delta for a terminal it does not hold.
- Also covered after review: the same-state retraction is run against both
  halves of its ordering rule (a not-newer reason is retracted, a newer one is
  not) so the refusal is discriminating rather than satisfied by never running;
  the Codex rail's retraction broadcast; SessionStart's retraction broadcast;
  a parked terminal never counting as prompting; bolding; the jump menu across
  all three of its sections; and two publish-frequency ratchet cases for the
  new delta.

`scripts/swift-safe build` is clean, `swiftlint --strict` reports 0 violations,
and `scripts/test.sh` passes. The failures the full run produces
(`an earlier idle hook cannot erase a later explicit interrupt`,
`virtualTimeoutReturnsTimedOutAndKillsChild`, and the replay firehose matrix
test) are load-sensitive flakes that reproduce identically on the unmodified
parent commit.

One more pre-existing flake was diagnosed on the way and deliberately not fixed
here, since it is unrelated to this change: `user interrupt replaces provenance
when raw state is already idle` fails intermittently on unmodified `origin/main`
(1 failure in 3 runs of its own suite alone). Its setup calls `setActivityState`
with the default `observedAt = Date()` and the router then stamps its own
`Date()`; GRDB persists dates at millisecond precision, so when the two land in
the same millisecond the stored order watermark can round above the incoming
stamp and the observation is rejected as stale. Passing an explicit `observedAt`
in the setup would fix it.

Not live-verified in the running app: driving a real session onto a permission
prompt was not exercised here. The rendering path this touches is the two-line
switch that maps the suffix enum to a glyph, and both the resolver feeding it
and the delta feeding that are covered above.

**Most of this is an app-side change.** `scripts/restart.sh` builds the debug bundle
only, so a running installed `/Applications/TBD.app` needs a rebuild and
reinstall to pick it up.

[20260824-breakable-cephalopod](https://cheapsteak.github.io/tbd/open/?worktree=B10AB14A-DC60-4E46-A1C5-115BC85F93C4)
