### PR TITLE
Fix: Keep the working indicator lit while a worktree waits on background subagents

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -473,6 +473,17 @@ extension AppState {
         // Remaining terminals: Codex (Ctrl+C), Claude, or legacy nil-kind sessions.
         if let idx = terminals[terminal.worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
             terminals[terminal.worktreeID]?[idx].activityState = .idle
+            // Clear the cached presentation value for every agent kind. The
+            // daemon drops its own claim on the `userInterrupt` origin below,
+            // but `TerminalActivityDelta` — the real-time push rail — carries
+            // no presentation field, so only a full `terminal.list` refresh
+            // would deliver that clear. Without this line the stale claim keeps
+            // the sidebar spinner lit until the next unscoped poll (~2s), which
+            // is the false-thinking direction the rail must never fail toward.
+            // Clearing it for Codex too is safe: Codex's foreground-working
+            // test requires a `.working` presentation value, so the row can
+            // only reach idle sooner.
+            terminals[terminal.worktreeID]?[idx].presentationActivityState = nil
             if isCodex {
                 let observedAt = Date()
                 terminals[terminal.worktreeID]?[idx].activityStateSource = .terminalInterrupt

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -483,10 +483,21 @@ extension AppState {
 
         Task {
             do {
+                // The origin travels for EVERY agent kind, not just Codex. The
+                // local optimistic assignments above stay Codex-only because
+                // they carry Codex's ordering semantics, but the daemon needs
+                // the interrupt fact for Claude too: an interrupted Claude turn
+                // often writes no `turn_duration`, so without this the
+                // delegation rail would re-read the pre-interrupt record on the
+                // next poll and relight the spinner with no agents running.
+                // The handler's other origin-conditional branches — the
+                // hook-event counter and the Stop-hook transcript sync — already
+                // read a present origin as "a user action, not an agent hook",
+                // which is what an Esc on a Claude session is.
                 try await daemonClient.setTerminalActivity(
                     terminalID: terminalID,
                     activityState: .idle,
-                    origin: isCodex ? .userInterrupt : nil
+                    origin: .userInterrupt
                 )
             } catch {
                 logger.debug("Failed to publish terminal interrupt state: \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -118,15 +118,24 @@ struct WorktreeRowView: View {
     /// transcript-derived presentation state is authoritative here unless the
     /// hook reports that Codex is waiting for the user. Missing transcript
     /// evidence deliberately renders idle instead of preserving a false
-    /// thinking indicator. Other terminal kinds retain their existing
-    /// hook-backed behavior.
+    /// thinking indicator. Claude instead composes both rails, as described
+    /// below.
     nonisolated static func isForegroundWorking(_ terminal: Terminal) -> Bool {
         if terminal.isCodexTerminal {
             return terminal.activityStateSource != .terminalInterrupt
                 && terminal.activityState != .waitingForUser
                 && terminal.presentationActivityState == .working
         }
-        return terminal.activityState == .working
+        // Claude composes its two rails by DISJUNCTION, unlike Codex above,
+        // which lets its transcript REPLACE the hook rail. Each Claude rail
+        // speaks about a different interval: the hook rail is authoritative
+        // during a turn, and the delegation rail only after one ends. An
+        // interrupt or a raised prompt defeats the delegation claim, because
+        // neither writes a `turn_duration` that could retract it.
+        if terminal.activityState == .working { return true }
+        return terminal.activityStateSource != .terminalInterrupt
+            && terminal.activityState != .waitingForUser
+            && terminal.presentationActivityState == .working
     }
 
     /// The collection form used by the row and by pure presentation tests.

--- a/Sources/TBDCLI/Commands/SessionEndCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEndCommand.swift
@@ -1,0 +1,43 @@
+import ArgumentParser
+import Foundation
+import os
+import TBDShared
+
+private let sessionEndLogger = Logger(subsystem: "com.tbd.cli", category: "sessionEnd")
+
+/// Bridges Claude Code's `SessionEnd` hook into TBD so a session that exits
+/// while background agents are live cannot leave a standing delegation claim.
+///
+/// Every failure is silent, like every other hook bridge: a hook must never
+/// wedge or redden the agent it observes.
+struct SessionEndCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "session-end",
+        abstract: "Internal: report that an agent session ended",
+        shouldDisplay: false
+    )
+
+    mutating func run() async throws {
+        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+              let terminalID = UUID(uuidString: terminalIDString) else {
+            sessionEndLogger.debug("suppressed reason=noTerminalID")
+            return
+        }
+
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            sessionEndLogger.debug("suppressed reason=daemonDown")
+            return
+        }
+
+        do {
+            try client.callVoid(
+                method: RPCMethod.terminalSessionEnded,
+                params: TerminalSessionEndedParams(terminalID: terminalID)
+            )
+        } catch {
+            sessionEndLogger.debug(
+                "suppressed reason=rpcFailed err=\(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -18,6 +18,7 @@ struct TBDCommand: AsyncParsableCommand {
             NotifyCommand.self,
             SessionEventCommand.self,
             TerminalActivityEventCommand.self,
+            SessionEndCommand.self,
             AskUserQuestionEventCommand.self,
             DaemonCommand.self,
             HooksCommand.self,

--- a/Sources/TBDDaemon/Claude/ClaudeDelegationSample.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeDelegationSample.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Reads the newest `turn_duration` record out of a transcript tail and
+/// reports how many background subagents Claude Code says are still live.
+///
+/// The field is a LEVEL, not an edge: Claude Code restates it at every turn
+/// end and omits it entirely when no agents remain. Sampling only the newest
+/// value is therefore correct however many earlier values went unread, which
+/// is what makes this rail immune to the drift a start/stop counter carries.
+///
+/// Every unreadable, absent, or malformed case collapses to `nil` — make no
+/// claim — because the rail may only ever fail toward the behavior that ships
+/// without it.
+enum ClaudeDelegationSample {
+    /// Records larger than this are skipped rather than parsed.
+    private static let recordByteLimit = 1 << 20
+
+    static func pendingCount(inTail tail: Data) -> Int? {
+        guard !tail.isEmpty else { return nil }
+        var newest: Int?
+        // A bounded tail almost always begins mid-record. Dropping through the
+        // first newline discards that fragment; a tail that happens to start
+        // exactly at a record boundary loses one record, which the level rail
+        // can afford because the NEWEST record is the one that matters.
+        let lines = tail.split(separator: UInt8(ascii: "\n"),
+                               omittingEmptySubsequences: true).dropFirst()
+        for line in lines {
+            guard line.count <= recordByteLimit else { continue }
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line)),
+                  let record = object as? [String: Any],
+                  record["subtype"] as? String == "turn_duration" else { continue }
+            // Present-and-positive is the only shape that claims. An omitted
+            // field is how Claude Code spells zero, and it retracts a claim an
+            // older record made.
+            if let count = record["pendingBackgroundAgentCount"] as? Int, count > 0 {
+                newest = count
+            } else {
+                newest = nil
+            }
+        }
+        return newest
+    }
+}

--- a/Sources/TBDDaemon/Claude/ClaudeDelegationSample.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeDelegationSample.swift
@@ -18,12 +18,15 @@ enum ClaudeDelegationSample {
     static func pendingCount(inTail tail: Data) -> Int? {
         guard !tail.isEmpty else { return nil }
         var newest: Int?
-        // A bounded tail almost always begins mid-record. Dropping through the
-        // first newline discards that fragment; a tail that happens to start
-        // exactly at a record boundary loses one record, which the level rail
-        // can afford because the NEWEST record is the one that matters.
+        // A bounded tail almost always begins mid-record, but a leading
+        // fragment does not need to be singled out and discarded: a byte
+        // range that starts mid-object is not valid JSON, so it already fails
+        // to parse below and is skipped like any other unreadable line. A
+        // tail that happens to start exactly at a record boundary — the
+        // common case for a short transcript read whole — keeps that record
+        // instead of losing it to a blind drop.
         let lines = tail.split(separator: UInt8(ascii: "\n"),
-                               omittingEmptySubsequences: true).dropFirst()
+                               omittingEmptySubsequences: true)
         for line in lines {
             guard line.count <= recordByteLimit else { continue }
             guard let object = try? JSONSerialization.jsonObject(with: Data(line)),

--- a/Sources/TBDDaemon/Claude/ClaudeDelegationSample.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeDelegationSample.swift
@@ -31,7 +31,10 @@ enum ClaudeDelegationSample {
             guard line.count <= recordByteLimit else { continue }
             guard let object = try? JSONSerialization.jsonObject(with: Data(line)),
                   let record = object as? [String: Any],
-                  record["subtype"] as? String == "turn_duration" else { continue }
+                  record["subtype"] as? String == "turn_duration",
+                  // A subagent's own sidechain turn must never speak for the
+                  // main loop's count.
+                  record["isSidechain"] as? Bool != true else { continue }
             // Present-and-positive is the only shape that claims. An omitted
             // field is how Claude Code spells zero, and it retracts a claim an
             // older record made.

--- a/Sources/TBDDaemon/Claude/ClaudeDelegationTracker.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeDelegationTracker.swift
@@ -1,0 +1,94 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-delegation")
+
+/// A terminal and the transcript that currently speaks for it.
+struct ClaudeDelegationTarget: Sendable, Equatable {
+    let terminalID: UUID
+    let transcriptPath: String?
+}
+
+/// Owns which Claude terminals owe a delegation sample and what the last
+/// sample said.
+///
+/// Sampling is deferred rather than performed when a terminal reports idle,
+/// and the reason is an ordering fact: Claude Code runs its `Stop` hooks
+/// first and writes the turn's `turn_duration` record about two milliseconds
+/// after they return. Reading while the hook is executing observes the
+/// PREVIOUS turn — exactly the difference between a count of zero and a count
+/// of one in the case this rail exists to catch.
+///
+/// All state is transient. Nothing here is persisted, and nothing here creates
+/// a durable external resource, so no reconciler covers it.
+actor ClaudeDelegationTracker {
+    /// How much of the transcript's end to read. Measured against a real
+    /// corpus, the newest `turn_duration` sits a median of ~1.3 KiB from end
+    /// of file and falls inside this window for ~98% of transcripts. The
+    /// remainder are transcripts with a long turn in progress, where the hook
+    /// rail already reports working and this rail is not needed.
+    private static let tailByteLimit = 64 * 1024
+
+    private struct Claim {
+        let transcriptPath: String
+        let count: Int
+    }
+
+    private var marked: Set<UUID> = []
+    private var claims: [UUID: Claim] = [:]
+
+    func mark(terminalID: UUID) {
+        marked.insert(terminalID)
+    }
+
+    func clear(terminalID: UUID) {
+        marked.remove(terminalID)
+        claims.removeValue(forKey: terminalID)
+    }
+
+    /// Re-reads every marked target, keeps standing claims for the rest, and
+    /// returns only terminals that currently claim outstanding agents.
+    func sample(targets: [ClaudeDelegationTarget]) -> [UUID: Int] {
+        var result: [UUID: Int] = [:]
+        for target in targets {
+            let id = target.terminalID
+            // A retargeted terminal's old count cannot describe its new
+            // transcript, so drop it whether or not a fresh mark arrived.
+            if let claim = claims[id], claim.transcriptPath != target.transcriptPath {
+                claims.removeValue(forKey: id)
+            }
+            if marked.remove(id) != nil {
+                claims.removeValue(forKey: id)
+                if let path = target.transcriptPath, !path.isEmpty,
+                   let tail = Self.readTail(path: path),
+                   let count = ClaudeDelegationSample.pendingCount(inTail: tail) {
+                    claims[id] = Claim(transcriptPath: path, count: count)
+                }
+            }
+            if let claim = claims[id] { result[id] = claim.count }
+        }
+        return result
+    }
+
+    /// Drops state for terminals that no longer exist.
+    func retain(terminalIDs: Set<UUID>) {
+        marked.formIntersection(terminalIDs)
+        claims = claims.filter { terminalIDs.contains($0.key) }
+    }
+
+    /// Reads at most the final `tailByteLimit` bytes. Any failure returns nil,
+    /// which makes no claim — inability to look is never evidence of work.
+    private static func readTail(path: String) -> Data? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        do {
+            let end = try handle.seekToEnd()
+            let start = end > UInt64(tailByteLimit) ? end - UInt64(tailByteLimit) : 0
+            try handle.seek(toOffset: start)
+            return try handle.read(upToCount: tailByteLimit)
+        } catch {
+            logger.debug("delegation tail read failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+}

--- a/Sources/TBDDaemon/Claude/ClaudeDelegationTracker.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeDelegationTracker.swift
@@ -41,6 +41,10 @@ actor ClaudeDelegationTracker {
         marked.insert(terminalID)
     }
 
+    /// Whether a terminal currently owes a sample. Exists so a test can pin
+    /// the mark independently of any filesystem evidence.
+    func isMarked(terminalID: UUID) -> Bool { marked.contains(terminalID) }
+
     func clear(terminalID: UUID) {
         marked.remove(terminalID)
         claims.removeValue(forKey: terminalID)

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -140,11 +140,13 @@ public enum ClaudeHookOverlay {
 
     /// Seconds Claude Code will wait for `sessionEndCommand` before killing it.
     ///
-    /// Explicit because Claude Code runs SessionEnd callbacks inside a
-    /// ~1.5-second shutdown budget: the 60-second default would let one wedged
-    /// daemon socket hold a quitting session open long past it. Losing the
-    /// clear to a timeout costs only a stale claim on a terminal whose session
-    /// is gone.
+    /// Explicit only to escape the 60-second default, which would let one
+    /// wedged daemon socket hold a quitting session open for a minute. What
+    /// actually bounds the hook is Claude Code's ~1.5-second SessionEnd
+    /// shutdown budget, which cuts the callback off first either way; this
+    /// value stays above it so a healthy RPC has the whole budget to land the
+    /// clear. Losing the clear to either bound costs only a stale claim on a
+    /// terminal whose session is gone.
     static let sessionEndTimeoutSeconds = 2
 
     /// The extended regex the prefilter greps a Bash hook payload for.

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -12,7 +12,7 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-overl
 /// its own overlay file pinned at spawn time without touching the user's
 /// settings.json at all.
 ///
-/// The overlay registers seven event types:
+/// The overlay registers eight event types:
 /// - `SessionStart` (matcher `*`): calls `tbd session-event`, which
 ///   relays the new session ID + transcript path to the daemon. This is
 ///   what fixes the post-`/clear`/`/compact` transcript freeze. Also
@@ -42,6 +42,10 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-overl
 /// - `Notification` (no matcher): runs `tbd hooks notification`, which
 ///   forwards the payload verbatim so the daemon can record a structured
 ///   reason an agent is waiting.
+/// - `SessionEnd` (no matcher): runs `tbd session-end`, which drops any
+///   standing delegation claim for the terminal. A session that exits
+///   while background subagents are live leaves a final `turn_duration`
+///   record still reporting them, and no later turn corrects it.
 ///
 /// The overlay is regenerated on every daemon startup so changes to the
 /// shape (new hooks, new commands) take effect on the next worktree open.
@@ -126,6 +130,22 @@ public enum ClaudeHookOverlay {
     /// Sets the terminal activity state to waiting_for_user.
     static let waitingForUserCommand =
         #"tbd terminal-activity waiting_for_user 2>/dev/null || true"#
+
+    /// Clears any standing delegation claim when a session ends. A session
+    /// that exits while background agents are live leaves a final
+    /// `turn_duration` record still reporting them, and no later turn ever
+    /// corrects it — so without this the claim would stand forever.
+    static let sessionEndCommand =
+        #"tbd session-end 2>/dev/null || true"#
+
+    /// Seconds Claude Code will wait for `sessionEndCommand` before killing it.
+    ///
+    /// Explicit because Claude Code runs SessionEnd callbacks inside a
+    /// ~1.5-second shutdown budget: the 60-second default would let one wedged
+    /// daemon socket hold a quitting session open long past it. Losing the
+    /// clear to a timeout costs only a stale claim on a terminal whose session
+    /// is gone.
+    static let sessionEndTimeoutSeconds = 2
 
     /// The extended regex the prefilter greps a Bash hook payload for.
     ///
@@ -267,6 +287,16 @@ public enum ClaudeHookOverlay {
                     [
                         "hooks": [
                             ["type": "command", "command": stopFailureCommand]
+                        ]
+                    ]
+                ],
+                // No "matcher" key: SessionEnd carries a reason, not a matcher
+                // subject, and every reason retires the session's claim.
+                "SessionEnd": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": sessionEndCommand,
+                             "timeout": sessionEndTimeoutSeconds] as [String: Any]
                         ]
                     ]
                 ],

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3278,6 +3278,17 @@ extension RPCRouter {
                     await limitResumeScheduler?.wake()
                 }
             }
+            // Marked BEFORE the unchanged-state guard below, deliberately. A
+            // background agent's completion wakes the parent, which runs a
+            // turn and ends it — a second `idle` with no `working` between.
+            // Marking below the guard would drop that boundary and latch the
+            // previous turn's count. Sampling itself is deferred to
+            // `terminal.list`: Claude Code writes the turn's `turn_duration`
+            // record a couple of milliseconds AFTER these hooks return, so a
+            // read here would observe the previous turn.
+            if params.activityState == .idle {
+                await claudeDelegationTracker.mark(terminalID: terminal.id)
+            }
             guard terminal.activityState != params.activityState else {
                 // Previously a pure no-op. A same-state observation still
                 // supersedes a not-newer wait reason: this is the only rail

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -629,6 +629,12 @@ extension RPCRouter {
         let delegationClaims = await claudeDelegationTracker.sample(
             targets: delegationTargets)
         for index in terminals.indices where !terminals[index].isCodexTerminal {
+            // A parked session runs nothing, so its last count speaks for work
+            // that is already gone. The row's indicator ranks working above
+            // hibernated, so publishing here would replace the moon with
+            // animated dots that nothing can ever retract.
+            guard terminals[index].hibernatedAt == nil,
+                  terminals[index].suspendedAt == nil else { continue }
             // Only a live claim writes. Absence must leave the field alone
             // rather than publish nil, which is a statement of its own.
             guard let count = delegationClaims[terminals[index].id] else { continue }
@@ -3332,7 +3338,15 @@ extension RPCRouter {
             // `terminal.list`: Claude Code writes the turn's `turn_duration`
             // record a couple of milliseconds AFTER these hooks return, so a
             // read here would observe the previous turn.
-            if params.activityState == .idle {
+            //
+            // An explicit interrupt CLEARS instead of marking. An interrupted
+            // turn frequently writes no `turn_duration`, so sampling after one
+            // would re-read the PRE-interrupt record and relight the indicator
+            // with nothing running — the false-thinking direction this rail is
+            // never allowed to fail toward.
+            if params.origin == .userInterrupt {
+                await claudeDelegationTracker.clear(terminalID: terminal.id)
+            } else if params.activityState == .idle {
                 await claudeDelegationTracker.mark(terminalID: terminal.id)
             }
             guard terminal.activityState != params.activityState else {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -83,6 +83,13 @@ extension RPCRouter {
 
     // MARK: - Terminal Handlers
 
+    /// A pending-agent count becomes a working presentation; its absence
+    /// makes no claim at all. Split out so the mapping is assertable without
+    /// standing up a router.
+    static func delegationPresentation(pendingCount: Int?) -> TerminalActivityState? {
+        pendingCount == nil ? nil : .working
+    }
+
     func handleTerminalCreate(
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
@@ -609,6 +616,35 @@ extension RPCRouter {
 
         await codexActivityTracker.retain(
             transcriptPaths: codexTranscriptPaths, scope: params.worktreeID)
+
+        // Claude delegation rail. Only terminals that just ended a turn were
+        // marked, so a session at rest costs neither a stat nor a read. The
+        // claim is stamped with the same instant the Codex observation above
+        // took, so one response never carries two different "now"s.
+        let delegationTargets = terminals.indices
+            .filter { !terminals[$0].isCodexTerminal }
+            .map { ClaudeDelegationTarget(
+                terminalID: terminals[$0].id,
+                transcriptPath: terminals[$0].transcriptPath) }
+        let delegationClaims = await claudeDelegationTracker.sample(
+            targets: delegationTargets)
+        for index in terminals.indices where !terminals[index].isCodexTerminal {
+            // Only a live claim writes. Absence must leave the field alone
+            // rather than publish nil, which is a statement of its own.
+            guard let count = delegationClaims[terminals[index].id] else { continue }
+            terminals[index].presentationActivityState =
+                Self.delegationPresentation(pendingCount: count)
+            terminals[index].presentationActivityObservedAt = codexObservation.observedAt
+        }
+        // Pruning may only follow a FLEET-WIDE listing. `terminals` is filtered
+        // by `params.worktreeID` when one is given, so retaining against a
+        // scoped list would read every other worktree's terminals as gone and
+        // drop marks that were never sampled. The unscoped listing is the
+        // app's recurring refresh, so pruning still happens regularly.
+        if params.worktreeID == nil {
+            await claudeDelegationTracker.retain(
+                terminalIDs: Set(terminals.map(\.id)))
+        }
         return try RPCResponse(result: terminals)
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3237,6 +3237,16 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// A Claude session ended. Drops any standing delegation claim: a session
+    /// that exits while background subagents are live leaves a final
+    /// `turn_duration` record still reporting them, and no later turn ever
+    /// arrives to retract it.
+    func handleTerminalSessionEnded(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalSessionEndedParams.self, from: paramsData)
+        await claudeDelegationTracker.clear(terminalID: params.terminalID)
+        return .ok()
+    }
+
     func handleTerminalActivityEvent(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalActivityEventParams.self, from: paramsData)
         guard params.origin != .userInterrupt || params.activityState == .idle else {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -418,6 +418,8 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalSessionEvent(request.paramsData)
             case RPCMethod.terminalActivityEvent:
                 return try await handleTerminalActivityEvent(request.paramsData)
+            case RPCMethod.terminalSessionEnded:
+                return try await handleTerminalSessionEnded(request.paramsData)
             case RPCMethod.terminalNotificationEvent:
                 return try await handleTerminalNotificationEvent(request.paramsData)
             case RPCMethod.sessionStates:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -201,6 +201,9 @@ public final class RPCRouter: Sendable {
     /// Daemon-lifetime incremental transcript baselines used only to enrich
     /// terminal-list responses for Codex presentation state.
     let codexActivityTracker = CodexTranscriptActivityTracker()
+    /// Which Claude terminals owe a delegation sample, and what their last
+    /// sample claimed. Marked at every idle report; read during `terminal.list`.
+    let claudeDelegationTracker = ClaudeDelegationTracker()
     /// Opt-in tmux control-mode wiring. `nil` when the daemon did not provide
     /// one (tests, older callers); when present, terminal handlers open a gated
     /// logging-only `tmux -CC` connection after each `ensureServer()`.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -203,6 +203,7 @@ public enum RPCMethod {
     public static let terminalSwapProfile = "terminal.swapProfile"
     public static let terminalSessionEvent = "terminal.sessionEvent"
     public static let terminalActivityEvent = "terminal.activityEvent"
+    public static let terminalSessionEnded = "terminal.sessionEnded"
     public static let terminalNotificationEvent = "terminal.notificationEvent"
     public static let terminalAskUserQuestionPending = "terminal.askUserQuestionPending"
     public static let terminalAskUserQuestionCleared = "terminal.askUserQuestionCleared"
@@ -3173,6 +3174,20 @@ public struct TerminalActivityEventParams: Codable, Sendable {
         self.sessionID = sessionID
         self.origin = origin
     }
+}
+
+/// Params for `terminal.sessionEnded` — sent by `tbd session-end` from the
+/// Claude Code `SessionEnd` hook. Carries identity only: the daemon decides
+/// what ending a session means.
+///
+/// A dedicated method rather than a new `TerminalActivityEventOrigin` case:
+/// an unknown enum raw value throws inside the shared params decode on an
+/// older daemon, while an unknown *method* fails cleanly and the hook's
+/// trailing `|| true` swallows it. `~/.local/bin/tbd` can be stale relative
+/// to a running daemon, so that skew is real.
+public struct TerminalSessionEndedParams: Codable, Sendable, Equatable {
+    public let terminalID: UUID
+    public init(terminalID: UUID) { self.terminalID = terminalID }
 }
 
 /// Params for `terminal.notificationEvent` — sent by `tbd hooks notification`

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -1783,6 +1783,41 @@ func appState_claudeInterruptRetainsLegacyRawIdle(viaEscape: Bool) {
 }
 
 @MainActor
+@Test(
+    "Interrupting a delegating Claude clears the cached delegation claim",
+    arguments: [false, true]
+)
+func appState_claudeInterruptClearsCachedPresentationState(viaEscape: Bool) {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Claude",
+                kind: .claude,
+                activityState: .idle,
+                presentationActivityState: .working,
+                activityStateSource: .hookEvent("Stop"),
+                activityStateObservedAt: Date(timeIntervalSinceReferenceDate: 20)
+            )
+        ]
+    ]
+    #expect(WorktreeRowView.isForegroundWorking(state.terminals[worktreeID]![0]))
+
+    state.handleTerminalInterrupt(terminalID: terminalID, viaEscape: viaEscape)
+
+    // The delta rail carries no presentation field, so only this optimistic
+    // clear keeps the spinner from outliving the interrupt by a poll interval.
+    #expect(state.terminals[worktreeID]?[0].presentationActivityState == nil)
+    #expect(!WorktreeRowView.isForegroundWorking(state.terminals[worktreeID]![0]))
+}
+
+@MainActor
 @Test func appState_escDoesNotInterruptCodex() {
     let state = AppState()
     let worktreeID = UUID()

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -88,6 +88,78 @@ struct WorktreeRowActivityTests {
         #expect(!WorktreeRowView.isForegroundWorking(codex))
     }
 
+    // MARK: - Claude delegation rail
+    //
+    // Claude ORs the delegation claim with the hook rail; Codex REPLACES its
+    // hook rail with the transcript. Inverting the two is the likely bug.
+
+    @Test func aDelegationClaimLightsTheIndicatorWhileTheHookRailSaysIdle() {
+        let claude = terminal(
+            kind: .claude,
+            activityState: .idle,
+            presentationActivityState: .working
+        )
+
+        #expect(WorktreeRowView.isForegroundWorking(claude))
+    }
+
+    /// The OR direction: the hook rail alone still suffices mid-turn, when no
+    /// delegation claim exists. Inverting to Codex's REPLACE semantics breaks
+    /// this and would darken the indicator for every ordinary working session.
+    @Test func theHookRailAloneStillLightsTheIndicator() {
+        let claude = terminal(
+            kind: .claude,
+            activityState: .working,
+            presentationActivityState: nil
+        )
+
+        #expect(WorktreeRowView.isForegroundWorking(claude))
+    }
+
+    @Test func noClaimAndAnIdleHookRailStaysDark() {
+        let claude = terminal(
+            kind: .claude,
+            activityState: .idle,
+            presentationActivityState: nil
+        )
+
+        #expect(!WorktreeRowView.isForegroundWorking(claude))
+    }
+
+    @Test func anInterruptDefeatsADelegationClaim() {
+        var claude = terminal(
+            kind: .claude,
+            activityState: .idle,
+            presentationActivityState: .working
+        )
+        claude.activityStateSource = .terminalInterrupt
+
+        #expect(!WorktreeRowView.isForegroundWorking(claude))
+    }
+
+    @Test func waitingForUserDefeatsADelegationClaim() {
+        let claude = terminal(
+            kind: .claude,
+            activityState: .waitingForUser,
+            presentationActivityState: .working
+        )
+
+        #expect(!WorktreeRowView.isForegroundWorking(claude))
+    }
+
+    /// Regression guard: Codex ships unflagged today and must keep REPLACE
+    /// semantics — a Codex terminal whose transcript is silent stays dark even
+    /// when its hook rail is latched at working.
+    @Test func codexStillRequiresTranscriptAgreement() {
+        let codex = terminal(
+            kind: .codex,
+            activityState: .working,
+            presentationActivityState: nil
+        )
+
+        #expect(!WorktreeRowView.isForegroundWorking(codex))
+    }
+
     @Test func terminalCollectionReportsAnyTruthfulForegroundWork() {
         let staleCodex = terminal(
             kind: .codex,

--- a/Tests/TBDAppTests/WorktreeRowActivityTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowActivityTests.swift
@@ -126,17 +126,6 @@ struct WorktreeRowActivityTests {
         #expect(!WorktreeRowView.isForegroundWorking(claude))
     }
 
-    @Test func anInterruptDefeatsADelegationClaim() {
-        var claude = terminal(
-            kind: .claude,
-            activityState: .idle,
-            presentationActivityState: .working
-        )
-        claude.activityStateSource = .terminalInterrupt
-
-        #expect(!WorktreeRowView.isForegroundWorking(claude))
-    }
-
     @Test func waitingForUserDefeatsADelegationClaim() {
         let claude = terminal(
             kind: .claude,

--- a/Tests/TBDDaemonTests/ClaudeDelegationMarkTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeDelegationMarkTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ClaudeDelegationMarkTests {
+    /// The trap this guards: `handleTerminalActivityEvent` returns early when
+    /// the reported state equals the stored one, and a background-agent wake
+    /// produces a second `idle` with no `working` between. A mark placed below
+    /// that guard is dropped, and the rail latches the previous turn's count.
+    @Test func aRepeatedIdleReportStillMarksTheTerminal() async {
+        let tracker = ClaudeDelegationTracker()
+        let id = UUID()
+
+        await tracker.mark(terminalID: id)
+        _ = await tracker.sample(
+            targets: [ClaudeDelegationTarget(terminalID: id, transcriptPath: nil)])
+
+        // Second idle for an already-idle terminal: still a turn boundary.
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.isMarked(terminalID: id))
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeDelegationSampleTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeDelegationSampleTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ClaudeDelegationSampleTests {
+    /// A real `turn_duration` record carrying a pending count.
+    static let pending = #"{"parentUuid":"222fdc13-cfb9-4c0d-9cc4-4952202f8fce","isSidechain":false,"type":"system","subtype":"turn_duration","durationMs":133243,"messageCount":132,"pendingBackgroundAgentCount":1,"timestamp":"2026-08-22T23:43:17.655Z","uuid":"11111111-1111-1111-1111-111111111111","isMeta":false,"userType":"external","entrypoint":"cli","cwd":"/tmp/tbd-test/worktree","sessionId":"00000000-0000-0000-0000-000000000001","version":"2.1.239","gitBranch":"feature-branch"}"#
+
+    /// The same record shape with the field OMITTED — how Claude Code spells zero.
+    static let absent = #"{"parentUuid":"632a67a1-63dc-4c07-be99-1b8f1fb39f5f","isSidechain":false,"type":"system","subtype":"turn_duration","durationMs":146367,"messageCount":74,"timestamp":"2026-08-22T22:53:13.020Z","uuid":"11111111-1111-1111-1111-111111111111","isMeta":false,"userType":"external","entrypoint":"cli","cwd":"/tmp/tbd-test/worktree","sessionId":"00000000-0000-0000-0000-000000000001","version":"2.1.239","gitBranch":"feature-branch"}"#
+
+    /// An ordinary assistant line, present so the scanner must skip non-matches.
+    static let noise = #"{"type":"assistant","isSidechain":false,"uuid":"22222222-2222-2222-2222-222222222222","timestamp":"2026-08-22T23:43:10.000Z"}"#
+
+    private func tail(_ lines: [String]) -> Data {
+        Data((lines.joined(separator: "\n") + "\n").utf8)
+    }
+
+    @Test func readsThePendingCountFromTheNewestRecord() {
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([Self.noise, Self.pending])) == 1)
+    }
+
+    @Test func anOmittedFieldMakesNoClaim() {
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([Self.noise, Self.absent])) == nil)
+    }
+
+    /// The whole point of the level rail: the NEWEST record wins, so a later
+    /// turn that reports no pending agents retracts an earlier claim.
+    @Test func theNewestRecordWinsOverAnOlderOne() {
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([Self.pending, Self.absent])) == nil)
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([Self.absent, Self.pending])) == 1)
+    }
+
+    @Test func aTailWithNoTurnDurationMakesNoClaim() {
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([Self.noise, Self.noise])) == nil)
+    }
+
+    /// A 64 KiB window starts mid-record. The leading fragment must be dropped,
+    /// not parsed — a half record is not evidence.
+    @Test func aTruncatedLeadingRecordIsDiscarded() {
+        let truncated = String(Self.pending.dropFirst(40))
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([truncated, Self.absent])) == nil)
+        // And the fragment must not be mistaken for a claim on its own.
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([truncated])) == nil)
+    }
+
+    @Test func emptyAndGarbageTailsMakeNoClaim() {
+        #expect(ClaudeDelegationSample.pendingCount(inTail: Data()) == nil)
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: Data("not json at all\n".utf8)) == nil)
+    }
+
+    @Test func aZeroCountMakesNoClaim() {
+        let zero = Self.pending.replacingOccurrences(
+            of: #""pendingBackgroundAgentCount":1"#,
+            with: #""pendingBackgroundAgentCount":0"#)
+        #expect(ClaudeDelegationSample.pendingCount(inTail: tail([zero])) == nil)
+    }
+
+    @Test func anOversizedRecordIsSkippedRatherThanParsed() {
+        let huge = #"{"subtype":"turn_duration","pad":"@","pendingBackgroundAgentCount":9}"#
+            .replacingOccurrences(of: "@", with: String(repeating: "x", count: 1 << 20))
+        #expect(ClaudeDelegationSample.pendingCount(inTail: tail([huge])) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeDelegationSampleTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeDelegationSampleTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Testing
 @testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
 
 @Suite struct ClaudeDelegationSampleTests {
     /// A real `turn_duration` record carrying a pending count.
@@ -40,8 +42,10 @@ import Testing
             inTail: tail([Self.noise, Self.noise])) == nil)
     }
 
-    /// A 64 KiB window starts mid-record. The leading fragment must be dropped,
-    /// not parsed — a half record is not evidence.
+    /// A 64 KiB window starts mid-record. The leading fragment needs no special
+    /// handling: a byte range beginning mid-object is not valid JSON, so it
+    /// fails to parse and is skipped like any other unreadable line. A half
+    /// record is not evidence either way.
     @Test func aTruncatedLeadingRecordIsDiscarded() {
         let truncated = String(Self.pending.dropFirst(40))
         #expect(ClaudeDelegationSample.pendingCount(
@@ -55,6 +59,19 @@ import Testing
         #expect(ClaudeDelegationSample.pendingCount(inTail: Data()) == nil)
         #expect(ClaudeDelegationSample.pendingCount(
             inTail: Data("not json at all\n".utf8)) == nil)
+    }
+
+    /// A background subagent runs its own turns in a sidechain, and those
+    /// records must never speak for the main loop's count.
+    @Test func aSidechainRecordMakesNoClaim() {
+        let sidechain = Self.pending.replacingOccurrences(
+            of: #""isSidechain":false"#,
+            with: #""isSidechain":true"#)
+        #expect(sidechain != Self.pending)
+        #expect(ClaudeDelegationSample.pendingCount(inTail: tail([sidechain])) == nil)
+        // And a sidechain record must not shadow the main loop's newest one.
+        #expect(ClaudeDelegationSample.pendingCount(
+            inTail: tail([Self.pending, sidechain])) == 1)
     }
 
     @Test func aZeroCountMakesNoClaim() {
@@ -78,5 +95,91 @@ import Testing
         #expect(RPCRouter.delegationPresentation(pendingCount: 2) == .working)
         #expect(RPCRouter.delegationPresentation(pendingCount: 1) == .working)
         #expect(RPCRouter.delegationPresentation(pendingCount: nil) == nil)
+    }
+}
+
+/// The publish step's parked skip, driven through `terminal.list`.
+///
+/// `RowStatusIndicator` ranks working above hibernated, and a parked session
+/// runs nothing that could ever restate the level, so a claim standing at park
+/// time would replace the calm moon with animated dots that nothing retracts.
+@Suite struct ClaudeDelegationParkedPublicationTests {
+    private func makeFixture() async throws -> (RPCRouter, TBDDatabase, Terminal, URL) {
+        let db = try TBDDatabase(inMemory: true)
+        let tmux = TmuxManager(dryRun: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+        let repo = try await db.repos.create(
+            path: "/tmp/cdp-repo-\(UUID().uuidString)",
+            displayName: "cdp-repo",
+            defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/cdp-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-cdp")
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-cdp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true)
+        let transcript = dir.appendingPathComponent("session.jsonl")
+        try Data((ClaudeDelegationSampleTests.pending + "\n").utf8).write(to: transcript)
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Claude",
+            kind: .claude)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "s1", transcriptPath: transcript.path)
+        await router.claudeDelegationTracker.mark(terminalID: terminal.id)
+        return (router, db, terminal, dir)
+    }
+
+    private func listPresentation(
+        _ router: RPCRouter, _ terminal: Terminal
+    ) async throws -> TerminalActivityState? {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: terminal.worktreeID))
+        let response = await router.handle(request)
+        #expect(response.success)
+        let terminals = try response.decodeResult([Terminal].self)
+        #expect(terminals.count == 1)
+        return terminals.first?.presentationActivityState
+    }
+
+    /// The un-parked control: without it the two parked cases below would pass
+    /// against a rail that publishes nothing at all.
+    @Test("a live Claude terminal publishes its delegation claim")
+    func aLiveTerminalPublishesItsClaim() async throws {
+        let (router, _, terminal, dir) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect(try await listPresentation(router, terminal) == .working)
+    }
+
+    @Test("a hibernated Claude terminal publishes no delegation claim")
+    func aHibernatedTerminalPublishesNoClaim() async throws {
+        let (router, db, terminal, dir) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s1")
+
+        #expect(try await listPresentation(router, terminal) == nil)
+    }
+
+    @Test("a suspended Claude terminal publishes no delegation claim")
+    func aSuspendedTerminalPublishesNoClaim() async throws {
+        let (router, db, terminal, dir) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.terminals.setSuspended(id: terminal.id, sessionID: "s1")
+
+        #expect(try await listPresentation(router, terminal) == nil)
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeDelegationSampleTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeDelegationSampleTests.swift
@@ -70,3 +70,13 @@ import Testing
         #expect(ClaudeDelegationSample.pendingCount(inTail: tail([huge])) == nil)
     }
 }
+
+@Suite struct ClaudeDelegationPublicationTests {
+    /// The rail publishes through the SAME response-derived field Codex uses,
+    /// so no column and no migration are involved.
+    @Test func aClaimMapsToWorkingAndNoClaimMapsToNil() {
+        #expect(RPCRouter.delegationPresentation(pendingCount: 2) == .working)
+        #expect(RPCRouter.delegationPresentation(pendingCount: 1) == .working)
+        #expect(RPCRouter.delegationPresentation(pendingCount: nil) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeDelegationTrackerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeDelegationTrackerTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ClaudeDelegationTrackerTests {
+    private func write(_ body: String) throws -> String {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-delegation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("transcript.jsonl").path
+        try body.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    private func record(pending: Int?) -> String {
+        let field = pending.map { #""pendingBackgroundAgentCount":\#($0),"# } ?? ""
+        return #"{"type":"system","subtype":"turn_duration",\#(field)"durationMs":1}"#
+    }
+
+    @Test func anUnmarkedTerminalIsNeverRead() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let path = try write(record(pending: 2) + "\n")
+        let id = UUID()
+        // No mark: the file says 2, but nothing asked for a sample.
+        let result = await tracker.sample(
+            targets: [ClaudeDelegationTarget(terminalID: id, transcriptPath: path)])
+        #expect(result[id] == nil)
+    }
+
+    @Test func aMarkedTerminalIsSampledAndTheClaimPersists() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let path = try write(record(pending: 2) + "\n")
+        let id = UUID()
+        await tracker.mark(terminalID: id)
+        let targets = [ClaudeDelegationTarget(terminalID: id, transcriptPath: path)]
+        #expect(await tracker.sample(targets: targets)[id] == 2)
+        // The mark is consumed, but the claim stands until the next turn end.
+        #expect(await tracker.sample(targets: targets)[id] == 2)
+    }
+
+    @Test func aLaterTurnWithoutPendingAgentsRetractsTheClaim() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let path = try write(record(pending: 1) + "\n")
+        let id = UUID()
+        let targets = [ClaudeDelegationTarget(terminalID: id, transcriptPath: path)]
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(targets: targets)[id] == 1)
+
+        try (record(pending: 1) + "\n" + record(pending: nil) + "\n")
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(targets: targets)[id] == nil)
+    }
+
+    @Test func aTranscriptPathChangeDiscardsTheCachedClaim() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let old = try write(record(pending: 3) + "\n")
+        let new = try write(record(pending: nil) + "\n")
+        let id = UUID()
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(
+            targets: [ClaudeDelegationTarget(terminalID: id, transcriptPath: old)])[id] == 3)
+        // A /clear or compaction retargets the terminal. The old file's count
+        // must not speak for the new one, even with no fresh mark.
+        #expect(await tracker.sample(
+            targets: [ClaudeDelegationTarget(terminalID: id, transcriptPath: new)])[id] == nil)
+    }
+
+    @Test func clearDropsALiveClaim() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let path = try write(record(pending: 1) + "\n")
+        let id = UUID()
+        let targets = [ClaudeDelegationTarget(terminalID: id, transcriptPath: path)]
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(targets: targets)[id] == 1)
+        await tracker.clear(terminalID: id)
+        #expect(await tracker.sample(targets: targets)[id] == nil)
+    }
+
+    @Test func anUnreadableOrAbsentPathMakesNoClaim() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let id = UUID()
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(targets: [
+            ClaudeDelegationTarget(terminalID: id, transcriptPath: nil)])[id] == nil)
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(targets: [
+            ClaudeDelegationTarget(terminalID: id, transcriptPath: "/nonexistent/x.jsonl")
+        ])[id] == nil)
+    }
+
+    @Test func retainPrunesTerminalsThatAreGone() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let path = try write(record(pending: 1) + "\n")
+        let id = UUID()
+        let targets = [ClaudeDelegationTarget(terminalID: id, transcriptPath: path)]
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(targets: targets)[id] == 1)
+        await tracker.retain(terminalIDs: [])
+        #expect(await tracker.sample(targets: targets)[id] == nil)
+    }
+
+    /// Only the tail is read, so a claim survives an arbitrarily large file.
+    @Test func onlyTheTailIsReadForALargeTranscript() async throws {
+        let filler = String(repeating:
+            #"{"type":"assistant","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}"# + "\n",
+            count: 4000)
+        let path = try write(filler + record(pending: 5) + "\n")
+        let id = UUID()
+        let tracker = ClaudeDelegationTracker()
+        await tracker.mark(terminalID: id)
+        #expect(await tracker.sample(
+            targets: [ClaudeDelegationTarget(terminalID: id, transcriptPath: path)])[id] == 5)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -726,6 +726,7 @@ extension TBDHomeSerialized {
             "PostToolUse|AskUserQuestion|\(ClaudeHookOverlay.askUserQuestionPostCommand)",
             "PostToolUse|Bash|\(ClaudeHookOverlay.prBindCommand)",
             "PreToolUse|AskUserQuestion|\(ClaudeHookOverlay.askUserQuestionPreCommand)",
+            "SessionEnd|<none>|\(ClaudeHookOverlay.sessionEndCommand)",
             "SessionStart|*|\(ClaudeHookOverlay.sessionStartCommand)",
             "Stop|<none>|\(ClaudeHookOverlay.stopCommand)",
             "Stop|<none>|\(ClaudeHookOverlay.stopRenameCheckCommand)",
@@ -733,6 +734,24 @@ extension TBDHomeSerialized {
             "UserPromptSubmit|<none>|\(ClaudeHookOverlay.workingCommand)"
         ].sorted()
         #expect(rendered == expected)
+    }
+
+    @Test func sessionEndCommandClearsTheClaimAndNeverFails() throws {
+        let rendered = try renderHookEntries(try ClaudeHookOverlay.generateBody())
+        let entry = try #require(rendered.first { $0.hasPrefix("SessionEnd|") })
+        #expect(entry.contains("tbd session-end"))
+        #expect(entry.hasSuffix("2>/dev/null || true"))
+    }
+
+    /// Claude Code runs SessionEnd callbacks inside a 1.5s shutdown budget, so
+    /// this entry carries an explicit short timeout rather than the 60s default.
+    @Test func sessionEndCarriesAnExplicitShortTimeout() throws {
+        let body = try ClaudeHookOverlay.generateBody()
+        let parsed = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        let hooks = (parsed?["hooks"] as? [String: Any])?["SessionEnd"] as? [[String: Any]]
+        let inner = try #require((hooks?.first?["hooks"] as? [[String: Any]])?.first)
+        #expect((inner["timeout"] as? Int) == ClaudeHookOverlay.sessionEndTimeoutSeconds)
+        #expect(ClaudeHookOverlay.sessionEndTimeoutSeconds <= 2)
     }
 
     @Test func notificationCommandInvokesTheHookBridgeAndNeverFails() throws {

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -272,6 +272,38 @@ struct TerminalActivityEventHandlerTests {
         #expect(updated.activityStateObservedAt == olderInterruptAt)
     }
 
+    /// Regression guard for the ordering inside `handleTerminalActivityEvent`'s
+    /// non-Codex path: the delegation mark MUST be taken BEFORE the
+    /// unchanged-state guard (`guard terminal.activityState != params.activityState`).
+    /// A background agent's completion wakes the parent, which runs a turn and
+    /// ends it — a second `idle` with no `working` between — so the reported
+    /// state equals the stored one and the handler early-returns. Move the mark
+    /// below that guard and this test fails: the turn boundary is dropped and
+    /// the sidebar latches the previous turn's delegation count forever.
+    @Test("an idle event for an already-idle Claude terminal still marks it")
+    func anIdleEventForAnAlreadyIdleClaudeTerminalStillMarksIt() async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .idle,
+            source: .hookEvent(RPCMethod.terminalActivityEvent))
+        let stored = try #require(await db.terminals.get(id: terminal.id))
+        // The crux: the stored state already equals the state about to be
+        // reported, so the unchanged-state guard would early-return.
+        #expect(stored.activityState == .idle)
+        #expect(await router.claudeDelegationTracker.isMarked(terminalID: terminal.id) == false)
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .idle))
+
+        #expect((await router.handle(request)).success)
+
+        #expect(await router.claudeDelegationTracker.isMarked(terminalID: terminal.id))
+    }
+
     @Test("unknown terminalID is a soft no-op")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -304,6 +304,58 @@ struct TerminalActivityEventHandlerTests {
         #expect(await router.claudeDelegationTracker.isMarked(terminalID: terminal.id))
     }
 
+    /// The interrupt leg of the delegation rail, driven through the handler
+    /// rather than by hand-setting a fact the Claude path never produces.
+    ///
+    /// An interrupted Claude turn frequently writes no `turn_duration` at all,
+    /// so the newest record in the tail still reports the PRE-interrupt count.
+    /// Treating the interrupt's `idle` as an ordinary turn boundary therefore
+    /// re-reads that record on the next `terminal.list` and relights the
+    /// indicator with nothing running — the false-thinking direction this rail
+    /// is never allowed to fail toward. The interrupt must CLEAR the claim.
+    @Test("a user interrupt clears a standing Claude delegation claim")
+    func aUserInterruptClearsAStandingClaudeDelegationClaim() async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        // The transcript is handed to the tracker as a sampling target rather
+        // than stored on the row, which keeps the unrelated Stop-hook
+        // project-dir sync out of this test.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-delegation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let transcript = dir.appendingPathComponent("session.jsonl")
+        try Data((ClaudeDelegationSampleTests.pending + "\n").utf8)
+            .write(to: transcript)
+        let target = ClaudeDelegationTarget(
+            terminalID: terminal.id, transcriptPath: transcript.path)
+
+        // A turn ends with one background agent still live: the handler marks,
+        // and the next sample turns that mark into a standing claim.
+        #expect((await router.handle(try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .idle)))).success)
+        #expect(await router.claudeDelegationTracker.sample(
+            targets: [target]) == [terminal.id: 1])
+
+        // The user then presses Esc.
+        #expect((await router.handle(try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .idle,
+                origin: .userInterrupt)))).success)
+
+        // No mark is owed, and the standing claim is gone. Mark the interrupt
+        // instead of clearing it and this sample re-reads the same unchanged
+        // transcript and republishes the pre-interrupt count.
+        #expect(await router.claudeDelegationTracker.isMarked(
+            terminalID: terminal.id) == false)
+        #expect(await router.claudeDelegationTracker.sample(targets: [target]).isEmpty)
+    }
+
     @Test("unknown terminalID is a soft no-op")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(

--- a/docs/specs/2026-08-24-claude-delegation-activity-design.md
+++ b/docs/specs/2026-08-24-claude-delegation-activity-design.md
@@ -1,0 +1,298 @@
+# Claude Delegation Activity Design
+
+## Purpose
+
+A Claude session that delegates to a background subagent presents as idle while
+its subagent works. The parent's turn genuinely ends at delegation, so the
+`Stop` hook fires and sets `activityState = .idle`, and the sidebar's thinking
+indicator goes dark for as long as the delegated work runs. Field measurement
+on a live session recorded twelve minutes between the end of the turn that
+dispatched a background agent and the notification that woke the parent.
+
+This design adds a display-only rail that keeps the indicator lit across that
+gap. It reads a count Claude Code already publishes, samples it only at turn
+boundaries, and never touches the persisted activity fact.
+
+## Goals
+
+- Keep the sidebar working indicator lit while a Claude session waits on
+  background subagents.
+- Derive the claim from a machine-readable fact, never from rendered terminal
+  text.
+- Add no per-poll cost proportional to fleet size.
+- Degrade to current behavior whenever evidence is missing or unreadable.
+- Leave Codex and shell activity semantics untouched.
+
+## Non-goals
+
+- Changing what `activityState` means, or what it gates.
+- Blocking hibernation for a delegating session.
+- Reporting the internal progress of a subagent.
+- Distinguishing foreground from background delegation in the UI.
+- Counting subagents for any consumer other than the indicator.
+
+## Product semantics
+
+A Claude terminal presents the working indicator when either rail says so:
+
+1. The hook rail reports `activityState == .working`, as today.
+2. The delegation rail reports outstanding background agents.
+
+An explicit interrupt or a waiting-for-user state defeats both. The two rails
+compose by disjunction because each speaks about a different interval: the hook
+rail is authoritative during a turn, and the delegation rail speaks only after
+one ends.
+
+The indicator renders identically in both cases. A viewer learns that the
+worktree is making progress, which is what the indicator has always claimed;
+it has never distinguished which layer of the session is busy.
+
+### Why this is a bug fix rather than a gated feature
+
+The rail restores the indicator's intended meaning instead of adding a
+capability. It performs no autonomous action, destroys no state, and replaces
+no load-bearing path. It cannot affect hibernation, because it never writes the
+field `HibernationGate` consults. Every failure mode resolves to the behavior
+that ships today. It therefore carries no feature flag, on the same reasoning
+that shipped the Codex activity reconciliation unflagged.
+
+## Relationship to the supervision session state
+
+This rail feeds the sidebar indicator and nothing else. It does not change
+`SessionStateResolver`, which composes the separate `SessionStateValue` that
+`session.states` and the fleet supervision readouts consume. A delegating
+session continues to resolve `.idle` there, carrying its source and observed-at
+so a consumer can see that `idle` means "the hook rail last reported a turn
+ending, at this time".
+
+The two answers differ because they are answers to different questions, and the
+separation is deliberate. The indicator asks whether the worktree is making
+progress, and a bounded, display-only, fail-toward-idle claim serves that well.
+Supervision asks whether a session needs a human, and it may act on the answer;
+it therefore holds a higher bar for what counts as evidence and prefers
+reporting ambiguity to guessing. Extending the delegation fact into the
+supervision model would be a separate design with a different risk profile,
+because that model's consumers are not confined to a spinner.
+
+## Authoritative signal
+
+Claude Code writes a `system` record with `subtype: "turn_duration"` at the end
+of every turn. When background agents remain live, that record carries
+`pendingBackgroundAgentCount` with their number; when none remain, it omits the
+field entirely. The distinction between a present count and an absent field is
+therefore the whole signal, and no other record needs reading.
+
+The field is a **level**, not an **edge**, and the design rests on that
+difference. A level restates current truth on every emission, so sampling only
+the newest value is correct regardless of how many earlier values went unread.
+An edge — a start and stop event pair counted into an accumulator — must be
+delivered exactly once or the count drifts, and a missed decrement latches the
+indicator on forever. Level sampling makes that failure structurally impossible.
+
+Two measurements establish that Claude Code, not TBD, maintains the level.
+Across a corpus of real sessions, agents reached four terminal states —
+completed, failed, killed, and stopped — and every one of them notified the
+parent, which ran a turn, which restated the count. Launches whose notification
+never appeared in the transcript were rarer than one in five hundred. In the one
+such case where the session kept running afterward, all nineteen subsequent
+`turn_duration` records reported the field absent. The count is maintained
+independently of whether any observer sees the notification.
+
+### Rejected signals
+
+- **`SubagentStart` / `SubagentStop` hooks.** Claude Code's documented and
+  supported interface, and instant rather than deferred. Rejected because the
+  pair is edge-triggered and therefore carries the drift failure described
+  above, because it fires for foreground subagents that can never change the
+  display, and because whether `SubagentStop` fires for a background agent
+  completing after its parent's turn has ended remained unverified. The
+  transcript lifecycle was verified end to end instead.
+- **`TaskCreated` / `TaskCompleted` hooks.** These exist, but they fire on the
+  `TaskCreate` tool — the task-list feature — and say nothing about subagents.
+- **An unresolved `Agent` tool-use.** A background launch writes its
+  `tool_result` immediately, carrying `status: "async_launched"`, so the
+  transcript shows a completed tool call while the work runs out of band.
+  `SessionStateResolver` documents this trap already.
+
+### Accepted risk
+
+Claude Code documents its transcript format as internal and subject to change
+on any release. The field has been present continuously across roughly
+thirty-five releases, and TBD already depends on this format in
+`TranscriptParser` and throughout the Codex reconciler, so the exposure is
+known rather than new. A release that removes the field produces no claim,
+which is exactly today's behavior.
+
+## Components and data flow
+
+### Delegation tracker
+
+`ClaudeDelegationTracker`, a daemon actor under `Sources/TBDDaemon/Claude/`,
+owns two pieces of transient state: the set of terminals awaiting a sample, and
+the last sampled count for each. Nothing persists. Its state is keyed by
+terminal and discarded when a terminal's transcript path changes, so a count
+read from a cleared or compacted session can never speak for its successor.
+
+The tracker mirrors `CodexTranscriptActivityTracker`'s role but needs far less
+machinery. The Codex tracker reduces an event stream and therefore may not miss
+a record, which is why it carries shared byte budgets, round-robin quanta and
+generation watermarks. A level sampler may skip everything except the newest
+value, so it needs none of them.
+
+### Marking a terminal for sampling
+
+`handleTerminalActivityEvent` already receives every Claude turn boundary. When
+a Claude terminal reports `idle`, the handler marks it for sampling.
+
+**The mark is set unconditionally, before the handler's unchanged-state early
+return.** That guard returns without acting when the reported state matches the
+stored one, and consecutive `idle` reports with no intervening `working` are
+reachable: a background agent's completion notification wakes the parent, which
+runs a turn and ends it. Marking after the guard would drop that second
+boundary and latch the previous count. Marking before it costs a set insertion
+and removes the dependency on whether an injected notification submits as a
+user prompt.
+
+### Sampling
+
+The next `terminal.list` satisfies outstanding marks. For each marked terminal
+the tracker stats the transcript path, reads at most the final 64 KiB, discards
+the partial leading record through its first newline, and scans backward for the
+newest `turn_duration`. A present `pendingBackgroundAgentCount` greater than
+zero becomes a claim; an absent field, an absent record, or an unreadable file
+produces none. The mark then clears.
+
+Sampling deliberately does not happen inside the activity handler, and the
+reason is an ordering fact that a reasonable implementation would otherwise get
+wrong. Claude Code runs the `Stop` hooks first, writes its hook summary once
+they return, and writes `turn_duration` about two milliseconds later. A read
+performed while the hook is executing therefore observes the *previous* turn's
+record — precisely the difference between a count of zero and a count of one in
+the case this design exists to catch. Deferring to the next poll clears the gap
+by three orders of magnitude.
+
+### Publication and composition
+
+A claim sets `presentationActivityState = .working` on the wire. That field is
+response-derived and never persisted, so this design adds no database column and
+no migration.
+
+`WorktreeRowView.isForegroundWorking` gains a Claude branch. **The two agent
+kinds compose their rails differently, and inverting them is the likely bug.**
+For Codex the presentation rail *replaces* the raw one: a Codex terminal shows
+working only when the transcript agrees. For Claude the presentation rail is
+*disjunctive* with the raw one: either rail alone suffices, because the hook
+rail stays correct during a turn and the delegation rail speaks only after one
+ends.
+
+### Clearing a stale claim
+
+Every ordinary ending restates the level, so no timeout constant appears
+anywhere in this design. What counts as a stalled agent is a theory on which
+reasonable projects differ, and compiling one would be the most expensive place
+to hold it. Two endings do not restate the level, and each gets a fact rather
+than a theory:
+
+- **Interrupt.** An interrupted turn frequently writes no `turn_duration` at
+  all, so the newest record keeps reporting the pre-interrupt count. TBD's own
+  `.terminalInterrupt` fact defeats the rail, matching the precedence the Codex
+  presentation path already follows.
+- **Session end.** A session that exits while agents remain live leaves a final
+  record reporting them, and no later turn corrects it. A `SessionEnd` entry in
+  the Claude hook overlay clears the claim. It follows the file's established
+  discipline — silent failure, never wedging the agent — and carries an explicit
+  short timeout, because Claude Code runs `SessionEnd` callbacks inside a
+  1.5-second shutdown budget.
+
+A crash that delivers no `SessionEnd` leaves a claim standing. The residual is
+bounded by the reconcilers and by hibernation, and it is cosmetic by
+construction, because the rail cannot reach anything but the indicator. This
+design accepts that case rather than introducing a timeout to cover it.
+
+## Cost
+
+The rail adds no term proportional to fleet size. A session that has not just
+ended a turn is neither stat'd nor read.
+
+Measured on a development fleet of roughly a hundred worktrees: stating every
+Claude transcript path costs about 0.2 ms, and a 64 KiB tail read with its parse
+costs about 0.5 ms. Because only marked terminals are sampled, steady-state work
+is one read per turn end rather than either figure per poll.
+
+Transcripts are large — a median around 2 MB and a maximum around 40 MB in that
+corpus — which is why the design stats first, reads a bounded tail, and never
+reads a whole file.
+
+## Failure modes
+
+Every failure produces no claim, and no claim means the indicator behaves
+exactly as it does today. The rail can therefore fail toward false idle but
+never toward false thinking, which is the safety direction the Codex
+reconciliation established.
+
+- A Claude Code release without the field yields no claim.
+- A tail containing no `turn_duration` yields no claim. This arises when much
+  has been appended since the last turn ended — a long turn in progress — where
+  the hook rail already reports working, so the delegation rail is not needed.
+  Measurement puts the newest record a median of about 1.3 KB from end of file,
+  within a 64 KiB tail for roughly 98% of transcripts.
+- A missing, empty, or unreadable transcript path yields no claim. Inability to
+  look is not evidence of work.
+- A truncated leading record in the tail is discarded through its newline.
+- A transcript path change discards the tracker's state for that terminal.
+- Removing a terminal prunes its tracker state on the existing retention path.
+
+## Durable resources
+
+This design creates none. Tracker state lives in memory and is pruned with the
+terminals it describes. No git ref, tmux object, spawned process, or file
+outlives the request that created it, so no reconciler needs extending.
+
+## Testing
+
+Two tests must fail against the current code for the right reason, because each
+guards a trap that a plausible implementation walks into and that a weaker test
+would pass regardless:
+
+- A transcript whose newest `turn_duration` belongs to the previous turn must
+  not publish that count. This fails if sampling moves into the activity
+  handler.
+- Two consecutive `idle` events with no intervening `working` must both mark.
+  This fails if the mark moves below the unchanged-state guard.
+
+Fixtures use real captured transcript bytes rather than hand-written JSON.
+Synthetic fixtures have twice measured a fallback path in this repository while
+appearing to exercise the real one. The captured set covers a present count, an
+absent field, a tail with no record, a truncated leading record, and an
+oversized record.
+
+Remaining coverage:
+
+- The composition asymmetry, including a Codex regression guard, since that path
+  ships unflagged today.
+- Interrupt and waiting-for-user each defeating the rail.
+- A transcript path change discarding a stale count.
+- An absent field reproducing current behavior exactly.
+- The hook overlay's exact-equality entry set, extended with the `SessionEnd`
+  entry, asserting its silent-failure suffix and its timeout.
+
+## Files
+
+New:
+
+- `Sources/TBDDaemon/Claude/ClaudeDelegationTracker.swift`
+- `Tests/TBDDaemonTests/ClaudeDelegationTrackerTests.swift`
+
+Modified:
+
+- `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` — mark before the
+  early return; satisfy marks during `terminal.list`.
+- `Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift` — `SessionEnd` entry and its
+  timeout constant.
+- `Sources/TBDApp/Sidebar/WorktreeRowView.swift` — the Claude branch.
+- `Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift` — the entry-set assertion.
+
+This design requires no migration, no configuration column, no feature flag, and
+no injected clock. Each is absent for a stated reason: the presentation field is
+never persisted, the behavior is a bug fix, and the existing `terminal.list`
+poll supplies the deferral rather than a new timer.

--- a/docs/specs/2026-08-24-claude-delegation-activity-design.md
+++ b/docs/specs/2026-08-24-claude-delegation-activity-design.md
@@ -74,6 +74,12 @@ Reaching that state requires a park to select a delegating session. The idle
 sweep's master switch defaults off, which leaves merge-park and an explicit
 manual park as the live paths.
 
+What the rail does carry is that a parked terminal publishes no claim at all.
+The row ranks working above hibernated, and a parked session runs nothing that
+could ever restate the level, so a claim standing at park time would replace
+the calm moon with animated dots permanently. The publish step therefore skips
+any terminal that is hibernated or suspended.
+
 **The safe direction for the gate is the opposite of the safe direction for the
 indicator, and conflating the two is the trap.** For the indicator, a false
 working claim misleads and a false idle claim costs nothing, so the rail prefers
@@ -192,11 +198,18 @@ user prompt.
 ### Sampling
 
 The next `terminal.list` satisfies outstanding marks. For each marked terminal
-the tracker stats the transcript path, reads at most the final 64 KiB, discards
-the partial leading record through its first newline, and scans backward for the
-newest `turn_duration`. A present `pendingBackgroundAgentCount` greater than
-zero becomes a claim; an absent field, an absent record, or an unreadable file
-produces none. The mark then clears.
+the tracker stats the transcript path, reads at most the final 64 KiB, and
+takes the newest `turn_duration` among the lines that parse. A present
+`pendingBackgroundAgentCount` greater than zero becomes a claim; an absent
+field, an absent record, or an unreadable file produces none. A record must
+also not be a subagent's own — a `turn_duration` carrying `isSidechain` never
+speaks for the main loop. The mark then clears.
+
+The tail's leading fragment needs no special handling. A byte range that
+starts mid-object is not valid JSON, so it fails to parse and is skipped like
+any other unreadable line, while a tail that happens to begin on a record
+boundary — the common case for a short transcript read whole — keeps that
+record instead of losing it to a blind drop through the first newline.
 
 Sampling deliberately does not happen inside the activity handler, and the
 reason is an ordering fact that a reasonable implementation would otherwise get
@@ -230,9 +243,13 @@ to hold it. Two endings do not restate the level, and each gets a fact rather
 than a theory:
 
 - **Interrupt.** An interrupted turn frequently writes no `turn_duration` at
-  all, so the newest record keeps reporting the pre-interrupt count. TBD's own
-  `.terminalInterrupt` fact defeats the rail, matching the precedence the Codex
-  presentation path already follows.
+  all, so the newest record keeps reporting the pre-interrupt count. The
+  interrupt is therefore carried to the daemon as an explicit `userInterrupt`
+  origin for every agent kind, and the handler clears the terminal's claim
+  rather than marking it for a sample that would re-read the stale record.
+  The row's `.terminalInterrupt` precedence defeats the rail in the same
+  direction, matching the Codex presentation path, but that fact is persisted
+  only on the Codex path, so the origin is what carries the Claude case.
 - **Session end.** A session that exits while agents remain live leaves a final
   record reporting them, and no later turn corrects it. A `SessionEnd` entry in
   the Claude hook overlay clears the claim. It follows the file's established
@@ -274,7 +291,8 @@ reconciliation established.
   within a 64 KiB tail for roughly 98% of transcripts.
 - A missing, empty, or unreadable transcript path yields no claim. Inability to
   look is not evidence of work.
-- A truncated leading record in the tail is discarded through its newline.
+- A truncated leading record in the tail fails to parse and yields no claim.
+- A `turn_duration` written by a subagent's own sidechain yields no claim.
 - A transcript path change discards the tracker's state for that terminal.
 - Removing a terminal prunes its tracker state on the existing retention path.
 
@@ -306,7 +324,9 @@ Remaining coverage:
 
 - The composition asymmetry, including a Codex regression guard, since that path
   ships unflagged today.
-- Interrupt and waiting-for-user each defeating the rail.
+- Interrupt and waiting-for-user each defeating the rail, the interrupt driven
+  through the real handler so the origin's own leg is exercised.
+- A parked terminal publishing no claim.
 - A transcript path change discarding a stale count.
 - An absent field reproducing current behavior exactly.
 - The hook overlay's exact-equality entry set, extended with the `SessionEnd`
@@ -322,7 +342,10 @@ New:
 Modified:
 
 - `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` — mark before the
-  early return; satisfy marks during `terminal.list`.
+  early return, clear on an interrupt origin; satisfy marks during
+  `terminal.list`, skipping parked terminals.
+- `Sources/TBDApp/AppState+Terminals.swift` — carry the `userInterrupt` origin
+  for every agent kind.
 - `Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift` — `SessionEnd` entry and its
   timeout constant.
 - `Sources/TBDApp/Sidebar/WorktreeRowView.swift` — the Claude branch.

--- a/docs/specs/2026-08-24-claude-delegation-activity-design.md
+++ b/docs/specs/2026-08-24-claude-delegation-activity-design.md
@@ -26,7 +26,8 @@ boundaries, and never touches the persisted activity fact.
 ## Non-goals
 
 - Changing what `activityState` means, or what it gates.
-- Blocking hibernation for a delegating session.
+- Blocking hibernation for a delegating session. See "The hibernation hazard
+  this design does not cover".
 - Reporting the internal progress of a subagent.
 - Distinguishing foreground from background delegation in the UI.
 - Counting subagents for any consumer other than the indicator.
@@ -55,6 +56,41 @@ no load-bearing path. It cannot affect hibernation, because it never writes the
 field `HibernationGate` consults. Every failure mode resolves to the behavior
 that ships today. It therefore carries no feature flag, on the same reasoning
 that shipped the Codex activity reconciliation unflagged.
+
+## The hibernation hazard this design does not cover
+
+Parking a delegating session destroys its delegated work, and this design does
+not prevent that. The hazard is recorded here because the rail deliberately
+stops short of it, not because the risk is theoretical.
+
+`performHibernate` terminates rather than suspends: it sends an in-band `/exit`,
+falls back to a graceful interrupt, and respawns the window, which guarantees
+the process is gone. Background subagents die with their parent. Resuming does
+not recover them, because the parent's transcript holds a launch record whose
+completion notification can no longer arrive, so the resumed session waits on a
+result that will never come.
+
+Reaching that state requires a park to select a delegating session. The idle
+sweep's master switch defaults off, which leaves merge-park and an explicit
+manual park as the live paths.
+
+**The safe direction for the gate is the opposite of the safe direction for the
+indicator, and conflating the two is the trap.** For the indicator, a false
+working claim misleads and a false idle claim costs nothing, so the rail prefers
+idle. For the gate, a false working claim refuses a park — visible, recoverable,
+and costing only memory — while a false idle claim destroys work silently. A
+gate consumer must therefore prefer working, which is why the indicator's rail
+cannot simply be extended to it and called done.
+
+Covering the hazard needs three things this design does not carry. The gate runs
+on the daemon's clock rather than in response to `terminal.list`, so it cannot
+read a response-derived field and would take its own bounded sample at park time;
+that sampling is affordable precisely because parking is rare, and a fresh read
+cannot latch. The veto belongs behind a default-off configuration column and a
+soak, following the typed-but-unsent input veto, which is the same shape of rail
+and refuses a park for the same class of reason. And a stale claim must not
+render a worktree permanently unparkable, which argues for consulting process
+liveness before refusing.
 
 ## Relationship to the supervision session state
 

--- a/docs/specs/2026-08-24-claude-delegation-activity-design.md
+++ b/docs/specs/2026-08-24-claude-delegation-activity-design.md
@@ -250,12 +250,21 @@ than a theory:
   The row's `.terminalInterrupt` precedence defeats the rail in the same
   direction, matching the Codex presentation path, but that fact is persisted
   only on the Codex path, so the origin is what carries the Claude case.
+  The app clears its own cached presentation value in the same gesture, for
+  every agent kind. Dropping the daemon's claim alone is not enough: the
+  real-time delta the daemon pushes carries no presentation field, so a clear
+  made only there would reach the sidebar on the next unscoped poll and leave
+  the indicator lit for as long as that interval — the false-thinking direction
+  this rail must never fail toward. Clearing it for Codex too is safe, because
+  Codex's foreground-working test requires a working presentation value and can
+  therefore only reach idle sooner.
 - **Session end.** A session that exits while agents remain live leaves a final
   record reporting them, and no later turn corrects it. A `SessionEnd` entry in
   the Claude hook overlay clears the claim. It follows the file's established
   discipline — silent failure, never wedging the agent — and carries an explicit
-  short timeout, because Claude Code runs `SessionEnd` callbacks inside a
-  1.5-second shutdown budget.
+  short timeout in place of Claude Code's 60-second default, so a wedged socket
+  cannot hold a quitting session open for a minute. Claude Code's own
+  ~1.5-second `SessionEnd` shutdown budget is the tighter bound in practice.
 
 A crash that delivers no `SessionEnd` leaves a claim standing. The residual is
 bounded by the reconcilers and by hibernation, and it is cosmetic by


### PR DESCRIPTION
## Summary

A Claude session that delegates to a background subagent shows as **idle** while its subagent works. The parent's turn genuinely ends at delegation, so the `Stop` hook fires, `activityState` becomes `.idle`, and the sidebar's thinking indicator goes dark for the whole delegation. Measured on a live session: **twelve minutes dark** between the turn that dispatched a background agent and the notification that woke the parent.

This adds a display-only rail that reads a count Claude Code already publishes, samples it only at turn boundaries, and never touches the persisted activity fact.

**Why it happens.** `ClaudeHookOverlay` drives `activityState` purely off turn boundaries — `UserPromptSubmit` → working, `Stop` → idle. Background delegation ends the parent's turn, so the hook rail is telling the truth; it just isn't the whole truth.

**Provenance.** Not a regression — the indicator has behaved this way since it was introduced. Background subagents made it visible. `SessionStateResolver` already documented the gap ("a session waiting on a background subagent reads as `idle`, and no machine signal fixes that") and correctly rejected the obvious detector, since a backgrounded agent's `tool_result` lands immediately with `status: "async_launched"`. That conclusion has since been overtaken by a signal that did not exist when it was written.

**The signal.** Claude Code writes `pendingBackgroundAgentCount` on its end-of-turn `turn_duration` record, omitting the field when none remain. It is a **level**, not an edge: it restates current truth at every turn end, so sampling only the newest value is correct however many earlier values went unread. That is what rules out a `SubagentStart`/`SubagentStop` counter — an accumulator drifts, and a missed decrement would latch the indicator on forever. Rationale and rejected alternatives: [`docs/specs/2026-08-24-claude-delegation-activity-design.md`](docs/specs/2026-08-24-claude-delegation-activity-design.md).

**Shape.** A terminal reporting `idle` is *marked*; the next `terminal.list` reads at most a 64 KiB tail and publishes through the existing response-derived `presentationActivityState`. Sampling is deferred deliberately: Claude Code writes `turn_duration` ~2 ms **after** the `Stop` hooks return, so reading at hook time samples the previous turn. A session that has not just ended a turn costs neither a stat nor a read.

No migration, config column, feature flag, or injected clock. Each is absent for a stated reason: the presentation field is never persisted, this restores intended meaning rather than adding a capability (same reasoning that shipped the Codex activity reconciliation unflagged), and the existing 2 s poll supplies the deferral.

**Durable resources:** none created. Tracker state is in-memory and pruned with the terminals it describes, so no reconciler needs extending.

### Three traps worth knowing about

- **The mark sits above the unchanged-state guard** in `handleTerminalActivityEvent`. A background agent's completion wakes the parent, which runs a turn and ends it — a second `idle` with no `working` between. Below the guard, that boundary is dropped and a stale count latches. Pinned by a router-level test verified to fail when the mark is moved.
- **The two agent kinds compose their rails differently.** Codex lets its transcript *replace* the hook rail; Claude *ORs* with it. Giving Claude REPLACE semantics compiles, passes most tests, and darkens the indicator for every ordinary working session. Pinned by `theHookRailAloneStillLightsTheIndicator`, likewise verified to fail under that mutation.
- **Clearing on interrupt takes two writes, not one.** The daemon drops its claim on the `userInterrupt` origin, but `TerminalActivityDelta` carries no presentation field, so that clear would otherwise reach the app only on the next unscoped poll. `handleTerminalInterrupt` clears the cached value too. A daemon-side test alone passes while the visible ~2 s window stays open — found in review, now covered by an app-side test over both interrupt paths.

### Known limits, stated rather than implied

- **A crash that delivers no `SessionEnd` leaves a claim standing.** Cosmetic by construction — the rail cannot reach anything but the indicator, and a parked terminal publishes no claim at all.
- **~2 ms write race latches rather than self-corrects.** If a sample lands inside that window it stores the previous turn's count until the next completed turn. Rare, and the fix (re-mark when the tail carries no record newer than the mark) is deliberately not guessed at here.
- **First delegating turn end can go dark for up to 2 s** before the poll relights it; later turns are unaffected because the claim already stands. This is the fail-closed direction and is left as is.
- **Hibernation is untouched.** Parking a delegating session destroys its delegated work, and this PR does not prevent that — the spec records the hazard and why a gate consumer needs the *opposite* safety polarity from the indicator.

## Test plan

- [x] `scripts/test.sh` full suite green in CI. Locally three tests fail on this box before and after the change (`parseLiveCWDs` shells out to real `ps`; the others differ run to run) — confirmed against a baseline run on the same tree.
- [x] Targeted suites green after rebase onto main: `ClaudeDelegation` 23, `WorktreeRow` 32, `TerminalActivityEventHandler` 26, `TerminalActivityAppState` 50, `ClaudeHookOverlay` 41, `Codex` 186, plus main's `NotificationHookRPC` 27 and `RowStatusIndicator` 29.
- [x] `swiftlint --strict` — 0 violations, 812 files.
- [x] Mutation-verified: mark placement, composition asymmetry, daemon interrupt clear, app-cache interrupt clear, and the parked-terminal skip each fail when their invariant is broken and pass when restored.
- [x] Live: `scripts/restart.sh`, daemon and app confirmed as this worktree's build by matching SHA-256; `terminal.list` observed serving `presentationActivityState`.
- [ ] **Reviewer:** dispatch a background agent, confirm the dots stay lit after the turn ends and go dark once it reports.
- [ ] **Reviewer:** the `SessionEnd` backstop needs a refreshed `~/.local/bin/tbd` — `restart.sh` does not update it, and a stale CLI silently no-ops the hook through its `|| true`.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=AAE1DD0B-E1AE-4DB6-9D3A-14125CC75C3B)