### PR TITLE
Fix: A GC parser test goes red on any machine that happens to have a /tmp/a

### DIFF
--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -359,25 +359,31 @@ struct OrphanGCTests {
                 "partial output from a failed lsof is not a complete cwd picture — fail toward keep")
     }
 
-    @Test func parseLiveCWDsParsesCompletedOutput() {
-        // Nonexistent paths pass through canon() unchanged (realpath fallback),
-        // so expectations are deterministic. Mixed lines: p-prefixed pid
-        // headers are dropped, n-prefixed cwds are kept (prefix stripped),
-        // duplicates are deduped preserving first-seen order, and a bare "n"
-        // (empty path) is dropped.
+    @Test func parseLiveCWDsParsesCompletedOutput() throws {
+        // Fixture cwds under a scratch directory whose own path is already
+        // realpath-resolved, so canon() is the identity on them whether or not
+        // they exist — a bare literal makes the expectation depend on the
+        // machine's filesystem instead. Mixed lines: p-prefixed pid headers are
+        // dropped from the path list, n-prefixed cwds are kept (prefix
+        // stripped), duplicates are deduped preserving first-seen order, and a
+        // bare "n" (empty path) is dropped.
+        let scratch = try makeCanonicalScratchDirectory(prefix: "tbd-gc-parse-cwds")
+        defer { try? FileManager.default.removeItem(atPath: scratch) }
+        let wtA = scratch + "/wt-a"
+        let wtB = scratch + "/wt-b"
         let stdout = """
         p101
-        n/nonexistent/gc-test/wt-a
+        n\(wtA)
         p102
-        n/nonexistent/gc-test/wt-b
+        n\(wtB)
         p103
-        n/nonexistent/gc-test/wt-a
+        n\(wtA)
         p104
         n
         """
         let outcome = BoundedProcessOutcome.completed(status: 0, stdout: Data(stdout.utf8), stderr: Data())
         let parsed = OrphanGC.parseLiveCWDs(outcome)
-        #expect(parsed?.paths == ["/nonexistent/gc-test/wt-a", "/nonexistent/gc-test/wt-b"])
+        #expect(parsed?.paths == [wtA, wtB])
     }
 
     // MARK: - lsof unavailable skips the entire sweep

--- a/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
+++ b/Tests/TBDDaemonTests/OrphanProcessCollectorTests.swift
@@ -2,10 +2,15 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 import TBDShared
+import TestSupport
 
 /// Tier 1: pure classification and parsing. No database, no filesystem, no
 /// subprocess and no real signal — the collector is handed its `ps` snapshot,
 /// its pid-to-cwd map and its root classification, and answers.
+///
+/// The exception is the pair of `parseLiveCWDs` tests that name real paths:
+/// canonicalizing a cwd is a `realpath(3)` call, so those are tier 2 and own a
+/// scratch directory rather than naming a path on the developer's machine.
 @Suite("OrphanProcessCollector")
 struct OrphanProcessCollectorTests {
 
@@ -521,13 +526,56 @@ struct OrphanProcessCollectorTests {
 
     /// The pid header lsof always printed and `parseLiveCWDs` used to discard.
     /// Both shapes come from one pass, and the path list is unchanged.
-    @Test("parseLiveCWDs yields both the deduped path list and the pid-to-cwd map")
-    func parseLiveCWDsKeepsThePID() throws {
-        let stdout = Data("p100\nn/tmp/a\np200\nn/tmp/b\np300\nn/tmp/a\n".utf8)
+    ///
+    /// The fixture cwds sit under a scratch directory this test owns, whose own
+    /// path is `realpath`-resolved, so the parser's canonicalization is the
+    /// identity on them — and the test runs with them absent from disk and with
+    /// them present to prove it. Bare `/tmp/a` and `/tmp/b` literals made this
+    /// test's outcome depend on whether an unrelated process had left those
+    /// paths lying around: existing, they canonicalize to `/private/tmp/...`.
+    @Test(
+        "parseLiveCWDs yields both the deduped path list and the pid-to-cwd map",
+        arguments: [false, true]
+    )
+    func parseLiveCWDsKeepsThePID(fixtureCWDsExistOnDisk: Bool) throws {
+        let scratch = try makeCanonicalScratchDirectory(prefix: "tbd-live-cwds")
+        defer { try? FileManager.default.removeItem(atPath: scratch) }
+        let pathA = scratch + "/a"
+        let pathB = scratch + "/b"
+        if fixtureCWDsExistOnDisk {
+            for path in [pathA, pathB] {
+                try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+            }
+        }
+
+        let stdout = Data("p100\nn\(pathA)\np200\nn\(pathB)\np300\nn\(pathA)\n".utf8)
         let parsed = try #require(
             OrphanGC.parseLiveCWDs(.completed(status: 0, stdout: stdout, stderr: Data())))
-        #expect(parsed.paths == ["/tmp/a", "/tmp/b"])
-        #expect(parsed.cwdByPID == [100: "/tmp/a", 200: "/tmp/b", 300: "/tmp/a"])
+        #expect(parsed.paths == [pathA, pathB])
+        #expect(parsed.cwdByPID == [100: pathA, 200: pathB, 300: pathA])
+    }
+
+    /// Canonicalization is load-bearing, not cosmetic: these cwds are compared
+    /// against git's own worktree paths, which git records already resolved. A
+    /// cwd lsof reports through a symlink has to arrive as the same string, or
+    /// a live worktree reads as idle and gets reaped out from under its agent.
+    /// It also has to happen before the dedup, so two spellings of one
+    /// directory collapse to a single entry.
+    @Test("parseLiveCWDs resolves each cwd to the path git would report")
+    func parseLiveCWDsCanonicalizes() throws {
+        let scratch = try makeCanonicalScratchDirectory(prefix: "tbd-live-cwds-canon")
+        defer { try? FileManager.default.removeItem(atPath: scratch) }
+        let worktree = scratch + "/worktree"
+        try FileManager.default.createDirectory(atPath: worktree, withIntermediateDirectories: true)
+        let viaSymlink = scratch + "/link-to-worktree"
+        try FileManager.default.createSymbolicLink(atPath: viaSymlink, withDestinationPath: worktree)
+
+        let stdout = Data("p100\nn\(viaSymlink)\np200\nn\(worktree)\n".utf8)
+        let parsed = try #require(
+            OrphanGC.parseLiveCWDs(.completed(status: 0, stdout: stdout, stderr: Data())))
+        #expect(parsed.paths == [worktree],
+                "a cwd reported through a symlink resolves to its target, and dedupes against it")
+        #expect(parsed.cwdByPID == [100: worktree, 200: worktree])
     }
 
     @Test("an unavailable lsof invalidates both halves together")

--- a/Tests/TestSupport/GitRepoHelpers.swift
+++ b/Tests/TestSupport/GitRepoHelpers.swift
@@ -33,6 +33,46 @@ public func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, rep
     return (tempDir: resolved, repoDir: repoDir)
 }
 
+/// Thrown when `realpath()` refuses a directory this process just created —
+/// never expected, but it is the one way `makeCanonicalScratchDirectory` can
+/// hand back a path that is not actually canonical, so it fails loudly instead.
+public struct CanonicalScratchDirectoryFailure: Error, CustomStringConvertible {
+    public let path: String
+    public let errnoValue: Int32
+    public var description: String {
+        "realpath() failed with errno \(errnoValue) on the freshly created scratch directory \(path)"
+    }
+}
+
+/// Creates a unique empty scratch directory and returns its `realpath`-resolved
+/// path, so every path built underneath it is already canonical. The caller
+/// owns it (`try? FileManager.default.removeItem(atPath: dir)`).
+///
+/// For tests whose subject canonicalizes the paths it is handed, which TBD
+/// does everywhere it compares a path against git's always-canonical worktree
+/// output. A hardcoded literal is the wrong fixture there, because `realpath(3)`
+/// takes a different branch depending on whether the path happens to exist:
+/// it resolves an existing one (following `/tmp` -> `/private/tmp`) and fails
+/// with `ENOENT` on a missing one, leaving callers to fall back to the input.
+/// So `/tmp/a` means `/private/tmp/a` on a machine where some unrelated
+/// process left that file lying around and `/tmp/a` on one where it did not —
+/// a unit test silently reading the developer's filesystem.
+///
+/// Paths built under this directory close that branch by construction: every
+/// component is already symlink-free, so resolving one of them is the identity
+/// whether or not it exists on disk.
+public func makeCanonicalScratchDirectory(prefix: String) throws -> String {
+    let raw = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(prefix)-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: raw, withIntermediateDirectories: true)
+    errno = 0
+    guard let resolved = realpath(raw.path, nil) else {
+        throw CanonicalScratchDirectoryFailure(path: raw.path, errnoValue: errno)
+    }
+    defer { free(resolved) }
+    return String(cString: resolved)
+}
+
 /// Sets up a temp git repo with one worktree at a non-canonical (external)
 /// path. Returns the canonicalized worktree path (via `realpath`) so it
 /// matches what `git worktree list` reports.


### PR DESCRIPTION
## What's broken

`scripts/test.sh` goes red for a developer whose machine happens to have a file
or directory at `/tmp/a`, in a test that has nothing to do with `/tmp`:

```
Test "parseLiveCWDs yields both the deduped path list and the pid-to-cwd map"
  recorded an issue: (parsed.paths → ["/private/tmp/a", "/private/tmp/b"])
                     == ["/tmp/a", "/tmp/b"]
```

It is not a flake — it fails deterministically, in about four milliseconds, on
every run. And it is invisible everywhere else: CI's `/tmp` is empty, so the
suite is green there and green for every developer whose `/tmp` happens to be
empty too. Nothing about the failure points at its own cause, so the cost lands
as time spent deciding whether a red suite is real.

`/tmp/a` is an unremarkable name. Anything that writes one — a scratch file, a
half-finished experiment, another tool's fixture — arms this.

## Why it happens

`OrphanGC.parseLiveCWDs` canonicalizes every cwd it reads out of `lsof`, so the
paths compare equal to the always-canonical paths git reports for a worktree.
Canonicalization goes through `AgentWorktreeCollector.canon`, which calls POSIX
`realpath(3)` and falls back to returning its input unchanged:

```swift
guard let cString = realpath(path, nil) else { return path }
```

`realpath(3)` fails with `ENOENT` for a path that **does not exist**. So `canon`
has two branches, and which one a path takes is decided by the filesystem:

- the path does not exist → `realpath` fails → the input is returned verbatim;
- the path exists → `realpath` succeeds → symlinks are resolved.

The test fed `/tmp/a` and asserted it came back as `/tmp/a`. That is true only
while `/tmp/a` does not exist. Once it does, `realpath` succeeds and resolves
macOS's `/tmp → private/tmp` symlink, so the parser correctly returns
`/private/tmp/a` and the assertion fails.

The production code is right. The test encoded an assumption about the
developer's filesystem and never said so.

## When it broke

The fixture arrived with #681 (2026-08-19), which added the pid-to-cwd map.
Latent from the start: it needed a machine with a `/tmp/a` to bite, and CI has
none.

The same assumption is older than that. #438 (2026-07-13) introduced a sibling
in `OrphanGCTests` using `/nonexistent/gc-test/wt-a`, with a comment reasoning
explicitly that "nonexistent paths pass through `canon()` unchanged". So this
was a deliberate, documented assumption rather than an oversight — it was simply
never robust, and the newer fixture picked a far likelier name than the older
one.

## What this PR does

Makes the fixtures immune to the branch that `canon` takes, rather than betting
on one of them.

A new `makeCanonicalScratchDirectory(prefix:)` helper in `TestSupport` creates a
scratch directory the test owns and returns its already-`realpath`-resolved
path. Every path built beneath it is symlink-free by construction, so both
branches of `canon` produce the same string — resolving it is a no-op, and
failing to resolve it returns the identical input. The choice matters: swapping
in a different unlikely-looking literal would just re-bet on one branch, which
is the mistake being fixed.

That equivalence is asserted rather than argued. `parseLiveCWDsKeepsThePID` is
now parameterized over `fixtureCWDsExistOnDisk: [false, true]`, so both
filesystem states run on every invocation and neither can rot unobserved.

Two other things fall out of it:

- **The canonicalization contract gains its first test.** Nothing asserted that
  `parseLiveCWDs` canonicalizes at all — the documented reason it does was
  unverified, and the only reason we learned it happens was this failure. A new
  test creates a real symlink and feeds both spellings under different pids,
  asserting they collapse to one entry. That also pins the ordering that makes
  the dedup correct: canonicalization has to happen *before* the dedup, or the
  same directory reached two ways counts twice.
- **The sibling from #438 is migrated to the same fixtures**, closing the same
  latent coupling at lower probability.

The suite's header comment claimed "no database, no filesystem, no subprocess".
That was already untrue for these two tests — `parseLiveCWDs` makes a
`realpath(3)` syscall, which is the whole bug — so the comment now names them as
the exception instead of asserting something false.

## Evidence & verification

**The repro**, on a machine where `/tmp/a` and `/tmp/b` exist:

```
Test run with 32 tests in 1 suite failed after 0.011 seconds with 2 issues.
```

`realpath(3)` was probed directly to confirm both branches rather than inferred
from the failure: an existing path resolved through the `/tmp` symlink, a
non-existent one returned NULL with `errno=2`.

**Discriminating evidence.** The fix is not "the assertion was loosened" — the
parameterized case proves the fixture is stable in both filesystem states, which
is precisely what the old fixture was not:

```
Test case passing fixtureCWDsExistOnDisk → false … started.
Test case passing fixtureCWDsExistOnDisk → true  … started.
Test "parseLiveCWDs yields both the deduped path list and the pid-to-cwd map"
  with 2 test cases passed after 4.040 seconds.
Test "parseLiveCWDs resolves each cwd to the path git would report" passed.
```

The new canonicalization test is discriminating by construction: without
canonicalization the symlink and its target are two distinct strings, so the
result is two entries rather than one.

Verified on a machine where `/tmp/a` and `/tmp/b` still exist and were left
untouched — deleting them would have made the suite green while leaving the bug
in place.

- `scripts/test.sh --filter Orphan` — 135 tests in 24 suites passed, zero issues.
  Count confirmed non-zero, since a `--filter` matching nothing exits green.
- `scripts/swift-safe build` — zero `error:` lines, grepped rather than inferred
  from the exit code.
- `swiftlint --strict` — 0 violations in 821 files.

https://claude.ai/code/session_01EWDFBr2uSuR618KFWwitXe

[20260815-consistent-reptile](https://cheapsteak.github.io/tbd/open/?worktree=92B3ECD3-C1E7-402F-8D90-3C8E28FB5524)