### PR TITLE
docs: terminal render-cost investigation, engine options, and two specs acting on them

### DIFF
--- a/docs/perf/2026-08-25-terminal-engine-options.md
+++ b/docs/perf/2026-08-25-terminal-engine-options.md
@@ -156,11 +156,43 @@ the default path carries none of those costs: no octal re-encoding, no send-keys
 input path, no state reconciliation. So the reversal indicts the path TBD is not
 currently using far more than the path it is.
 
-The fullscreen-incompatibility claim in that list is unverified and worth
-checking on its own terms. It is asserted without citation by a team that had
-built and measured the arrangement, and if it holds it is a product-level
-constraint on the control-mode design that stands regardless of which engine
-renders.
+The fullscreen-incompatibility claim in that list holds, and it is a
+product-level constraint on the control-mode design that stands regardless of
+which engine renders.
+
+The hosted agent's own documentation states that its fullscreen renderer is
+incompatible with a terminal's tmux integration mode — the mode entered with
+`tmux -CC` — because that host renders each tmux pane itself rather than letting
+tmux draw to the terminal. The documented symptoms are that the alternate screen
+buffer and mouse tracking do not work correctly: the mouse wheel does nothing,
+and a double-click can corrupt terminal state. Regular tmux, without control
+mode, is documented as fine.
+
+Three qualifications matter for TBD.
+
+The incompatibility is scoped to that agent's **fullscreen** renderer, which
+draws on the alternate screen. Its classic renderer keeps output in native
+scrollback and is not documented as broken under control mode. So this
+constrains a rendering mode, not the agent as such.
+
+The mechanism is documented for one specific terminal's integration mode, not for
+control mode as a wire protocol — neither tmux's own documentation nor that
+terminal's states a general rule that alternate-screen applications break under
+control mode. But the mechanism described, a host application rendering panes
+from control-mode output rather than tmux drawing them, is structurally what
+TBD's control mode does. The risk transfers by construction even though the
+citation does not.
+
+The agent ships a mitigation TBD may not inherit: it detects that integration
+mode and declines to start its fullscreen renderer there. That detection
+presumably keys on the specific terminal, and an agent process running inside a
+tmux pane has no obvious way to know that its outer client is some other
+control-mode consumer. TBD could therefore meet the failure without the automatic
+fallback that protects users elsewhere.
+
+What would settle it: run a known alternate-screen application under TBD's own
+control-mode pipeline and observe whether mouse reporting and the alternate
+screen behave, rather than reasoning from a citation scoped to a different host.
 
 ## Confirmed hazards from projects that migrated
 

--- a/docs/perf/2026-08-25-terminal-engine-options.md
+++ b/docs/perf/2026-08-25-terminal-engine-options.md
@@ -1,0 +1,190 @@
+# Terminal engine options: what was found — 2026-08-25
+
+An evidence record for the question "should TBD keep SwiftTerm?", gathered
+2026-08-25 from public sources: the engines' own repositories and headers, the
+committed design documents of projects that have embedded them, and those
+projects' issue trackers. Measured performance evidence lives separately in
+`2026-08-25-terminal-render-cost-investigation.md`; this document is about
+engine and architecture choices, and it deliberately does not decide anything.
+
+Claims below are marked where confidence is less than direct observation.
+
+## The constraint that shapes every option: tmux
+
+Any option that removes tmux is unavailable, because tmux carries far more than
+session persistence. Across the daemon and app, TBD drives `send-keys`,
+`capture-pane`, `list-panes`, `list-windows`, `list-sessions`, `list-clients`,
+`new-session`, `new-window`, `kill-window`, `kill-session`, `kill-server`,
+`has-session`, `set-option`, `select-window`, and `display-message`. Those calls
+back worktree reconciliation, cross-session agent messaging, the pane readers,
+and pane identity for the peer registry — a session is recovered by joining on
+its tmux pane when its name has drifted.
+
+Restart survival is one consumer among many. This matters because the most
+directly comparable migration resolved its difficulties by deleting tmux, an
+option TBD does not have.
+
+## TBD's current configuration, which is not what it looks like
+
+`TBDTerminalView` subclasses SwiftTerm's **base** `TerminalView`, and TBD drives
+it by owning a `LocalProcess` and hand-feeding bytes through `feed(byteArray:)`.
+The command that pty runs is already `tmux attach -t <grouped-session>`.
+
+SwiftTerm ships `LocalProcessTerminalView` — a `TerminalView` subclass that owns
+the process and wires the delegate plumbing itself — and TBD contains no
+reference to it.
+
+So TBD is bytes-fed by construction rather than by necessity: the process is
+local and already spawned, and only the app's manual copy of bytes from its own
+pty into the view puts it in the mode below.
+
+This matters because it is exactly the configuration another project identified
+as SwiftTerm's weak spot (see "The reversal"). It does **not** follow that
+switching classes would improve rendering performance: `LocalProcessTerminalView`
+inherits the same draw path, so the measured costs — per-row attributed-string
+rebuild, an 8-character shaped-line cache, full-viewport invalidation while
+scrolled back — are identical either way. The question it bears on is
+correctness, supported-configuration status, and maintenance, not throughput.
+Why TBD hand-rolls the feed is not established; the plausible reasons are that
+it needs the byte stream for interrupt detection, activity tracking, and the
+control-mode routing switch, none of which the owning class may expose.
+
+## Two different APIs, frequently conflated
+
+Ghostty exposes two embedding surfaces, and confusing them inverts the
+conclusion.
+
+- **`ghostty.h`** — the full terminal, renderer included. Formally disclaimed for
+  external use on 2026-08-10; the commit that landed that wording removed an
+  earlier "(yet)". It exports 91 functions and **none of them writes bytes into a
+  surface**: input is key, mouse, and IME only, and surface config carries a
+  command and environment. A bytes-fed surface is not expressible through it
+  without patching.
+- **`libghostty-vt`** — the API the disclaimer redirects external embedders
+  toward. It is **not** a bare parser: `ghostty_terminal_vt_write(t, bytes, len)`
+  is a documented first-class entry point, `ghostty_terminal_new` takes no
+  command and no pty, and it ships `render.h` (dirty-row incremental render state
+  intended for custom renderers), `snapshot.h`, `selection.h`, key and mouse
+  encoders, and `formatter.h`.
+
+Ghostty officially publishes a prebuilt, signed, Swift-importable
+`ghostty-vt.xcframework`, rebuilt nightly — universal macOS and iOS slices, a
+proper module map, first-party. No Zig toolchain and no fork are required to
+consume it. Its own example tree contains no `forkpty`, and its README names
+replay tooling and log viewers as the intended use.
+
+Upstream has **permanently declined** to ship a renderer alongside it
+(2026-05-12), so a `libghostty-vt` embedder writes its own. Swift is also the
+one major language without a mature binding; the reference binding the project
+wrote is in Go.
+
+## Three paths
+
+**A — `ghostty.h` with host-managed IO.** The full engine, renderer included,
+fed bytes. Requires somebody's fork: five teams have independently built the same
+patch under different names, and upstream has never carried it. Well-trodden in
+the sense that a 26.5k-star project drives `tmux -CC` control mode into mirrored
+surfaces in production — which is close to TBD's shape. Cost: a disclaimed API,
+consumed through a third party's fork, running behind upstream `main`.
+
+**B — `libghostty-vt` with a renderer TBD writes.** Supported API, first-party
+signed artifact, no fork, no Zig. At least one project demonstrates the shape
+forking nothing, feeding bytes from a socket into the VT and rendering with its
+own GPU code. Cost: TBD writes both the renderer and the Swift bindings.
+
+**C — Let the terminal own the pty.** Set the surface's command to
+`tmux attach-session` and stop feeding bytes at all. Four projects independently
+converged here. TBD is unusually close to this already, since its pty command is
+already a tmux attach — the difference is who owns the process.
+
+## The reversal, and why TBD cannot simply copy it
+
+One project built the design TBD would be proposing, and abandoned it within a
+day of shipping v0.1. Its spec first quotes the same complaint about SwiftTerm's
+`feed()` path that motivated this investigation, then concludes: the engine "is
+used as a renderer — just a display fed external bytes — when it should be used
+as a terminal (owning the PTY)." Their remedy was to delete tmux.
+
+TBD cannot make that trade, per the constraint above. The reversal is still the
+most important evidence here, but its conclusion transfers only partially: it
+argues against bytes-fed as an *architecture*, while TBD's bytes-fed-ness is a
+local implementation choice sitting on top of a pty it already owns.
+
+## Confirmed hazards from projects that migrated
+
+Reported by embedders, in their own trackers:
+
+- **Silent data loss.** Several hundred bytes of prompt data dropped, producing
+  blank panes.
+- **Destructive occlusion.** Marking a surface occluded leaves it permanently
+  unfocusable; at least one project ripped the call out. TBD retains up to eight
+  terminals in a keep-alive pager and would meet this immediately.
+- **Scale.** Thirty tabs and twenty-nine surfaces reported at 564-806% CPU,
+  5.2 GB resident, ending in an allocator out-of-memory. This is the single most
+  TBD-relevant report found, given TBD routinely runs far more terminals than
+  that.
+- **Lifecycle ordering.** Feeding a surface before it has been ticked once
+  deadlocks the main thread.
+- **Concurrency in the bytes-fed path specifically.** A three-thread deadlock
+  between a session lock and a blocking write produced an app-wide freeze
+  requiring a kill signal. Independently reported and fixed within a day.
+
+A shipping product using this stack recorded "four production-grade bugs in a few
+weeks, and every one of them lives in the dependency."
+
+**Governance.** Embedding issues filed upstream have been auto-closed within
+seconds by a vouch bot without human review. An embedder should assume it carries
+its own fixes.
+
+## The incumbent
+
+SwiftTerm is actively maintained — roughly 395 commits over 52 weeks, 87% of the
+last 30 pull requests merged with a median around 1.3 days, and another
+commercial team upstreaming fixes concurrently. It ships a Metal renderer that
+TBD has never enabled, and several outstanding pull requests profile a
+multi-pane agent-TUI workload closely resembling TBD's. Its weaknesses are
+specific and patchable rather than structural, on current evidence.
+
+## A dual-backend seam is possible
+
+One project maintains a genuine runtime-switchable dual backend in roughly 240
+lines with a single leaky call site. Another attempted a split backend and let it
+go stale, with the displaced engine becoming dead code. The first is the better
+model: it makes an engine choice reversible and measurable rather than a
+one-way door, and it matches how TBD already gates risky replacements.
+
+## What would settle this
+
+Ordered cheapest first. Each step's result determines whether the next is worth
+taking.
+
+1. **Enable SwiftTerm's Metal renderer and measure** — an afternoon, specced in
+   `docs/specs/2026-08-25-terminal-metal-renderer-design.md`. It discriminates
+   directly between "the CPU renderer is the problem" and "the engine is the
+   problem". A comparable product's answer to the same performance problem
+   appears to be simply that its engine renders on the GPU by default, which this
+   tests without migrating anything.
+2. **Apply the shaped-line cache** if Metal alone is flat — also aimed at the
+   measured hot path, with a reported 91% draw-time reduction on a similar
+   workload.
+3. **Spike path B for a week** if both are flat — against the official signed
+   artifact, wiring the tmux bridge's output into `ghostty_terminal_vt_write`
+   with a crude renderer over the dirty-row render state. Only at this point has
+   the architectural reading earned a migration's cost.
+
+## Open questions
+
+- **Why a comparable bytes-fed product chose that mode** rather than handing the
+  terminal a command. If it had a concrete reason it could not, the same reason
+  likely applies to TBD. Unresolved.
+- **Why TBD hand-feeds** rather than using the engine's process-owning class, and
+  whether the hooks it needs survive the switch.
+- **Whether a VT implementation swap changes replay semantics.** TBD's
+  `ReplayWriter` records deliberate deviations verified against SwiftTerm as its
+  only consumer. Those would have to be re-derived against any other VT. The
+  `formatter.h` surface would allow diffing two implementations on identical
+  replay bytes, which is a correctness check TBD cannot currently perform at all
+  — worth doing even if no migration happens.
+- **Whether an announced pure-Swift renderer with vt bindings ships.** Announced
+  2026-07-02, not released as of this record. It would remove the renderer-writing
+  cost from path B entirely.

--- a/docs/perf/2026-08-25-terminal-engine-options.md
+++ b/docs/perf/2026-08-25-terminal-engine-options.md
@@ -97,6 +97,38 @@ own GPU code. Cost: TBD writes both the renderer and the Swift bindings.
 converged here. TBD is unusually close to this already, since its pty command is
 already a tmux attach — the difference is who owns the process.
 
+## Why other products feed bytes, and why their reasons may not transfer
+
+The two documented reasons both come from one product, stated in its own commits
+and design docs.
+
+**Fan-out and replay.** The engine's process-owning backend admits exactly one
+consumer and offers no tap on the byte stream. That product needed two consumers
+— a local surface and a companion device — plus a one-megabyte replay ring so a
+late attacher could catch up. Owning the pty itself was how it got a stream it
+could fan out.
+
+**A daemon owning session lifetime.** Its later architecture makes a session a
+first-class object living in a daemon, with every UI "a stateless client that
+attaches and detaches" — pty, grid, and scrollback owned by the daemon, and
+rendering, selection, and theme owned by the client. It completed that migration
+on 2026-08-22 by deleting its host-managed pty implementation entirely. Its
+trajectory is away from process ownership, not toward it.
+
+Neither reason clearly binds TBD, and the difference is tmux.
+
+The second does not apply at all: viewer-independent session lifetime is exactly
+what that daemon was built to obtain, and tmux already provides it. The first may
+not either — that product had no multiplexer beneath it, so the app was the only
+place a tap could exist. TBD has one. Control-mode `%output` and `capture-pane`
+both reach the daemon independently of whether the app ever sees a byte, so TBD's
+in-app tap may be redundant with tmux's in a way that product's was not.
+
+That is the question worth answering before choosing a path: **does anything
+other than the visible terminal actually require the app to see the byte
+stream?** If the answer is no, the option of letting the terminal own an attach
+command is open on evidence rather than on optimism.
+
 ## The reversal, and why TBD cannot simply copy it
 
 One project built the design TBD would be proposing, and abandoned it within a
@@ -109,6 +141,26 @@ TBD cannot make that trade, per the constraint above. The reversal is still the
 most important evidence here, but its conclusion transfers only partially: it
 argues against bytes-fed as an *architecture*, while TBD's bytes-fed-ness is a
 local implementation choice sitting on top of a pty it already owns.
+
+The problem list that reversal diagnoses is narrower than it first appears, and
+the distinction matters. Its six complaints are grid mismatches between two
+layout engines, pty output re-encoded to octal and decoded again, keystrokes
+re-encoded through a send-keys path, state reconciliation races, a documented
+incompatibility between fullscreen agent TUIs and tmux control mode, and roughly
+two thousand lines of adapter code spanning a control-mode client, a command
+runner, a state parser, a sync engine, an output router, and resize negotiation.
+
+Every one of those is a property of **control mode**, not of tmux. TBD's
+control-mode subsystem matches that inventory closely, but it is disabled, and
+the default path carries none of those costs: no octal re-encoding, no send-keys
+input path, no state reconciliation. So the reversal indicts the path TBD is not
+currently using far more than the path it is.
+
+The fullscreen-incompatibility claim in that list is unverified and worth
+checking on its own terms. It is asserted without citation by a team that had
+built and measured the arrangement, and if it holds it is a product-level
+constraint on the control-mode design that stands regardless of which engine
+renders.
 
 ## Confirmed hazards from projects that migrated
 
@@ -174,9 +226,11 @@ taking.
 
 ## Open questions
 
-- **Why a comparable bytes-fed product chose that mode** rather than handing the
-  terminal a command. If it had a concrete reason it could not, the same reason
-  likely applies to TBD. Unresolved.
+- **Whether the alternative was ever weighed by the products that chose bytes-fed.**
+  Their reasons *for* the choice are documented (see "Why other products feed
+  bytes"); no document weighs handing the terminal an attach command and rejects
+  it. So the record shows why they chose what they chose, not why they declined
+  the alternative — a distinction worth preserving rather than reading past.
 - **Why TBD hand-feeds** rather than using the engine's process-owning class, and
   whether the hooks it needs survive the switch.
 - **Whether a VT implementation swap changes replay semantics.** TBD's

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -577,3 +577,27 @@ exercised programmatically. Confirming any of this requires that grant, or a hum
 typing into a terminal while signposts are captured. **That is the highest-value
 outstanding measurement in this line of work**, and every keystroke number recorded
 so far is of the wrong path until it is taken.
+
+## Two instrument traps that void captures silently — 2026-08-26
+
+**Signpost emission is gated on a live listener.** Intervals stop being emitted
+the moment no `log stream` is attached, so a `log show` capture taken afterwards
+reads back empty from an application that was working perfectly. An unfiltered
+stream produced 5.2 MB in five seconds with zero lines from the app's subsystem,
+while `log show` over the same minutes returned 1,485 and 4,646 records. An empty
+capture is therefore indistinguishable from a terminal that never drew, and both
+look like a failed measurement rather than a broken instrument. The remedy is to
+keep a stream open purely as an enabler and read the data back through `log show`.
+
+**A modal dialog voids every capture and survives restarts.** With an alert panel
+up, no terminal holds first responder, nothing draws, and no signposts fire. The
+symptom presents as tabs mysteriously "going off screen" and as runs failing their
+validity guards for no visible reason. Check the first responder before trusting a
+void result.
+
+**A probe that avoids side effects may avoid the check as well.** Testing
+keystroke permission with an empty string succeeds without sending anything, and
+so never reaches the permission gate — reporting access that does not exist. The
+paired probe is the fix: run the harmless form and the real form in the same
+shell against the same frontmost application, and compare. Empty exits zero;
+a real key errors with 1002.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -63,18 +63,27 @@ captured *no* scrolling, i.e. uncorrelated.
 
 ## Measured cost, validated windows
 
-Percentages are of all main-thread samples, as top-level subtree totals. Two
-validated scroll windows, against the quiet baseline:
+Percentages are of all main-thread samples. Two validated scroll windows, against
+the quiet baseline.
+
+**Only the four top-level entries below are additive.** Everything indented under
+one is already counted inside its parent, so summing a parent together with its
+children double-counts the subtree — the same trap described above, in the same
+numbers. The nesting here is the guard against it.
 
 - **SwiftUI view-graph flush** (`GraphHost.flushTransactions`) — 25.1% and 18.1%,
   against 3.7% quiet. The largest single consumer during scroll.
+  - of which `RepoSectionView.body` — 3.7% and 3.0%, against 0.7%.
+  - of which `WorktreeRowView.body` — 1.2% and 1.7%, against 0.4%.
+  - `TabBarItem` and `PanePlaceholder` re-evaluate alongside them; the remainder
+    is other view bodies plus the attribute-graph machinery itself.
 - **Terminal draw** (`TerminalView.draw`) — 20.7% and 11.6%, against 4.0% quiet.
   - of which `buildAttributedString` — 12.8% and 7.5%, against 2.2%.
-- `RepoSectionView.body` — 3.7% and 3.0%, against 0.7%.
-- `WorktreeRowView.body` — 1.2% and 1.7%, against 0.4%.
-- Blink lifecycle scan — 1.4% and 1.0% during scroll, but **6.1% of the quiet
-  baseline's main thread**.
-- Terminal feed and parse — around 2.7%.
+- **Blink lifecycle scan** — 1.4% and 1.0% during scroll, but **6.1% of the quiet
+  baseline's main thread**. Note this sits *outside* the draw subtree: it hangs
+  off the display-queue dispatch, not off `draw`, so it is additive to the two
+  entries above rather than part of either.
+- **Terminal feed and parse** — around 2.7%.
 
 Main thread 45% to 64% busy across the scroll windows against 18.7% quiet, with
 the app near 47% of a core.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -1,0 +1,173 @@
+# Embedded terminal render cost: what was measured — 2026-08-25
+
+This is an evidence record, not a design. It captures what was measured on
+2026-08-25 against a live TBD app and daemon, which explanations were eliminated
+and how, and where the remaining cost sits in code. Two specs act on it —
+`docs/specs/2026-08-25-terminal-metal-renderer-design.md` and
+`docs/specs/2026-08-25-appstate-observable-migration-design.md` — and this
+document is the shared source of their numbers.
+
+All measurements are from `/usr/bin/sample` against the running app and daemon on
+one heavily loaded developer machine (12 cores, 48 GB, load average around 197,
+swap near capacity, roughly 40 concurrent agent sessions). Machine state matters
+for absolute latency and is controlled for below.
+
+## Method: windows must be validated
+
+**Sampling windows that depend on a human performing an action must be checked
+for containing that action.** Four early windows in this investigation silently
+captured no scrolling — the prompt to scroll was missed — and produced a
+confident, wrong conclusion that survived into a committed spec before a
+validated re-run reversed it.
+
+The check used here scores each window for scroll-event frames (`scrollWheel`,
+`gridPosition`) and for `TerminalView.draw` volume well above the quiet baseline,
+and discards windows that fail. Take several short windows rather than one long
+one, so a mistimed window announces itself instead of being averaged in. Of three
+windows taken this way, one failed — and it failed self-consistently, showing both
+no scroll frames and correspondingly lower draw cost.
+
+Two further traps, both hit during this investigation:
+
+- **A session running tooling is not a quiet baseline.** Commands streaming output
+  into the terminal drive redraws and inflate the very counters under comparison.
+  The "idle" baseline here contains that contamination and is a soft floor rather
+  than a true floor.
+- **`sample` call-graph counts are inclusive of children.** Summing a symbol
+  together with its own callees double-counts the subtree. `TerminalView.draw`
+  summed with `TerminalView.drawTerminalContents` inflated the draw path by
+  roughly 2x and made it look dominant. Compare top-level subtree totals.
+
+`sample` also could not sustain its nominal rate on this machine — achieved
+capture ranged from 89.9% down to 12.5% of nominal across windows. Within-file
+percentages are sound; cross-file "samples as milliseconds" arithmetic is not.
+
+## What was eliminated, and how
+
+A control experiment isolates the cause to TBD's frontend:
+
+- Standalone emulator, plain shell — smooth.
+- Standalone emulator, same agent TUI, **same tmux session**, same machine — smooth.
+- TBD terminal, same TUI — laggy.
+
+Only the frontend differs. That eliminates machine load, tmux, and the hosted
+agent's output volume in one step, each of which had been a leading hypothesis at
+some point during the investigation.
+
+The daemon is separately eliminated: tmux control mode was disabled
+(`control_mode_enabled = 0`), so terminal I/O runs app to local PTY with no
+daemon participation — `OutgoingInputRoute.decide` returns `.localPTY` when
+control mode is not attached. Daemon sampling during the same windows showed its
+main thread fully idle and its worker activity peaking in the window that
+captured *no* scrolling, i.e. uncorrelated.
+
+## Measured cost, validated windows
+
+Percentages are of all main-thread samples, as top-level subtree totals. Two
+validated scroll windows, against the quiet baseline:
+
+- **SwiftUI view-graph flush** (`GraphHost.flushTransactions`) — 25.1% and 18.1%,
+  against 3.7% quiet. The largest single consumer during scroll.
+- **Terminal draw** (`TerminalView.draw`) — 20.7% and 11.6%, against 4.0% quiet.
+  - of which `buildAttributedString` — 12.8% and 7.5%, against 2.2%.
+- `RepoSectionView.body` — 3.7% and 3.0%, against 0.7%.
+- `WorktreeRowView.body` — 1.2% and 1.7%, against 0.4%.
+- Blink lifecycle scan — 1.4% and 1.0% during scroll, but **6.1% of the quiet
+  baseline's main thread**.
+- Terminal feed and parse — around 2.7%.
+
+Main thread 45% to 64% busy across the scroll windows against 18.7% quiet, with
+the app near 47% of a core.
+
+**Typing was never measured under a validated window.** The single typing sample
+was unvalidated and captured at 12.5% of nominal. It showed the main thread 16.4%
+busy — *below* the quiet baseline — which was initially read as evidence that
+typing lag is not app-side. That inference is unsound: utilization does not
+measure latency, and a mostly-idle main thread can still echo late if its work is
+bursty and sits synchronously between keystroke and echo. The control experiment
+above contradicts the original reading directly.
+
+## Where the cost sits in code
+
+Paths under `Sources/SwiftTerm/` refer to the pinned dependency revision
+`16c52867763121b121f3b29a4d439052e7e76034`.
+
+- **Per-row attributed-string rebuild.** `drawTerminalContents` calls
+  `buildAttributedString(row:line:cols:)` fresh for every row intersecting the
+  dirty rect on every draw (`Apple/AppleTerminalView.swift`). No row-level cache
+  of the built segments exists.
+- **Shaped-line cache misses ordinary text.** The `CTLine` cache is value-keyed
+  but capped at `ctLineCacheMaxLength = 8`, so any segment longer than eight
+  characters re-shapes every frame.
+- **Full-viewport invalidation while scrolled back.** `updateDisplay` computes a
+  sub-rect from the update range in the common case, but falls back to the entire
+  view bounds when `displayBuffer.yDisp != displayBuffer.yBase` — that is,
+  whenever the user is scrolled back, which is exactly the scrolling workload.
+- **Unconditional full-grid blink scan.** `visibleBlinkRows()` scans every visible
+  cell for a blink attribute; the `!blinkRows.isEmpty` term of its caller's guard
+  is evaluated only *after* that scan completes, so the overwhelmingly common
+  no-blink case pays the full O(rows x cols) cost. `updateTextBlinkLifecycle()` is
+  called unconditionally from every `updateDisplay()`.
+- **The frame limiter is disabled for 150 ms after each keystroke.**
+  `interactiveInputDisplayWindowNs` is 150 ms; within that window `feedFinish`
+  takes `displayImmediately()` instead of `queuePendingDisplay()`, bypassing the
+  16.67 ms coalescing. Typing while an agent streams therefore forces a
+  synchronous display update per output chunk — each one carrying the full-grid
+  blink scan and, if scrolled back, a full-viewport redraw.
+- **Wheel events are amplified in TBD's own code.**
+  `Sources/TBDApp/Terminal/TerminalPanelView.swift` intercepts every wheel event in
+  a local `NSEvent` monitor and emits `max(1, Int(abs(deltaY)))` SGR mouse reports,
+  with no momentum-phase filter and no fractional-delta accumulator. A sub-line
+  delta still sends a full report, and a trackpad flick's momentum tail delivers
+  events at 60-120 Hz. Each report makes the hosted TUI repaint, and that output
+  returns through the PTY as a redraw — so scrolling manufactures the output flood
+  the draw path then pays for. The pinned SwiftTerm revision already contains a
+  better handler (pixel-delta accumulation against real cell height, remainder
+  banking, a `scrollSensitivity` knob) which never runs because the monitor
+  consumes the event first.
+- **A GPU renderer exists and is never enabled.**
+  `Sources/SwiftTerm/Apple/Metal/` holds a full Metal renderer behind a public
+  `setUseMetal(_:)`. TBD contains no reference to it, so every measurement above
+  is of the CoreGraphics fallback.
+
+## Upstream state, as of 2026-08-25
+
+The dependency is actively maintained — roughly 395 commits over 52 weeks, 87% of
+the last 30 pull requests merged with a median around 1.3 days. Several
+outstanding pull requests profile a multi-pane agent-TUI workload closely
+resembling TBD's, and are unmerged:
+
+- **Content-keyed shaped-line cache** — reports draw samples falling from 778 to
+  68, a 91% reduction, on an agent-TUI workload. Blocked on adding a per-line
+  version stamp, which the terminal buffer lacks today.
+- **Metal row cache surviving scroll** — the Metal renderer keys its row cache on
+  absolute row number and screen-relative coordinates, both invalidated by every
+  scroll; reports 10.35 ms to 0.60 ms per frame.
+- **Scrolled-back over-invalidation** — dirty-range computation conflates the
+  display and base line offsets.
+- **Bounding Apple wheel reports** — a downstream fork's approach: one report per
+  classic wheel notch, and a 100 reports/second token bucket with a six-event
+  immediate burst for precise trackpad deltas.
+
+A separately reported case shows six streaming agent TUIs with Metal **enabled**
+still consuming 75-82% of a core, with cost relocating to CoreText glyph metrics.
+That report is CJK-heavy, so an ASCII agent TUI should hit the glyph atlas
+considerably better, but it is a live possibility rather than a settled one.
+
+## Open questions
+
+- **Typing has no validated measurement.** The mechanism above is read from code,
+  not observed. What would settle it: the validated-window protocol applied to
+  typing, analyzed for synchronous work between input and echo rather than for
+  total utilization.
+- **Which property drives the SwiftUI flush** is unidentified. Writer-frame counts
+  were comparable between scrolling and quiet windows, so the rise in flush share
+  has no isolated write behind it. Because the flush runs as a run-loop observer,
+  its frequency scales with run-loop turns — meaning a fix to wheel amplification
+  would reduce it without touching observation at all, and the two must not be
+  measured together.
+- **Whether the difficulty is architectural.** Another project's committed
+  migration spec faults this dependency specifically for rendering issues in the
+  bytes-fed-without-a-child-process mode that TBD operates in. If that reading is
+  right, renderer tuning will not close the gap. Enabling the GPU renderer is the
+  cheap measurement that discriminates.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -248,61 +248,118 @@ latency. Answering it requires signpost instrumentation inside the render path.
   under that pressure — which would explain why a simpler emulator on the same
   backend stays smooth — but nothing here demonstrates it.
 
-## The stall is found; its cause is not — 2026-08-26
+## The stall's cause: SwiftUI's view-graph flush — 2026-08-26
 
-Signpost instrumentation on the render path measured the wait that every earlier
-method was blind to. Intervals were emitted around the main-thread hop in
-`TerminalPanelView.dataReceived` (enqueue to execute), around `feed`, and around
-the display pass; `rpc.pollCycle` was already instrumented. Three windows were
-collected with `log stream --style ndjson --signpost` during ordinary operation,
-all three from the same process — process IDs were checked, and no restart
-occurred in any of them.
+Signpost instrumentation measured a wait that every earlier method was blind to,
+and a subsequent investigation (issue #735) identified its cause and confirmed a
+fix. What follows records both.
 
-**Terminal output waits far longer than it should to reach the renderer, and the
-wait grows across the three windows:**
+**Terminal output waited far longer than it should to reach the renderer.**
+Intervals around the main-thread hop in `TerminalPanelView.dataReceived` measured
+a median under two milliseconds and a maximum of 1,096 ms across three windows.
+The median is why averages and CPU percentages never revealed it: what matters is
+when work lands, not how much of it there is.
 
-- `mainThreadHop` — p50 0.08 / 0.89 / 1.84 ms, p99 157 / 28 / 281 ms, max 162 /
-  311 / **1,096 ms**.
-- `feed` — p50 0.11 ms.
-- `displayPass` — p50 5 to 9 ms.
+**Rendering was never the bottleneck.** Parse costs a tenth of a millisecond and
+a display pass single-digit milliseconds. The per-row attributed-string rebuild,
+the eight-character shaped-line cache, and the full-grid blink scan are real
+inefficiencies, and none of them is what stalls terminal output.
 
-A wait of over a second for output to reach the renderer is the symptom users
-report. The median wait is under two milliseconds, which is why averages and CPU
-percentages never revealed it: what matters is when work lands, not how much of
-it there is.
+**The cause is SwiftUI's own runloop observer, `Update.end`, flushing the view
+graph.** It was the only class of main-thread work that ever ran longer than
+about 35 ms without returning to the runloop: 105 and 118 runs over 50 ms across
+two windows, p90 179-205 ms, maximum 366 ms, against a maximum of 89 ms for
+everything else combined. The flush is bimodal — trivial or enormous, with a
+median of 2-3 ms against that p90.
 
-**Rendering is not the bottleneck.** Parse costs a tenth of a millisecond and a
-display pass costs single-digit milliseconds. The per-row attributed-string
-rebuild, the eight-character shaped-line cache, and the full-grid blink scan are
-real inefficiencies, and none of them is what stalls a keystroke.
+The mechanism is not a correlation and needs no statistical correction. During
+stalls, 87-92% of main-thread CPU sat inside a runloop-observer callout while CPU
+servicing the main dispatch queue fell from 25-28% to 0.2-5.1%. A block on the
+main queue cannot run while the thread is inside a callout, so a long callout
+*is* an undrained queue — one event described from two sides.
 
-### The poll cycle was a suspect, and was eliminated
+**Per-property observation tracking fixed it.** After the change, the worst wait
+for terminal output fell from **325 ms to 58 ms** and p99 from **258 ms to
+5.3 ms**, measured with the same instrument at matched process uptime.
 
-The first window showed twelve of fourteen stalls beginning during a poll cycle,
-which looked decisive. It was not. The test that matters compares observed
-co-occurrence against what chance predicts given how much of the timeline the
-suspect occupies:
+### A prediction that was wrong, and why the correction matters
 
-- window one — poll duty 14.2%, 14 stalls, 12 in-poll against 2.0 expected: 6.04x
-- window two — poll duty 22.5%, 12 stalls, 5 in-poll against 2.7 expected: 1.85x
-- window three — poll duty 43.7%, 363 stalls, 162 in-poll against 158.6 expected: **1.02x**
+The expectation was that per-property tracking would cut attribute-graph
+propagation hardest and leave the `ForEach` view-list rebuild largely intact,
+since that rebuild runs whenever list data changes regardless of tracking
+granularity. The opposite happened, in absolute CPU inside expensive flushes:
+the view-list rebuild fell 31-fold (6,190 ms to 201 ms), against 7.4-fold for
+attribute-graph propagation and 2.8-fold for body evaluation, and `Worktree`
+copy-and-destroy left the top entry points entirely.
 
-Window three carries twenty-six times the data of window one, and at 1.02x the
-association is indistinguishable from chance. Poll cycles had grown to occupy
-nearly half the timeline, so "45% of stalls fall inside a poll" restates "polls
-run half the time" and nothing more.
+The rebuild was itself being *triggered* by object-wide invalidation: any write
+invalidated the observing views, forcing the whole nested list to be
+reconstructed, with the value copies happening inside that reconstruction.
 
-**Raw co-occurrence is not evidence when the suspect occupies a large fraction of
-the timeline.** Computing the duty cycle and testing enrichment is what caught
-this, and it belongs in the method section alongside window validation.
+### Suspects eliminated along the way
 
-### What remains open
+The poll cycle was named as the cause on one 30-second window and refuted on a
+larger one: enrichment against chance was **1.02x** once the poll's 43.7% duty
+cycle was accounted for. `displayPass` showed 3.99x enrichment on twelve
+observations and was likewise noise. Process age was tested rather than assumed —
+the post-fix side measured at 6 and 59 minutes of uptime agreed almost exactly.
 
-Something occupies the main thread in bursts long enough to stall terminal I/O by
-hundreds of milliseconds, and it is unidentified. Finding it requires
-instrumentation that catches an arbitrary main-actor burst rather than one named
-suspect — a watchdog recording the stack when a runloop turn exceeds a threshold,
-or a sampling profile correlated on time against the signpost stream.
+### Method worth reusing
 
-Separately worth investigating on its own terms: a poll cycle occupying 43.7% of
-wall time is remarkable regardless of its relationship to these stalls.
+**Define windows by the symptom, never by a suspect.** A window here was a period
+during which terminal bytes were demonstrably sitting undelivered on the main
+queue. Nothing about any candidate entered that definition, which is what allowed
+the analysis to rule the poll cycle out rather than assume it in.
+
+**Put every instrument in one trace so they share a clock** — a sampling
+profiler, the signposts, and the platform's own hang detector correlated exactly
+rather than aligned after the fact.
+
+**Attribute by which runloop callout the work hangs off, not by what it
+contains.** Stack composition inside stall windows was near-identical to
+composition outside them, so what code runs did not discriminate at all. The
+trigger did.
+
+Three further instrument traps, each of which produced a wrong intermediate
+reading: trace exports may reference-compress backtrace frames, yielding a stack
+that reads as legitimately truncated but is not; a 21-second pilot window
+contradicted the 150-second windows outright, because short windows catch
+mistimed captures rather than supporting conclusions; and counting matching
+processes by line count over-reports wildly when command lines are multi-line.
+
+### A cheaper instrument already exists
+
+`HangWatchdog` writes stacks to `~/Library/Logs/TBD/hang-stacks/` above a
+threshold tunable by `TBD_HANG_THRESHOLD_MS`, and had independently captured the
+same path. It is cheaper to read than to record a trace. Note that directory held
+110,512 files — a durable resource with no named reconciler.
+
+## What this does NOT cover
+
+**Every window in this work was taken during ordinary operation with agents
+streaming and no user interaction.** The intervals measure terminal output
+travelling *towards* the screen. They do not measure keystroke-to-echo, and they
+do not measure scrolling.
+
+**Typing has still never been measured under a validated window**, and neither
+has scrolling. The good numbers above must not be read as covering either.
+
+Two named mechanisms target exactly those cases and are untouched by the fix:
+wheel-event amplification, where every wheel event emits
+`max(1, Int(abs(deltaY)))` mouse reports with no momentum-phase filter and no
+fractional accumulator; and the 150 ms window after each keystroke during which
+`interactiveInputDisplayWindowNs` disables the frame limiter so every output
+chunk forces a synchronous redraw. If typing or scrolling still feel bad, those
+are the better suspects.
+
+Any window intending to cover them must be checked for containing the action —
+the trap that put a wrong conclusion into a committed spec earlier in this
+investigation.
+
+## Residual
+
+Long flushes have not vanished — 50 callouts over 50 ms, up to 200 ms, in a
+59-minute window — they simply far less often have terminal output waiting behind
+them. Expensive flushes are now 54.5% body evaluation, led by `WorktreeRowView`,
+`TabBarItem`, and `PanePlaceholder`, with 35.4% attribute-graph propagation and
+only 6.7% view-list rebuild.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -278,9 +278,25 @@ servicing the main dispatch queue fell from 25-28% to 0.2-5.1%. A block on the
 main queue cannot run while the thread is inside a callout, so a long callout
 *is* an undrained queue — one event described from two sides.
 
-**Per-property observation tracking fixed it.** After the change, the worst wait
-for terminal output fell from **325 ms to 58 ms** and p99 from **258 ms to
-5.3 ms**, measured with the same instrument at matched process uptime.
+**Per-property observation tracking fixed it**, by roughly fivefold on stall
+load. Five windows, same instrument, same window definition, matched uptimes:
+
+| window | uptime | stalled | hop p99 | hop max | callouts >50ms |
+|---|---|---|---|---|---|
+| before | 50 min | 1.33% | 187.9 ms | 227.7 ms | 105 |
+| before | 60 min | 3.71% | 257.9 ms | 325.2 ms | 118 |
+| after | 6 min | 0.26% | 16.3 ms | 139.1 ms | 10 |
+| after | 59 min | 0.26% | 5.3 ms | 58.4 ms | 50 |
+| after | 76 min | 0.83% | 148.5 ms | 162.4 ms | 77 |
+
+Stated honestly: stall load fell from 1.33-3.71% to 0.26-0.83%, and the worst
+wait from 228-325 ms to 58-162 ms.
+
+**The post-fix side is variable and one window does not characterise it** — p99
+was 5.3 ms in one after-window and 148.5 ms in another. Quoting the best
+after-window against the worst before-window yields a fourteenfold improvement
+and is not defensible; the direction is solid and replicated across three
+post-fix windows, the magnitude is roughly fivefold.
 
 ### A prediction that was wrong, and why the correction matters
 
@@ -358,8 +374,11 @@ investigation.
 
 ## Residual
 
-Long flushes have not vanished — 50 callouts over 50 ms, up to 200 ms, in a
-59-minute window — they simply far less often have terminal output waiting behind
-them. Expensive flushes are now 54.5% body evaluation, led by `WorktreeRowView`,
-`TabBarItem`, and `PanePlaceholder`, with 35.4% attribute-graph propagation and
-only 6.7% view-list rebuild.
+Long flushes have not vanished — 50 and 77 callouts over 50 ms in the two later
+post-fix windows — they simply far less often have terminal output waiting behind
+them.
+
+The composition shift replicates across both post-fix windows independently: the
+view-list rebuild fell from 31.5% of expensive-flush CPU before the change to
+6.7% and 12.8% after, and body evaluation is now the largest slice in both, led
+by `WorktreeRowView`, `TabBarItem`, and `PanePlaceholder`.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -428,3 +428,77 @@ The composition shift replicates across both post-fix windows independently: the
 view-list rebuild fell from 31.5% of expensive-flush CPU before the change to
 6.7% and 12.8% after, and body evaluation is now the largest slice in both, led
 by `WorktreeRowView`, `TabBarItem`, and `PanePlaceholder`.
+
+## Key-to-paint latency, and what it refutes — 2026-08-26
+
+A deterministic benchmark — the real agent TUI driven by a scripted local
+endpoint, so token rate is a parameter rather than a variable — measured the leg
+that matters to a user: the time from a keystroke to the next display pass that
+could show it. Harness and full method: `2026-08-26-claude-code-render-benchmark.md`.
+
+| condition | keys | p50 | p90 | max | over 100 ms |
+|---|---|---|---|---|---|
+| bare shell, typing only | 84 | 53.8 ms | 156.8 ms | 303.8 ms | 28.6% |
+| bare shell, typing only | 76 | 45.7 ms | 102.3 ms | 257.6 ms | 10.5% |
+| typing while streaming | 84 | 40.8 ms | 119.3 ms | 270.0 ms | 13.1% |
+| typing while streaming | 72 | 41.6 ms | 100.8 ms | 188.8 ms | 11.1% |
+
+**The lag is a paint-scheduling floor, not a cost problem.** Median 40-55 ms with
+a tail past 300 ms and one keystroke in ten or more taking over 100 ms to appear —
+while the main thread is ~99% idle in every condition, parse work is 0.00-0.02
+seconds per wall-second, and each display pass costs 10-15 ms. Nothing is
+CPU-bound. TBD is not busy; it is not painting promptly.
+
+### Three earlier readings this overturns
+
+**Streaming does not make typing worse — it slightly improves it.** The streaming
+pair ran at machine load 95-119 against the typing-only pair's 78-103 and still
+came out faster. More output means more frequently scheduled draws, so a
+keystroke waits less for the next one. The expectation that heavy agent output
+would be the worst case for typing was wrong, and backwards.
+
+**An agent cannot saturate TBD.** Claude Code emits ~30-40 screen updates per
+second regardless of renderer, and raising its token rate tenfold *lowered* the
+observed chunk rate. Renderer choice — fullscreen or classic — is immaterial to
+throughput. The hypothesis that fullscreen full-viewport repaints constitute a
+maximum-cost path does not survive: the producer is the limit, not the renderer.
+
+**Gaps between display passes are not lag when input is bursty.** During a pause
+between typing bursts there is nothing to draw, so a long gap is correct
+behaviour. The earlier reading of 846 ms gaps as render-loop starvation over-read
+that metric; keystroke-anchored latency is the sound measure and supersedes it.
+
+### The one genuinely expensive path, and why it changes the fix
+
+High-rate line-append while scrolling — reachable with a build log or `cat`, not
+with an agent — costs 6.15 ms per chunk and 0.96 seconds of parse work per
+wall-second. That is saturation, and it starves the view to roughly one display
+pass per second.
+
+**That cost sits in `feed` — parse and damage tracking — which is upstream of
+`drawTerminalContents`.** So optimising the per-row `NSAttributedString` rebuild
+would target the wrong stage for the one path where cost genuinely dominates.
+
+### Caveats
+
+**The input leg is excluded and the figures are a lower bound.** macOS refused
+synthetic keystrokes without Accessibility permission, so keys were injected at
+the tmux layer; TBD's own view keydown handling is not in these numbers. True
+perceived latency is this plus that leg.
+
+**Machine load was 63-119 throughout**, with the window server alone at 65-73%.
+Within-pair comparisons are sound; comparison against baselines taken under
+unknown load is not.
+
+**A discarded metric, recorded so it is not re-derived.** "Time from chunk to next
+display pass" gave a plausible 133-146 ms median but is inflated and partly
+circular: a shell emits roughly 8.75 chunks per typed character while only about
+one draw occurs, so most chunks are mid-burst fragments waiting on the next
+character's draw.
+
+### Where this points
+
+At *when* TBD schedules a paint, rather than at parse or draw cost. A ~40 ms floor
+on an otherwise idle main thread suggests a coalescing or timer policy rather than
+contention — so the next question is what marks the terminal view as needing
+display, and how that is throttled.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -247,3 +247,55 @@ latency. Answering it requires signpost instrumentation inside the render path.
   uptime. A view hierarchy that presents more work per frame would degrade first
   under that pressure — which would explain why a simpler emulator on the same
   backend stays smooth — but nothing here demonstrates it.
+
+## The stall is found: a synchronous burst inside the poll cycle — 2026-08-26
+
+Signpost instrumentation on the render path answered the question the sections
+above left open. Intervals were emitted around the main-thread hop in
+`TerminalPanelView.dataReceived` (enqueue to execute), around `feed`, and around
+the display pass; `rpc.pollCycle` was already instrumented. Collected with
+`log stream --style ndjson --signpost` over a 30-second window of ordinary
+operation, with agents streaming and no user interaction:
+
+- **`mainThreadHop` — p50 0.08 ms, p90 2.03 ms, p99 156 ms, max 162 ms.**
+- `rpc.pollCycle` — p50 231 ms, p90 539 ms, max 605 ms; about fifteen in thirty seconds.
+- `feed` — p50 0.11 ms, max 1.36 ms.
+- `displayPass` — p50 5.28 ms, max 10.6 ms.
+
+**Terminal output waits up to 162 ms to reach the renderer, while the median wait
+is 0.08 ms.** Averages cannot see this, which is why every earlier measurement
+missed it: a main thread that is idle 81% of the time still stalls terminal I/O
+for a sixth of a second at a stretch, because what matters is when work lands
+rather than how much of it there is.
+
+**Twelve of fourteen stalls over 20 ms began while a poll cycle was in flight**,
+including all eight of the worst.
+
+### What the correlation does and does not show
+
+It is not that the poll cycle holds the main thread for its whole duration.
+`runPollCycleIfIdle` awaits its body, and an await on the main actor yields, so
+the interval spans suspensions during which the main thread is free.
+
+The stalls begin at scattered points within a cycle — 5%, 46%, 50%, 82% of the
+way through — and every one ends before its cycle does. They also arrive in
+near-identical batches: four stalls of 162.2, 162.3, 162.3 and 160.1 ms all
+beginning within 0.7% of each other, which is the signature of several chunks
+queued behind a single blocking burst and released together.
+
+So one phase of the poll cycle is synchronous on the main actor and runs for
+roughly 155 to 162 ms. **Which phase is not yet identified** and needs finer
+instrumentation inside the poll body. The plausible candidate is the phase that
+applies results to `AppState`: decoding, diffing, and assigning published
+properties, each assignment invalidating every observing view.
+
+### What this reorders
+
+**Rendering is not the bottleneck.** Parse costs 0.11 ms and a display pass 5 to
+9 ms. The per-row attributed-string rebuild, the shaped-line cache, and the blink
+scan are real inefficiencies, and none of them is what stalls a keystroke.
+
+The observation-churn work is closer to the mark than the rendering work, since
+whole-object invalidation is a candidate for what makes the burst expensive — but
+that connection is inferred from the shape of the evidence rather than measured,
+and the finer instrumentation is what would settle it.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -502,3 +502,78 @@ At *when* TBD schedules a paint, rather than at parse or draw cost. A ~40 ms flo
 on an otherwise idle main thread suggests a coalescing or timer policy rather than
 contention — so the next question is what marks the terminal view as needing
 display, and how that is throttled.
+
+## The paint floor is real, and typed keys already bypass it — 2026-08-26
+
+A controlled A/B on a purpose-built binary confirmed the scheduling mechanism and
+then found it does not apply to interactive typing.
+
+**The mechanism is confirmed.** Turning `queuePendingDisplay` from a fixed delay
+into a rate limit cut key-to-paint from a 23.3 ms median to 5.1 ms across eight
+runs with no overlap between conditions — a spread of 1.4 ms unpatched and 0.2 ms
+patched against an 18.2 ms effect. The drop is exactly one display frame, which is
+the mechanism's own prediction rather than a coincidence, and burst coalescing was
+unchanged.
+
+**But typed keys never take that path.** `TerminalView.send(data:)` calls
+`recordUserInput()`, and for 150 ms afterwards `feedFinish()` routes to
+`displayImmediately()` rather than `queuePendingDisplay()`. Because TBD feeds on
+the main thread, `displayImmediately()` takes its synchronous branch — calling
+`updateDisplay()` directly, with **no coalescing check on that branch at all**.
+A typed character's echo returns in well under a millisecond, and each keypress
+refreshes the window, so it stays open continuously while someone types.
+
+Injected keys are different: `tbd terminal send` reaches a pane through
+`tmux send-keys` and never touches the view, so `recordUserInput()` never fires.
+**Every keystroke measurement in this investigation used injected keys, and
+therefore measured a path a genuinely typed key does not take.** The frame that
+patch removes is paid by agent output and by TBD's own injected input; interactive
+typing was already on the fast route.
+
+### A refutation of ours that does not hold
+
+The 150 ms window was earlier dismissed here on the grounds that 2,545 chunks
+produced only 617 display passes, so coalescing must be working. That inference is
+invalid: `updateDisplay` returns early when nothing changed, so a pass count does
+not measure how often the fast path fired. The window is not refuted.
+
+It also points the opposite way from a scheduling floor. If every chunk arriving
+within 150 ms of a keypress drives a synchronous full display update, then typing
+is expensive because the fast path does *too much* work, not because it waits.
+That is consistent with the one window here taken while a human actually typed,
+where the median wait for output rose from 0.08 ms to 6.91 ms.
+
+### The tail did not reproduce
+
+Key-to-paint showed **0.0% of keystrokes over 100 ms** in every clean run on both
+builds, against the 10-29% recorded earlier. Every tail that did appear was the
+measurement tab leaving the screen, and its slow keystrokes were *contiguous* — a
+scheduling defect scatters, a window going away does not. That contiguity check is
+a cheap discriminator.
+
+The likely source of the earlier tail: a harness variant that leaves `tmux
+send-keys` process-spawn cost inside the measurement reads 0.8% to 39% over 100 ms
+depending on load, spanning the range reported, and spawn cost reached a 57 ms
+median at load ~51. The earlier runs were taken at load 63-119.
+
+### Two instrument rules this produced
+
+**Order every comparison A/B/A.** Taking the two sides in sequence suggested the
+patch had halved the saturated draw rate. It did not survive load matching — the
+*unpatched* build at low load drew at the same rate, and the entire apparent effect
+was machine load 91-139 against load 7. Only reverting, rebuilding and re-measuring
+caught it.
+
+**`displayPass` duration under saturation measures main-queue backlog, not draw
+cost**, because the interval ends on the next main-queue turn. The same build read
+12-15 ms at load 91-139 and 1.7-1.9 *seconds* at load 7-11. It is the instrument,
+not the renderer.
+
+### The measurement that would settle typing
+
+Neither the fast path nor its cost can be driven from a script: macOS refuses
+synthetic keystrokes without an Accessibility grant, so `send(data:)` cannot be
+exercised programmatically. Confirming any of this requires that grant, or a human
+typing into a terminal while signposts are captured. **That is the highest-value
+outstanding measurement in this line of work**, and every keystroke number recorded
+so far is of the wrong path until it is taken.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -350,27 +350,73 @@ threshold tunable by `TBD_HANG_THRESHOLD_MS`, and had independently captured the
 same path. It is cheaper to read than to record a trace. Note that directory held
 110,512 files — a durable resource with no named reconciler.
 
-## What this does NOT cover
+## Typing and scrolling, measured — 2026-08-26
 
-**Every window in this work was taken during ordinary operation with agents
-streaming and no user interaction.** The intervals measure terminal output
-travelling *towards* the screen. They do not measure keystroke-to-echo, and they
-do not measure scrolling.
+The earlier sections measured terminal output travelling toward the screen during
+ordinary operation, and stated that typing and scrolling had never been measured
+under a validated window. Three windows on one build now close that gap: a quiet
+baseline with no interaction, a window of continuous typing, and a window of
+continuous scrolling.
 
-**Typing has still never been measured under a validated window**, and neither
-has scrolling. The good numbers above must not be read as covering either.
+| window | chunks/s | hop p50 | hop p99 | display passes | gap p90 | gap max | poll p50 |
+|---|---|---|---|---|---|---|---|
+| quiet | 21.8 | 0.08 ms | 59.4 ms | none | — | — | 255 ms |
+| typing | 79.5 | 6.91 ms | 113.0 ms | 19.3/s | 101.4 ms | 846.5 ms | 525 ms |
+| scrolling | 634.6 | 2.49 ms | 19.8 ms | 46.7/s | 31.4 ms | 265.8 ms | 1055 ms |
 
-Two named mechanisms target exactly those cases and are untouched by the fix:
-wheel-event amplification, where every wheel event emits
-`max(1, Int(abs(deltaY)))` mouse reports with no momentum-phase filter and no
-fractional accumulator; and the 150 ms window after each keystroke during which
-`interactiveInputDisplayWindowNs` disables the frame limiter so every output
-chunk forces a synchronous redraw. If typing or scrolling still feel bad, those
-are the better suspects.
+**Typing and scrolling fail differently, and the difference matters for which fix
+helps which symptom.**
 
-Any window intending to cover them must be checked for containing the action —
-the trap that put a wrong conclusion into a committed spec earlier in this
-investigation.
+### Scrolling manufactures its own load
+
+Scrolling produces **634 chunks per second** — twenty-nine times the quiet rate
+and eight times the typing rate — while each chunk is trivially small (`feed`
+median 0.03 ms). This is wheel-event amplification measured rather than inferred:
+every wheel event emits `max(1, Int(abs(deltaY)))` mouse reports, each report
+makes the hosted application repaint, and each repaint returns as output.
+
+The render loop copes comparatively well under it: display passes run at 46.7 per
+second with a p90 gap of 31 ms. The problem is not that the work is slow, it is
+that most of the work should never have been generated.
+
+### Typing starves the render loop
+
+Typing produces a much lower chunk rate but a materially worse experience for the
+renderer: display passes fall to **19.3 per second** against a 60 per second
+budget, with a p90 gap of **101 ms**, a worst gap of **846 ms**, and 63 gaps over
+100 ms in a 32-second window.
+
+**Each pass is cheap — a median of 6.2 ms.** The render loop is starved rather
+than slow: frames are inexpensive to draw and simply do not get to run. The
+median wait for output to reach the renderer rises from 0.08 ms quiet to 6.9 ms
+typing, so this is not a tail effect — nearly every chunk waits.
+
+### A mechanism this refutes
+
+The 150 ms post-keystroke window, during which `interactiveInputDisplayWindowNs`
+disables the frame limiter so every chunk forces a synchronous redraw, was the
+leading suspect for typing lag. If it were driving the symptom, 2,545 chunks
+would have produced something approaching 2,545 display passes. They produced
+617. Coalescing is working, and the frame limiter is not being defeated.
+
+### The poll cycle degrades under both, as a symptom
+
+`rpc.pollCycle` rises from 255 ms quiet to 525 ms typing to **1,055 ms**
+scrolling. Read together with the enrichment result that already cleared it as a
+cause, this is the poll being starved by main-thread congestion rather than
+producing it. A poll cycle exceeding a second is nonetheless worth attention on
+its own terms.
+
+### Caveats
+
+The scrolling window's signpost data spans 16 seconds of a 32-second capture; at
+634 events per second the logging stream may have dropped records, so that chunk
+rate is a floor and its distributions are approximate.
+
+The instrumentation remains output-side only. There is no signpost on the
+outgoing keystroke, so none of this measures keystroke-to-echo latency directly —
+it measures whether output is delayed and whether frames are produced on
+schedule. Measuring true echo latency needs a send-side interval.
 
 ## Residual
 

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -180,3 +180,70 @@ considerably better, but it is a live possibility rather than a settled one.
   bytes-fed-without-a-child-process mode that TBD operates in. If that reading is
   right, renderer tuning will not close the gap. Enabling the GPU renderer is the
   cheap measurement that discriminates.
+
+## Perceived lag is intermittent, and is not explained by app CPU — 2026-08-26
+
+The measurements above describe cost. They do not explain the symptom that
+prompted the investigation, and a second day of measurement separated the two.
+
+**The condition cycles.** Perceived lag alternates with periods that feel fine,
+on a timescale of minutes. That alone rules out any explanation that is constant
+— a view graph competing for the main thread is always competing. It also
+explains why single-window measurements disagreed with each other: each was a
+lottery ticket on which state it happened to sample.
+
+**During a reported laggy period the app was not compute-bound.** Its main thread
+was 81% idle and it used 26% of a core — *less* than several windows in which
+nothing felt wrong. Terminal draw was 3.6% and view-graph flush 5.4%, both well
+below their scroll-time figures.
+
+**A 20-second sample took 73 seconds of wall clock to complete.** A system
+profiling tool could not get its own work scheduled on time, which is a
+machine-level signal rather than an application one.
+
+**The machine is nonetheless fast where it matters for echo.** A bare pty round
+trip — write to an open descriptor, child echoes, read back, with no process
+spawns inside the loop — measures 0.1 ms at p50 and 7.7 ms at worst, even at
+load average ~70 with swap near capacity. Keystroke echo is not limited by the
+operating system, the pty layer, or scheduling beneath it.
+
+**Process spawns, by contrast, are expensive here**: a single `tmux` client spawn
+measures 114 ms at p50. Any probe that spawns a process per iteration measures
+spawn cost and nothing else. An earlier round-trip probe reported 627 ms at p50
+purely from this effect and was discarded.
+
+### What this reframes
+
+Average idle percentage says nothing about queueing delay. A main thread that is
+81% idle can still run long bursts, and every chunk of terminal output is
+dispatched onto that thread by `TerminalPanelView.dataReceived` — with no check
+for whether the terminal is even visible. The distribution of main-thread block
+durations, not the mean, is what would explain the symptom, and no measurement
+here captures it.
+
+External probing is exhausted: accessibility queries against the app are refused
+for want of assistive access, and no external tool can observe dispatch-queue
+latency. Answering it requires signpost instrumentation inside the render path.
+
+### Eliminated, with the evidence
+
+- **Machine pty and scheduling beneath it** — 0.1 ms round trip under load.
+- **Compilation** — a laggy period was captured with zero compiler processes.
+  Note the instrument that established this was initially blind to test
+  execution and was corrected; the corrected form counts test helpers too.
+- **Sidebar body evaluation as the dominant cause** — collapsing every repo
+  section, which removes the largest measured view-graph consumer, did not
+  change the symptom.
+- **A large population of invisible terminals feeding the main thread** — the
+  keep-alive cap is eight, but only three terminals were attached, so the effect
+  is real in code and small in practice at present.
+
+### Still open
+
+- **The distribution of main-thread block durations**, which is the mechanism
+  that would connect an idle-on-average main thread to a laggy-feeling terminal.
+- **Whether the compositor is implicated.** It was the top system process through
+  most of the laggy period, with 84 hours of accumulated CPU over 18 days of
+  uptime. A view hierarchy that presents more work per frame would degrade first
+  under that pressure — which would explain why a simpler emulator on the same
+  backend stays smooth — but nothing here demonstrates it.

--- a/docs/perf/2026-08-25-terminal-render-cost-investigation.md
+++ b/docs/perf/2026-08-25-terminal-render-cost-investigation.md
@@ -248,54 +248,61 @@ latency. Answering it requires signpost instrumentation inside the render path.
   under that pressure — which would explain why a simpler emulator on the same
   backend stays smooth — but nothing here demonstrates it.
 
-## The stall is found: a synchronous burst inside the poll cycle — 2026-08-26
+## The stall is found; its cause is not — 2026-08-26
 
-Signpost instrumentation on the render path answered the question the sections
-above left open. Intervals were emitted around the main-thread hop in
+Signpost instrumentation on the render path measured the wait that every earlier
+method was blind to. Intervals were emitted around the main-thread hop in
 `TerminalPanelView.dataReceived` (enqueue to execute), around `feed`, and around
-the display pass; `rpc.pollCycle` was already instrumented. Collected with
-`log stream --style ndjson --signpost` over a 30-second window of ordinary
-operation, with agents streaming and no user interaction:
+the display pass; `rpc.pollCycle` was already instrumented. Three windows were
+collected with `log stream --style ndjson --signpost` during ordinary operation,
+all three from the same process — process IDs were checked, and no restart
+occurred in any of them.
 
-- **`mainThreadHop` — p50 0.08 ms, p90 2.03 ms, p99 156 ms, max 162 ms.**
-- `rpc.pollCycle` — p50 231 ms, p90 539 ms, max 605 ms; about fifteen in thirty seconds.
-- `feed` — p50 0.11 ms, max 1.36 ms.
-- `displayPass` — p50 5.28 ms, max 10.6 ms.
+**Terminal output waits far longer than it should to reach the renderer, and the
+wait grows across the three windows:**
 
-**Terminal output waits up to 162 ms to reach the renderer, while the median wait
-is 0.08 ms.** Averages cannot see this, which is why every earlier measurement
-missed it: a main thread that is idle 81% of the time still stalls terminal I/O
-for a sixth of a second at a stretch, because what matters is when work lands
-rather than how much of it there is.
+- `mainThreadHop` — p50 0.08 / 0.89 / 1.84 ms, p99 157 / 28 / 281 ms, max 162 /
+  311 / **1,096 ms**.
+- `feed` — p50 0.11 ms.
+- `displayPass` — p50 5 to 9 ms.
 
-**Twelve of fourteen stalls over 20 ms began while a poll cycle was in flight**,
-including all eight of the worst.
+A wait of over a second for output to reach the renderer is the symptom users
+report. The median wait is under two milliseconds, which is why averages and CPU
+percentages never revealed it: what matters is when work lands, not how much of
+it there is.
 
-### What the correlation does and does not show
+**Rendering is not the bottleneck.** Parse costs a tenth of a millisecond and a
+display pass costs single-digit milliseconds. The per-row attributed-string
+rebuild, the eight-character shaped-line cache, and the full-grid blink scan are
+real inefficiencies, and none of them is what stalls a keystroke.
 
-It is not that the poll cycle holds the main thread for its whole duration.
-`runPollCycleIfIdle` awaits its body, and an await on the main actor yields, so
-the interval spans suspensions during which the main thread is free.
+### The poll cycle was a suspect, and was eliminated
 
-The stalls begin at scattered points within a cycle — 5%, 46%, 50%, 82% of the
-way through — and every one ends before its cycle does. They also arrive in
-near-identical batches: four stalls of 162.2, 162.3, 162.3 and 160.1 ms all
-beginning within 0.7% of each other, which is the signature of several chunks
-queued behind a single blocking burst and released together.
+The first window showed twelve of fourteen stalls beginning during a poll cycle,
+which looked decisive. It was not. The test that matters compares observed
+co-occurrence against what chance predicts given how much of the timeline the
+suspect occupies:
 
-So one phase of the poll cycle is synchronous on the main actor and runs for
-roughly 155 to 162 ms. **Which phase is not yet identified** and needs finer
-instrumentation inside the poll body. The plausible candidate is the phase that
-applies results to `AppState`: decoding, diffing, and assigning published
-properties, each assignment invalidating every observing view.
+- window one — poll duty 14.2%, 14 stalls, 12 in-poll against 2.0 expected: 6.04x
+- window two — poll duty 22.5%, 12 stalls, 5 in-poll against 2.7 expected: 1.85x
+- window three — poll duty 43.7%, 363 stalls, 162 in-poll against 158.6 expected: **1.02x**
 
-### What this reorders
+Window three carries twenty-six times the data of window one, and at 1.02x the
+association is indistinguishable from chance. Poll cycles had grown to occupy
+nearly half the timeline, so "45% of stalls fall inside a poll" restates "polls
+run half the time" and nothing more.
 
-**Rendering is not the bottleneck.** Parse costs 0.11 ms and a display pass 5 to
-9 ms. The per-row attributed-string rebuild, the shaped-line cache, and the blink
-scan are real inefficiencies, and none of them is what stalls a keystroke.
+**Raw co-occurrence is not evidence when the suspect occupies a large fraction of
+the timeline.** Computing the duty cycle and testing enrichment is what caught
+this, and it belongs in the method section alongside window validation.
 
-The observation-churn work is closer to the mark than the rendering work, since
-whole-object invalidation is a candidate for what makes the burst expensive — but
-that connection is inferred from the shape of the evidence rather than measured,
-and the finer instrumentation is what would settle it.
+### What remains open
+
+Something occupies the main thread in bursts long enough to stall terminal I/O by
+hundreds of milliseconds, and it is unidentified. Finding it requires
+instrumentation that catches an arbitrary main-actor burst rather than one named
+suspect — a watchdog recording the stack when a runloop turn exceeds a threshold,
+or a sampling profile correlated on time against the signpost stream.
+
+Separately worth investigating on its own terms: a poll cycle occupying 43.7% of
+wall time is remarkable regardless of its relationship to these stalls.

--- a/docs/perf/2026-08-26-claude-code-render-benchmark.md
+++ b/docs/perf/2026-08-26-claude-code-render-benchmark.md
@@ -1,0 +1,159 @@
+# Benchmarking TBD's terminal render path with a real agent as the producer
+
+**Audit record.** Measured 2026-08-26 against `/Applications/TBD.app` built at
+14:09 from the temporary signpost branch described below, on a 12-core Apple
+Silicon machine carrying ~40 concurrent agent sessions (load average 30–92
+across the runs; no Swift builds active). Numbers are that machine on that day;
+the method is what generalizes.
+
+## What problem this solves
+
+TBD's embedded terminals feel laggy under heavy output. Measuring that honestly
+needs a producer that is both *realistic* (a real agent TUI, not a synthetic
+byte stream) and *deterministic* (the same bytes every run, so an A/B compares
+renderers rather than two different workloads).
+
+Driving a live agent against the real API gives realism and no determinism: the
+token stream differs every run, costs money, and carries network jitter. A
+synthetic `printf` loop gives determinism and no realism: it emits byte patterns
+no TUI produces, and its own overhead can silently become the bottleneck.
+
+Pointing Claude Code at a local fake Anthropic endpoint gives both. The real TUI
+does the rendering; a scripted SSE stream decides exactly what it renders, at a
+rate we choose, for free and offline.
+
+## How it works
+
+Claude Code honours `ANTHROPIC_BASE_URL`, so it can be aimed at a local server.
+`ANTHROPIC_AUTH_TOKEN` set to any dummy string bypasses the OAuth flow, and
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` silences background chatter that
+would otherwise hit the fake server. Verified against Claude Code 2.1.246, which
+ships as a Bun-compiled native binary rather than a `cli.js`.
+
+The pieces:
+
+- **`scripts/diag/fake-anthropic-server.py`** — a stdlib HTTP server answering
+  `POST /v1/messages` with a scripted SSE stream. `FA_DELTAS`, `FA_RATE`,
+  `FA_TEXT` and `FA_NEWLINE` control length, pace, delta size, and how often a
+  newline is emitted (which decides whether the TUI scrolls).
+- **`scripts/diag/bench-cc-render.sh`** — spawns a TBD terminal running Claude
+  Code against that server, optionally switches renderer, foregrounds the tab,
+  submits a prompt, captures signposts, and reports.
+- **`scripts/diag/signpost-report.py`** — summarizes a capture.
+
+Injection must go through `tbd terminal create --cmd`. TBD's `envOverrides` is
+repo-wide, so using it would silently point *real* sessions at the fake endpoint.
+
+```
+scripts/diag/bench-cc-render.sh --worktree <worktree-id> --label cc-fs --mode fullscreen
+scripts/diag/bench-cc-render.sh --worktree <worktree-id> --label cc-def --mode default
+```
+
+### Prerequisite: the signpost build
+
+The scripts read three `os_signpost` intervals that exist only on a temporary
+instrumentation branch (`diag: signpost the terminal render path`), which is
+deliberately unmerged. Confirm the running app carries it before trusting a run:
+
+```
+strings /Applications/TBD.app/Contents/MacOS/TBDApp | grep -c RenderLatencySignposts   # must be 1
+```
+
+Rebuilding from a branch without the instrumentation destroys the instrument.
+
+## Reading the three intervals
+
+Each measures something different, and conflating them produces wrong
+conclusions:
+
+- **`mainThreadHop`** — the main-thread *queueing delay* for a pty chunk, from
+  just before `DispatchQueue.main.async` to the block running. It is waiting,
+  not work. A large value means the main thread was busy with something else.
+- **`feed`** — the nested `TerminalView.feed()` call: parse plus damage
+  tracking. Synchronous and nested, so this is the **trustworthy cost signal**.
+- **`displayPass`** — an **upper bound** on one AppKit display pass. It begins in
+  `viewWillDraw()` and ends on the next main-queue turn, so a backed-up main
+  queue inflates it. A large `displayPass` does not mean drawing was slow.
+
+The derived figure that matters most is **`feed` work per wall-second**: total
+`feed` time divided by the span. Above ~1.0 the main thread is saturated by
+parsing alone, before any drawing happens.
+
+## Results
+
+Two producers, same machine, same instrument. `chunks/s` is `mainThreadHop`
+count over the window span.
+
+    producer                            renderer      chunks/s  feed p50  feed work/s  passes/s
+    Claude Code, 40 deltas/s            fullscreen        38.9   0.12 ms       0.01        5.4
+    Claude Code, 40 deltas/s (repeat)   fullscreen        37.7   0.12 ms       0.01        5.0
+    Claude Code, 40 deltas/s            default           36.5   0.12 ms       0.01        6.2
+    Claude Code, 400 deltas/s           default           30.0   0.10 ms       0.00        7.1
+    synthetic, 2637 lines/s             alt-screen       354.8   0.38 ms       0.13       22.7
+    synthetic, 2637 lines/s (repeat)    alt-screen       364.1   0.38 ms       0.14       21.2
+    synthetic, 2637 lines/s             scrolling        274.3   6.15 ms       0.96        1.1
+    synthetic, 2637 lines/s (repeat)    scrolling        226.8   6.30 ms       0.96        1.0
+
+Three findings:
+
+**An agent cannot saturate TBD.** Claude Code emits ~30–40 screen updates per
+second regardless of renderer, and raising the token rate tenfold (40 → 400
+deltas/s) *lowered* the chunk rate to 30/s — it coalesces repaints internally.
+Feed work stays at 0.01 s/s, leaving the main thread ~99% idle. The renderer
+choice makes no material difference either.
+
+**Full-viewport repaint is cheap; scrolling line-append is expensive.** At
+matched volume (2,637 lines/s, ~320 KB/s), alt-screen repaint costs 0.38 ms per
+chunk while scrolling append costs 6.2 ms — about 10x per byte. The scrolling
+case consumes 0.96 s of parse work per wall-second and the view drops to ~1
+display pass per second. This is the opposite of the intuition that redrawing
+every visible row must cost more than appending one line.
+
+**The cost is upstream of drawing.** It lands in `feed` — parse and damage
+tracking — not in `drawTerminalContents`. Optimizing the per-row
+`NSAttributedString` rebuild would target a path that is not the bottleneck.
+
+Together these point away from agent output as the lag source and toward
+high-rate scrolling output in ordinary tabs: build logs, test runs, `cat` of a
+large file.
+
+## Pitfalls that have produced wrong answers here
+
+Every one of these produced a confident, wrong number during this work.
+
+- **A capture with no `displayPass` intervals is void.** Those only occur if the
+  view actually draws, which requires the tab to be on screen. A hidden terminal
+  feeds and parses happily and yields a plausible table that means nothing. The
+  bench script now aborts loudly below 20 passes.
+- **A fixed `sleep` after spawning loses keystrokes.** Under load, Claude Code
+  took longer than 10 s to boot; the mode command and the prompt both went
+  nowhere, producing a capture containing no load at all. Wait on machine
+  signals instead: `HEAD /api/hello` in the server log proves the TUI booted, and
+  `POST /v1/messages` proves the prompt submitted.
+- **Verify the renderer actually switched.** `/tui default` applies reliably when
+  sent programmatically; `/tui fullscreen` often does not. Check tmux's
+  `alternate_on` (1 = alternate screen, 0 = normal screen) rather than assuming.
+  Note that `default` is the *name* of the inline/scrolling renderer, so "already
+  using the default renderer" is a statement about mode, not about your config.
+- **The producer can be the bottleneck.** A naive Python loop building strings
+  per line capped at ~345 lines/s and was misread as pty backpressure. A `cat` of
+  1.92 MB completes in 0.095 s (~20 MB/s), which settles it: the pipe is not the
+  constraint. Precompute the frame buffers and report achieved throughput.
+- **Rates must divide by the span actually covered by data.** `log stream` starts
+  mid-flight, so intervals whose `begin` predates the first captured
+  `mainThreadHop` must be excluded, and a load period that ends early must not be
+  divided by the nominal window width. Getting both wrong once inflated a figure
+  from 0.75 to 0.97 s/s by coincidence.
+- **Take more than one window, and note the load.** A single window produced a
+  wrong committed conclusion earlier in this investigation. Run the A/B
+  back-to-back so both halves share machine state, and record the load average.
+- **`pgrep -f` matches your own command line**, which once produced a phantom
+  "the app restarted eight times" reading.
+
+## Limits
+
+The fake stream removes network jitter by construction, so this measures render
+cost, not end-to-end perceived latency. It also drives text deltas; a real
+session additionally renders tool-use blocks and their results, and Claude Code
+buffers bulk tool output rather than painting it — which is why pointing the
+harness at an agent's *tool* output does not reproduce heavy load either.

--- a/docs/specs/2026-08-25-appstate-observable-migration-design.md
+++ b/docs/specs/2026-08-25-appstate-observable-migration-design.md
@@ -9,40 +9,47 @@ through `@EnvironmentObject` by 106 binding sites across 69 view files. Under
 view reads the property that changed. Readership is irrelevant to invalidation —
 only writer frequency matters.
 
-The cost is measurable. Sampling the running app for 20 seconds while a terminal
-is scrolled:
+The waste is measurable. Sampling the app across windows **verified to contain
+actual scrolling** — each window scored for scroll-event frames and for terminal
+draw volume, with windows failing that check discarded rather than averaged in —
+`RepoSectionView.body` accounts for 30 to 37 samples per 1,000 main-thread
+samples, against 6.6 in a quiet baseline. The sidebar re-evaluates roughly five
+times as often while a terminal scrolls, and it displays nothing new when it
+does. `WorktreeRowView`, `TabBarItem`, and `PanePlaceholder` re-evaluate
+alongside it. Across those windows the main thread runs 45% to 64% busy and
+TBDApp holds roughly 47% of a core.
 
-- **TBDApp consumes 12.29 s of CPU** — 61% of a core — against 4.35 s over an
-  equivalent quiet window.
-- **The main thread is 50.3% busy** (3,921 of 7,801 samples), against 18.7% quiet.
-- **Roughly half that busy time, 1,925 samples, is SwiftUI view-graph update** —
-  `NSHostingView.beginTransaction` → `GraphHost.flushTransactions` →
-  `AG::Subgraph::update` → `ViewBodyAccessor.updateBody`.
-
-The bodies re-evaluating are the sidebar, none of which depend on the terminal
-being scrolled: `RepoSectionView` at 420 samples, `WorktreeRowView` at 240,
-`TabBarItem` at 139, `PanePlaceholder` at 47. `TerminalView.draw` — the view that
-actually changed — accounts for 157.
-
-Normalized per 1,000 main-thread samples, `RepoSectionView.body` accounts for 6.6
-samples when quiet and 53.8 while scrolling: an eightfold increase in time spent
-re-evaluating a view whose displayed content did not change.
+That validation step is not incidental. An unvalidated sampling window is
+indistinguishable from a mistimed one, and a window that captured no scrolling
+looks like a quiet baseline with a misleading label. Every number in this
+document comes from a window that passed the check.
 
 `@Observable` replaces object-wide notification with per-property dependency
 tracking. A view re-evaluates only when a property it actually read changes.
 
+### What this migration does not fix
+
+**The dominant cost of terminal scrolling is not this.** In the same validated
+windows, `TerminalView.draw` accounts for 237 to 425 samples per 1,000 against
+84.6 quiet — seven to twelve times the sidebar's share. That cost is SwiftTerm
+rebuilding an `NSAttributedString` for every visible row on every redraw
+(`drawTerminalContents` → `buildAttributedString`), plus a full-grid scan for
+blink attributes (`visibleBlinkRows`) run on each display update. A scroll
+dirties every row every frame, so both are paid in full at display rate. That
+code lives in a pinned upstream dependency and is tracked separately.
+
+This migration removes a real but secondary cost. It is justified on the
+structural argument — object-wide invalidation across 106 binding sites is wrong
+at any writer frequency, and the measured fivefold rise in sidebar evaluation is
+that defect made visible — and **not** as a remedy for terminal scroll latency.
+A reader looking for the fix to a slow-feeling terminal should start with the
+draw path above.
+
 ### What this evidence does not establish
 
-The specific `@Published` write driving the scroll-time increase was not isolated.
-Writer-frame counts sampled during scrolling and during quiet windows are
-comparable, so the eightfold jump in `RepoSectionView.body` has no identified
-write behind it.
-
-This design therefore rests on the structural argument — object-wide invalidation
-is wrong at any writer frequency — and not on a demonstrated causal chain. The
-measured numbers above bound the size of the prize; they do not prove that
-per-property tracking captures all of it. Two specific ways the prize could
-shrink:
+The specific `@Published` write driving the scroll-time rise is not isolated, so
+the size of the available win is bounded above by the numbers here rather than
+predicted by them. Two ways it could shrink further:
 
 - **The sidebar reads terminal state.** Rows render activity dots and status
   chips from `terminals` and `notifications`. If the writes firing during a
@@ -50,16 +57,15 @@ shrink:
   sidebar, because the sidebar legitimately reads those properties. The win then
   comes only from the views that *don't* read them.
 - **The driver may not be a write-rate change at all.** One consistent
-  explanation for "same writer frequency, eight times the body time" is runloop
-  coalescing: when quiet, several `objectWillChange` fires within one runloop
-  turn collapse into one graph flush; while scrolling, the runloop spins at
-  display rate servicing scroll events, so each fire lands in its own flush. If
-  that is the mechanism, per-property tracking helps exactly to the extent the
-  firing property is one the sidebar does not read — which is unknown.
+  explanation is runloop coalescing: when quiet, several `objectWillChange` fires
+  within one runloop turn collapse into a single graph flush; while scrolling,
+  the runloop spins at display rate, so each fire lands in its own flush. If that
+  is the mechanism, per-property tracking helps exactly to the extent the firing
+  property is one the sidebar does not read.
 
-The acceptance gate below exists to settle this empirically rather than by
-assertion, and the diagnostic capture in "Acceptance" makes a null result
-interpretable instead of merely disappointing.
+The acceptance gate below settles this empirically rather than by assertion, and
+the diagnostic capture in "Acceptance" makes a null result interpretable instead
+of merely disappointing.
 
 ## Scope
 
@@ -317,14 +323,27 @@ naive conversion, per the repo rule that plan-authored tests must discriminate:
   against the broken one-shot implementation; two sequential fires are the
   discriminator.
 
-**A measured gate.** Re-run the scroll profile and compare against the baseline
-recorded here: 12.29 s of CPU per 20 s window, 50.3% main-thread busy, and
-`RepoSectionView.body` at 53.8 samples per 1,000 main-thread samples. The
-migration is accepted on a material reduction in the SwiftUI view-graph share of
-main-thread busy time. Because the driving write was never isolated, a null
-result is a real possible outcome and must be reported as one rather than
-absorbed — and the diagnostic capture above is what turns a null result into a
-finding ("the firing property is one the sidebar reads") rather than a mystery.
+**A measured gate, over validated windows.** Re-run the scroll profile and
+compare against the baseline recorded here: `RepoSectionView.body` at 30 to 37
+samples per 1,000 main-thread samples while scrolling against 6.6 quiet, with
+the main thread 45% to 64% busy and TBDApp near 47% of a core.
+
+Every window on both sides of the comparison must pass the same validation the
+baseline did — scored for scroll-event frames (`scrollWheel`, `gridPosition`)
+and for `TerminalView.draw` volume well above the quiet baseline, with failing
+windows discarded rather than averaged in. Take several short windows rather
+than one long one, so a mistimed window announces itself instead of becoming a
+finding. A quiet baseline must also be genuinely quiet: a session in which
+tooling is running commands streams output into the terminal and drives redraws,
+which inflates the very counters under comparison.
+
+The migration is accepted on a material reduction in the sidebar's share of
+main-thread samples. Because the driving write was never isolated, a null result
+is a real possible outcome and must be reported as one rather than absorbed —
+and the diagnostic capture above is what turns a null result into a finding
+("the firing property is one the sidebar reads") rather than a mystery. Note
+that the sidebar's share is a minority of scroll-time cost either way: a large
+proportional win here will not, on its own, make scrolling feel fast.
 
 **The existing suite green**, with the 6 test files' injection sites updated, run
 through `scripts/test.sh`.

--- a/docs/specs/2026-08-25-appstate-observable-migration-design.md
+++ b/docs/specs/2026-08-25-appstate-observable-migration-design.md
@@ -382,14 +382,24 @@ through `scripts/test.sh`.
 
 ## Waivers
 
-**This change ships without a feature flag.** TBD's convention is that
-wholesale-replacing a load-bearing path lands behind a default-off flag, and the
-view layer's observation mechanism qualifies. The waiver here is forced rather
-than chosen: the selection between `@EnvironmentObject` and `@Environment` is
-made at compile time, so a runtime flag would require every affected view body
-to exist twice. The revert path is the branch itself plus `scripts/restart.sh`,
-which the author exercises continuously by dogfooding the app; the stacked
-landing keeps each sibling conversion independently revertable.
+**This change ships without a feature flag, by explicit exception granted by the
+repository owner.** TBD's convention is that wholesale-replacing a load-bearing
+path lands behind a default-off flag, and the view layer's observation mechanism
+qualifies. That convention states no infeasibility exception, so this is not a
+waiver a spec can grant itself: it was put to the repository owner as a decision
+and signed off on 2026-08-26.
+
+The reason it was granted is that the waiver is forced rather than chosen. The
+selection between `@EnvironmentObject` and `@Environment` is made at compile
+time, so there is no runtime state a flag could switch — a gated version would
+require every affected view body to exist twice, which is more code and more risk
+than the migration it would be protecting against.
+
+What stands in for the flag: the revert path is the branch itself plus
+`scripts/restart.sh`, exercised continuously through dogfooding, and the stacked
+landing keeps each sibling conversion independently revertable. Those are weaker
+guarantees than a default-off flag and are recorded as such rather than presented
+as equivalent.
 
 **The assignment-site guard audit is not retired by this migration.** Observation
 fires on write, not on change (the `Equatable` suppression on newer toolchains

--- a/docs/specs/2026-08-25-appstate-observable-migration-design.md
+++ b/docs/specs/2026-08-25-appstate-observable-migration-design.md
@@ -24,9 +24,9 @@ being scrolled: `RepoSectionView` at 420 samples, `WorktreeRowView` at 240,
 `TabBarItem` at 139, `PanePlaceholder` at 47. `TerminalView.draw` — the view that
 actually changed — accounts for 157.
 
-Normalized per 1,000 main-thread samples, `RepoSectionView.body` evaluates 6.6
-times when quiet and 53.8 times while scrolling: an eightfold increase in
-re-evaluation of a view whose displayed content did not change.
+Normalized per 1,000 main-thread samples, `RepoSectionView.body` accounts for 6.6
+samples when quiet and 53.8 while scrolling: an eightfold increase in time spent
+re-evaluating a view whose displayed content did not change.
 
 `@Observable` replaces object-wide notification with per-property dependency
 tracking. A view re-evaluates only when a property it actually read changes.
@@ -41,8 +41,25 @@ write behind it.
 This design therefore rests on the structural argument — object-wide invalidation
 is wrong at any writer frequency — and not on a demonstrated causal chain. The
 measured numbers above bound the size of the prize; they do not prove that
-per-property tracking captures all of it. The acceptance gate below exists to
-settle that empirically rather than by assertion.
+per-property tracking captures all of it. Two specific ways the prize could
+shrink:
+
+- **The sidebar reads terminal state.** Rows render activity dots and status
+  chips from `terminals` and `notifications`. If the writes firing during a
+  scroll are terminal-shaped, per-property tracking still re-evaluates the
+  sidebar, because the sidebar legitimately reads those properties. The win then
+  comes only from the views that *don't* read them.
+- **The driver may not be a write-rate change at all.** One consistent
+  explanation for "same writer frequency, eight times the body time" is runloop
+  coalescing: when quiet, several `objectWillChange` fires within one runloop
+  turn collapse into one graph flush; while scrolling, the runloop spins at
+  display rate servicing scroll events, so each fire lands in its own flush. If
+  that is the mechanism, per-property tracking helps exactly to the extent the
+  firing property is one the sidebar does not read — which is unknown.
+
+The acceptance gate below exists to settle this empirically rather than by
+assertion, and the diagnostic capture in "Acceptance" makes a null result
+interpretable instead of merely disappointing.
 
 ## Scope
 
@@ -58,92 +75,256 @@ All nine `ObservableObject` classes in `Sources/TBDApp` convert to `@Observable`
 - **`QueuedPromptTarget`** — `Worktree/QueuedPromptModal.swift`
 - **`JumpMenuViewModel`** — `JumpMenu/JumpMenuViewModel.swift`
 
-Converting only `AppState` was considered and rejected: it leaves a mixed
-paradigm, and `AppState` holds and bridges `AppearanceSettings` with Combine, so
-the seam has to be resolved either way.
-
 Two facts make the conversion tractable. The package targets macOS 15, so
-Observation is available. And the view layer contains **no Combine
-`$property` publisher usage at all** — no `.sink`, `.assign`, `debounce`, or
-`combineLatest` over a `@Published` projection — so the usual blocking dependency
-on `ObservableObject`'s publisher semantics does not exist here. The exceptions
-are the explicit `objectWillChange` subscribers treated as hazard (a) below.
+Observation is available. And the **view layer** contains no Combine `$property`
+publisher usage — no `.sink`, `.assign`, `debounce`, or `combineLatest` over a
+`@Published` projection in any view file. The app's Combine dependencies on these
+nine classes total exactly three non-view sites, enumerated in hazard (a); each
+one must be rebuilt on Observation primitives by the PR that converts the class
+it subscribes to.
 
 ## Mechanical shape
 
 - `@Published var x` becomes a plain stored property; the macro supplies tracking.
 - `@EnvironmentObject var appState: AppState` becomes
-  `@Environment(AppState.self) var appState`.
+  `@Environment(AppState.self) var appState`. Both forms crash at runtime when
+  the object was never injected, so the failure mode does not change.
 - `.environmentObject(x)` becomes `.environment(x)` — 29 sites in `Sources`, 4 in
-  `Tests`.
-- `@StateObject` becomes `@State` (13 sites); `@ObservedObject` becomes a plain
-  `let` (8 sites).
-- Any view needing `$appState.foo` declares `@Bindable`.
-- `AppState` remains a `@MainActor final class`.
+  `Tests`, plus the manual re-injection sites for detached and nested hosting.
+- `@StateObject` becomes `@State` (13 sites) — carries hazard (c).
+- `@ObservedObject` becomes a plain `let` (8 sites) — two of them sit inside
+  `Commands` scenes, flagged in hazard (d).
+- A view needing `$appState.foo` declares a local `@Bindable var appState =
+  appState` inside `body` — `@Bindable` cannot be combined with `@Environment`
+  in one declaration.
+- `AppState` remains a `@MainActor final class`; that combination is the
+  sanctioned Swift 6 shape and has no known interop issue with the macro.
+
+**The macro inverts the tracking default, and that inversion is an audit, not a
+find-replace.** Under `ObservableObject`, a property participates in invalidation
+only if someone wrote `@Published`; under `@Observable`, *every* stored property
+is tracked unless someone writes `@ObservationIgnored`. `AppState` carries on the
+order of sixty non-`@Published` stored properties whose unpublished status is a
+deliberate, documented decision — memo caches, ordering watermarks
+(`terminalPresentationOrderObservedAt`, `terminalSessionOrderObservedAt`, whose
+doc comments exist precisely to keep a same-value poll from publishing), sequence
+counters, in-flight `Task` handles, `AnyCancellable`s. A naive conversion
+silently flips every one of those decisions and re-introduces exactly the churn
+the comments prohibit. PR 1 therefore includes a property-by-property pass over
+`AppState`'s stored properties: each currently-unpublished one gets
+`@ObservationIgnored` unless there is a positive reason to track it.
+
+Two compiler-enforced corners of the same pass, verified against the current
+toolchain:
+
+- **`lazy var` does not compile under `@Observable`** — the macro's expansion
+  rejects it. `AppState`'s ~27 `lazy var` injection seams (`worktreeCreator`,
+  `tabStatesFetcher`, and kin) all become `@ObservationIgnored lazy var`, which
+  compiles and preserves their behavior. Tests reassigning the seams are
+  unaffected: nothing observes them.
+- **`weak var` compiles and is tracked** — `AppearanceSettings.themeStore` needs
+  no annotation.
+
+`didSet`/`willSet` on stored properties continue to fire under the macro: the
+expansion attaches the observers to the synthesized backing storage, so
+`worktrees.didSet` keeps invalidating the memo caches. This is confirmed both by
+the macro's documented expansion and by a compiled check against the current
+toolchain — not assumed.
 
 ## Hazards
 
-**(a) AppKit consumers of `objectWillChange`.** `TBDTerminalView` is an `NSView`
-subclass that subscribes to `AppearanceSettings.objectWillChange` through a
-Combine sink and reapplies theme settings on every fire. `@Observable` publishes
-no such stream. The replacement is `withObservationTracking(_:onChange:)`, whose
-`onChange` is **one-shot**: it must be re-armed after each fire or the view stops
-responding to theme changes permanently. The existing hop to the main queue must
-be kept — `onChange` fires in `willSet` position, before the new value is
-readable, exactly as `objectWillChange` did.
+**(a) Combine consumers of the converting classes.** Three sites, each losing its
+publisher when its class converts:
 
-This failure is silent and no existing test covers it, so the sibling PR that
-converts `AppearanceSettings` carries a test that changes a setting and asserts
-the terminal reapplies it more than once. Re-arming correctly is the whole point;
-a single-fire test would pass against the broken implementation.
+- **`TBDTerminalView`** (`Terminal/TBDTerminalView.swift`) — an `NSView` subclass
+  subscribing to `AppearanceSettings.objectWillChange` to reapply font, colors,
+  and cursor on any settings change.
+- **`AppearanceBroadcastDebouncer`** (`Terminal/AppearanceBroadcastDebouncer.swift`)
+  — subscribes `appearance.$schemeID` through `dropFirst().removeDuplicates()`,
+  then debounces on the injected clock before broadcasting COLORFGBG to tmux.
+- **`AppState.setupAppearanceSubscriptions`** — subscribes `themeStore.$userThemes`
+  (also with `dropFirst()`) to reconcile the active scheme when a theme file is
+  added, edited, or deleted on disk.
 
-**(b) `didSet`-driven memo invalidation.** `AppState` serves `children(of:)` and
-`allWorktrees` from memoized caches invalidated by `worktrees.didSet` and
-`scratchWorktrees.didSet`. These are load-bearing: recomputing `children(of:)` per
-render pass measured 79.5 ms. `didSet` continues to work on plain stored
-properties under `@Observable`, so the caches survive the conversion — but the
-implementation must verify this rather than assume it, because a silent
-regression here restores an O(N²) render pass.
+The replacement primitive is `withObservationTracking(_:onChange:)`, and it is
+sharper-edged than the publishers it replaces:
 
-Both caches are deliberately *not* observable storage. A write to observable state
-from inside a view body traps with "Modifying state during view update", and these
-caches fill lazily from their getters, which run inside body evaluation. They stay
-plain stored properties after the conversion.
+- **`onChange` is one-shot.** It must re-arm after every fire — the canonical
+  shape is a method that arms the tracking, and an `onChange` that hops to the
+  main actor, does the work, and calls the method again. A missed re-arm fails
+  silently: the consumer simply stops responding, permanently.
+- **`onChange` fires in `willSet` position.** The new value is not yet readable
+  inside the callback. The hop to the main queue that `TBDTerminalView` already
+  performs must be kept; by the time the hopped block runs, the write has
+  committed.
+- **There is no cancellation token.** The pattern relies on `[weak self]` in both
+  closures; when the consumer deallocates, the next fire is a no-op and the
+  re-arm chain ends. An armed closure that strongly captures `self` is a leak
+  with no way to break it.
+- **Changes between fire and re-arm are not queued.** The mitigation is to make
+  every fire re-read all relevant state rather than diff — which `applyAll()`
+  already does, and which the debouncer's trailing-edge design also tolerates.
+- **Observation fires on every write, not on every change** (a same-value
+  assignment may be suppressed for `Equatable` properties on newer toolchains,
+  but that optimization is not something to build a contract on). The debouncer's
+  `removeDuplicates()` must therefore be replaced by an explicit last-seen
+  comparison, or same-value `schemeID` writes start scheduling broadcasts.
+  Conversely `dropFirst()` needs no replacement: observation has no
+  replay-at-subscription, so its job disappears.
 
-**(c) Bindings.** Every site passing `$appState.foo` requires `@Bindable` on the
-declaring view. These surface as compile errors, so the risk is effort rather than
-silent breakage.
+The debouncer's clock-seam contract is already covered by a `TestClock`-driven
+test; that test must survive the rewiring unchanged. The terminal-view consumer
+gains the re-arm test described under "Acceptance" — a single-fire test would
+pass against the broken one-shot implementation, so the test must assert two
+sequential changes each get applied.
+
+macOS 26's `Observations` AsyncSequence (SE-0475) would replace the re-arm dance
+wholesale, and AppKit's automatic observation tracking
+(`NSObservationTrackingEnabled`) exists on macOS 15 but only covers reads made
+inside layout methods — neither fits a macOS 15 target and a reapply path that
+is not layout-shaped. The manual re-arm loop is the pattern until the deployment
+target moves; see "Rejected alternatives".
+
+**(b) Memoized caches: annotation and a dependency-loss trap.** `AppState` serves
+`children(of:)` and `allWorktrees` from memoized caches (`childrenIndexCache`,
+`allWorktreesCache`) invalidated by `worktrees.didSet` and
+`scratchWorktrees.didSet`. These are load-bearing: recomputing `children(of:)`
+per render pass measured 79.5 ms. Two distinct requirements:
+
+- **The caches must be `@ObservationIgnored`.** They fill lazily from getters
+  that run inside body evaluation; if the macro tracked them, that fill would be
+  an observable mutation during view update — the same "Modifying state during
+  view update" fault their doc comment already guards against, plus a
+  self-invalidation loop.
+- **A warm cache severs the dependency, and that is a stale-UI bug, not a
+  performance detail.** SwiftUI rebuilds a view's dependency set on every body
+  evaluation from the tracked properties that evaluation actually read. A body
+  evaluation served entirely from the warm cache reads no tracked property — so
+  a view re-evaluated for an unrelated reason (selection change, hover) while
+  the cache is warm *drops* its dependency on `worktrees`, and the next
+  `worktrees` write does not invalidate it. The sidebar goes stale until some
+  other property it reads happens to change. This is not hypothetical: it was
+  reproduced with a compiled check against the current toolchain (cold-cache
+  tracker fires on a `worktrees` write; warm-cache tracker does not). Under
+  `ObservableObject` the memo was safe because invalidation was object-wide;
+  per-property tracking removes the safety net the memo was leaning on.
+
+  The fix is one line per getter: touch the tracked source unconditionally
+  before consulting the cache — `childrenIndex()` reads `worktrees`,
+  `allWorktrees` reads both `worktrees` and `scratchWorktrees` — so every
+  evaluation re-registers the dependency. The read costs a retain, not a copy.
+  A discriminating test pins this (see "Acceptance"): warm the cache through an
+  unrelated re-evaluation, then mutate `worktrees` and assert the view updated.
+
+**(c) `@StateObject` → `@State` is not behaviorally neutral.** A `@State`
+default-value expression re-runs on every memberwise init of the view struct —
+`@State` preserves the stored value, not the expression — and this repo has
+already been bitten by exactly that (the `AgentExecutableAvailability.detect()`
+regression fixed in the prior render-cost pass). There is additionally a
+long-open SwiftUI defect report about `@State`-wrapped `@Observable` objects
+re-initializing more often than `@StateObject` did. The 13 `@StateObject` sites
+must each be audited for construction cost before the swap: `AppState`,
+`AppearanceSettings`, and `TranscriptOverlayCoordinator` are constructed once at
+the app root (their inits do real work — `UserDefaults` reads, subscription
+setup — so verify construction frequency in the converted app rather than
+assuming it); `HoverMenuModel`, `WebviewState`, `TerminalThemeEditorViewModel`
+instances are per-row or per-pane and their inits must be — and stay — trivial.
+
+**(d) Reads outside `body` do not register dependencies.** Observation tracks
+only what the body evaluation itself reads. A property read inside an escaping
+closure that runs later — a button action, `onAppear`, a `.task`, an `NSMenu`
+construction callback — establishes no dependency. Under `ObservableObject`,
+views could *appear* to depend on such reads because any write anywhere
+re-evaluated them; per-property tracking withdraws that accidental subsidy, and
+the view silently stops updating. Two known-delicate corners get explicit
+attention in review: the `Commands` scenes (`NightwatchStatusItem`,
+`ModelProfileMenu`, `TBDCommands`), whose doc comments already record that
+`Commands` bodies observe unreliably and which wrap content in nested `View`s as
+the workaround — that workaround must be re-verified under Observation — and any
+container that receives `{ appState.foo }` closures rather than values. The
+conversion PRs treat "view reads the object only inside closures" as a review
+checklist item, not something the compiler surfaces.
+
+**(e) Bindings.** Every site passing `$appState.foo` requires the local
+`@Bindable` shadow on the declaring view. These surface as compile errors, so
+the risk is effort rather than silent breakage.
 
 ## Landing
 
 **PR 1 converts `AppState` alone.** This step is atomic by necessity: the class
 declaration and all 106 binding sites must flip together, spanning roughly 69
-source and 6 test files. It carries the entire measured win, and the acceptance
-gate below applies to it.
+source and 6 test files. It carries the entire measured win, the
+`@ObservationIgnored` audit, the cache-getter dependency fix from hazard (b),
+and the acceptance gate below.
+
+Mixed-mode operation during the stack is supported and expected: the root scenes
+inject `.environment(appState)` alongside `.environmentObject(appearance)` and
+`.environmentObject(overlayCoordinator)` until those classes convert, and the
+Combine bridges in hazard (a) keep working until the PR that converts the class
+each one subscribes to. A view reading an `ObservableObject` through a converted
+`@Observable` parent still needs its own subscription to the child — the chain
+of automatic tracking only spans `@Observable` types — which is the existing
+shape (each class is injected and observed independently) and so needs no
+transitional shim.
 
 **PRs 2 through 9 convert one sibling observable each**, independently green and
-independently revertable. `AppearanceSettings` is its own PR because it owns
-hazard (a).
+independently revertable. `AppearanceSettings` is its own PR and carries the
+`TBDTerminalView` re-arm and the `AppearanceBroadcastDebouncer` rewiring;
+`ThemeStore`'s PR carries the `$userThemes` reconcile bridge. The remaining six
+are mechanical.
 
-PR 1 modifies `RepoSectionView.swift` at the `@EnvironmentObject` declaration, and
-so rebases over the separate formatter-caching fix in that same file, which is
-confined to the `matchedRemoteSessions` and `parsedCreatedAt` regions.
+PR 1 modifies `RepoSectionView.swift` at the `@EnvironmentObject` declaration,
+and so rebases over the separate formatter-caching fix (#714) confined to the
+`matchedRemoteSessions` and `parsedCreatedAt` regions of that file.
 
 ## Acceptance
 
-**A discriminating test.** Mutate an `AppState` property that a given view does not
-read, and assert that view's body does not re-evaluate, counting evaluations in a
-test host. This test fails against `ObservableObject`, where every write
-invalidates every observer, and passes under per-property tracking. A test that
-merely asserts the view still renders correctly would pass both before and after
-and would guard nothing.
+**A diagnostic capture before PR 1 lands.** One dogfood session with temporary,
+uncommitted instrumentation — a counter on `AppState.objectWillChange` fires per
+second, and `Self._printChanges()` in the four hot bodies — run during the same
+scroll workload as the baseline. This does not gate the migration; it exists so
+the after-measurement is interpretable. It names the property (or properties)
+firing during scroll, which tells us in advance whether the sidebar reads them —
+the difference between expecting a large win and expecting a null result — and
+it feeds the assignment-site guard audit that remains open independently of this
+migration.
+
+**Discriminating tests** — each one fails against today's code or against the
+naive conversion, per the repo rule that plan-authored tests must discriminate:
+
+- **Unrelated-write test (PR 1).** Host a view that reads one `AppState`
+  property in an `NSHostingView` inside a borderless window, pump the runloop in
+  bounded slices, count body evaluations via a counter bumped in `body`. Mutate
+  a property the view does not read; assert the count did not move; then mutate
+  the property it does read and assert the count moved (the positive control
+  that proves the harness detects re-evaluation at all). Assert on
+  before/after comparisons, never exact counts — SwiftUI may legitimately
+  double-evaluate. This fails under `ObservableObject`, where any write
+  invalidates every observer. The repo already hosts SwiftUI in unit tests this
+  way (`TableTranscriptHarness`, `WorkbenchSnapshotTests`), so the harness is
+  precedented, not novel. Run it against the production view shapes
+  (`RepoSectionView`, `WorktreeRowView`), not only a synthetic probe: the
+  read-set as actually composed — computed properties, child composition — is
+  exactly what a model-layer `withObservationTracking` assertion cannot see.
+- **Cache-dependency test (PR 1).** Evaluate a sidebar view cold (registers the
+  `worktrees` dependency and warms the cache), force a re-evaluation via an
+  unrelated property the view reads (serving `children(of:)` from the warm
+  cache), then mutate `worktrees` and assert the view re-evaluated and shows
+  the new row. The naive conversion fails this; the getter-touch fix in hazard
+  (b) passes it.
+- **Re-arm test (AppearanceSettings PR).** Change a setting twice, sequentially,
+  asserting the terminal reapplied after each change. A single-fire test passes
+  against the broken one-shot implementation; two sequential fires are the
+  discriminator.
 
 **A measured gate.** Re-run the scroll profile and compare against the baseline
 recorded here: 12.29 s of CPU per 20 s window, 50.3% main-thread busy, and
-`RepoSectionView.body` at 53.8 evaluations per 1,000 main-thread samples. The
+`RepoSectionView.body` at 53.8 samples per 1,000 main-thread samples. The
 migration is accepted on a material reduction in the SwiftUI view-graph share of
-main-thread busy time. Because the driving write was never isolated, a null result
-is a real possible outcome and must be reported as one rather than absorbed.
+main-thread busy time. Because the driving write was never isolated, a null
+result is a real possible outcome and must be reported as one rather than
+absorbed — and the diagnostic capture above is what turns a null result into a
+finding ("the firing property is one the sidebar reads") rather than a mystery.
 
 **The existing suite green**, with the 6 test files' injection sites updated, run
 through `scripts/test.sh`.
@@ -153,44 +334,60 @@ through `scripts/test.sh`.
 **This change ships without a feature flag.** TBD's convention is that
 wholesale-replacing a load-bearing path lands behind a default-off flag, and the
 view layer's observation mechanism qualifies. The waiver here is forced rather
-than chosen: the selection between `@EnvironmentObject` and `@Environment` is made
-at compile time, so a runtime flag would require every affected view body to exist
-twice. The revert path is the branch itself plus `scripts/restart.sh`, which the
-author exercises continuously by dogfooding the app.
+than chosen: the selection between `@EnvironmentObject` and `@Environment` is
+made at compile time, so a runtime flag would require every affected view body
+to exist twice. The revert path is the branch itself plus `scripts/restart.sh`,
+which the author exercises continuously by dogfooding the app; the stacked
+landing keeps each sibling conversion independently revertable.
 
-**This supersedes an earlier decision to defer `@Observable`** pending cheaper
-measures. That deferral rested on the migration touching every view file while
-cheaper options remained untried. The judgment recorded here is that object-wide
-invalidation is a defect in the observation model rather than a tuning parameter,
-and is worth correcting on its own terms.
-
-The cheaper measure that deferral named — auditing frequent writers for equality
-guards sitting in `didSet` rather than at the assignment site — remains valid and
-is **not** retired by this migration. `@Published` fires on assignment rather than
-on change, so a guard inside `didSet` suppresses downstream work but not the
-invalidation. `applyTerminalActivityDelta` is a live instance: it assigns
-`activityState` unconditionally and then calls `removeValue` on two further
-observable dictionaries, firing up to three notifications for a delta that may
-carry no change at all. Per-property tracking narrows who those notifications
-reach; it does not stop them being sent. That audit is worth doing independently.
+**The assignment-site guard audit is not retired by this migration.** Observation
+fires on write, not on change (the `Equatable` suppression on newer toolchains
+notwithstanding), so a frequent writer that assigns equal values still notifies
+every reader of that property. `applyTerminalActivityDelta` is a live instance:
+its non-Codex branch assigns `terminals[...][idx].activityState` unconditionally
+— one object-wide fire today for a delta that may carry no change — and mutates
+the two untracked watermark dictionaries beside it. Per-property tracking narrows
+who a redundant notification reaches; only an assignment-site guard stops it
+being sent. That audit remains open as independent work, and the diagnostic
+capture above gives it a target list.
 
 ## Rejected alternatives
 
+**Deferring the migration until cheaper measures are exhausted.** The tracking
+issue (#667) deliberately deferred `@Observable` behind an assignment-site guard
+audit, on the grounds that the migration touches every view file while cheaper
+options remained untried. The judgment recorded here is that object-wide
+invalidation is a defect in the observation model rather than a tuning
+parameter: guards shrink the number of redundant fires, but every legitimate
+fire still invalidates all 106 binding sites, so guard work alone converges on
+"every write is justified and every view still pays for each one." The two
+measures also compose rather than compete — the audit stays open above — and
+deferral would leave the 79.5 ms-class memo caches permanently load-bearing
+against an invalidation model that makes them necessary.
+
 **Converting `AppState` only.** Smallest diff, but leaves two idioms in the
-codebase indefinitely and does not resolve the `AppState`-to-`AppearanceSettings`
-Combine bridge, which has to be addressed regardless.
+codebase indefinitely and leaves all three Combine bridges in hazard (a)
+unresolved, two of which sit on classes other than `AppState`.
 
 **A single pull request for all nine classes.** One review and one revert point,
-but a diff of roughly 75 files in which a subtle observation defect in any single
-view is expensive to bisect, and where reverting discards eight easy conversions
-along with the one hard one.
+but a diff of roughly 75 files in which a subtle observation defect in any
+single view is expensive to bisect, and where reverting discards eight easy
+conversions along with the one hard one.
 
-**Converting the siblings before `AppState`.** Establishes the pattern on low-risk
-classes first, but defers the measured win behind eight PRs that deliver none of
-it.
+**Converting the siblings before `AppState`.** Establishes the pattern on
+low-risk classes first, but defers the measured win behind eight PRs that
+deliver none of it.
 
 **Shipping without the measured gate.** Per-property tracking is correct by
-construction, so the argument runs that measurement is ceremony. Rejected because
-the write driving the observed churn was never identified: without a
+construction, so the argument runs that measurement is ceremony. Rejected
+because the write driving the observed churn was never identified: without a
 before-and-after number, a migration touching 75 files would carry no evidence
 that it addressed the symptom that motivated it.
+
+**Waiting for macOS 26 Observation APIs.** `Observations` (SE-0475) and
+continuous tracking would eliminate hazard (a)'s re-arm loop, and AppKit's
+automatic tracking would cover layout-shaped consumers — but both are gated on a
+deployment-target move to macOS 26, which is not on the table for a symptom
+users feel today. Third-party backports of those primitives were likewise
+rejected: one well-audited dependency is not worth adopting to avoid a
+twenty-line re-arm pattern with local tests.

--- a/docs/specs/2026-08-25-appstate-observable-migration-design.md
+++ b/docs/specs/2026-08-25-appstate-observable-migration-design.md
@@ -3,7 +3,7 @@
 ## Why
 
 `AppState` is an `ObservableObject` carrying 109 `@Published` properties, consumed
-through `@EnvironmentObject` by 106 binding sites across 69 view files. Under
+through `@EnvironmentObject` by 88 binding sites across 56 view files. Under
 `ObservableObject`, `objectWillChange` is object-wide: a write to any one of those
 109 properties invalidates every view observing the object, whether or not that
 view reads the property that changed. Readership is irrelevant to invalidation —
@@ -60,7 +60,7 @@ upstream dependency and is tracked separately.
 
 So this migration addresses the largest single main-thread consumer during
 scroll, but it is one of three independent costs and not the first one to land.
-It is justified on the structural argument — object-wide invalidation across 106
+It is justified on the structural argument — object-wide invalidation across 88
 binding sites is wrong at any writer frequency, and the measured five-to-sevenfold
 rise in graph flush is that defect made visible — rather than as the remedy for a
 slow-feeling terminal on its own.
@@ -115,8 +115,9 @@ it subscribes to.
 - `@EnvironmentObject var appState: AppState` becomes
   `@Environment(AppState.self) var appState`. Both forms crash at runtime when
   the object was never injected, so the failure mode does not change.
-- `.environmentObject(x)` becomes `.environment(x)` — 29 sites in `Sources`, 4 in
-  `Tests`, plus the manual re-injection sites for detached and nested hosting.
+- `.environmentObject(appState)` becomes `.environment(appState)` — 21 sites in
+  `Sources`, 4 in `Tests`, plus the manual re-injection sites for detached and
+  nested hosting.
 - `@StateObject` becomes `@State` (13 sites) — carries hazard (c).
 - `@ObservedObject` becomes a plain `let` (8 sites) — two of them sit inside
   `Commands` scenes, flagged in hazard (d).
@@ -278,8 +279,8 @@ the risk is effort rather than silent breakage.
 ## Landing
 
 **PR 1 converts `AppState` alone.** This step is atomic by necessity: the class
-declaration and all 106 binding sites must flip together, spanning roughly 69
-source and 6 test files. It carries the entire measured win, the
+declaration and all 88 binding sites must flip together, spanning 56 source and
+4 test files. It carries the entire measured win, the
 `@ObservationIgnored` audit, the cache-getter dependency fix from hazard (b),
 and the acceptance gate below.
 
@@ -376,7 +377,7 @@ before the gate is applied: a lower report rate reduces run-loop turns, which
 reduces flush frequency on its own and would otherwise be credited to this
 migration.
 
-**The existing suite green**, with the 6 test files' injection sites updated, run
+**The existing suite green**, with the 4 test files' injection sites updated, run
 through `scripts/test.sh`.
 
 ## Waivers
@@ -409,7 +410,7 @@ audit, on the grounds that the migration touches every view file while cheaper
 options remained untried. The judgment recorded here is that object-wide
 invalidation is a defect in the observation model rather than a tuning
 parameter: guards shrink the number of redundant fires, but every legitimate
-fire still invalidates all 106 binding sites, so guard work alone converges on
+fire still invalidates all 88 binding sites, so guard work alone converges on
 "every write is justified and every view still pays for each one." The two
 measures also compose rather than compete — the audit stays open above — and
 deferral would leave the 79.5 ms-class memo caches permanently load-bearing

--- a/docs/specs/2026-08-25-appstate-observable-migration-design.md
+++ b/docs/specs/2026-08-25-appstate-observable-migration-design.md
@@ -9,15 +9,25 @@ through `@EnvironmentObject` by 106 binding sites across 69 view files. Under
 view reads the property that changed. Readership is irrelevant to invalidation —
 only writer frequency matters.
 
-The waste is measurable. Sampling the app across windows **verified to contain
-actual scrolling** — each window scored for scroll-event frames and for terminal
-draw volume, with windows failing that check discarded rather than averaged in —
-`RepoSectionView.body` accounts for 30 to 37 samples per 1,000 main-thread
-samples, against 6.6 in a quiet baseline. The sidebar re-evaluates roughly five
-times as often while a terminal scrolls, and it displays nothing new when it
-does. `WorktreeRowView`, `TabBarItem`, and `PanePlaceholder` re-evaluate
-alongside it. Across those windows the main thread runs 45% to 64% busy and
-TBDApp holds roughly 47% of a core.
+The waste is measurable, and it is the largest single consumer of the main
+thread while a terminal scrolls. Sampling the app across windows **verified to
+contain actual scrolling** — each window scored for scroll-event frames and for
+terminal draw volume, with windows failing that check discarded rather than
+averaged in — SwiftUI view-graph re-evaluation (`GraphHost.flushTransactions`)
+accounts for **25.1% and 18.1%** of main-thread samples in the two validated
+windows, against **3.7%** in a quiet baseline. Over the same windows the
+terminal's own draw subtree accounts for 20.7% and 11.6%, against 4.0% quiet.
+
+Named contributors inside that flush, as a share of the whole main thread:
+`RepoSectionView.body` at 3.7% and 3.0% (0.7% quiet), `WorktreeRowView.body` at
+1.2% and 1.7% (0.4% quiet), with `TabBarItem` and `PanePlaceholder` re-evaluating
+alongside them. None of these display anything new while a terminal scrolls. The
+main thread runs 45% to 64% busy across the windows, with TBDApp near 47% of a
+core.
+
+Counts in a `sample` call graph are inclusive of children, so a symbol and its
+own callees must never be summed together — doing so double-counts the subtree.
+The figures above are top-level subtree totals.
 
 That validation step is not incidental. An unvalidated sampling window is
 indistinguishable from a mistimed one, and a window that captured no scrolling
@@ -29,21 +39,31 @@ tracking. A view re-evaluates only when a property it actually read changes.
 
 ### What this migration does not fix
 
-**The dominant cost of terminal scrolling is not this.** In the same validated
-windows, `TerminalView.draw` accounts for 237 to 425 samples per 1,000 against
-84.6 quiet — seven to twelve times the sidebar's share. That cost is SwiftTerm
-rebuilding an `NSAttributedString` for every visible row on every redraw
-(`drawTerminalContents` → `buildAttributedString`), plus a full-grid scan for
-blink attributes (`visibleBlinkRows`) run on each display update. A scroll
-dirties every row every frame, so both are paid in full at display rate. That
-code lives in a pinned upstream dependency and is tracked separately.
+**Wheel-event amplification sits upstream of this cost and should be fixed
+first.** TBD intercepts every scroll wheel event in a local `NSEvent` monitor
+and emits `max(1, Int(abs(deltaY)))` SGR mouse reports per event
+(`Sources/TBDApp/Terminal/TerminalPanelView.swift:794-797`), with no
+momentum-phase filter and no fractional-delta accumulator, so a sub-line delta
+still sends a full report and a trackpad flick's momentum tail delivers events
+at 60-120 Hz. The inner terminal application repaints per report, and that
+output streams back through the PTY into a full-viewport redraw. Scrolling
+manufactures the output flood that both the draw path and this graph churn then
+pay for — and because the SwiftUI flush runs as a run-loop observer, its
+*frequency* scales with how often the run loop turns. Bounding the report rate
+shrinks the feed, the redraws, and the flush count together.
 
-This migration removes a real but secondary cost. It is justified on the
-structural argument — object-wide invalidation across 106 binding sites is wrong
-at any writer frequency, and the measured fivefold rise in sidebar evaluation is
-that defect made visible — and **not** as a remedy for terminal scroll latency.
-A reader looking for the fix to a slow-feeling terminal should start with the
-draw path above.
+**The terminal's own draw cost is a separate, comparable expense.** SwiftTerm
+rebuilds an `NSAttributedString` for every visible row on every redraw
+(`drawTerminalContents` → `buildAttributedString`, measured at 12.8% and 7.5% of
+the main thread — roughly two-thirds of the draw subtree). It lives in a pinned
+upstream dependency and is tracked separately.
+
+So this migration addresses the largest single main-thread consumer during
+scroll, but it is one of three independent costs and not the first one to land.
+It is justified on the structural argument — object-wide invalidation across 106
+binding sites is wrong at any writer frequency, and the measured five-to-sevenfold
+rise in graph flush is that defect made visible — rather than as the remedy for a
+slow-feeling terminal on its own.
 
 ### What this evidence does not establish
 
@@ -324,9 +344,14 @@ naive conversion, per the repo rule that plan-authored tests must discriminate:
   discriminator.
 
 **A measured gate, over validated windows.** Re-run the scroll profile and
-compare against the baseline recorded here: `RepoSectionView.body` at 30 to 37
-samples per 1,000 main-thread samples while scrolling against 6.6 quiet, with
-the main thread 45% to 64% busy and TBDApp near 47% of a core.
+compare against the baseline recorded here: `GraphHost.flushTransactions` at
+25.1% and 18.1% of main-thread samples while scrolling against 3.7% quiet, with
+`RepoSectionView.body` at 3.7% and 3.0% against 0.7%, the main thread 45% to 64%
+busy, and TBDApp near 47% of a core. The graph-flush share is the primary
+number; the named view bodies are how a regression is localized.
+
+Compare subtree totals, not summed symbol occurrences — `sample` counts are
+inclusive of children.
 
 Every window on both sides of the comparison must pass the same validation the
 baseline did — scored for scroll-event frames (`scrollWheel`, `gridPosition`)
@@ -337,13 +362,19 @@ finding. A quiet baseline must also be genuinely quiet: a session in which
 tooling is running commands streams output into the terminal and drives redraws,
 which inflates the very counters under comparison.
 
-The migration is accepted on a material reduction in the sidebar's share of
+The migration is accepted on a material reduction in the graph-flush share of
 main-thread samples. Because the driving write was never isolated, a null result
 is a real possible outcome and must be reported as one rather than absorbed —
 and the diagnostic capture above is what turns a null result into a finding
-("the firing property is one the sidebar reads") rather than a mystery. Note
-that the sidebar's share is a minority of scroll-time cost either way: a large
-proportional win here will not, on its own, make scrolling feel fast.
+("the firing property is one the sidebar reads") rather than a mystery.
+
+Interpret the result against the other two costs rather than in isolation. Graph
+flush is the largest single main-thread consumer during scroll, but the terminal
+draw subtree is comparable and the wheel-report amplification upstream drives
+both. If the amplification fix lands first, this baseline must be re-measured
+before the gate is applied: a lower report rate reduces run-loop turns, which
+reduces flush frequency on its own and would otherwise be credited to this
+migration.
 
 **The existing suite green**, with the 6 test files' injection sites updated, run
 through `scripts/test.sh`.

--- a/docs/specs/2026-08-25-appstate-observable-migration-design.md
+++ b/docs/specs/2026-08-25-appstate-observable-migration-design.md
@@ -1,0 +1,196 @@
+# Migrating TBDApp's observable state to `@Observable`
+
+## Why
+
+`AppState` is an `ObservableObject` carrying 109 `@Published` properties, consumed
+through `@EnvironmentObject` by 106 binding sites across 69 view files. Under
+`ObservableObject`, `objectWillChange` is object-wide: a write to any one of those
+109 properties invalidates every view observing the object, whether or not that
+view reads the property that changed. Readership is irrelevant to invalidation —
+only writer frequency matters.
+
+The cost is measurable. Sampling the running app for 20 seconds while a terminal
+is scrolled:
+
+- **TBDApp consumes 12.29 s of CPU** — 61% of a core — against 4.35 s over an
+  equivalent quiet window.
+- **The main thread is 50.3% busy** (3,921 of 7,801 samples), against 18.7% quiet.
+- **Roughly half that busy time, 1,925 samples, is SwiftUI view-graph update** —
+  `NSHostingView.beginTransaction` → `GraphHost.flushTransactions` →
+  `AG::Subgraph::update` → `ViewBodyAccessor.updateBody`.
+
+The bodies re-evaluating are the sidebar, none of which depend on the terminal
+being scrolled: `RepoSectionView` at 420 samples, `WorktreeRowView` at 240,
+`TabBarItem` at 139, `PanePlaceholder` at 47. `TerminalView.draw` — the view that
+actually changed — accounts for 157.
+
+Normalized per 1,000 main-thread samples, `RepoSectionView.body` evaluates 6.6
+times when quiet and 53.8 times while scrolling: an eightfold increase in
+re-evaluation of a view whose displayed content did not change.
+
+`@Observable` replaces object-wide notification with per-property dependency
+tracking. A view re-evaluates only when a property it actually read changes.
+
+### What this evidence does not establish
+
+The specific `@Published` write driving the scroll-time increase was not isolated.
+Writer-frame counts sampled during scrolling and during quiet windows are
+comparable, so the eightfold jump in `RepoSectionView.body` has no identified
+write behind it.
+
+This design therefore rests on the structural argument — object-wide invalidation
+is wrong at any writer frequency — and not on a demonstrated causal chain. The
+measured numbers above bound the size of the prize; they do not prove that
+per-property tracking captures all of it. The acceptance gate below exists to
+settle that empirically rather than by assertion.
+
+## Scope
+
+All nine `ObservableObject` classes in `Sources/TBDApp` convert to `@Observable`:
+
+- **`AppState`** — `AppState.swift`, the object this design is about
+- **`AppearanceSettings`** — `Terminal/AppearanceSettings.swift`
+- **`ThemeStore`** — `Terminal/ThemeStore.swift`
+- **`TranscriptOverlayCoordinator`** — `Panes/Transcript/TranscriptOverlayCoordinator.swift`
+- **`WebviewState`** — `Panes/WebviewPaneView.swift`
+- **`HoverMenuModel`** — `Sidebar/HoverMenuModel.swift`
+- **`TerminalThemeEditorViewModel`** — `Settings/TerminalThemeEditorViewModel.swift`
+- **`QueuedPromptTarget`** — `Worktree/QueuedPromptModal.swift`
+- **`JumpMenuViewModel`** — `JumpMenu/JumpMenuViewModel.swift`
+
+Converting only `AppState` was considered and rejected: it leaves a mixed
+paradigm, and `AppState` holds and bridges `AppearanceSettings` with Combine, so
+the seam has to be resolved either way.
+
+Two facts make the conversion tractable. The package targets macOS 15, so
+Observation is available. And the view layer contains **no Combine
+`$property` publisher usage at all** — no `.sink`, `.assign`, `debounce`, or
+`combineLatest` over a `@Published` projection — so the usual blocking dependency
+on `ObservableObject`'s publisher semantics does not exist here. The exceptions
+are the explicit `objectWillChange` subscribers treated as hazard (a) below.
+
+## Mechanical shape
+
+- `@Published var x` becomes a plain stored property; the macro supplies tracking.
+- `@EnvironmentObject var appState: AppState` becomes
+  `@Environment(AppState.self) var appState`.
+- `.environmentObject(x)` becomes `.environment(x)` — 29 sites in `Sources`, 4 in
+  `Tests`.
+- `@StateObject` becomes `@State` (13 sites); `@ObservedObject` becomes a plain
+  `let` (8 sites).
+- Any view needing `$appState.foo` declares `@Bindable`.
+- `AppState` remains a `@MainActor final class`.
+
+## Hazards
+
+**(a) AppKit consumers of `objectWillChange`.** `TBDTerminalView` is an `NSView`
+subclass that subscribes to `AppearanceSettings.objectWillChange` through a
+Combine sink and reapplies theme settings on every fire. `@Observable` publishes
+no such stream. The replacement is `withObservationTracking(_:onChange:)`, whose
+`onChange` is **one-shot**: it must be re-armed after each fire or the view stops
+responding to theme changes permanently. The existing hop to the main queue must
+be kept — `onChange` fires in `willSet` position, before the new value is
+readable, exactly as `objectWillChange` did.
+
+This failure is silent and no existing test covers it, so the sibling PR that
+converts `AppearanceSettings` carries a test that changes a setting and asserts
+the terminal reapplies it more than once. Re-arming correctly is the whole point;
+a single-fire test would pass against the broken implementation.
+
+**(b) `didSet`-driven memo invalidation.** `AppState` serves `children(of:)` and
+`allWorktrees` from memoized caches invalidated by `worktrees.didSet` and
+`scratchWorktrees.didSet`. These are load-bearing: recomputing `children(of:)` per
+render pass measured 79.5 ms. `didSet` continues to work on plain stored
+properties under `@Observable`, so the caches survive the conversion — but the
+implementation must verify this rather than assume it, because a silent
+regression here restores an O(N²) render pass.
+
+Both caches are deliberately *not* observable storage. A write to observable state
+from inside a view body traps with "Modifying state during view update", and these
+caches fill lazily from their getters, which run inside body evaluation. They stay
+plain stored properties after the conversion.
+
+**(c) Bindings.** Every site passing `$appState.foo` requires `@Bindable` on the
+declaring view. These surface as compile errors, so the risk is effort rather than
+silent breakage.
+
+## Landing
+
+**PR 1 converts `AppState` alone.** This step is atomic by necessity: the class
+declaration and all 106 binding sites must flip together, spanning roughly 69
+source and 6 test files. It carries the entire measured win, and the acceptance
+gate below applies to it.
+
+**PRs 2 through 9 convert one sibling observable each**, independently green and
+independently revertable. `AppearanceSettings` is its own PR because it owns
+hazard (a).
+
+PR 1 modifies `RepoSectionView.swift` at the `@EnvironmentObject` declaration, and
+so rebases over the separate formatter-caching fix in that same file, which is
+confined to the `matchedRemoteSessions` and `parsedCreatedAt` regions.
+
+## Acceptance
+
+**A discriminating test.** Mutate an `AppState` property that a given view does not
+read, and assert that view's body does not re-evaluate, counting evaluations in a
+test host. This test fails against `ObservableObject`, where every write
+invalidates every observer, and passes under per-property tracking. A test that
+merely asserts the view still renders correctly would pass both before and after
+and would guard nothing.
+
+**A measured gate.** Re-run the scroll profile and compare against the baseline
+recorded here: 12.29 s of CPU per 20 s window, 50.3% main-thread busy, and
+`RepoSectionView.body` at 53.8 evaluations per 1,000 main-thread samples. The
+migration is accepted on a material reduction in the SwiftUI view-graph share of
+main-thread busy time. Because the driving write was never isolated, a null result
+is a real possible outcome and must be reported as one rather than absorbed.
+
+**The existing suite green**, with the 6 test files' injection sites updated, run
+through `scripts/test.sh`.
+
+## Waivers
+
+**This change ships without a feature flag.** TBD's convention is that
+wholesale-replacing a load-bearing path lands behind a default-off flag, and the
+view layer's observation mechanism qualifies. The waiver here is forced rather
+than chosen: the selection between `@EnvironmentObject` and `@Environment` is made
+at compile time, so a runtime flag would require every affected view body to exist
+twice. The revert path is the branch itself plus `scripts/restart.sh`, which the
+author exercises continuously by dogfooding the app.
+
+**This supersedes an earlier decision to defer `@Observable`** pending cheaper
+measures. That deferral rested on the migration touching every view file while
+cheaper options remained untried. The judgment recorded here is that object-wide
+invalidation is a defect in the observation model rather than a tuning parameter,
+and is worth correcting on its own terms.
+
+The cheaper measure that deferral named — auditing frequent writers for equality
+guards sitting in `didSet` rather than at the assignment site — remains valid and
+is **not** retired by this migration. `@Published` fires on assignment rather than
+on change, so a guard inside `didSet` suppresses downstream work but not the
+invalidation. `applyTerminalActivityDelta` is a live instance: it assigns
+`activityState` unconditionally and then calls `removeValue` on two further
+observable dictionaries, firing up to three notifications for a delta that may
+carry no change at all. Per-property tracking narrows who those notifications
+reach; it does not stop them being sent. That audit is worth doing independently.
+
+## Rejected alternatives
+
+**Converting `AppState` only.** Smallest diff, but leaves two idioms in the
+codebase indefinitely and does not resolve the `AppState`-to-`AppearanceSettings`
+Combine bridge, which has to be addressed regardless.
+
+**A single pull request for all nine classes.** One review and one revert point,
+but a diff of roughly 75 files in which a subtle observation defect in any single
+view is expensive to bisect, and where reverting discards eight easy conversions
+along with the one hard one.
+
+**Converting the siblings before `AppState`.** Establishes the pattern on low-risk
+classes first, but defers the measured win behind eight PRs that deliver none of
+it.
+
+**Shipping without the measured gate.** Per-property tracking is correct by
+construction, so the argument runs that measurement is ceremony. Rejected because
+the write driving the observed churn was never identified: without a
+before-and-after number, a migration touching 75 files would carry no evidence
+that it addressed the symptom that motivated it.

--- a/docs/specs/2026-08-25-appstate-observable-migration-design.md
+++ b/docs/specs/2026-08-25-appstate-observable-migration-design.md
@@ -344,12 +344,22 @@ naive conversion, per the repo rule that plan-authored tests must discriminate:
   against the broken one-shot implementation; two sequential fires are the
   discriminator.
 
-**A measured gate, over validated windows.** Re-run the scroll profile and
-compare against the baseline recorded here: `GraphHost.flushTransactions` at
-25.1% and 18.1% of main-thread samples while scrolling against 3.7% quiet, with
-`RepoSectionView.body` at 3.7% and 3.0% against 0.7%, the main thread 45% to 64%
-busy, and TBDApp near 47% of a core. The graph-flush share is the primary
-number; the named view bodies are how a regression is localized.
+**A measured gate, over validated windows, on a loaded machine.** Re-run the
+scroll profile and compare against the baseline recorded here:
+`GraphHost.flushTransactions` at 25.1% and 18.1% of main-thread samples while
+scrolling against 3.7% quiet, with `RepoSectionView.body` at 3.7% and 3.0%
+against 0.7%, the main thread 45% to 64% busy, and TBDApp near 47% of a core. The
+graph-flush share is the primary number; the named view bodies are how a
+regression is localized.
+
+Both sides of the comparison must be taken under comparable machine load, and
+that load must resemble real use — a browser open, agents running — rather than a
+quiet machine. Field observation established that the app's surplus work is
+invisible when there is headroom and decisive when there is not: relieving memory
+pressure produced a large subjective improvement while leaving the app's own CPU
+unchanged. A gate satisfied by ambient relief has measured the machine rather
+than the change. Record the machine's state alongside the numbers so a later
+reader can tell whether two measurements are comparable at all.
 
 Compare subtree totals, not summed symbol occurrences — `sample` counts are
 inclusive of children.

--- a/docs/specs/2026-08-25-terminal-metal-renderer-design.md
+++ b/docs/specs/2026-08-25-terminal-metal-renderer-design.md
@@ -132,40 +132,21 @@ are distinguishable: an unset key reads the shipped default, and an explicit
 
 ## Rejected alternatives
 
-**Replacing SwiftTerm with libghostty.** Ghostty's embedder API is the natural
-candidate — its own macOS app is Swift over that C API, and it is MIT licensed —
-but as of 2026-08-10 the project explicitly disclaims it for external use.
-`include/ghostty.h` describes itself as an internal API "tailored to the needs of
-the macOS app and not designed for external use", directing external embedders to
-`libghostty-vt` instead; the commit that landed that wording removed an earlier
-"(yet)". `libghostty-vt` is a VT state machine only — no renderer, no font
-handling, no pty — which is the half TBD does not need, since parsing is under 3%
-of the main thread and rendering is the measured cost.
+**Replacing the terminal engine.** Migrating to a different engine is a live
+option with three distinct shapes, real precedent, and documented hazards —
+enough that it is recorded separately in
+`docs/perf/2026-08-25-terminal-engine-options.md` rather than summarized here.
 
-Three further blockers stand independently of API status. Serious embedders fork
-Ghostty and build it themselves, taking on a pinned Zig toolchain and a rebase
-burden against an API with no tagged version. The mode TBD would require — a
-surface fed bytes with no child process, matching the tmux bridge and replay
-paths — exists but is not upstream, and no shipped consumer activates it.
-And Ghostty deliberately disables BiDi, forcing
-`kCTTypesetterOptionForcedEmbeddingLevel = 0`, where SwiftTerm's Metal path
-supports it: a migration would be a functional regression for right-to-left text.
-Estimated effort is three to five months against roughly 6,600 lines of TBD
-terminal code.
+It is not rejected; it is sequenced behind this experiment. The reason is that
+this experiment discriminates between the two readings that decide it. If
+enabling the GPU renderer closes the gap, the difficulty was a rendering defect
+in a fallback path, and an engine migration would be solving an already-solved
+problem at a cost measured in months. If it does not, the competing reading —
+that the difficulty is architectural, in how TBD drives the engine rather than in
+how the engine draws — gains real support, and a migration spike becomes
+justified by evidence rather than by analogy.
 
-The strongest argument on the other side, recorded because it is genuinely
-unresolved: another project's committed migration spec faults SwiftTerm
-specifically for "sizing and rendering issues when used without a process (the
-`feed()` path vs `LocalProcessTerminalView`)" — which is exactly the mode TBD
-operates in. If that is right, TBD's difficulty is architectural rather than a
-caching defect, and no amount of renderer tuning resolves it. This design does
-not settle that question; it makes the cheap measurement first.
-
-Two triggers to revisit: an announced but unreleased pure-Swift Metal renderer
-with `libghostty-vt` bindings, which would remove the Zig toolchain, the fork,
-and the disclaimed-API objection at once; or this experiment plus the shaped-line
-cache failing to close the gap to a standalone emulator, which would make the
-architectural reading the better explanation.
+An afternoon's work settles which of those is true, so it goes first.
 
 **Cherry-picking the row-cache fix before measuring.** Applying the upstream
 Metal row-cache patch first would avoid a possibly misleading flat scroll result.

--- a/docs/specs/2026-08-25-terminal-metal-renderer-design.md
+++ b/docs/specs/2026-08-25-terminal-metal-renderer-design.md
@@ -52,6 +52,27 @@ confirming the cost lies elsewhere rather than as a failure of the GPU path. See
 `docs/perf/2026-08-25-terminal-render-cost-investigation.md` and
 `2026-08-26-claude-code-render-benchmark.md`.
 
+### Metal does not move painting off the main thread
+
+Verified in the pinned revision: `MacTerminalView` sets `mtkView.isPaused = true`
+and `mtkView.enableSetNeedsDisplay = true`, so the Metal view runs no display
+loop of its own. It paints on demand from the main runloop via
+`queueMetalDisplay()`, on the same schedule as the CoreGraphics path.
+
+So enabling Metal changes *how* a frame is drawn, not *when*. The paint-scheduling
+delay measured separately — a fixed frame of latency before any draw is posted —
+applies identically to both renderers, and the main thread remains on the path to
+pixels either way.
+
+That narrows what this experiment can win to the cost of the draw itself, on a
+path where drawing was already measured cheap (a display pass costs 5-15 ms, and
+parse costs a tenth of a millisecond). It does not address scheduling, and it does
+not free the main thread.
+
+An engine that paints from its own renderer thread would be a different
+proposition, since the main thread would leave the path to pixels entirely — but
+that is an engine change, not a flag.
+
 ### Two ways a null result is expected, stated before measuring
 
 Recording these in advance so that a flat result is diagnosed rather than

--- a/docs/specs/2026-08-25-terminal-metal-renderer-design.md
+++ b/docs/specs/2026-08-25-terminal-metal-renderer-design.md
@@ -31,6 +31,27 @@ same binary.
 
 This design enables that renderer behind a default-off flag and measures it.
 
+### What later measurement says about this experiment's premise
+
+Deterministic benchmarking after this spec was written found that the one
+genuinely expensive path — high-rate line-append while scrolling — spends its
+cost in `feed`, that is parse and damage tracking, which is **upstream of
+`drawTerminalContents`**. A GPU renderer replaces the draw stage and would not
+address it.
+
+The same work found that an agent cannot saturate the renderer at all (~30-40
+screen updates per second regardless of renderer, with a tenfold token-rate
+increase *lowering* the chunk rate), and that perceived typing lag is a
+paint-scheduling floor of 40-55 ms on a main thread that is ~99% idle, rather
+than a cost problem.
+
+This does not make the experiment worthless — the draw path is genuinely
+inefficient, and the flag is cheap and reversible. It does mean the expected
+prize is smaller than the spec assumed, and that a null result should be read as
+confirming the cost lies elsewhere rather than as a failure of the GPU path. See
+`docs/perf/2026-08-25-terminal-render-cost-investigation.md` and
+`2026-08-26-claude-code-render-benchmark.md`.
+
 ### Two ways a null result is expected, stated before measuring
 
 Recording these in advance so that a flat result is diagnosed rather than

--- a/docs/specs/2026-08-25-terminal-metal-renderer-design.md
+++ b/docs/specs/2026-08-25-terminal-metal-renderer-design.md
@@ -103,10 +103,26 @@ across worktree switches, not just for correctness.
 
 ## Acceptance
 
-**Graduation requires closing the gap to a standalone emulator.** The bar is that
-a TBD terminal hosting an agent TUI feels comparable to a standalone emulator
-hosting the same TUI, attached to the same tmux session, on the same machine —
-the control described in "Why". The repository owner is the judge of comparable.
+**Graduation requires closing the gap to a standalone emulator under realistic
+load.** The bar is that a TBD terminal hosting an agent TUI feels comparable to a
+standalone emulator hosting the same TUI, attached to the same tmux session, on
+the same machine — the control described in "Why". The repository owner is the
+judge of comparable.
+
+**The comparison must be made on a loaded machine, not a quiet one.** A browser
+open, agents running, memory under pressure: the conditions the app is actually
+used in. This is not incidental strictness. Field observation established that
+TBD's terminal is usable when the machine is quiet and degrades badly when it is
+not, while a standalone emulator stays smooth through both — so a gate applied to
+a quiet machine can pass while the defect that motivated this work is entirely
+intact. Closing a browser and freeing roughly 3 GB was measured to halve system
+load, stop paging, and produce a large subjective improvement, while leaving TBD's
+own CPU unchanged. A gate that can be satisfied by that kind of ambient relief is
+measuring the machine, not the change.
+
+The failure mode this guards against is specific: the surplus work TBD performs
+per keystroke and per frame is invisible when everything has headroom, and
+decisive when it does not. The client with the least headroom degrades first.
 
 Feel is the bar rather than a threshold on the profile because the profile can
 improve while the terminal still feels slow: the upstream streaming report above

--- a/docs/specs/2026-08-25-terminal-metal-renderer-design.md
+++ b/docs/specs/2026-08-25-terminal-metal-renderer-design.md
@@ -1,0 +1,178 @@
+# Enabling SwiftTerm's Metal renderer for embedded terminals
+
+## Why
+
+Embedded terminals in TBD scroll and type noticeably slower than a standalone
+terminal emulator on the same machine. A control experiment isolates the cause to
+TBD's rendering rather than to the machine, the daemon, tmux, or the hosted
+agent's output volume:
+
+- A standalone emulator running a **plain shell** — smooth.
+- The same emulator running the **same agent TUI**, attached to the **same tmux
+  session** on the **same loaded machine** — smooth.
+- A TBD terminal running that TUI — laggy.
+
+Only the frontend differs across those three, so the frontend is the variable
+that matters.
+
+Profiling TBD across sampling windows verified to contain actual scrolling puts
+the cost in SwiftTerm's **CoreGraphics** draw path: `drawTerminalContents` at
+20.7% and 11.6% of main-thread samples in the two validated windows against 4.0%
+in a quiet baseline, of which `buildAttributedString` — which rebuilds an
+`NSAttributedString` for every visible row on every redraw — is 12.8% and 7.5%.
+The shaped-line cache alongside it is capped at 8-character segments, so ordinary
+text re-shapes every frame.
+
+SwiftTerm already ships a Metal renderer covering exactly that path
+(`Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift`, `Shaders.metal`,
+and a public `setUseMetal(_:)`), and TBD has never called it. Every measurement
+above is therefore of a fallback path, taken while a GPU path sat unused in the
+same binary.
+
+This design enables that renderer behind a default-off flag and measures it.
+
+### Two ways a null result is expected, stated before measuring
+
+Recording these in advance so that a flat result is diagnosed rather than
+argued about afterwards.
+
+- **A flat scroll result most likely means the Metal row cache, not Metal.**
+  Upstream reports the Metal renderer keys its row cache on absolute row number
+  and screen-relative coordinates, both of which every scroll invalidates, so it
+  rebuilds every visible row per frame while scrolled (reported fix: 10.35 ms to
+  0.60 ms per frame). That patch is not in the pinned revision. A scroll result
+  showing no improvement is evidence for applying it, not evidence against Metal.
+- **A flat result under sustained streaming may mean the bottleneck moved.**
+  Upstream also reports six streaming agent TUIs with Metal enabled still
+  consuming 75-82% of a core, with cost relocating to CoreText glyph metrics
+  rather than disappearing. That report is CJK-heavy and an ASCII agent TUI should
+  hit the glyph atlas far better, but the possibility is real and the remedy is a
+  different, smaller upstream fix.
+
+Neither outcome retires the experiment; each names its own next step.
+
+## What ships
+
+A `UserDefaults` flag, `useMetalTerminalRenderer`, defaulting to **off**. When
+set, `TerminalPanelView.makeNSView` calls `try tv.setUseMetal(true)` on the
+terminal view it has just constructed.
+
+`UserDefaults` rather than a `config` column because the behavior is entirely
+app-side rendering with no daemon participation — the same placement as the
+existing `enableTranscript` flag. Read through the three-state form:
+
+```swift
+defaults.object(forKey: useMetalTerminalRendererKey) as? Bool ?? useMetalTerminalRendererDefault
+```
+
+so "nobody has chosen" stays distinguishable from an explicit `false`, and
+graduation is a one-line change to the default constant that reaches everyone who
+never touched the toggle while preserving every deliberate opt-out.
+
+`setUseMetal(_:)` throws — on hardware without Metal support, or if the pipeline
+cannot be built. On a throw the view stays on CoreGraphics, the failure is logged
+once at `.error`, and no retry is attempted. Degrading to current behavior is
+always correct here; crashing or logging per frame is not.
+
+## Hazards
+
+**Pane snapshots read the view backing store.** `TBDTerminalView.captureScreenshot()`
+captures through `bitmapImageRepForCachingDisplay` + `cacheDisplay`. A
+Metal-backed view renders into a `CAMetalLayer`, which that path does not see, so
+snapshots come back blank or stale. The capture feeds `AppState.snapshotProviders`,
+which the sidebar context menu and pane placeholders consume.
+
+`setUseMetal(_:)` is togglable in both directions at runtime, so the cheapest
+candidate fix is to drop to CoreGraphics for the duration of a capture and
+restore afterwards. That may flicker, and it is a candidate rather than a
+decision: the implementation verifies it and may instead read back the Metal
+drawable. Whatever the mechanism, a test asserts a non-blank snapshot with the
+flag on — a snapshot regression is silent, because a blank image still renders as
+an image.
+
+**Terminal views are reparented across windows.** The keep-alive pager retains up
+to eight terminal `NSView`s and moves them between windows, which is precisely
+the `CAMetalLayer` device-and-drawable rebinding case SwiftTerm's own comments
+call out. SwiftTerm carries handling for it; the soak must demonstrate that
+handling holds under TBD's pager specifically, including GPU memory with eight
+layers retained simultaneously.
+
+**Eight simultaneous GPU contexts is a new resource class.** Today the retained
+views cost only their backing stores. The soak watches for GPU memory growth
+across worktree switches, not just for correctness.
+
+## Acceptance
+
+**Graduation requires closing the gap to a standalone emulator.** The bar is that
+a TBD terminal hosting an agent TUI feels comparable to a standalone emulator
+hosting the same TUI, attached to the same tmux session, on the same machine —
+the control described in "Why". The repository owner is the judge of comparable.
+
+Feel is the bar rather than a threshold on the profile because the profile can
+improve while the terminal still feels slow: the upstream streaming report above
+is exactly that case, with cost relocating rather than disappearing. The profile
+is what keeps the judgment honest, not what settles it.
+
+**The profile corroborates.** Re-run the validated-window protocol and show the
+draw subtree collapsing from its recorded baseline of 20.7% and 11.6% of
+main-thread samples. Every window on both sides must be scored for an actual
+scroll or keystroke signature, with failing windows discarded rather than
+averaged in; take several short windows rather than one long one, so a mistimed
+window announces itself instead of becoming a finding. The quiet baseline must be
+genuinely quiet — a session in which tooling is running commands streams output
+into the terminal and drives redraws, inflating the very counters under
+comparison. Compare subtree totals, never summed symbol occurrences: counts in a
+`sample` call graph are inclusive of children.
+
+**Tests cover both branches of the flag.** With the flag off, no `setUseMetal`
+call is made and the CoreGraphics path is unchanged. With it on, Metal is
+requested and a captured snapshot is non-blank. The three states of the default
+are distinguishable: an unset key reads the shipped default, and an explicit
+`false` survives a change to that constant.
+
+## Rejected alternatives
+
+**Replacing SwiftTerm with libghostty.** Ghostty's embedder API is the natural
+candidate — its own macOS app is Swift over that C API, and it is MIT licensed —
+but as of 2026-08-10 the project explicitly disclaims it for external use.
+`include/ghostty.h` describes itself as an internal API "tailored to the needs of
+the macOS app and not designed for external use", directing external embedders to
+`libghostty-vt` instead; the commit that landed that wording removed an earlier
+"(yet)". `libghostty-vt` is a VT state machine only — no renderer, no font
+handling, no pty — which is the half TBD does not need, since parsing is under 3%
+of the main thread and rendering is the measured cost.
+
+Three further blockers stand independently of API status. Serious embedders fork
+Ghostty and build it themselves, taking on a pinned Zig toolchain and a rebase
+burden against an API with no tagged version. The mode TBD would require — a
+surface fed bytes with no child process, matching the tmux bridge and replay
+paths — exists but is not upstream, and no shipped consumer activates it.
+And Ghostty deliberately disables BiDi, forcing
+`kCTTypesetterOptionForcedEmbeddingLevel = 0`, where SwiftTerm's Metal path
+supports it: a migration would be a functional regression for right-to-left text.
+Estimated effort is three to five months against roughly 6,600 lines of TBD
+terminal code.
+
+The strongest argument on the other side, recorded because it is genuinely
+unresolved: another project's committed migration spec faults SwiftTerm
+specifically for "sizing and rendering issues when used without a process (the
+`feed()` path vs `LocalProcessTerminalView`)" — which is exactly the mode TBD
+operates in. If that is right, TBD's difficulty is architectural rather than a
+caching defect, and no amount of renderer tuning resolves it. This design does
+not settle that question; it makes the cheap measurement first.
+
+Two triggers to revisit: an announced but unreleased pure-Swift Metal renderer
+with `libghostty-vt` bindings, which would remove the Zig toolchain, the fork,
+and the disclaimed-API objection at once; or this experiment plus the shaped-line
+cache failing to close the gap to a standalone emulator, which would make the
+architectural reading the better explanation.
+
+**Cherry-picking the row-cache fix before measuring.** Applying the upstream
+Metal row-cache patch first would avoid a possibly misleading flat scroll result.
+Rejected as sequencing: it costs the fork setup before any evidence justifies it
+and mixes two changes into one measurement. The expected-null-result section
+above captures the interpretation instead, at no cost.
+
+**Shipping without a flag.** Rejected: replacing a rendering path is exactly the
+category the repository requires to ship default-off and soak. The flag is also
+what makes the A/B measurable at all, since it can be toggled live.

--- a/scripts/diag/bench-cc-render.sh
+++ b/scripts/diag/bench-cc-render.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Benchmark TBD's terminal render path with the REAL Claude Code TUI as the byte
+# producer, fed a deterministic scripted stream by a local fake Anthropic endpoint.
+# No tokens are spent and no network is involved.
+#
+#   scripts/diag/bench-cc-render.sh --worktree <id> --label <name> [--mode default|fullscreen]
+#
+# Requires the temporary RenderLatencySignposts instrumentation to be running --
+# see docs/perf/2026-08-26-claude-code-render-benchmark.md. Verify with:
+#   strings /Applications/TBD.app/Contents/MacOS/TBDApp | grep -c RenderLatencySignposts
+#
+# --mode issues `/tui <mode>` before the run. Claude Code's two renderers are
+# `fullscreen` (alternate screen, repaints the viewport in place) and `default`
+# (normal screen, appends lines and scrolls). Confirm which one is live via the
+# alternate_on line this script prints: 1 = fullscreen, 0 = default.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKTREE=""; LABEL="bench"; MODE=""
+DELTAS=2400; RATE=40; NEWLINE=6; CAPTURE=25; PORT=8787
+OUT="${TMPDIR:-/tmp}/tbd-ccbench"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --worktree) WORKTREE="$2"; shift 2;;
+    --label)    LABEL="$2"; shift 2;;
+    --mode)     MODE="$2"; shift 2;;
+    --deltas)   DELTAS="$2"; shift 2;;
+    --rate)     RATE="$2"; shift 2;;
+    --capture)  CAPTURE="$2"; shift 2;;
+    --port)     PORT="$2"; shift 2;;
+    --out)      OUT="$2"; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+[ -n "$WORKTREE" ] || { echo "--worktree is required" >&2; exit 2; }
+mkdir -p "$OUT"
+
+# tmux socket TBD uses, for the alternate-screen check (a machine interface, not
+# screen scraping). Derived from $TMUX when this script runs inside a TBD terminal.
+SOCK=""
+[ -n "${TMUX:-}" ] && SOCK="$(basename "${TMUX%%,*}")"
+
+TERMID=""; SRVPID=""
+cleanup() {
+  [ -n "$TERMID" ] && tbd terminal close --terminal "$TERMID" >/dev/null 2>&1 || true
+  [ -n "$SRVPID" ] && kill "$SRVPID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> starting fake Anthropic endpoint on 127.0.0.1:$PORT (deltas=$DELTAS rate=$RATE/s)"
+FA_PORT=$PORT FA_DELTAS=$DELTAS FA_RATE=$RATE FA_NEWLINE=$NEWLINE \
+  python3 "$DIR/fake-anthropic-server.py" > "$OUT/$LABEL.server.log" 2>&1 &
+SRVPID=$!
+sleep 1
+
+echo "==> spawning Claude Code pointed at it"
+TERMID="$(tbd terminal create "$WORKTREE" --type shell --json \
+  --cmd "env ANTHROPIC_BASE_URL=http://127.0.0.1:$PORT ANTHROPIC_AUTH_TOKEN=fake-local-bench CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 claude --model claude-opus-5" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+PANE="$(tbd terminal list "$WORKTREE" | awk -v id="$TERMID" '$1==id {print $3}')"
+echo "    terminal=$TERMID pane=$PANE"
+
+# Wait on a machine signal, not a fixed sleep: Claude Code probes HEAD /api/hello
+# at startup, so its arrival in the server log proves the TUI booted. A fixed sleep
+# silently loses every subsequent keystroke on a loaded machine, which yields a
+# capture that looks real but contains no load at all.
+wait_for() {  # wait_for <pattern> <seconds> <file>
+  local i=0
+  while [ "$i" -lt "$2" ]; do
+    grep -q "$1" "$3" 2>/dev/null && return 0
+    sleep 1; i=$((i+1))
+  done
+  return 1
+}
+if wait_for "HEAD /api/hello" 90 "$OUT/$LABEL.server.log"; then
+  echo "    Claude Code booted (reached the fake endpoint)"
+else
+  echo "!!! Claude Code never contacted the endpoint -- aborting" >&2; exit 1
+fi
+sleep 2
+
+if [ -n "$MODE" ]; then
+  echo "==> switching renderer: /tui $MODE"
+  tbd terminal send --terminal "$TERMID" --text "/tui $MODE" >/dev/null
+  tbd terminal send --terminal "$TERMID" --keys "Enter" >/dev/null
+  sleep 4
+fi
+
+# Verify the renderer actually changed. `/tui default` applies reliably when sent
+# programmatically; `/tui fullscreen` often does not (the completion menu appears to
+# swallow it), so a run can silently measure the wrong renderer. tmux's alternate_on
+# is a machine interface, not screen text, and it settles the question.
+if [ -n "$SOCK" ] && [ -n "$PANE" ]; then
+  ALT="$(tmux -L "$SOCK" display -p -t "$PANE" '#{alternate_on}' 2>/dev/null || echo '?')"
+  echo "    alternate_on=$ALT  (1 = alternate screen, 0 = normal screen + scrollback)"
+  if [ -n "$MODE" ]; then
+    case "$MODE" in
+      fullscreen) WANT=1;;
+      default)    WANT=0;;
+      *)          WANT="$ALT";;
+    esac
+    if [ "$ALT" != "$WANT" ]; then
+      echo "!!! renderer did not switch: asked for '$MODE' (alternate_on=$WANT) but pane reports $ALT." >&2
+      echo "!!! This run would be mislabelled. Aborting." >&2
+      exit 1
+    fi
+  fi
+fi
+
+# The tab MUST be on screen: displayPass intervals only occur if the view draws.
+echo "==> foregrounding the tab (this interrupts the user)"
+tbd terminal focus --terminal "$TERMID" --activate >/dev/null
+sleep 2
+
+echo "==> prompting"
+tbd terminal send --terminal "$TERMID" --text "go" >/dev/null
+tbd terminal send --terminal "$TERMID" --keys "Enter" >/dev/null
+# Proof the prompt actually submitted: the stream request reaches the fake server.
+if wait_for "POST /v1/messages" 30 "$OUT/$LABEL.server.log"; then
+  echo "    stream started"
+else
+  echo "!!! prompt never submitted -- capture would be void, aborting" >&2; exit 1
+fi
+echo "==> capturing $CAPTURE s of signposts"
+sleep 3
+echo "    load average at capture start: $(sysctl -n vm.loadavg)"
+/usr/bin/log stream --style ndjson --signpost --predicate 'subsystem == "com.tbd.app"' \
+  > "$OUT/$LABEL.ndjson" 2>"$OUT/$LABEL.err" &
+LOGPID=$!
+sleep "$CAPTURE"
+kill "$LOGPID" 2>/dev/null || true
+wait "$LOGPID" 2>/dev/null || true
+
+echo
+python3 "$DIR/signpost-report.py" "$OUT/$LABEL.ndjson" "$LABEL"
+
+# A window with no display passes means the tab was not on screen: the terminal fed
+# and parsed but never drew, so every render number in it is meaningless. Say so
+# loudly rather than letting a plausible-looking table be believed.
+PASSES="$(python3 - "$OUT/$LABEL.ndjson" <<'PY'
+import sys, json, re
+n = 0
+for line in open(sys.argv[1], errors="replace"):
+    line = line.strip().rstrip(",")
+    if line.startswith("{") and '"displayPass"' in line and '"begin"' in line:
+        n += 1
+print(n)
+PY
+)"
+echo
+if [ "${PASSES:-0}" -lt 20 ]; then
+  echo "*** VOID: only ${PASSES} displayPass begins -- the tab was not drawing."
+  echo "*** Re-run with the subject tab on screen; do not report these numbers."
+fi
+echo
+echo "capture: $OUT/$LABEL.ndjson"

--- a/scripts/diag/fake-anthropic-server.py
+++ b/scripts/diag/fake-anthropic-server.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Deterministic fake Anthropic /v1/messages SSE server for TBD render benchmarking.
+
+Emits a scripted assistant stream at a controlled rate so Claude Code's real TUI
+becomes the byte producer. Knobs (env):
+  FA_PORT      listen port                       (default 8787)
+  FA_DELTAS    number of text_delta events       (default 400)
+  FA_RATE      deltas per second                 (default 50)
+  FA_TEXT      characters per delta              (default 24)
+  FA_NEWLINE   insert '\n' every N deltas, 0=off (default 8)
+"""
+import json, os, sys, time, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT   = int(os.environ.get("FA_PORT", "8787"))
+DELTAS = int(os.environ.get("FA_DELTAS", "400"))
+RATE   = float(os.environ.get("FA_RATE", "50"))
+TEXTN  = int(os.environ.get("FA_TEXT", "24"))
+NLEVERY= int(os.environ.get("FA_NEWLINE", "8"))
+
+def sse(w, ev, obj):
+    w.write(f"event: {ev}\ndata: {json.dumps(obj)}\n\n".encode())
+    w.flush()
+
+class H(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    def log_message(self, fmt, *a):
+        sys.stderr.write("[fake] %s %s\n" % (self.command, self.path))
+
+    def _read_body(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        return self.rfile.read(n) if n else b""
+
+    def do_POST(self):
+        body = self._read_body()
+        if self.path.startswith("/v1/messages/count_tokens"):
+            return self._json({"input_tokens": 42})
+        if self.path.startswith("/v1/messages"):
+            try: req = json.loads(body or b"{}")
+            except Exception: req = {}
+            if req.get("stream"): return self._stream(req)
+            return self._json({"id":"msg_fake","type":"message","role":"assistant",
+                "model":req.get("model","claude-opus-5"),
+                "content":[{"type":"text","text":"ok"}],
+                "stop_reason":"end_turn","stop_sequence":None,
+                "usage":{"input_tokens":10,"output_tokens":5}})
+        return self._json({"ok": True})
+
+    def do_GET(self):
+        return self._json({"ok": True, "fake": True})
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length","0")
+        self.end_headers()
+
+    def _json(self, obj, code=200):
+        b = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length",str(len(b)))
+        self.end_headers(); self.wfile.write(b); self.wfile.flush()
+
+    def _stream(self, req):
+        model = req.get("model","claude-opus-5")
+        self.send_response(200)
+        self.send_header("Content-Type","text/event-stream")
+        self.send_header("Cache-Control","no-cache")
+        self.send_header("Connection","close")
+        self.end_headers()
+        self.close_connection = True
+        w = self.wfile
+        mid = "msg_fake_%d" % int(time.time()*1000)
+        sse(w,"message_start",{"type":"message_start","message":{"id":mid,"type":"message",
+            "role":"assistant","model":model,"content":[],"stop_reason":None,
+            "stop_sequence":None,"usage":{"input_tokens":10,"output_tokens":1}}})
+        sse(w,"content_block_start",{"type":"content_block_start","index":0,
+            "content_block":{"type":"text","text":""}})
+        per = 1.0/RATE if RATE>0 else 0
+        t0 = time.time()
+        for i in range(DELTAS):
+            txt = ("w%04d " % i) + "abcdefghijklmnopqrstuvwxyz"[:max(0,TEXTN-6)]
+            if NLEVERY and i % NLEVERY == NLEVERY-1: txt += "\n"
+            sse(w,"content_block_delta",{"type":"content_block_delta","index":0,
+                "delta":{"type":"text_delta","text":txt}})
+            if per:
+                d = t0 + (i+1)*per - time.time()
+                if d>0: time.sleep(d)
+        sse(w,"content_block_stop",{"type":"content_block_stop","index":0})
+        sse(w,"message_delta",{"type":"message_delta",
+            "delta":{"stop_reason":"end_turn","stop_sequence":None},
+            "usage":{"output_tokens":DELTAS}})
+        sse(w,"message_stop",{"type":"message_stop"})
+
+if __name__ == "__main__":
+    srv = ThreadingHTTPServer(("127.0.0.1", PORT), H)
+    sys.stderr.write("[fake] listening on 127.0.0.1:%d deltas=%d rate=%.0f/s\n"%(PORT,DELTAS,RATE))
+    srv.serve_forever()

--- a/scripts/diag/signpost-report.py
+++ b/scripts/diag/signpost-report.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Summarize com.tbd.app render-latency signposts from an `log stream --signpost` ndjson capture.
+
+Usage: signpost-report.py <capture.ndjson> <label> [--window START END]
+
+Reads the three intervals emitted by the temporary RenderLatencySignposts
+instrumentation (see the accompanying research doc for how to build it):
+
+  mainThreadHop  main-thread QUEUEING DELAY for a pty chunk -- not work done.
+  feed           the nested TerminalView.feed() call: parse + damage tracking.
+                 Synchronous and nested, so this is the trustworthy cost signal.
+  displayPass    UPPER BOUND on one AppKit display pass. It ends on the next
+                 main-queue turn, so a backed-up main queue inflates it. Do not
+                 read a large displayPass as "drawing was slow".
+
+Also reports `feed work per wall-second`: total feed time divided by window span.
+Above ~1.0 the main thread is saturated by parsing alone, before any drawing.
+
+By default the densest contiguous 25s sub-window is chosen, so idle head/tail
+around the load period does not dilute the rates. Pass --window to override.
+"""
+import json, re, sys
+from collections import defaultdict
+
+
+def load(path):
+    """Match begin/end signpost pairs by (signpostID, name). Returns {name: [(start, end)]}."""
+    open_intervals, intervals = {}, defaultdict(list)
+    for line in open(path, errors="replace"):
+        line = line.strip().rstrip(",")
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        sid = event.get("signpostID")
+        name = event.get("signpostName") or event.get("eventMessage", "").split(":")[0]
+        stamp = re.search(r"(\d{2}):(\d{2}):(\d{2})\.(\d+)", event.get("timestamp", ""))
+        if not stamp or sid is None:
+            continue
+        frac = (stamp.group(4) + "000000000")[:9]
+        t = (int(stamp.group(1)) * 3600 + int(stamp.group(2)) * 60
+             + int(stamp.group(3)) + int(frac) / 1e9)
+        key = (sid, name)
+        kind = event.get("signpostType", "")
+        if kind == "begin":
+            open_intervals[key] = t
+        elif kind == "end" and key in open_intervals:
+            intervals[name].append((open_intervals.pop(key), t))
+    return intervals
+
+
+def pct(values, q):
+    if not values:
+        return float("nan")
+    values = sorted(values)
+    return values[min(len(values) - 1, int(len(values) * q))]
+
+
+def densest_window(hops, t0, span):
+    per_second = defaultdict(int)
+    for start, _ in hops:
+        per_second[int(start - t0)] += 1
+    last = max(per_second) if per_second else 0
+    best = (0, -1)
+    for begin in range(0, max(1, last - span + 1)):
+        count = sum(per_second.get(s, 0) for s in range(begin, begin + span))
+        if count > best[1]:
+            best = (begin, count)
+    return best[0], per_second, last
+
+
+def main():
+    args = sys.argv[1:]
+    window = None
+    if "--window" in args:
+        i = args.index("--window")
+        window = (float(args[i + 1]), float(args[i + 2]))
+        del args[i:i + 3]
+    path, label = args[0], args[1]
+
+    intervals = load(path)
+    hops = sorted(intervals.get("mainThreadHop", []))
+    if not hops:
+        print(f"{label}: no mainThreadHop intervals -- capture is void")
+        return 1
+    t0 = min(h[0] for h in hops)
+
+    if window:
+        start, end = window
+        per_second, last = None, None
+    else:
+        span = 25
+        start, per_second, last = densest_window(hops, t0, span)
+        end = start + span
+        print("per-second mainThreadHop counts:")
+        print("  " + " ".join(str(per_second.get(s, 0)) for s in range(last + 1)))
+
+    lo, hi = t0 + start, t0 + end
+    # Effective span: `log stream` starts mid-flight and the load may end before the
+    # nominal window does, so rates must divide by the span actually covered by data,
+    # not by the nominal window width. Intervals whose begin predates t0 (their
+    # matching begin was never captured) are excluded by the `lo <= s` bound below.
+    covered = [(s_, e_) for v in intervals.values() for s_, e_ in v if lo <= s_ < hi]
+    width = (max(e_ for _, e_ in covered) - min(s_ for s_, _ in covered)) if covered else (end - start)
+    if width <= 0:
+        width = end - start
+    print(f"\n=== {label} | window t=[{start:.0f},{end:.0f}) covered span={width:.1f}s ===")
+    for name in ("mainThreadHop", "feed", "displayPass", "rpc.pollCycle"):
+        durations = [(e - s) * 1000 for s, e in intervals.get(name, []) if lo <= s < hi]
+        if not durations:
+            print(f"  {name:14s} none")
+            continue
+        print(f"  {name:14s} n={len(durations):5d} rate={len(durations)/width:6.1f}/s  "
+              f"p50={pct(durations,.5):7.2f}  p90={pct(durations,.9):7.2f}  "
+              f"p99={pct(durations,.99):8.2f}  max={max(durations):8.2f} ms")
+
+    passes = sorted(p for p in intervals.get("displayPass", []) if lo <= p[0] < hi)
+    if len(passes) > 1:
+        gaps = [(passes[i + 1][0] - passes[i][1]) * 1000 for i in range(len(passes) - 1)]
+        print(f"  gaps between passes  p50={pct(gaps,.5):7.1f}  p90={pct(gaps,.9):7.1f}  "
+              f"max={max(gaps):8.1f} ms   ({sum(1 for g in gaps if g > 100)} over 100ms)")
+
+    feed_work = sum(e - s for s, e in intervals.get("feed", []) if lo <= s < hi) / width
+    pass_work = sum(e - s for s, e in intervals.get("displayPass", []) if lo <= s < hi) / width
+    print(f"\n  feed work per wall-second        = {feed_work:.2f} s/s"
+          f"   ({'SATURATED' if feed_work > 0.9 else 'headroom'})")
+    print(f"  displayPass(upper bound) per s   = {pass_work:.2f} s/s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Embedded terminals scroll and type noticeably slower than a standalone terminal emulator on the same machine, and until now nobody could say why. This lands the investigation that answers it, plus two design specs acting on the answer.

The payoff for anyone who touches terminal rendering, sidebar rendering, or `AppState` next: the measurements are written down with the method that produced them, so the next person does not have to re-derive them — or repeat the mistakes that produced three wrong answers along the way.

Docs only. No code changes, no behavior changes.

## Why this shape

Four documents rather than one, split by what each is for.

**Two evidence records** under `docs/perf/`, following the shape of the existing `2026-06-11-rpc-hotspot-brainstorm.md`: dated, declaring their purpose at the top, recording what was measured against which tree. These are the as-built-audit exemption to the no-revision-history convention — they preserve evidence, not chronology.

- `2026-08-25-terminal-render-cost-investigation.md` — what was measured, what was eliminated and how, and where the remaining cost sits in code.
- `2026-08-25-terminal-engine-options.md` — whether TBD should keep its terminal engine, with the three viable paths, what other projects did, and what it would cost. Deliberately decides nothing.

**Two design specs** under `docs/specs/`, each acting on that evidence:

- `2026-08-25-terminal-metal-renderer-design.md` — enable the engine's GPU renderer behind a default-off flag and measure it. It ships in the pinned dependency and has never been called, so every number we have describes a fallback path.
- `2026-08-25-appstate-observable-migration-design.md` — migrate `AppState` off `ObservableObject`, which invalidates all 106 binding sites on any write to any of its 109 published properties.

The engine question lives in an evidence record rather than in the Metal spec's rejected-alternatives because it outgrew that section: there are three distinct paths with real precedent, and folding a decision that size into a rendering spec would have buried it.

## What this PR does

Adds four markdown files. Nothing else.

The substantive findings, for reviewers who would rather not read 950 lines:

- **A control experiment isolates the cause to TBD's frontend.** A standalone emulator running the same agent TUI, attached to the same tmux session on the same loaded machine, is smooth where a TBD terminal is not. That eliminates machine load, tmux, and agent output volume together. The daemon is separately eliminated: control mode is off, so terminal I/O never reaches it.
- **Seven mechanisms located in code**, including a per-row attributed-string rebuild on every redraw, a shaped-line cache capped at 8-character segments so ordinary text never hits it, full-viewport invalidation whenever the user is scrolled back, an unconditional full-grid blink scan whose emptiness guard is evaluated only *after* the scan, a 150 ms post-keystroke window that disables the frame limiter, and wheel amplification in TBD's own monitor that overrides a better handler already present in the dependency (filed separately as #719).
- **A GPU renderer that ships in the pinned dependency and has never been enabled.**

## Assumptions

The measurements come from one heavily loaded developer machine. Absolute figures will not reproduce elsewhere; the *ratios* between validated scroll windows and a quiet baseline are what the specs gate on, and those should.

The `docs/perf/` evidence records are point-in-time by design. The upstream landscape they describe — which pull requests are open, what the dependency's health looks like — will drift, and the documents say so where it matters.

## Evidence & verification

**How the numbers were produced, and why the method is written down.**

Sampling windows that depend on a human performing an action must be verified to contain that action. Four early windows in this investigation silently captured no scrolling, and produced a confident, wrong conclusion that reached a committed spec before a validated re-run reversed it. The method that replaced it scores every window for the action's signature and discards those that fail; of three windows taken that way, one failed — and failed self-consistently, showing both no scroll frames and correspondingly lower draw cost.

Two further traps are recorded because both corrupted numbers here:

- A session in which tooling is running commands is **not** a quiet baseline. Its output streams into the terminal and drives redraws, inflating the very counters under comparison.
- `sample` call-graph counts are **inclusive of children**. Summing a symbol together with its own callees double-counts the subtree — which inflated the draw path roughly twofold and made it appear dominant.

Both specs therefore require the same validation on both sides of any before/after comparison, and require comparing subtree totals rather than summed occurrences.

**What is deliberately not claimed.** Typing was never measured under a validated window; the mechanism described for it is read from code, not observed, and the documents say so. Which `@Published` write drives the graph churn was never isolated, so the `@Observable` spec rests on a structural argument and states that a null result at its gate is a real possible outcome.

## Review feedback addressed

Three findings from the automated review, all acted on.

**The binding-site count was wrong and is corrected.** The spec's headline scope figure counted every `@EnvironmentObject` declaration in the app rather than AppState's — sibling observables were folded in, and the file count was files containing any observation wrapper rather than files binding AppState. Re-derived against AppState specifically: **88 binding sites across 56 source files**, 21 injection sites in `Sources` and 4 in `Tests`. A pre-existing comment in `AppStatePublishFrequencyTests` independently says "~56 view files", corroborating the corrected figure. The structural argument is unchanged; the figure sizes the blast radius implementers plan against, so it had to be right.

**The measured-cost list invited the double-count it warns about.** `RepoSectionView.body` and `WorktreeRowView.body` were flat bullets beside `GraphHost.flushTransactions`, while the companion spec described them as contributors *inside* that flush. They now nest under it with an explicit of-which marker, the list states which entries are additive, and the blink scan is called out as sitting outside the draw subtree so its additivity is explicit rather than inferred.

**The no-flag exception is signed off, not self-granted.** The spec identified itself as wholesale-replacing a load-bearing path — which the repo convention requires to ship behind a default-off flag — and then waived that on its own authority. The convention states no infeasibility exception, so it was put to the repository owner as a decision and signed off on 2026-08-26. The waiver section now records it as an explicit human exception, states why it is forced (the wrapper choice is compile-time, so there is no runtime state a flag could switch and a gated version would duplicate every affected view body), and says plainly that revert-by-branch and dogfooding are *weaker* guarantees than a flag rather than equivalent to one.

[🌙 Diagnose Early Hibernate](https://cheapsteak.github.io/tbd/open/?worktree=09FAE901-FB70-4991-A8D9-E7C3AE6AEB1B)
