### PR TITLE
Fix: stop rebuilding ISO8601 formatters inside the sidebar's remote-session sort

### DIFF
--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -78,13 +78,46 @@ struct RepoSectionView: View {
     /// == repo.id`) that do NOT already own a worktree row in this section,
     /// rendered after every local worktree. See
     /// `RepoSectionView.matchedRemoteSessions` for the filter/sort rule.
+    ///
+    /// Memoized on the two arrays it derives from, because this property is
+    /// evaluated far more often than either of them changes: terminal output
+    /// flushes the SwiftUI graph continuously, and each evaluation would
+    /// otherwise re-run the filter and the date-parsing sort. A hit costs one
+    /// pointer comparison per array — `Array`'s `==` short-circuits on buffer
+    /// identity, and both arrays are handed out unchanged by `AppState` while
+    /// nothing has mutated them.
     var matchedRemoteSessions: [RemoteSessionInfo] {
-        RepoSectionView.matchedRemoteSessions(
-            appState.remoteSessions,
+        let sessions = appState.remoteSessions
+        let sectionWorktrees = appState.worktrees[repo.id] ?? []
+        if let cached = RepoSectionView.matchedRemoteSessionsCache[repo.id],
+           cached.sessions == sessions,
+           cached.worktrees == sectionWorktrees {
+            return cached.result
+        }
+        let result = RepoSectionView.matchedRemoteSessions(
+            sessions,
             repoID: repo.id,
-            worktrees: appState.worktrees[repo.id] ?? []
+            worktrees: sectionWorktrees
         )
+        RepoSectionView.matchedRemoteSessionsCache[repo.id] =
+            (sessions: sessions, worktrees: sectionWorktrees, result: result)
+        return result
     }
+
+    /// Backing store for the memoization above: one entry per repo section
+    /// that has rendered, replaced in place. It is bounded by the number of
+    /// repos, and each entry holds only arrays `AppState` already owns.
+    ///
+    /// A plain `static var` rather than `@State`: it is written from inside a
+    /// `body` evaluation, and SwiftUI state written during a view update
+    /// faults with "Modifying state during view update" (the same hazard that
+    /// keeps `AppState`'s derived caches off `@Published`). `RepoSectionView`
+    /// is inferred `@MainActor` from `View`, so this storage is
+    /// main-actor-isolated and race-free; the `nonisolated` statics below
+    /// deliberately never touch it, which keeps them callable — and pure —
+    /// from a plain test context.
+    @MainActor private static var matchedRemoteSessionsCache:
+        [UUID: (sessions: [RemoteSessionInfo], worktrees: [Worktree], result: [RemoteSessionInfo])] = [:]
 
     private var activeWorktreeCount: Int {
         (appState.worktrees[repo.id] ?? [])
@@ -420,26 +453,40 @@ struct RepoSectionView: View {
         }
     }
 
+    /// Parses the fractional-seconds ISO 8601 profile
+    /// (`2026-07-24T18:02:11.123Z`). Shared rather than built per call:
+    /// `ISO8601DateFormatter.init` bottoms out in ICU's `udat_open`, and
+    /// `isOrderedByCreation` parses both of its operands on every comparison.
+    ///
+    /// `nonisolated(unsafe)`, the pattern `DiffSyntaxHighlighter`'s shared
+    /// highlighters use, keeps it reachable from `parsedCreatedAt` — which is
+    /// `nonisolated` so a plain test context can call it without hopping to
+    /// `RepoSectionView`'s inferred `@MainActor` isolation. `formatOptions` is
+    /// set once here and never mutated afterwards, and a configured
+    /// `ISO8601DateFormatter` is safe to read from concurrently.
+    nonisolated(unsafe) private static let fractionalSecondsFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// Parses the whole-second ISO 8601 profile (`2026-07-24T18:00:00Z`),
+    /// shared for the same reason as `fractionalSecondsFormatter`. Two
+    /// formatters and not one: `ISO8601DateFormatter` does not accept both
+    /// profiles in a single `formatOptions` value.
+    nonisolated(unsafe) private static let wholeSecondsFormatter = ISO8601DateFormatter()
+
     nonisolated static func parsedCreatedAt(_ raw: String?) -> Date? {
         guard let raw else { return nil }
-        // A fresh formatter per call (rather than a cached `static let`)
-        // sidesteps `RepoSectionView`'s inferred `@MainActor` isolation
-        // (from being a `View`) so this stays callable from a plain
-        // `nonisolated` test context — session counts are small enough that
-        // the allocation cost here is a non-issue.
-        //
         // `docs/remote-provider-contract.md` shows a whole-second
         // `created_at` example but never pins a profile, so a conforming
         // provider can legally emit fractional seconds
         // (`2026-07-24T18:02:11.123Z`) — a default-options formatter rejects
         // those outright, sorting every such row as undated. Try
         // `.withFractionalSeconds` first, then fall back to the plain
-        // whole-second profile — `ISO8601DateFormatter` does not accept both
-        // in one `formatOptions` value.
-        let fractional = ISO8601DateFormatter()
-        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = fractional.date(from: raw) { return date }
-        return ISO8601DateFormatter().date(from: raw)
+        // whole-second profile.
+        if let date = RepoSectionView.fractionalSecondsFormatter.date(from: raw) { return date }
+        return RepoSectionView.wholeSecondsFormatter.date(from: raw)
     }
 
     // MARK: - The cloud gate — pure, view-free forms of what the two owned

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import os
 import SwiftUI
 import TBDShared
 
@@ -82,10 +83,16 @@ struct RepoSectionView: View {
     /// Memoized on the two arrays it derives from, because this property is
     /// evaluated far more often than either of them changes: terminal output
     /// flushes the SwiftUI graph continuously, and each evaluation would
-    /// otherwise re-run the filter and the date-parsing sort. A hit costs one
-    /// pointer comparison per array — `Array`'s `==` short-circuits on buffer
-    /// identity, and both arrays are handed out unchanged by `AppState` while
-    /// nothing has mutated them.
+    /// otherwise re-run the filter and the date-parsing sort.
+    ///
+    /// The two comparisons are not equally cheap. `AppState` guards its
+    /// `worktrees` writes on inequality, so a refresh that changed nothing
+    /// hands back the same buffer and `Array`'s `==` short-circuits on buffer
+    /// identity. `remoteSessions` is assigned unconditionally on every
+    /// `refreshRemote()`, so that comparison degrades to an elementwise one —
+    /// still far cheaper than the sort it replaces, and `refreshRemote()` is
+    /// driven by change events rather than a timer, so it mostly runs when a
+    /// recompute was due anyway.
     var matchedRemoteSessions: [RemoteSessionInfo] {
         let sessions = appState.remoteSessions
         let sectionWorktrees = appState.worktrees[repo.id] ?? []
@@ -105,8 +112,13 @@ struct RepoSectionView: View {
     }
 
     /// Backing store for the memoization above: one entry per repo section
-    /// that has rendered, replaced in place. It is bounded by the number of
-    /// repos, and each entry holds only arrays `AppState` already owns.
+    /// that has rendered, replaced in place. Entries are never evicted, so the
+    /// bound is repos rendered over the life of the process, not repos
+    /// currently registered — removing a repo from the list leaves an inert
+    /// entry behind. That is deliberate: repos are low-cardinality and
+    /// user-created, each entry only retains array buffers `AppState` already
+    /// owns, and a removed repo whose section renders again wants the entry
+    /// anyway.
     ///
     /// A plain `static var` rather than `@State`: it is written from inside a
     /// `body` evaluation, and SwiftUI state written during a view update
@@ -453,28 +465,43 @@ struct RepoSectionView: View {
         }
     }
 
-    /// Parses the fractional-seconds ISO 8601 profile
-    /// (`2026-07-24T18:02:11.123Z`). Shared rather than built per call:
-    /// `ISO8601DateFormatter.init` bottoms out in ICU's `udat_open`, and
-    /// `isOrderedByCreation` parses both of its operands on every comparison.
+    /// The two ISO 8601 profiles `parsedCreatedAt` accepts, built once and
+    /// reused. `ISO8601DateFormatter.init` bottoms out in ICU's `udat_open`,
+    /// and `isOrderedByCreation` parses both of its operands on every
+    /// comparison, so building them per call dominated the sort.
     ///
-    /// `nonisolated(unsafe)`, the pattern `DiffSyntaxHighlighter`'s shared
-    /// highlighters use, keeps it reachable from `parsedCreatedAt` — which is
-    /// `nonisolated` so a plain test context can call it without hopping to
-    /// `RepoSectionView`'s inferred `@MainActor` isolation. `formatOptions` is
-    /// set once here and never mutated afterwards, and a configured
-    /// `ISO8601DateFormatter` is safe to read from concurrently.
-    nonisolated(unsafe) private static let fractionalSecondsFormatter: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter
-    }()
+    /// Two formatters and not one: `ISO8601DateFormatter` does not accept both
+    /// profiles in a single `formatOptions` value. `formatOptions` is set here
+    /// and never mutated afterwards.
+    ///
+    /// `@unchecked Sendable` because `ISO8601DateFormatter` is not `Sendable`:
+    /// the conformance is what lets the value sit behind
+    /// `OSAllocatedUnfairLock`, and the lock is what makes it true — the
+    /// instances are unreachable except through `withLock`, and nothing
+    /// mutates them after `init`.
+    private struct CreatedAtParsers: @unchecked Sendable {
+        let fractionalSeconds: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+        let wholeSeconds = ISO8601DateFormatter()
+    }
 
-    /// Parses the whole-second ISO 8601 profile (`2026-07-24T18:00:00Z`),
-    /// shared for the same reason as `fractionalSecondsFormatter`. Two
-    /// formatters and not one: `ISO8601DateFormatter` does not accept both
-    /// profiles in a single `formatOptions` value.
-    nonisolated(unsafe) private static let wholeSecondsFormatter = ISO8601DateFormatter()
+    /// Guards the shared parsers. `parsedCreatedAt` is `nonisolated` so a
+    /// plain test context can call it without hopping to `RepoSectionView`'s
+    /// inferred `@MainActor` isolation, and Swift Testing runs suites in
+    /// parallel — so two threads genuinely can reach one formatter at once,
+    /// even though every caller in the app is already on the main actor.
+    ///
+    /// A lock rather than `nonisolated(unsafe)` because the platform does not
+    /// promise what that would assume: `DateFormatter` is declared
+    /// `NS_SWIFT_SENDABLE`, and `ISO8601DateFormatter` — sharing the same
+    /// audited header — is not. An uncontended `os_unfair_lock` acquire is
+    /// nothing next to the ICU parse it wraps, so the guarantee is close to
+    /// free here.
+    nonisolated private static let createdAtParsers =
+        OSAllocatedUnfairLock(initialState: CreatedAtParsers())
 
     nonisolated static func parsedCreatedAt(_ raw: String?) -> Date? {
         guard let raw else { return nil }
@@ -485,8 +512,10 @@ struct RepoSectionView: View {
         // those outright, sorting every such row as undated. Try
         // `.withFractionalSeconds` first, then fall back to the plain
         // whole-second profile.
-        if let date = RepoSectionView.fractionalSecondsFormatter.date(from: raw) { return date }
-        return RepoSectionView.wholeSecondsFormatter.date(from: raw)
+        return RepoSectionView.createdAtParsers.withLock { parsers -> Date? in
+            if let date = parsers.fractionalSeconds.date(from: raw) { return date }
+            return parsers.wholeSeconds.date(from: raw)
+        }
     }
 
     // MARK: - The cloud gate — pure, view-free forms of what the two owned

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -87,9 +87,11 @@ struct RepoSectionView: View {
     ///
     /// The two comparisons are not equally cheap. `AppState` guards its
     /// `worktrees` writes on inequality, so a refresh that changed nothing
-    /// hands back the same buffer and `Array`'s `==` short-circuits on buffer
-    /// identity. `remoteSessions` is assigned unconditionally on every
-    /// `refreshRemote()`, so that comparison degrades to an elementwise one —
+    /// hands back the same buffer, which `Array`'s `==` is implemented to
+    /// short-circuit on — an optimization, not a guaranteed contract, and
+    /// correctness here does not rest on it: without the short-circuit the
+    /// comparison is merely elementwise. `remoteSessions` is assigned
+    /// unconditionally on every `refreshRemote()`, so it is elementwise —
     /// still far cheaper than the sort it replaces, and `refreshRemote()` is
     /// driven by change events rather than a timer, so it mostly runs when a
     /// recompute was due anyway.
@@ -115,10 +117,12 @@ struct RepoSectionView: View {
     /// that has rendered, replaced in place. Entries are never evicted, so the
     /// bound is repos rendered over the life of the process, not repos
     /// currently registered — removing a repo from the list leaves an inert
-    /// entry behind. That is deliberate: repos are low-cardinality and
-    /// user-created, each entry only retains array buffers `AppState` already
-    /// owns, and a removed repo whose section renders again wants the entry
-    /// anyway.
+    /// entry behind, holding the two source arrays as they stood at that
+    /// render — including a snapshot of the whole `remoteSessions` list, which
+    /// `AppState` may since have replaced — plus the derived result, which is
+    /// this cache's own. That is deliberate: repos are low-cardinality and
+    /// user-created, and a removed repo whose section renders again wants the
+    /// entry anyway.
     ///
     /// A plain `static var` rather than `@State`: it is written from inside a
     /// `body` evaluation, and SwiftUI state written during a view update
@@ -474,12 +478,11 @@ struct RepoSectionView: View {
     /// profiles in a single `formatOptions` value. `formatOptions` is set here
     /// and never mutated afterwards.
     ///
-    /// `@unchecked Sendable` because `ISO8601DateFormatter` is not `Sendable`:
-    /// the conformance is what lets the value sit behind
-    /// `OSAllocatedUnfairLock`, and the lock is what makes it true — the
-    /// instances are unreachable except through `withLock`, and nothing
-    /// mutates them after `init`.
-    private struct CreatedAtParsers: @unchecked Sendable {
+    /// Deliberately NOT `Sendable`, which is what makes the confinement below
+    /// machine-checked rather than merely intended: `withLock` requires its
+    /// return type to be `Sendable`, so a body that handed a formatter back
+    /// out — `withLock { $0 }` — fails to compile.
+    private struct CreatedAtParsers {
         let fractionalSeconds: ISO8601DateFormatter = {
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -495,13 +498,21 @@ struct RepoSectionView: View {
     /// even though every caller in the app is already on the main actor.
     ///
     /// A lock rather than `nonisolated(unsafe)` because the platform does not
-    /// promise what that would assume: `DateFormatter` is declared
-    /// `NS_SWIFT_SENDABLE`, and `ISO8601DateFormatter` — sharing the same
-    /// audited header — is not. An uncontended `os_unfair_lock` acquire is
-    /// nothing next to the ICU parse it wraps, so the guarantee is close to
+    /// promise what that would assume. Both `NSDateFormatter.h` and
+    /// `NSISO8601DateFormatter.h` are audited for sendability, and only
+    /// `DateFormatter` carries `NS_SWIFT_SENDABLE` ("All mutable state
+    /// protected by locks") — so the subclass's silence is a deliberate
+    /// withholding, not an oversight. An uncontended `os_unfair_lock` acquire
+    /// is nothing next to the ICU parse it wraps, so the guarantee is close to
     /// free here.
+    ///
+    /// `uncheckedState:` rather than `initialState:` because the state is not
+    /// `Sendable` — see `CreatedAtParsers`. That is the point: it is the
+    /// unconstrained initializer that lets a non-`Sendable` value be locked,
+    /// and keeping the value non-`Sendable` is what makes escaping it a
+    /// compile error.
     nonisolated private static let createdAtParsers =
-        OSAllocatedUnfairLock(initialState: CreatedAtParsers())
+        OSAllocatedUnfairLock(uncheckedState: CreatedAtParsers())
 
     nonisolated static func parsedCreatedAt(_ raw: String?) -> Date? {
         guard let raw else { return nil }


### PR DESCRIPTION
## What's broken

Scrolling a terminal in TBD burns main-thread time in the sidebar, in
proportion to how many repo sections are expanded. The work has nothing to do
with the terminal: it is the repo sections re-deriving their list of remote
sessions, over and over, while nothing about those sessions changes.

As reported on #714, sampling a live app during a 20-second terminal scroll put
**318 of 3,921 busy main-thread samples (~8%)** in a single sort — multiplied
by every expanded repo section, of which the profiled machine had seven. That
profile is the issue's, not re-measured on this branch; the chain it resolved
to:

    RepoSectionView.body -> expandedContent -> matchedRemoteSessions
      -> Sequence.sorted(by:) -> _insertionSort -> isOrderedByCreation
      -> parsedCreatedAt -> NSISO8601DateFormatter.init -> udat_open (ICU)

## Why it happens

Two compounding causes, one per layer.

`matchedRemoteSessions` was a computed property, so it re-ran its filter and
its sort on *every* SwiftUI body evaluation. Terminal output flushes the
SwiftUI graph continuously, so "every body evaluation" is a great many times a
second — while the underlying session list changes rarely.

Underneath it, the comparator parsed both operands' `created_at` on every
comparison, and each parse built a fresh `ISO8601DateFormatter` — up to two, as
it tries the fractional-seconds profile before falling back to whole seconds.
Constructing one bottoms out in ICU's `udat_open`, which is expensive out of
proportion to the parse it enables.

The session count was never the problem: 26 on the profiled machine. The call
frequency was.

## What this PR does

**Shares the formatters.** The two profiles now live in a `CreatedAtParsers`
value built once, instead of being constructed per call. Both parse branches
are preserved in the same order — `ISO8601DateFormatter` cannot express the
fractional and whole-second profiles in one `formatOptions` value, and
`docs/remote-provider-contract.md` pins neither, so a conforming provider may
legally emit either.

**Memoizes the property.** `matchedRemoteSessions` caches its result per repo,
keyed on the two `AppState` arrays it derives from. A body evaluation that
changed neither reuses the previous answer.

Sort order and tie-breaking are untouched: undated sessions still sort last,
ties still break on `id.uuidString`, and the existing ordering tests pass
unmodified.

### Why a lock rather than `nonisolated(unsafe)`

The obvious shape for shared formatters here is `nonisolated(unsafe) static
let`, the pattern `DiffSyntaxHighlighter` uses. This PR puts them behind an
`OSAllocatedUnfairLock` instead, because that pattern's own comment states the
precondition it relies on — "keep call sites main-actor-only" — and
`parsedCreatedAt` deliberately breaks it. It is `nonisolated` so a plain test
context can call it, and Swift Testing runs suites in parallel, so more than
one thread really can reach one formatter.

The platform does not back the guarantee that would make the unsafe version
sound. Both `NSDateFormatter.h` and `NSISO8601DateFormatter.h` are audited for
sendability, and only `DateFormatter` carries `NS_SWIFT_SENDABLE` ("All mutable
state protected by locks") — so the subclass's silence is a deliberate
withholding, not an oversight. An uncontended `os_unfair_lock` acquire is
negligible against an ICU parse, so this buys the guarantee rather than
assuming it. In the app the lock is uncontended anyway; every caller is already
on the main actor.

The state is deliberately **not** `Sendable`, and is constructed with
`init(uncheckedState:)`. That is what makes the confinement machine-checked:
`withLock` constrains its return type to `Sendable`, so a body that handed a
formatter back out — `withLock { $0 }` — does not compile. An earlier revision
of this branch marked the state `@unchecked Sendable` and thereby made exactly
that escape legal, while the comment claimed it was impossible; the review
caught it.

## Assumptions

- **The memoization assumes `matchedRemoteSessions(_:repoID:worktrees:)` stays
  pure in its three arguments.** It reads no clock and no ambient state today.
  If a future filter consults anything outside those arguments, the cache will
  serve stale rows and the memoization must gain that input as a key.
- **It assumes `Equatable` on the models stays total over the fields the
  filter reads.** `RemoteSessionInfo`, `RemoteSessionPayload`, `Worktree`, and
  `WorktreeLocation` all use synthesized conformances. A hand-written `==` that
  ignored a field the filter reads would make equal-but-different inputs
  indistinguishable to the cache.
- **Cache entries are never evicted.** The bound is repos rendered over the
  process lifetime, not repos currently registered; removing a repo leaves an
  inert entry holding array buffers `AppState` already owns. Deliberate — repos
  are low-cardinality and user-created.

## Evidence & verification

- **The repro** (from #714, not re-run here): `sample` against a live app during
  a 20s terminal scroll with seven repo sections expanded, yielding the
  318/3,921 figure and the call chain above. This branch did not reproduce that
  profile, so the sampling evidence is cited rather than claimed — the
  measurements below are the ones taken here.
- **Discriminating measurement**: a harness running the old fresh-per-call
  implementation against the new shared one over 20,000 parses, three runs.
  Cached was consistently **4.4-5x faster** (e.g. 5001 ms -> 993 ms). Absolute
  per-parse numbers are inflated by concurrent builds from sibling worktrees on
  this machine and are not quoted; the ratio is the signal.
- **Parse parity**: the same harness asserts old and new return equal `Date?`
  for a whole-second timestamp, a fractional-seconds timestamp, and an
  unparseable string. All three agree, so both branches still behave
  identically.
- **Ordering**: `RepoSectionRemoteSessionsTests`, `RemoteSectionViewTests`, and
  `RemoteLaneSurfaceTests` — 93 tests in 3 suites, passing unmodified.
- **The no-escape guarantee is mutation-checked, not asserted**: the sanctioned
  `withLock { ... -> Date? }` compiles and parses all three profiles, while
  `withLock { $0 }` fails to compile with "type `CreatedAtParsers` does not
  conform to the `Sendable` protocol". Both directions were compiled, not
  reasoned about.

**Not covered by tests**: the memoization itself. `matchedRemoteSessions` at
`:81` reads `appState` through `@EnvironmentObject`, which traps outside a view
hierarchy, so the cache-hit path is not reachable from a plain test context —
and making it reachable would mean reshaping the property's inputs, which is
the surface #667 is actively migrating. The pure static function keeps its
existing coverage; the memoization is covered by live verification instead.

## Relationship to #667

Deliberately disjoint from the `AppState` `@Observable` migration. This change
does not touch `RepoSectionView.swift:29` or the observation mechanism, so #667
rebases over it cleanly. The two are complementary: #667 reduces how often the
body runs, this reduces what each run costs. The memoization also stays correct
under `@Observable` — both arrays are read unconditionally *before* the cache
check, so dependency tracking still registers on a cache hit.

## Follow-ups, deliberately not in this PR

- **The cache's home.** Review suggested moving it to `AppState` beside
  `childrenIndexCache`, which would give it `didSet` invalidation instead of a
  per-read array comparison, bound its lifetime to `AppState`, and make it
  testable. That is probably the better long-term shape, but it means touching
  `AppState` and the observation mechanism, which this PR stays clear of so
  #667 rebases cleanly. Worth revisiting after #667 lands.
- **`TranscriptParser.swift:11-19`** carries the claim this PR's review
  rejected — "`ISO8601DateFormatter` is documented as thread-safe for read-only
  use" — over an unlocked shared formatter in a `nonisolated enum`. Pre-existing
  and outside this diff, but the header evidence above says that comment is
  wrong. Precedent for the fix: `032c204e`, which wrapped the identical pattern
  in `SuspendResumeCoordinator` with an `NSLock`.

Fixes #714

[20260825-hostile-chicken](https://cheapsteak.github.io/tbd/open/?worktree=5FB7ED38-C53A-4677-BA79-44E6A1F6C658)
