### PR TITLE
Fix: Archived-worktree backfill rewrote remote lanes' branches from the local reflog

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
+++ b/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
@@ -42,9 +42,16 @@ public struct ArchivedWorktreeBackfill: Sendable {
 
     /// Run the backfill for a single repo. `internal` so tests can drive it directly.
     func runForRepo(repo: Repo) async {
-        let archived: [Worktree]
+        // `listLocal`, not `list`: this pass probes each row's branch against
+        // the repo's checkout on THIS disk, so a remote lane — which has no
+        // checkout here — is not broken, it is out of scope. Probing one would
+        // classify it broken on every daemon start, and a local reflog rename
+        // that happened to key on its branch name would rewrite a row that was
+        // never wrong. (`limit`/`offset` are applied in SQL before the
+        // location filter; this call passes neither, so that caveat is moot.)
+        let archived: [LocalWorktree]
         do {
-            archived = try await db.worktrees.list(repoID: repo.id, status: .archived)
+            archived = try await db.worktrees.listLocal(repoID: repo.id, status: .archived)
         } catch {
             logger.warning("backfill: failed to list archived worktrees for \(repo.displayName, privacy: .public): \(error, privacy: .public)")
             return
@@ -70,7 +77,7 @@ public struct ArchivedWorktreeBackfill: Sendable {
                 renameMap = await mineReflogRenames(repoPath: repo.path)
             }
 
-            await attemptRepair(worktree: wt, repo: repo, renameMap: renameMap ?? [:])
+            await attemptRepair(worktree: wt.worktree, repo: repo, renameMap: renameMap ?? [:])
         }
     }
 

--- a/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
+++ b/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
@@ -249,6 +249,59 @@ import Testing
     #expect(after?.archivedHeadSHA == beforeSHA)
 }
 
+/// A remote lane has no checkout on this disk, so the backfill — which probes
+/// every archived row's branch against the LOCAL repo — must leave it alone.
+/// Made to bite: the local reflog carries a rename keyed by exactly the lane's
+/// branch name, so a pass that fetches location-neutrally does not merely log a
+/// spurious warning, it rewrites the lane's branch to an unrelated local one.
+@Test func testBackfillIgnoresRemoteLanes() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let git = GitManager()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // A local archived row that genuinely needs repair, so the assertions below
+    // tell "skipped the remote lane" apart from "did nothing at all".
+    let local = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    let localOriginal = local.branch
+    let localRenamed = "renamed-\(UUID().uuidString.prefix(6))"
+    try await shell("git branch -m \(localRenamed)", at: URL(fileURLWithPath: local.localPath))
+    try await lifecycle.archiveWorktree(worktreeID: local.id, force: true)
+    try await db.worktrees.updateBranch(id: local.id, branch: localOriginal)
+    try await db.worktrees.updateArchivedHeadSHA(id: local.id, sha: nil)
+
+    // The trap: a local branch named like the lane's, renamed away. The lane's
+    // branch now resolves to nothing locally AND appears as a rename key.
+    let laneBranch = "lane-\(UUID().uuidString.prefix(6))"
+    let decoyBranch = "decoy-\(UUID().uuidString.prefix(6))"
+    try await shell(
+        "git branch \(laneBranch) && git branch -m \(laneBranch) \(decoyBranch)", at: repoDir)
+
+    // Mint the lane through the production path, then archive it the same way.
+    let lane = try await db.worktrees.createRemote(
+        repoID: repo.id, name: "lane", branch: laneBranch,
+        provider: "agentbox", sessionID: "s-\(UUID().uuidString.prefix(6))")
+    try await db.worktrees.archive(id: lane.id)
+
+    let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+    await backfill.run()
+
+    // The lane is untouched: branch not rewritten to the decoy, no SHA invented.
+    let laneAfter = try await db.worktrees.get(id: lane.id)
+    #expect(laneAfter?.branch == laneBranch)
+    #expect(laneAfter?.archivedHeadSHA == nil)
+
+    // ...while the local row it was listed alongside still got repaired.
+    let localAfter = try await db.worktrees.get(id: local.id)
+    #expect(localAfter?.branch == localRenamed)
+    #expect(localAfter?.archivedHeadSHA?.isEmpty == false)
+}
+
 // MARK: - Revive must --resume archived Claude sessions
 
 /// Captures the argv tmux would have been invoked with so we can assert the


### PR DESCRIPTION
## What's broken

Every time the daemon starts, a one-shot pass walks each repo's archived worktrees looking for rows whose branch was renamed out from under them, and repairs those from the repo's reflog. That pass also picked up **remote lanes** — archived rows for agent sessions running on a machine TBD does not manage, which have no checkout on this disk at all.

A remote lane's branch generally does not exist in the local repo, so every one of them was classified "broken" on every daemon start. Cheapest outcome: a wasted `git` subprocess per remote row, a full local reflog mine (`git log -g --all`) that would otherwise have been skipped, and a warning logged forever — `branch '<name>' missing and no rename found in reflog` — for a row that was never wrong.

The expensive outcome is silent corruption. If the local reflog happens to contain a rename keyed by that branch name — someone renamed a local branch that shares the name, which is entirely plausible when a lane and a local worktree are working the same ticket — the pass "repairs" the remote lane by rewriting its branch to the local one and inventing an `archivedHeadSHA` from that local branch's HEAD. The lane's own branch name is then lost from the DB, and a later revive would follow the wrong ref.

## Why it happens

`ArchivedWorktreeBackfill.runForRepo` fetched its rows with the location-neutral `db.worktrees.list(repoID:status:.archived)`. That list is deliberately location-blind — it is what the `worktree.list` RPC needs — so it returns remote rows alongside local ones. Each row then went straight into `git.refExists(repoPath: repo.path, ref: wt.branch)`, a probe against this machine's checkout, which is a question a remote lane has no meaningful answer to.

The repo already has the fence for exactly this: `WorktreeStore.listLocal(...)` returns `[LocalWorktree]`, a type over rows proven to have files here. Reconcile states the rationale in as many words:

> Every fetch in this sweep is `listLocal`, not `list`. Reconcile's whole job is to make DB rows agree with what git and tmux report on THIS disk, so a row with no local checkout is not stale — it is out of scope.

The backfill has the same job and the same scope. It simply was not switched over.

## When it broke

Remote lanes, `WorktreeLocation`, `LocalWorktree` and the `listLocal` fence all arrived together in #613, which converted the local-only subsystems it found — reconcile, orphan GC, crash recovery, the scratchpad sweeps — to the fenced fetch. `ArchivedWorktreeBackfill` predates all of that (it landed in #93, when every row was local by construction) and was missed in that sweep. It has been reading remote rows since the first remote lane was archived. Nothing caught it because the pass never throws, never deletes, and logs at warning level from a daemon-start path nobody reads — and the corrupting branch only fires on a reflog-name coincidence.

## What this PR does

Swaps the one fetch to `listLocal`, so the pass only ever sees rows with a checkout on this disk, and passes `wt.worktree` through to the unchanged repair helper. Everything else is identical: same trigger, same cadence, same repair logic, same idempotence.

This restores the pass to the theory the system already holds, so it ships as a bug fix — no spec, no flag, no config column, no migration. It deliberately does **not** change whether or how often the backfill runs, add a persisted "unresolvable" marker, or bound the pass; those are separate work.

`listLocal`'s doc comment warns that `limit`/`offset` are applied in SQL *before* the location filter, so a page containing remote rows yields fewer than `limit` locals. Checked rather than assumed: this call site passes neither, so the caveat does not apply.

## Assumptions

- Assumes `LocalWorktree.init?` remains the single definition of "has files on this disk". If a third location kind appears that is local-ish but not a plain checkout, this call site inherits whatever that constructor decides — which is the intent.

## Evidence & verification

**Discriminating test.** `testBackfillIgnoresRemoteLanes` seeds one repo with two archived rows: a local one that genuinely needs repair, and a remote lane minted through the production path (`db.worktrees.createRemote` + `db.worktrees.archive`, not a hand-built row). The lane's branch name is also the key of a real rename in the repo's reflog, so an unfixed pass does not merely log — it rewrites the row.

Verified by actually reverting the production change and re-running:

```
✘ Expectation failed: (laneAfter?.branch → "decoy-811206") == (laneBranch → "lane-92B70B")
✘ Expectation failed: (laneAfter?.archivedHeadSHA → "ac16f82d...") == nil
✘ Test testBackfillIgnoresRemoteLanes() failed after 0.430 seconds with 2 issues.
```

That is the corruption, reproduced. With the fix restored, all 5 `testBackfill*` tests pass, and the local row alongside the lane is still repaired — so the assertion distinguishes "skipped the lane" from "did nothing at all".

**Full suite.** 8156 tests, 789 suites. Three reds, all reproduced-clean on rerun or known: `OrphanProcessCollector.parseLiveCWDs` (the standing `/tmp` vs `/private/tmp` realpath red on this box, still failing in isolation), plus a `MarkdownStylesheet` FileWatcher test and a `terminal.activityEvent` `waitUntil` timeout that both pass when rerun in isolation — load flakes, not assertion failures.

`swiftlint --strict`: 0 violations in 824 files. `scripts/swift-safe build`: clean, no `error:` lines.

## Note for the reviewer: a conflicting change is in flight

Branch `tbd/20260825-healthy-spider` is rewriting this same function — deferring the whole pass to after the RPC listener binds, and replacing the per-row `refExists` with a single `GitManager.refTips(repoPath:)` fast negative filter. It has no PR open as of this writing, so this one lands first. If it goes in ahead, the resolution stays a one-line fetch swap regardless of how the surrounding loop ends up: the `list` → `listLocal` change and the `wt.worktree` unwrap are the whole of it, and they are orthogonal to both of those changes.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0C57DBB1-1A7D-4F25-AD2E-689C93B4F14D)