### PR TITLE
DX: Stop swift-safe failures reading as success behind the pipe every caller uses

### DIFF
--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -65,6 +65,19 @@ stale binaries were already there, which is this repo's documented
 test lane cannot silently stop a developer's rebuild.  A build that finds the
 variable set says so once on stderr and queues as usual, because a knob that is
 ignored in silence is indistinguishable from one that does not work.
+
+Every failure of the wrapper itself also names its numeric exit status on a
+final stderr line.  The status is already the process's, but almost nobody
+reads it: this wrapper is nearly always run piped — ``scripts/swift-safe build
+2>&1 | tail -30`` — to keep compiler output out of a context window, and a
+pipeline's ``$?`` belongs to the last command, so the number is `tail`'s and the
+wrapper's is discarded.  Readers of the surviving text have repeatedly
+concluded from that that this wrapper swallows failures and exits 0 — a false
+claim that has reached both a memory file and a CLAUDE.md draft.  Prose cannot
+inoculate against a trap that regenerates the belief on contact, so the number
+is put into the text, where the pipe carries it.  There is deliberately no such
+line for a *compile* failure: the success path execs SwiftPM and this process is
+gone, and that status belongs to SwiftPM.
 """
 
 from __future__ import annotations
@@ -91,6 +104,19 @@ HOLDER_FIELDS = ("pid", "cwd", "command")
 MAX_REPORTED_COMMAND_CHARACTERS = 120
 COMPILE_SUBCOMMANDS = {"build", "run", "test"}
 SUPPORTED_SUBCOMMANDS = COMPILE_SUBCOMMANDS
+# Every status this wrapper produces itself, and what it means.  SwiftPM's own
+# status is deliberately absent and cannot be added: by then this process has
+# been replaced by the compiler.  A status missing from here still gets its
+# number reported, only without a name.
+EXIT_MEANINGS = {
+    1: "invalid argument or environment value; nothing was compiled",
+    64: "EX_USAGE: unsupported subcommand; nothing was compiled",
+    69: "EX_UNAVAILABLE: no swift executable; nothing was compiled",
+    71: "EX_OSERR: could not exec swift; nothing was compiled",
+    75: "EX_TEMPFAIL: the shared build slot was not obtained, nothing was "
+    "compiled; retrying later is reasonable",
+    76: "yielded the place in the queue; verify this run elsewhere",
+}
 RUN_OPTIONS_WITH_VALUES = {
     "--build-system",
     "--cache-path",
@@ -282,6 +308,24 @@ def _lock_path() -> Path:
 def _report(message: str) -> None:
     """Waiting is diagnostics: stderr only, so stdout stays SwiftPM's alone."""
     print(message, file=sys.stderr, flush=True)
+
+
+def _reported_status(status: int) -> int:
+    """Name a non-zero exit status on stderr, and return it unchanged.
+
+    See the module docstring: the status survives on its own only for a caller
+    that does not pipe us, and almost every caller does.  Complements the
+    explanatory line each failure path already prints rather than repeating it
+    — that line says what went wrong, this one says what `$?` would have been.
+
+    Every failure funnels through here, from `_entry` rather than from the call
+    sites, so a path added later cannot forget the line.
+    """
+    if status:
+        meaning = EXIT_MEANINGS.get(status)
+        detail = f" ({meaning})" if meaning else ""
+        _report(f"swift-safe: exit status {status}{detail}")
+    return status
 
 
 def _holder_fields(lock_path: Path) -> dict[str, str]:
@@ -613,5 +657,25 @@ def main(arguments: list[str]) -> int:
             return 71
 
 
+def _entry(arguments: list[str]) -> int:
+    """`main`, plus the exit-status line, for every way this wrapper can fail.
+
+    Two shapes of failure reach here.  `main` returns a status for the ones it
+    decides itself, and the validation helpers raise `SystemExit` with a message
+    from wherever they are called — the interpreter would print that message and
+    exit 1, so it is printed here instead and the 1 named like any other status.
+    A `SystemExit` carrying anything but a message is re-raised untouched; none
+    is raised today, and guessing a status for one would be inventing a number.
+    """
+    try:
+        status = main(arguments)
+    except SystemExit as refusal:
+        if not isinstance(refusal.code, str):
+            raise
+        _report(refusal.code)
+        return _reported_status(1)
+    return _reported_status(status)
+
+
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    raise SystemExit(_entry(sys.argv[1:]))

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import shlex
 import signal
 import subprocess
+import sys
 import tempfile
 import textwrap
 import time
@@ -474,6 +475,112 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TBD_SWIFT_QUEUE_YIELD_SECONDS", result.stderr)
         self.assertEqual(result.stdout, "")
+
+    # ---- the exit-status line ------------------------------------------
+    #
+    # Every failure of the wrapper ITSELF names the number `$?` would have
+    # carried.  Almost every caller runs this wrapper piped to keep compiler
+    # output out of a context window, and a pipeline's `$?` belongs to the last
+    # command, so the status is discarded and readers of the surviving text
+    # have repeatedly concluded the wrapper exits 0 on failure.  A compile
+    # failure has no such line and cannot: by then the wrapper has exec'd and
+    # the status is SwiftPM's own.
+
+    EXIT_STATUS_PREFIX = "swift-safe: exit status"
+
+    def assertNamesExitStatus(self, result, status, meaning=None):
+        """`$?`, the line naming it, and stdout still free of both."""
+        self.assertEqual(result.returncode, status, result.stderr)
+        self.assertIn(f"{self.EXIT_STATUS_PREFIX} {status}", result.stderr)
+        if meaning is not None:
+            self.assertIn(meaning, result.stderr)
+        # The docstring's standing invariant: a caller parsing SwiftPM's
+        # output sees nothing from this wrapper.
+        self.assertNotIn(self.EXIT_STATUS_PREFIX, result.stdout)
+
+    def test_the_exit_status_survives_a_pipeline_that_discards_it(self):
+        """The whole point: `$?` is `tail`'s, so the number must be in the text."""
+        piped = subprocess.run(
+            [
+                "/bin/sh",
+                "-c",
+                f"{shlex.quote(str(RUNNER))} package resolve 2>&1 | tail -5",
+            ],
+            text=True,
+            capture_output=True,
+            env=self.runner_env(),
+            check=False,
+        )
+        self.assertEqual(piped.returncode, 0, "the pipeline's own status changed")
+        self.assertIn(f"{self.EXIT_STATUS_PREFIX} 64", piped.stdout)
+
+    def test_a_refused_value_names_its_exit_status_and_still_explains(self):
+        """Validation exits through `SystemExit`, not through `main`'s return.
+
+        The status line must reach those paths too — the demonstration that
+        started this was `TBD_SWIFT_JOBS=notanumber` — and must not cost the
+        explanation, which is the half that says what to fix.
+        """
+        refusals = (
+            ({"TBD_SWIFT_JOBS": "notanumber"}, (), "must be a positive integer"),
+            ({"TBD_SWIFT_JOBS": "2"}, ("--jobs", "8"), "exceeds TBD_SWIFT_JOBS"),
+            ({"TBD_SWIFT_LOCK_TIMEOUT_SECONDS": "nan"}, (), "must be a finite number"),
+        )
+        for environment, arguments, explanation in refusals:
+            with self.subTest(environment=environment, arguments=arguments):
+                result = self.run_runner("build", *arguments, **environment)
+                self.assertNamesExitStatus(result, 1)
+                self.assertIn(explanation, result.stderr)
+                self.assertEqual(result.stdout, "")
+
+    def test_an_unsupported_subcommand_names_its_exit_status(self):
+        result = self.run_runner("package", "resolve")
+        self.assertNamesExitStatus(result, 64, "EX_USAGE")
+        self.assertIn("usage:", result.stderr)
+
+    def test_a_missing_swift_names_its_exit_status(self):
+        """No `swift` on PATH and none configured: 69, said in the output.
+
+        `PATH` is narrowed to a directory holding only this interpreter, so
+        the wrapper's own `#!/usr/bin/env python3` still resolves.
+        """
+        without_swift = Path(self.temp.name) / "path-without-swift"
+        without_swift.mkdir()
+        (without_swift / "python3").symlink_to(sys.executable)
+        result = self.run_runner("build", TBD_SWIFT_BIN="", PATH=str(without_swift))
+        self.assertNamesExitStatus(result, 69, "EX_UNAVAILABLE")
+        self.assertIn("swift executable not found", result.stderr)
+
+    def test_a_swift_that_cannot_be_execed_names_its_exit_status(self):
+        """The one failure past the lock: the slot was taken, the exec failed."""
+        self.fake_swift.chmod(0o644)
+        result = self.run_runner("build")
+        self.assertNamesExitStatus(result, 71, "EX_OSERR")
+        self.assertIn("could not exec", result.stderr)
+
+    def test_a_timed_out_wait_names_its_exit_status(self):
+        result = self._contended("build", TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.05")
+        self.assertNamesExitStatus(result, 75, "EX_TEMPFAIL")
+        self.assertIn("timed out", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_a_yielded_queue_place_names_its_exit_status(self):
+        """76 and 75 are routed on differently, so the line must tell them apart."""
+        result = self._contended(
+            "test",
+            TBD_SWIFT_QUEUE_YIELD_SECONDS="0.05",
+            TBD_SWIFT_LOCK_TIMEOUT_SECONDS="30",
+        )
+        self.assertNamesExitStatus(result, 76, "verify this run elsewhere")
+        self.assertNotIn("EX_TEMPFAIL", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_a_run_that_reaches_swiftpm_names_no_exit_status(self):
+        """Success execs SwiftPM; a line here would be this wrapper's, not its."""
+        result = self.run_runner("build")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(self.EXIT_STATUS_PREFIX, result.stderr)
+        self.assertNotIn(self.EXIT_STATUS_PREFIX, result.stdout)
 
 
 class WaitReportingTests(unittest.TestCase):
@@ -1129,6 +1236,23 @@ class OrphanedWrapperTests(unittest.TestCase):
         )
         self.assertNotIn(f"pid={self.wrapper_pid}", self.lock_path.read_text())
         self.assertIn("exited while it was queued", self.reported())
+
+    def test_an_abandoned_wait_names_its_exit_status(self):
+        """75 in the text, for the one failure path no caller can provoke.
+
+        A killed requester is invisible to whoever piped the wrapper — there is
+        no shell left to read `$?` — so the wrapper's own stderr is the only
+        place the status can be recovered from.
+        """
+        shell = self.start_queued_wrapper()
+        self.kill_the_requester(shell)
+        self.assertTrue(
+            self.until(lambda: not swift_safe._process_is_alive(self.wrapper_pid)),
+            "the orphaned wrapper kept waiting for the shared build slot",
+        )
+        self.assertIn("exited while it was queued", self.reported())
+        self.assertIn("swift-safe: exit status 75", self.reported())
+        self.assertIn("EX_TEMPFAIL", self.reported())
 
     def test_allow_orphan_keeps_a_deliberately_detached_wrapper_waiting(self):
         shell = self.start_queued_wrapper(TBD_SWIFT_ALLOW_ORPHAN="1")


### PR DESCRIPTION
## Summary

`scripts/swift-safe` reports its failures correctly — a meaningful exit status,
and an explanatory line on stderr. But nobody runs it bare. Agents and humans
pipe it (`scripts/swift-safe build 2>&1 | tail -30`) to keep compiler output out
of a context window, and in a pipeline `$?` belongs to `tail`. The status is
gone.

That is not a cosmetic loss. A wrapper whose failures read as success trains
readers into a false model of the tool, and this one has done exactly that,
repeatedly:

- the claim "swift-safe exits 0 on failure" was written into an agent memory as
  settled fact;
- PR #679 shipped it from there into `CLAUDE.md` as guidance for every future
  agent, and the review gate blocked it — no supporting evidence existed
  anywhere in the repo, and `os.execv` contradicted the proposed mechanism;
- a subagent re-derived the same false claim again this week, from a piped run,
  and reported it as an observation.

Refuting it in prose does not hold, because the trap regenerates the belief on
contact. The fix has to be in the tool.

After this change, a failure of the wrapper itself ends with a greppable line
naming the number:

```
swift-safe: timed out after 1800s waiting for <lock> (<holder>)
swift-safe: exit status 75 (EX_TEMPFAIL: the shared build slot was not obtained, nothing was compiled; retrying later is reasonable)
```

`$?` is still `tail`'s `0`. The number is now recoverable from the text.

## Why this shape

**No spec.** This adds a diagnostic line to existing failure paths. It revises
no theory of the system, changes no interface anyone routes on, and gates
nothing.

**Not stdout.** The module docstring establishes that this wrapper says nothing
on stdout, so a caller parsing SwiftPM's output sees only SwiftPM. The new line
is stderr, like every other line it emits.

**No exit status value changed.** `scripts/test.sh` routes on them — 75 is
propagated untouched, 76 means "yielded the queue, verify remotely". Moving a
number would break that routing silently. This is additive output only.

**One funnel, above `main`, not a call at each site.** A helper invoked at every
`return` would be forgotten by the next failure path added. It sits above `main`
for a second reason found while building it: the validation refusals
(`_positive_number`, `_requested_jobs`, `_bounded_arguments`, …) `raise
SystemExit(message)` from wherever they are called, so the interpreter prints
and exits 1 without `main` ever returning. A per-return helper would have missed
every one of them. `_entry` catches a message-carrying `SystemExit`, prints it,
and names the 1 like any other status; a `SystemExit` carrying a non-string code
is re-raised untouched rather than having a number invented for it.

## What this PR does

- `EXIT_MEANINGS` — the symbolic meaning of each status the wrapper can exit
  with, so the line says what the number means, not just what it is.
- `_reported_status(status)` — prints for a non-zero status and returns it
  unchanged. Zero is guarded, so the success path stays silent.
- `_entry(arguments)` — wraps `main`, handles the `SystemExit`-raising
  refusals, and is what `__main__` now calls.
- Nine cases in `scripts/test-swift-safe.py`, which already runs in CI.

Covered: **1** (every argument/environment refusal), **64** (unsupported
subcommand), **69** (no `swift` executable), **71** (`os.execv` failed), **75**
(wait timed out, wait abandoned), **76** (queue place yielded).

## Assumptions

**A compile failure is structurally out of reach, and stays that way.** On
success the wrapper `os.execv`s and *becomes* SwiftPM, deliberately: the kernel
flock must be held by the exact process that is compiling, or a killed wrapper
would release the lock while leaving an orphaned compiler running for the next
worktree to overlap. So a compile failure's status is SwiftPM's own and this
process no longer exists to annotate it. Reaching it would mean running SwiftPM
as a subprocess, reintroducing precisely the overlap the lock exists to prevent.
Not attempted; both the module docstring and a test now state the boundary.

The practical consequence for callers is unchanged: **grep build output for
`error:` to detect a compile failure.** What this PR fixes is the separate case
where the wrapper never reached the compiler at all.

## Evidence & verification

**Discriminating.** The new tests were run against the *pre-change* script
(`git show HEAD:scripts/swift-safe` in a scratch tree) alongside the new test
file: `Ran 77 tests … FAILED (failures=10)`. Every new case failed except
`test_a_run_that_reaches_swiftpm_names_no_exit_status`, which is a negative
guard asserting the line is *absent* on the exec path — it passes both before
and after by design, so a future edit cannot leak the line onto a successful
run.

**The win, end to end**, piped exactly as callers pipe it:

```
$ TBD_SWIFT_JOBS=notanumber scripts/swift-safe build 2>&1 | tail -3
TBD_SWIFT_JOBS must be a positive integer, got 'notanumber'
swift-safe: exit status 1 (invalid argument or environment value; nothing was compiled)
piped $?=0
```

- `python3 scripts/test-swift-safe.py` — **77 tests, OK** (was 68).
- `scripts/test.test.sh` — green; it drives the real `swift-safe` end to end.
- No Swift build was run, and none is needed. Nothing in the repo parses this
  wrapper's stderr; `scripts/test.sh` routes on the numeric status, unchanged.

https://claude.ai/code/session_01EWDFBr2uSuR618KFWwitXe

[20260815-consistent-reptile](https://cheapsteak.github.io/tbd/open/?worktree=92B3ECD3-C1E7-402F-8D90-3C8E28FB5524)