### PR TITLE
Feat: Optional left-hand project chevron, and a collapsible Scratch section

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3292,6 +3292,18 @@ final class AppState: ObservableObject {
     /// is the pure form of the gate the two placements disagree about.
     static let chevronAfterProjectNameKey = "chevronAfterProjectName"
 
+    /// UserDefaults key for whether the sidebar's Scratch section is
+    /// expanded. A project's equivalent is `Repo.expanded`, which the daemon
+    /// owns because a repo is a daemon-side record; a scratch section is
+    /// app-side chrome over a filter of worktrees, with no row of its own to
+    /// carry the bit, so it lives here. Default expanded — collapsing is a
+    /// gesture the user makes, never the state they are handed.
+    static let scratchSectionExpandedKey = "scratchSectionExpanded"
+
+    /// The one default for `scratchSectionExpandedKey`, for the reason
+    /// spelled out on `enableTranscriptDefault`.
+    static let scratchSectionExpandedDefault = true
+
     /// The one default for `chevronAfterProjectNameKey`. Every read site — the
     /// Settings toggle and `RepoSectionView`'s `@AppStorage` — must spell the
     /// default with this constant rather than a bare literal, for the reason

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3283,6 +3283,21 @@ final class AppState: ObservableObject {
     /// turns it off for users who find the hover card noisy.
     static let showClaudeTabUsageTooltipKey = "showClaudeTabUsageTooltip"
 
+    /// UserDefaults key for where a sidebar project row's disclosure chevron
+    /// sits. Off (the default) puts it before the project name, always
+    /// mounted, so every row's chevron lines up in one column. On moves it to
+    /// immediately after the name, where it also picks up the row's hover gate
+    /// — see `RepoSectionView.chevronButton`. Read via `@AppStorage` in the
+    /// view layer; `RepoSectionView.chevronMounted(afterName:hovered:menuOpen:)`
+    /// is the pure form of the gate the two placements disagree about.
+    static let chevronAfterProjectNameKey = "chevronAfterProjectName"
+
+    /// The one default for `chevronAfterProjectNameKey`. Every read site — the
+    /// Settings toggle and `RepoSectionView`'s `@AppStorage` — must spell the
+    /// default with this constant rather than a bare literal, for the reason
+    /// spelled out on `enableTranscriptDefault`.
+    static let chevronAfterProjectNameDefault = false
+
     /// Pure, testable mirror of the sidebar's Scratch-section gate:
     /// shown whenever the setting is on, regardless of whether any scratch
     /// spaces exist yet. This keeps the section (and its hover "+" create

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3284,13 +3284,23 @@ final class AppState: ObservableObject {
     static let showClaudeTabUsageTooltipKey = "showClaudeTabUsageTooltip"
 
     /// UserDefaults key for where a sidebar project row's disclosure chevron
-    /// sits. Off (the default) puts it before the project name, always
-    /// mounted, so every row's chevron lines up in one column. On moves it to
-    /// immediately after the name, where it also picks up the row's hover gate
-    /// — see `RepoSectionView.chevronButton`. Read via `@AppStorage` in the
-    /// view layer; `RepoSectionView.chevronMounted(afterName:hovered:menuOpen:)`
-    /// is the pure form of the gate the two placements disagree about.
-    static let chevronAfterProjectNameKey = "chevronAfterProjectName"
+    /// sits. Off — the default, and what shipped before this setting existed —
+    /// leaves it immediately after the project name, hover-gated with the
+    /// row's `+`. On moves it before the name, always mounted, so every row's
+    /// chevron lines up in one column; the sidebar's titles and rows shift
+    /// right to clear that column with it (`SidebarHeaderMetrics`).
+    ///
+    /// Read via `@AppStorage` in the view layer;
+    /// `SidebarHeaderMetrics.chevronMounted(beforeTitle:revealed:)` is the
+    /// pure form of the gate the two placements disagree about.
+    static let chevronBeforeProjectNameKey = "chevronBeforeProjectName"
+
+    /// The one default for `chevronBeforeProjectNameKey`. Every read site —
+    /// the Settings toggle and each view's `@AppStorage` — must spell the
+    /// default with this constant rather than a bare literal, for the reason
+    /// spelled out on `enableTranscriptDefault`. Off: nobody's sidebar moves
+    /// until they ask for it.
+    static let chevronBeforeProjectNameDefault = false
 
     /// UserDefaults key for whether the sidebar's Scratch section is
     /// expanded. A project's equivalent is `Repo.expanded`, which the daemon
@@ -3303,12 +3313,6 @@ final class AppState: ObservableObject {
     /// The one default for `scratchSectionExpandedKey`, for the reason
     /// spelled out on `enableTranscriptDefault`.
     static let scratchSectionExpandedDefault = true
-
-    /// The one default for `chevronAfterProjectNameKey`. Every read site — the
-    /// Settings toggle and `RepoSectionView`'s `@AppStorage` — must spell the
-    /// default with this constant rather than a bare literal, for the reason
-    /// spelled out on `enableTranscriptDefault`.
-    static let chevronAfterProjectNameDefault = false
 
     /// Pure, testable mirror of the sidebar's Scratch-section gate:
     /// shown whenever the setting is on, regardless of whether any scratch

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -42,6 +42,8 @@ struct GeneralSettingsTab: View {
     @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = AppState.enableTranscriptDefault
     @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
+    @AppStorage(AppState.chevronAfterProjectNameKey)
+    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
     @AppStorage(QueuedPromptComposer.sendImmediatelyKey)
     private var sendFirstMessageImmediately: Bool = QueuedPromptComposer.sendImmediatelyDefault
     @AppStorage(AppState.showClaudeTabUsageTooltipKey) private var showClaudeTabUsageTooltip: Bool = true
@@ -163,6 +165,9 @@ struct GeneralSettingsTab: View {
 
                 Toggle("Show Scratch section", isOn: $showScratchSection)
                     .help("Hide the repo-less Scratch section. Existing scratch spaces and their terminals keep running.")
+
+                Toggle("Put the project chevron after the name", isOn: $chevronAfterProjectName)
+                    .help("Off: each project's expand/collapse chevron sits before its name, in the same column on every row. On: the chevron trails the name, appearing on hover alongside the row's +, so its position shifts with the length of each name.")
 
                 Toggle("Send first messages immediately", isOn: $sendFirstMessageImmediately)
                     .help("Default for first messages you write while a new worktree is coming up. On: TBD presses Return, and the agent starts working the moment the message is in. Off: the text waits in the composer for you to read and send. The \"Send immediately\" checkbox in that creation sheet changes this too; the identical-looking checkbox on an already-parked message edits only that message.")

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -42,8 +42,8 @@ struct GeneralSettingsTab: View {
     @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = AppState.enableTranscriptDefault
     @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
-    @AppStorage(AppState.chevronAfterProjectNameKey)
-    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
+    @AppStorage(AppState.chevronBeforeProjectNameKey)
+    private var chevronBeforeProjectName: Bool = AppState.chevronBeforeProjectNameDefault
     @AppStorage(QueuedPromptComposer.sendImmediatelyKey)
     private var sendFirstMessageImmediately: Bool = QueuedPromptComposer.sendImmediatelyDefault
     @AppStorage(AppState.showClaudeTabUsageTooltipKey) private var showClaudeTabUsageTooltip: Bool = true
@@ -166,8 +166,8 @@ struct GeneralSettingsTab: View {
                 Toggle("Show Scratch section", isOn: $showScratchSection)
                     .help("Hide the repo-less Scratch section. Existing scratch spaces and their terminals keep running.")
 
-                Toggle("Put the project chevron after the name", isOn: $chevronAfterProjectName)
-                    .help("Off: each project's expand/collapse chevron sits before its name, in the same column on every row. On: the chevron trails the name, appearing on hover alongside the row's +, so its position shifts with the length of each name.")
+                Toggle("Put the project chevron before the name", isOn: $chevronBeforeProjectName)
+                    .help("Off: each project's expand/collapse chevron trails its name, appearing on hover alongside the row's +, so its position shifts with the length of each name. On: the chevron leads the name in the same column on every row, always visible, and the sidebar's titles and rows shift right to clear that column.")
 
                 Toggle("Send first messages immediately", isOn: $sendFirstMessageImmediately)
                     .help("Default for first messages you write while a new worktree is coming up. On: TBD presses Return, and the agent starts working the moment the message is in. Off: the text waits in the composer for you to read and send. The \"Send immediately\" checkbox in that creation sheet changes this too; the identical-looking checkbox on an already-parked message edits only that message.")

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -25,8 +25,8 @@ struct RemoteSectionView: View {
     @EnvironmentObject var appState: AppState
     /// Read only to place the session rows under their provider's title —
     /// see `SidebarHeaderMetrics.childRowLeadingInset`.
-    @AppStorage(AppState.chevronAfterProjectNameKey)
-    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
+    @AppStorage(AppState.chevronBeforeProjectNameKey)
+    private var chevronBeforeProjectName: Bool = AppState.chevronBeforeProjectNameDefault
 
     var body: some View {
         let knownRepoIDs = RemoteSectionView.knownRepoIDs(repos: appState.repos, repoFilter: appState.repoFilter)
@@ -46,7 +46,7 @@ struct RemoteSectionView: View {
                     .listRowInsets(EdgeInsets(
                         top: 0,
                         leading: SidebarHeaderMetrics.childRowLeadingInset(
-                            chevronAfterProjectName: chevronAfterProjectName),
+                            chevronBeforeProjectName: chevronBeforeProjectName),
                         bottom: 0,
                         trailing: 0))
                     .listRowSeparator(.hidden)
@@ -189,8 +189,8 @@ struct RemoteProviderHeaderRow: View {
     /// `ScratchSectionView`'s copy: this header has no chevron, and a project
     /// row's chevron placement decides which column every section title sits
     /// in. See `SidebarHeaderMetrics.titleLeadingInset`.
-    @AppStorage(AppState.chevronAfterProjectNameKey)
-    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
+    @AppStorage(AppState.chevronBeforeProjectNameKey)
+    private var chevronBeforeProjectName: Bool = AppState.chevronBeforeProjectNameDefault
 
     private var issueSummary: String? {
         RemoteProviderStatusPresentation.issueSummary(provider)
@@ -251,7 +251,7 @@ struct RemoteProviderHeaderRow: View {
                 }
                 .buttonStyle(.plain)
                 .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
-                    chevronAfterProjectName: chevronAfterProjectName))
+                    chevronBeforeProjectName: chevronBeforeProjectName))
                 .accessibilityLabel("Open \(provider.describe?.name ?? provider.config.name) provider desk")
                 healthSuffix
                 if canCreate {
@@ -280,7 +280,7 @@ struct RemoteProviderHeaderRow: View {
                     // Same inset as the name above, so the summary keeps
                     // hanging under it rather than under the chevron column.
                     .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
-                        chevronAfterProjectName: chevronAfterProjectName))
+                        chevronBeforeProjectName: chevronBeforeProjectName))
                     .help(issueSummary)
             }
         }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -176,6 +176,12 @@ struct RemoteProviderHeaderRow: View {
     /// sheet. Presented from the ROW, not from inside the popover — a
     /// popover can't host a sheet of its own.
     @State private var runningRemediation: RemoteRemediationRun?
+    /// Read only to place the title, for the same reason as
+    /// `ScratchSectionView`'s copy: this header has no chevron, and a project
+    /// row's chevron placement decides which column every section title sits
+    /// in. See `SidebarHeaderMetrics.titleLeadingInset`.
+    @AppStorage(AppState.chevronAfterProjectNameKey)
+    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
 
     private var issueSummary: String? {
         RemoteProviderStatusPresentation.issueSummary(provider)
@@ -214,10 +220,12 @@ struct RemoteProviderHeaderRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: -1) {
-            HStack(spacing: 4) {
+            HStack(spacing: SidebarHeaderMetrics.headerSpacing) {
                 // The name spans the row's free width instead of a trailing
                 // `Spacer()`, so the whole empty stretch is the desk's hit
-                // target rather than dead chrome.
+                // target rather than dead chrome. The title inset is padding
+                // on the button, not on the label inside it, so the indent
+                // doesn't come out of the desk's hit target.
                 Button {
                     appState.selectRemoteProvider(provider.config.name)
                 } label: {
@@ -233,6 +241,8 @@ struct RemoteProviderHeaderRow: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
+                    chevronAfterProjectName: chevronAfterProjectName))
                 .accessibilityLabel("Open \(provider.describe?.name ?? provider.config.name) provider desk")
                 healthSuffix
                 if canCreate {
@@ -258,6 +268,10 @@ struct RemoteProviderHeaderRow: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    // Same inset as the name above, so the summary keeps
+                    // hanging under it rather than under the chevron column.
+                    .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
+                        chevronAfterProjectName: chevronAfterProjectName))
                     .help(issueSummary)
             }
         }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -233,8 +233,9 @@ struct RemoteProviderHeaderRow: View {
                 // The name spans the row's free width instead of a trailing
                 // `Spacer()`, so the whole empty stretch is the desk's hit
                 // target rather than dead chrome. The title inset is padding
-                // on the button, not on the label inside it, so the indent
-                // doesn't come out of the desk's hit target.
+                // INSIDE the label, ahead of that full-width frame, so the
+                // indent still belongs to the desk's hit target — padding the
+                // button instead would carve the gutter back out of it.
                 Button {
                     appState.selectRemoteProvider(provider.config.name)
                 } label: {
@@ -246,12 +247,12 @@ struct RemoteProviderHeaderRow: View {
                                 : HierarchicalShapeStyle.secondary
                         )
                         .lineLimit(1)
+                        .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
+                            chevronBeforeProjectName: chevronBeforeProjectName))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
-                    chevronBeforeProjectName: chevronBeforeProjectName))
                 .accessibilityLabel("Open \(provider.describe?.name ?? provider.config.name) provider desk")
                 healthSuffix
                 if canCreate {

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -23,6 +23,10 @@ private let remoteRowLogger = Logger(subsystem: "com.tbd.app", category: "remote
 /// registered — see `AppState.remoteSectionVisible(providers:)`.
 struct RemoteSectionView: View {
     @EnvironmentObject var appState: AppState
+    /// Read only to place the session rows under their provider's title —
+    /// see `SidebarHeaderMetrics.childRowLeadingInset`.
+    @AppStorage(AppState.chevronAfterProjectNameKey)
+    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
 
     var body: some View {
         let knownRepoIDs = RemoteSectionView.knownRepoIDs(repos: appState.repos, repoFilter: appState.repoFilter)
@@ -39,7 +43,12 @@ struct RemoteSectionView: View {
             RemoteProviderHeaderRow(provider: provider)
             ForEach(RemoteSectionView.sessions(in: appState.remoteSessions, forProvider: provider.config.name, knownRepoIDs: knownRepoIDs)) { session in
                 RemoteSessionRowView(session: session)
-                    .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                    .listRowInsets(EdgeInsets(
+                        top: 0,
+                        leading: SidebarHeaderMetrics.childRowLeadingInset(
+                            chevronAfterProjectName: chevronAfterProjectName),
+                        bottom: 0,
+                        trailing: 0))
                     .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
                     .tag(session.id)
@@ -276,7 +285,8 @@ struct RemoteProviderHeaderRow: View {
             }
         }
         .frame(minHeight: 22, alignment: .bottom)
-        .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
+        .listRowInsets(EdgeInsets(top: 0, leading: SidebarHeaderMetrics.headerRowLeadingInset,
+                                  bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(
             appState.selectedRemoteProvider == provider.config.name

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -41,11 +41,11 @@ struct RepoSectionView: View {
     // Hover the `+` (or ⌥-click it) to open the model-profile picker; a plain
     // click still creates a worktree with the default profile.
     @StateObject private var newWorktreeMenu = HoverMenuModel()
-    /// Where this row's disclosure chevron sits — before the name (the
-    /// default) or after it. See `AppState.chevronAfterProjectNameKey` and
+    /// Where this row's disclosure chevron sits — after the name (the
+    /// default) or before it. See `AppState.chevronBeforeProjectNameKey` and
     /// `chevronButton`.
-    @AppStorage(AppState.chevronAfterProjectNameKey)
-    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
+    @AppStorage(AppState.chevronBeforeProjectNameKey)
+    private var chevronBeforeProjectName: Bool = AppState.chevronBeforeProjectNameDefault
 
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
@@ -182,17 +182,17 @@ struct RepoSectionView: View {
     }
 
     /// The header row's actual content (the chevron and the name in the order
-    /// `chevronAfterProjectName` asks for, an optional "missing" badge, and
+    /// `chevronBeforeProjectName` asks for, an optional "missing" badge, and
     /// the `+`), with none of `headerRow`'s trailing modifiers — see
     /// `headerRow`'s doc comment.
     @ViewBuilder
     private var headerHStack: some View {
         HStack(spacing: SidebarHeaderMetrics.headerSpacing) {
-            if !chevronAfterProjectName {
+            if chevronBeforeProjectName {
                 chevronButton
             }
             nameLabel
-            if chevronAfterProjectName {
+            if !chevronBeforeProjectName {
                 chevronButton
             }
             if repo.status == .missing {
@@ -205,16 +205,17 @@ struct RepoSectionView: View {
 
     /// Whether the chevron button is mounted at all right now — the one
     /// behavior the two placements disagree about, in pure form so a test can
-    /// call it without a SwiftUI render. Before the name it is always mounted;
-    /// after the name it rides the row's hover gate along with the `+`.
+    /// call it without a SwiftUI render. After the name (the default) it rides
+    /// the row's hover gate along with the `+`; before the name it is always
+    /// mounted.
     ///
     /// Main-actor isolated, unlike this file's other pure statics: it forwards
     /// to `HoverMenuModel.shouldShowPlus`, which is isolated itself, and
     /// calling the real gate matters more here than callability from a
     /// nonisolated test.
-    static func chevronMounted(afterName: Bool, hovered: Bool, menuOpen: Bool) -> Bool {
+    static func chevronMounted(beforeName: Bool, hovered: Bool, menuOpen: Bool) -> Bool {
         SidebarHeaderMetrics.chevronMounted(
-            afterTitle: afterName,
+            beforeTitle: beforeName,
             revealed: HoverMenuModel.shouldShowPlus(hovered: hovered, menuOpen: menuOpen)
         )
     }
@@ -226,9 +227,9 @@ struct RepoSectionView: View {
     private var chevronButton: some View {
         SectionDisclosureChevron(
             isExpanded: repo.expanded,
-            afterTitle: chevronAfterProjectName,
+            beforeTitle: chevronBeforeProjectName,
             isMounted: RepoSectionView.chevronMounted(
-                afterName: chevronAfterProjectName,
+                beforeName: chevronBeforeProjectName,
                 hovered: isSectionHovered,
                 menuOpen: newWorktreeMenu.isOpen
             ),
@@ -261,11 +262,12 @@ struct RepoSectionView: View {
                 .foregroundStyle(nameForegroundStyle)
         }
         // Claw back the chevron's trailing slack when it leads the name, so
-        // the pair reads as one label. Nothing to claw back when the chevron
-        // trails instead — see `chevronButton`'s own leading padding. The
-        // constant lives in `SidebarHeaderMetrics` because the chevron-less
-        // section headers derive their own title inset from it.
-        .padding(.leading, chevronAfterProjectName ? 0 : SidebarHeaderMetrics.nameLeadingClawback)
+        // the pair reads as one label. Nothing to claw back in the default
+        // placement, where the chevron trails instead — see `chevronButton`'s
+        // own leading padding there. The constant lives in
+        // `SidebarHeaderMetrics` because the chevron-less section headers
+        // derive their own title inset from it.
+        .padding(.leading, chevronBeforeProjectName ? SidebarHeaderMetrics.nameLeadingClawback : 0)
     }
 
     @ViewBuilder
@@ -332,7 +334,7 @@ struct RepoSectionView: View {
         EdgeInsets(
             top: 0,
             leading: SidebarHeaderMetrics.childRowLeadingInset(
-                chevronAfterProjectName: chevronAfterProjectName),
+                chevronBeforeProjectName: chevronBeforeProjectName),
             bottom: 0,
             trailing: 0)
     }

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -41,6 +41,11 @@ struct RepoSectionView: View {
     // Hover the `+` (or ⌥-click it) to open the model-profile picker; a plain
     // click still creates a worktree with the default profile.
     @StateObject private var newWorktreeMenu = HoverMenuModel()
+    /// Where this row's disclosure chevron sits — before the name (the
+    /// default) or after it. See `AppState.chevronAfterProjectNameKey` and
+    /// `chevronButton`.
+    @AppStorage(AppState.chevronAfterProjectNameKey)
+    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
 
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
@@ -134,7 +139,7 @@ struct RepoSectionView: View {
         }
     }
 
-    /// The section header row (name + chevron + `+`) and every modifier
+    /// The section header row (chevron, name, `+`) and every modifier
     /// attached to it — extracted out of `body` alongside `expandedContent`,
     /// and further split into `headerHStack` + its own sub-pieces below, so
     /// the type checker sees several smaller expressions instead of one
@@ -175,14 +180,20 @@ struct RepoSectionView: View {
         .tag(repo.id)
     }
 
-    /// The header row's actual content (name + chevron + optional "missing"
-    /// badge + `+`), with none of `headerRow`'s trailing modifiers — see
+    /// The header row's actual content (the chevron and the name in the order
+    /// `chevronAfterProjectName` asks for, an optional "missing" badge, and
+    /// the `+`), with none of `headerRow`'s trailing modifiers — see
     /// `headerRow`'s doc comment.
     @ViewBuilder
     private var headerHStack: some View {
         HStack(spacing: 4) {
+            if !chevronAfterProjectName {
+                chevronButton
+            }
             nameLabel
-            chevronButton
+            if chevronAfterProjectName {
+                chevronButton
+            }
             if repo.status == .missing {
                 missingBadge
             }
@@ -191,60 +202,97 @@ struct RepoSectionView: View {
         }
     }
 
-    /// The disclosure chevron, revealed on the same hover gate as the `+` (see
-    /// `newWorktreePlusButton`) so the two hover affordances appear and vanish
-    /// together. The hidden branch keeps the 18pt square so the "missing" badge
-    /// doesn't slide sideways as the chevron comes and goes.
+    /// Whether the chevron button is mounted at all right now — the one
+    /// behavior the two placements disagree about, in pure form so a test can
+    /// call it without a SwiftUI render. Before the name it is always mounted;
+    /// after the name it rides the row's hover gate along with the `+`.
     ///
-    /// Hover-gating a disclosure control is deliberate, not incidental, and
-    /// was signed off by the maintainer. It trades two things for a quieter
-    /// sidebar: the at-a-glance expanded/collapsed read, and pointer-free
-    /// reachability — `isSectionHovered` is driven only by `.onHover`, so the
-    /// button is absent from the focus tree entirely until a pointer enters
-    /// the section, and Tab/Full Keyboard Access skips it. The accepted answer
-    /// for keyboard-only users is the header's context-menu Collapse/Expand
-    /// item (below), which is not gated on hover and performs the same action.
-    /// The `+` on this same row already made this exact trade.
+    /// Main-actor isolated, unlike this file's other pure statics: it forwards
+    /// to `HoverMenuModel.shouldShowPlus`, which is isolated itself, and
+    /// calling the real gate matters more here than callability from a
+    /// nonisolated test.
+    static func chevronMounted(afterName: Bool, hovered: Bool, menuOpen: Bool) -> Bool {
+        guard afterName else { return true }
+        return HoverMenuModel.shouldShowPlus(hovered: hovered, menuOpen: menuOpen)
+    }
+
+    private var chevronIsMounted: Bool {
+        RepoSectionView.chevronMounted(
+            afterName: chevronAfterProjectName,
+            hovered: isSectionHovered,
+            menuOpen: newWorktreeMenu.isOpen
+        )
+    }
+
+    /// The disclosure chevron, in whichever of its two presentations
+    /// `AppState.chevronAfterProjectNameKey` selects.
     ///
-    /// So do not "fix" this by always-mounting the button — that reverses a
-    /// decision someone made on purpose. The `.accessibilityLabel` below is
-    /// worth keeping regardless: it serves VoiceOver whenever the button is
-    /// mounted, which it never did before.
+    /// Before the name (the default) it is always mounted and plainly styled,
+    /// so the glyph sits in the same column on every row and reads the
+    /// expanded/collapsed state at a glance without a pointer.
+    ///
+    /// After the name it trails the title and takes the `+`'s hover wash and
+    /// hover gate, so the two affordances appear and vanish together and the
+    /// resting sidebar is quieter. That gate is deliberate and was signed off
+    /// by the maintainer: it costs the at-a-glance state read and pointer-free
+    /// reachability, because `isSectionHovered` is driven only by `.onHover`,
+    /// so the button is absent from the focus tree until a pointer enters the
+    /// section and Tab/Full Keyboard Access skips it. The accepted answer for
+    /// keyboard-only users is the header's ungated context-menu
+    /// Collapse/Expand item (below), which performs the same action — and the
+    /// setting itself, whose default placement is never gated. So do not
+    /// "fix" the trailing placement by always-mounting it; that reverses a
+    /// decision someone made on purpose.
+    ///
+    /// The unmounted branch keeps the 18pt square so the "missing" badge
+    /// doesn't slide sideways as the chevron comes and goes. The
+    /// `.accessibilityLabel` serves VoiceOver in both placements — the glyph
+    /// carries no text of its own.
     @ViewBuilder
     private var chevronButton: some View {
         Group {
-            if HoverMenuModel.shouldShowPlus(hovered: isSectionHovered, menuOpen: newWorktreeMenu.isOpen) {
-                Button {
-                    Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
-                } label: {
-                    Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
-                        .font(.system(size: 10))
-                        // Applied to the glyph, not the button, so it wins over
-                        // `HoverPressButtonStyle`'s blanket `.secondary` and a
-                        // missing repo still renders dimmed.
-                        .foregroundStyle(chevronForegroundStyle)
-                        .frame(width: 18, height: 18)
-                        .contentShape(Rectangle())
+            if chevronIsMounted {
+                if chevronAfterProjectName {
+                    chevronToggle.buttonStyle(HoverPressButtonStyle())
+                } else {
+                    chevronToggle.buttonStyle(.plain)
                 }
-                .buttonStyle(HoverPressButtonStyle())
-                // The glyph carries no text, so VoiceOver has nothing to
-                // announce without this — parity with the `+`'s label.
-                .accessibilityLabel(repo.expanded ? "Collapse \(repo.displayName)" : "Expand \(repo.displayName)")
-                .onHover { isChevronHovered = $0 }
-                .help(repo.expanded ? "Collapse" : "Expand")
             } else {
                 Color.clear
             }
         }
         .frame(width: 18, height: 18)
-        // The 18pt-square hit target centers the 10pt glyph, leaving ~4pt of
-        // slack on each side. Trim the leading slack so the chevron reads as
-        // attached to the name rather than floating after it.
-        .padding(.leading, -3)
-        // Nudge down so the chevron sits on the name's optical baseline
-        // rather than its cap-height center. Layout-neutral by design — the
-        // hit target rides along with the glyph.
-        .offset(y: 2)
+        // The 18pt-square hit target centers the glyph, leaving ~4pt of slack
+        // on each side. Trailing the name, trim the leading slack so the
+        // chevron reads as attached to the name rather than floating after it,
+        // and nudge down so it sits on the name's optical baseline rather than
+        // its cap-height center. Both are layout-neutral for the hit target,
+        // which rides along with the glyph. Leading the name, the slack is
+        // what separates the glyph from the window edge, so it stays.
+        .padding(.leading, chevronAfterProjectName ? -3 : 0)
+        .offset(y: chevronAfterProjectName ? 2 : 0)
+    }
+
+    /// The chevron's button and label without a button style — `chevronButton`
+    /// applies the style its placement calls for. The glyph is a point smaller
+    /// trailing the name so it doesn't outweigh the title it follows.
+    @ViewBuilder
+    private var chevronToggle: some View {
+        Button {
+            Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
+        } label: {
+            Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
+                .font(.system(size: chevronAfterProjectName ? 10 : 11))
+                // Applied to the glyph, not the button, so it wins over
+                // `HoverPressButtonStyle`'s blanket `.secondary` and a
+                // missing repo still renders dimmed.
+                .foregroundStyle(chevronForegroundStyle)
+                .frame(width: 18, height: 18)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel(repo.expanded ? "Collapse \(repo.displayName)" : "Expand \(repo.displayName)")
+        .onHover { isChevronHovered = $0 }
+        .help(repo.expanded ? "Collapse" : "Expand")
     }
 
     @ViewBuilder
@@ -264,6 +312,10 @@ struct RepoSectionView: View {
                 .truncationMode(.tail)
                 .foregroundStyle(nameForegroundStyle)
         }
+        // Claw back the chevron's trailing slack when it leads the name, so
+        // the pair reads as one label. Nothing to claw back when the chevron
+        // trails instead — see `chevronButton`'s own leading padding.
+        .padding(.leading, chevronAfterProjectName ? 0 : -2)
     }
 
     @ViewBuilder

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -174,7 +174,8 @@ struct RepoSectionView: View {
         } message: {
             Text(removeConfirmMessage)
         }
-        .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
+        .listRowInsets(EdgeInsets(top: 0, leading: SidebarHeaderMetrics.headerRowLeadingInset,
+                                  bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
         .tag(repo.id)
@@ -212,89 +213,34 @@ struct RepoSectionView: View {
     /// calling the real gate matters more here than callability from a
     /// nonisolated test.
     static func chevronMounted(afterName: Bool, hovered: Bool, menuOpen: Bool) -> Bool {
-        guard afterName else { return true }
-        return HoverMenuModel.shouldShowPlus(hovered: hovered, menuOpen: menuOpen)
-    }
-
-    private var chevronIsMounted: Bool {
-        RepoSectionView.chevronMounted(
-            afterName: chevronAfterProjectName,
-            hovered: isSectionHovered,
-            menuOpen: newWorktreeMenu.isOpen
+        SidebarHeaderMetrics.chevronMounted(
+            afterTitle: afterName,
+            revealed: HoverMenuModel.shouldShowPlus(hovered: hovered, menuOpen: menuOpen)
         )
     }
 
-    /// The disclosure chevron, in whichever of its two presentations
-    /// `AppState.chevronAfterProjectNameKey` selects.
-    ///
-    /// Before the name (the default) it is always mounted and plainly styled,
-    /// so the glyph sits in the same column on every row and reads the
-    /// expanded/collapsed state at a glance without a pointer.
-    ///
-    /// After the name it trails the title and takes the `+`'s hover wash and
-    /// hover gate, so the two affordances appear and vanish together and the
-    /// resting sidebar is quieter. That gate is deliberate and was signed off
-    /// by the maintainer: it costs the at-a-glance state read and pointer-free
-    /// reachability, because `isSectionHovered` is driven only by `.onHover`,
-    /// so the button is absent from the focus tree until a pointer enters the
-    /// section and Tab/Full Keyboard Access skips it. The accepted answer for
-    /// keyboard-only users is the header's ungated context-menu
-    /// Collapse/Expand item (below), which performs the same action — and the
-    /// setting itself, whose default placement is never gated. So do not
-    /// "fix" the trailing placement by always-mounting it; that reverses a
-    /// decision someone made on purpose.
-    ///
-    /// The unmounted branch keeps the 18pt square so the "missing" badge
-    /// doesn't slide sideways as the chevron comes and goes. The
-    /// `.accessibilityLabel` serves VoiceOver in both placements — the glyph
-    /// carries no text of its own.
-    @ViewBuilder
+    /// This row's disclosure chevron. Everything about how it looks and when
+    /// it is mounted lives in `SectionDisclosureChevron`, which the Scratch
+    /// section wears too; what a project row adds is the dimming of a
+    /// `.missing` repo and the hover edge that dims its worktree rows.
     private var chevronButton: some View {
-        Group {
-            if chevronIsMounted {
-                if chevronAfterProjectName {
-                    chevronToggle.buttonStyle(HoverPressButtonStyle())
-                } else {
-                    chevronToggle.buttonStyle(.plain)
-                }
-            } else {
-                Color.clear
+        SectionDisclosureChevron(
+            isExpanded: repo.expanded,
+            afterTitle: chevronAfterProjectName,
+            isMounted: RepoSectionView.chevronMounted(
+                afterName: chevronAfterProjectName,
+                hovered: isSectionHovered,
+                menuOpen: newWorktreeMenu.isOpen
+            ),
+            accessibilityLabel: repo.expanded
+                ? "Collapse \(repo.displayName)"
+                : "Expand \(repo.displayName)",
+            glyphStyle: chevronForegroundStyle,
+            onHoverChange: { isChevronHovered = $0 },
+            toggle: {
+                Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
             }
-        }
-        .frame(width: SidebarHeaderMetrics.chevronColumnWidth,
-               height: SidebarHeaderMetrics.chevronColumnWidth)
-        // The 18pt-square hit target centers the glyph, leaving ~4pt of slack
-        // on each side. Trailing the name, trim the leading slack so the
-        // chevron reads as attached to the name rather than floating after it,
-        // and nudge down so it sits on the name's optical baseline rather than
-        // its cap-height center. Both are layout-neutral for the hit target,
-        // which rides along with the glyph. Leading the name, the slack is
-        // what separates the glyph from the window edge, so it stays.
-        .padding(.leading, chevronAfterProjectName ? -3 : 0)
-        .offset(y: chevronAfterProjectName ? 2 : 0)
-    }
-
-    /// The chevron's button and label without a button style — `chevronButton`
-    /// applies the style its placement calls for. The glyph is a point smaller
-    /// trailing the name so it doesn't outweigh the title it follows.
-    @ViewBuilder
-    private var chevronToggle: some View {
-        Button {
-            Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
-        } label: {
-            Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
-                .font(.system(size: chevronAfterProjectName ? 10 : 11))
-                // Applied to the glyph, not the button, so it wins over
-                // `HoverPressButtonStyle`'s blanket `.secondary` and a
-                // missing repo still renders dimmed.
-                .foregroundStyle(chevronForegroundStyle)
-                .frame(width: SidebarHeaderMetrics.chevronColumnWidth,
-                       height: SidebarHeaderMetrics.chevronColumnWidth)
-                .contentShape(Rectangle())
-        }
-        .accessibilityLabel(repo.expanded ? "Collapse \(repo.displayName)" : "Expand \(repo.displayName)")
-        .onHover { isChevronHovered = $0 }
-        .help(repo.expanded ? "Collapse" : "Expand")
+        )
     }
 
     @ViewBuilder
@@ -380,6 +326,17 @@ struct RepoSectionView: View {
         .frame(width: 20, height: 20)
     }
 
+    /// Insets for every row under this section's title, so the rows track
+    /// the title's own column rather than a hardcoded number of their own.
+    private var childRowInsets: EdgeInsets {
+        EdgeInsets(
+            top: 0,
+            leading: SidebarHeaderMetrics.childRowLeadingInset(
+                chevronAfterProjectName: chevronAfterProjectName),
+            bottom: 0,
+            trailing: 0)
+    }
+
     /// The expanded repo's rows: main worktree, top-level worktree subtree
     /// (with drag reorder), then matched remote sessions — extracted out of
     /// `body` alongside `headerRow`. Pure restructuring: identical content,
@@ -392,7 +349,7 @@ struct RepoSectionView: View {
                 .background(Color.white.opacity(0.0001))
                 .opacity(isChevronHovered ? 0.7 : 1.0)
                 .onHover { onSectionHoverChange($0) }
-                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                .listRowInsets(childRowInsets)
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
                 .tag(main.id)
@@ -419,7 +376,7 @@ struct RepoSectionView: View {
             RemoteSessionRowView(session: session)
                 .opacity(isChevronHovered ? 0.7 : 1.0)
                 .onHover { onSectionHoverChange($0) }
-                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                .listRowInsets(childRowInsets)
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
                 .tag(session.id)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -186,7 +186,7 @@ struct RepoSectionView: View {
     /// `headerRow`'s doc comment.
     @ViewBuilder
     private var headerHStack: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: SidebarHeaderMetrics.headerSpacing) {
             if !chevronAfterProjectName {
                 chevronButton
             }
@@ -261,7 +261,8 @@ struct RepoSectionView: View {
                 Color.clear
             }
         }
-        .frame(width: 18, height: 18)
+        .frame(width: SidebarHeaderMetrics.chevronColumnWidth,
+               height: SidebarHeaderMetrics.chevronColumnWidth)
         // The 18pt-square hit target centers the glyph, leaving ~4pt of slack
         // on each side. Trailing the name, trim the leading slack so the
         // chevron reads as attached to the name rather than floating after it,
@@ -287,7 +288,8 @@ struct RepoSectionView: View {
                 // `HoverPressButtonStyle`'s blanket `.secondary` and a
                 // missing repo still renders dimmed.
                 .foregroundStyle(chevronForegroundStyle)
-                .frame(width: 18, height: 18)
+                .frame(width: SidebarHeaderMetrics.chevronColumnWidth,
+                       height: SidebarHeaderMetrics.chevronColumnWidth)
                 .contentShape(Rectangle())
         }
         .accessibilityLabel(repo.expanded ? "Collapse \(repo.displayName)" : "Expand \(repo.displayName)")
@@ -314,8 +316,10 @@ struct RepoSectionView: View {
         }
         // Claw back the chevron's trailing slack when it leads the name, so
         // the pair reads as one label. Nothing to claw back when the chevron
-        // trails instead — see `chevronButton`'s own leading padding.
-        .padding(.leading, chevronAfterProjectName ? 0 : -2)
+        // trails instead — see `chevronButton`'s own leading padding. The
+        // constant lives in `SidebarHeaderMetrics` because the chevron-less
+        // section headers derive their own title inset from it.
+        .padding(.leading, chevronAfterProjectName ? 0 : SidebarHeaderMetrics.nameLeadingClawback)
     }
 
     @ViewBuilder

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -3,25 +3,69 @@ import SwiftUI
 import TBDShared
 
 /// Pinned sidebar section for repo-less scratch spaces (`Worktree.isScratch`).
-/// Modeled on `RepoSectionView`: a header row with a hover `+` to create a new
-/// scratch space, followed by the scratch worktree rows.
+/// Modeled on `RepoSectionView`: a header row with a disclosure chevron and a
+/// hover `+` to create a new scratch space, followed by the scratch worktree
+/// rows when the section is expanded.
 struct ScratchSectionView: View {
     @EnvironmentObject var appState: AppState
     @State private var isHeaderHovered = false
+    @State private var isChevronHovered = false
     @State private var showingScratchInstructions = false
-    /// Read only to place the title: this section has no chevron of its own,
-    /// but a project row does, and its position decides which column every
-    /// section title sits in. See `SidebarHeaderMetrics.titleLeadingInset`.
+    /// Whether the pads below the header are showing. App-side state, unlike a
+    /// project's daemon-owned `Repo.expanded` — see
+    /// `AppState.scratchSectionExpandedKey`.
+    @AppStorage(AppState.scratchSectionExpandedKey)
+    private var isExpanded: Bool = AppState.scratchSectionExpandedDefault
+    /// Which side of the title this section's chevron sits on, and with it
+    /// where every sidebar title and row sits. Shared with the project rows so
+    /// the two sections cannot disagree — see `SidebarHeaderMetrics`.
     @AppStorage(AppState.chevronAfterProjectNameKey)
     private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
 
+    private var chevronButton: some View {
+        SectionDisclosureChevron(
+            isExpanded: isExpanded,
+            afterTitle: chevronAfterProjectName,
+            // The `+` on this row is gated on plain hover rather than
+            // `HoverMenuModel` (this section has no profile picker to hold
+            // itself open), so that is the gate the chevron shares.
+            isMounted: SidebarHeaderMetrics.chevronMounted(
+                afterTitle: chevronAfterProjectName, revealed: isHeaderHovered),
+            accessibilityLabel: isExpanded
+                ? "Collapse \(AppState.scratchSectionLabel)"
+                : "Expand \(AppState.scratchSectionLabel)",
+            onHoverChange: { isChevronHovered = $0 },
+            toggle: { isExpanded.toggle() }
+        )
+    }
+
+    /// Insets for the rows under the title, tracking the title's own column —
+    /// the same helper the project sections use, so a scratch pad and a
+    /// worktree land in one column.
+    private var childRowInsets: EdgeInsets {
+        EdgeInsets(
+            top: 0,
+            leading: SidebarHeaderMetrics.childRowLeadingInset(
+                chevronAfterProjectName: chevronAfterProjectName),
+            bottom: 0,
+            trailing: 0)
+    }
+
     var body: some View {
         HStack(spacing: SidebarHeaderMetrics.headerSpacing) {
+            if !chevronAfterProjectName {
+                chevronButton
+            }
             Text(AppState.scratchSectionLabel)
                 .font(.headline)
                 .foregroundStyle(appState.selectedScratchSection ? .primary : .secondary)
-                .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
-                    chevronAfterProjectName: chevronAfterProjectName))
+                // Claw back the chevron square's slack when it leads the
+                // title, exactly as a project name does.
+                .padding(.leading, chevronAfterProjectName
+                         ? 0 : SidebarHeaderMetrics.nameLeadingClawback)
+            if chevronAfterProjectName {
+                chevronButton
+            }
             Spacer()
             if isHeaderHovered {
                 SectionHeaderPlusButton(help: "New scratch space", action: { appState.createScratch() })
@@ -32,8 +76,20 @@ struct ScratchSectionView: View {
         .onTapGesture {
             appState.selectScratchSection()
         }
-        .onHover { isHeaderHovered = $0 }
+        .onHover { hovering in
+            isHeaderHovered = hovering
+            // Trailing the title, the chevron is torn down by this same gate,
+            // so its own `onHover(false)` may never arrive — without this the
+            // pads would stay dimmed at 0.7 forever.
+            if !hovering { isChevronHovered = false }
+        }
         .contextMenu {
+            // Ungated, unlike the chevron when it trails the title — the
+            // keyboard-reachable path to the same action. See
+            // `SectionDisclosureChevron`.
+            Button(isExpanded ? "Collapse" : "Expand") {
+                isExpanded.toggle()
+            }
             Button("Edit Scratch Instructions…") {
                 showingScratchInstructions = true
             }
@@ -41,10 +97,20 @@ struct ScratchSectionView: View {
         .sheet(isPresented: $showingScratchInstructions) {
             ScratchInstructionsView().environmentObject(appState)
         }
-        .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
+        .listRowInsets(EdgeInsets(top: 0, leading: SidebarHeaderMetrics.headerRowLeadingInset,
+                                  bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
 
+        if isExpanded {
+            expandedContent
+        }
+    }
+
+    /// The pads themselves, plus the create-your-first-one CTA that stands in
+    /// for them while there are none.
+    @ViewBuilder
+    private var expandedContent: some View {
         if appState.scratchWorktrees.isEmpty {
             Button {
                 appState.createScratch()
@@ -59,7 +125,10 @@ struct ScratchSectionView: View {
             .onHover { hovering in
                 if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
             }
-            .listRowInsets(EdgeInsets(top: 2, leading: 14, bottom: 4, trailing: 0))
+            // The CTA stands where a pad row would, plus the 2pt it has always
+            // carried to sit optically under the header.
+            .listRowInsets(EdgeInsets(
+                top: 2, leading: childRowInsets.leading + 2, bottom: 4, trailing: 0))
             .listRowSeparator(.hidden)
             .listRowBackground(Color.clear)
         }
@@ -67,7 +136,10 @@ struct ScratchSectionView: View {
         ForEach(appState.scratchWorktrees) { wt in
             WorktreeRowView(worktree: wt)   // sectionRepoID nil → no (repo) suffix; repo affordances vanish
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                // Dimmed while the chevron is hovered, as a project's rows
+                // are — the gesture is about to hide them.
+                .opacity(isChevronHovered ? 0.7 : 1.0)
+                .listRowInsets(childRowInsets)
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
                 .tag(wt.id)

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -19,18 +19,18 @@ struct ScratchSectionView: View {
     /// Which side of the title this section's chevron sits on, and with it
     /// where every sidebar title and row sits. Shared with the project rows so
     /// the two sections cannot disagree — see `SidebarHeaderMetrics`.
-    @AppStorage(AppState.chevronAfterProjectNameKey)
-    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
+    @AppStorage(AppState.chevronBeforeProjectNameKey)
+    private var chevronBeforeProjectName: Bool = AppState.chevronBeforeProjectNameDefault
 
     private var chevronButton: some View {
         SectionDisclosureChevron(
             isExpanded: isExpanded,
-            afterTitle: chevronAfterProjectName,
+            beforeTitle: chevronBeforeProjectName,
             // The `+` on this row is gated on plain hover rather than
             // `HoverMenuModel` (this section has no profile picker to hold
             // itself open), so that is the gate the chevron shares.
             isMounted: SidebarHeaderMetrics.chevronMounted(
-                afterTitle: chevronAfterProjectName, revealed: isHeaderHovered),
+                beforeTitle: chevronBeforeProjectName, revealed: isHeaderHovered),
             accessibilityLabel: isExpanded
                 ? "Collapse \(AppState.scratchSectionLabel)"
                 : "Expand \(AppState.scratchSectionLabel)",
@@ -46,14 +46,14 @@ struct ScratchSectionView: View {
         EdgeInsets(
             top: 0,
             leading: SidebarHeaderMetrics.childRowLeadingInset(
-                chevronAfterProjectName: chevronAfterProjectName),
+                chevronBeforeProjectName: chevronBeforeProjectName),
             bottom: 0,
             trailing: 0)
     }
 
     var body: some View {
         HStack(spacing: SidebarHeaderMetrics.headerSpacing) {
-            if !chevronAfterProjectName {
+            if chevronBeforeProjectName {
                 chevronButton
             }
             Text(AppState.scratchSectionLabel)
@@ -61,9 +61,9 @@ struct ScratchSectionView: View {
                 .foregroundStyle(appState.selectedScratchSection ? .primary : .secondary)
                 // Claw back the chevron square's slack when it leads the
                 // title, exactly as a project name does.
-                .padding(.leading, chevronAfterProjectName
-                         ? 0 : SidebarHeaderMetrics.nameLeadingClawback)
-            if chevronAfterProjectName {
+                .padding(.leading, chevronBeforeProjectName
+                         ? SidebarHeaderMetrics.nameLeadingClawback : 0)
+            if !chevronBeforeProjectName {
                 chevronButton
             }
             Spacer()
@@ -78,7 +78,8 @@ struct ScratchSectionView: View {
         }
         .onHover { hovering in
             isHeaderHovered = hovering
-            // Trailing the title, the chevron is torn down by this same gate,
+            // Trailing the title — the default — the chevron is torn down by
+            // this same gate,
             // so its own `onHover(false)` may never arrive — without this the
             // pads would stay dimmed at 0.7 forever.
             if !hovering { isChevronHovered = false }

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -9,12 +9,19 @@ struct ScratchSectionView: View {
     @EnvironmentObject var appState: AppState
     @State private var isHeaderHovered = false
     @State private var showingScratchInstructions = false
+    /// Read only to place the title: this section has no chevron of its own,
+    /// but a project row does, and its position decides which column every
+    /// section title sits in. See `SidebarHeaderMetrics.titleLeadingInset`.
+    @AppStorage(AppState.chevronAfterProjectNameKey)
+    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: SidebarHeaderMetrics.headerSpacing) {
             Text(AppState.scratchSectionLabel)
                 .font(.headline)
                 .foregroundStyle(appState.selectedScratchSection ? .primary : .secondary)
+                .padding(.leading, SidebarHeaderMetrics.titleLeadingInset(
+                    chevronAfterProjectName: chevronAfterProjectName))
             Spacer()
             if isHeaderHovered {
                 SectionHeaderPlusButton(help: "New scratch space", action: { appState.createScratch() })

--- a/Sources/TBDApp/Sidebar/SectionDisclosureChevron.swift
+++ b/Sources/TBDApp/Sidebar/SectionDisclosureChevron.swift
@@ -5,17 +5,13 @@ import SwiftUI
 /// this one view so the two cannot drift apart in placement, glyph size, hover
 /// treatment, or what a screen reader hears.
 ///
-/// `AppState.chevronAfterProjectNameKey` decides which of two presentations
+/// `AppState.chevronBeforeProjectNameKey` decides which of two presentations
 /// every section uses; the caller reads the setting and passes it as
-/// `afterTitle`, along with the placement's `isMounted` gate from
-/// `SidebarHeaderMetrics.chevronMounted(afterTitle:revealed:)`.
+/// `beforeTitle`, along with the placement's `isMounted` gate from
+/// `SidebarHeaderMetrics.chevronMounted(beforeTitle:revealed:)`.
 ///
-/// Before the title (the default) the chevron is always mounted and plainly
-/// styled, so the glyph sits in the same column on every row and the
-/// expanded/collapsed state reads at a glance.
-///
-/// After the title it trails the name and takes the `+`'s hover wash and hover
-/// gate, so the two affordances appear and vanish together and the resting
+/// After the title (the default) it trails the name and takes the `+`'s hover
+/// wash and hover gate, so the two affordances appear and vanish together and the resting
 /// sidebar is quieter. That gate is deliberate and was signed off by the
 /// maintainer: it costs the at-a-glance state read and pointer-free
 /// reachability, because the caller's hover state is driven only by `.onHover`,
@@ -26,13 +22,17 @@ import SwiftUI
 /// default placement is never gated. So do not "fix" the trailing placement by
 /// always-mounting it; that reverses a decision someone made on purpose.
 ///
+/// Before the title, the chevron is always mounted and plainly styled, so the
+/// glyph sits in the same column on every row and the expanded/collapsed state
+/// reads at a glance.
+///
 /// The unmounted branch keeps the chevron's square so nothing beside it slides
 /// sideways as the glyph comes and goes.
 struct SectionDisclosureChevron: View {
     let isExpanded: Bool
     /// Where this chevron sits relative to its section title — read from
-    /// `AppState.chevronAfterProjectNameKey` by the caller.
-    let afterTitle: Bool
+    /// `AppState.chevronBeforeProjectNameKey` by the caller.
+    let beforeTitle: Bool
     /// Whether the button is mounted right now; `Color.clear` holds its place
     /// when it isn't. See `SidebarHeaderMetrics.chevronMounted`.
     let isMounted: Bool
@@ -49,10 +49,10 @@ struct SectionDisclosureChevron: View {
     var body: some View {
         Group {
             if isMounted {
-                if afterTitle {
-                    button.buttonStyle(HoverPressButtonStyle())
-                } else {
+                if beforeTitle {
                     button.buttonStyle(.plain)
+                } else {
+                    button.buttonStyle(HoverPressButtonStyle())
                 }
             } else {
                 Color.clear
@@ -67,8 +67,8 @@ struct SectionDisclosureChevron: View {
         // its cap-height center. Both are layout-neutral for the hit target,
         // which rides along with the glyph. Leading the title, that slack is
         // what separates the glyph from the window edge, so it stays.
-        .padding(.leading, afterTitle ? -3 : 0)
-        .offset(y: afterTitle ? 2 : 0)
+        .padding(.leading, beforeTitle ? 0 : -3)
+        .offset(y: beforeTitle ? 0 : 2)
     }
 
     /// The button and its label, styleless — `body` applies the style the
@@ -77,7 +77,7 @@ struct SectionDisclosureChevron: View {
     private var button: some View {
         Button(action: toggle) {
             Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                .font(.system(size: afterTitle ? 10 : 11))
+                .font(.system(size: beforeTitle ? 11 : 10))
                 // Applied to the glyph, not the button, so it wins over
                 // `HoverPressButtonStyle`'s blanket `.secondary` and a missing
                 // repo still renders dimmed.

--- a/Sources/TBDApp/Sidebar/SectionDisclosureChevron.swift
+++ b/Sources/TBDApp/Sidebar/SectionDisclosureChevron.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// The disclosure chevron a collapsible sidebar section wears — a project row
+/// (`RepoSectionView`) and the Scratch section (`ScratchSectionView`) share
+/// this one view so the two cannot drift apart in placement, glyph size, hover
+/// treatment, or what a screen reader hears.
+///
+/// `AppState.chevronAfterProjectNameKey` decides which of two presentations
+/// every section uses; the caller reads the setting and passes it as
+/// `afterTitle`, along with the placement's `isMounted` gate from
+/// `SidebarHeaderMetrics.chevronMounted(afterTitle:revealed:)`.
+///
+/// Before the title (the default) the chevron is always mounted and plainly
+/// styled, so the glyph sits in the same column on every row and the
+/// expanded/collapsed state reads at a glance.
+///
+/// After the title it trails the name and takes the `+`'s hover wash and hover
+/// gate, so the two affordances appear and vanish together and the resting
+/// sidebar is quieter. That gate is deliberate and was signed off by the
+/// maintainer: it costs the at-a-glance state read and pointer-free
+/// reachability, because the caller's hover state is driven only by `.onHover`,
+/// so the button is absent from the focus tree until a pointer enters the
+/// section and Tab/Full Keyboard Access skips it. The accepted answer for
+/// keyboard-only users is each section's ungated context-menu Collapse/Expand
+/// item, which performs the same action — and the setting itself, whose
+/// default placement is never gated. So do not "fix" the trailing placement by
+/// always-mounting it; that reverses a decision someone made on purpose.
+///
+/// The unmounted branch keeps the chevron's square so nothing beside it slides
+/// sideways as the glyph comes and goes.
+struct SectionDisclosureChevron: View {
+    let isExpanded: Bool
+    /// Where this chevron sits relative to its section title — read from
+    /// `AppState.chevronAfterProjectNameKey` by the caller.
+    let afterTitle: Bool
+    /// Whether the button is mounted right now; `Color.clear` holds its place
+    /// when it isn't. See `SidebarHeaderMetrics.chevronMounted`.
+    let isMounted: Bool
+    /// What VoiceOver announces — the glyph carries no text of its own.
+    let accessibilityLabel: String
+    /// Overridden by a project row so a `.missing` repo's chevron dims with
+    /// the rest of its header.
+    var glyphStyle: AnyShapeStyle = AnyShapeStyle(HierarchicalShapeStyle.secondary)
+    /// The section dims its rows while the chevron is hovered, so it needs the
+    /// hover edges the button sees.
+    var onHoverChange: (Bool) -> Void = { _ in }
+    let toggle: () -> Void
+
+    var body: some View {
+        Group {
+            if isMounted {
+                if afterTitle {
+                    button.buttonStyle(HoverPressButtonStyle())
+                } else {
+                    button.buttonStyle(.plain)
+                }
+            } else {
+                Color.clear
+            }
+        }
+        .frame(width: SidebarHeaderMetrics.chevronColumnWidth,
+               height: SidebarHeaderMetrics.chevronColumnWidth)
+        // The square hit target centers the glyph, leaving ~4pt of slack on
+        // each side. Trailing the title, trim the leading slack so the chevron
+        // reads as attached to the title rather than floating after it, and
+        // nudge down so it sits on the title's optical baseline rather than
+        // its cap-height center. Both are layout-neutral for the hit target,
+        // which rides along with the glyph. Leading the title, that slack is
+        // what separates the glyph from the window edge, so it stays.
+        .padding(.leading, afterTitle ? -3 : 0)
+        .offset(y: afterTitle ? 2 : 0)
+    }
+
+    /// The button and its label, styleless — `body` applies the style the
+    /// placement calls for. The glyph is a point smaller trailing the title so
+    /// it doesn't outweigh the title it follows.
+    private var button: some View {
+        Button(action: toggle) {
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                .font(.system(size: afterTitle ? 10 : 11))
+                // Applied to the glyph, not the button, so it wins over
+                // `HoverPressButtonStyle`'s blanket `.secondary` and a missing
+                // repo still renders dimmed.
+                .foregroundStyle(glyphStyle)
+                .frame(width: SidebarHeaderMetrics.chevronColumnWidth,
+                       height: SidebarHeaderMetrics.chevronColumnWidth)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel(accessibilityLabel)
+        .onHover { onHoverChange($0) }
+        .help(isExpanded ? "Collapse" : "Expand")
+    }
+}

--- a/Sources/TBDApp/Sidebar/SidebarHeaderMetrics.swift
+++ b/Sources/TBDApp/Sidebar/SidebarHeaderMetrics.swift
@@ -22,6 +22,15 @@ enum SidebarHeaderMetrics {
     /// name read as one label.
     static let nameLeadingClawback: CGFloat = -2
 
+    /// The `listRowInsets` leading every section HEADER row carries — the
+    /// left edge of a section's chrome, chevron included.
+    static let headerRowLeadingInset: CGFloat = -2
+
+    /// How far a child row's content sits past its section's title, so the
+    /// rows under a title read as belonging to it. Constant across the
+    /// chevron placements: what moves is the title, and the children follow.
+    static let childRowIndent: CGFloat = 14
+
     /// How far a section title sits from its row's leading edge.
     ///
     /// With the chevron before the project name (the default), a project
@@ -33,5 +42,23 @@ enum SidebarHeaderMetrics {
         chevronAfterProjectName
             ? 0
             : chevronColumnWidth + headerSpacing + nameLeadingClawback
+    }
+
+    /// The `listRowInsets` leading for the rows under a section title —
+    /// worktrees, scratch pads, remote sessions. Derived from the title's own
+    /// position so children track it: with the chevron before the project
+    /// name the titles sit a chevron column in, and the rows come with them.
+    static func childRowLeadingInset(chevronAfterProjectName: Bool) -> CGFloat {
+        headerRowLeadingInset
+            + titleLeadingInset(chevronAfterProjectName: chevronAfterProjectName)
+            + childRowIndent
+    }
+
+    /// Whether a section's disclosure chevron is mounted at all. Before the
+    /// title it always is, so the expanded/collapsed state reads without a
+    /// pointer; after the title it appears only once `revealed` — the row's
+    /// hover gate, shared with its `+`.
+    static func chevronMounted(afterTitle: Bool, revealed: Bool) -> Bool {
+        !afterTitle || revealed
     }
 }

--- a/Sources/TBDApp/Sidebar/SidebarHeaderMetrics.swift
+++ b/Sources/TBDApp/Sidebar/SidebarHeaderMetrics.swift
@@ -1,14 +1,15 @@
 import CoreGraphics
 
-/// Shared geometry for the sidebar's section headers, so a project row, the
-/// Scratch header, and a remote-provider header put their titles in one
-/// column instead of each carrying its own copy of the arithmetic.
+/// Shared geometry for the sidebar's section headers and the rows beneath
+/// them, so a project row, the Scratch header, and a remote-provider header
+/// put their titles in one column instead of each carrying its own copy of the
+/// arithmetic.
 ///
-/// A project row is the only section header with a disclosure chevron, so it
-/// is the one whose title can start somewhere other than the row's leading
-/// edge — and where that is depends on
-/// `AppState.chevronAfterProjectNameKey`. Every other section header follows
-/// it via `titleLeadingInset(chevronAfterProjectName:)`.
+/// Everything here turns on `AppState.chevronBeforeProjectNameKey`, off by
+/// default. Off, every value below reproduces the layout that shipped before
+/// the setting existed: titles start at their row's leading edge and rows sit
+/// 12pt in. On, a project row's chevron moves to the left of its name, so the
+/// titles clear a chevron column and every row follows its title.
 enum SidebarHeaderMetrics {
     /// The square a project row's disclosure chevron occupies — its hit
     /// target, wider than the glyph inside it.
@@ -19,46 +20,47 @@ enum SidebarHeaderMetrics {
 
     /// Leading padding on a project row's name while the chevron leads it,
     /// clawing back the chevron square's trailing slack so the glyph and the
-    /// name read as one label.
+    /// name read as one label. Zero while the chevron trails instead.
     static let nameLeadingClawback: CGFloat = -2
 
     /// The `listRowInsets` leading every section HEADER row carries — the
     /// left edge of a section's chrome, chevron included.
     static let headerRowLeadingInset: CGFloat = -2
 
-    /// How far a child row's content sits past its section's title, so the
-    /// rows under a title read as belonging to it. Constant across the
-    /// chevron placements: what moves is the title, and the children follow.
+    /// How far a child row's content sits past its section's title. Applied
+    /// only where the title has moved: with the chevron trailing the name,
+    /// this reproduces the historical 12pt row inset exactly.
     static let childRowIndent: CGFloat = 14
 
     /// How far a section title sits from its row's leading edge.
     ///
-    /// With the chevron before the project name (the default), a project
-    /// title clears the chevron column, so a chevron-less header needs this
-    /// much leading padding to land in the same column. With the chevron
-    /// after the name, project titles start at the row's edge and no header
-    /// needs padding at all.
-    static func titleLeadingInset(chevronAfterProjectName: Bool) -> CGFloat {
-        chevronAfterProjectName
-            ? 0
-            : chevronColumnWidth + headerSpacing + nameLeadingClawback
+    /// With the chevron before the project name, a project title clears the
+    /// chevron column, so a chevron-less header needs this much leading
+    /// padding to land in the same column. With the chevron after the name —
+    /// the default — every title starts at the row's edge and no header needs
+    /// padding at all.
+    static func titleLeadingInset(chevronBeforeProjectName: Bool) -> CGFloat {
+        chevronBeforeProjectName
+            ? chevronColumnWidth + headerSpacing + nameLeadingClawback
+            : 0
     }
 
     /// The `listRowInsets` leading for the rows under a section title —
     /// worktrees, scratch pads, remote sessions. Derived from the title's own
     /// position so children track it: with the chevron before the project
     /// name the titles sit a chevron column in, and the rows come with them.
-    static func childRowLeadingInset(chevronAfterProjectName: Bool) -> CGFloat {
+    /// With the chevron after the name this is the historical 12pt.
+    static func childRowLeadingInset(chevronBeforeProjectName: Bool) -> CGFloat {
         headerRowLeadingInset
-            + titleLeadingInset(chevronAfterProjectName: chevronAfterProjectName)
+            + titleLeadingInset(chevronBeforeProjectName: chevronBeforeProjectName)
             + childRowIndent
     }
 
     /// Whether a section's disclosure chevron is mounted at all. Before the
     /// title it always is, so the expanded/collapsed state reads without a
-    /// pointer; after the title it appears only once `revealed` — the row's
-    /// hover gate, shared with its `+`.
-    static func chevronMounted(afterTitle: Bool, revealed: Bool) -> Bool {
-        !afterTitle || revealed
+    /// pointer; after the title — the default — it appears only once
+    /// `revealed` by the row's hover gate, shared with its `+`.
+    static func chevronMounted(beforeTitle: Bool, revealed: Bool) -> Bool {
+        beforeTitle || revealed
     }
 }

--- a/Sources/TBDApp/Sidebar/SidebarHeaderMetrics.swift
+++ b/Sources/TBDApp/Sidebar/SidebarHeaderMetrics.swift
@@ -1,0 +1,37 @@
+import CoreGraphics
+
+/// Shared geometry for the sidebar's section headers, so a project row, the
+/// Scratch header, and a remote-provider header put their titles in one
+/// column instead of each carrying its own copy of the arithmetic.
+///
+/// A project row is the only section header with a disclosure chevron, so it
+/// is the one whose title can start somewhere other than the row's leading
+/// edge — and where that is depends on
+/// `AppState.chevronAfterProjectNameKey`. Every other section header follows
+/// it via `titleLeadingInset(chevronAfterProjectName:)`.
+enum SidebarHeaderMetrics {
+    /// The square a project row's disclosure chevron occupies — its hit
+    /// target, wider than the glyph inside it.
+    static let chevronColumnWidth: CGFloat = 18
+
+    /// Spacing between a section header's `HStack` items.
+    static let headerSpacing: CGFloat = 4
+
+    /// Leading padding on a project row's name while the chevron leads it,
+    /// clawing back the chevron square's trailing slack so the glyph and the
+    /// name read as one label.
+    static let nameLeadingClawback: CGFloat = -2
+
+    /// How far a section title sits from its row's leading edge.
+    ///
+    /// With the chevron before the project name (the default), a project
+    /// title clears the chevron column, so a chevron-less header needs this
+    /// much leading padding to land in the same column. With the chevron
+    /// after the name, project titles start at the row's edge and no header
+    /// needs padding at all.
+    static func titleLeadingInset(chevronAfterProjectName: Bool) -> CGFloat {
+        chevronAfterProjectName
+            ? 0
+            : chevronColumnWidth + headerSpacing + nameLeadingClawback
+    }
+}

--- a/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
@@ -20,6 +20,11 @@ struct WorktreeSubtreeView: View {
     let depth: Int
     let sectionRepoID: UUID
     @EnvironmentObject var appState: AppState
+    /// Read only to place the row: the project chevron's position decides
+    /// which column every section title sits in, and rows follow their title.
+    /// See `SidebarHeaderMetrics.childRowLeadingInset`.
+    @AppStorage(AppState.chevronAfterProjectNameKey)
+    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
 
     var body: some View {
         WorktreeRowView(
@@ -29,7 +34,12 @@ struct WorktreeSubtreeView: View {
         )
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white.opacity(0.0001))
-        .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+        .listRowInsets(EdgeInsets(
+            top: 0,
+            leading: SidebarHeaderMetrics.childRowLeadingInset(
+                chevronAfterProjectName: chevronAfterProjectName),
+            bottom: 0,
+            trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
         .tag(worktree.id)

--- a/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
@@ -23,8 +23,8 @@ struct WorktreeSubtreeView: View {
     /// Read only to place the row: the project chevron's position decides
     /// which column every section title sits in, and rows follow their title.
     /// See `SidebarHeaderMetrics.childRowLeadingInset`.
-    @AppStorage(AppState.chevronAfterProjectNameKey)
-    private var chevronAfterProjectName: Bool = AppState.chevronAfterProjectNameDefault
+    @AppStorage(AppState.chevronBeforeProjectNameKey)
+    private var chevronBeforeProjectName: Bool = AppState.chevronBeforeProjectNameDefault
 
     var body: some View {
         WorktreeRowView(
@@ -37,7 +37,7 @@ struct WorktreeSubtreeView: View {
         .listRowInsets(EdgeInsets(
             top: 0,
             leading: SidebarHeaderMetrics.childRowLeadingInset(
-                chevronAfterProjectName: chevronAfterProjectName),
+                chevronBeforeProjectName: chevronBeforeProjectName),
             bottom: 0,
             trailing: 0))
         .listRowSeparator(.hidden)

--- a/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
+++ b/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
@@ -59,3 +59,35 @@ struct ChevronMountedTests {
         #expect(RepoSectionView.chevronMounted(afterName: true, hovered: false, menuOpen: true))
     }
 }
+
+/// The sidebar's section titles all sit in one column, and where that column
+/// is depends on the chevron placement. Pins the arithmetic both ways so a
+/// chevron-less header (Scratch, a remote provider) can't drift out of line
+/// with the project titles it's supposed to match.
+@MainActor
+@Suite("sidebar header title inset")
+struct SidebarHeaderMetricsTests {
+    /// What a project row's own name ends up at, computed from the row's
+    /// pieces rather than from the value under test — so a change to either
+    /// one alone fails this.
+    private func projectTitleOffset(chevronAfterName: Bool) -> CGFloat {
+        guard !chevronAfterName else { return 0 }
+        return SidebarHeaderMetrics.chevronColumnWidth
+            + SidebarHeaderMetrics.headerSpacing
+            + SidebarHeaderMetrics.nameLeadingClawback
+    }
+
+    @Test("chevron before the name: a chevron-less title clears the chevron column")
+    func leadingChevronIndentsSiblings() {
+        let inset = SidebarHeaderMetrics.titleLeadingInset(chevronAfterProjectName: false)
+        #expect(inset == projectTitleOffset(chevronAfterName: false))
+        #expect(inset > 0)
+    }
+
+    @Test("chevron after the name: every title starts at the row edge")
+    func trailingChevronNeedsNoIndent() {
+        let inset = SidebarHeaderMetrics.titleLeadingInset(chevronAfterProjectName: true)
+        #expect(inset == projectTitleOffset(chevronAfterName: true))
+        #expect(inset == 0)
+    }
+}

--- a/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
+++ b/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
@@ -91,3 +91,80 @@ struct SidebarHeaderMetricsTests {
         #expect(inset == 0)
     }
 }
+
+/// The Scratch section's own collapse bit — app-side, unlike a project's
+/// daemon-owned `Repo.expanded`. Pins that it ships expanded and that both
+/// explicit values persist.
+@MainActor
+@Suite("scratchSectionExpanded setting")
+struct ScratchSectionExpandedTests {
+    @Test func defaultsToExpanded() {
+        #expect(AppState.scratchSectionExpandedDefault == true)
+    }
+
+    @Test func storesBothBranches() {
+        let suiteName = "scratch-expanded-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(defaults.object(forKey: AppState.scratchSectionExpandedKey) == nil)
+        defaults.set(false, forKey: AppState.scratchSectionExpandedKey)
+        #expect(defaults.bool(forKey: AppState.scratchSectionExpandedKey) == false)
+        defaults.set(true, forKey: AppState.scratchSectionExpandedKey)
+        #expect(defaults.bool(forKey: AppState.scratchSectionExpandedKey) == true)
+    }
+}
+
+/// The rows under a section title track that title's column, in both chevron
+/// placements — a scratch pad, a worktree and a remote session all read this
+/// one helper, so the numbers here are what keeps them in one column.
+@MainActor
+@Suite("sidebar child row inset")
+struct SidebarChildRowInsetTests {
+    /// Where a section title's text lands, measured from the list edge rather
+    /// than from the value under test.
+    private func titleOrigin(chevronAfterName: Bool) -> CGFloat {
+        SidebarHeaderMetrics.headerRowLeadingInset
+            + SidebarHeaderMetrics.titleLeadingInset(chevronAfterProjectName: chevronAfterName)
+    }
+
+    @Test("chevron before the name: rows sit indented past the title")
+    func leadingChevronRowsIndented() {
+        let rows = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: false)
+        #expect(rows > titleOrigin(chevronAfterName: false))
+        #expect(rows - titleOrigin(chevronAfterName: false) == SidebarHeaderMetrics.childRowIndent)
+    }
+
+    @Test("chevron after the name: rows sit indented past the title there too")
+    func trailingChevronRowsIndented() {
+        let rows = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: true)
+        #expect(rows > titleOrigin(chevronAfterName: true))
+        #expect(rows - titleOrigin(chevronAfterName: true) == SidebarHeaderMetrics.childRowIndent)
+    }
+
+    @Test("the indent step is the same whichever side the chevron is on")
+    func stepIsPlacementIndependent() {
+        let leading = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: false)
+            - titleOrigin(chevronAfterName: false)
+        let trailing = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: true)
+            - titleOrigin(chevronAfterName: true)
+        #expect(leading == trailing)
+    }
+}
+
+/// The mount gate every collapsible section shares.
+@MainActor
+@Suite("section chevron mount gate")
+struct SectionChevronMountTests {
+    @Test("before the title: mounted whether or not the row is revealed")
+    func leadingAlwaysMounted() {
+        #expect(SidebarHeaderMetrics.chevronMounted(afterTitle: false, revealed: false))
+        #expect(SidebarHeaderMetrics.chevronMounted(afterTitle: false, revealed: true))
+    }
+
+    @Test("after the title: mounted only once the row is revealed")
+    func trailingFollowsReveal() {
+        #expect(!SidebarHeaderMetrics.chevronMounted(afterTitle: true, revealed: false))
+        #expect(SidebarHeaderMetrics.chevronMounted(afterTitle: true, revealed: true))
+    }
+}

--- a/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
+++ b/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
@@ -5,12 +5,12 @@ import Testing
 /// The chevron-placement setting's storage contract: unset means "never
 /// chose", and both explicit values persist as written. Mirrors
 /// `ShowScratchSectionSettingTests`, and pins that the shipped default is
-/// off — the chevron leads the project name unless a user asks otherwise.
+/// off — nobody's chevron moves, and no row shifts, until they ask.
 @MainActor
-@Suite("chevronAfterProjectName setting")
+@Suite("chevronBeforeProjectName setting")
 struct ChevronPlacementSettingTests {
     @Test func defaultsToOff() {
-        #expect(AppState.chevronAfterProjectNameDefault == false)
+        #expect(AppState.chevronBeforeProjectNameDefault == false)
     }
 
     @Test func storesBothBranches() {
@@ -18,11 +18,11 @@ struct ChevronPlacementSettingTests {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        #expect(defaults.object(forKey: AppState.chevronAfterProjectNameKey) == nil)
-        defaults.set(true, forKey: AppState.chevronAfterProjectNameKey)
-        #expect(defaults.bool(forKey: AppState.chevronAfterProjectNameKey) == true)
-        defaults.set(false, forKey: AppState.chevronAfterProjectNameKey)
-        #expect(defaults.bool(forKey: AppState.chevronAfterProjectNameKey) == false)
+        #expect(defaults.object(forKey: AppState.chevronBeforeProjectNameKey) == nil)
+        defaults.set(true, forKey: AppState.chevronBeforeProjectNameKey)
+        #expect(defaults.bool(forKey: AppState.chevronBeforeProjectNameKey) == true)
+        defaults.set(false, forKey: AppState.chevronBeforeProjectNameKey)
+        #expect(defaults.bool(forKey: AppState.chevronBeforeProjectNameKey) == false)
     }
 }
 
@@ -34,29 +34,29 @@ struct ChevronPlacementSettingTests {
 @MainActor
 @Suite("chevronMounted gate")
 struct ChevronMountedTests {
-    @Test("leading the name: mounted with no pointer in the section")
+    @Test("setting on, leading the name: mounted with no pointer in the section")
     func leadingUnhoveredMounted() {
-        #expect(RepoSectionView.chevronMounted(afterName: false, hovered: false, menuOpen: false))
+        #expect(RepoSectionView.chevronMounted(beforeName: true, hovered: false, menuOpen: false))
     }
 
-    @Test("leading the name: still mounted while hovered")
+    @Test("setting on, leading the name: still mounted while hovered")
     func leadingHoveredMounted() {
-        #expect(RepoSectionView.chevronMounted(afterName: false, hovered: true, menuOpen: false))
+        #expect(RepoSectionView.chevronMounted(beforeName: true, hovered: true, menuOpen: false))
     }
 
-    @Test("trailing the name: hidden with no pointer in the section")
+    @Test("default, trailing the name: hidden with no pointer in the section")
     func trailingUnhoveredHidden() {
-        #expect(!RepoSectionView.chevronMounted(afterName: true, hovered: false, menuOpen: false))
+        #expect(!RepoSectionView.chevronMounted(beforeName: false, hovered: false, menuOpen: false))
     }
 
-    @Test("trailing the name: revealed on hover")
+    @Test("default, trailing the name: revealed on hover")
     func trailingHoveredMounted() {
-        #expect(RepoSectionView.chevronMounted(afterName: true, hovered: true, menuOpen: false))
+        #expect(RepoSectionView.chevronMounted(beforeName: false, hovered: true, menuOpen: false))
     }
 
-    @Test("trailing the name: stays mounted while the + menu is open off-hover")
+    @Test("default, trailing the name: stays mounted while the + menu is open off-hover")
     func trailingMenuOpenMounted() {
-        #expect(RepoSectionView.chevronMounted(afterName: true, hovered: false, menuOpen: true))
+        #expect(RepoSectionView.chevronMounted(beforeName: false, hovered: false, menuOpen: true))
     }
 }
 
@@ -70,24 +70,24 @@ struct SidebarHeaderMetricsTests {
     /// What a project row's own name ends up at, computed from the row's
     /// pieces rather than from the value under test — so a change to either
     /// one alone fails this.
-    private func projectTitleOffset(chevronAfterName: Bool) -> CGFloat {
-        guard !chevronAfterName else { return 0 }
+    private func projectTitleOffset(chevronBeforeName: Bool) -> CGFloat {
+        guard chevronBeforeName else { return 0 }
         return SidebarHeaderMetrics.chevronColumnWidth
             + SidebarHeaderMetrics.headerSpacing
             + SidebarHeaderMetrics.nameLeadingClawback
     }
 
-    @Test("chevron before the name: a chevron-less title clears the chevron column")
+    @Test("setting on: a chevron-less title clears the chevron column")
     func leadingChevronIndentsSiblings() {
-        let inset = SidebarHeaderMetrics.titleLeadingInset(chevronAfterProjectName: false)
-        #expect(inset == projectTitleOffset(chevronAfterName: false))
+        let inset = SidebarHeaderMetrics.titleLeadingInset(chevronBeforeProjectName: true)
+        #expect(inset == projectTitleOffset(chevronBeforeName: true))
         #expect(inset > 0)
     }
 
-    @Test("chevron after the name: every title starts at the row edge")
+    @Test("default: every title starts at the row edge")
     func trailingChevronNeedsNoIndent() {
-        let inset = SidebarHeaderMetrics.titleLeadingInset(chevronAfterProjectName: true)
-        #expect(inset == projectTitleOffset(chevronAfterName: true))
+        let inset = SidebarHeaderMetrics.titleLeadingInset(chevronBeforeProjectName: false)
+        #expect(inset == projectTitleOffset(chevronBeforeName: false))
         #expect(inset == 0)
     }
 }
@@ -123,32 +123,32 @@ struct ScratchSectionExpandedTests {
 struct SidebarChildRowInsetTests {
     /// Where a section title's text lands, measured from the list edge rather
     /// than from the value under test.
-    private func titleOrigin(chevronAfterName: Bool) -> CGFloat {
+    private func titleOrigin(chevronBeforeName: Bool) -> CGFloat {
         SidebarHeaderMetrics.headerRowLeadingInset
-            + SidebarHeaderMetrics.titleLeadingInset(chevronAfterProjectName: chevronAfterName)
+            + SidebarHeaderMetrics.titleLeadingInset(chevronBeforeProjectName: chevronBeforeName)
     }
 
-    @Test("chevron before the name: rows sit indented past the title")
+    @Test("setting on: rows sit indented past the title")
     func leadingChevronRowsIndented() {
-        let rows = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: false)
-        #expect(rows > titleOrigin(chevronAfterName: false))
-        #expect(rows - titleOrigin(chevronAfterName: false) == SidebarHeaderMetrics.childRowIndent)
+        let rows = SidebarHeaderMetrics.childRowLeadingInset(chevronBeforeProjectName: true)
+        #expect(rows > titleOrigin(chevronBeforeName: true))
+        #expect(rows - titleOrigin(chevronBeforeName: true) == SidebarHeaderMetrics.childRowIndent)
     }
 
-    @Test("chevron after the name: rows sit indented past the title there too")
+    @Test("default: rows sit indented past the title there too")
     func trailingChevronRowsIndented() {
-        let rows = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: true)
-        #expect(rows > titleOrigin(chevronAfterName: true))
-        #expect(rows - titleOrigin(chevronAfterName: true) == SidebarHeaderMetrics.childRowIndent)
+        let rows = SidebarHeaderMetrics.childRowLeadingInset(chevronBeforeProjectName: false)
+        #expect(rows > titleOrigin(chevronBeforeName: false))
+        #expect(rows - titleOrigin(chevronBeforeName: false) == SidebarHeaderMetrics.childRowIndent)
     }
 
     @Test("the indent step is the same whichever side the chevron is on")
     func stepIsPlacementIndependent() {
-        let leading = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: false)
-            - titleOrigin(chevronAfterName: false)
-        let trailing = SidebarHeaderMetrics.childRowLeadingInset(chevronAfterProjectName: true)
-            - titleOrigin(chevronAfterName: true)
-        #expect(leading == trailing)
+        let onSetting = SidebarHeaderMetrics.childRowLeadingInset(chevronBeforeProjectName: true)
+            - titleOrigin(chevronBeforeName: true)
+        let byDefault = SidebarHeaderMetrics.childRowLeadingInset(chevronBeforeProjectName: false)
+            - titleOrigin(chevronBeforeName: false)
+        #expect(onSetting == byDefault)
     }
 }
 
@@ -158,13 +158,51 @@ struct SidebarChildRowInsetTests {
 struct SectionChevronMountTests {
     @Test("before the title: mounted whether or not the row is revealed")
     func leadingAlwaysMounted() {
-        #expect(SidebarHeaderMetrics.chevronMounted(afterTitle: false, revealed: false))
-        #expect(SidebarHeaderMetrics.chevronMounted(afterTitle: false, revealed: true))
+        #expect(SidebarHeaderMetrics.chevronMounted(beforeTitle: true, revealed: false))
+        #expect(SidebarHeaderMetrics.chevronMounted(beforeTitle: true, revealed: true))
     }
 
     @Test("after the title: mounted only once the row is revealed")
     func trailingFollowsReveal() {
-        #expect(!SidebarHeaderMetrics.chevronMounted(afterTitle: true, revealed: false))
-        #expect(SidebarHeaderMetrics.chevronMounted(afterTitle: true, revealed: true))
+        #expect(!SidebarHeaderMetrics.chevronMounted(beforeTitle: false, revealed: false))
+        #expect(SidebarHeaderMetrics.chevronMounted(beforeTitle: false, revealed: true))
+    }
+}
+
+/// The whole point of the default being off: with nobody's setting touched,
+/// the sidebar's geometry is the geometry that shipped before this setting
+/// existed. These are the literal numbers the views used to hardcode, so a
+/// change that moves anybody's rows without them asking fails here.
+@MainActor
+@Suite("default placement changes nothing")
+struct DefaultSidebarGeometryTests {
+    /// What `ScratchSectionView` and `RemoteProviderHeaderRow` used before the
+    /// setting existed: no inset, titles flush with the row's leading edge.
+    private let historicalTitleInset: CGFloat = 0
+    /// What every child row hardcoded before the setting existed.
+    private let historicalChildRowInset: CGFloat = 12
+
+    @Test("titles keep their historical position")
+    func titlesUnmoved() {
+        #expect(AppState.chevronBeforeProjectNameDefault == false)
+        #expect(
+            SidebarHeaderMetrics.titleLeadingInset(
+                chevronBeforeProjectName: AppState.chevronBeforeProjectNameDefault
+            ) == historicalTitleInset)
+    }
+
+    @Test("worktrees, scratch pads and remote sessions keep their historical inset")
+    func rowsUnmoved() {
+        #expect(
+            SidebarHeaderMetrics.childRowLeadingInset(
+                chevronBeforeProjectName: AppState.chevronBeforeProjectNameDefault
+            ) == historicalChildRowInset)
+    }
+
+    @Test("the project chevron keeps its hover gate")
+    func chevronStillHoverGated() {
+        let byDefault = AppState.chevronBeforeProjectNameDefault
+        #expect(!RepoSectionView.chevronMounted(beforeName: byDefault, hovered: false, menuOpen: false))
+        #expect(RepoSectionView.chevronMounted(beforeName: byDefault, hovered: true, menuOpen: false))
     }
 }

--- a/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
+++ b/Tests/TBDAppTests/ChevronPlacementSettingTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// The chevron-placement setting's storage contract: unset means "never
+/// chose", and both explicit values persist as written. Mirrors
+/// `ShowScratchSectionSettingTests`, and pins that the shipped default is
+/// off — the chevron leads the project name unless a user asks otherwise.
+@MainActor
+@Suite("chevronAfterProjectName setting")
+struct ChevronPlacementSettingTests {
+    @Test func defaultsToOff() {
+        #expect(AppState.chevronAfterProjectNameDefault == false)
+    }
+
+    @Test func storesBothBranches() {
+        let suiteName = "chevron-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(defaults.object(forKey: AppState.chevronAfterProjectNameKey) == nil)
+        defaults.set(true, forKey: AppState.chevronAfterProjectNameKey)
+        #expect(defaults.bool(forKey: AppState.chevronAfterProjectNameKey) == true)
+        defaults.set(false, forKey: AppState.chevronAfterProjectNameKey)
+        #expect(defaults.bool(forKey: AppState.chevronAfterProjectNameKey) == false)
+    }
+}
+
+/// Direct proof of the one behavior the two chevron placements disagree
+/// about — whether the button is mounted when nothing is hovered. Tests the
+/// extracted pure function rather than a live view, the same way
+/// `ScratchSectionVisibleTests` does, so an inverted or dropped gate fails
+/// here instead of only in the running app.
+@MainActor
+@Suite("chevronMounted gate")
+struct ChevronMountedTests {
+    @Test("leading the name: mounted with no pointer in the section")
+    func leadingUnhoveredMounted() {
+        #expect(RepoSectionView.chevronMounted(afterName: false, hovered: false, menuOpen: false))
+    }
+
+    @Test("leading the name: still mounted while hovered")
+    func leadingHoveredMounted() {
+        #expect(RepoSectionView.chevronMounted(afterName: false, hovered: true, menuOpen: false))
+    }
+
+    @Test("trailing the name: hidden with no pointer in the section")
+    func trailingUnhoveredHidden() {
+        #expect(!RepoSectionView.chevronMounted(afterName: true, hovered: false, menuOpen: false))
+    }
+
+    @Test("trailing the name: revealed on hover")
+    func trailingHoveredMounted() {
+        #expect(RepoSectionView.chevronMounted(afterName: true, hovered: true, menuOpen: false))
+    }
+
+    @Test("trailing the name: stays mounted while the + menu is open off-hover")
+    func trailingMenuOpenMounted() {
+        #expect(RepoSectionView.chevronMounted(afterName: true, hovered: false, menuOpen: true))
+    }
+}


### PR DESCRIPTION
## Summary

The project disclosure chevron moved to the right of the project name in #706. Trailing a name, it lands in a different horizontal position on every row (each project name is a different length), and it is only there on hover, so a section's expanded/collapsed state can't be read at a glance.

This PR makes the leading placement available again as a setting, and adds a disclosure chevron to the Scratch section so scratch pads can be folded away like a project's worktrees.

**Nothing moves for anyone who doesn't ask.** The setting is off by default, and off reproduces today's sidebar exactly.

## Why this shape

No spec: this is UI placement plus a preference toggle, not a revision of how the system works. It revises nothing about worktrees, sessions, or the daemon. The whole change lives in four sidebar views, two of their metrics, and one UserDefaults key.

**The placement and the indent ride one flag, not two.** Where the chevron sits decides where a project title starts, which decides where a chevron-less section title (Scratch, a remote provider) has to sit to match it, which decides where the rows under any title belong. Splitting those into separate settings would let a user reach a combination nobody designed: a leading chevron with titles still flush left, rows indented past titles that never moved. One flag, one coherent layout on each side of it.

**The Scratch chevron is not gated**, and that is the one thing here that changes for a user who never opens Settings. Collapsibility is its own feature; gating it behind a preference about which side a glyph sits on would make it undiscoverable for the people most likely to want it. With the setting off it renders after the "Scratch" title, hover-gated, exactly like a project's, so it reads as consistent with what is already there rather than as novel chrome.

**Scratch's expanded bit lives in UserDefaults**, not the database. A project's `Repo.expanded` is daemon-owned because a repo is a daemon-side record. The Scratch section is app-side chrome over a filter of worktrees; it has no row of its own to carry the bit, and inventing one for a piece of sidebar state would be the wrong shape.

**Hover-gating a disclosure control stays deliberate.** #706 traded the at-a-glance state read and pointer-free reachability for a quieter sidebar, and the maintainer signed that off with the ungated context-menu Collapse/Expand as the keyboard-only path. This PR keeps that trade as the default rather than reversing it, and the source comment recording the sign-off moved intact into the shared chevron view. The setting is now a second answer for keyboard-only users: its placement is never hover-gated.

## What this PR does

- **`AppState.chevronBeforeProjectNameKey`** (default off): the one flag, read via `@AppStorage` in the view layer. Settings > General > Worktrees > "Put the project chevron before the name".
- **`SidebarHeaderMetrics`**: owns the chevron column width, the header stack's spacing, the name's leading claw-back, the header row's own inset, and the child-row indent step, and derives the two placement-dependent values (`titleLeadingInset`, `childRowLeadingInset`) plus the mount gate from them. Four views used to hardcode these numbers separately.
- **`SectionDisclosureChevron`**: the chevron itself, worn by both `RepoSectionView` and `ScratchSectionView`, so the two cannot drift in placement, glyph size, hover treatment, or what VoiceOver announces.
- **`ScratchSectionView`**: gains the chevron, an `AppStorage`-backed expanded bit, an ungated context-menu Collapse/Expand, and the same row dimming a project section does while its chevron is hovered.
- **`RepoSectionView`, `WorktreeSubtreeView`, `RemoteSectionView`**: read their title and row insets from `SidebarHeaderMetrics` instead of literals.

## Flag & rollout

`chevronBeforeProjectName`, a UserDefaults key (app-only behavior, so no config column; precedent: `enableTranscript`), **default off**.

Enable it in Settings > General > Worktrees, or with `defaults write com.github.cheapsteak.tbd chevronBeforeProjectName -bool true`.

This is a preference, not a soak flag: there is no graduation plan and no intent to flip the default. Both placements are supported indefinitely, which is why the branch that is off by default is held by tests rather than left to rot.

## Assumptions

- Assumes the chevron's 18pt square, the 4pt header spacing, and the 2pt name claw-back are the only things standing between a row's leading edge and a project title. If a project header grows another leading element, `titleLeadingInset` has to learn about it or the chevron-less headers drift out of column.
- Assumes a section's rows want to track their own title. Remote provider headers have no chevron and never will (a provider isn't collapsible), so their titles and rows follow the *project* chevron's placement. The sidebar has one column scheme, not one per section type.

## Evidence & verification

Tests cover both branches of the flag throughout. 41 pass across the sidebar suites:

- `DefaultSidebarGeometryTests` pins the off branch against the literal numbers the views used to hardcode: title inset 0, child row inset 12, project chevron still hover-gated. A change that moves someone's rows without them asking fails here rather than in their sidebar.
- `SidebarHeaderMetricsTests` and `SidebarChildRowInsetTests` recompute the title's position and the row's indent from the header's own pieces rather than from the value under test, so a change to either side alone fails.
- `ChevronMountedTests` and `SectionChevronMountTests` cover the mount gate on both sides: always mounted leading the title, hover-gated trailing it, and still mounted while the `+` menu holds itself open off-hover.
- `ChevronPlacementSettingTests` and `ScratchSectionExpandedTests` cover the two keys' storage contract: unset reads as "never chose", and both explicit values persist.

Live: `scripts/restart.sh` from this worktree, both placements exercised in the running app (chevron position, the hover gate, Scratch collapse and expand, and the row indents following the title on each side of the setting).

`scripts/swift-safe build` clean; `swiftlint --strict` clean across 814 files.

[◀️ Chevron Left With Setting](https://cheapsteak.github.io/tbd/open/?worktree=DD3F9921-86F5-4945-942D-124E6D0833E0)
