### PR TITLE
feat: render the workspace from the daemon-owned panel surface (phase 3b)

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1420,8 +1420,20 @@ final class AppState: ObservableObject {
         { [daemonClient] params in try await daemonClient.panelImportLegacy(params) }
     /// How the shadow-compare diagnostic (spec C §11.3) fetches the daemon's
     /// imported surface — injectable for the same reason as `panelImportTrigger`.
+    /// Also the mirror's load/refetch seam (`loadPanelSurface`); deliberately
+    /// one seam, not two, so a test that stubs `panel.get` stubs it everywhere.
     lazy var panelGetFetcher: @MainActor (UUID) async throws -> PanelGetResult =
         { [daemonClient] worktreeID in try await daemonClient.panelGet(worktreeID: worktreeID) }
+    /// How `applyPanelOperation` fires its RPC — injectable for the same
+    /// reason as `panelImportTrigger`, so chokepoint tests can record the
+    /// envelope (and force the rejection branch) without a real daemon.
+    lazy var panelApplyTrigger: @MainActor (PanelOperationEnvelope) async throws -> PanelApplyResult =
+        { [daemonClient] envelope in try await daemonClient.panelApply(envelope) }
+    /// In-memory mirror of the daemon-owned panel surface, keyed by worktree
+    /// ID. Deliberately NOT persisted — the daemon is the store; this is a
+    /// cache rebuilt from `panel.get` and kept current by
+    /// `.panelSurfaceChanged` deltas. See `AppState+PanelSurface.swift`.
+    @Published var panelSurfaces: [UUID: PanelGetResult] = [:]
     /// Guards the one-shot legacy panel import to at most once per launch.
     /// Deliberately NOT persisted — the daemon's create-if-absent import guard
     /// (spec C §11.2) is the real idempotence boundary; this only avoids
@@ -2090,6 +2102,11 @@ final class AppState: ObservableObject {
             Task { [weak self] in await self?.refreshRemote() }
         case .remoteSessionAttention(let d):
             handleRemoteSessionAttentionDelta(d)
+        case .panelSurfaceChanged(let d):
+            // Guarded inside: the daemon broadcasts these during the
+            // store-only soak (daemon_panel_surface_enabled on, render flag
+            // off), and nothing may mutate app state on that path.
+            applyPanelSurfaceDelta(d)
         default:
             break
         }
@@ -3438,6 +3455,30 @@ final class AppState: ObservableObject {
     /// touched the toggle, matching the `@AppStorage` default.
     static func transcriptFeatureEnabled(defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: enableTranscriptKey) as? Bool ?? enableTranscriptDefault
+    }
+
+    /// UserDefaults key for the phase-3b render switch: when on, the app
+    /// renders its workspace from the daemon-owned panel surface and routes
+    /// its own gestures through `panel.apply` instead of mutating the legacy
+    /// `LayoutNode` tree. Same shape as `enableTranscriptKey` (app-only
+    /// presentation toggle, `UserDefaults` rather than a daemon `config`
+    /// column).
+    static let enableDaemonManagedPanelsKey = "enableDaemonManagedPanels"
+
+    /// The one default for `enableDaemonManagedPanelsKey`. **Default OFF** —
+    /// 3b ships behind a soak flag; graduation is a later phase. Every read
+    /// site must spell the default with this constant, never a bare literal
+    /// (see `enableTranscriptDefault` for why a disagreeing default is
+    /// invisible).
+    static let enableDaemonManagedPanelsDefault = false
+
+    /// Read of the daemon-managed-panels render switch for non-View callers
+    /// (the View layer uses `@AppStorage`). This is only the *user* half of
+    /// the switch — the effective one is `daemonManagedPanelsActive`, which
+    /// also requires the daemon to report `panelSurfaceEnabled`.
+    static func daemonManagedPanelsEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enableDaemonManagedPanelsKey) as? Bool
+            ?? enableDaemonManagedPanelsDefault
     }
 
     /// UserDefaults key for a Claude spawn-env setting, by registry ID.

--- a/Sources/TBDApp/PanelSurface/AppState+PanelSurface.swift
+++ b/Sources/TBDApp/PanelSurface/AppState+PanelSurface.swift
@@ -49,10 +49,16 @@ extension AppState {
     /// Also the snap-to-truth path after a rejected apply. Failures are
     /// logged and swallowed — the mirror keeps its last known value, and the
     /// next delta or load repairs it.
+    ///
+    /// The result is merged per tab rather than assigned wholesale, because
+    /// `panel.get` is an `await`: a delta can commit a newer revision of one
+    /// tab while this fetch is in flight, and assigning the snapshot over it
+    /// would revert the mirror one operation with no delta left to correct it
+    /// (the daemon emits deltas only on change). See `mergePanelSurface`.
     func loadPanelSurface(worktreeID: UUID) async {
         guard daemonManagedPanelsFlagEnabled else { return }
         do {
-            panelSurfaces[worktreeID] = try await panelGetFetcher(worktreeID)
+            mergePanelSurface(try await panelGetFetcher(worktreeID), worktreeID: worktreeID)
         } catch {
             logger.error("""
                 panel.get failed for \(worktreeID, privacy: .public): \
@@ -106,13 +112,11 @@ extension AppState {
     func applyPanelSurfaceDelta(_ delta: PanelSurfaceDelta) {
         guard daemonManagedPanelsFlagEnabled else { return }
         let existing = panelSurfaces[delta.worktreeID]
+        // Removal is unconditional and comes first: a tab the daemon dropped
+        // is gone whatever revision the mirror holds for it.
         var tabs = (existing?.tabs ?? []).filter { !delta.removedTabIDs.contains($0.id) }
         for tab in delta.tabs {
-            if let index = tabs.firstIndex(where: { $0.id == tab.id }) {
-                tabs[index] = tab
-            } else {
-                tabs.append(tab)
-            }
+            merge(tab, into: &tabs)
         }
         var activeTabID = delta.activeTabID ?? existing?.activeTabID
         if let active = activeTabID, delta.removedTabIDs.contains(active) {
@@ -137,13 +141,65 @@ extension AppState {
         let existing = panelSurfaces[worktreeID]
         var tabs = existing?.tabs ?? []
         for tab in updated {
-            if let index = tabs.firstIndex(where: { $0.id == tab.id }) {
-                tabs[index] = tab
-            } else {
-                tabs.append(tab)
-            }
+            merge(tab, into: &tabs)
         }
         panelSurfaces[worktreeID] = PanelGetResult(
             tabs: tabs, activeTabID: existing?.activeTabID)
+    }
+
+    /// Adopt a whole `panel.get` snapshot, per tab.
+    ///
+    /// Two rules, and they cover different tabs:
+    ///
+    /// - **Which tabs exist** comes from the fetch, unconditionally. A tab the
+    ///   mirror holds and the snapshot does not is removed — otherwise a
+    ///   refetch could never drop anything and the merge would be append-only.
+    /// - **What each surviving tab contains** goes through the revision guard,
+    ///   so a snapshot that was taken before an in-flight delta cannot revert
+    ///   that tab. Only tabs present in both are affected.
+    ///
+    /// `activeTabID` follows the snapshot: it is consistent with the tab set
+    /// the snapshot just defined.
+    private func mergePanelSurface(_ fetched: PanelGetResult, worktreeID: UUID) {
+        let mirrored = panelSurfaces[worktreeID]?.tabs ?? []
+        let tabs = fetched.tabs.map { fetchedTab -> WorkspaceTabSurface in
+            guard let mirroredTab = mirrored.first(where: { $0.id == fetchedTab.id }),
+                  mirroredTab.revision > fetchedTab.revision
+            else { return fetchedTab }
+            logDroppedStaleTab(fetchedTab, mirroredRevision: mirroredTab.revision)
+            return mirroredTab
+        }
+        panelSurfaces[worktreeID] = PanelGetResult(
+            tabs: tabs, activeTabID: fetched.activeTabID)
+    }
+
+    /// Replace-or-append one incoming tab, dropping it when the mirror already
+    /// holds a strictly newer revision of that tab.
+    ///
+    /// The mirror is fed by two racing writers — the `panel.apply` response
+    /// and the broadcast delta — and a `panel.get` refetch can resolve after
+    /// either. Revisions are the daemon's monotonic per-tab counter, so
+    /// "strictly lower wins nothing" is the whole rule. Equal revisions still
+    /// assign: same revision means same content, so it is a no-op either way,
+    /// and taking the newer object keeps the common apply-then-delta path on
+    /// one code path.
+    private func merge(_ incoming: WorkspaceTabSurface, into tabs: inout [WorkspaceTabSurface]) {
+        guard let index = tabs.firstIndex(where: { $0.id == incoming.id }) else {
+            tabs.append(incoming)
+            return
+        }
+        guard incoming.revision >= tabs[index].revision else {
+            logDroppedStaleTab(incoming, mirroredRevision: tabs[index].revision)
+            return
+        }
+        tabs[index] = incoming
+    }
+
+    private func logDroppedStaleTab(_ tab: WorkspaceTabSurface, mirroredRevision: UInt64) {
+        logger.debug("""
+            dropped stale panel surface for tab \(tab.id, privacy: .public): \
+            incoming revision \(tab.revision, privacy: .public) < \
+            mirrored \(mirroredRevision, privacy: .public)
+            """)
     }
 }

--- a/Sources/TBDApp/PanelSurface/AppState+PanelSurface.swift
+++ b/Sources/TBDApp/PanelSurface/AppState+PanelSurface.swift
@@ -1,0 +1,149 @@
+import Foundation
+import TBDShared
+import os
+
+/// Phase 3b (`docs/specs/2026-07-31-panel-3b-app-rendering-design.md`) — the
+/// app-side mirror of the daemon-owned panel surface, plus the single
+/// chokepoint every app gesture goes through.
+///
+/// The daemon owns the surface. This file holds a read cache of it
+/// (`AppState.panelSurfaces`, declared in `AppState.swift` because Swift
+/// forbids stored properties in extensions), keeps it current from
+/// `.panelSurfaceChanged` deltas, and turns gestures into `panel.apply`
+/// round-trips. There is no local reducer: `panel.apply` is a local
+/// unix-socket hop that returns the authoritative tab synchronously, so the
+/// app renders from the response and the broadcast delta that follows lands
+/// as a no-op at the same revision.
+///
+/// Everything here is inert with `enableDaemonManagedPanels` off — the daemon
+/// broadcasts panel deltas during the store-only soak (its own
+/// `daemon_panel_surface_enabled` flag), and nothing on that path may touch
+/// app state.
+private let logger = Logger(subsystem: "com.tbd.app", category: "panelSurface")
+
+extension AppState {
+
+    // MARK: - The switch
+
+    /// The user half of the render switch — `enableDaemonManagedPanels` read
+    /// from this instance's defaults domain. Gates every mirror mutation
+    /// below. Deliberately NOT `daemonManagedPanelsActive`: the mirror is a
+    /// plain cache, and dropping delta updates because a capabilities refresh
+    /// transiently failed would leave it silently stale.
+    var daemonManagedPanelsFlagEnabled: Bool {
+        Self.daemonManagedPanelsEnabled(defaults: userDefaults)
+    }
+
+    /// The effective switch, and the one thing the render site reads: the app
+    /// may render from the daemon surface only when the user enabled it AND
+    /// the daemon reports the store is on. A surface that was never imported
+    /// cannot be rendered, so with `panelSurfaceEnabled` false the workspace
+    /// stays on the legacy path.
+    var daemonManagedPanelsActive: Bool {
+        daemonManagedPanelsFlagEnabled && daemonCapabilities?.panelSurfaceEnabled == true
+    }
+
+    // MARK: - Loading
+
+    /// Populate (or refresh) the mirror for one worktree from `panel.get`.
+    /// Also the snap-to-truth path after a rejected apply. Failures are
+    /// logged and swallowed — the mirror keeps its last known value, and the
+    /// next delta or load repairs it.
+    func loadPanelSurface(worktreeID: UUID) async {
+        guard daemonManagedPanelsFlagEnabled else { return }
+        do {
+            panelSurfaces[worktreeID] = try await panelGetFetcher(worktreeID)
+        } catch {
+            logger.error("""
+                panel.get failed for \(worktreeID, privacy: .public): \
+                \(error, privacy: .public)
+                """)
+        }
+    }
+
+    // MARK: - The apply chokepoint
+
+    /// The single path from an app gesture to daemon-owned state. Sends the
+    /// mirror's current `revision` for the target tab as `baseRevision`; a
+    /// stale value means an agent applied to the same tab in between, the
+    /// daemon rejects, and the catch below refetches so the UI snaps to
+    /// daemon truth and the user retries (last-writer-wins, spec §Conflicts).
+    ///
+    /// Never throws: a gesture that cannot commit is a logged diagnostic plus
+    /// a resync, not an error the view layer has to handle.
+    func applyPanelOperation(
+        worktreeID: UUID, tabID: WorkspaceTabID, operation: PanelOperation
+    ) async {
+        guard daemonManagedPanelsFlagEnabled else { return }
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(),
+            worktreeID: worktreeID,
+            tabID: tabID,
+            baseRevision: panelSurfaceTab(worktreeID: worktreeID, tabID: tabID)?.revision,
+            origin: .appUser,
+            operation: operation)
+        do {
+            let result = try await panelApplyTrigger(envelope)
+            upsertPanelSurfaceTabs([result.tab], worktreeID: worktreeID)
+        } catch {
+            logger.error("""
+                panel.apply rejected for worktree=\(worktreeID, privacy: .public) \
+                tab=\(tabID, privacy: .public): \(error, privacy: .public) — refetching
+                """)
+            await loadPanelSurface(worktreeID: worktreeID)
+        }
+    }
+
+    // MARK: - Delta reconciliation
+
+    /// Reconcile a broadcast `.panelSurfaceChanged` into the mirror: upsert
+    /// the affected tabs, drop the removed ones, adopt a newly selected tab.
+    ///
+    /// A nil `activeTabID` means "unchanged", not "cleared" — the daemon
+    /// sends nil on every ordinary surface mutation and only fills it for
+    /// `selectTab` and the legacy import
+    /// (`PanelCoordinator.apply` / `RPCRouter+PanelHandlers`).
+    func applyPanelSurfaceDelta(_ delta: PanelSurfaceDelta) {
+        guard daemonManagedPanelsFlagEnabled else { return }
+        let existing = panelSurfaces[delta.worktreeID]
+        var tabs = (existing?.tabs ?? []).filter { !delta.removedTabIDs.contains($0.id) }
+        for tab in delta.tabs {
+            if let index = tabs.firstIndex(where: { $0.id == tab.id }) {
+                tabs[index] = tab
+            } else {
+                tabs.append(tab)
+            }
+        }
+        var activeTabID = delta.activeTabID ?? existing?.activeTabID
+        if let active = activeTabID, delta.removedTabIDs.contains(active) {
+            activeTabID = nil
+        }
+        panelSurfaces[delta.worktreeID] = PanelGetResult(tabs: tabs, activeTabID: activeTabID)
+    }
+
+    // MARK: - Mirror reads and writes
+
+    /// The mirrored surface for one tab, or nil when the mirror has no entry
+    /// for that worktree/tab yet.
+    func panelSurfaceTab(worktreeID: UUID, tabID: WorkspaceTabID) -> WorkspaceTabSurface? {
+        panelSurfaces[worktreeID]?.tabs.first { $0.id == tabID }
+    }
+
+    /// Replace-or-append the given tabs in one worktree's mirror entry,
+    /// leaving `activeTabID` and every other tab untouched.
+    private func upsertPanelSurfaceTabs(
+        _ updated: [WorkspaceTabSurface], worktreeID: UUID
+    ) {
+        let existing = panelSurfaces[worktreeID]
+        var tabs = existing?.tabs ?? []
+        for tab in updated {
+            if let index = tabs.firstIndex(where: { $0.id == tab.id }) {
+                tabs[index] = tab
+            } else {
+                tabs.append(tab)
+            }
+        }
+        panelSurfaces[worktreeID] = PanelGetResult(
+            tabs: tabs, activeTabID: existing?.activeTabID)
+    }
+}

--- a/Sources/TBDApp/PanelSurface/PanelSurfaceWorkspaceView.swift
+++ b/Sources/TBDApp/PanelSurface/PanelSurfaceWorkspaceView.swift
@@ -397,6 +397,14 @@ extension PaneActions {
                 // see. Surfacing real history needs `panel.get` to return it
                 // (a daemon change, deliberately out of this phase).
                 PaneHistory.seeded(with: content)
+            },
+            canClose: {
+                // Only a viewer panel can be closed. The primary anchor has
+                // no `PanelID` — there is nothing to name in a `.close`
+                // operation, and the reducer would reject one anyway — so its
+                // × renders disabled rather than looking live and doing
+                // nothing.
+                ownPanelID != nil
             }
         )
     }

--- a/Sources/TBDApp/PanelSurface/PanelSurfaceWorkspaceView.swift
+++ b/Sources/TBDApp/PanelSurface/PanelSurfaceWorkspaceView.swift
@@ -1,0 +1,427 @@
+import SwiftUI
+import TBDShared
+import os
+
+/// Phase 3b (`docs/specs/2026-07-31-panel-3b-app-rendering-design.md`) — the
+/// workspace renderer for the daemon-owned panel surface.
+///
+/// This is the half of the dual path that the legacy `SplitLayoutView` cannot
+/// be: it walks a `PanelLayoutNode`, which has a `.primary` anchor the legacy
+/// homogeneous pane tree has no concept of. What it does NOT do is rebuild a
+/// `LayoutNode` — the leaf-content mapping below is content-only, and that is
+/// exactly what separates this from the rejected adapter bridge (spec
+/// §Approach B): the tree renderer and the source of truth stay separate per
+/// path, and no `@Binding` races the daemon.
+private let logger = Logger(subsystem: "com.tbd.app", category: "panelSurface")
+
+// MARK: - Render-path selection
+
+/// Which renderer the workspace root uses for one tab. Extracted from the
+/// view so both branches are assertable without touching SwiftUI internals.
+enum WorkspaceRenderPath: Equatable {
+    /// Today's `SplitLayoutView` over the app-side `LayoutNode` tree.
+    case legacy
+    /// `PanelSurfaceWorkspaceView` over this mirrored daemon surface.
+    case daemonSurface(WorkspaceTabSurface)
+}
+
+extension AppState {
+    /// The render path for one worktree tab.
+    ///
+    /// Two conditions, both required. `daemonManagedPanelsActive` is the
+    /// user flag AND the daemon's store flag. The mirror lookup is the
+    /// second: the mirror starts EMPTY and fills asynchronously from
+    /// `panel.get`, so a flag-on tab with nothing loaded yet must fall
+    /// through to legacy rather than render blank.
+    func workspaceRenderPath(worktreeID: UUID, tabID: WorkspaceTabID) -> WorkspaceRenderPath {
+        guard daemonManagedPanelsActive,
+              let surface = panelSurfaceTab(worktreeID: worktreeID, tabID: tabID)
+        else { return .legacy }
+        return .daemonSurface(surface)
+    }
+}
+
+/// `.task(id:)` key for the mirror's initial load. A struct rather than an
+/// interpolated string so adding a dimension is a compile error at the call
+/// site instead of a silently unchanged key.
+struct PanelSurfaceLoadKey: Equatable {
+    let worktreeID: UUID
+    let active: Bool
+    let connected: Bool
+}
+
+// MARK: - Leaf content mapping
+
+/// Content-only bridges from the new model's leaf content to the legacy
+/// `PaneContent` the shared leaf view (`PanePlaceholder`) renders.
+///
+/// Total in the direction that matters: `PanelContent` is a strict subset of
+/// `PaneContent` (Spec C §5.5 — no terminal case in a viewer panel), and
+/// `PrimaryContent` adds only the terminal case, which `PaneContent` has.
+///
+/// **Never use these to reconstruct a `LayoutNode` tree.** They exist so one
+/// leaf view can render on top of either source of truth; flattening the
+/// primary/viewer distinction back into a homogeneous tree is the rejected
+/// adapter bridge.
+enum PanelSurfaceLeaf {
+
+    /// A viewer panel's content as the leaf view understands it. The panel's
+    /// own `PanelID` supplies the legacy pane identity for the content cases
+    /// that carry one.
+    static func paneContent(for content: PanelContent, panelID: PanelID) -> PaneContent {
+        switch content {
+        case .file(let reference):
+            return .codeViewer(id: panelID, path: reference.path)
+        case .web(let url):
+            return .webview(id: panelID, url: url)
+        case .transcript(let terminalID):
+            return .liveTranscript(id: panelID, terminalID: terminalID)
+        case .note(let noteID):
+            return .note(noteID: noteID)
+        }
+    }
+
+    /// The primary anchor's content as the leaf view understands it. The
+    /// anchor has no `PanelID` — there is exactly one per tab — so the tab's
+    /// own ID stands in as the legacy pane identity where one is needed.
+    static func paneContent(for content: PrimaryContent, primaryID: UUID) -> PaneContent {
+        switch content {
+        case .terminal(let terminalID):
+            return .terminal(terminalID: terminalID)
+        case .note(let noteID):
+            return .note(noteID: noteID)
+        case .file(let reference):
+            return .codeViewer(id: primaryID, path: reference.path)
+        case .web(let url):
+            return .webview(id: primaryID, url: url)
+        case .transcript(let terminalID):
+            return .liveTranscript(id: primaryID, terminalID: terminalID)
+        }
+    }
+
+    /// The reverse, for the one gesture that names its own content: the
+    /// leaf's "open this file beside me". Partial by design — a terminal can
+    /// never be a viewer panel (§5.5), and nothing in the app asks to open
+    /// one this way.
+    static func panelContent(for content: PaneContent) -> PanelContent? {
+        switch content {
+        case .terminal:
+            return nil
+        case .webview(_, let url):
+            return .web(url)
+        case .codeViewer(_, let path):
+            return .file(FileReference(path: path))
+        case .note(let noteID):
+            return .note(noteID: noteID)
+        case .liveTranscript(_, let terminalID):
+            return .transcript(terminalID: terminalID)
+        }
+    }
+}
+
+// MARK: - Tree renderer
+
+/// Renders one `WorkspaceTabSurface` from the mirror.
+struct PanelSurfaceWorkspaceView: View {
+    let surface: WorkspaceTabSurface
+    let worktree: Worktree
+
+    var body: some View {
+        PanelSurfaceNodeView(node: surface.layout, surface: surface, worktree: worktree)
+    }
+}
+
+/// One node of the panel tree: the primary anchor, a viewer panel, or a
+/// split. Mirrors `SplitLayoutView`'s shape over the new model.
+private struct PanelSurfaceNodeView: View {
+    let node: PanelLayoutNode
+    let surface: WorkspaceTabSurface
+    let worktree: Worktree
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        switch node {
+        case .primary:
+            PanePlaceholder(
+                content: PanelSurfaceLeaf.paneContent(
+                    for: surface.primary, primaryID: surface.id),
+                worktree: worktree,
+                tabID: surface.id,
+                actions: actions(anchor: .primary)
+            )
+        case .panel(let slot):
+            PanePlaceholder(
+                content: PanelSurfaceLeaf.paneContent(for: slot.content, panelID: slot.id),
+                worktree: worktree,
+                tabID: surface.id,
+                actions: actions(anchor: .panel(slot.id))
+            )
+        case .split(let split):
+            PanelSurfaceSplitContainer(
+                split: split, surface: surface, worktree: worktree,
+                // Resize is the one gesture that names a split rather than a
+                // leaf, so the anchor it is built with is irrelevant.
+                resize: actions(anchor: .primary).resize
+            )
+        }
+    }
+
+    private func actions(anchor: PanelAnchor) -> PaneActions {
+        .daemonManaged(
+            appState: appState,
+            worktreeID: surface.worktreeID,
+            tabID: surface.id,
+            anchor: anchor
+        )
+    }
+}
+
+/// Divides space among a `SplitNode`'s children, reusing the existing
+/// `SplitDivider` verbatim — the unified divider / native resize indicator is
+/// a separate follow-up and deliberately not attempted here.
+///
+/// Ratios are `Double` in the new model and `CGFloat` in the divider; the
+/// local drag copy is the conversion boundary, and the commit on release
+/// converts back.
+private struct PanelSurfaceSplitContainer: View {
+    let split: SplitNode
+    let surface: WorkspaceTabSurface
+    let worktree: Worktree
+    let resize: @MainActor (UUID, [CGFloat]) -> Void
+
+    /// Local mutable copy of ratios used during drag operations. Nothing
+    /// reaches the daemon until release (spec §Ownership: no per-frame RPC).
+    @State private var currentRatios: [CGFloat] = []
+
+    /// The node's ratios, widened to the divider's `CGFloat`. Falls back to
+    /// equal shares on a count mismatch: the daemon's validator forbids that
+    /// state, but indexing out of range here would take the whole workspace
+    /// down rather than render one split oddly.
+    private var modelRatios: [CGFloat] {
+        guard !split.children.isEmpty else { return [] }
+        guard split.ratios.count == split.children.count else {
+            return Array(repeating: 1 / CGFloat(split.children.count), count: split.children.count)
+        }
+        return split.ratios.map { CGFloat($0) }
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let totalSize = split.direction == .horizontal
+                ? geometry.size.width
+                : geometry.size.height
+            let dividerThickness: CGFloat = 4
+            let totalDividerSpace = dividerThickness * CGFloat(max(split.children.count - 1, 0))
+            let availableSpace = max(totalSize - totalDividerSpace, 0)
+
+            let activeRatios = currentRatios.count == split.children.count
+                ? currentRatios
+                : modelRatios
+
+            buildLayout(
+                activeRatios: activeRatios,
+                availableSpace: availableSpace,
+                dividerThickness: dividerThickness
+            )
+        }
+        .onAppear {
+            currentRatios = modelRatios
+        }
+        .onChange(of: split.ratios) { _, _ in
+            currentRatios = modelRatios
+        }
+    }
+
+    @ViewBuilder
+    private func buildLayout(
+        activeRatios: [CGFloat],
+        availableSpace: CGFloat,
+        dividerThickness: CGFloat
+    ) -> some View {
+        if split.direction == .horizontal {
+            HStack(spacing: 0) {
+                ForEach(Array(split.children.enumerated()), id: \.element.renderIdentity) { index, child in
+                    PanelSurfaceNodeView(node: child, surface: surface, worktree: worktree)
+                        .frame(width: activeRatios[index] * availableSpace)
+
+                    if index < split.children.count - 1 {
+                        divider(index: index, availableSpace: availableSpace,
+                                thickness: dividerThickness)
+                    }
+                }
+            }
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(split.children.enumerated()), id: \.element.renderIdentity) { index, child in
+                    PanelSurfaceNodeView(node: child, surface: surface, worktree: worktree)
+                        .frame(height: activeRatios[index] * availableSpace)
+
+                    if index < split.children.count - 1 {
+                        divider(index: index, availableSpace: availableSpace,
+                                thickness: dividerThickness)
+                    }
+                }
+            }
+        }
+    }
+
+    private func divider(index: Int, availableSpace: CGFloat, thickness: CGFloat) -> some View {
+        SplitDivider(
+            direction: split.direction,
+            thickness: thickness,
+            index: index,
+            ratios: $currentRatios,
+            availableSpace: availableSpace,
+            onDragEnd: { resize(split.id, currentRatios) }
+        )
+    }
+}
+
+// MARK: - Render identity
+
+extension PanelLayoutNode {
+    /// Stable `ForEach` identity, matching `LayoutNode.nodeID`'s role. A tab
+    /// has exactly one primary anchor, so a constant stands in for it.
+    var renderIdentity: UUID {
+        switch self {
+        case .primary: return Self.primaryRenderIdentity
+        case .panel(let slot): return slot.id
+        case .split(let split): return split.id
+        }
+    }
+
+    /// Fixed sentinel for the single `.primary` node in a tab. The all-zero
+    /// UUID is never a real `PanelID` — the daemon mints those with `UUID()`.
+    static let primaryRenderIdentity = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+}
+
+// MARK: - Daemon-backed action set
+
+extension PaneActions {
+    /// The daemon-backed twin of `PaneActions.legacy`: every structural
+    /// mutation becomes a `PanelOperation` through `AppState`'s single
+    /// `panel.apply` chokepoint, and the two queries are answered from the
+    /// mirrored surface instead of a local tree.
+    ///
+    /// Built per leaf: `anchor` is what this leaf *is*, which the new model
+    /// needs (a `PanelID`, or the primary anchor) and the legacy `paneID`
+    /// arguments cannot supply — a note panel's legacy pane ID is its note
+    /// ID, not its `PanelID`. Every closure therefore ignores the `paneID`
+    /// it is handed; the leaf only ever passes its own.
+    ///
+    /// **Close is not delete.** Closing a note panel here removes the panel
+    /// and leaves the note file alone, unlike the legacy set. That is the
+    /// intended new semantics (spec §Non-goals); an explicit delete-note
+    /// affordance is a separate follow-up.
+    @MainActor
+    static func daemonManaged(
+        appState: AppState,
+        worktreeID: UUID,
+        tabID: WorkspaceTabID,
+        anchor: PanelAnchor
+    ) -> PaneActions {
+        // nil for the primary anchor, which has no PanelID: `.primary` is
+        // unremovable and history-less by type in the shared reducer, so the
+        // close and history gestures are no-ops there.
+        let ownPanelID: PanelID? = {
+            if case .panel(let id) = anchor { return id }
+            return nil
+        }()
+
+        @MainActor func fire(_ operation: PanelOperation) {
+            Task {
+                await appState.applyPanelOperation(
+                    worktreeID: worktreeID, tabID: tabID, operation: operation)
+            }
+        }
+
+        /// The panel currently showing this terminal's transcript, if any.
+        @MainActor func openTranscriptPanelID(terminalID: UUID) -> PanelID? {
+            guard let layout = appState.panelSurfaceTab(
+                worktreeID: worktreeID, tabID: tabID)?.layout else { return nil }
+            return layout.allPanelIDs.first { panelID in
+                if case .transcript(let openFor)? = layout.panelSlot(id: panelID)?.content {
+                    return openFor == terminalID
+                }
+                return false
+            }
+        }
+
+        return PaneActions(
+            openBeside: { _, direction, content in
+                guard let panelContent = PanelSurfaceLeaf.panelContent(for: content) else {
+                    logger.error("""
+                        openBeside: \(String(describing: content), privacy: .public) \
+                        has no viewer-panel form — dropped
+                        """)
+                    return
+                }
+                fire(.open(
+                    content: panelContent,
+                    placement: .beside(
+                        target: anchor, edge: direction.trailingPanelEdge, share: nil)))
+            },
+            routeFile: { _, path in
+                // `.automatic` IS the reducer's "reuse the first viewer panel,
+                // else split right of the primary anchor" contract — the same
+                // routing the legacy `routeFileClick` did by hand.
+                fire(.open(content: .file(FileReference(path: path)), placement: .automatic))
+            },
+            toggleTranscript: { _, terminalID in
+                if let openPanelID = openTranscriptPanelID(terminalID: terminalID) {
+                    fire(.close(panelID: openPanelID))
+                } else {
+                    fire(.open(content: .transcript(terminalID: terminalID), placement: .automatic))
+                }
+            },
+            historyStep: { _, step in
+                guard let panelID = ownPanelID else { return }
+                fire(.history(panelID: panelID, action: step.panelHistoryAction))
+            },
+            close: { _ in
+                guard let panelID = ownPanelID else { return }
+                fire(.close(panelID: panelID))
+            },
+            resize: { splitID, ratios in
+                fire(.resize(splitID: splitID, ratios: ratios.map { Double($0) }))
+            },
+            isTranscriptOpen: { terminalID in
+                openTranscriptPanelID(terminalID: terminalID) != nil
+            },
+            history: { _, content in
+                // The mirror carries no per-panel history: `panel.get`
+                // returns tabs only, and the daemon keeps histories in its
+                // own store. So a leaf on this path reports the honest
+                // single-entry history — its chevrons stay disabled rather
+                // than pretending to a back/forward state the app cannot
+                // see. Surfacing real history needs `panel.get` to return it
+                // (a daemon change, deliberately out of this phase).
+                PaneHistory.seeded(with: content)
+            }
+        )
+    }
+}
+
+// MARK: - Gesture vocabulary bridges
+
+extension SplitDirection {
+    /// The edge a legacy "split off me" gesture lands on in the new model's
+    /// user-facing edge vocabulary. Matches the legacy behavior: a horizontal
+    /// split puts the new pane on the right, a vertical one below.
+    var trailingPanelEdge: PanelEdge {
+        switch self {
+        case .horizontal: return .right
+        case .vertical: return .below
+        }
+    }
+}
+
+extension PaneActions.HistoryStep {
+    var panelHistoryAction: PanelHistoryAction {
+        switch self {
+        case .back: return .back
+        case .forward: return .forward
+        case .to(let index): return .jump(index: index)
+        }
+    }
+}

--- a/Sources/TBDApp/PanelSurface/PanelSurfaceWorkspaceView.swift
+++ b/Sources/TBDApp/PanelSurface/PanelSurfaceWorkspaceView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 import os
@@ -124,7 +125,7 @@ enum PanelSurfaceLeaf {
 /// Renders one `WorkspaceTabSurface` from the mirror.
 struct PanelSurfaceWorkspaceView: View {
     let surface: WorkspaceTabSurface
-    let worktree: Worktree
+    let worktree: LocalWorktree
 
     var body: some View {
         PanelSurfaceNodeView(node: surface.layout, surface: surface, worktree: worktree)
@@ -136,7 +137,7 @@ struct PanelSurfaceWorkspaceView: View {
 private struct PanelSurfaceNodeView: View {
     let node: PanelLayoutNode
     let surface: WorkspaceTabSurface
-    let worktree: Worktree
+    let worktree: LocalWorktree
     @EnvironmentObject var appState: AppState
 
     var body: some View {
@@ -186,7 +187,7 @@ private struct PanelSurfaceNodeView: View {
 private struct PanelSurfaceSplitContainer: View {
     let split: SplitNode
     let surface: WorkspaceTabSurface
-    let worktree: Worktree
+    let worktree: LocalWorktree
     let resize: @MainActor (UUID, [CGFloat]) -> Void
 
     /// Local mutable copy of ratios used during drag operations. Nothing
@@ -366,6 +367,19 @@ extension PaneActions {
                 // else split right of the primary anchor" contract — the same
                 // routing the legacy `routeFileClick` did by hand.
                 fire(.open(content: .file(FileReference(path: path)), placement: .automatic))
+            },
+            openTranscriptLink: { _, target in
+                // The file case cannot reuse `TranscriptLinkDestination.live`:
+                // it decides by rewriting a `LayoutNode`, and this path has
+                // none. `.daemonManaged` makes the same choice in panel
+                // vocabulary; the browser case is layout-independent and
+                // therefore byte-identical to the legacy set's.
+                switch TranscriptLinkDestination.daemonManaged(target) {
+                case .apply(let operation):
+                    fire(operation)
+                case .openInBrowser(let url):
+                    NSWorkspace.shared.open(url)
+                }
             },
             toggleTranscript: { _, terminalID in
                 if let openPanelID = openTranscriptPanelID(terminalID: terminalID) {

--- a/Sources/TBDApp/Panes/PaneActions.swift
+++ b/Sources/TBDApp/Panes/PaneActions.swift
@@ -45,6 +45,23 @@ struct PaneActions {
 
     /// Commit new child ratios for the split identified by `splitID`.
     var resize: @MainActor (_ splitID: UUID, _ ratios: [CGFloat]) -> Void
+
+    // MARK: - Queries
+    //
+    // Not mutations, but they belong to the same seam: they are the only
+    // things the leaf needs to know about the tree *around* it, and each
+    // rendering path answers them from its own source of truth. Keeping them
+    // here is what lets `PanePlaceholder` drop its `@Binding var layout` and
+    // render on top of the daemon surface unchanged.
+
+    /// Whether this tab already shows a live transcript for `terminalID` —
+    /// drives the toolbar button's filled/accented state and its help text.
+    var isTranscriptOpen: @MainActor (_ terminalID: UUID) -> Bool
+
+    /// The slot history behind a viewer pane's back/forward chevrons and its
+    /// history palette. `content` is the pane's current content, used to seed
+    /// a single-entry history for a slot that has never navigated.
+    var history: @MainActor (_ paneID: UUID, _ content: PaneContent) -> PaneHistory
 }
 
 // MARK: - Legacy action set
@@ -138,6 +155,17 @@ extension PaneActions {
                 // Write back current ratios into the layout binding, targeting
                 // this split by its stable ID (never by child-array equality).
                 layout.wrappedValue = layout.wrappedValue.updatingRatios(forSplitID: splitID, to: ratios)
+            },
+            isTranscriptOpen: { terminalID in
+                layout.wrappedValue.firstPaneID(
+                    where: { isLiveTranscriptPane($0, for: terminalID) }
+                ) != nil
+            },
+            history: { paneID, content in
+                // A pane that hasn't navigated yet has no recorded history —
+                // but it always has its current content, so fall back to a
+                // single-entry history seeded with it rather than an empty one.
+                appState.paneHistories[paneID] ?? PaneHistory.seeded(with: content)
             }
         )
     }

--- a/Sources/TBDApp/Panes/PaneActions.swift
+++ b/Sources/TBDApp/Panes/PaneActions.swift
@@ -62,6 +62,17 @@ struct PaneActions {
     /// history palette. `content` is the pane's current content, used to seed
     /// a single-entry history for a slot that has never navigated.
     var history: @MainActor (_ paneID: UUID, _ content: PaneContent) -> PaneHistory
+
+    /// Whether `close` on this leaf would actually do anything — the leaf
+    /// disables its × button when it would not.
+    ///
+    /// The two paths disagree, and the disagreement has to be *visible*: the
+    /// legacy tree can always close a leaf (the last one takes its tab with
+    /// it), while the daemon path's primary anchor has no `PanelID` and is
+    /// unremovable by type in the shared reducer. Without this query the ×
+    /// still renders on a primary anchor and swallows the click — no state
+    /// change, no RPC, no diagnostic.
+    var canClose: @MainActor () -> Bool
 }
 
 // MARK: - Legacy action set
@@ -166,6 +177,12 @@ extension PaneActions {
                 // but it always has its current content, so fall back to a
                 // single-entry history seeded with it rather than an empty one.
                 appState.paneHistories[paneID] ?? PaneHistory.seeded(with: content)
+            },
+            canClose: {
+                // Always: `close` above removes the pane from the tree, and
+                // for the last pane in a tab it removes the tab. There is no
+                // leaf here whose × does nothing.
+                true
             }
         )
     }

--- a/Sources/TBDApp/Panes/PaneActions.swift
+++ b/Sources/TBDApp/Panes/PaneActions.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+import TBDShared
+
+// MARK: - PaneActions
+
+/// The structural mutations a pane leaf can ask for, injected instead of
+/// performed in place.
+///
+/// `PanePlaceholder` renders one leaf of a workspace, but it used to also
+/// rewrite the surrounding tree through its `@Binding var layout`. Routing
+/// every mutation through this action set keeps the leaf's chrome and content
+/// rendering usable on top of a different source of truth without duplicating
+/// the view.
+///
+/// `PaneActions.legacy` is today's behavior — the app-side `LayoutNode` tree
+/// plus its `AppState` bookkeeping — moved here unchanged.
+struct PaneActions {
+    /// One step of slot-history navigation, as requested by a viewer pane's
+    /// back/forward chevrons and its history palette. Resolving the step
+    /// against the slot's recorded history is the action set's job, not the
+    /// leaf's.
+    enum HistoryStep: Equatable {
+        case back
+        case forward
+        case to(index: Int)
+    }
+
+    /// Split `paneID` and put `content` in the new sibling.
+    var openBeside: @MainActor (_ paneID: UUID, _ direction: SplitDirection, _ content: PaneContent) -> Void
+
+    /// Open the file a terminal link pointed at, routed to whichever pane
+    /// should show it (reuse a viewer slot, else split off the terminal).
+    var routeFile: @MainActor (_ terminalID: UUID, _ path: String) -> Void
+
+    /// Toggle the live-transcript pane for `terminalID`, opening it beside
+    /// `paneID` when there is no viewer slot to reuse.
+    var toggleTranscript: @MainActor (_ paneID: UUID, _ terminalID: UUID) -> Void
+
+    /// Navigate the viewer slot `paneID` one step through its history.
+    var historyStep: @MainActor (_ paneID: UUID, _ step: HistoryStep) -> Void
+
+    /// Close the pane showing `content`. Takes the content, not just the pane
+    /// ID, because closing a note pane also deletes the note.
+    var close: @MainActor (_ content: PaneContent) -> Void
+
+    /// Commit new child ratios for the split identified by `splitID`.
+    var resize: @MainActor (_ splitID: UUID, _ ratios: [CGFloat]) -> Void
+}
+
+// MARK: - Legacy action set
+
+extension PaneActions {
+    /// Today's behavior: mutate the app-side `LayoutNode` tree in `layout` and
+    /// keep `AppState`'s pane bookkeeping (histories, tabs, notes) in step.
+    ///
+    /// Every closure body below came verbatim from the call site it replaced
+    /// in `PanePlaceholder` / `SplitContainer`.
+    @MainActor
+    static func legacy(
+        layout: Binding<LayoutNode>,
+        appState: AppState,
+        worktreeID: UUID
+    ) -> PaneActions {
+        PaneActions(
+            openBeside: { paneID, direction, content in
+                layout.wrappedValue = layout.wrappedValue.splitPane(
+                    id: paneID,
+                    direction: direction,
+                    newContent: content
+                )
+            },
+            routeFile: { terminalID, path in
+                let result = routeFileClick(into: layout.wrappedValue, terminalID: terminalID, path: path)
+                if let replaced = result.replaced {
+                    appState.recordPaneReplacement(replaced)
+                }
+                layout.wrappedValue = result.layout
+            },
+            toggleTranscript: { paneID, terminalID in
+                let result = TBDShared.toggleTranscript(
+                    into: layout.wrappedValue,
+                    terminalID: terminalID,
+                    fromPaneID: paneID
+                )
+                if let replaced = result.replaced {
+                    appState.recordPaneReplacement(replaced)
+                }
+                if let removed = result.removedPaneID {
+                    // Reused slot: restore its pre-transcript content in place instead
+                    // of applying the removal layout.
+                    if let previous = appState.popHistoryForRemovedPane(removed),
+                       let restored = layout.wrappedValue.replacingContent(at: removed, with: previous) {
+                        layout.wrappedValue = restored
+                        return
+                    }
+                }
+                layout.wrappedValue = result.layout
+            },
+            historyStep: { paneID, step in
+                // Mutate the slot's history, then swap the layout content in
+                // place keeping the pane UUID. Goes through `replacingContent`
+                // directly — never through the routing functions — so
+                // navigating does not push new history entries.
+                guard var history = appState.paneHistories[paneID] else { return }
+                let target: PaneContent?
+                switch step {
+                case .back: target = history.goBack()
+                case .forward: target = history.goForward()
+                case .to(let index): target = history.go(to: index)
+                }
+                guard let target,
+                      let updated = layout.wrappedValue.replacingContent(at: paneID, with: target)
+                else { return }
+                appState.paneHistories[paneID] = history
+                layout.wrappedValue = updated
+            },
+            close: { content in
+                // Delete the underlying resource for note panes
+                if case .note(let noteID) = content {
+                    Task { await appState.deleteNote(noteID: noteID, worktreeID: worktreeID) }
+                }
+
+                appState.paneHistories.removeValue(forKey: content.paneID)
+
+                if let newLayout = layout.wrappedValue.removePane(id: content.paneID) {
+                    layout.wrappedValue = newLayout
+                } else {
+                    // Last pane in this tab — remove the entire tab
+                    if let tabIndex = appState.tabs[worktreeID]?.firstIndex(where: {
+                        $0.id == content.paneID || $0.content.paneID == content.paneID
+                    }) {
+                        appState.tabs[worktreeID]?.remove(at: tabIndex)
+                        appState.layouts.removeValue(forKey: content.paneID)
+                    }
+                }
+            },
+            resize: { splitID, ratios in
+                // Write back current ratios into the layout binding, targeting
+                // this split by its stable ID (never by child-array equality).
+                layout.wrappedValue = layout.wrappedValue.updatingRatios(forSplitID: splitID, to: ratios)
+            }
+        )
+    }
+}

--- a/Sources/TBDApp/Panes/PaneActions.swift
+++ b/Sources/TBDApp/Panes/PaneActions.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
@@ -31,6 +32,15 @@ struct PaneActions {
     /// Open the file a terminal link pointed at, routed to whichever pane
     /// should show it (reuse a viewer slot, else split off the terminal).
     var routeFile: @MainActor (_ terminalID: UUID, _ path: String) -> Void
+
+    /// Route a link clicked inside the live transcript of `terminalID` — a
+    /// file into whichever pane should show it, a URL out to the browser.
+    ///
+    /// Separate from `routeFile` because the two arrive with different
+    /// vocabulary: this one is handed the undecided `TranscriptLinkTarget`,
+    /// and deciding between "route into the workspace" and "leave the app"
+    /// is per-path (`TranscriptLinkDestination`), not the leaf's.
+    var openTranscriptLink: @MainActor (_ terminalID: UUID, _ target: TranscriptLinkTarget) -> Void
 
     /// Toggle the live-transcript pane for `terminalID`, opening it beside
     /// `paneID` when there is no viewer slot to reuse.
@@ -103,6 +113,19 @@ extension PaneActions {
                     appState.recordPaneReplacement(replaced)
                 }
                 layout.wrappedValue = result.layout
+            },
+            openTranscriptLink: { terminalID, target in
+                switch TranscriptLinkDestination.live(
+                    target, layout: layout.wrappedValue, terminalID: terminalID
+                ) {
+                case .route(let result):
+                    if let replaced = result.replaced {
+                        appState.recordPaneReplacement(replaced)
+                    }
+                    layout.wrappedValue = result.layout
+                case .openInBrowser(let url):
+                    NSWorkspace.shared.open(url)
+                }
             },
             toggleTranscript: { paneID, terminalID in
                 let result = TBDShared.toggleTranscript(

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -356,17 +356,7 @@ struct PanePlaceholder: View {
                     overlayCoordinator.open(terminalID: terminalID, itemID: itemID)
                 }
                 .environment(\.openTranscriptLink) { target in
-                    switch TranscriptLinkDestination.live(
-                        target, layout: layout, terminalID: terminalID
-                    ) {
-                    case .route(let result):
-                        if let replaced = result.replaced {
-                            appState.recordPaneReplacement(replaced)
-                        }
-                        layout = result.layout
-                    case .openInBrowser(let url):
-                        NSWorkspace.shared.open(url)
-                    }
+                    actions.openTranscriptLink(terminalID, target)
                 }
             } else {
                 transcriptDisabledPlaceholder

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -48,7 +48,10 @@ struct PanePlaceholder: View {
     /// proven-local wrapper rather than a bare `Worktree`.
     let worktree: LocalWorktree
     let tabID: UUID?
+    /// Read-only view of the surrounding tree (the transcript button's
+    /// open-state check). All structural mutation goes through `actions`.
     @Binding var layout: LayoutNode
+    let actions: PaneActions
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
     @State private var isHeaderHovering = false
@@ -202,7 +205,7 @@ struct PanePlaceholder: View {
         case .terminal(let terminalID):
             if terminal(for: terminalID)?.isClaudeResumable == true && transcriptFeatureEnabled {
                 let transcriptOpen = isTranscriptOpen(terminalID: terminalID)
-                Button(action: { toggleTranscriptPane(terminalID: terminalID) }) {
+                Button(action: { actions.toggleTranscript(content.paneID, terminalID) }) {
                     HStack(spacing: 2) {
                         Image(systemName: transcriptOpen ? "text.bubble.fill" : "text.bubble")
                         Text("Transcript")
@@ -260,14 +263,14 @@ struct PanePlaceholder: View {
         historyButton(
             icon: "chevron.left",
             help: "Back",
-            action: { navigateHistory { $0.goBack() } }
+            action: { actions.historyStep(content.paneID, .back) }
         )
         .disabled(!history.canGoBack)
 
         historyButton(
             icon: "chevron.right",
             help: "Forward",
-            action: { navigateHistory { $0.goForward() } }
+            action: { actions.historyStep(content.paneID, .forward) }
         )
         .disabled(!history.canGoForward)
     }
@@ -295,7 +298,7 @@ struct PanePlaceholder: View {
         .disabled(!PaneHistoryPaletteButtonModel.isEnabled(entryCount: history.entries.count))
         .popover(isPresented: $showHistoryPalette, arrowEdge: .bottom) {
             PaneHistoryPaletteView(history: history) { index in
-                navigateHistory { $0.go(to: index) }
+                actions.historyStep(content.paneID, .to(index: index))
             }
         }
     }
@@ -321,19 +324,6 @@ struct PanePlaceholder: View {
         .help(help)
     }
 
-    /// Applies a history navigation to this slot: mutate the slot's history,
-    /// then swap the layout content in place keeping the pane UUID. Goes
-    /// through `replacingContent` directly — never through the routing
-    /// functions — so navigating does not push new history entries.
-    private func navigateHistory(_ step: (inout PaneHistory) -> PaneContent?) {
-        guard var history = appState.paneHistories[content.paneID],
-              let target = step(&history),
-              let updated = layout.replacingContent(at: content.paneID, with: target)
-        else { return }
-        appState.paneHistories[content.paneID] = history
-        layout = updated
-    }
-
     // MARK: - Pane Body
 
     @ViewBuilder
@@ -352,7 +342,7 @@ struct PanePlaceholder: View {
                 TableTranscriptPaneView(terminalID: terminalID, worktreeID: worktree.id)
                 .environment(\.openFilePreview, { path in
                     let newContent = PaneContent.codeViewer(id: UUID(), path: path)
-                    layout = layout.splitPane(id: content.paneID, direction: .horizontal, newContent: newContent)
+                    actions.openBeside(content.paneID, .horizontal, newContent)
                 })
                 .environment(\.openTranscriptOverlay) { itemID in
                     overlayCoordinator.open(terminalID: terminalID, itemID: itemID)
@@ -428,11 +418,7 @@ struct PanePlaceholder: View {
                     worktreePath: worktree.path,
                     remoteURL: appState.repos.first(where: { $0.id == worktree.repoID })?.remoteURL,
                     onFilePathClicked: { path in
-                        let result = routeFileClick(into: layout, terminalID: terminalID, path: path)
-                        if let replaced = result.replaced {
-                            appState.recordPaneReplacement(replaced)
-                        }
-                        layout = result.layout
+                        actions.routeFile(terminalID, path)
                     },
                     onTerminalNotification: { title, body in
                         debugLog("OSC 777: \(title) — \(body)")
@@ -497,7 +483,7 @@ struct PanePlaceholder: View {
                         )
                         .environment(\.openFilePreview, { path in
                             let newContent = PaneContent.codeViewer(id: UUID(), path: path)
-                            layout = layout.splitPane(id: content.paneID, direction: .horizontal, newContent: newContent)
+                            actions.openBeside(content.paneID, .horizontal, newContent)
                         })
                         .padding(16)
                     }
@@ -566,23 +552,7 @@ struct PanePlaceholder: View {
     // MARK: - Close
 
     private func closePane() {
-        // Delete the underlying resource for note panes
-        if case .note(let noteID) = content {
-            Task { await appState.deleteNote(noteID: noteID, worktreeID: worktree.id) }
-        }
-
-        appState.paneHistories.removeValue(forKey: content.paneID)
-
-        if let newLayout = layout.removePane(id: content.paneID) {
-            layout = newLayout
-        } else {
-            // Last pane in this tab — remove the entire tab
-            let worktreeID = worktree.id
-            if let tabIndex = appState.tabs[worktreeID]?.firstIndex(where: { $0.id == content.paneID || $0.content.paneID == content.paneID }) {
-                appState.tabs[worktreeID]?.remove(at: tabIndex)
-                appState.layouts.removeValue(forKey: content.paneID)
-            }
-        }
+        actions.close(content)
     }
 
     // MARK: - Webview Actions
@@ -599,23 +569,6 @@ struct PanePlaceholder: View {
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             didCopyURL = false
         }
-    }
-
-    private func toggleTranscriptPane(terminalID: UUID) {
-        let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: content.paneID)
-        if let replaced = result.replaced {
-            appState.recordPaneReplacement(replaced)
-        }
-        if let removed = result.removedPaneID {
-            // Reused slot: restore its pre-transcript content in place instead
-            // of applying the removal layout.
-            if let previous = appState.popHistoryForRemovedPane(removed),
-               let restored = layout.replacingContent(at: removed, with: previous) {
-                layout = restored
-                return
-            }
-        }
-        layout = result.layout
     }
 
     private func isTranscriptOpen(terminalID: UUID) -> Bool {

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -48,9 +48,12 @@ struct PanePlaceholder: View {
     /// proven-local wrapper rather than a bare `Worktree`.
     let worktree: LocalWorktree
     let tabID: UUID?
-    /// Read-only view of the surrounding tree (the transcript button's
-    /// open-state check). All structural mutation goes through `actions`.
-    @Binding var layout: LayoutNode
+    /// Everything this leaf knows about the tree around it — both the
+    /// structural mutations it can request and the two queries it needs
+    /// (transcript-open state, slot history). Deliberately the leaf's ONLY
+    /// window onto the surrounding workspace, so the same view renders on
+    /// top of the legacy `LayoutNode` tree and the daemon-owned panel
+    /// surface without knowing which it is sitting on.
     let actions: PaneActions
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
@@ -204,7 +207,7 @@ struct PanePlaceholder: View {
         switch content {
         case .terminal(let terminalID):
             if terminal(for: terminalID)?.isClaudeResumable == true && transcriptFeatureEnabled {
-                let transcriptOpen = isTranscriptOpen(terminalID: terminalID)
+                let transcriptOpen = actions.isTranscriptOpen(terminalID)
                 Button(action: { actions.toggleTranscript(content.paneID, terminalID) }) {
                     HStack(spacing: 2) {
                         Image(systemName: transcriptOpen ? "text.bubble.fill" : "text.bubble")
@@ -252,11 +255,11 @@ struct PanePlaceholder: View {
     @ViewBuilder
     private var historyNavigation: some View {
         // A pane that hasn't navigated yet has no recorded history — but it
-        // always has its current content, so fall back to a single-entry
-        // history seeded with it rather than an empty one. Otherwise the
-        // search button would wrongly read as "nothing to show" for the
-        // common case of a freshly opened viewer slot.
-        let history = appState.paneHistories[content.paneID] ?? PaneHistory.seeded(with: content)
+        // always has its current content, so the action set falls back to a
+        // single-entry history seeded with it rather than an empty one.
+        // Otherwise the search button would wrongly read as "nothing to
+        // show" for the common case of a freshly opened viewer slot.
+        let history = actions.history(content.paneID, content)
 
         historySearchButton(history: history)
 
@@ -569,10 +572,6 @@ struct PanePlaceholder: View {
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             didCopyURL = false
         }
-    }
-
-    private func isTranscriptOpen(terminalID: UUID) -> Bool {
-        layout.firstPaneID(where: { isLiveTranscriptPane($0, for: terminalID) }) != nil
     }
 }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -131,6 +131,10 @@ struct PanePlaceholder: View {
 
             toolbarActions
 
+            // Kept in the layout and disabled rather than omitted when the
+            // leaf cannot be closed (the daemon path's primary anchor): the
+            // header keeps the same shape on both rendering paths, and a
+            // greyed × reads as "not closable" instead of swallowing clicks.
             Button(action: closePane) {
                 Image(systemName: "xmark")
                     .font(.system(size: 9, weight: .bold))
@@ -138,6 +142,7 @@ struct PanePlaceholder: View {
                     .frame(width: 16, height: 16)
             }
             .buttonStyle(.borderless)
+            .disabled(!actions.canClose())
             .help("Close pane")
         }
         .padding(.horizontal, 8)

--- a/Sources/TBDApp/Panes/Transcript/TranscriptLinkDestination.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptLinkDestination.swift
@@ -25,12 +25,35 @@ enum TranscriptLinkDestination {
         case openInBrowser(URL)
     }
 
+    /// The daemon-managed panel path's decision (Phase 3b).
+    ///
+    /// Same two outcomes as `live`, but the file case names a
+    /// `PanelOperation` instead of a rewritten `LayoutNode`: that path has no
+    /// app-side tree to route into, and rebuilding one would be the rejected
+    /// adapter bridge. `.automatic` is the reducer's "reuse the first viewer
+    /// panel, else split right of the primary anchor" contract — the same
+    /// intent `routeFileClick` expresses by hand for `live`. The web case is
+    /// layout-independent and therefore identical on both paths.
+    enum DaemonManaged: Equatable {
+        case apply(PanelOperation)
+        case openInBrowser(URL)
+    }
+
     static func live(
         _ target: TranscriptLinkTarget, layout: LayoutNode, terminalID: UUID
     ) -> Live {
         switch target {
         case .file(let path):
             return .route(routeFileClick(into: layout, terminalID: terminalID, path: path))
+        case .web(let url):
+            return .openInBrowser(url)
+        }
+    }
+
+    static func daemonManaged(_ target: TranscriptLinkTarget) -> DaemonManaged {
+        switch target {
+        case .file(let path):
+            return .apply(.open(content: .file(FileReference(path: path)), placement: .automatic))
         case .web(let url):
             return .openInBrowser(url)
         }

--- a/Sources/TBDApp/Terminal/SplitLayoutView.swift
+++ b/Sources/TBDApp/Terminal/SplitLayoutView.swift
@@ -7,7 +7,6 @@ struct SplitLayoutView: View {
     let node: LayoutNode
     let worktree: LocalWorktree
     let tabID: UUID?
-    @Binding var layout: LayoutNode
     let actions: PaneActions
 
     var body: some View {
@@ -17,7 +16,6 @@ struct SplitLayoutView: View {
                 content: content,
                 worktree: worktree,
                 tabID: tabID,
-                layout: $layout,
                 actions: actions
             )
         case .split(let id, let direction, let children, let ratios):
@@ -28,7 +26,6 @@ struct SplitLayoutView: View {
                 ratios: ratios,
                 worktree: worktree,
                 tabID: tabID,
-                layout: $layout,
                 actions: actions
             )
         }
@@ -46,7 +43,6 @@ struct SplitContainer: View {
     let ratios: [CGFloat]
     let worktree: LocalWorktree
     let tabID: UUID?
-    @Binding var layout: LayoutNode
     let actions: PaneActions
 
     /// Local mutable copy of ratios used during drag operations.
@@ -92,7 +88,6 @@ struct SplitContainer: View {
                         node: child,
                         worktree: worktree,
                         tabID: tabID,
-                        layout: $layout,
                         actions: actions
                     )
                     .frame(width: activeRatios[index] * availableSpace)
@@ -116,7 +111,6 @@ struct SplitContainer: View {
                         node: child,
                         worktree: worktree,
                         tabID: tabID,
-                        layout: $layout,
                         actions: actions
                     )
                     .frame(height: activeRatios[index] * availableSpace)

--- a/Sources/TBDApp/Terminal/SplitLayoutView.swift
+++ b/Sources/TBDApp/Terminal/SplitLayoutView.swift
@@ -8,6 +8,7 @@ struct SplitLayoutView: View {
     let worktree: LocalWorktree
     let tabID: UUID?
     @Binding var layout: LayoutNode
+    let actions: PaneActions
 
     var body: some View {
         switch node {
@@ -16,7 +17,8 @@ struct SplitLayoutView: View {
                 content: content,
                 worktree: worktree,
                 tabID: tabID,
-                layout: $layout
+                layout: $layout,
+                actions: actions
             )
         case .split(let id, let direction, let children, let ratios):
             SplitContainer(
@@ -26,7 +28,8 @@ struct SplitLayoutView: View {
                 ratios: ratios,
                 worktree: worktree,
                 tabID: tabID,
-                layout: $layout
+                layout: $layout,
+                actions: actions
             )
         }
     }
@@ -44,6 +47,7 @@ struct SplitContainer: View {
     let worktree: LocalWorktree
     let tabID: UUID?
     @Binding var layout: LayoutNode
+    let actions: PaneActions
 
     /// Local mutable copy of ratios used during drag operations.
     @State private var currentRatios: [CGFloat] = []
@@ -88,7 +92,8 @@ struct SplitContainer: View {
                         node: child,
                         worktree: worktree,
                         tabID: tabID,
-                        layout: $layout
+                        layout: $layout,
+                        actions: actions
                     )
                     .frame(width: activeRatios[index] * availableSpace)
 
@@ -111,7 +116,8 @@ struct SplitContainer: View {
                         node: child,
                         worktree: worktree,
                         tabID: tabID,
-                        layout: $layout
+                        layout: $layout,
+                        actions: actions
                     )
                     .frame(height: activeRatios[index] * availableSpace)
 
@@ -130,10 +136,10 @@ struct SplitContainer: View {
         }
     }
 
-    /// Write back current ratios into the layout binding, targeting this
-    /// split by its stable ID (never by child-array equality).
+    /// Write back current ratios, targeting this split by its stable ID
+    /// (never by child-array equality).
     private func commitRatios() {
-        layout = layout.updatingRatios(forSplitID: splitID, to: currentRatios)
+        actions.resize(splitID, currentRatios)
     }
 }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -295,7 +295,12 @@ struct SingleWorktreeView: View {
                 node: layoutBinding.wrappedValue,
                 worktree: worktree,
                 tabID: tab.id,
-                layout: layoutBinding
+                layout: layoutBinding,
+                actions: .legacy(
+                    layout: layoutBinding,
+                    appState: appState,
+                    worktreeID: worktree.id
+                )
             )
             .id(tab.id) // Force new view hierarchy when switching tabs
         } else {
@@ -717,11 +722,17 @@ private struct MultiWorktreeCell: View {
                     appState.gridLayouts[worktreeID] = newLayout
                 }
             )
+            // Grid mode stays on the legacy app-side layout tree.
             PanePlaceholder(
                 content: .terminal(terminalID: terminal.id),
                 worktree: worktree,
                 tabID: activeTab?.id,
-                layout: layoutBinding
+                layout: layoutBinding,
+                actions: .legacy(
+                    layout: layoutBinding,
+                    appState: appState,
+                    worktreeID: worktree.id
+                )
             )
         } else {
             ZStack {

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -262,6 +262,21 @@ struct SingleWorktreeView: View {
                     await appState.createTerminal(worktreeID: worktreeID)
                 }
             }
+            // Phase 3b: seed the daemon panel-surface mirror for this
+            // worktree — nothing else calls `panel.get` for rendering. Keyed
+            // on the effective switch AND the connection so it re-runs when
+            // capabilities land (flipping the switch false → true) and again
+            // after a reconnect, when the daemon may have moved on while the
+            // app was away. Inert with the flag off: the guard skips it and
+            // `loadPanelSurface` would refuse to fetch anyway.
+            .task(id: PanelSurfaceLoadKey(
+                worktreeID: worktreeID,
+                active: appState.daemonManagedPanelsActive,
+                connected: appState.isConnected
+            )) {
+                guard appState.daemonManagedPanelsActive, appState.isConnected else { return }
+                await appState.loadPanelSurface(worktreeID: worktreeID)
+            }
             .task(id: worktreeTabs.isEmpty) {
                 // When a non-main worktree has no tabs, populate session
                 // history so the empty state can show it. `.main` worktrees
@@ -286,23 +301,34 @@ struct SingleWorktreeView: View {
         if appState.historyActiveWorktrees.contains(worktreeID) {
             HistoryPaneView(worktreeID: worktreeID)
         } else if let tab = activeTab, let worktree {
-            let layoutBinding = Binding<LayoutNode>(
-                get: { appState.layouts[tab.id] ?? .pane(tab.content) },
-                set: { appState.layouts[tab.id] = $0 }
-            )
-
-            SplitLayoutView(
-                node: layoutBinding.wrappedValue,
-                worktree: worktree,
-                tabID: tab.id,
-                layout: layoutBinding,
-                actions: .legacy(
-                    layout: layoutBinding,
-                    appState: appState,
-                    worktreeID: worktree.id
+            // Phase 3b: with `enableDaemonManagedPanels` on AND a surface
+            // actually mirrored for this tab, render from the daemon. The
+            // mirror starts empty and fills asynchronously (the
+            // `PanelSurfaceLoadKey` task on the body above), so "flag on,
+            // nothing loaded yet" deliberately falls through to the legacy
+            // path rather than flashing blank.
+            switch appState.workspaceRenderPath(worktreeID: worktree.id, tabID: tab.id) {
+            case .daemonSurface(let surface):
+                PanelSurfaceWorkspaceView(surface: surface, worktree: worktree)
+                    .id(tab.id) // Force new view hierarchy when switching tabs
+            case .legacy:
+                let layoutBinding = Binding<LayoutNode>(
+                    get: { appState.layouts[tab.id] ?? .pane(tab.content) },
+                    set: { appState.layouts[tab.id] = $0 }
                 )
-            )
-            .id(tab.id) // Force new view hierarchy when switching tabs
+
+                SplitLayoutView(
+                    node: layoutBinding.wrappedValue,
+                    worktree: worktree,
+                    tabID: tab.id,
+                    actions: .legacy(
+                        layout: layoutBinding,
+                        appState: appState,
+                        worktreeID: worktree.id
+                    )
+                )
+                .id(tab.id) // Force new view hierarchy when switching tabs
+            }
         } else {
             switch (appState.historyLoadStates[worktreeID] ?? .idle).emptyTabsContent {
             case .history:
@@ -727,7 +753,6 @@ private struct MultiWorktreeCell: View {
                 content: .terminal(terminalID: terminal.id),
                 worktree: worktree,
                 tabID: activeTab?.id,
-                layout: layoutBinding,
                 actions: .legacy(
                     layout: layoutBinding,
                     appState: appState,

--- a/Tests/TBDAppTests/PanelSurfaceMirrorTests.swift
+++ b/Tests/TBDAppTests/PanelSurfaceMirrorTests.swift
@@ -195,6 +195,84 @@ struct PanelSurfaceMirrorTests {
         }
     }
 
+    // MARK: - Revision monotonicity
+
+    @Test("flag ON: a delta carrying an older revision of a tab is dropped")
+    func staleDeltaIsDropped() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 9, label: "current")],
+                activeTabID: tabID)
+
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID,
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 8, label: "stale")])))
+
+            #expect(state.panelSurfaces[worktreeID]?.tabs.first?.label == "current",
+                    "revisions are monotonic per tab; a lower one is a late arrival")
+            #expect(state.panelSurfaces[worktreeID]?.tabs.first?.revision == 9)
+        }
+    }
+
+    @Test("flag ON: removedTabIDs removes a tab whatever revision the mirror holds")
+    func removalIgnoresRevisions() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 40)],
+                activeTabID: tabID)
+
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID, removed: [tabID])))
+
+            #expect(state.panelSurfaces[worktreeID]?.tabs.isEmpty == true,
+                    "the revision guard applies to content, never to removal")
+        }
+    }
+
+    @Test("a panel.get that resolved behind a newer delta cannot revert that tab")
+    func staleGetDoesNotRevertANewerTab() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let racedID = UUID()
+            let untouchedID = UUID()
+            let goneID = UUID()
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [
+                    // A delta committed rev 11 while the get was in flight.
+                    Self.tab(id: racedID, worktreeID: worktreeID, revision: 11, label: "newer"),
+                    Self.tab(id: untouchedID, worktreeID: worktreeID, revision: 2),
+                    // Closed in the daemon; the get is authoritative about it
+                    // being gone even though the mirror still holds it.
+                    Self.tab(id: goneID, worktreeID: worktreeID, revision: 5),
+                ],
+                activeTabID: racedID)
+            state.panelGetFetcher = { _ in
+                PanelGetResult(
+                    tabs: [
+                        Self.tab(id: racedID, worktreeID: worktreeID, revision: 10, label: "older"),
+                        Self.tab(id: untouchedID, worktreeID: worktreeID, revision: 4, label: "fresh"),
+                    ],
+                    activeTabID: untouchedID)
+            }
+
+            await state.loadPanelSurface(worktreeID: worktreeID)
+
+            let tabs = state.panelSurfaces[worktreeID]?.tabs ?? []
+            #expect(tabs.count == 2, "a tab absent from the fetch is removed, not kept")
+            #expect(tabs.first { $0.id == racedID }?.label == "newer",
+                    "the in-flight get is a snapshot from before the delta")
+            #expect(tabs.first { $0.id == untouchedID }?.revision == 4,
+                    "a tab the fetch advances is still adopted")
+            #expect(tabs.allSatisfy { $0.id != goneID })
+            #expect(state.panelSurfaces[worktreeID]?.activeTabID == untouchedID,
+                    "selection follows the fetch, which defines the tab set")
+        }
+    }
+
     // MARK: - Loading
 
     @Test("loadPanelSurface populates the mirror when the flag is on and is inert when off")
@@ -297,6 +375,30 @@ struct PanelSurfaceMirrorTests {
                     "a sibling tab is untouched by an apply")
             #expect(state.panelSurfaces[worktreeID]?.activeTabID == tabID,
                     "an apply does not move the active tab")
+        }
+    }
+
+    @Test("an apply response older than the mirror does not revert it")
+    func staleApplyResponseIsDropped() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 30)],
+                activeTabID: tabID)
+            state.panelApplyTrigger = { _ in
+                // A delta for a later operation landed while this apply was
+                // in flight, so its response is already behind the mirror.
+                PanelApplyResult(
+                    tab: Self.tab(id: tabID, worktreeID: worktreeID, revision: 29, label: "stale"),
+                    replayed: false)
+            }
+
+            await state.applyPanelOperation(
+                worktreeID: worktreeID, tabID: tabID, operation: .close(panelID: UUID()))
+
+            #expect(state.panelSurfaces[worktreeID]?.tabs.first?.revision == 30)
+            #expect(state.panelSurfaces[worktreeID]?.tabs.first?.label == nil)
         }
     }
 

--- a/Tests/TBDAppTests/PanelSurfaceMirrorTests.swift
+++ b/Tests/TBDAppTests/PanelSurfaceMirrorTests.swift
@@ -1,0 +1,371 @@
+import Foundation
+import TBDShared
+import Testing
+
+@testable import TBDApp
+
+/// Phase 3b slice 2 — the app-side mirror of the daemon-owned panel surface,
+/// its delta reconciliation, and the single `panel.apply` chokepoint.
+///
+/// Tier 1: deterministic, in-process only. Every daemon hop goes through the
+/// injected `panelGetFetcher` / `panelApplyTrigger` closures, so no socket is
+/// opened, and every `AppState` gets its own `UserDefaults` suite so the
+/// developer's real `TBDApp.plist` is never touched.
+@Suite("Panel surface mirror")
+@MainActor
+struct PanelSurfaceMirrorTests {
+
+    // MARK: - Fixtures
+
+    /// An `AppState` on a throwaway defaults suite, with the render flag set
+    /// as requested and the daemon reporting the store flag.
+    private static func makeState(
+        flagEnabled: Bool?, panelSurfaceEnabled: Bool = true,
+        _ body: @MainActor (AppState, UserDefaults) async throws -> Void
+    ) async rethrows {
+        let suiteName = "PanelSurfaceMirrorTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        if let flagEnabled {
+            defaults.set(flagEnabled, forKey: AppState.enableDaemonManagedPanelsKey)
+        }
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(
+            controlModeEnabled: false, panelSurfaceEnabled: panelSurfaceEnabled)
+        // Fail loudly if a test reaches a seam it did not stub.
+        state.panelApplyTrigger = { _ in
+            Issue.record("unexpected panel.apply")
+            throw UnstubbedSeam()
+        }
+        state.panelGetFetcher = { _ in
+            Issue.record("unexpected panel.get")
+            throw UnstubbedSeam()
+        }
+        try await body(state, defaults)
+    }
+
+    private struct UnstubbedSeam: Error {}
+    private struct ApplyRejected: Error {}
+
+    private static func tab(
+        id: UUID, worktreeID: UUID, revision: UInt64, label: String? = nil
+    ) -> WorkspaceTabSurface {
+        WorkspaceTabSurface(
+            id: id, worktreeID: worktreeID, label: label,
+            primary: .terminal(terminalID: id), layout: .primary, revision: revision)
+    }
+
+    private static func delta(
+        worktreeID: UUID, tabs: [WorkspaceTabSurface] = [], removed: [UUID] = [],
+        activeTabID: UUID? = nil
+    ) -> PanelSurfaceDelta {
+        PanelSurfaceDelta(
+            worktreeID: worktreeID, tabs: tabs, removedTabIDs: removed,
+            activeTabID: activeTabID, originOperationID: nil)
+    }
+
+    // MARK: - The flag itself
+
+    @Test("the render flag defaults to OFF")
+    func flagDefaultsOff() {
+        let suiteName = "PanelSurfaceMirrorTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(AppState.enableDaemonManagedPanelsDefault == false)
+        #expect(AppState.daemonManagedPanelsEnabled(defaults: defaults) == false,
+                "an untouched defaults domain must read as off")
+    }
+
+    @Test("daemonManagedPanelsActive requires BOTH the render flag and the daemon store flag")
+    func activeRequiresBothFlags() async {
+        await Self.makeState(flagEnabled: true, panelSurfaceEnabled: true) { state, _ in
+            #expect(state.daemonManagedPanelsActive)
+        }
+        // The one the plan calls out: user opted in, but the surface was
+        // never imported, so there is nothing to render.
+        await Self.makeState(flagEnabled: true, panelSurfaceEnabled: false) { state, _ in
+            #expect(state.daemonManagedPanelsActive == false)
+        }
+        await Self.makeState(flagEnabled: false, panelSurfaceEnabled: true) { state, _ in
+            #expect(state.daemonManagedPanelsActive == false)
+        }
+        // Capabilities not yet fetched — same as the store being off.
+        await Self.makeState(flagEnabled: true, panelSurfaceEnabled: true) { state, _ in
+            state.daemonCapabilities = nil
+            #expect(state.daemonManagedPanelsActive == false)
+        }
+    }
+
+    // MARK: - Delta reconciliation
+
+    @Test("flag OFF: a panelSurfaceChanged delta leaves the mirror empty")
+    func flagOffDeltaIsInert() async {
+        await Self.makeState(flagEnabled: false) { state, _ in
+            let worktreeID = UUID()
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID,
+                tabs: [Self.tab(id: UUID(), worktreeID: worktreeID, revision: 3)],
+                activeTabID: UUID())))
+
+            #expect(state.panelSurfaces.isEmpty,
+                    "the daemon broadcasts during the store-only soak; the render flag is off")
+        }
+    }
+
+    @Test("flag ON: a delta upserts tabs, drops removedTabIDs, and sets the active tab")
+    func flagOnDeltaReconciles() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let keptID = UUID()
+            let staleID = UUID()
+            let doomedID = UUID()
+
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID,
+                tabs: [
+                    Self.tab(id: keptID, worktreeID: worktreeID, revision: 1, label: "kept"),
+                    Self.tab(id: staleID, worktreeID: worktreeID, revision: 1, label: "old"),
+                    Self.tab(id: doomedID, worktreeID: worktreeID, revision: 1),
+                ],
+                activeTabID: keptID)))
+
+            #expect(state.panelSurfaces[worktreeID]?.tabs.count == 3)
+            #expect(state.panelSurfaces[worktreeID]?.activeTabID == keptID)
+
+            // Second delta: update one tab in place, remove another, move the
+            // active tab. Untouched tabs survive.
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID,
+                tabs: [Self.tab(id: staleID, worktreeID: worktreeID, revision: 7, label: "fresh")],
+                removed: [doomedID],
+                activeTabID: staleID)))
+
+            let tabs = state.panelSurfaces[worktreeID]?.tabs ?? []
+            #expect(tabs.count == 2)
+            #expect(tabs.contains { $0.id == keptID && $0.label == "kept" },
+                    "an unaffected tab must survive an upsert")
+            #expect(tabs.contains { $0.id == staleID && $0.revision == 7 && $0.label == "fresh" },
+                    "the affected tab is replaced wholesale by the delta's snapshot")
+            #expect(tabs.allSatisfy { $0.id != doomedID }, "removedTabIDs must drop the tab")
+            #expect(state.panelSurfaces[worktreeID]?.activeTabID == staleID)
+        }
+    }
+
+    @Test("flag ON: a nil activeTabID means unchanged, not cleared")
+    func nilActiveTabIDPreservesSelection() async {
+        // The daemon sends activeTabID: nil on EVERY ordinary surface
+        // mutation (PanelCoordinator.apply) and fills it only for selectTab
+        // and the legacy import. Treating nil as "clear" would blank the
+        // selection on every open/close/resize.
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID,
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 1)],
+                activeTabID: tabID)))
+
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID,
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 2)],
+                activeTabID: nil)))
+
+            #expect(state.panelSurfaces[worktreeID]?.activeTabID == tabID)
+            #expect(state.panelSurfaces[worktreeID]?.tabs.first?.revision == 2)
+        }
+    }
+
+    @Test("flag ON: removing the active tab clears the selection")
+    func removingActiveTabClearsSelection() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            state.handleDelta(.panelSurfaceChanged(Self.delta(
+                worktreeID: worktreeID,
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 1)],
+                activeTabID: tabID)))
+
+            state.handleDelta(.panelSurfaceChanged(
+                Self.delta(worktreeID: worktreeID, removed: [tabID])))
+
+            #expect(state.panelSurfaces[worktreeID]?.tabs.isEmpty == true)
+            #expect(state.panelSurfaces[worktreeID]?.activeTabID == nil,
+                    "the mirror must not point at a tab it no longer holds")
+        }
+    }
+
+    // MARK: - Loading
+
+    @Test("loadPanelSurface populates the mirror when the flag is on and is inert when off")
+    func loadRespectsTheFlag() async {
+        let worktreeID = UUID()
+        let tabID = UUID()
+        let fetched = PanelGetResult(
+            tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 4)], activeTabID: tabID)
+
+        await Self.makeState(flagEnabled: true) { state, _ in
+            var gets: [UUID] = []
+            state.panelGetFetcher = { id in
+                gets.append(id)
+                return fetched
+            }
+            await state.loadPanelSurface(worktreeID: worktreeID)
+
+            #expect(gets == [worktreeID])
+            #expect(state.panelSurfaces[worktreeID] == fetched)
+        }
+
+        await Self.makeState(flagEnabled: false) { state, _ in
+            var gets: [UUID] = []
+            state.panelGetFetcher = { id in
+                gets.append(id)
+                return fetched
+            }
+            await state.loadPanelSurface(worktreeID: worktreeID)
+
+            #expect(gets.isEmpty, "flag off must not even fetch")
+            #expect(state.panelSurfaces.isEmpty)
+        }
+    }
+
+    @Test("a failing panel.get leaves the previous mirror value in place")
+    func loadFailureKeepsLastKnownMirror() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let known = PanelGetResult(
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 9)],
+                activeTabID: tabID)
+            state.panelSurfaces[worktreeID] = known
+            state.panelGetFetcher = { _ in throw ApplyRejected() }
+
+            await state.loadPanelSurface(worktreeID: worktreeID)
+
+            #expect(state.panelSurfaces[worktreeID] == known)
+        }
+    }
+
+    // MARK: - The apply chokepoint
+
+    @Test("applyPanelOperation sends the mirror's current revision and upserts the result")
+    func applySendsBaseRevisionAndUpserts() async throws {
+        try await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let otherTabID = UUID()
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [
+                    Self.tab(id: tabID, worktreeID: worktreeID, revision: 12),
+                    Self.tab(id: otherTabID, worktreeID: worktreeID, revision: 3, label: "other"),
+                ],
+                activeTabID: tabID)
+
+            let panelID = UUID()
+            let committed = WorkspaceTabSurface(
+                id: tabID, worktreeID: worktreeID, label: "after",
+                primary: .terminal(terminalID: tabID),
+                layout: .split(SplitNode(
+                    id: UUID(), direction: .horizontal,
+                    children: [.primary, .panel(PanelSlot(id: panelID, content: .web(URL(string: "https://example.com")!)))],
+                    ratios: [0.5, 0.5])),
+                revision: 13)
+            var envelopes: [PanelOperationEnvelope] = []
+            state.panelApplyTrigger = { envelope in
+                envelopes.append(envelope)
+                return PanelApplyResult(tab: committed, replayed: false)
+            }
+
+            await state.applyPanelOperation(
+                worktreeID: worktreeID, tabID: tabID,
+                operation: .open(content: .web(URL(string: "https://example.com")!),
+                                 placement: .automatic))
+
+            #expect(envelopes.count == 1)
+            let envelope = try #require(envelopes.first)
+            #expect(envelope.baseRevision == 12, "baseRevision is the mirror's CURRENT revision")
+            #expect(envelope.worktreeID == worktreeID)
+            #expect(envelope.tabID == tabID)
+            #expect(envelope.origin == .appUser)
+            #expect(envelope.operation == .open(
+                content: .web(URL(string: "https://example.com")!), placement: .automatic))
+
+            let tabs = state.panelSurfaces[worktreeID]?.tabs ?? []
+            #expect(tabs.first { $0.id == tabID } == committed,
+                    "the mirror takes the daemon's authoritative tab from the response")
+            #expect(tabs.first { $0.id == otherTabID }?.label == "other",
+                    "a sibling tab is untouched by an apply")
+            #expect(state.panelSurfaces[worktreeID]?.activeTabID == tabID,
+                    "an apply does not move the active tab")
+        }
+    }
+
+    @Test("applyPanelOperation sends a nil baseRevision when the mirror has no such tab")
+    func applyWithoutMirrorEntrySendsNilBaseRevision() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let committed = Self.tab(id: tabID, worktreeID: worktreeID, revision: 1)
+            var envelopes: [PanelOperationEnvelope] = []
+            state.panelApplyTrigger = { envelope in
+                envelopes.append(envelope)
+                return PanelApplyResult(tab: committed, replayed: false)
+            }
+
+            await state.applyPanelOperation(
+                worktreeID: worktreeID, tabID: tabID, operation: .close(panelID: UUID()))
+
+            #expect(envelopes.first?.baseRevision == nil)
+            #expect(state.panelSurfaces[worktreeID]?.tabs == [committed],
+                    "the response seeds the mirror even when it had no entry")
+        }
+    }
+
+    @Test("a rejected apply refetches the surface so the UI snaps to daemon truth")
+    func applyFailureRefetches() async {
+        await Self.makeState(flagEnabled: true) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            // The mirror is stale: an agent already moved the tab to rev 20.
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 5)],
+                activeTabID: tabID)
+            let truth = PanelGetResult(
+                tabs: [Self.tab(id: tabID, worktreeID: worktreeID, revision: 20, label: "truth")],
+                activeTabID: tabID)
+
+            state.panelApplyTrigger = { _ in throw ApplyRejected() }
+            var gets: [UUID] = []
+            state.panelGetFetcher = { id in
+                gets.append(id)
+                return truth
+            }
+
+            await state.applyPanelOperation(
+                worktreeID: worktreeID, tabID: tabID, operation: .close(panelID: UUID()))
+
+            #expect(gets == [worktreeID], "a rejected apply must refetch exactly once")
+            #expect(state.panelSurfaces[worktreeID] == truth)
+        }
+    }
+
+    @Test("flag OFF: applyPanelOperation fires no RPC and mutates nothing")
+    func applyIsInertWithFlagOff() async {
+        await Self.makeState(flagEnabled: false) { state, _ in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            var applyCalls = 0
+            state.panelApplyTrigger = { _ in
+                applyCalls += 1
+                return PanelApplyResult(
+                    tab: Self.tab(id: tabID, worktreeID: worktreeID, revision: 1), replayed: false)
+            }
+
+            await state.applyPanelOperation(
+                worktreeID: worktreeID, tabID: tabID, operation: .close(panelID: UUID()))
+
+            #expect(applyCalls == 0)
+            #expect(state.panelSurfaces.isEmpty)
+        }
+    }
+}

--- a/Tests/TBDAppTests/PanelSurfaceRenderBranchTests.swift
+++ b/Tests/TBDAppTests/PanelSurfaceRenderBranchTests.swift
@@ -341,6 +341,69 @@ struct PanelSurfaceRenderBranchTests {
         }
     }
 
+    @Test("a transcript link to a file becomes an .automatic file open")
+    func openTranscriptLinkFileMapsToAutomaticOpen() async throws {
+        try await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let terminalID = UUID()
+            let panelID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
+                panelID: panelID, splitID: UUID(),
+                panelContent: .transcript(terminalID: terminalID))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
+
+            let envelope = try Self.single(await Self.collect(state, committing: surface) {
+                actions.openTranscriptLink(terminalID, .file("/tmp/linked.swift"))
+            })
+
+            // Same destination the legacy path reaches by rewriting the tree:
+            // reuse a viewer slot, else split off the primary anchor.
+            #expect(envelope.operation == .open(
+                content: .file(FileReference(path: "/tmp/linked.swift")), placement: .automatic))
+        }
+    }
+
+    // The `.web` arm of `openTranscriptLink` is covered as a VALUE in
+    // `TranscriptLinkPaneRoutingTests` (`daemonManaged(.web:) ==
+    // .openInBrowser`), not by firing the closure: firing it calls
+    // `NSWorkspace.shared.open`, and a unit test must not launch a browser.
+    // Since both action sets switch exhaustively over that decision, proving
+    // a URL decides `.openInBrowser` proves it never becomes a panel
+    // operation or a layout rewrite.
+
+    @Test("the legacy path routes a transcript file link into its own tree")
+    func legacyOpenTranscriptLinkRoutesIntoTheTree() async {
+        await Self.makeState(flagEnabled: false) { state in
+            let terminalID = UUID()
+            let transcriptID = UUID()
+            var tree = LayoutNode.split(
+                id: UUID(), direction: .horizontal,
+                children: [
+                    .pane(.terminal(terminalID: terminalID)),
+                    .pane(.liveTranscript(id: transcriptID, terminalID: terminalID)),
+                ],
+                ratios: [0.5, 0.5])
+            let binding = Binding(get: { tree }, set: { tree = $0 })
+            let actions = PaneActions.legacy(
+                layout: binding, appState: state, worktreeID: UUID())
+
+            actions.openTranscriptLink(terminalID, .file("/tmp/linked.swift"))
+
+            // Byte-for-byte what the inline body in `PanePlaceholder` did
+            // before the seam: the transcript slot is reused for the file,
+            // keeping its pane identity, and the swap lands in that slot's
+            // history via `recordPaneReplacement`.
+            let incoming = PaneContent.codeViewer(id: transcriptID, path: "/tmp/linked.swift")
+            #expect(tree.firstPaneID(where: { $0 == incoming }) == transcriptID)
+            #expect(state.paneHistories[transcriptID]?.entries.contains(incoming) == true,
+                    "the replacement must be recorded in the reused slot's history")
+        }
+    }
+
     @Test("toggleTranscript opens when closed and closes the open transcript panel")
     func toggleTranscriptBothDirections() async throws {
         let worktreeID = UUID()

--- a/Tests/TBDAppTests/PanelSurfaceRenderBranchTests.swift
+++ b/Tests/TBDAppTests/PanelSurfaceRenderBranchTests.swift
@@ -1,0 +1,516 @@
+import Foundation
+import SwiftUI
+import TBDShared
+import Testing
+
+@testable import TBDApp
+
+/// Phase 3b slice 3 — the workspace render-path branch, the leaf content
+/// mapping the shared leaf view is fed through, and the daemon-backed
+/// `PaneActions` set.
+///
+/// Tier 1: deterministic, in-process only. Every daemon hop goes through the
+/// injected `panelApplyTrigger` / `panelGetFetcher` closures, so no socket is
+/// opened, and every `AppState` gets its own `UserDefaults` suite so the
+/// developer's real `TBDApp.plist` is never touched.
+@Suite("Panel surface render branch")
+@MainActor
+struct PanelSurfaceRenderBranchTests {
+
+    // MARK: - Fixtures
+
+    private static let fileURL = URL(string: "https://example.com/panels")!
+
+    private struct UnstubbedSeam: Error {}
+
+    private static func makeState(
+        flagEnabled: Bool, panelSurfaceEnabled: Bool = true,
+        _ body: @MainActor (AppState) async throws -> Void
+    ) async rethrows {
+        let suiteName = "PanelSurfaceRenderBranchTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(flagEnabled, forKey: AppState.enableDaemonManagedPanelsKey)
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(
+            controlModeEnabled: false, panelSurfaceEnabled: panelSurfaceEnabled)
+        // Fail loudly if a test reaches a seam it did not stub.
+        state.panelApplyTrigger = { _ in
+            Issue.record("unexpected panel.apply")
+            throw UnstubbedSeam()
+        }
+        state.panelGetFetcher = { _ in
+            Issue.record("unexpected panel.get")
+            throw UnstubbedSeam()
+        }
+        try await body(state)
+    }
+
+    /// A one-viewer-panel tab: primary terminal on the left, `panelID` on the
+    /// right, joined by `splitID`.
+    private static func surface(
+        tabID: UUID, worktreeID: UUID, terminalID: UUID,
+        panelID: UUID, splitID: UUID, panelContent: PanelContent,
+        revision: UInt64 = 1
+    ) -> WorkspaceTabSurface {
+        WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID,
+            primary: .terminal(terminalID: terminalID),
+            layout: .split(SplitNode(
+                id: splitID, direction: .horizontal,
+                children: [.primary, .panel(PanelSlot(id: panelID, content: panelContent))],
+                ratios: [0.65, 0.35])),
+            revision: revision)
+    }
+
+    /// Fire `gesture` and return the envelope the chokepoint handed to
+    /// `panel.apply`. Deterministic — the stub resumes the continuation, so
+    /// nothing here polls or yields on a hope.
+    private static func capture(
+        _ state: AppState, committing tab: WorkspaceTabSurface,
+        _ gesture: @MainActor () -> Void
+    ) async -> PanelOperationEnvelope {
+        await withCheckedContinuation(isolation: MainActor.shared) { continuation in
+            state.panelApplyTrigger = { envelope in
+                continuation.resume(returning: envelope)
+                return PanelApplyResult(tab: tab, replayed: false)
+            }
+            gesture()
+        }
+    }
+
+    // MARK: - Leaf content mapping (spec §Components — content only)
+
+    @Test("every PanelContent case maps to a leaf PaneContent carrying the panel's identity")
+    func panelContentMappingIsTotal() {
+        let panelID = UUID()
+        let terminalID = UUID()
+        let noteID = UUID()
+
+        #expect(PanelSurfaceLeaf.paneContent(
+            for: .file(FileReference(path: "/tmp/a.swift")), panelID: panelID)
+            == .codeViewer(id: panelID, path: "/tmp/a.swift"))
+        #expect(PanelSurfaceLeaf.paneContent(for: .web(Self.fileURL), panelID: panelID)
+            == .webview(id: panelID, url: Self.fileURL))
+        #expect(PanelSurfaceLeaf.paneContent(for: .transcript(terminalID: terminalID), panelID: panelID)
+            == .liveTranscript(id: panelID, terminalID: terminalID))
+        // A note's legacy pane identity IS its note ID, not the panel ID —
+        // which is exactly why the daemon action set captures its own
+        // PanelID rather than reading it back off the leaf content.
+        #expect(PanelSurfaceLeaf.paneContent(for: .note(noteID: noteID), panelID: panelID)
+            == .note(noteID: noteID))
+    }
+
+    @Test("every PrimaryContent case maps to a leaf PaneContent, terminal included")
+    func primaryContentMappingIsTotal() {
+        let primaryID = UUID()
+        let terminalID = UUID()
+        let noteID = UUID()
+
+        #expect(PanelSurfaceLeaf.paneContent(for: .terminal(terminalID: terminalID), primaryID: primaryID)
+            == .terminal(terminalID: terminalID))
+        #expect(PanelSurfaceLeaf.paneContent(for: .note(noteID: noteID), primaryID: primaryID)
+            == .note(noteID: noteID))
+        #expect(PanelSurfaceLeaf.paneContent(
+            for: .file(FileReference(path: "/tmp/b.md")), primaryID: primaryID)
+            == .codeViewer(id: primaryID, path: "/tmp/b.md"))
+        #expect(PanelSurfaceLeaf.paneContent(for: .web(Self.fileURL), primaryID: primaryID)
+            == .webview(id: primaryID, url: Self.fileURL))
+        #expect(PanelSurfaceLeaf.paneContent(for: .transcript(terminalID: terminalID), primaryID: primaryID)
+            == .liveTranscript(id: primaryID, terminalID: terminalID))
+    }
+
+    @Test("leaf content survives the round trip back to PanelContent")
+    func panelContentRoundTrips() {
+        let panelID = UUID()
+        let cases: [PanelContent] = [
+            .file(FileReference(path: "/tmp/c.swift")),
+            .web(Self.fileURL),
+            .transcript(terminalID: UUID()),
+            .note(noteID: UUID()),
+        ]
+        for content in cases {
+            let leaf = PanelSurfaceLeaf.paneContent(for: content, panelID: panelID)
+            #expect(PanelSurfaceLeaf.panelContent(for: leaf) == content,
+                    "content identity must survive the leaf mapping for \(content)")
+        }
+    }
+
+    @Test("a terminal has no viewer-panel form")
+    func terminalHasNoPanelForm() {
+        // Spec C §5.5 — the invariant is enforced at the type level, so the
+        // reverse mapping is partial by construction, not by oversight.
+        #expect(PanelSurfaceLeaf.panelContent(for: .terminal(terminalID: UUID())) == nil)
+    }
+
+    // MARK: - Render-path branch
+
+    @Test("flag OFF selects the legacy renderer even with a surface mirrored")
+    func flagOffSelectsLegacy() async {
+        await Self.makeState(flagEnabled: false) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            // The mirror can be non-empty with the flag off only if something
+            // seeded it directly; assert the branch ignores it regardless.
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [Self.surface(
+                    tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                    panelID: UUID(), splitID: UUID(), panelContent: .web(Self.fileURL))],
+                activeTabID: tabID)
+
+            #expect(state.workspaceRenderPath(worktreeID: worktreeID, tabID: tabID) == .legacy)
+        }
+    }
+
+    @Test("flag ON with an EMPTY mirror still selects legacy — never a blank workspace")
+    func flagOnWithoutSurfaceSelectsLegacy() async {
+        await Self.makeState(flagEnabled: true) { state in
+            #expect(state.daemonManagedPanelsActive, "precondition: the switch is on")
+            #expect(state.panelSurfaces.isEmpty, "precondition: the mirror starts empty")
+
+            #expect(state.workspaceRenderPath(worktreeID: UUID(), tabID: UUID()) == .legacy)
+        }
+    }
+
+    @Test("flag ON with a mirrored surface selects the daemon renderer")
+    func flagOnWithSurfaceSelectsDaemon() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                panelID: UUID(), splitID: UUID(), panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+
+            #expect(state.workspaceRenderPath(worktreeID: worktreeID, tabID: tabID)
+                == .daemonSurface(surface))
+            // A sibling tab that the mirror does not hold still falls back.
+            #expect(state.workspaceRenderPath(worktreeID: worktreeID, tabID: UUID()) == .legacy)
+        }
+    }
+
+    @Test("the daemon store flag OFF selects legacy even with a mirrored surface")
+    func storeFlagOffSelectsLegacy() async {
+        await Self.makeState(flagEnabled: true, panelSurfaceEnabled: false) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            state.panelSurfaces[worktreeID] = PanelGetResult(
+                tabs: [Self.surface(
+                    tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                    panelID: UUID(), splitID: UUID(), panelContent: .web(Self.fileURL))],
+                activeTabID: tabID)
+
+            #expect(state.workspaceRenderPath(worktreeID: worktreeID, tabID: tabID) == .legacy)
+        }
+    }
+
+    // MARK: - Daemon-backed PaneActions → PanelOperation
+
+    @Test("openBeside becomes a .beside open anchored on the leaf's own panel")
+    func openBesideMapsToBeside() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let panelID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                panelID: panelID, splitID: UUID(), panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
+
+            let envelope = await Self.capture(state, committing: surface) {
+                actions.openBeside(panelID, .horizontal, .codeViewer(id: UUID(), path: "/tmp/x.swift"))
+            }
+
+            #expect(envelope.origin == .appUser)
+            #expect(envelope.baseRevision == 1)
+            #expect(envelope.operation == .open(
+                content: .file(FileReference(path: "/tmp/x.swift")),
+                placement: .beside(target: .panel(panelID), edge: .right, share: nil)))
+        }
+    }
+
+    @Test("a vertical openBeside off the primary anchor lands below the primary")
+    func openBesideVerticalFromPrimary() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let terminalID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
+                panelID: UUID(), splitID: UUID(), panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
+
+            let envelope = await Self.capture(state, committing: surface) {
+                actions.openBeside(terminalID, .vertical, .webview(id: UUID(), url: Self.fileURL))
+            }
+
+            #expect(envelope.operation == .open(
+                content: .web(Self.fileURL),
+                placement: .beside(target: .primary, edge: .below, share: nil)))
+        }
+    }
+
+    @Test("openBeside with terminal content is dropped, not sent")
+    func openBesideDropsTerminalContent() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let panelID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                panelID: panelID, splitID: UUID(), panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
+
+            // Absence is proved by ordering, not by waiting: the dropped
+            // gesture fires first and the next envelope to arrive must be the
+            // known-good one.
+            let envelope = await Self.capture(state, committing: surface) {
+                actions.openBeside(panelID, .horizontal, .terminal(terminalID: UUID()))
+                actions.close(.webview(id: panelID, url: Self.fileURL))
+            }
+
+            #expect(envelope.operation == .close(panelID: panelID))
+        }
+    }
+
+    @Test("routeFile becomes an .automatic file open — the reducer's reuse-then-split contract")
+    func routeFileMapsToAutomaticOpen() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let terminalID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
+                panelID: UUID(), splitID: UUID(), panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
+
+            let envelope = await Self.capture(state, committing: surface) {
+                actions.routeFile(terminalID, "/tmp/clicked.swift")
+            }
+
+            #expect(envelope.operation == .open(
+                content: .file(FileReference(path: "/tmp/clicked.swift")), placement: .automatic))
+        }
+    }
+
+    @Test("toggleTranscript opens when closed and closes the open transcript panel")
+    func toggleTranscriptBothDirections() async {
+        let worktreeID = UUID()
+        let tabID = UUID()
+        let terminalID = UUID()
+        let panelID = UUID()
+
+        await Self.makeState(flagEnabled: true) { state in
+            let closed = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
+                panelID: panelID, splitID: UUID(), panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [closed], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
+            #expect(actions.isTranscriptOpen(terminalID) == false)
+
+            let envelope = await Self.capture(state, committing: closed) {
+                actions.toggleTranscript(terminalID, terminalID)
+            }
+            #expect(envelope.operation == .open(
+                content: .transcript(terminalID: terminalID), placement: .automatic))
+        }
+
+        await Self.makeState(flagEnabled: true) { state in
+            let open = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
+                panelID: panelID, splitID: UUID(),
+                panelContent: .transcript(terminalID: terminalID))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [open], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
+            #expect(actions.isTranscriptOpen(terminalID))
+            #expect(actions.isTranscriptOpen(UUID()) == false,
+                    "another terminal's transcript must not read as open")
+
+            let envelope = await Self.capture(state, committing: open) {
+                actions.toggleTranscript(terminalID, terminalID)
+            }
+            #expect(envelope.operation == .close(panelID: panelID))
+        }
+    }
+
+    @Test("each history step maps to its PanelHistoryAction")
+    func historyStepsMap() async {
+        let expected: [(PaneActions.HistoryStep, PanelHistoryAction)] = [
+            (.back, .back), (.forward, .forward), (.to(index: 3), .jump(index: 3)),
+        ]
+        for (step, action) in expected {
+            await Self.makeState(flagEnabled: true) { state in
+                let worktreeID = UUID()
+                let tabID = UUID()
+                let panelID = UUID()
+                let surface = Self.surface(
+                    tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                    panelID: panelID, splitID: UUID(), panelContent: .web(Self.fileURL))
+                state.panelSurfaces[worktreeID] = PanelGetResult(
+                    tabs: [surface], activeTabID: tabID)
+                let actions = PaneActions.daemonManaged(
+                    appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
+
+                let envelope = await Self.capture(state, committing: surface) {
+                    actions.historyStep(panelID, step)
+                }
+                #expect(envelope.operation == .history(panelID: panelID, action: action))
+            }
+        }
+    }
+
+    @Test("resize maps the divider's CGFloat ratios onto the split")
+    func resizeMaps() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let splitID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                panelID: UUID(), splitID: splitID, panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
+
+            let envelope = await Self.capture(state, committing: surface) {
+                actions.resize(splitID, [0.4, 0.6])
+            }
+
+            #expect(envelope.operation == .resize(splitID: splitID, ratios: [0.4, 0.6]))
+        }
+    }
+
+    @Test("the primary anchor cannot be closed or history-navigated")
+    func primaryAnchorGesturesAreNoOps() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let terminalID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
+                panelID: UUID(), splitID: UUID(), panelContent: .web(Self.fileURL))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
+
+            // `.primary` is unremovable and history-less by type in the shared
+            // reducer; both gestures must be dropped app-side rather than sent
+            // and rejected. Absence proved by ordering (see above).
+            let envelope = await Self.capture(state, committing: surface) {
+                actions.close(.terminal(terminalID: terminalID))
+                actions.historyStep(terminalID, .back)
+                actions.routeFile(terminalID, "/tmp/marker.swift")
+            }
+
+            #expect(envelope.operation == .open(
+                content: .file(FileReference(path: "/tmp/marker.swift")), placement: .automatic))
+        }
+    }
+
+    // MARK: - Close is not delete
+
+    @Test("closing a note panel removes the panel only — the note survives")
+    func closingANoteDoesNotDeleteIt() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let panelID = UUID()
+            let noteID = UUID()
+            let surface = Self.surface(
+                tabID: tabID, worktreeID: worktreeID, terminalID: UUID(),
+                panelID: panelID, splitID: UUID(), panelContent: .note(noteID: noteID))
+            state.panelSurfaces[worktreeID] = PanelGetResult(tabs: [surface], activeTabID: tabID)
+            state.notes[worktreeID] = [
+                Note(id: noteID, worktreeID: worktreeID, title: "keep me", content: "body",
+                     createdAt: Date(), updatedAt: Date()),
+            ]
+            // Legacy state that the daemon path must leave completely alone.
+            let legacyTabID = UUID()
+            state.layouts[legacyTabID] = .pane(.note(noteID: noteID))
+            state.paneHistories[noteID] = PaneHistory.seeded(with: .note(noteID: noteID))
+
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
+            let envelope = await Self.capture(state, committing: surface) {
+                actions.close(.note(noteID: noteID))
+            }
+
+            // The panel goes; nothing else does. Close ≠ delete is the
+            // intended new semantics (spec §Non-goals) — the delete
+            // affordance is a separate follow-up, so a note closed here is
+            // deliberately left with no in-app removal path.
+            #expect(envelope.operation == .close(panelID: panelID),
+                    "the note's PanelID, not its note ID, identifies the panel")
+            #expect(state.notes[worktreeID]?.contains { $0.id == noteID } == true)
+            #expect(state.layouts[legacyTabID] == .pane(.note(noteID: noteID)),
+                    "the daemon path must not touch the legacy layout store")
+            #expect(state.paneHistories[noteID] != nil,
+                    "the daemon path must not touch legacy pane histories")
+        }
+    }
+
+    // MARK: - Queries
+
+    @Test("the daemon path reports an honest single-entry history")
+    func historyQueryIsSeeded() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let panelID = UUID()
+            let content = PaneContent.codeViewer(id: panelID, path: "/tmp/y.swift")
+            // A stale legacy entry under the same key must NOT leak through:
+            // the mirror carries no histories, so anything the legacy store
+            // happens to hold is unrelated to the daemon-owned panel.
+            state.paneHistories[panelID] = PaneHistory.seeded(with: .note(noteID: UUID()))
+
+            let actions = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
+            let history = actions.history(panelID, content)
+
+            #expect(history.entries == [content])
+            #expect(history.canGoBack == false)
+            #expect(history.canGoForward == false)
+        }
+    }
+
+    @Test("the legacy action set still answers both queries from the tree")
+    func legacyQueriesUnchanged() async {
+        await Self.makeState(flagEnabled: false) { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            let transcriptID = UUID()
+            let paneID = UUID()
+            var tree = LayoutNode.split(
+                id: UUID(), direction: .horizontal,
+                children: [
+                    .pane(.terminal(terminalID: terminalID)),
+                    .pane(.liveTranscript(id: transcriptID, terminalID: terminalID)),
+                ],
+                ratios: [0.5, 0.5])
+            let binding = Binding(get: { tree }, set: { tree = $0 })
+            let recorded = PaneHistory.seeded(with: .note(noteID: UUID()))
+            state.paneHistories[paneID] = recorded
+
+            let actions = PaneActions.legacy(
+                layout: binding, appState: state, worktreeID: worktreeID)
+
+            #expect(actions.isTranscriptOpen(terminalID))
+            #expect(actions.isTranscriptOpen(UUID()) == false)
+            #expect(actions.history(paneID, .terminal(terminalID: terminalID)) == recorded)
+            let unknown = UUID()
+            #expect(actions.history(unknown, .terminal(terminalID: terminalID))
+                == PaneHistory.seeded(with: .terminal(terminalID: terminalID)),
+                "a pane with no recorded history falls back to its current content")
+        }
+    }
+}

--- a/Tests/TBDAppTests/PanelSurfaceRenderBranchTests.swift
+++ b/Tests/TBDAppTests/PanelSurfaceRenderBranchTests.swift
@@ -63,20 +63,58 @@ struct PanelSurfaceRenderBranchTests {
             revision: revision)
     }
 
-    /// Fire `gesture` and return the envelope the chokepoint handed to
-    /// `panel.apply`. Deterministic — the stub resumes the continuation, so
-    /// nothing here polls or yields on a hope.
-    private static func capture(
+    /// Every envelope the chokepoint handed to `panel.apply` during a gesture,
+    /// in arrival order.
+    @MainActor
+    private final class EnvelopeCollector {
+        private(set) var envelopes: [PanelOperationEnvelope] = []
+        func record(_ envelope: PanelOperationEnvelope) { envelopes.append(envelope) }
+    }
+
+    /// Fire `gesture` and return every envelope it produced.
+    ///
+    /// Collecting, rather than resuming a `CheckedContinuation` from the stub:
+    /// several tests here assert that a gesture produces *no* envelope, and a
+    /// regression that made one fire would resume the continuation twice —
+    /// `SWIFT TASK CONTINUATION MISUSE`, which kills the test process instead
+    /// of failing the test. As an array the same regression is one extra
+    /// element and a readable diff.
+    private static func collect(
         _ state: AppState, committing tab: WorkspaceTabSurface,
         _ gesture: @MainActor () -> Void
-    ) async -> PanelOperationEnvelope {
-        await withCheckedContinuation(isolation: MainActor.shared) { continuation in
-            state.panelApplyTrigger = { envelope in
-                continuation.resume(returning: envelope)
-                return PanelApplyResult(tab: tab, replayed: false)
-            }
-            gesture()
+    ) async -> [PanelOperationEnvelope] {
+        let collector = EnvelopeCollector()
+        state.panelApplyTrigger = { envelope in
+            collector.record(envelope)
+            return PanelApplyResult(tab: tab, replayed: false)
         }
+        gesture()
+        await drainMainActor()
+        return collector.envelopes
+    }
+
+    /// Let the `Task {}` bodies the action set spawns run to completion.
+    ///
+    /// The gestures are synchronous closures that enqueue a MainActor task
+    /// each, so handing the main actor back repeatedly is all the
+    /// synchronization needed. No clock and no sleep is involved, and —
+    /// unlike an "absence proved by ordering" assertion — nothing here
+    /// depends on two sequentially created tasks running in creation order.
+    private static func drainMainActor() async {
+        for _ in 0..<64 { await Task.yield() }
+    }
+
+    /// The one envelope a gesture was supposed to produce. Fails cleanly,
+    /// naming everything that actually arrived, rather than indexing off the
+    /// end of an empty array.
+    private static func single(
+        _ envelopes: [PanelOperationEnvelope],
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> PanelOperationEnvelope {
+        try #require(
+            envelopes.count == 1 ? envelopes.first : nil,
+            "expected exactly one envelope, observed \(envelopes.map(\.operation))",
+            sourceLocation: sourceLocation)
     }
 
     // MARK: - Leaf content mapping (spec §Components — content only)
@@ -207,8 +245,8 @@ struct PanelSurfaceRenderBranchTests {
     // MARK: - Daemon-backed PaneActions → PanelOperation
 
     @Test("openBeside becomes a .beside open anchored on the leaf's own panel")
-    func openBesideMapsToBeside() async {
-        await Self.makeState(flagEnabled: true) { state in
+    func openBesideMapsToBeside() async throws {
+        try await Self.makeState(flagEnabled: true) { state in
             let worktreeID = UUID()
             let tabID = UUID()
             let panelID = UUID()
@@ -219,9 +257,9 @@ struct PanelSurfaceRenderBranchTests {
             let actions = PaneActions.daemonManaged(
                 appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
 
-            let envelope = await Self.capture(state, committing: surface) {
+            let envelope = try Self.single(await Self.collect(state, committing: surface) {
                 actions.openBeside(panelID, .horizontal, .codeViewer(id: UUID(), path: "/tmp/x.swift"))
-            }
+            })
 
             #expect(envelope.origin == .appUser)
             #expect(envelope.baseRevision == 1)
@@ -232,8 +270,8 @@ struct PanelSurfaceRenderBranchTests {
     }
 
     @Test("a vertical openBeside off the primary anchor lands below the primary")
-    func openBesideVerticalFromPrimary() async {
-        await Self.makeState(flagEnabled: true) { state in
+    func openBesideVerticalFromPrimary() async throws {
+        try await Self.makeState(flagEnabled: true) { state in
             let worktreeID = UUID()
             let tabID = UUID()
             let terminalID = UUID()
@@ -244,9 +282,9 @@ struct PanelSurfaceRenderBranchTests {
             let actions = PaneActions.daemonManaged(
                 appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
 
-            let envelope = await Self.capture(state, committing: surface) {
+            let envelope = try Self.single(await Self.collect(state, committing: surface) {
                 actions.openBeside(terminalID, .vertical, .webview(id: UUID(), url: Self.fileURL))
-            }
+            })
 
             #expect(envelope.operation == .open(
                 content: .web(Self.fileURL),
@@ -267,21 +305,23 @@ struct PanelSurfaceRenderBranchTests {
             let actions = PaneActions.daemonManaged(
                 appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
 
-            // Absence is proved by ordering, not by waiting: the dropped
-            // gesture fires first and the next envelope to arrive must be the
-            // known-good one.
-            let envelope = await Self.capture(state, committing: surface) {
+            // The dropped gesture contributes nothing to the collected
+            // sequence. The known-good close alongside it is a positive
+            // control: it proves the drain is long enough to have seen an
+            // envelope, so the empty half is absence and not impatience.
+            let envelopes = await Self.collect(state, committing: surface) {
                 actions.openBeside(panelID, .horizontal, .terminal(terminalID: UUID()))
                 actions.close(.webview(id: panelID, url: Self.fileURL))
             }
 
-            #expect(envelope.operation == .close(panelID: panelID))
+            #expect(envelopes.map(\.operation) == [.close(panelID: panelID)],
+                    "terminal content has no viewer-panel form and must be dropped app-side")
         }
     }
 
     @Test("routeFile becomes an .automatic file open — the reducer's reuse-then-split contract")
-    func routeFileMapsToAutomaticOpen() async {
-        await Self.makeState(flagEnabled: true) { state in
+    func routeFileMapsToAutomaticOpen() async throws {
+        try await Self.makeState(flagEnabled: true) { state in
             let worktreeID = UUID()
             let tabID = UUID()
             let terminalID = UUID()
@@ -292,9 +332,9 @@ struct PanelSurfaceRenderBranchTests {
             let actions = PaneActions.daemonManaged(
                 appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
 
-            let envelope = await Self.capture(state, committing: surface) {
+            let envelope = try Self.single(await Self.collect(state, committing: surface) {
                 actions.routeFile(terminalID, "/tmp/clicked.swift")
-            }
+            })
 
             #expect(envelope.operation == .open(
                 content: .file(FileReference(path: "/tmp/clicked.swift")), placement: .automatic))
@@ -302,13 +342,13 @@ struct PanelSurfaceRenderBranchTests {
     }
 
     @Test("toggleTranscript opens when closed and closes the open transcript panel")
-    func toggleTranscriptBothDirections() async {
+    func toggleTranscriptBothDirections() async throws {
         let worktreeID = UUID()
         let tabID = UUID()
         let terminalID = UUID()
         let panelID = UUID()
 
-        await Self.makeState(flagEnabled: true) { state in
+        try await Self.makeState(flagEnabled: true) { state in
             let closed = Self.surface(
                 tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
                 panelID: panelID, splitID: UUID(), panelContent: .web(Self.fileURL))
@@ -317,14 +357,14 @@ struct PanelSurfaceRenderBranchTests {
                 appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
             #expect(actions.isTranscriptOpen(terminalID) == false)
 
-            let envelope = await Self.capture(state, committing: closed) {
+            let envelope = try Self.single(await Self.collect(state, committing: closed) {
                 actions.toggleTranscript(terminalID, terminalID)
-            }
+            })
             #expect(envelope.operation == .open(
                 content: .transcript(terminalID: terminalID), placement: .automatic))
         }
 
-        await Self.makeState(flagEnabled: true) { state in
+        try await Self.makeState(flagEnabled: true) { state in
             let open = Self.surface(
                 tabID: tabID, worktreeID: worktreeID, terminalID: terminalID,
                 panelID: panelID, splitID: UUID(),
@@ -336,20 +376,20 @@ struct PanelSurfaceRenderBranchTests {
             #expect(actions.isTranscriptOpen(UUID()) == false,
                     "another terminal's transcript must not read as open")
 
-            let envelope = await Self.capture(state, committing: open) {
+            let envelope = try Self.single(await Self.collect(state, committing: open) {
                 actions.toggleTranscript(terminalID, terminalID)
-            }
+            })
             #expect(envelope.operation == .close(panelID: panelID))
         }
     }
 
     @Test("each history step maps to its PanelHistoryAction")
-    func historyStepsMap() async {
+    func historyStepsMap() async throws {
         let expected: [(PaneActions.HistoryStep, PanelHistoryAction)] = [
             (.back, .back), (.forward, .forward), (.to(index: 3), .jump(index: 3)),
         ]
         for (step, action) in expected {
-            await Self.makeState(flagEnabled: true) { state in
+            try await Self.makeState(flagEnabled: true) { state in
                 let worktreeID = UUID()
                 let tabID = UUID()
                 let panelID = UUID()
@@ -361,17 +401,17 @@ struct PanelSurfaceRenderBranchTests {
                 let actions = PaneActions.daemonManaged(
                     appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
 
-                let envelope = await Self.capture(state, committing: surface) {
+                let envelope = try Self.single(await Self.collect(state, committing: surface) {
                     actions.historyStep(panelID, step)
-                }
+                })
                 #expect(envelope.operation == .history(panelID: panelID, action: action))
             }
         }
     }
 
     @Test("resize maps the divider's CGFloat ratios onto the split")
-    func resizeMaps() async {
-        await Self.makeState(flagEnabled: true) { state in
+    func resizeMaps() async throws {
+        try await Self.makeState(flagEnabled: true) { state in
             let worktreeID = UUID()
             let tabID = UUID()
             let splitID = UUID()
@@ -382,9 +422,9 @@ struct PanelSurfaceRenderBranchTests {
             let actions = PaneActions.daemonManaged(
                 appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
 
-            let envelope = await Self.capture(state, committing: surface) {
+            let envelope = try Self.single(await Self.collect(state, committing: surface) {
                 actions.resize(splitID, [0.4, 0.6])
-            }
+            })
 
             #expect(envelope.operation == .resize(splitID: splitID, ratios: [0.4, 0.6]))
         }
@@ -405,23 +445,62 @@ struct PanelSurfaceRenderBranchTests {
 
             // `.primary` is unremovable and history-less by type in the shared
             // reducer; both gestures must be dropped app-side rather than sent
-            // and rejected. Absence proved by ordering (see above).
-            let envelope = await Self.capture(state, committing: surface) {
+            // and rejected. The trailing routeFile is a positive control (see
+            // `openBesideDropsTerminalContent`).
+            let envelopes = await Self.collect(state, committing: surface) {
                 actions.close(.terminal(terminalID: terminalID))
                 actions.historyStep(terminalID, .back)
                 actions.routeFile(terminalID, "/tmp/marker.swift")
             }
 
-            #expect(envelope.operation == .open(
-                content: .file(FileReference(path: "/tmp/marker.swift")), placement: .automatic))
+            #expect(envelopes.map(\.operation) == [.open(
+                content: .file(FileReference(path: "/tmp/marker.swift")), placement: .automatic)],
+                "close and history on the primary anchor must contribute no envelope")
+        }
+    }
+
+    // MARK: - canClose
+
+    @Test("the daemon path can close a viewer panel but not the primary anchor")
+    func canCloseTracksTheAnchor() async {
+        await Self.makeState(flagEnabled: true) { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let panelID = UUID()
+
+            let onPanel = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
+            #expect(onPanel.canClose(), "a viewer panel has a PanelID to close")
+
+            let onPrimary = PaneActions.daemonManaged(
+                appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .primary)
+            // The leaf disables its × on this branch. Without the query the
+            // button renders live and swallows the click, because `close`
+            // has no PanelID to name.
+            #expect(onPrimary.canClose() == false,
+                    "the primary anchor is unremovable — its close button must be disabled")
+        }
+    }
+
+    @Test("the legacy path can always close a leaf")
+    func legacyCanCloseAlways() async {
+        await Self.makeState(flagEnabled: false) { state in
+            var tree = LayoutNode.pane(.terminal(terminalID: UUID()))
+            let binding = Binding(get: { tree }, set: { tree = $0 })
+            let actions = PaneActions.legacy(
+                layout: binding, appState: state, worktreeID: UUID())
+
+            // Including the last pane in a tab, where `close` falls back to
+            // removing the whole tab rather than doing nothing.
+            #expect(actions.canClose())
         }
     }
 
     // MARK: - Close is not delete
 
     @Test("closing a note panel removes the panel only — the note survives")
-    func closingANoteDoesNotDeleteIt() async {
-        await Self.makeState(flagEnabled: true) { state in
+    func closingANoteDoesNotDeleteIt() async throws {
+        try await Self.makeState(flagEnabled: true) { state in
             let worktreeID = UUID()
             let tabID = UUID()
             let panelID = UUID()
@@ -441,9 +520,9 @@ struct PanelSurfaceRenderBranchTests {
 
             let actions = PaneActions.daemonManaged(
                 appState: state, worktreeID: worktreeID, tabID: tabID, anchor: .panel(panelID))
-            let envelope = await Self.capture(state, committing: surface) {
+            let envelope = try Self.single(await Self.collect(state, committing: surface) {
                 actions.close(.note(noteID: noteID))
-            }
+            })
 
             // The panel goes; nothing else does. Close ≠ delete is the
             // intended new semantics (spec §Non-goals) — the delete

--- a/Tests/TBDAppTests/TranscriptLinkPaneRoutingTests.swift
+++ b/Tests/TBDAppTests/TranscriptLinkPaneRoutingTests.swift
@@ -74,6 +74,26 @@ struct TranscriptLinkPaneRoutingTests {
         #expect(destination == .openInBrowser(url))
     }
 
+    // The daemon-managed panel path (Phase 3b) has no `LayoutNode` to route
+    // into, so it names the operation instead of a rewritten tree.
+    // `.automatic` is the reducer's "reuse the first viewer panel, else split
+    // right of the primary anchor" contract — the same intent `live` spells
+    // out by hand through `routeFileClick`.
+    @Test func daemonManagedDestination_forAFile_opensAPanelAutomatically() {
+        #expect(TranscriptLinkDestination.daemonManaged(.file("/w/a.md"))
+                == .apply(.open(
+                    content: .file(FileReference(path: "/w/a.md")),
+                    placement: .automatic)))
+    }
+
+    // Leaving the app is layout-independent, so both live paths agree — and
+    // asserting it as a value is the only way to cover the branch without a
+    // unit test launching a browser.
+    @Test func daemonManagedDestination_forAURL_leavesTheApp() {
+        let url = URL(string: "https://example.com/x")!
+        #expect(TranscriptLinkDestination.daemonManaged(.web(url)) == .openInBrowser(url))
+    }
+
     // History REVEALS. Opening would execute a resolved path that happens to be
     // a shell script, and transcript text is agent-authored.
     @Test func historyDestination_forAFile_revealsInFinder() {

--- a/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
+++ b/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
@@ -86,11 +86,23 @@ chokepoint and changes no other component, so it is deliberately not built now.
 
 ### Conflicts
 
-The app sends the mirror's current `revision` as `baseRevision`. A stale value
-means an agent applied to the same tab in between — single-user, rare. The
-daemon rejects the operation; the app refetches via `panel.get` and re-renders,
-so the UI snaps to daemon truth and the user retries. Last-writer-wins. No CRDT,
-no operational transform.
+The app sends the mirror's current `revision` as `baseRevision`. Note what the
+daemon actually does with it: `PanelCoordinator` does not reject an otherwise
+valid operation for being based on a stale revision — it only *relabels* an
+already-failing vanished-target error as `.staleTarget`. A valid operation
+applies against current truth regardless. So `baseRevision` is diagnostic here,
+not a lock, and the refetch path is reached mainly through transport or daemon
+errors rather than through concurrency.
+
+Staleness is instead handled where it can actually bite: the mirror never
+accepts a tab whose `revision` is strictly older than the one it already holds.
+Without that guard a `panel.get` in flight (snapshotted at revision N) can
+resolve after an agent's delta at N+1 and silently revert the mirror — and
+because deltas are only emitted on change, nothing would correct it until the
+next mutation. The same window exists between an `apply` and its own response.
+Removal is exempt: a tab absent from a full `panel.get`, or named in a delta's
+`removedTabIDs`, is dropped whatever revision the mirror holds. Last-writer-wins
+on content, authoritative-set on existence. No CRDT, no operational transform.
 
 ## Ownership and operations
 
@@ -200,6 +212,14 @@ config column; app-only behavior may gate on `UserDefaults`).
   import reuses legacy pane IDs as panel IDs for viewers, so the same key returns
   plausible but stale legacy state. The fix is to return per-panel history from
   `panel.get` / `PanelApplyResult`, which is a daemon + `TBDShared` change.
+- **Surfaces for tabs created after the import — required before graduation.**
+  The legacy import is one-shot per worktree, and nothing in the daemon creates a
+  `WorkspaceTabSurface` outside it. A tab created after that import therefore has
+  no surface, so the render branch falls back to legacy for that tab. The
+  fallback is correct — rendering blank would be worse — but it means one window
+  can hold both models at once, with `tbd panel …` silently doing nothing on the
+  legacy tabs. That materially narrows what the soak exercises. The fix is
+  daemon-side surface creation on tab creation, outside 3b's app-only scope.
 - Note deletion affordance (#7) — required before graduation, since close no
   longer deletes.
 - Native resize indicator / unified divider (#9).

--- a/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
+++ b/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
@@ -1,0 +1,181 @@
+# Phase 3b — Render the app from the daemon panel surface
+
+Status: design, approved for implementation planning
+Date: 2026-07-31
+Precedes: flag soak/graduation (Phase 3c, not covered here)
+
+## Problem
+
+The daemon owns a panel surface (`WorkspaceTabSurface` per worktree/tab,
+Approach C, spec `2026-07-22-panel-agent-surface-c-primary-anchor-design.md`).
+The store, the `panel.get`/`panel.apply` RPCs, the one-shot legacy import, the
+shadow comparator, and the `tbd panel` CLI are all built and merged. But the
+app still **renders** from the legacy `Pane*` model: `SplitLayoutView` draws a
+`LayoutNode` tree, gestures mutate it locally, and `panelSurfaceChanged` deltas
+hit `default: break` in `AppState.handleDelta`. So the already-shipped agent
+write path (`tbd panel open/close/navigate/...`) is inert — a mutation commits
+in the daemon but never appears on screen.
+
+Phase 3b makes the app render its workspace from the daemon surface and route
+its own gestures through `panel.apply`, so daemon-owned state — whether changed
+by the user or by an agent — is what the user sees.
+
+## Non-goals
+
+- **Flipping any flag's default.** 3b ships default-off; graduation is a later
+  phase (task #8).
+- **Note deletion.** Once the app renders from the new model, closing a note
+  panel removes the panel but the note file survives (close ≠ delete). A delete
+  affordance is deferred (task #7); in the interim a note is removable only via
+  the filesystem. Accepted for a default-off soak feature.
+- **`move` (drag-a-panel-to-another-edge).** Drag-and-drop repositioning is its
+  own UI project and unneeded day one. Deferred.
+- **Native resize indicator / unified divider** (task #9). 3b ports the existing
+  divider behavior; the native-resize rework is a follow-up.
+- **Retiring legacy app-side persistence.** It stays live during the soak as the
+  flag-off fallback. Retiring it is a later phase.
+
+## Approach: flag-switched dual path with an optimistic local mirror
+
+Three cutover strategies were weighed:
+
+- **A — flag-switched dual path (chosen).** A new app flag picks the rendering
+  path at the workspace root. Off = today's legacy path, untouched. On = a new
+  view renders an in-memory `WorkspaceTabSurface` mirror.
+- **B — adapter bridge (rejected).** Feed the existing `SplitLayoutView` from a
+  `WorkspaceTabSurface → LayoutNode` adapter and translate its `@Binding`
+  mutations back into operations. Rejected: the legacy `LayoutNode` is a
+  homogeneous pane tree whose `PaneContent` *has* a terminal case, while the new
+  model is a primary-anchor tree whose viewer `PanelContent` has none. Adapting
+  flattens and re-inflates the exact primary/viewer distinction the redesign
+  exists to make, and the synchronous `@Binding` write-back races the async
+  daemon commit (two writers, one binding).
+- **C — read-first, mutate-later (rejected).** Render read-only from the surface
+  while gestures still mutate legacy. Rejected: the import is one-shot per
+  launch, so the rendered surface would be stale mid-session — strictly worse
+  than legacy — and it can't validate the `apply → delta → render` round-trip
+  because there are no applies.
+
+### Why "daemon-owned" does not mean "laggy"
+
+The pure reducer already lives in `TBDShared` (`PanelSurfaceReducer.swift`), so
+the app runs the *same* reducer the daemon runs, locally, on the main thread.
+A user gesture never waits on the round-trip:
+
+1. Gesture → run `PanelSurfaceReducer` against the local mirror → render
+   immediately (as instant as today's `@Binding` mutation).
+2. Fire `apply(origin: .appUser)` in the background.
+3. The daemon runs the same reducer, commits, broadcasts `panelSurfaceChanged`.
+4. The app reconciles: the delta almost always matches what the app already
+   computed (same reducer, same input) → no-op.
+
+Async only appears where it is imperceptible: the agent path (nobody waits on a
+CLI command) and the background commit of a user gesture (masked by the
+optimistic render). The daemon is also a local unix-socket process — the
+round-trip is sub-millisecond regardless.
+
+### Conflicts
+
+Divergence between the optimistic local result and the daemon's broadcast
+happens only on genuine concurrency — an agent applied to the same tab between
+the app's `baseRevision` and its commit. Single-user, rare. Resolution is
+last-writer-wins: snap the mirror to daemon truth from the delta. If the app's
+own `apply` is rejected for a stale `baseRevision`, refetch via `panel.get` and
+re-render. No CRDT, no operational transform.
+
+## Ownership and operations
+
+The daemon owns the whole surface, **including split ratios**. Widths must
+survive restart (design decision), and ratios are welded to the split nodes the
+daemon already owns for open/close — splitting ratio ownership app-side would
+force a permanent dual-store reconciliation (daemon owns structure, app owns
+per-`SplitID` ratios, reconciled on every structural change) plus app-side
+auto-placement of agent-opened panels. Single ownership with one shared reducer
+is simpler; the app just fires operations and renders.
+
+Operations wired in 3b: `open`, `close`, `navigate`, `history`, `resize`.
+
+- **Resize** stays purely local during the drag (no per-frame RPC); one
+  `apply(resize)` fires on drag-end. On release the daemon persists the ratios,
+  so widths survive restart.
+- **Ephemeral state** — keyboard focus, scroll position, in-progress drag —
+  never reaches the daemon. Only structural state (which panels exist, their
+  content, split ratios, history) is daemon-owned.
+
+Deferred operations: `move`.
+
+## Components
+
+### `AppState` — the mirror and the delta handler
+
+- Hold an in-memory mirror of the surface: `[worktreeID: PanelGetResult]` (tabs
+  + active tab), populated from `panel.get` when `enableDaemonManagedPanels` is
+  on, and kept current by the delta handler.
+- Replace `default: break` for `.panelSurfaceChanged` in `handleDelta` with a
+  reconcile: upsert the delta's affected `tabs`, drop `removedTabIDs`, set the
+  active tab. Guarded to mutate the mirror only when the render flag is on (the
+  daemon may broadcast during the store-only soak with the render flag off).
+- A gesture chokepoint that: runs `PanelSurfaceReducer` against the mirror,
+  updates the mirror (optimistic render), then fires
+  `panel.apply(envelope, origin: .appUser)` with the mirror's current
+  `revision` as `baseRevision`; on rejection, refetch + re-render.
+
+### `PanelSurfaceWorkspaceView` (new) — the renderer
+
+- Renders a `WorkspaceTabSurface`: the `.primary` anchor plus the recursive
+  viewer-panel split tree, from the mirror.
+- Emits gestures (open/close/navigate/history/resize) to the `AppState`
+  chokepoint. Ports the existing divider's drag behavior (native-resize rework
+  is #9).
+
+### Workspace root — the switch
+
+At the point that today instantiates `SplitLayoutView`, branch on the flag:
+render `PanelSurfaceWorkspaceView` when `enableDaemonManagedPanels` is on **and**
+the daemon reports `panelSurfaceEnabled` (the store must be on for a surface to
+exist); otherwise the legacy path, unchanged.
+
+## Flags — the soak ladder (three independent rungs)
+
+- `daemon_panel_surface_enabled` (existing daemon `config` column, default off) —
+  store + import + shadow-compare. Already built. Unchanged here.
+- **`enableDaemonManagedPanels` (new, app `UserDefaults`, default off)** — the
+  app renders panels from the daemon surface and routes its gestures through
+  `panel.apply`. Precedent: `enableTranscript` (app-only presentation toggle,
+  default off). Guarded to require `daemon_panel_surface_enabled` on; with the
+  store flag off it falls back to the legacy path (can't render a surface that
+  was never imported).
+- `agent_panel_control_enabled` (existing, default off) — gates
+  `origin: .agentCLI` applies. **Not touched in 3b.** App gestures use
+  `origin: .appUser`, which the coordinator gates only on
+  `daemon_panel_surface_enabled`, so the app write path works without the agent
+  flag.
+
+No new database migration — the config column already exists (added with the
+daemon surface). This is an app-only presentation flag, so `UserDefaults` is the
+right home per the project convention (large/risky *daemon* behavior gates on a
+config column; app-only behavior may gate on `UserDefaults`).
+
+## Testing
+
+- **Flag off:** the workspace root renders the legacy `SplitLayoutView`; gestures
+  still mutate the legacy model and persist; `panelSurfaceChanged` deltas do not
+  touch any rendering state.
+- **Flag on:** the workspace root renders `PanelSurfaceWorkspaceView` from the
+  mirror; each gesture updates the mirror and fires an `apply`.
+- **Reconcile:** an `apply`-then-matching-delta is a no-op on the mirror; a
+  concurrent-divergence delta snaps the mirror to daemon truth; a
+  `baseRevision`-rejected apply triggers a refetch + re-render.
+- **Guard:** with the render flag on but the store flag off, the root still
+  renders legacy.
+- Shared-reducer parity (local vs daemon result) is already covered by existing
+  `PanelSurfaceReducer` tests; 3b does not re-cover it.
+
+## Open follow-ups (not in 3b)
+
+- Note deletion affordance (#7) — required before graduation, since close no
+  longer deletes.
+- Native resize indicator / unified divider (#9).
+- `move` / drag-to-reposition.
+- Flag soak and graduation (#8): enable `enableDaemonManagedPanels`, dogfood,
+  then graduate; retire legacy app-side persistence afterward.

--- a/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
+++ b/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
@@ -190,6 +190,16 @@ config column; app-only behavior may gate on `UserDefaults`).
 
 ## Open follow-ups (not in 3b)
 
+- **Per-panel history on the wire — required before graduation.**
+  `PanelGetResult` carries tabs only, and `WorkspaceTabSurface` has no histories;
+  the daemon keeps `PanelHistory` in its own store. So on the daemon path the app
+  cannot know a panel's back/forward state, and the history chevrons render
+  disabled even after the daemon has recorded navigations. The `.history`
+  operation itself is wired and correct — only the affordance is dark. Reading
+  `paneHistories` as a stand-in would be wrong, not merely incomplete: the legacy
+  import reuses legacy pane IDs as panel IDs for viewers, so the same key returns
+  plausible but stale legacy state. The fix is to return per-panel history from
+  `panel.get` / `PanelApplyResult`, which is a daemon + `TBDShared` change.
 - Note deletion affordance (#7) — required before graduation, since close no
   longer deletes.
 - Native resize indicator / unified divider (#9).

--- a/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
+++ b/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
@@ -220,6 +220,21 @@ config column; app-only behavior may gate on `UserDefaults`).
   can hold both models at once, with `tbd panel …` silently doing nothing on the
   legacy tabs. That materially narrows what the soak exercises. The fix is
   daemon-side surface creation on tab creation, outside 3b's app-only scope.
+- **Legacy `layouts` read sites are stale on a daemon-rendered tab — required
+  before graduation.** Several call sites still derive "which terminals does
+  this tab render" from the legacy `layouts` store (`AppState`,
+  `AppState+Terminals`, `AppState+TerminalFocus`, `TerminalContainerView`), and
+  the terminal-pane reconciliation in `AppState.removingTerminalPanes(notIn:)`
+  writes to `layouts` without touching the mirror. On a daemon-rendered tab they
+  fall back to `.pane(tab.content)`, which is correct today only because the
+  primary anchor is the sole terminal-bearing node. That stops holding the
+  moment a surface carries a terminal anywhere else. Inert while the flag is
+  off.
+- **Features that create tabs widen the split-model window.** Anything that
+  parks a new tab without a user gesture — automatic notes tabs, opening a PR as
+  a webview tab — produces a tab with no surface, so it renders legacy while its
+  siblings render from the daemon. Worth naming in the soak plan, since the
+  effect compounds with the post-import gap above.
 - Note deletion affordance (#7) — required before graduation, since close no
   longer deletes.
 - Native resize indicator / unified divider (#9).

--- a/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
+++ b/docs/specs/2026-07-31-panel-3b-app-rendering-design.md
@@ -58,30 +58,39 @@ Three cutover strategies were weighed:
 
 ### Why "daemon-owned" does not mean "laggy"
 
-The pure reducer already lives in `TBDShared` (`PanelSurfaceReducer.swift`), so
-the app runs the *same* reducer the daemon runs, locally, on the main thread.
-A user gesture never waits on the round-trip:
+No gesture in the app is continuous with respect to the layout tree. The
+divider's `DragGesture.onChanged` moves a local overlay only; `onEnded` commits,
+and `SplitContainer.commitRatios()` is the sole writer into the tree
+(`SplitLayoutView.swift:135-137`). Every other operation — open, close,
+navigate, history — is a discrete click. So there is no per-frame path that
+could accumulate round-trip cost.
 
-1. Gesture → run `PanelSurfaceReducer` against the local mirror → render
-   immediately (as instant as today's `@Binding` mutation).
-2. Fire `apply(origin: .appUser)` in the background.
-3. The daemon runs the same reducer, commits, broadcasts `panelSurfaceChanged`.
-4. The app reconciles: the delta almost always matches what the app already
-   computed (same reducer, same input) → no-op.
+The flow for a user gesture is therefore a single round-trip:
 
-Async only appears where it is imperceptible: the agent path (nobody waits on a
-CLI command) and the background commit of a user gesture (masked by the
-optimistic render). The daemon is also a local unix-socket process — the
-round-trip is sub-millisecond regardless.
+1. Gesture → `panel.apply(origin: .appUser)`.
+2. The daemon reduces, commits, and returns the authoritative
+   `PanelApplyResult.tab` in the response.
+3. The app upserts that tab into the mirror → render.
+4. The broadcast `panelSurfaceChanged` that follows carries the same tab at the
+   same revision, so it lands as a no-op.
+
+The daemon is a local unix-socket process, so this is a sub-millisecond hop plus
+one SQLite commit — far under a frame, and it buys a single source of truth with
+no reconciliation machinery.
+
+The pure reducer in `TBDShared` (`PanelSurfaceReducer.swift`) makes an
+optimistic local layer available if soak measurement ever shows a perceptible
+gap: the app can run the same reducer the daemon runs, render immediately, and
+let the response confirm. That is strictly additive in front of the same
+chokepoint and changes no other component, so it is deliberately not built now.
 
 ### Conflicts
 
-Divergence between the optimistic local result and the daemon's broadcast
-happens only on genuine concurrency — an agent applied to the same tab between
-the app's `baseRevision` and its commit. Single-user, rare. Resolution is
-last-writer-wins: snap the mirror to daemon truth from the delta. If the app's
-own `apply` is rejected for a stale `baseRevision`, refetch via `panel.get` and
-re-render. No CRDT, no operational transform.
+The app sends the mirror's current `revision` as `baseRevision`. A stale value
+means an agent applied to the same tab in between — single-user, rare. The
+daemon rejects the operation; the app refetches via `panel.get` and re-renders,
+so the UI snaps to daemon truth and the user retries. Last-writer-wins. No CRDT,
+no operational transform.
 
 ## Ownership and operations
 
@@ -125,8 +134,16 @@ Deferred operations: `move`.
 - Renders a `WorkspaceTabSurface`: the `.primary` anchor plus the recursive
   viewer-panel split tree, from the mirror.
 - Emits gestures (open/close/navigate/history/resize) to the `AppState`
-  chokepoint. Ports the existing divider's drag behavior (native-resize rework
-  is #9).
+  chokepoint. Reuses the existing `SplitDivider` (native-resize rework is #9).
+- Reuses the existing leaf view (`PanePlaceholder` — toolbar, pane label, history
+  controls, content rendering) rather than duplicating it, by way of a mutation
+  seam: the leaf calls an injected action set, which the legacy path fills with
+  today's local tree mutations and this path fills with `panel.apply` calls. The
+  leaf is fed by a `PanelContent → PaneContent` mapping, total because
+  `PanelContent` is a strict subset (no terminal case). This is content-only —
+  the mapping is never used to rebuild a `LayoutNode` tree, which is what makes
+  it different from the rejected adapter bridge: the tree renderer and the source
+  of truth stay separate per path, and no `@Binding` races the daemon.
 
 ### Workspace root — the switch
 


### PR DESCRIPTION
## Summary

TBD's workspace panels have been daemon-owned for a while: the daemon stores the panel surface, `panel.get`/`panel.apply` are live, and `tbd panel open/close/navigate/...` has shipped in the CLI. But the app still *rendered* from its own client-side layout tree, so an agent running `tbd panel open --web ...` committed a change the user never saw. The write path was real and inert.

This PR makes the app render its workspace from the daemon surface, so what an agent does to your panels actually shows up — and what you do with the mouse goes through the same path the agent uses. Behind a default-off flag.

## Why this shape

Full rationale and the rejected alternatives are in [`docs/specs/2026-07-31-panel-3b-app-rendering-design.md`](docs/specs/2026-07-31-panel-3b-app-rendering-design.md). The three decisions worth surfacing here:

- **A flag-switched dual path, not an adapter.** Feeding the existing `SplitLayoutView` from a `WorkspaceTabSurface → LayoutNode` adapter looks cheaper, but the legacy tree is homogeneous (its `PaneContent` *has* a terminal case) while the new model is a primary-anchor tree whose viewer content has none. Adapting flattens and re-inflates the exact distinction the redesign exists to make, and a synchronous `@Binding` write-back races the daemon commit. So the tree renderer is new; only the leaf is shared.
- **A mutation seam instead of a duplicated leaf.** `PanePlaceholder` is ~700 lines of toolbar, history controls, and content rendering that both paths want. Rather than fork it, it now performs no structural mutation itself — it calls an injected `PaneActions` set. Legacy fills that with today's local tree mutations; the daemon path fills it with `panel.apply` calls. Content reaches the shared leaf through a `PanelContent → PaneContent` mapping that is total (no terminal case to lose); it is never used to rebuild a tree.
- **A single round-trip, no optimistic layer.** No gesture in this app is continuous with respect to the tree — the divider moves a local overlay during a drag and only commits on release, and everything else is a discrete click. So a gesture fires `panel.apply` and renders the authoritative tab the daemon returns. The shared reducer in `TBDShared` makes an optimistic layer available later if soak shows a perceptible gap; it would sit in front of the same chokepoint and change nothing else.

## What this PR does

- **`PaneActions` seam** (`Sources/TBDApp/Panes/PaneActions.swift`) — the leaf calls injected closures for open/close/navigate/history/resize/transcript-toggle/file-routing/transcript-links, plus `isTranscriptOpen`, `history`, and `canClose` queries. `PanePlaceholder` no longer holds a layout binding at all.
- **Surface mirror** (`Sources/TBDApp/PanelSurface/AppState+PanelSurface.swift`) — an in-memory cache of the daemon surface, seeded by `panel.get`, kept current by the `panelSurfaceChanged` delta (which previously fell through `handleDelta`'s `default: break`). `applyPanelOperation` is the single chokepoint that builds the envelope, sends it, and adopts the returned tab.
- **Renderer** (`Sources/TBDApp/PanelSurface/PanelSurfaceWorkspaceView.swift`) — walks `PanelLayoutNode`, rendering the primary anchor, viewer panels, and splits, reusing the existing `SplitDivider`.
- **Render branch** (`TerminalContainerView.layoutContent`) — `workspaceRenderPath(worktreeID:tabID:)` picks daemon or legacy; extracted as a plain computed function so it is testable without touching SwiftUI.

Two behaviors change on the daemon path only. Closing a note removes the panel but keeps the note (close ≠ delete); a delete affordance is deferred, so a note closed there is currently removable only via the filesystem. And the close button is disabled on the primary anchor, which is unremovable by type.

## Flag & rollout

`enableDaemonManagedPanels` — app-side `UserDefaults`, **default OFF** (precedent: `enableTranscript`). It is app-only presentation, so it takes a UserDefaults key rather than a `config` column and needs no migration. It is additionally gated on the daemon's existing `daemon_panel_surface_enabled`: with the store off there is no surface to render, and the branch falls back to legacy.

Enable for the soak with `daemon_panel_surface_enabled` on the daemon side plus `defaults write TBDApp enableDaemonManagedPanels -bool true`.

Graduation is deliberately **not** this PR, and two daemon-side gaps block it:

- **Per-panel history is not on the wire.** `PanelGetResult` carries tabs only, so the app cannot know a panel's back/forward state and the history chevrons render disabled on the daemon path even after the daemon has recorded navigations. The `.history` operation itself is wired and correct. Reading the legacy `paneHistories` as a stand-in would be wrong rather than merely incomplete — the import reuses legacy pane IDs as panel IDs, so the same key returns stale legacy state.
- **Tabs created after the one-shot import have no surface**, so they fall back to legacy. One window can hold both models at once, with `tbd panel ...` silently doing nothing on the legacy tabs. This narrows what the soak exercises.

Both need daemon + `TBDShared` changes, outside this app-only scope.

## Assumptions

- Assumes a delta's `activeTabID: nil` means "unchanged", not "cleared". `PanelCoordinator` sends nil on every ordinary mutation and fills it only for `selectTab` and the legacy import; if that ever changes, tab selection would blank on every panel operation.
- Assumes `baseRevision` is diagnostic rather than a lock. The daemon does not reject an otherwise-valid operation for a stale base — it only relabels an already-failing vanished-target error. Staleness is therefore handled in the mirror, which refuses any tab older than the one it holds.
- Assumes the daemon is local and its commit is far under a frame. If `panel.apply` ever became a network hop, the single-round-trip model would need the optimistic layer described in the spec.

## Evidence & verification

- **The rollback guarantee was verified expression-by-expression**, not assumed: every closure body moved into `PaneActions.legacy` was diffed against what `PanePlaceholder`/`SplitContainer` did before, including the `popHistoryForRemovedPane` early-return branch and the last-pane-closes-the-tab fallback. The seam commit changed no test, and the full suite passed unmodified — that is the refactor's proof.
- **Both branches of every new conditional are tested**, asserting opposite outcomes: flag off leaves the mirror untouched and selects the legacy render path; flag on with an empty mirror still selects legacy; flag on with a surface selects the daemon path; store flag off deactivates regardless.
- **Three review findings were fixed and mutation-checked** rather than trusted green: a live-but-dead close button on the primary anchor (clicking × did nothing at all on the daemon path), a missing revision-monotonicity guard that let an in-flight refetch revert the mirror behind a newer delta, and absence-tests that fatal-errored on a double-resumed continuation instead of failing cleanly. Reintroducing each defect reddens exactly the tests that cover it.

Verified locally on the rebased tree: build clean, `swiftlint --strict` 0 violations across 818 files, and the panel suites green (147 tests / 21 suites). The full run shows pre-existing reds unrelated to this diff — the `EventDrivenTestClock` starvation family named in `Tests/CLAUDE.md`, which passes in isolation, and `OrphanProcessCollectorTests.parseLiveCWDs`, a deterministic `/tmp` vs `/private/tmp` symlink mismatch in a daemon fixture. This branch touches no daemon, shared, or CLI source, so neither can originate here.

Not yet exercised in the running app — the flag is off by default, so this lands inert either way, but the daemon path wants a click-through before the soak begins.

[20260714-disabled-lemming](https://cheapsteak.github.io/tbd/open/?worktree=308213B4-EA0D-4A90-8381-A31157D1B083)
