### PR TITLE
Add a setting for automatic Notes tabs

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -16,7 +16,7 @@ extension AppState {
     /// Refresh the full model profile list and global default ID from the daemon.
     func loadModelProfiles() async {
         do {
-            let result = try await daemonClient.listModelProfiles()
+            let result = try await modelProfilesFetcher()
             if result.profiles != modelProfiles {
                 modelProfiles = result.profiles
             }
@@ -37,6 +37,9 @@ extension AppState {
             }
             if result.gcEnabled != gcEnabled {
                 gcEnabled = result.gcEnabled
+            }
+            if result.autoCreateNotesEnabled != autoCreateNotesEnabled {
+                autoCreateNotesEnabled = result.autoCreateNotesEnabled
             }
             if result.nightwatchMode != nightwatchMode {
                 nightwatchMode = result.nightwatchMode
@@ -202,6 +205,17 @@ extension AppState {
         } catch {
             logger.error("Failed to set gcEnabled: \(error, privacy: .public)")
             showAlert("Failed to update GC setting: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set whether ordinary new worktrees start with an empty Notes tab.
+    func setAutoCreateNotesEnabled(_ enabled: Bool) async {
+        do {
+            try await autoCreateNotesSetter(enabled)
+            autoCreateNotesEnabled = enabled
+        } catch {
+            logger.error("Failed to set automatic Notes creation: \(error, privacy: .public)")
+            showAlert("Failed to update Notes setting: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -829,6 +829,9 @@ final class AppState: ObservableObject {
     /// `Config.gcEnabled`). Loaded from the daemon alongside
     /// `autoArchiveOnMergeDefault` via `loadModelProfiles()`.
     @Published var gcEnabled: Bool = true
+    /// Whether ordinary new worktrees start with an empty Notes tab. Loaded
+    /// from the daemon alongside the other config-backed worktree defaults.
+    @Published var autoCreateNotesEnabled: Bool = Config.autoCreateNotesDefault
     @Published var nightwatchMode: NightwatchMode = .off
     /// Auto-hibernate master switch. Loaded from the daemon `Config` via
     /// `loadHibernationConfig()`.
@@ -1238,6 +1241,11 @@ final class AppState: ObservableObject {
     /// Published so the Settings control-mode toggle re-renders after
     /// `setControlModeEnabled` refreshes it.
     @Published var daemonCapabilities: DaemonCapabilitiesResult?
+    /// How `loadModelProfiles()` fetches its config-bearing response.
+    /// Injectable because `DaemonClient` is concrete, matching the other
+    /// settings seams below.
+    lazy var modelProfilesFetcher: @MainActor () async throws -> ModelProfileListResult =
+        { [daemonClient] in try await daemonClient.listModelProfiles() }
     /// How `refreshDaemonCapabilities()` fetches — injectable because
     /// `DaemonClient` is concrete (no protocol), so state-level tests stub the
     /// RPC here. Production default asks the daemon; nil result = fetch failed.
@@ -1273,6 +1281,10 @@ final class AppState: ObservableObject {
     /// same reason as `controlModeSetter`.
     lazy var autoTrustWorktreesSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setAutoTrustWorktrees(enabled: enabled) }
+    /// How the automatic Notes preference is persisted — injectable for the
+    /// same reason as `controlModeSetter`.
+    lazy var autoCreateNotesSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in try await daemonClient.setAutoCreateNotes(enabled: enabled) }
     /// How `setQueuedPromptEnabled` persists the queued-prompt soak flag —
     /// injectable for the same reason as `controlModeSetter`.
     lazy var queuedPromptFlagSetter: @MainActor (Bool) async throws -> Void =

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -981,6 +981,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set whether ordinary new worktrees start with an empty Notes tab.
+    func setAutoCreateNotes(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoCreateNotes,
+            params: ConfigSetAutoCreateNotesParams(enabled: enabled)
+        )
+    }
+
     /// Persist supervision's fleet-wide authority switch (design 2026-07-26
     /// §3, §7). `enabled: true` releases the fleet brake; `false` engages it.
     /// Shipped OFF (braked); for now inert, since the rest of the supervision

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -163,6 +163,12 @@ struct GeneralSettingsTab: View {
                 Toggle("Send first messages immediately", isOn: $sendFirstMessageImmediately)
                     .help("Default for first messages you write while a new worktree is coming up. On: TBD presses Return, and the agent starts working the moment the message is in. Off: the text waits in the composer for you to read and send. The \"Send immediately\" checkbox in that creation sheet changes this too; the identical-looking checkbox on an already-parked message edits only that message.")
 
+                Toggle("Create a Notes tab for new worktrees", isOn: Binding(
+                    get: { appState.autoCreateNotesEnabled },
+                    set: { newValue in Task { await appState.setAutoCreateNotesEnabled(newValue) } }
+                ))
+                .help("Turn this off to skip empty Notes tabs in ordinary new worktrees. Restored or revived conversations still receive their populated note.")
+
                 Toggle("Automatically clean up orphaned agent worktrees", isOn: Binding(
                     get: { appState.gcEnabled },
                     set: { newValue in Task { await appState.setGCEnabled(newValue) } }

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -31,6 +31,10 @@ struct SettingsView: View {
 // MARK: - General Tab
 
 struct GeneralSettingsTab: View {
+    static let autoCreateNotesHelp =
+        "Turn this off to skip empty Notes tabs in ordinary new worktrees. " +
+        "Conversations revived on a fresh branch still receive their populated provenance note."
+
     @EnvironmentObject var appState: AppState
     @AppStorage("enableNotifications") private var enableNotifications: Bool = true
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
@@ -167,7 +171,7 @@ struct GeneralSettingsTab: View {
                     get: { appState.autoCreateNotesEnabled },
                     set: { newValue in Task { await appState.setAutoCreateNotesEnabled(newValue) } }
                 ))
-                .help("Turn this off to skip empty Notes tabs in ordinary new worktrees. Restored or revived conversations still receive their populated note.")
+                .help(Self.autoCreateNotesHelp)
 
                 Toggle("Automatically clean up orphaned agent worktrees", isOn: Binding(
                     get: { appState.gcEnabled },

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -49,6 +49,11 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// default, so `nil` here means "never chose" rather than "off". Resolve it
     /// through `Config.queuedPromptDefault`, never through `?? false`.
     var queued_prompt_enabled: Bool?
+    /// Whether ordinary new worktrees start with an empty Notes tab.
+    /// **Genuinely tri-state**: the backing migration carries no SQL default,
+    /// so `nil` means "never chose" and resolves through
+    /// `Config.autoCreateNotesDefault`.
+    var auto_create_notes_enabled: Bool?
     /// The fleet supervision brake (design 2026-07-26 §3, §7). **Genuinely
     /// tri-state**, same shape as `queued_prompt_enabled`: the
     /// `v75_config_supervision_enabled` column carries no SQL default, so
@@ -80,6 +85,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   `queued_prompt_enabled` resolves to. Defaulted to the real constant;
     ///   the parameter exists so tests can prove that NULL *follows* a changed
     ///   default while an explicit `false` does not.
+    /// - Parameter autoCreateNotesDefault: same shape, for
+    ///   `auto_create_notes_enabled` — the parameter proves that an untouched
+    ///   preference follows the shipped default while explicit choices stick.
     /// - Parameter supervisionEnabledDefault: same shape, for
     ///   `supervision_enabled` — the parameter exists so tests can prove the
     ///   same NULL-follows/explicit-sticks property for the fleet brake
@@ -95,6 +103,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   gate.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
+        autoCreateNotesDefault: Bool = Config.autoCreateNotesDefault,
         supervisionEnabledDefault: Bool = Config.supervisionEnabledDefault,
         gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault,
         claudeCloudEnabledDefault: Bool = Config.claudeCloudEnabledDefault,
@@ -142,6 +151,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // means "never chose" and must resolve to the shipped default —
             // that is the whole point of v70_config_queued_prompt.
             queuedPromptEnabled: queued_prompt_enabled ?? queuedPromptDefault,
+            autoCreateNotesEnabled: auto_create_notes_enabled ?? autoCreateNotesDefault,
             // Same reasoning, for the fleet supervision brake — NOT `?? false`.
             supervisionEnabled: supervision_enabled ?? supervisionEnabledDefault,
             // Same reasoning again, for the profile-dir collector's gate —
@@ -395,6 +405,17 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET queued_prompt_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist whether ordinary new worktrees start with an empty Notes tab.
+    /// Writing either value records an explicit choice, distinct from NULL.
+    public func setAutoCreateNotes(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_create_notes_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Migrations/20260824214437_auto_create_notes_setting.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260824214437_auto_create_notes_setting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE config ADD COLUMN auto_create_notes_enabled INTEGER;

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -525,15 +525,12 @@ extension WorktreeLifecycle {
                         carryover: carryover,
                         preparedCodexLaunch: preparedCodexLaunch
                     )
-                    // Fresh creates get an initial note tab, appended after the
-                    // primary spawn set the tab order. Create path only — a
-                    // revive's surviving note rows re-materialize via the app's
-                    // reconcile instead. Best-effort: if the worktree row
-                    // vanished mid-wait, the note insert FK-fails and is logged.
-                    await createInitialNoteTab(
-                        worktreeID: worktree.id,
-                        seed: carryover?.notesSeed
-                    )
+                    if let carryover {
+                        await createCarryoverNoteTab(
+                            worktreeID: worktree.id,
+                            seed: carryover.notesSeed
+                        )
+                    }
                 }
                 return .preSessionPending(phase3: phase3)
             }
@@ -558,12 +555,14 @@ extension WorktreeLifecycle {
             let terminalSpawnElapsedMs = terminalSpawnStart.duration(to: clock.now) / .milliseconds(1)
             timingLogger.debug("terminal-spawn \(worktreeID.uuidString, privacy: .public) \(Int(terminalSpawnElapsedMs))ms")
 
-            // 3c. Fresh repo-backed creates get an initial note tab (appended
-            // last; the primary terminal keeps focus).
-            await createInitialNoteTab(
-                worktreeID: worktreeID,
-                seed: carryover?.notesSeed
-            )
+            // 3c. A conversation carryover gets a seeded provenance note,
+            // appended last while the primary terminal keeps focus.
+            if let carryover {
+                await createCarryoverNoteTab(
+                    worktreeID: worktreeID,
+                    seed: carryover.notesSeed
+                )
+            }
 
             // 4. Update status to active
             let markActiveStart = clock.now
@@ -582,29 +581,26 @@ extension WorktreeLifecycle {
         }
     }
 
-    /// Creates the initial "Notes" tab for a freshly created repo-backed
-    /// worktree and appends it to the tab order (last; the primary terminal
-    /// keeps focus). Ordinary creates leave the note empty; callers may provide
-    /// a seed for flows whose initial Notes should carry context. The app
-    /// materializes the tab from the note row via its `reconcileNoteTabs` poll
-    /// — note tabs use the note row's UUID as the tab ID. Best-effort: a failure
-    /// (e.g. the worktree row vanished mid-create, FK-failing the insert) must
-    /// never fail the create, whose checkout and terminals are already valid.
-    func createInitialNoteTab(worktreeID: UUID, seed: String? = nil) async {
+    /// Creates the seeded provenance note for a conversation carryover and
+    /// appends it to the tab order (last; the primary terminal keeps focus).
+    /// The app materializes the tab from the note row via its
+    /// `reconcileNoteTabs` poll — note tabs use the note row's UUID as the tab
+    /// ID. Best-effort: a failure (e.g. the worktree row vanished mid-create,
+    /// FK-failing the insert) must never fail the create, whose checkout and
+    /// terminals are already valid.
+    func createCarryoverNoteTab(worktreeID: UUID, seed: String) async {
         do {
             let note = try await db.notes.create(worktreeID: worktreeID, title: "Notes")
-            if let seed {
-                _ = try await db.notes.update(
-                    id: note.id,
-                    title: note.title,
-                    content: seed
-                )
-            }
+            _ = try await db.notes.update(
+                id: note.id,
+                title: note.title,
+                content: seed
+            )
             var order = try await db.worktrees.getTabOrder(worktreeID: worktreeID)
             order.append(note.id)
             try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: order)
         } catch {
-            logger.warning("failed to create initial note tab for \(worktreeID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.warning("failed to create carryover note tab for \(worktreeID, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -249,6 +249,8 @@ extension WorktreeLifecycle {
             let clock = ContinuousClock()
             let phaseStart = clock.now
             let creationConfig = try await db.config.get()
+            let shouldCreateInitialNote = carryover != nil
+                || creationConfig.autoCreateNotesEnabled
             let creationPrimaryKind: TerminalKind = carryover == nil
                 ? resolvePrimaryTerminalKind(
                     skipClaude: skipClaude,
@@ -525,10 +527,10 @@ extension WorktreeLifecycle {
                         carryover: carryover,
                         preparedCodexLaunch: preparedCodexLaunch
                     )
-                    if let carryover {
-                        await createCarryoverNoteTab(
+                    if shouldCreateInitialNote {
+                        await createInitialNoteTab(
                             worktreeID: worktree.id,
-                            seed: carryover.notesSeed
+                            seed: carryover?.notesSeed
                         )
                     }
                 }
@@ -555,12 +557,13 @@ extension WorktreeLifecycle {
             let terminalSpawnElapsedMs = terminalSpawnStart.duration(to: clock.now) / .milliseconds(1)
             timingLogger.debug("terminal-spawn \(worktreeID.uuidString, privacy: .public) \(Int(terminalSpawnElapsedMs))ms")
 
-            // 3c. A conversation carryover gets a seeded provenance note,
-            // appended last while the primary terminal keeps focus.
-            if let carryover {
-                await createCarryoverNoteTab(
+            // 3c. Conversation carryover always gets a seeded provenance note;
+            // ordinary creates get an empty note only when configured. Either
+            // is appended last while the primary terminal keeps focus.
+            if shouldCreateInitialNote {
+                await createInitialNoteTab(
                     worktreeID: worktreeID,
-                    seed: carryover.notesSeed
+                    seed: carryover?.notesSeed
                 )
             }
 
@@ -581,26 +584,29 @@ extension WorktreeLifecycle {
         }
     }
 
-    /// Creates the seeded provenance note for a conversation carryover and
-    /// appends it to the tab order (last; the primary terminal keeps focus).
-    /// The app materializes the tab from the note row via its
+    /// Creates an initial Notes tab and appends it to the tab order (last; the
+    /// primary terminal keeps focus). Ordinary creates leave it empty; a
+    /// conversation carryover supplies the populated provenance seed. The app
+    /// materializes the tab from the note row via its
     /// `reconcileNoteTabs` poll — note tabs use the note row's UUID as the tab
     /// ID. Best-effort: a failure (e.g. the worktree row vanished mid-create,
     /// FK-failing the insert) must never fail the create, whose checkout and
     /// terminals are already valid.
-    func createCarryoverNoteTab(worktreeID: UUID, seed: String) async {
+    func createInitialNoteTab(worktreeID: UUID, seed: String? = nil) async {
         do {
             let note = try await db.notes.create(worktreeID: worktreeID, title: "Notes")
-            _ = try await db.notes.update(
-                id: note.id,
-                title: note.title,
-                content: seed
-            )
+            if let seed {
+                _ = try await db.notes.update(
+                    id: note.id,
+                    title: note.title,
+                    content: seed
+                )
+            }
             var order = try await db.worktrees.getTabOrder(worktreeID: worktreeID)
             order.append(note.id)
             try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: order)
         } catch {
-            logger.warning("failed to create carryover note tab for \(worktreeID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.warning("failed to create initial note tab for \(worktreeID, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -138,6 +138,16 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist whether ordinary new worktrees start with an empty Notes tab.
+    /// The create lifecycle snapshots this setting per creation, so the change
+    /// applies to the next worktree without a daemon restart.
+    func handleConfigSetAutoCreateNotes(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoCreateNotesParams.self, from: paramsData)
+        try await db.config.setAutoCreateNotes(params.enabled)
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the Claude cloud sessions gate (design 2026-08-15 §7).
     ///
     /// The daemon builds its provider manager, and registers the built-in

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -61,7 +61,8 @@ extension RPCRouter {
             nightwatchMode: config.nightwatchMode,
             autoResumeOnLimitReset: config.autoResumeOnLimitReset,
             autoResumeOnApiError: config.autoResumeOnApiError,
-            gcEnabled: config.gcEnabled
+            gcEnabled: config.gcEnabled,
+            autoCreateNotesEnabled: config.autoCreateNotesEnabled
         ))
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -620,6 +620,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetQueuedPrompt(request.paramsData)
             case RPCMethod.configSetClaudeCloud:
                 return try await handleConfigSetClaudeCloud(request.paramsData)
+            case RPCMethod.configSetAutoCreateNotes:
+                return try await handleConfigSetAutoCreateNotes(request.paramsData)
             case RPCMethod.configSetAutoCloseSetup:
                 return try await handleConfigSetAutoCloseSetup(request.paramsData)
             case RPCMethod.configSetAutoTrustWorktrees:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1269,6 +1269,13 @@ public struct Config: Codable, Sendable, Equatable {
     /// chose" and follows the shipped default wherever it goes; `0`/`1` is an
     /// explicit gesture and is honored forever.
     public var queuedPromptEnabled: Bool
+    /// Whether ordinary new worktrees start with an empty Notes tab.
+    ///
+    /// **Resolved, not stored.** The backing column carries no SQL default and
+    /// stays NULL until somebody touches the toggle, so this property is
+    /// `auto_create_notes_enabled ?? Config.autoCreateNotesDefault`. NULL
+    /// follows the shipped default; `0`/`1` remains an explicit choice.
+    public var autoCreateNotesEnabled: Bool
     /// The fleet brake for supervision
     /// (`docs/specs/2026-07-26-fleet-supervision-design.md` §3, §8): one bit,
     /// fleet-wide, ANDed over every project's mark and writing none of them.
@@ -1342,6 +1349,9 @@ public struct Config: Codable, Sendable, Equatable {
     /// the feature is a change to this constant — no forcing `UPDATE`
     /// migration, and an explicit opt-out is left alone.
     public static let queuedPromptDefault = false
+    /// The shipped default for `autoCreateNotesEnabled`. Existing behavior is
+    /// preserved until a user explicitly turns automatic Notes tabs off.
+    public static let autoCreateNotesDefault = true
     /// The shipped default for `supervisionEnabled`, and the single place it
     /// lives. Supervision ships with the brake engaged; graduating it is a
     /// change to this constant — no forcing `UPDATE` migration, and an explicit
@@ -1388,6 +1398,7 @@ public struct Config: Codable, Sendable, Equatable {
                 remoteBackendsEnabled: Bool = false,
                 deliveryVerificationEnabled: Bool = false,
                 queuedPromptEnabled: Bool = Config.queuedPromptDefault,
+                autoCreateNotesEnabled: Bool = Config.autoCreateNotesDefault,
                 supervisionEnabled: Bool = Config.supervisionEnabledDefault,
                 gcProfileDirsEnabled: Bool = Config.gcProfileDirsEnabledDefault,
                 claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault,
@@ -1418,6 +1429,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.remoteBackendsEnabled = remoteBackendsEnabled
         self.deliveryVerificationEnabled = deliveryVerificationEnabled
         self.queuedPromptEnabled = queuedPromptEnabled
+        self.autoCreateNotesEnabled = autoCreateNotesEnabled
         self.supervisionEnabled = supervisionEnabled
         self.gcProfileDirsEnabled = gcProfileDirsEnabled
         self.claudeCloudEnabled = claudeCloudEnabled
@@ -1480,6 +1492,8 @@ public struct Config: Codable, Sendable, Equatable {
         // fall through to the shipped default rather than hardcoding `false`.
         queuedPromptEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .queuedPromptEnabled) ?? Config.queuedPromptDefault
+        autoCreateNotesEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .autoCreateNotesEnabled) ?? Config.autoCreateNotesDefault
         // Same tri-state as above: absent means the sender knew nothing about
         // the flag, which is the NULL column's situation — follow the shipped
         // default rather than hardcoding `false` here as well.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -261,6 +261,7 @@ public enum RPCMethod {
     public static let configSetDeliveryVerification = "config.setDeliveryVerification"
     public static let configSetQueuedPrompt = "config.setQueuedPrompt"
     public static let configSetClaudeCloud = "config.setClaudeCloud"
+    public static let configSetAutoCreateNotes = "config.setAutoCreateNotes"
     public static let configSetSupervisionEnabled = "config.setSupervisionEnabled"
     public static let superviseStatus = "supervise.status"
     public static let superviseSetProjectMark = "supervise.setProjectMark"
@@ -750,6 +751,8 @@ public struct ModelProfileListResult: Codable, Sendable {
     public let autoResumeOnApiError: Bool
     /// The orphan-GC master switch (config mirror, default true).
     public let gcEnabled: Bool
+    /// Whether ordinary new worktrees start with an empty Notes tab.
+    public let autoCreateNotesEnabled: Bool
     public init(
         profiles: [ModelProfileWithUsage],
         defaultID: UUID? = nil,
@@ -760,7 +763,8 @@ public struct ModelProfileListResult: Codable, Sendable {
         nightwatchMode: NightwatchMode = .off,
         autoResumeOnLimitReset: Bool = false,
         autoResumeOnApiError: Bool = false,
-        gcEnabled: Bool = true
+        gcEnabled: Bool = true,
+        autoCreateNotesEnabled: Bool = Config.autoCreateNotesDefault
     ) {
         self.profiles = profiles
         self.defaultID = defaultID
@@ -772,6 +776,7 @@ public struct ModelProfileListResult: Codable, Sendable {
         self.autoResumeOnLimitReset = autoResumeOnLimitReset
         self.autoResumeOnApiError = autoResumeOnApiError
         self.gcEnabled = gcEnabled
+        self.autoCreateNotesEnabled = autoCreateNotesEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -797,6 +802,9 @@ public struct ModelProfileListResult: Codable, Sendable {
         autoResumeOnApiError = try c.decodeIfPresent(
             Bool.self, forKey: .autoResumeOnApiError) ?? false
         gcEnabled = try c.decodeIfPresent(Bool.self, forKey: .gcEnabled) ?? true
+        autoCreateNotesEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .autoCreateNotesEnabled
+        ) ?? Config.autoCreateNotesDefault
     }
 }
 
@@ -2118,6 +2126,14 @@ public struct ConfigSetDeliveryVerificationParams: Codable, Sendable {
 /// until this verb writes to it, and a written `false` stays off even after the
 /// shipped default graduates.
 public struct ConfigSetQueuedPromptParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setAutoCreateNotes` — the default-ON preference for
+/// adding an empty Notes tab to ordinary new worktrees. Conversation carryover
+/// creates its populated provenance note independently of this preference.
+public struct ConfigSetAutoCreateNotesParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Tests/TBDAppTests/AutoCreateNotesSettingTests.swift
+++ b/Tests/TBDAppTests/AutoCreateNotesSettingTests.swift
@@ -63,4 +63,13 @@ struct AutoCreateNotesSettingTests {
         #expect(state.alertIsError)
         #expect(state.alertMessage != nil)
     }
+
+    @Test("help text names only fresh-branch conversation revival")
+    func helpTextNamesPreciseException() {
+        #expect(
+            GeneralSettingsTab.autoCreateNotesHelp ==
+                "Turn this off to skip empty Notes tabs in ordinary new worktrees. " +
+                "Conversations revived on a fresh branch still receive their populated provenance note."
+        )
+    }
 }

--- a/Tests/TBDAppTests/AutoCreateNotesSettingTests.swift
+++ b/Tests/TBDAppTests/AutoCreateNotesSettingTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@Suite("Automatic Notes setting")
+@MainActor
+struct AutoCreateNotesSettingTests {
+    @Test("defaults to creating Notes tabs")
+    func defaultsEnabled() {
+        let state = AppState()
+
+        #expect(state.autoCreateNotesEnabled)
+    }
+
+    @Test("loads a disabled preference from the config-bearing response")
+    func loadsDisabledPreference() async {
+        let state = AppState()
+        state.modelProfilesFetcher = {
+            ModelProfileListResult(profiles: [], autoCreateNotesEnabled: false)
+        }
+
+        await state.loadModelProfiles()
+
+        #expect(!state.autoCreateNotesEnabled)
+    }
+
+    @Test("loads an enabled preference from the config-bearing response")
+    func loadsEnabledPreference() async {
+        let state = AppState()
+        state.autoCreateNotesEnabled = false
+        state.modelProfilesFetcher = {
+            ModelProfileListResult(profiles: [], autoCreateNotesEnabled: true)
+        }
+
+        await state.loadModelProfiles()
+
+        #expect(state.autoCreateNotesEnabled)
+    }
+
+    @Test("successful update changes the local mirror")
+    func successfulUpdateChangesMirror() async {
+        let state = AppState()
+        state.autoCreateNotesEnabled = true
+        state.autoCreateNotesSetter = { _ in }
+
+        await state.setAutoCreateNotesEnabled(false)
+
+        #expect(!state.autoCreateNotesEnabled)
+    }
+
+    @Test("failed update keeps the local mirror")
+    func failedUpdateKeepsMirror() async {
+        struct Rejected: Error {}
+
+        let state = AppState()
+        state.autoCreateNotesEnabled = true
+        state.autoCreateNotesSetter = { _ in throw Rejected() }
+
+        await state.setAutoCreateNotesEnabled(false)
+
+        #expect(state.autoCreateNotesEnabled)
+        #expect(state.alertIsError)
+        #expect(state.alertMessage != nil)
+    }
+}

--- a/Tests/TBDDaemonTests/AutoCreateNotesRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoCreateNotesRPCTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+private final class AutoCreateNotesBroadcastRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock()
+        defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock()
+        defer { lock.unlock() }
+        return deltas
+    }
+}
+
+@Suite("Auto-create notes RPC")
+struct AutoCreateNotesRPCTests {
+    private func makeRouter(
+        db: TBDDatabase,
+        subscriptions: StateSubscriptionManager = StateSubscriptionManager()
+    ) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subscriptions,
+            actuationLog: makeTestActuationLog()
+        )
+    }
+
+    @Test("setter persists both values and broadcasts each change")
+    func setterPersistsAndBroadcasts() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let subscriptions = StateSubscriptionManager()
+        let recorder = AutoCreateNotesBroadcastRecorder()
+        subscriptions.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                recorder.append(delta)
+            }
+            return true
+        }
+        let router = makeRouter(db: db, subscriptions: subscriptions)
+
+        for enabled in [false, true] {
+            let request = try RPCRequest(
+                method: RPCMethod.configSetAutoCreateNotes,
+                params: ConfigSetAutoCreateNotesParams(enabled: enabled)
+            )
+            let response = await router.handle(request)
+            #expect(response.success)
+            #expect(try await db.config.get().autoCreateNotesEnabled == enabled)
+        }
+
+        let broadcasts = recorder.snapshot().filter {
+            if case .modelProfilesChanged = $0 { return true }
+            return false
+        }
+        #expect(broadcasts.count == 2)
+    }
+
+    @Test("model-profile list carries the resolved setting")
+    func modelProfileListCarriesSetting() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoCreateNotes(false)
+        let router = makeRouter(db: db)
+
+        let response = await router.handle(RPCRequest(method: RPCMethod.modelProfileList))
+        #expect(response.success)
+        let result = try response.decodeResult(ModelProfileListResult.self)
+        #expect(result.autoCreateNotesEnabled == false)
+    }
+
+    @Test("legacy model-profile list JSON defaults automatic notes on")
+    func legacyListDefaultsOn() throws {
+        let json = Data(#"{"profiles":[],"globalEnvOverrides":{}}"#.utf8)
+        let result = try JSONDecoder().decode(ModelProfileListResult.self, from: json)
+        #expect(result.autoCreateNotesEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/AutoCreateNotesSchemaTests.swift
+++ b/Tests/TBDDaemonTests/AutoCreateNotesSchemaTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("Auto-create notes config schema")
+struct AutoCreateNotesSchemaTests {
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { connection in
+            try ConfigRecord.fetchOne(connection, key: ConfigStore.singletonID)
+        }
+    }
+
+    @Test("migration adds a nullable column without a schema default")
+    func migrationKeepsNeverChosenDistinct() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let column = try db.writerForTests.read { connection in
+            return try Row.fetchAll(connection, sql: "PRAGMA table_info(config)")
+                .first { ($0["name"] as String) == "auto_create_notes_enabled" }
+        }
+
+        let required = try #require(column)
+        #expect((required["notnull"] as Int) == 0)
+        #expect((required["dflt_value"] as DatabaseValue).isNull)
+
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(record.auto_create_notes_enabled == nil)
+    }
+
+    @Test("NULL follows the injected default")
+    func nullFollowsInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", auto_create_notes_enabled: nil)
+
+        #expect(record.toModel(autoCreateNotesDefault: false).autoCreateNotesEnabled == false)
+        #expect(record.toModel(autoCreateNotesDefault: true).autoCreateNotesEnabled == true)
+    }
+
+    @Test("explicit false and true persist independently of the shipped default")
+    func explicitValuesPersist() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        try await db.config.setAutoCreateNotes(false)
+        var record = try #require(try await fetchConfigRecord(db))
+        #expect(record.auto_create_notes_enabled == false)
+        #expect(record.toModel(autoCreateNotesDefault: true).autoCreateNotesEnabled == false)
+        #expect(record.toModel(autoCreateNotesDefault: false).autoCreateNotesEnabled == false)
+
+        try await db.config.setAutoCreateNotes(true)
+        record = try #require(try await fetchConfigRecord(db))
+        #expect(record.auto_create_notes_enabled == true)
+        #expect(record.toModel(autoCreateNotesDefault: true).autoCreateNotesEnabled == true)
+        #expect(record.toModel(autoCreateNotesDefault: false).autoCreateNotesEnabled == true)
+    }
+
+    @Test("the shipped default preserves automatic Notes tabs")
+    func shippedDefaultIsOn() async throws {
+        #expect(Config.autoCreateNotesDefault == true)
+        #expect(Config().autoCreateNotesEnabled == true)
+
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().autoCreateNotesEnabled == true)
+    }
+
+    @Test("legacy Config JSON defaults the setting on")
+    func legacyJSONDefaultsOn() throws {
+        let config = try JSONDecoder().decode(Config.self, from: Data("{}".utf8))
+        #expect(config.autoCreateNotesEnabled == true)
+    }
+
+    @Test("Config JSON round-trips explicit values", arguments: [false, true])
+    func configJSONRoundTrips(_ enabled: Bool) throws {
+        let encoded = try JSONEncoder().encode(Config(autoCreateNotesEnabled: enabled))
+        let decoded = try JSONDecoder().decode(Config.self, from: encoded)
+        #expect(decoded.autoCreateNotesEnabled == enabled)
+    }
+}

--- a/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
+++ b/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
@@ -9,10 +9,10 @@ import Testing
 // TBD_HOME mutation) so hook resolution and runtime dirs never touch the
 // developer's real ~/tbd. See TBDHomeSerializedSuites.swift.
 extension TBDHomeSerialized {
-@Suite("Initial note tab on worktree create")
+@Suite("No default note tab on worktree create")
 struct NoteTabOnCreateTests {
 
-    @Test func createAppendsNotesTabLast() async throws {
+    @Test func ordinaryCreateDoesNotCreateNotesTab() async throws {
         let (_, cleanup) = isolateTBDHome()
         defer { cleanup() }
         let (tempDir, repoDir) = try await createTestRepo()
@@ -24,24 +24,16 @@ struct NoteTabOnCreateTests {
 
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
 
-        let notes = try await db.notes.list(worktreeID: wt.id)
-        #expect(notes.count == 1)
-        let note = try #require(notes.first)
-        #expect(note.title == "Notes")
-        #expect(note.content.isEmpty)
+        #expect(try await db.notes.list(worktreeID: wt.id).isEmpty)
 
-        // The note tab rides last in the stored order; focus stays on the
-        // primary terminal.
         let terminals = try await db.terminals.list(worktreeID: wt.id)
         let order = try await db.worktrees.getTabOrder(worktreeID: wt.id)
-        #expect(order.last == note.id)
-        #expect(order.count == terminals.count + 1)
+        #expect(Set(order) == Set(terminals.map(\.id)))
         let active = try await db.worktrees.getActiveTabID(worktreeID: wt.id)
-        #expect(active != note.id)
         #expect(terminals.map(\.id).contains(try #require(active)))
     }
 
-    @Test func preSessionGatedCreateAlsoGetsNotesTab() async throws {
+    @Test func preSessionGatedCreateDoesNotCreateNotesTab() async throws {
         let (_, cleanup) = isolateTBDHome()
         defer { cleanup() }
         let (tempDir, repoDir) = try await createTestRepo()
@@ -63,13 +55,13 @@ struct NoteTabOnCreateTests {
         try writeMarker(worktreeID: pending.id, exitCode: 0)
         await phase3.value
 
-        let notes = try await db.notes.list(worktreeID: pending.id)
-        #expect(notes.count == 1)
+        #expect(try await db.notes.list(worktreeID: pending.id).isEmpty)
+        let terminals = try await db.terminals.list(worktreeID: pending.id)
         let order = try await db.worktrees.getTabOrder(worktreeID: pending.id)
-        #expect(order.last == notes.first?.id)
+        #expect(Set(order) == Set(terminals.map(\.id)))
     }
 
-    @Test func rowDeletedMidCreateLeavesNoOrphanNote() async throws {
+    @Test func rowDeletedMidCarryoverCreateLeavesNoOrphanNote() async throws {
         let (_, cleanup) = isolateTBDHome()
         defer { cleanup() }
         let (tempDir, repoDir) = try await createTestRepo()
@@ -82,14 +74,19 @@ struct NoteTabOnCreateTests {
 
         let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
         let completion = try await lifecycle.completeCreateWorktree(
-            worktreeID: pending.id, skipClaude: true
+            worktreeID: pending.id,
+            skipClaude: true,
+            carryover: ConversationCarryover(
+                sourceSessionID: UUID().uuidString,
+                notesSeed: "# Revived conversation\n"
+            )
         )
         guard case .preSessionPending(let phase3) = completion else {
             Issue.record("expected .preSessionPending")
             return
         }
-        // Repo removal mid-wait deletes the worktree row; the note FK must
-        // block a stray note insert (best-effort helper swallows the error).
+        // Repo removal mid-wait deletes the worktree row; the carryover-note
+        // FK must block a stray insert (best-effort helper swallows the error).
         try await db.worktrees.deleteForRepo(repoID: repo.id)
         try writeMarker(worktreeID: pending.id, exitCode: 0)
         await phase3.value

--- a/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
+++ b/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
@@ -9,10 +9,10 @@ import Testing
 // TBD_HOME mutation) so hook resolution and runtime dirs never touch the
 // developer's real ~/tbd. See TBDHomeSerializedSuites.swift.
 extension TBDHomeSerialized {
-@Suite("No default note tab on worktree create")
+@Suite("Automatic note tab on worktree create")
 struct NoteTabOnCreateTests {
 
-    @Test func ordinaryCreateDoesNotCreateNotesTab() async throws {
+    @Test func ordinaryCreateDefaultsToNotesTabAppendedLast() async throws {
         let (_, cleanup) = isolateTBDHome()
         defer { cleanup() }
         let (tempDir, repoDir) = try await createTestRepo()
@@ -24,8 +24,35 @@ struct NoteTabOnCreateTests {
 
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
 
-        #expect(try await db.notes.list(worktreeID: wt.id).isEmpty)
+        let notes = try await db.notes.list(worktreeID: wt.id)
+        #expect(notes.count == 1)
+        let note = try #require(notes.first)
+        #expect(note.title == "Notes")
+        #expect(note.content.isEmpty)
 
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        let order = try await db.worktrees.getTabOrder(worktreeID: wt.id)
+        #expect(order.last == note.id)
+        #expect(order.count == terminals.count + 1)
+        let active = try await db.worktrees.getActiveTabID(worktreeID: wt.id)
+        #expect(active != note.id)
+        #expect(terminals.map(\.id).contains(try #require(active)))
+    }
+
+    @Test func ordinaryCreateDoesNotCreateNotesTabWhenDisabled() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoCreateNotes(false)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+        #expect(try await db.notes.list(worktreeID: wt.id).isEmpty)
         let terminals = try await db.terminals.list(worktreeID: wt.id)
         let order = try await db.worktrees.getTabOrder(worktreeID: wt.id)
         #expect(Set(order) == Set(terminals.map(\.id)))
@@ -33,13 +60,49 @@ struct NoteTabOnCreateTests {
         #expect(terminals.map(\.id).contains(try #require(active)))
     }
 
-    @Test func preSessionGatedCreateDoesNotCreateNotesTab() async throws {
+    @Test func preSessionGatedCreateCreatesNotesTabWhenEnabled() async throws {
         let (_, cleanup) = isolateTBDHome()
         defer { cleanup() }
         let (tempDir, repoDir) = try await createTestRepo()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoCreateNotes(true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true
+        )
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending when a preSession hook resolves")
+            return
+        }
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        await phase3.value
+
+        let notes = try await db.notes.list(worktreeID: pending.id)
+        #expect(notes.count == 1)
+        let note = try #require(notes.first)
+        let terminals = try await db.terminals.list(worktreeID: pending.id)
+        let order = try await db.worktrees.getTabOrder(worktreeID: pending.id)
+        #expect(order.last == note.id)
+        #expect(order.count == terminals.count + 1)
+        let active = try await db.worktrees.getActiveTabID(worktreeID: pending.id)
+        #expect(active != note.id)
+        #expect(terminals.map(\.id).contains(try #require(active)))
+    }
+
+    @Test func preSessionGatedCreateDoesNotCreateNotesTabWhenDisabled() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoCreateNotes(false)
         let lifecycle = makeLifecycle(db: db)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         try await installPreSessionHook(repoDir: repoDir)
@@ -59,6 +122,8 @@ struct NoteTabOnCreateTests {
         let terminals = try await db.terminals.list(worktreeID: pending.id)
         let order = try await db.worktrees.getTabOrder(worktreeID: pending.id)
         #expect(Set(order) == Set(terminals.map(\.id)))
+        let active = try await db.worktrees.getActiveTabID(worktreeID: pending.id)
+        #expect(terminals.map(\.id).contains(try #require(active)))
     }
 
     @Test func rowDeletedMidCarryoverCreateLeavesNoOrphanNote() async throws {

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -168,9 +168,10 @@ struct PreSessionHookTests {
         #expect(setupBody.contains("export TBD_REPO_PATH='\(repo.path)'"))
         #expect(setupBody.contains("export TBD_BRANCH='\(wt.branch)'"))
 
-        // Tab order [claude, setup, initial note], active = claude.
-        let note = try #require(try await db.notes.list(worktreeID: wt.id).first)
-        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id, note.id])
+        // Tab order [claude, setup], active = claude. Ordinary creates do not
+        // seed a Notes tab.
+        #expect(try await db.notes.list(worktreeID: wt.id).isEmpty)
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id])
         #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == claude.id)
         #expect(try await db.notifications.unread(worktreeID: wt.id).isEmpty)
     }
@@ -302,10 +303,10 @@ struct PreSessionHookTests {
                 "a clean hook run must delete its own terminal row")
         let claude = try #require(terminals.first { $0.label == "Claude Code" })
         let setup = try #require(terminals.first { $0.label == "setup" })
-        let note = try #require(try await db.notes.list(worktreeID: pending.id).first)
+        #expect(try await db.notes.list(worktreeID: pending.id).isEmpty)
         #expect(try await db.worktrees.getTabOrder(worktreeID: pending.id)
-                == [claude.id, setup.id, note.id],
-                "tab order must be [claude, setup, note] once the pre-session tab is closed")
+                == [claude.id, setup.id],
+                "tab order must be [claude, setup] once the pre-session tab is closed")
         #expect(try await db.worktrees.getActiveTabID(worktreeID: pending.id) == claude.id)
         #expect(try await db.worktrees.get(id: pending.id)?.status == .active)
         // Exit 0 → no notification.

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -168,10 +168,10 @@ struct PreSessionHookTests {
         #expect(setupBody.contains("export TBD_REPO_PATH='\(repo.path)'"))
         #expect(setupBody.contains("export TBD_BRANCH='\(wt.branch)'"))
 
-        // Tab order [claude, setup], active = claude. Ordinary creates do not
-        // seed a Notes tab.
-        #expect(try await db.notes.list(worktreeID: wt.id).isEmpty)
-        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id])
+        // Tab order [claude, setup, initial note], active = claude.
+        let note = try #require(try await db.notes.list(worktreeID: wt.id).first)
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id)
+                == [claude.id, setup.id, note.id])
         #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == claude.id)
         #expect(try await db.notifications.unread(worktreeID: wt.id).isEmpty)
     }
@@ -303,10 +303,10 @@ struct PreSessionHookTests {
                 "a clean hook run must delete its own terminal row")
         let claude = try #require(terminals.first { $0.label == "Claude Code" })
         let setup = try #require(terminals.first { $0.label == "setup" })
-        #expect(try await db.notes.list(worktreeID: pending.id).isEmpty)
+        let note = try #require(try await db.notes.list(worktreeID: pending.id).first)
         #expect(try await db.worktrees.getTabOrder(worktreeID: pending.id)
-                == [claude.id, setup.id],
-                "tab order must be [claude, setup] once the pre-session tab is closed")
+                == [claude.id, setup.id, note.id],
+                "tab order must be [claude, setup, note] once the pre-session tab is closed")
         #expect(try await db.worktrees.getActiveTabID(worktreeID: pending.id) == claude.id)
         #expect(try await db.worktrees.get(id: pending.id)?.status == .active)
         // Exit 0 → no notification.

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -478,21 +478,22 @@ import Testing
         #expect(message.contains("/nowhere/Migrations"))
     }
 
-    // MARK: - The inert cutover
+    // MARK: - Shipped migration manifest
 
-    /// The mechanism ships with an EMPTY `Migrations/` directory, so
-    /// `buildMigrator()` is byte-for-byte today's migrator. When the first real
-    /// `.sql` migration lands this expectation changes with it — deliberately.
-    @Test func theShippedMigrationsDirectoryIsEmptyAndTheMigratorIsUnchanged() throws {
+    /// Every shipped timestamp migration is named here deliberately. Adding or
+    /// removing a resource must update this manifest, while the frozen Swift
+    /// block remains independently pinned by `SchemaBaselineDriftTests`.
+    @Test func theShippedMigrationsMatchTheExpectedManifest() throws {
+        let expected = ["20260824214437_auto_create_notes_setting"]
         let found = try SQLMigrationLoader.bundled.get()
-        #expect(found.files.isEmpty, "expected an inert Migrations/ directory, found \(found.files.map(\.identifier))")
+        #expect(found.files.map(\.identifier) == expected)
         #expect(SQLMigrationLoader.inlineTimestampMigrations.isEmpty)
-        #expect(SQLMigrationLoader.migrationsForRegistration().isEmpty)
+        #expect(SQLMigrationLoader.migrationsForRegistration().map(\.identifier) == expected)
 
         let identifiers = TBDDatabase.buildMigratorForTests().migrations
         #expect(identifiers.first == "v1")
-        #expect(identifiers.last == SchemaBaselineDriftTests.frozenBlockLastIdentifier)
-        #expect(!identifiers.contains(where: SQLMigrationLoader.isTimestampIdentifier))
+        #expect(identifiers.last == expected.last)
+        #expect(identifiers.filter(SQLMigrationLoader.isTimestampIdentifier) == expected)
     }
 
     /// Whatever the directory holds, the registered timestamp migrations are

--- a/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
@@ -106,7 +106,7 @@ struct WorktreeConversationCarryoverTests {
         )
     }
 
-    @Test func ordinaryCreateKeepsConfiguredPrimaryAndEmptyNotes() async throws {
+    @Test func ordinaryCreateKeepsConfiguredPrimaryWithoutNotes() async throws {
         let (_, cleanup) = isolateTBDHome()
         defer { cleanup() }
         let (tempDir, repoDir) = try await createTestRepo()
@@ -130,9 +130,7 @@ struct WorktreeConversationCarryoverTests {
         let terminals = try await db.terminals.list(worktreeID: pending.id)
         #expect(terminals.filter { $0.kind == .codex }.count == 1)
         #expect(terminals.allSatisfy { $0.kind != .claude })
-        let note = try #require(try await db.notes.list(worktreeID: pending.id).first)
-        #expect(note.title == "Notes")
-        #expect(note.content.isEmpty)
+        #expect(try await db.notes.list(worktreeID: pending.id).isEmpty)
     }
 
     /// An ordinary archived-session resume never carried an initial prompt, and
@@ -355,6 +353,8 @@ struct WorktreeConversationCarryoverTests {
         let note = try #require(try await db.notes.list(worktreeID: worktree.id).first)
         #expect(note.title == "Notes")
         #expect(note.content == notesSeed)
+        let order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
+        #expect(order.last == note.id)
     }
 }
 }

--- a/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
@@ -19,6 +19,7 @@ struct WorktreeConversationCarryoverTests {
 
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setPrimaryAgentPreference(.codex)
+        try await db.config.setAutoCreateNotes(false)
         let recorder = PreSessionRecordedCommands()
         let claudeHome = tempDir.appendingPathComponent("claude-home", isDirectory: true)
         let lifecycle = makeCarryoverLifecycle(
@@ -65,6 +66,7 @@ struct WorktreeConversationCarryoverTests {
 
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setPrimaryAgentPreference(.codex)
+        try await db.config.setAutoCreateNotes(false)
         let recorder = PreSessionRecordedCommands()
         let claudeHome = tempDir.appendingPathComponent("claude-home", isDirectory: true)
         let lifecycle = makeCarryoverLifecycle(
@@ -114,6 +116,7 @@ struct WorktreeConversationCarryoverTests {
 
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setPrimaryAgentPreference(.codex)
+        try await db.config.setAutoCreateNotes(false)
         let lifecycle = makeCarryoverLifecycle(
             db: db,
             recorder: PreSessionRecordedCommands(),

--- a/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
@@ -371,6 +371,8 @@ struct WorktreeReviveFreshTests {
 
             """
         )
+        let order = try await db.worktrees.getTabOrder(worktreeID: created.id)
+        #expect(order.last == note.id)
     }
 
     @Test func fetchFailureCreatesFromLocalBaseAndReturnsStaleWarning() async throws {

--- a/docs/specs/2026-07-27-revive-conversation-fresh-branch-design.md
+++ b/docs/specs/2026-07-27-revive-conversation-fresh-branch-design.md
@@ -135,7 +135,11 @@ the fact, because on the `preSession` branch `createInitialNoteTab` runs *inside
 the detached phase-3 task — `completeCreateWorktree` returns `.preSessionPending`
 before any note row exists, so a caller-side write would race it.
 `createInitialNoteTab` gains an optional `seed: String?` parameter, defaulting to
-nil so the ordinary create path is unchanged.
+nil. An ordinary create has no `ConversationCarryover`, so
+`completeCreateWorktree` applies the global automatic-notes preference before
+calling the helper with no seed. Fresh-branch revival supplies a carryover and
+its provenance seed, so it always calls the helper regardless of that
+preference.
 
 Threaded from `completeCreateWorktree` down to `spawnPrimaryTerminals`. When
 present, `spawnPrimaryTerminals`:

--- a/docs/specs/2026-08-24-auto-create-notes-setting-design.md
+++ b/docs/specs/2026-08-24-auto-create-notes-setting-design.md
@@ -1,0 +1,175 @@
+# Automatic Notes tabs for new worktrees
+
+Status: **implemented**.
+
+## Problem
+
+An ordinary repo-backed worktree starts with an empty Notes tab. The daemon
+creates the note after the primary terminal, appends it to the tab order, and
+leaves the primary terminal focused. This is intentional: Notes are immediately
+available without requiring a second gesture, and existing users rely on that
+default.
+
+The same convenience is unwanted for users who do not keep worktree notes. For
+them, every new worktree opens with an empty tab they must ignore or remove. The
+choice is stable across worktrees, so it belongs in a durable global preference
+rather than in every creation sheet.
+
+Fresh-branch conversation revival has a different requirement. Its Notes tab is
+populated with provenance for the forked conversation and the branch it came
+from. That note is part of the revival result, not an empty convenience tab, and
+must exist regardless of the preference for ordinary worktrees.
+
+## Design
+
+Settings › Worktrees contains a global toggle named **Create a Notes tab for
+new worktrees**. It defaults on, preserving the established creation behavior.
+Turning it off affects future ordinary repo-backed worktrees created through any
+client; it neither removes existing notes nor changes a creation already in
+progress.
+
+The preference is daemon-backed rather than app-local. The daemon owns
+worktree creation for both the app and the CLI, so it is the only layer that can
+apply one choice consistently to every client.
+
+The preference distinguishes two creation cases:
+
+- **Ordinary creation** — `completeCreateWorktree` receives no
+  `ConversationCarryover`. It creates an empty initial Notes tab only when
+  `autoCreateNotesEnabled` is true.
+- **Fresh-branch conversation revival** — `completeCreateWorktree` receives a
+  `ConversationCarryover` with a provenance seed. It always creates the
+  populated Notes tab, even when `autoCreateNotesEnabled` is false.
+
+Scratch spaces use a separate creation lifecycle and are outside this setting.
+Plain revival of an existing worktree restores its existing state rather than
+creating an initial note, so it is unchanged as well.
+
+## Persistence and defaults
+
+The singleton `config` row stores the choice in
+`auto_create_notes_enabled INTEGER`. The migration adds the column without a
+SQL `DEFAULT`, preserving three states:
+
+- **NULL** — the user has never chosen. `ConfigRecord.toModel()` resolves this
+  through `Config.autoCreateNotesDefault`.
+- **0** — the user explicitly disabled automatic empty Notes tabs.
+- **1** — the user explicitly enabled automatic empty Notes tabs.
+
+`Config.autoCreateNotesDefault` is `true`, the single shipped default. The
+shared `Config` model exposes the resolved nonoptional
+`autoCreateNotesEnabled` value, while `ConfigRecord` retains the nullable stored
+value. `ConfigStore.setAutoCreateNotes(_:)` writes either explicit choice.
+
+Keeping the SQL column nullable matters even with a permanent default-on
+preference. It preserves the difference between an untouched installation and
+a deliberate choice, so a future product-default change can follow the Swift
+constant for untouched rows without overriding either explicit state.
+
+## Lifecycle semantics
+
+`completeCreateWorktree` reads `Config` once near the start of creation and
+computes whether an initial note is required from that snapshot. A preference
+change during creation therefore applies to the next worktree, not partway
+through the current one.
+
+Both terminal-spawn branches use the same decision:
+
+- **Inline spawn** — after the primary terminal is spawned, the daemon creates
+  the initial note when required.
+- **`preSession` spawn** — the detached phase-three task creates the initial
+  note after the hook completes and the primary terminal is spawned.
+
+When created, the note is titled `Notes`, appended after terminal IDs in the
+worktree's tab order, and does not take focus from the primary terminal. An
+ordinary note has empty content. A conversation carryover writes its provenance
+seed into the note.
+
+Initial-note creation remains best-effort. A note insert, seed update, or tab
+order update that fails is logged and does not fail an otherwise valid worktree
+whose checkout and terminals already exist. Failures earlier in the ordinary
+creation lifecycle retain that lifecycle's existing cleanup behavior.
+
+## RPC and app refresh
+
+The app initializes its mirror from `Config.autoCreateNotesDefault` and refreshes
+it from `ModelProfileListResult`, the existing config-bearing response returned
+by `modelProfile.list`.
+
+Changing the toggle calls `config.setAutoCreateNotes`. The handler persists the
+explicit value and broadcasts the existing `modelProfilesChanged` delta. Each
+connected app responds by fetching `modelProfile.list` again, so the setting
+converges across app windows without a daemon restart.
+
+The app changes its local mirror only after the setter RPC succeeds. If the RPC
+fails, the previous value remains visible and the established error alert is
+shown. The daemon therefore remains authoritative, and a failed write cannot
+make the UI claim that future worktrees will follow a value it did not persist.
+
+## Compatibility
+
+Existing databases receive a nullable column, so their singleton config row
+stays NULL and resolves to the default-on behavior. No backfill turns an
+untouched row into an explicit choice.
+
+The custom decoders for both `Config` and `ModelProfileListResult` resolve a
+missing `autoCreateNotesEnabled` key through
+`Config.autoCreateNotesDefault`. New code therefore treats payloads from before
+the field existed as enabled, matching the behavior those payloads represented.
+Older decoders ignore the additive response field. If the setter is unavailable,
+the app follows the normal RPC failure path and retains its previous mirror.
+
+## Rollout and permanence
+
+This toggle is a permanent user preference, not a temporary rollout flag. The
+underlying default-on behavior already exists, creates only an empty app-owned
+note, and neither destroys state nor acts without a worktree-creation gesture.
+The change adds an explicit opt-out while preserving that behavior for untouched
+installations.
+
+There is no graduation step that removes the preference. Users can reasonably
+want either workspace shape indefinitely, and explicit false and true values
+remain durable choices.
+
+## Testing
+
+The lifecycle branch matrix covers:
+
+- ordinary inline creation with an untouched/default-on setting creates one
+  empty Notes tab, appended last without stealing focus;
+- ordinary inline creation with an explicit false setting creates no note;
+- ordinary `preSession` creation with an explicit true setting creates the
+  empty Notes tab after phase three;
+- ordinary `preSession` creation with an explicit false setting creates no
+  note;
+- inline conversation carryover with the setting false still creates the
+  populated provenance note;
+- `preSession` conversation carryover with the setting false still creates the
+  populated provenance note.
+
+Persistence and compatibility tests prove that the migration has no SQL
+default, NULL follows a supplied default in either direction, explicit false
+and true survive a changed supplied default, the store persists both values,
+and legacy shared-model JSON resolves enabled.
+
+RPC tests prove that the setter persists both values and broadcasts
+`modelProfilesChanged`, that `modelProfile.list` carries the resolved value,
+and that a legacy list response resolves enabled. App-state tests cover loading
+both values, changing the mirror only after success, retaining it on failure,
+and the help text that names the carryover exception.
+
+## Rejected alternatives
+
+- **Turn automatic notes off for everyone** — this removes an intentional
+  behavior that existing users rely on instead of letting each user choose.
+- **Store the preference in `UserDefaults`** — the daemon would not see it for
+  CLI-created worktrees, and app and daemon state could disagree.
+- **Make the preference per repository** — the choice describes a user's
+  workspace habit rather than a repository property, while per-repo storage
+  would add configuration and UI complexity without a distinct lifecycle need.
+- **Apply the preference to conversation carryover** — disabling an empty
+  convenience tab must not discard the populated provenance that explains the
+  revived conversation's origin.
+- **Use a temporary feature flag around the setting** — the behavior already
+  ships default-on, and an additional gate would duplicate a permanent control
+  without protecting a risky rollout.

--- a/docs/specs/2026-08-24-auto-create-notes-setting-design.md
+++ b/docs/specs/2026-08-24-auto-create-notes-setting-design.md
@@ -24,9 +24,11 @@ must exist regardless of the preference for ordinary worktrees.
 
 Settings › Worktrees contains a global toggle named **Create a Notes tab for
 new worktrees**. It defaults on, preserving the established creation behavior.
-Turning it off affects future ordinary repo-backed worktrees created through any
-client; it neither removes existing notes nor changes a creation already in
-progress.
+Turning it off affects ordinary repo-backed worktrees whose
+`completeCreateWorktree` config snapshot occurs after the preference is
+persisted, regardless of which client created them. It does not remove existing
+notes. A visibly pending creation may use either value depending on whether it
+has already taken that snapshot.
 
 The preference is daemon-backed rather than app-local. The daemon owns
 worktree creation for both the app and the CLI, so it is the only layer that can
@@ -69,9 +71,11 @@ constant for untouched rows without overriding either explicit state.
 ## Lifecycle semantics
 
 `completeCreateWorktree` reads `Config` once near the start of creation and
-computes whether an initial note is required from that snapshot. A preference
-change during creation therefore applies to the next worktree, not partway
-through the current one.
+computes whether an initial note is required from that snapshot. Once the read
+completes, later preference changes do not affect that creation. Any creation
+whose snapshot occurs after a new value is persisted uses the new value. This
+code boundary, rather than the worktree's visible pending state, determines
+which preference applies.
 
 Both terminal-spawn branches use the same decision:
 


### PR DESCRIPTION
If people like the notes tab opening by default, I can make this into a flag?

## Summary

TBD currently opens an empty Notes tab for every ordinary repo-backed worktree. This PR adds a global setting under Settings → Worktrees so people who do not use that tab can turn automatic creation off.

The setting defaults on to preserve the intentional existing behavior. Conversations revived on a fresh branch still receive their populated provenance note even when automatic empty notes are off.

## Why this shape

The preference is global because worktrees can be created through several paths, while the daemon is the single place that creates their initial tabs. Creation snapshots the resolved config once, so inline and pre-session flows make the same decision.

This makes an existing behavior configurable rather than introducing a new autonomous behavior, so it does not need a rollout spec. The fresh-branch revival exception remains unconditional because that note contains source context rather than being an empty convenience tab.

## What this PR does

- Adds a nullable `auto_create_notes_enabled` config column with no SQL default.
- Resolves an unset value through the shipped Swift default of `true`, while preserving explicit on and off choices.
- Adds a config RPC and reuses the existing `modelProfilesChanged` refresh path to keep app state synchronized.
- Adds “Create a Notes tab for new worktrees” under Settings → Worktrees.
- Gates empty Notes creation for ordinary inline and pre-session worktrees without changing primary focus or tab ordering.
- Keeps populated provenance notes for conversations revived on a fresh branch.
- Updates the shipped timestamp-migration manifest and adds branch coverage across persistence, RPC, lifecycle, carryover, and UI state.

## Flag & rollout

This is a permanent user preference, not a temporary soak flag.

- **Preference** — `autoCreateNotesEnabled`; persisted as `auto_create_notes_enabled`.
- **Default** — on, matching the behavior before this PR.
- **Opt out** — turn off “Create a Notes tab for new worktrees” in Settings → Worktrees.
- **Stored states** — NULL means untouched and follows the shipped default; explicit false and true remain stable if that default changes later.
- **Graduation** — none; the preference remains available.

## Evidence & verification

- Test-first failures covered the missing persistence contract, RPC, lifecycle branches, app-state wiring, and migration manifest before their implementations were added.
- `scripts/test.sh --filter 'AutoCreateNotesSchemaTests|AutoCreateNotesRPCTests|NoteTabOnCreateTests|WorktreeConversationCarryoverTests|PreSessionHookTests|ModelProfileRPCTests|AutoCreateNotesSettingTests|SQLMigrationLoaderTests|SchemaBaselineDriftTests'` — 150 tests passed in 10 suites.
- `scripts/swift-safe build` — passed.
- `scripts/lint-migrations.py` — passed, 1 migration and 7 checks.
- `git diff --check origin/main...HEAD` — passed.
- `scripts/test.sh` ran 7,862 tests. All changed and affected suites passed; the command remains nonzero from 10 issues in unchanged suites: ScratchpadCollector (3), Codex usage fetcher lifecycle (1), replay live integration (1), transcript row-height estimator (1), and Markdown web-view navigation (4). The run also reported 85 existing known issues.
- Live UI verification was not performed in this worktree.

[⚙️ Add Notes Tab Setting](https://cheapsteak.github.io/tbd/open/?worktree=ABF8B4FA-91BA-4093-A085-A41412A8D2B1)

