### PR TITLE
Fix: Stop sharing a date formatter Foundation never promised is thread-safe

### DIFF
--- a/Sources/TBDShared/Transcript/TranscriptParser.swift
+++ b/Sources/TBDShared/Transcript/TranscriptParser.swift
@@ -8,15 +8,6 @@ import os
 /// Code may be partial during live polling; we tolerate that.
 public enum TranscriptParser {
     private static let perfLog = Logger(subsystem: "com.tbd.shared", category: "perf-transcript")
-    /// Shared ISO8601 formatter that accepts Claude Code's fractional-seconds
-    /// timestamps (e.g. `2026-05-05T03:06:16.813Z`). Without
-    /// `.withFractionalSeconds`, every such timestamp silently fails to parse.
-    /// `ISO8601DateFormatter` is documented as thread-safe for read-only use.
-    nonisolated(unsafe) private static let iso8601: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
 
     /// Parse a top-level Claude session JSONL into transcript items in file order.
     ///
@@ -213,6 +204,31 @@ public enum TranscriptParser {
         toolResultsByID: [String: ToolResult]
     ) -> [TranscriptItem] {
         var items: [TranscriptItem] = []
+
+        // Local, not shared. This was a `nonisolated(unsafe)` static justified
+        // by a comment claiming `ISO8601DateFormatter` "is documented as
+        // thread-safe for read-only use". It is not: `NSISO8601DateFormatter.h`
+        // sits inside `NS_HEADER_AUDIT_BEGIN(nullability, sendability)` and
+        // carries no `NS_SWIFT_SENDABLE`, while its superclass `DateFormatter`
+        // in the same audit regime does. Swift reports the conformance as
+        // explicitly unavailable (`@_nonSendable(_assumed)`), so
+        // `nonisolated(unsafe)` was asserting a guarantee the platform
+        // withholds — on a site reached concurrently, since `TranscriptParser`
+        // is a nonisolated enum called from unstructured RPC handler tasks.
+        //
+        // A lock would restore safety but put the ICU parse inside the critical
+        // section, serializing concurrent whole-file parses. A local formatter
+        // shares nothing instead. Construction measured ~130us against ~25us
+        // per `date(from:)`: free for the whole-file paths, which amortize it
+        // over thousands of lines, and a real but sub-millisecond cost for
+        // `IncrementalTranscript`'s per-batch and single-line patch calls,
+        // which is the same order as the JSON work already in those calls.
+        //
+        // `.withFractionalSeconds` is required: Claude Code emits
+        // `2026-05-05T03:06:16.813Z`, and without it every such timestamp
+        // silently fails to parse.
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
         for (i, json) in rawLines.enumerated() {
             // Subagent (sidechain) lines belong to a nested agent's own


### PR DESCRIPTION
## What's broken

Nothing observable — and that is the honest framing. This is an **unsupported
safety claim on a genuinely concurrent access site**, not a reproduced data race.

`TranscriptParser` holds one shared `ISO8601DateFormatter` as
`nonisolated(unsafe) private static let`. `nonisolated(unsafe)` is a promise to
the compiler that the author has ensured the safety the compiler can no longer
check, and the doc comment states the grounds for that promise:

> `ISO8601DateFormatter` is documented as thread-safe for read-only use.

That sentence is false. Every transcript parse has been leaning on it.

## Why it happens

**The claim does not hold.** `NSISO8601DateFormatter.h` declares the class inside
`NS_HEADER_AUDIT_BEGIN(nullability, sendability)`, holding `CFDateFormatterRef
_formatter`, `NSTimeZone *_timeZone` and `_formatOptions` as private mutable
ivars — and carries no `NS_SWIFT_SENDABLE`. Its superclass `DateFormatter` sits
in the same audit regime and *does* carry it, annotated "All mutable state
protected by locks, subclasses must be thread-safe". Both headers were audited;
only one was granted the guarantee. The subclass's silence is a deliberate
withholding.

Swift is blunter than the header. Asking the compiler to treat the type as
`Sendable` reports the conformance as not merely absent but *explicitly
unavailable*:

```
error: conformance of 'ISO8601DateFormatter' to 'Sendable' is unavailable in macOS
note: conformance ... has been explicitly marked unavailable here
  @_nonSendable(_assumed)
```

**The site is genuinely concurrent.** `TranscriptParser` is a nonisolated enum,
so nothing serializes its callers, and the callers include the daemon's RPC
handlers (`RPCRouter+SessionHandlers.swift:61`,
`RPCRouter+TerminalHandlers.swift:5205`/`:5209`). `RPCRouter` is a `Sendable`
class rather than an actor and `SocketServer` spawns an unstructured `Task` per
request line, so handlers run concurrently. The app reaches the same parser
through `TranscriptDetailReader`. Two parses can be inside `date(from:)` on the
one formatter at once.

Transcript parsing is not a once-at-startup path either: `TranscriptParseCache`
keys on mtime + size, so an actively streaming session misses on every poll.

**What I could not show.** I could not produce an observable failure. 1.5M
concurrent `date(from:)` calls on one shared instance returned correct results,
and the internal `_formatter` ivar is populated eagerly at init rather than
lazily, which removes the most obvious racy-initialization window. The defect
being fixed is the unsupported promise, not a demonstrated corruption.

## What this PR does

Deletes the shared formatter rather than guarding it. `buildItems` is the sole
timestamp-parsing funnel, so the formatter becomes a local there:

```swift
let iso8601 = ISO8601DateFormatter()
iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
```

Nothing is shared, so there is nothing to make safe — no lock, no `@unchecked`
conformance, no confinement discipline for a future author to maintain.

**Why not a lock.** Two established patterns exist for this exact bug, and the
`OSAllocatedUnfairLock(uncheckedState:)` confinement from #717 was implemented
first and worked. But a lock puts the ICU parse *inside* the critical section,
so concurrent parses serialize on per-line work they currently do in parallel.
#717's site does not have that problem — its callers are already on the main
actor and it formats once per row, not once per line of a 30MB file. Copying the
pattern would have carried its reasoning somewhere the reasoning does not hold.

**The cost, measured.** Constructing the formatter is ~130µs against ~25µs per
`date(from:)` (quiet box, two agreeing runs). For the whole-file paths that
amortizes over thousands of lines to nothing. `IncrementalTranscript` calls
`buildItems` once per ingest batch and once per newly-resolved tool result — the
latter with a single line — so there it is a real but sub-millisecond cost, the
same order as the JSON deserialization already in those calls. That trade is
recorded in the code comment rather than left for a future reader to rediscover.

**No spec.** Per CLAUDE.md a bug fix restores the system to its existing theory
rather than revising it. `formatOptions` is byte-identical and parsing behavior
is unchanged.

## Assumptions

- Assumes `buildItems` remains the sole timestamp-parsing funnel. A second parse
  site would need its own local formatter, not a revived shared one.
- Assumes formatter construction stays small relative to the JSON work in the
  same call. Measured above; it holds at every current call site.

## Evidence & verification

**No repro to offer, and none is claimed.** The failure mode is a promise the
platform declines to make, so the evidence is the platform's own declaration.

- **The false claim, refuted at its source.** Both headers read directly from the
  macOS SDK; the audit regime and the presence/absence of `NS_SWIFT_SENDABLE` are
  quoted above.
- **Compile-checked, not asserted.** The escape analysis was proved with a
  standalone `xcrun swiftc -swift-version 6` file rather than trusted: the
  guarded call compiled (exit 0) and an escaping `withLock { $0.iso8601 }` failed
  (exit 1) with the `@_nonSendable(_assumed)` diagnostic above. That is what
  established the "explicitly unavailable" wording — and why the shipped version
  needs no lock at all.
- **Behavior preserved.** `formatOptions` unchanged at `[.withInternetDateTime,
  .withFractionalSeconds]`. Without `.withFractionalSeconds` every Claude Code
  timestamp (`2026-05-05T03:06:16.813Z`) silently fails to parse and every
  transcript item loses its date; `TranscriptParserTests` already pins that path.
- **Build and CI.** `scripts/swift-safe build` clean, log grepped for `error:`
  rather than piped. Whole-suite verification is CI's, on this PR.

**No live verification, deliberately.** A confinement fix cannot be observed in a
running app: a race that does not reproduce under 1.5M concurrent calls will not
reveal itself in a UI. This branch never ran `scripts/restart.sh`, which on a
shared machine would replace the daemon fleet-wide for no diagnostic gain.

Related: #717 (the app-side twin, `RepoSectionView`) and `032c204e` (the `NSLock`
precedent).

https://claude.ai/code/session_01FCCz5KkUeykVHwEtqZ75SJ

[transcript formatter lock](https://cheapsteak.github.io/tbd/open/?worktree=0A7E031A-419B-41F8-9B69-6BF36BAD7D99)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript timestamp parsing reliability, including timestamps with fractional seconds.
  * Avoided shared date-formatting state to support safer concurrent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->