### PR TITLE
Track AppState per property with @Observable, so a write only re-renders the views that read it

### DIFF
--- a/Sources/TBDApp/AccountPickerSheet.swift
+++ b/Sources/TBDApp/AccountPickerSheet.swift
@@ -13,7 +13,7 @@ import TBDShared
 /// blocking spinner). Selecting a row spawns a Claude session pinned to that
 /// profile for life.
 struct AccountPickerSheet: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
 
     /// Called with the chosen profile id; the caller owns the actual spawn.
@@ -26,6 +26,7 @@ struct AccountPickerSheet: View {
     }
 
     var body: some View {
+        @Bindable var appState = appState
         VStack(alignment: .leading, spacing: 12) {
             header
 

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -88,7 +88,7 @@ extension AppState {
     /// clamp that would land on the trailing note tab.
     ///
     /// Writes nothing when the entry already holds the right value — every
-    /// write to `activeTabIndices` publishes an `AppState.objectWillChange`.
+    /// write to `activeTabIndices` notifies every view that reads it.
     func repointActiveTab(worktreeID: UUID, to tabID: UUID?) {
         guard let tabID,
               let newIdx = tabs[worktreeID]?.firstIndex(where: { $0.id == tabID }) else {
@@ -149,8 +149,8 @@ extension AppState {
     /// Called the first time a worktree's tabs appear in memory.
     ///
     /// Every state write below is guarded on an actual change: this runs on a
-    /// retry path, and an unconditional `@Published` write fires a full
-    /// `AppState.objectWillChange` for a response that changed nothing.
+    /// retry path, and an unconditional write to a tracked property notifies
+    /// every reader of it for a response that changed nothing.
     func loadTabStates(worktreeID: UUID) async {
         do {
             let response = try await tabStatesFetcher(worktreeID)

--- a/Sources/TBDApp/AppState+TerminalFocus.swift
+++ b/Sources/TBDApp/AppState+TerminalFocus.swift
@@ -40,8 +40,18 @@ extension AppState {
     /// this touch, `canCloseFocusedTab` would register no dependency on the one
     /// property that actually moves when focus does, and the File ▸ Close Tab
     /// item would stay stuck at whatever it computed last. `TerminalPanelView`
-    /// writes `focusedTabCloseContext` on every focus in and out, which makes it
-    /// the correct observable proxy for a first-responder change.
+    /// writes `focusedTabCloseContext` on mouse-driven focus changes, in and
+    /// out, which makes it the best observable proxy available for a
+    /// first-responder change.
+    ///
+    /// It is a proxy, not a mirror. Focus can also move programmatically —
+    /// `makeFirstResponder` from the webview find bar, an inline rename field,
+    /// a submitting text editor — and those paths do not write the property, so
+    /// Close Tab can stay *enabled* after focus leaves a terminal that way.
+    /// Pressing ⌘W then re-resolves and no-ops, so the consequence is a stale
+    /// menu state rather than a wrong close. Closing that gap properly means
+    /// writing nil on resign-first-responder, which is a change to the focus
+    /// bookkeeping rather than to this read.
     func resolvedFocusedTabCloseContext() -> TabCloseContext? {
         let lastFocused = focusedTabCloseContext
         if terminalFocusTargets.isEmpty {

--- a/Sources/TBDApp/AppState+TerminalFocus.swift
+++ b/Sources/TBDApp/AppState+TerminalFocus.swift
@@ -29,9 +29,23 @@ extension AppState {
         terminalTabCloseContexts.removeValue(forKey: terminalID)
     }
 
+    /// The tab ⌘W would close: the one owning the focused terminal view, or the
+    /// last-focused context when no terminal view has registered yet.
+    ///
+    /// The unconditional read of `focusedTabCloseContext` is load-bearing even
+    /// though the non-empty branch below ignores its value. Everything that
+    /// branch consults is invisible to Observation — `terminalFocusTargets` and
+    /// `terminalTabCloseContexts` are `@ObservationIgnored`, and
+    /// `NSApp.keyWindow?.firstResponder` is not observable at all — so without
+    /// this touch, `canCloseFocusedTab` would register no dependency on the one
+    /// property that actually moves when focus does, and the File ▸ Close Tab
+    /// item would stay stuck at whatever it computed last. `TerminalPanelView`
+    /// writes `focusedTabCloseContext` on every focus in and out, which makes it
+    /// the correct observable proxy for a first-responder change.
     func resolvedFocusedTabCloseContext() -> TabCloseContext? {
+        let lastFocused = focusedTabCloseContext
         if terminalFocusTargets.isEmpty {
-            return focusedTabCloseContext
+            return lastFocused
         }
         guard let terminalView = NSApp.keyWindow?.firstResponder as? TBDTerminalView else {
             return nil

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -81,14 +81,19 @@ enum TmuxStartupResolutionDiagnostic: Equatable {
 }
 
 @MainActor
-final class AppState: ObservableObject {
+@Observable
+final class AppState {
     /// Reference to the global appearance settings, wired by `TBDAppMain`
-    /// after both StateObjects are constructed. Used by
+    /// after both root-owned objects are constructed. Used by
     /// `mainAreaTerminalSize()` to compute initial tmux pane dimensions
     /// from the user's current font, before any `TBDTerminalView` exists.
     /// Plain (non-weak) optional — `AppState` and `AppearanceSettings` share
     /// the app's lifetime, so this reference cannot outlive its target.
-    var appearance: AppearanceSettings? {
+    ///
+    /// `@ObservationIgnored`: no view body reads it — the one consumer is
+    /// `mainAreaTerminalSize()` — and it is assigned from the root scene's
+    /// `onAppear`, where an observed write would land inside a view update.
+    @ObservationIgnored var appearance: AppearanceSettings? {
         didSet {
             if let appearance {
                 appearance.themeStore = themeStore
@@ -97,14 +102,14 @@ final class AppState: ObservableObject {
         }
     }
     /// Subscription to appearance.$schemeID changes for pushing COLORFGBG updates to running tmux servers.
-    private var appearanceSubscription: AnyCancellable?
+    @ObservationIgnored private var appearanceSubscription: AnyCancellable?
     /// Owns the trailing-edge quiet window in front of that subscription.
     private let appearanceDebouncer = AppearanceBroadcastDebouncer()
     /// Subscription to themeStore.$userThemes changes for reconciling the active scheme.
-    private var themeStoreSubscription: AnyCancellable?
+    @ObservationIgnored private var themeStoreSubscription: AnyCancellable?
 
-    @Published var repos: [Repo] = []
-    @Published var worktrees: [UUID: [Worktree]] = [:] {
+    var repos: [Repo] = []
+    var worktrees: [UUID: [Worktree]] = [:] {
         didSet {
             childrenIndexCache = nil
             allWorktreesCache = nil
@@ -112,7 +117,7 @@ final class AppState: ObservableObject {
     }
     /// Repo-less scratch spaces (`Worktree.isScratch`), surfaced separately
     /// in the sidebar's Scratch section rather than under any repo group.
-    @Published var scratchWorktrees: [Worktree] = [] {
+    var scratchWorktrees: [Worktree] = [] {
         // Only `allWorktrees` reads this — `childrenIndex()` is dict-only by
         // design (see `children(of:)`), so its cache survives scratch churn.
         didSet { allWorktreesCache = nil }
@@ -120,21 +125,37 @@ final class AppState: ObservableObject {
 
     // MARK: - Derived worktree caches
     //
-    // Both are plain stored properties, NOT `@Published`: their getters fill
-    // them lazily, and a `@Published` write from inside a SwiftUI `body`
-    // evaluation would fault with "Modifying state during view update".
-    // `AppState` is `@MainActor`, so plain storage is race-free here.
+    // Both are `@ObservationIgnored`: their getters fill them lazily, and an
+    // observed write from inside a SwiftUI `body` evaluation would fault with
+    // "Modifying state during view update" — and, because the getters are
+    // themselves called from `body`, would also close a self-invalidation
+    // loop. `AppState` is `@MainActor`, so plain storage is race-free here.
     //
     // Invalidation is the two `didSet`s above. Every mutation site in the app
     // goes through these stored properties — including in-place element writes
     // like `worktrees[key]?[idx].pinSortOrder = order`, which are a
     // get-modify-set on the stored property and therefore fire `didSet` too —
     // so there is no bypassing path.
+    //
+    // THE WARM-CACHE DEPENDENCY TRAP. Untracked storage means a cache hit
+    // reads nothing observable, and under Observation SwiftUI rebuilds a
+    // view's dependency set from what each `body` evaluation actually read.
+    // A body served entirely from a warm cache would therefore *drop* its
+    // dependency on `worktrees`, and the next write to it would not
+    // invalidate that view — the sidebar going stale until some other
+    // property it reads happens to change. Both getters below defeat this by
+    // touching their tracked source unconditionally, before consulting the
+    // cache, so every evaluation re-registers the dependency whether it hits
+    // or misses. The touch costs a retain, not a copy.
+    //
+    // `AppStateWarmCacheDependencySourceTests` pins this: it warms the cache
+    // through a re-evaluation it proves happened, then asserts a `worktrees`
+    // write still reaches the view. Delete either touch and it fails.
 
     /// Memoized parent-keyed child index; see `childrenIndex()`.
-    private var childrenIndexCache: [UUID: [Worktree]]?
+    @ObservationIgnored private var childrenIndexCache: [UUID: [Worktree]]?
     /// Memoized flattening for `allWorktrees`.
-    private var allWorktreesCache: [Worktree]?
+    @ObservationIgnored private var allWorktreesCache: [Worktree]?
 
     /// Every active/creating worktree bucketed by `parentWorktreeID`, in
     /// `sortOrder`. Backs `children(of:)`, which the sidebar calls once per
@@ -145,6 +166,9 @@ final class AppState: ObservableObject {
     /// Deliberately dict-only, never `allWorktrees`: scratch spaces can never
     /// be children (see `children(of:)`).
     func childrenIndex() -> [UUID: [Worktree]] {
+        // Re-register the `worktrees` dependency on every call, including
+        // cache hits — see "THE WARM-CACHE DEPENDENCY TRAP" above.
+        _ = worktrees
         if let cached = childrenIndexCache { return cached }
         var index: [UUID: [Worktree]] = [:]
         for rows in worktrees.values {
@@ -167,39 +191,39 @@ final class AppState: ObservableObject {
         childrenIndexCache = index
         return index
     }
-    @Published var terminals: [UUID: [Terminal]] = [:]
+    var terminals: [UUID: [Terminal]] = [:]
     /// Ordering watermark for transcript presentation snapshots whose value
     /// did not change. Kept outside `Terminal` so a two-second poll confirming
     /// the same state does not publish a different row solely because its
     /// response stamp advanced; still rejects an older overlapping response
     /// that carries a different value.
-    var terminalPresentationOrderObservedAt: [UUID: Date] = [:]
+    @ObservationIgnored var terminalPresentationOrderObservedAt: [UUID: Date] = [:]
     /// Session identity ordering is independent of the published Terminal row
     /// so a pushed SessionStart can fence an older list response even in the
     /// brief interval before its activity delta arrives.
-    var terminalSessionOrderObservedAt: [UUID: Date] = [:]
-    @Published var notes: [UUID: [Note]] = [:]
-    @Published var focusedTabCloseContext: TabCloseContext?
+    @ObservationIgnored var terminalSessionOrderObservedAt: [UUID: Date] = [:]
+    var notes: [UUID: [Note]] = [:]
+    var focusedTabCloseContext: TabCloseContext?
     /// Unread notification summaries keyed by worktree ID. The cmd-K jump
     /// menu sorts by `mostRecentAt`; the sidebar consumes `.type` for the
     /// severity dot. Worktrees the user is currently viewing are excluded
     /// from this dictionary because `refreshNotifications` auto-marks them
     /// read on every poll.
-    @Published var unreadByWorktree: [UUID: UnreadSummary] = [:]
+    var unreadByWorktree: [UUID: UnreadSummary] = [:]
     /// Unread notification summaries for remote sessions, keyed by
     /// `RemoteSessionSelection` (provider + provider-minted session id —
     /// remote sessions have no UUID). Mirrors `unreadByWorktree`: written by
     /// `handleRemoteSessionAttentionDelta` when an attention delta arrives,
     /// cleared by `selectRemoteSession`. App-local and in-memory only, same
     /// as `unreadByWorktree` — not persisted across restarts.
-    @Published var unreadByRemoteSession: [RemoteSessionSelection: UnreadSummary] = [:]
+    var unreadByRemoteSession: [RemoteSessionSelection: UnreadSummary] = [:]
     /// Terminal IDs that fired a `.responseComplete` notification while their
     /// tab was NOT the active tab of a focused worktree. Drives the bold tab
     /// label in `TabBar`, mirroring the worktree-row bold. App-local and
     /// in-memory only — cleared when the user activates the tab (or focuses the
     /// worktree on that tab); intentionally not persisted across app restarts.
-    @Published var unreadTerminals: Set<UUID> = []
-    @Published var selectedWorktreeIDs: Set<UUID> = [] {
+    var unreadTerminals: Set<UUID> = []
+    var selectedWorktreeIDs: Set<UUID> = [] {
         didSet {
             // If the List selected a repo header tag (not a worktree), treat it
             // as a repo selection and remove the ID from the worktree set.
@@ -343,7 +367,7 @@ final class AppState: ObservableObject {
     /// Persists to UserDefaults on every change (gated on `isInitialStateLoaded`) so the
     /// final, correctly-ordered value is always what gets saved — regardless of whether
     /// the change came from a user selection, back/forward navigation, or startup restore.
-    @Published var selectionOrder: [UUID] = [] {
+    var selectionOrder: [UUID] = [] {
         didSet { persistSelectionOrder() }
     }
     /// A one-shot request to reveal a specific section of a repo's detail pane.
@@ -353,10 +377,10 @@ final class AppState: ObservableObject {
         case preSessionHook(repoID: UUID)
     }
 
-    @Published var repoDetailReveal: RepoDetailReveal?
+    var repoDetailReveal: RepoDetailReveal?
 
     /// Selected repo ID — set when a repo header is clicked, shows archived worktrees in content pane.
-    @Published var selectedRepoID: UUID? = nil {
+    var selectedRepoID: UUID? = nil {
         didSet {
             if let old = oldValue, old != selectedRepoID {
                 clearRevivingArchived(repoID: old)
@@ -368,17 +392,17 @@ final class AppState: ObservableObject {
     /// When set, the next `RepoDetailView` to appear selects this tab instead
     /// of its default (`.archived`). Consumed (cleared) by the view on apply.
     /// Drives the toolbar repo-name dropdown → repo detail tab navigation.
-    @Published var pendingRepoDetailTab: RepoDetailTab?
+    var pendingRepoDetailTab: RepoDetailTab?
     /// Selected — set when the "Scratch" sidebar section header is clicked,
     /// shows `ScratchDetailView` (Archived/Instructions/Settings tabs) in the
     /// content pane. Parallel to `selectedRepoID` but with no `NavigationEntry`
     /// integration for v1 (documented scope cut — see `selectScratchSection()`).
-    @Published var selectedScratchSection: Bool = false
+    var selectedScratchSection: Bool = false
     /// Selected provider header, showing its read-only Provider Desk. This is
     /// mutually exclusive with worktree, repo, scratch, and remote-session
     /// selection, but intentionally stays out of back/forward history for the
     /// first desk slice.
-    @Published var selectedRemoteProvider: String?
+    var selectedRemoteProvider: String?
     /// Selected — set when a `RemoteSectionView` session row is clicked, shows
     /// `RemoteSessionDetailView` (Task 10) in the content pane. Parallel to
     /// `selectedScratchSection` but keyed by the provider/session composite id
@@ -388,7 +412,7 @@ final class AppState: ObservableObject {
     /// records a `.remoteSession` `NavigationEntry` — since remote sessions
     /// now sit inside a repo's own sidebar section beside local worktrees
     /// (see `selectRemoteSession`'s doc comment).
-    @Published var selectedRemoteSession: RemoteSessionSelection? = nil
+    var selectedRemoteSession: RemoteSessionSelection? = nil
     /// One-shot hint for which tab `RemoteSessionDetailView` should land on,
     /// set when a sidebar context-menu action (e.g. "View Log") jumps
     /// straight to a specific tab instead of the default. Consumed (read AND
@@ -398,7 +422,7 @@ final class AppState: ObservableObject {
     /// checked in BOTH onAppear and onChange, or a stale hint replays on an
     /// unrelated later selection. `selectRemoteSession(provider:sessionID:tab:)`
     /// sets this alongside `selectedRemoteSession`; nil means "default tab".
-    @Published var remoteSessionRequestedTab: RemoteSessionDetailTab?
+    var remoteSessionRequestedTab: RemoteSessionDetailTab?
 
     // MARK: - Navigation history (back/forward)
 
@@ -407,20 +431,20 @@ final class AppState: ObservableObject {
     /// `updateNavigationFlags()` to keep the published toolbar flags in sync.
 
     /// Published flags driving the toolbar back/forward buttons.
-    @Published private(set) var canGoBack: Bool = false
-    @Published private(set) var canGoForward: Bool = false
+    private(set) var canGoBack: Bool = false
+    private(set) var canGoForward: Bool = false
     /// Recorded navigation entries (most recent at the end).
-    var navigationEntries: [NavigationEntry] = []
+    @ObservationIgnored var navigationEntries: [NavigationEntry] = []
     /// Index into `navigationEntries` of the currently-displayed view state, or -1 if none.
-    var navigationIndex: Int = -1
+    @ObservationIgnored var navigationIndex: Int = -1
     /// True while applying a back/forward entry, to suppress recording the resulting selection change.
-    var isNavigating: Bool = false
+    @ObservationIgnored var isNavigating: Bool = false
 
-    /// Refresh the @Published `canGoBack` / `canGoForward` flags from the index.
+    /// Refresh the tracked `canGoBack` / `canGoForward` flags from the index.
     /// Usability-aware: a flag is only true when an actually-usable entry exists
     /// in that direction, so the toolbar buttons don't render enabled when
     /// back/forward would skip-walk past every remaining entry and no-op.
-    /// Lives in the same file as the @Published properties so the `private(set)`
+    /// Lives in the same file as those properties so the `private(set)`
     /// setters are reachable.
     func updateNavigationFlags() {
         let back = usableEntryIndex(from: navigationIndex - 1, step: -1) != nil
@@ -430,17 +454,17 @@ final class AppState: ObservableObject {
         if forward != canGoForward { canGoForward = forward }
     }
     /// Archived worktrees keyed by repo ID, fetched on demand.
-    @Published var archivedWorktrees: [UUID: [Worktree]] = [:]
+    var archivedWorktrees: [UUID: [Worktree]] = [:]
 
     /// Archived scratch spaces (repo-less), fetched on demand by
     /// `ScratchArchivedView`. Unlike `archivedWorktrees`, this is a flat list —
     /// scratch archive volume is expected to be low, so no pagination for v1.
-    @Published var archivedScratchWorktrees: [Worktree] = []
+    var archivedScratchWorktrees: [Worktree] = []
 
     /// Whether there are more archived worktrees to load beyond what's in `archivedWorktrees`.
-    @Published var archivedWorktreesHasMore: [UUID: Bool] = [:]
+    var archivedWorktreesHasMore: [UUID: Bool] = [:]
     /// Guards against concurrent loadMoreArchivedWorktrees calls (double-tap, race with refresh).
-    @Published var isLoadingMoreArchived: [UUID: Bool] = [:]
+    var isLoadingMoreArchived: [UUID: Bool] = [:]
 
     // MARK: Archived-worktree search
     //
@@ -459,29 +483,29 @@ final class AppState: ObservableObject {
     /// inside `ArchivedSearchResults`. Deciding what to *display* from this
     /// value would render the previous query's rows as if they were the answer
     /// for the new one during the whole in-flight window.
-    @Published var archivedSearchQuery: [UUID: String] = [:]
+    var archivedSearchQuery: [UUID: String] = [:]
     /// Daemon-side search results (page-accumulated) and the query they answer,
     /// keyed by repo ID. Absent until some response has landed.
-    @Published var archivedSearchResults: [UUID: ArchivedSearchResults] = [:]
+    var archivedSearchResults: [UUID: ArchivedSearchResults] = [:]
     /// Repos whose most recent archived-search RPC failed. Set only for the
     /// query that was in flight, cleared when the next search starts or the
     /// search is cleared. The rail reads it so a failed search degrades to a
     /// *labelled* client-side view rather than silently claiming the loaded
     /// rows are the whole answer.
-    @Published var archivedSearchFailed: [UUID: Bool] = [:]
+    var archivedSearchFailed: [UUID: Bool] = [:]
     /// Guards against concurrent `loadMoreArchivedSearchResults` calls.
-    @Published var isLoadingMoreArchivedSearch: [UUID: Bool] = [:]
+    var isLoadingMoreArchivedSearch: [UUID: Bool] = [:]
 
     /// Orphan-GC reap records (History → Reclaimed), keyed by repo ID and
     /// fetched on demand alongside `archivedWorktrees`.
-    @Published var reapRecords: [UUID: [ReapRecord]] = [:]
+    var reapRecords: [UUID: [ReapRecord]] = [:]
 
     /// Every registered remote-agent provider's negotiated contract + health,
     /// fetched by `refreshRemote()`. See `AppState+Remote.swift`.
-    @Published var remoteProviders: [RemoteProviderStatus] = []
+    var remoteProviders: [RemoteProviderStatus] = []
     /// The daemon's remote-session mirror across all providers, fetched by
     /// `refreshRemote()`. See `AppState+Remote.swift`.
-    @Published var remoteSessions: [RemoteSessionInfo] = []
+    var remoteSessions: [RemoteSessionInfo] = []
     /// TBD-owned display-name overrides for remote sessions, keyed by
     /// `AppState.remoteSessionKey(provider:sessionID:)`. Mirrors the
     /// worktree pattern (`Worktree.displayName` living in TBD's own DB
@@ -498,77 +522,77 @@ final class AppState: ObservableObject {
     /// sessionID:displayName:)` writes here first, then fires the provider
     /// push (`pushRemoteRenameIfSupported`) fire-and-forget, so a rename is
     /// never gated on — or rolled back by — whether that push lands.
-    @Published var remoteSessionDisplayNames: [String: String] = [:] {
+    var remoteSessionDisplayNames: [String: String] = [:] {
         didSet { persistRemoteSessionDisplayNames() }
     }
 
     /// Set briefly when a deep link lands on an archived worktree. The
     /// ArchivedWorktreesView observes this and scrolls/flashes the matching
     /// row, then clears the value after the flash animation completes.
-    @Published var highlightedArchivedWorktreeID: UUID?
+    var highlightedArchivedWorktreeID: UUID?
 
     // MARK: - Toast (deep-link feedback)
 
     /// The single visible in-app toast; nil when hidden. See AppState+Toast.swift.
-    @Published var activeToast: Toast?
+    var activeToast: Toast?
     /// One auto-dismiss tick. Tests shrink this to milliseconds.
-    var toastTickDuration: Duration = .seconds(1)
+    @ObservationIgnored var toastTickDuration: Duration = .seconds(1)
     /// In-flight auto-dismiss task for `activeToast`.
-    var toastDismissTask: Task<Void, Never>?
+    @ObservationIgnored var toastDismissTask: Task<Void, Never>?
 
     /// Request-generation token for archived deep-link lookups. Stamped fresh
     /// at the start of every `navigateToArchivedWorktree(_:)`; a lookup that
     /// resolves after a newer deep link superseded it is dropped. Guards
     /// out-of-order RPC resolution (deep link A then B, A resolves late).
-    var deepLinkRequestID: UUID?
+    @ObservationIgnored var deepLinkRequestID: UUID?
 
     /// Set briefly when external navigation (notification click, deep link,
     /// jump menu) lands on an active worktree. `SidebarView` observes this
     /// to scroll the worktree row into view, then clears the value.
-    @Published var pendingScrollToWorktreeID: UUID?
+    var pendingScrollToWorktreeID: UUID?
 
     /// Test seam: when set, replaces the daemon roundtrip for archived
     /// lookups in `navigateToArchivedWorktree(_:)`. Production code leaves
     /// this nil; tests assign a closure returning a deterministic worktree
     /// list — or one that throws, to exercise the RPC-failure toast branch.
-    var archivedLookupOverride: ((UUID) async throws -> [Worktree])?
+    @ObservationIgnored var archivedLookupOverride: ((UUID) async throws -> [Worktree])?
 
     /// Test seam: when set, replaces the daemon rename RPC in
     /// `renameWorktree(id:displayName:)`. Production code leaves this nil;
     /// tests assign a closure to observe the RPC path (or throw from it to
     /// exercise the rollback branch) without a live daemon.
-    var renameRPCOverride: (@MainActor (UUID, String) async throws -> Void)?
+    @ObservationIgnored var renameRPCOverride: (@MainActor (UUID, String) async throws -> Void)?
 
     /// True once `connectAndLoadInitialState()` has finished its initial
     /// `refreshAll()` and the worktree list is populated. Used by
     /// `navigateToWorktree(_:)` to detect cold-start clicks that arrive
     /// before the daemon RPC has returned.
-    @Published var isInitialStateLoaded: Bool = false
+    var isInitialStateLoaded: Bool = false
 
     /// Buffers a deep-link target UUID when `.onOpenURL` fires before the
     /// initial state load completes. Drained at the end of
     /// `connectAndLoadInitialState()`. Internal-only — never written from
     /// outside the AppState extension that consumes it.
-    var pendingDeepLinkID: UUID?
+    @ObservationIgnored var pendingDeepLinkID: UUID?
 
     /// Companion to `pendingDeepLinkID`: buffers the originating terminal so
     /// cold-start clicks land on the right tab after the drain. Drained
     /// alongside `pendingDeepLinkID` at the end of
     /// `connectAndLoadInitialState()`. Internal-only — never written from
     /// outside the AppState extension that consumes it.
-    var pendingDeepLinkTerminalID: UUID?
+    @ObservationIgnored var pendingDeepLinkTerminalID: UUID?
 
     /// Profile IDs with an "Open login session" spawn currently in flight.
     /// Guards rapid repeat clicks: the first click spawns, subsequent clicks
     /// during the RPC are dropped, and once the terminal lands in state the
     /// dedupe path in `openLoginSession` focuses it instead of spawning again.
-    var loginSessionSpawnsInFlight: Set<UUID> = []
+    @ObservationIgnored var loginSessionSpawnsInFlight: Set<UUID> = []
 
     /// Terminal IDs with a wake RPC in flight, so a rapid re-focus (or a menu
     /// "Wake" racing the auto-wake-on-focus) doesn't fire a second `terminal.wake`
     /// while the first is still respawning. The daemon singleflights too; this
     /// is the app-side first line so we don't even round-trip twice.
-    var wakeInFlight: Set<UUID> = []
+    @ObservationIgnored var wakeInFlight: Set<UUID> = []
 
     /// The first selected worktree, if any.
     var selectedWorktree: Worktree? {
@@ -668,14 +692,14 @@ final class AppState: ObservableObject {
         dockedTerminalIDs.contains(terminalID)
     }
 
-    @Published var dockRatio: CGFloat = 0.3 {
+    var dockRatio: CGFloat = 0.3 {
         didSet { userDefaults.set(Double(dockRatio), forKey: Self.dockRatioKey) }
     }
     /// "Use default without asking": when true, the plain "Claude" action
     /// spawns silently on the global default profile instead of opening the
     /// spawn-time account picker. Toggleable from the picker itself and
     /// Settings → Model Profiles. Persisted per-user.
-    @Published var skipAccountPicker: Bool = false {
+    var skipAccountPicker: Bool = false {
         didSet { userDefaults.set(skipAccountPicker, forKey: Self.skipAccountPickerKey) }
     }
     /// Pixel size of the main terminal area (the SingleWorktreeView slot
@@ -683,7 +707,7 @@ final class AppState: ObservableObject {
     /// Default matches the typical window: 1200 wide window − sidebar (~280) ≈ 920;
     /// 800 tall window − toolbar (~24) ≈ 776. Conservative fallback for the
     /// first RPC before the GeometryReader publishes a real value.
-    @Published var mainAreaSize: CGSize = CGSize(width: 1120, height: 776) {
+    var mainAreaSize: CGSize = CGSize(width: 1120, height: 776) {
         didSet {
             guard mainAreaSize != oldValue else { return }
             scheduleMainAreaSizeBroadcast()
@@ -692,40 +716,40 @@ final class AppState: ObservableObject {
     /// Debounce token for broadcasting `mainAreaSize` changes to the daemon.
     /// Cancelled and re-scheduled on every change so we send one RPC per
     /// resize gesture rather than per AppKit layout pass.
-    private var mainAreaSizeBroadcastTask: Task<Void, Never>?
-    private var lastBroadcastCols: Int = 0
-    private var lastBroadcastRows: Int = 0
-    @Published var isConnected: Bool = false
-    @Published var layouts: [UUID: LayoutNode] = [:] {
+    @ObservationIgnored private var mainAreaSizeBroadcastTask: Task<Void, Never>?
+    @ObservationIgnored private var lastBroadcastCols: Int = 0
+    @ObservationIgnored private var lastBroadcastRows: Int = 0
+    var isConnected: Bool = false
+    var layouts: [UUID: LayoutNode] = [:] {
         didSet { persistLayouts() }
     }
     /// Multi-worktree grid layouts, keyed by WORKTREE ID. Presentation-only
     /// (spec C §3.12): never persisted, never mirrored, never part of the
     /// panel surface. Kept separate from `layouts` (tab-ID-keyed) so the two
     /// keying schemes can't collide in one dictionary.
-    @Published var gridLayouts: [UUID: LayoutNode] = [:]
+    var gridLayouts: [UUID: LayoutNode] = [:]
     /// Back/forward history per viewer-class slot pane, keyed by the slot's
     /// paneID (stable across in-place content replacements).
-    @Published var paneHistories: [UUID: PaneHistory] = [:] {
+    var paneHistories: [UUID: PaneHistory] = [:] {
         didSet { persistPaneHistories() }
     }
-    @Published var tabs: [UUID: [TBDShared.Tab]] = [:]
+    var tabs: [UUID: [TBDShared.Tab]] = [:]
     /// EXPLICIT per-worktree tab selection. Absent (or out of range) means "no
     /// deliberate selection" — read it through `resolvedActiveTabIndex` rather
     /// than defaulting to 0 or clamping at the call site.
-    @Published var activeTabIndices: [UUID: Int] = [:]
-    @Published var worktreeTabOrders: [UUID: [UUID]] = [:]
+    var activeTabIndices: [UUID: Int] = [:]
+    var worktreeTabOrders: [UUID: [UUID]] = [:]
     /// Worktrees whose persisted tab order / active tab has been hydrated from
     /// the daemon with actual content. Distinct from `worktreeTabOrders[id] != nil`,
     /// which is also true for the empty response a poll gets while the daemon is
     /// still mid-create — treating that as loaded stranded the worktree without
     /// its persisted "active = agent" selection for the rest of the session.
-    var tabStateHydratedWorktreeIDs: Set<UUID> = []
+    @ObservationIgnored var tabStateHydratedWorktreeIDs: Set<UUID> = []
     /// `listTabs` fetches already spent trying to hydrate a worktree, capped at
     /// `maxTabStateHydrationAttempts`. Without a cap, a worktree whose tab state
     /// is legitimately and permanently empty re-fires the RPC on every
     /// `reconcileTabs` — which is every terminal-list change — forever.
-    var tabStateFetchAttempts: [UUID: Int] = [:]
+    @ObservationIgnored var tabStateFetchAttempts: [UUID: Int] = [:]
     /// The in-flight hydration `Task` per worktree, so overlapping reconciles
     /// can't stack `Task`s for the same worktree. Holding the handle rather than
     /// a bare `Set<UUID>` marker means the completion of that work is directly
@@ -733,40 +757,40 @@ final class AppState: ObservableObject {
     /// wall time for the flag to clear, and only the scheduler's own `Task`
     /// clears the entry, so a direct `loadTabStates(worktreeID:)` call can no
     /// longer clear an in-flight marker it does not own.
-    var tabStateFetchTasks: [UUID: Task<Void, Never>] = [:]
+    @ObservationIgnored var tabStateFetchTasks: [UUID: Task<Void, Never>] = [:]
     /// Hydration attempt budget. The gap this covers is one poll wide — the
     /// daemon persists tab order milliseconds after inserting the terminal
     /// rows — so a single retry is always enough; the extra one is slack.
     static let maxTabStateHydrationAttempts = 3
-    @Published var draggingTabID: UUID? = nil
-    @Published var repoFilter: UUID? = nil
-    @Published var pendingWorktreeIDs: Set<UUID> = []
+    var draggingTabID: UUID? = nil
+    var repoFilter: UUID? = nil
+    var pendingWorktreeIDs: Set<UUID> = []
     /// Remote lanes drawn optimistically while `remote.create` is in flight,
     /// one entry per placeholder row (whose id is also in `pendingWorktreeIDs`,
     /// so a poll landing mid-create preserves the row like any other
-    /// placeholder). Not `@Published` — no view reads it; it is the bookkeeping
+    /// placeholder). `@ObservationIgnored` — no view reads it; it is the bookkeeping
     /// `AppState+Remote`'s create path uses to retire each placeholder on the
     /// `(provider, sessionID)` pair. See `PendingRemoteLane`.
-    var pendingRemoteLanes: [PendingRemoteLane] = []
+    @ObservationIgnored var pendingRemoteLanes: [PendingRemoteLane] = []
     /// Worktree IDs optimistically removed by an archive that has not yet been
     /// confirmed by daemon data. `refreshWorktrees` filters these out so a
     /// `listWorktrees` poll issued before the daemon flipped the status cannot
     /// resurrect the row. Value is the time the tombstone was created, used for
     /// TTL-based eviction when an archive fails or stalls.
-    var recentlyArchivedWorktreeIDs: [UUID: Date] = [:]
-    @Published var suspendingTerminalIDs: Set<UUID> = []
+    @ObservationIgnored var recentlyArchivedWorktreeIDs: [UUID: Date] = [:]
+    var suspendingTerminalIDs: Set<UUID> = []
     /// Closures registered by live TerminalPanelView instances to capture a screenshot.
     /// Keyed by terminal UUID. Populated in makeNSView, cleared on view disappear.
-    var snapshotProviders: [UUID: () -> NSImage?] = [:]
+    @ObservationIgnored var snapshotProviders: [UUID: () -> NSImage?] = [:]
     /// Weak terminal views keyed by terminal UUID, used to restore AppKit first
     /// responder after worktree navigation.
-    var terminalFocusTargets: [UUID: TerminalFocusTarget] = [:]
+    @ObservationIgnored var terminalFocusTargets: [UUID: TerminalFocusTarget] = [:]
     /// Tab-close ownership keyed by terminal UUID for views that belong to a
     /// visible tab, used to resolve the currently focused closable tab.
-    var terminalTabCloseContexts: [UUID: TabCloseContext] = [:]
+    @ObservationIgnored var terminalTabCloseContexts: [UUID: TabCloseContext] = [:]
     /// Visual screenshots taken at suspend-click time, shown while daemon works.
     /// Keyed by terminal UUID. Cleared when suspend completes.
-    @Published var suspendingSnapshots: [UUID: NSImage] = [:]
+    var suspendingSnapshots: [UUID: NSImage] = [:]
 
     func setSuspendingSnapshot(_ image: NSImage, for id: UUID) {
         suspendingSnapshots[id] = image
@@ -775,36 +799,36 @@ final class AppState: ObservableObject {
     func removeSuspendingSnapshot(for id: UUID) {
         suspendingSnapshots.removeValue(forKey: id)
     }
-    @Published var editingWorktreeID: UUID? = nil
-    @Published var isRenamingWorktree = false
-    @Published var prStatuses: [UUID: PRStatus] = [:]
+    var editingWorktreeID: UUID? = nil
+    var isRenamingWorktree = false
+    var prStatuses: [UUID: PRStatus] = [:]
     /// The outcome of the daemon's last attempt to learn each worktree's PR
     /// state. Kept beside `prStatuses`, never merged into it: a worktree absent
     /// from `prStatuses` has no PR only when this says `.none`, and a worktree
     /// present in it may be showing a value the last attempt could not
     /// reconfirm. A missing key means no attempt is on record.
-    @Published var prObservations: [UUID: PRObservation] = [:]
+    var prObservations: [UUID: PRObservation] = [:]
     /// Every live PR bound to each worktree, in bind order — the multi-PR
     /// surface behind the toolbar dropdown. `prStatuses` remains the single
     /// worst-of summary the daemon writes to `Worktree.prStatus`; this is the
     /// full set, and the two are refreshed together.
-    @Published var prBindings: [UUID: [PRBinding]] = [:]
+    var prBindings: [UUID: [PRBinding]] = [:]
     /// How many of each worktree's bindings are tombstoned, for the worktrees
     /// that have any (a worktree with none is absent, not zero). Refreshed in
     /// the same call as `prBindings` and kept separately because it outlives
     /// them: detaching a worktree's last PR empties `prBindings` and leaves this
     /// non-zero, which is precisely the signal that suppresses the
     /// legacy-status fallback below.
-    @Published var prDetachedCounts: [UUID: Int] = [:]
+    var prDetachedCounts: [UUID: Int] = [:]
     /// Start order for `refreshPRBindings`: every call takes the next ticket
     /// before it fetches, so the two counters below can be compared to tell an
     /// older snapshot from a newer one.
-    private var prBindingsRefreshSeq = 0
+    @ObservationIgnored private var prBindingsRefreshSeq = 0
     /// The highest ticket that has actually PUBLISHED. Deliberately not the
     /// same fact as the one above — a call that started later and then failed
     /// put nothing on screen, so it must not silence an earlier call whose
     /// fetch succeeded. Only a publish moves this.
-    private var prBindingsPublishedSeq = 0
+    @ObservationIgnored private var prBindingsPublishedSeq = 0
     /// What every PR surface — toolbar split button, sidebar row indicator,
     /// status-bar chips — must read, so they cannot disagree about a worktree.
     /// Bindings when there are any; otherwise the legacy single `prStatuses`
@@ -823,67 +847,67 @@ final class AppState: ObservableObject {
         )
     }
 
-    @Published var modelProfiles: [ModelProfileWithUsage] = []
-    @Published var defaultProfileID: UUID? = nil
+    var modelProfiles: [ModelProfileWithUsage] = []
+    var defaultProfileID: UUID? = nil
     /// Ephemeral one-shot Codex account/usage snapshot loaded when the
     /// worktree picker opens. It is intentionally neither polled nor persisted.
-    @Published var codexUsage: CodexUsageResult?
-    @Published var isLoadingCodexUsage = false
-    @Published var primaryAgentPreference: PrimaryAgentPreference = .defaultValue
+    var codexUsage: CodexUsageResult?
+    var isLoadingCodexUsage = false
+    var primaryAgentPreference: PrimaryAgentPreference = .defaultValue
     /// Global free-form env overrides (config scope). Loaded from the daemon
     /// alongside `defaultProfileID` via `loadModelProfiles()`.
-    @Published var globalEnvOverrides: [String: String] = [:]
+    var globalEnvOverrides: [String: String] = [:]
     /// Machine-wide remote create-param defaults (config scope), keyed by the
     /// provider's own `create_params` field names. The fall-through level
     /// beneath `Repo.remoteCreateDefaults`. Loaded from the daemon alongside
     /// `globalEnvOverrides` via `loadModelProfiles()`.
-    @Published var globalRemoteCreateDefaults: [String: String] = [:]
+    var globalRemoteCreateDefaults: [String: String] = [:]
     /// Global default for auto-archive-on-PR-merge. Loaded from the daemon
     /// alongside `globalEnvOverrides` via `loadModelProfiles()`.
-    @Published var autoArchiveOnMergeDefault: Bool = false
+    var autoArchiveOnMergeDefault: Bool = false
     /// Global default for auto-hibernate-on-PR-merge. Loaded from the daemon
     /// alongside `autoArchiveOnMergeDefault` via `loadModelProfiles()`.
-    @Published var autoHibernateOnMergeDefault: Bool = false
+    var autoHibernateOnMergeDefault: Bool = false
     /// Orphan-GC master switch (Config mirror, default true to match
     /// `Config.gcEnabled`). Loaded from the daemon alongside
     /// `autoArchiveOnMergeDefault` via `loadModelProfiles()`.
-    @Published var gcEnabled: Bool = true
+    var gcEnabled: Bool = true
     /// Whether ordinary new worktrees start with an empty Notes tab. Loaded
     /// from the daemon alongside the other config-backed worktree defaults.
-    @Published var autoCreateNotesEnabled: Bool = Config.autoCreateNotesDefault
-    @Published var nightwatchMode: NightwatchMode = .off
+    var autoCreateNotesEnabled: Bool = Config.autoCreateNotesDefault
+    var nightwatchMode: NightwatchMode = .off
     /// Auto-hibernate master switch. Loaded from the daemon `Config` via
     /// `loadHibernationConfig()`.
-    @Published var autoHibernateEnabled: Bool = false
+    var autoHibernateEnabled: Bool = false
     /// Auto-hibernate idle timeout in minutes. Loaded from `Config`.
-    @Published var hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes
+    var hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes
     /// Supervision's fleet-wide authority switch (design 2026-07-26 §3, §7).
     /// `true` means supervision is enabled — the fleet brake is *released*,
     /// the opposite sense from the brake's own name. Shipped OFF (braked);
     /// for now inert, since the rest of the supervision subsystem is landing
     /// in the same series of changes. Loaded from the daemon `Config` via
     /// `loadSupervisionConfig()`.
-    @Published var supervisionEnabled: Bool = false
+    var supervisionEnabled: Bool = false
     /// Daemon-persisted gate for session-limit auto-resume (default OFF).
     /// Daemon-side (not @AppStorage) because the daemon must act while the
     /// app is closed.
-    @Published var autoResumeOnLimitReset: Bool = false
+    var autoResumeOnLimitReset: Bool = false
     /// Daemon-persisted gate for transient-API-error auto-continue (default
     /// OFF). Daemon-side (not @AppStorage) because the daemon must act while
     /// the app is closed.
-    @Published var autoResumeOnApiError: Bool = false
+    var autoResumeOnApiError: Bool = false
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
-    @Published var dismissedProxyWarnings: Set<UUID> = []
+    var dismissedProxyWarnings: Set<UUID> = []
     /// Non-nil when the connected daemon reports an executable path that
     /// doesn't belong to this app's build (another worktree's restart.sh won
     /// the shared daemon). Rendered as a persistent, non-blocking banner in
     /// ContentView. Set by `checkDaemonBuildIdentity()` on every connect, so
     /// it self-clears once a matching daemon is connected.
-    @Published var daemonBuildMismatchMessage: String?
+    var daemonBuildMismatchMessage: String?
     /// User dismissed the build-mismatch banner. In-memory only (advisory);
     /// reset whenever the mismatch message changes.
-    @Published var daemonBuildMismatchDismissed = false
+    var daemonBuildMismatchDismissed = false
     /// Panes currently rendered through a live control-mode attach, mapped to
     /// the attach GENERATION the record belongs to (`nil` when the daemon
     /// vended none). Maintained by `TerminalPanelRepresentable.Coordinator`
@@ -894,23 +918,23 @@ final class AppState: ObservableObject {
     /// landing after a fresh attach's set for the same pane under adverse
     /// MainActor scheduling — cannot drop a healthy pane's attached state
     /// (the app-side twin of the daemon's generation-checked detach).
-    @Published private(set) var controlModeAttachedPanes: [ControlModePaneKey: UInt64?] = [:]
+    private(set) var controlModeAttachedPanes: [ControlModePaneKey: UInt64?] = [:]
     /// Panes the daemon has flagged input-failing via edge-triggered
     /// `controlModeInputHealthChanged` deltas. A `healthy: true` delta or a
     /// detach clears the flag. Read through `isInputDeliveryFailing(_:)`,
     /// which applies the attached-pane gate.
-    @Published private(set) var controlModeFailingInputPanes: Set<ControlModePaneKey> = []
-    @Published var historyActiveWorktrees: Set<UUID> = []
-    @Published var historyLoadStates: [UUID: HistoryLoadState] = [:]
-    @Published var selectedSessionIDs: [UUID: String] = [:]       // worktreeID → sessionId
-    @Published var sessionTranscripts: [String: [TranscriptItem]] = [:]  // sessionId → items
-    @Published var sessionTranscriptLoading: Set<String> = []
+    private(set) var controlModeFailingInputPanes: Set<ControlModePaneKey> = []
+    var historyActiveWorktrees: Set<UUID> = []
+    var historyLoadStates: [UUID: HistoryLoadState] = [:]
+    var selectedSessionIDs: [UUID: String] = [:]       // worktreeID → sessionId
+    var sessionTranscripts: [String: [TranscriptItem]] = [:]  // sessionId → items
+    var sessionTranscriptLoading: Set<String> = []
     // Closed-terminal history (Session History → Closed Terminals).
-    @Published var closedTerminalHistories: [UUID: [TerminalHistoryEntry]] = [:]  // worktreeID → entries
-    @Published var selectedClosedTerminalIDs: [UUID: UUID] = [:]                  // worktreeID → entry id
+    var closedTerminalHistories: [UUID: [TerminalHistoryEntry]] = [:]  // worktreeID → entries
+    var selectedClosedTerminalIDs: [UUID: UUID] = [:]                  // worktreeID → entry id
     /// Captured text of the currently selected closed terminal only —
     /// deliberately a one-entry cache so large scrollbacks never accumulate.
-    @Published var closedTerminalContents: [UUID: String] = [:]                   // entry id → text
+    var closedTerminalContents: [UUID: String] = [:]                   // entry id → text
 
     /// Raw most-recent-first log of recently-visited worktrees, the recency
     /// input to the keep-alive policy. Bounded by `touchVisitedWorktree`, which
@@ -918,13 +942,13 @@ final class AppState: ObservableObject {
     /// mount set the view consumes is the computed `keepAliveWorktreeIDs`, which
     /// re-merges the live protection set; do not feed this raw log to the pager
     /// directly.
-    @Published private(set) var recentlyVisitedWorktreeIDs: [UUID] = []
+    private(set) var recentlyVisitedWorktreeIDs: [UUID] = []
 
     /// LRU of recently-selected worktrees consumed by the cmd-K jump menu.
     /// Distinct from `recentlyVisitedWorktreeIDs` (which has a much smaller
     /// cap and drives the SingleWorktreeView keep-alive cache). In-memory
     /// only — resets on app relaunch, matching Slack's "Recent" semantics.
-    @Published private(set) var recentWorktreeIDs: [UUID] = []
+    private(set) var recentWorktreeIDs: [UUID] = []
 
     private static let recentWorktreeCap = 32
 
@@ -938,7 +962,7 @@ final class AppState: ObservableObject {
     /// `attachedRemoteSelections` re-merges the current selection (protected)
     /// and eligibility/detach state on every read, so this log alone doesn't
     /// say what's actually attached right now.
-    @Published private(set) var recentlyAttachedRemoteSessions: [RemoteSessionSelection] = []
+    private(set) var recentlyAttachedRemoteSessions: [RemoteSessionSelection] = []
 
     /// Sessions whose attach terminal ended (pty exit — clean or not; the
     /// pane exiting never means the remote session died, only that the
@@ -952,7 +976,7 @@ final class AppState: ObservableObject {
     /// would spawn a fresh process every render, an unbounded respawn loop
     /// against a resource this codebase must not spam (SSM/ssh concurrency
     /// and cost — see `RemoteAttachLifecycle`'s doc comment).
-    @Published private(set) var explicitlyDetachedRemoteSessions: [RemoteSessionSelection: RemoteAttachDetachInfo] = [:]
+    private(set) var explicitlyDetachedRemoteSessions: [RemoteSessionSelection: RemoteAttachDetachInfo] = [:]
 
     /// Sessions whose attach terminal ended UNEXPECTEDLY (nonzero/unreadable
     /// exit — `RemoteAttachTerminalView.isUnexpectedExit`) — the transport's
@@ -968,7 +992,7 @@ final class AppState: ObservableObject {
     /// `dismissed` exclusion, and above all `remoteAttachKeepAliveLimit`),
     /// so a laptop waking from a long outage can't reattach more than the
     /// cap at once even with many pending entries at once.
-    @Published private(set) var pendingReconnectRemoteSessions: [RemoteSessionSelection: RemotePendingReconnect] = [:]
+    private(set) var pendingReconnectRemoteSessions: [RemoteSessionSelection: RemotePendingReconnect] = [:]
 
     /// Cap on how many WARM BACKGROUND remote sessions may keep a live
     /// attach terminal around at once. The current selection is separately
@@ -1186,7 +1210,7 @@ final class AppState: ObservableObject {
     /// Insertion/access order for `sessionTranscripts`. The most recently
     /// touched sessionID is at the END. Evict from the FRONT when the cap
     /// is exceeded.
-    private var sessionTranscriptOrder: [String] = []
+    @ObservationIgnored private var sessionTranscriptOrder: [String] = []
     private let sessionTranscriptCap = 50
 
     /// Touch a sessionID — moves it to most-recently-used, evicts the LRU
@@ -1204,7 +1228,7 @@ final class AppState: ObservableObject {
     }
 
     /// Selected archived worktree per repo (left rail of the archived view's nested master-detail).
-    @Published var selectedArchivedWorktreeIDs: [UUID: UUID] = [:]
+    var selectedArchivedWorktreeIDs: [UUID: UUID] = [:]
 
     /// Selected "Reclaimed" (orphan-GC reap record) row per repo, in the same
     /// left rail as `selectedArchivedWorktreeIDs`. The two are mutually
@@ -1212,38 +1236,38 @@ final class AppState: ObservableObject {
     /// `selectReapRecord(_:repoID:)` (AppState+Worktrees.swift) to change
     /// either, which keep that invariant instead of mutating these
     /// dictionaries directly.
-    @Published var selectedReapRecordIDs: [UUID: UUID] = [:]
+    var selectedReapRecordIDs: [UUID: UUID] = [:]
 
     /// Worktrees the user just revived from the archived view. Keeps the row
     /// visible with a status indicator until the user navigates away from the
     /// archived section. Cleared by `AppState+Navigation` when the active
     /// sidebar selection moves elsewhere.
-    @Published var revivingArchived: [UUID: ReviveState] = [:]
+    var revivingArchived: [UUID: ReviveState] = [:]
 
     /// Terminal IDs currently being recreated — prevents duplicate RPC calls.
-    var recreatingTerminalIDs: Set<UUID> = []
+    @ObservationIgnored var recreatingTerminalIDs: Set<UUID> = []
 
     /// Terminal deletions waiting for an already-dispatched recreation RPC to
     /// finish. This set is bounded by `recreatingTerminalIDs` and is cleared
     /// when the matching recreation completes.
-    var terminalDeletionsAwaitingRecreationCompletion: Set<UUID> = []
+    @ObservationIgnored var terminalDeletionsAwaitingRecreationCompletion: Set<UUID> = []
 
     /// Short-lived guard against daemon responses that were already in flight
     /// when a terminal was deleted. Pruned on every mutation and adoption.
-    var recentlyDeletedTerminalIDs: [UUID: Date] = [:]
+    @ObservationIgnored var recentlyDeletedTerminalIDs: [UUID: Date] = [:]
 
     /// App-lifetime automatic recovery attempts, keyed by stable terminal UUID.
     /// View/coordinator reconstruction must not reset this budget.
-    var terminalRecoveryBudget = TerminalRecoveryBudget()
+    @ObservationIgnored var terminalRecoveryBudget = TerminalRecoveryBudget()
 
     // Alert state for user feedback
-    @Published var alertMessage: String? = nil
-    @Published var alertIsError: Bool = false
+    var alertMessage: String? = nil
+    var alertIsError: Bool = false
 
-    @Published private(set) var tmuxExecutableResolution: TmuxExecutableResolution?
-    @Published private(set) var savedTmuxExecutablePath: String?
-    @Published private(set) var isTmuxLocationPromptPresented = false
-    private var hasCheckedTmuxAvailabilityAtStartup = false
+    private(set) var tmuxExecutableResolution: TmuxExecutableResolution?
+    private(set) var savedTmuxExecutablePath: String?
+    private(set) var isTmuxLocationPromptPresented = false
+    @ObservationIgnored private var hasCheckedTmuxAvailabilityAtStartup = false
 
     let themeStore = ThemeStore()
 
@@ -1259,21 +1283,21 @@ final class AppState: ObservableObject {
     /// derive these locally: it is launched via `open`, which drops shell env.
     /// Published so the Settings control-mode toggle re-renders after
     /// `setControlModeEnabled` refreshes it.
-    @Published var daemonCapabilities: DaemonCapabilitiesResult?
+    var daemonCapabilities: DaemonCapabilitiesResult?
     /// How `loadModelProfiles()` fetches its config-bearing response.
     /// Injectable because `DaemonClient` is concrete, matching the other
     /// settings seams below.
-    lazy var modelProfilesFetcher: @MainActor () async throws -> ModelProfileListResult =
+    @ObservationIgnored lazy var modelProfilesFetcher: @MainActor () async throws -> ModelProfileListResult =
         { [daemonClient] in try await daemonClient.listModelProfiles() }
     /// How `refreshDaemonCapabilities()` fetches — injectable because
     /// `DaemonClient` is concrete (no protocol), so state-level tests stub the
     /// RPC here. Production default asks the daemon; nil result = fetch failed.
-    lazy var daemonCapabilitiesFetcher: @MainActor () async -> DaemonCapabilitiesResult? =
+    @ObservationIgnored lazy var daemonCapabilitiesFetcher: @MainActor () async -> DaemonCapabilitiesResult? =
         { [daemonClient] in try? await daemonClient.daemonCapabilities() }
     /// How `reviveConversationOnFreshBranch` asks the daemon to create the
     /// destination worktree and resume its selected session. Injectable so
     /// AppState tests can exercise the action without a live daemon.
-    lazy var freshConversationReviver:
+    @ObservationIgnored lazy var freshConversationReviver:
         @MainActor (UUID, String, Int?, Int?) async throws
             -> WorktreeReviveConversationFreshResult = { [daemonClient] worktreeID, sessionID, cols, rows in
                 try await daemonClient.reviveConversationOnFreshBranch(
@@ -1286,32 +1310,32 @@ final class AppState: ObservableObject {
     /// How `setControlModeEnabled` persists the flag — injectable for the same
     /// reason as `daemonCapabilitiesFetcher` (`DaemonClient` is concrete, no
     /// protocol), so the Settings-toggle tests can exercise the success branch.
-    lazy var controlModeSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var controlModeSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setControlMode(enabled: enabled) }
     /// How `setHibernateInputVetoEnabled` persists the flag — injectable for
     /// the same reason as `controlModeSetter`.
-    lazy var hibernateInputVetoSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var hibernateInputVetoSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setHibernateInputVeto(enabled: enabled) }
     /// How `setAutoCloseSetupEnabled` persists the flag — injectable for the
     /// same reason as `controlModeSetter`.
-    lazy var autoCloseSetupSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var autoCloseSetupSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setAutoCloseSetup(enabled: enabled) }
     /// How `setAutoTrustWorktrees` persists the flag — injectable for the
     /// same reason as `controlModeSetter`.
-    lazy var autoTrustWorktreesSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var autoTrustWorktreesSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setAutoTrustWorktrees(enabled: enabled) }
     /// How the automatic Notes preference is persisted — injectable for the
     /// same reason as `controlModeSetter`.
-    lazy var autoCreateNotesSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var autoCreateNotesSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setAutoCreateNotes(enabled: enabled) }
     /// How `setQueuedPromptEnabled` persists the queued-prompt soak flag —
     /// injectable for the same reason as `controlModeSetter`.
-    lazy var queuedPromptFlagSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var queuedPromptFlagSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setQueuedPrompt(enabled: enabled) }
     /// How `setClaudeCloudEnabled` persists the Claude cloud gate — injectable
     /// for the same reason as `controlModeSetter`, so the Settings toggle's
     /// success and failure branches are testable without a real daemon.
-    lazy var claudeCloudFlagSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var claudeCloudFlagSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setClaudeCloud(enabled: enabled) }
     /// The worktree a queued prompt is being composed for, driving
     /// `ContentView`'s `.sheet(item:)`. Non-nil only while the modal is up, and
@@ -1325,7 +1349,7 @@ final class AppState: ObservableObject {
     /// because `.sheet(item:)` writes the nil itself when the sheet closes —
     /// submit, Cancel and Escape all arrive that way and none of them can be
     /// asked to call something first.
-    @Published var queuedPromptTarget: QueuedPromptTarget? {
+    var queuedPromptTarget: QueuedPromptTarget? {
         didSet {
             if queuedPromptTarget == nil { advanceQueuedPromptBacklog() }
         }
@@ -1337,7 +1361,7 @@ final class AppState: ObservableObject {
     /// first — `.sheet(item:)` swapping a live item is unreliable on macOS, so
     /// the operator can be left typing into a modal bound to the *previous*
     /// target. They queue instead.
-    var queuedPromptBacklog: [QueuedPromptTarget] = []
+    @ObservationIgnored var queuedPromptBacklog: [QueuedPromptTarget] = []
     /// The parked prompt being read back, sharing `ContentView`'s single
     /// prompt `.sheet(item:)` with the compose modal. A prompt that could not
     /// be delivered stays in the `worktree.pending_prompt` column; this is how
@@ -1346,7 +1370,7 @@ final class AppState: ObservableObject {
     /// Closing it frees the shared sheet slot, so a creation that queued behind
     /// it can open — the same observer `queuedPromptTarget` carries, for the
     /// same reason.
-    @Published var parkedPromptReadback: ParkedPromptReadback? {
+    var parkedPromptReadback: ParkedPromptReadback? {
         didSet {
             if parkedPromptReadback == nil { advanceQueuedPromptBacklog() }
         }
@@ -1355,10 +1379,10 @@ final class AppState: ObservableObject {
     /// Parking is not idempotent from the agent's point of view — a second
     /// click parks the same text again, and the daemon delivers what it is
     /// told, so the operator's message arrives twice.
-    @Published var parkedPromptDeliveryInFlight = false
+    var parkedPromptDeliveryInFlight = false
     /// How the read-back's Copy button reaches the pasteboard. Injectable so
     /// tests never write to the developer's real pasteboard.
-    lazy var pasteboardWriter: @MainActor (String) -> Void = { text in
+    @ObservationIgnored lazy var pasteboardWriter: @MainActor (String) -> Void = { text in
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
     }
@@ -1366,7 +1390,7 @@ final class AppState: ObservableObject {
     /// same reason as `daemonCapabilitiesFetcher` (`DaemonClient` is concrete,
     /// no protocol), so the queued-prompt tests can pin the RPC ordering
     /// without a live daemon.
-    lazy var worktreeCreator: @MainActor (WorktreeCreateRequest) async throws -> Worktree =
+    @ObservationIgnored lazy var worktreeCreator: @MainActor (WorktreeCreateRequest) async throws -> Worktree =
         { [daemonClient] request in
             try await daemonClient.createWorktree(
                 repoID: request.repoID,
@@ -1388,7 +1412,7 @@ final class AppState: ObservableObject {
     /// A `nil` text unparks — the daemon clears the column and disarms any
     /// wait — which is how the composer's Discard reaches the store without a
     /// verb of its own.
-    lazy var pendingPromptSetter:
+    @ObservationIgnored lazy var pendingPromptSetter:
         @MainActor (UUID, String?, Bool) async throws -> WorktreeSetPendingPromptResult =
             { [daemonClient] worktreeID, text, submit in
                 try await daemonClient.setPendingPrompt(
@@ -1398,7 +1422,7 @@ final class AppState: ObservableObject {
     /// closing a note tab hard-deletes the note row (`closeTab` →
     /// `deleteNote`). Injectable so tests can exercise both branches without
     /// a real modal NSAlert.
-    lazy var noteCloseConfirmer: @MainActor (Note) -> Bool = { note in
+    @ObservationIgnored lazy var noteCloseConfirmer: @MainActor (Note) -> Bool = { note in
         let filePath = TBDConstants.noteContentPath(worktreeID: note.worktreeID, noteID: note.id)
             .replacingOccurrences(of: NSHomeDirectory(), with: "~")
         let alert = NSAlert()
@@ -1417,12 +1441,12 @@ final class AppState: ObservableObject {
     /// injectable for the same reason as `daemonCapabilitiesFetcher`
     /// (`DaemonClient` is concrete, no protocol), so a poll can be driven
     /// without a daemon.
-    lazy var prBindingsFetcher: @MainActor () async throws -> PRBindingsAllResult =
+    @ObservationIgnored lazy var prBindingsFetcher: @MainActor () async throws -> PRBindingsAllResult =
         { [daemonClient] in try await daemonClient.listAllPRBindings() }
     /// How `detachPR` untracks one PR — injectable for the same reason as
     /// `prBindingsFetcher`, so the status bar's untrack gesture and each of its
     /// outcomes can be driven without a daemon.
-    lazy var prDetacher: @MainActor (UUID, String?, Int) async throws -> PRDetachResult =
+    @ObservationIgnored lazy var prDetacher: @MainActor (UUID, String?, Int) async throws -> PRDetachResult =
         { [daemonClient] worktreeID, url, number in
             try await daemonClient.detachPR(worktreeID: worktreeID, url: url, number: number)
         }
@@ -1430,37 +1454,37 @@ final class AppState: ObservableObject {
     /// active tab — injectable for the same reason as `daemonCapabilitiesFetcher`
     /// (`DaemonClient` is concrete, no protocol), so hydration tests can drive
     /// the sequence of responses without a daemon.
-    lazy var tabStatesFetcher: @MainActor (UUID) async throws -> TabListResponse =
+    @ObservationIgnored lazy var tabStatesFetcher: @MainActor (UUID) async throws -> TabListResponse =
         { [daemonClient] worktreeID in try await daemonClient.listTabs(worktreeID: worktreeID) }
     /// How the one-shot legacy panel import fires its RPC — injectable for the
     /// same reason as `daemonCapabilitiesFetcher` (`DaemonClient` is concrete,
     /// no protocol), so trigger tests can record calls without a real daemon.
-    lazy var panelImportTrigger: @MainActor (PanelImportParams) async throws -> PanelImportResult =
+    @ObservationIgnored lazy var panelImportTrigger: @MainActor (PanelImportParams) async throws -> PanelImportResult =
         { [daemonClient] params in try await daemonClient.panelImportLegacy(params) }
     /// How the shadow-compare diagnostic (spec C §11.3) fetches the daemon's
     /// imported surface — injectable for the same reason as `panelImportTrigger`.
-    lazy var panelGetFetcher: @MainActor (UUID) async throws -> PanelGetResult =
+    @ObservationIgnored lazy var panelGetFetcher: @MainActor (UUID) async throws -> PanelGetResult =
         { [daemonClient] worktreeID in try await daemonClient.panelGet(worktreeID: worktreeID) }
     /// Guards the one-shot legacy panel import to at most once per launch.
     /// Deliberately NOT persisted — the daemon's create-if-absent import guard
     /// (spec C §11.2) is the real idempotence boundary; this only avoids
     /// redundant RPC fan-out as `loadTabStates` runs per worktree.
-    private var hasAttemptedPanelImport = false
+    @ObservationIgnored private var hasAttemptedPanelImport = false
     /// How `refreshRemote()` fetches the provider roster — injectable for the
     /// same reason as `daemonCapabilitiesFetcher` (`DaemonClient` is concrete,
     /// no protocol), so tests can exercise the disabled-refusal and
     /// genuine-error branches without a real daemon.
-    lazy var remoteProvidersFetcher: @MainActor () async throws -> RemoteProvidersResult =
+    @ObservationIgnored lazy var remoteProvidersFetcher: @MainActor () async throws -> RemoteProvidersResult =
         { [daemonClient] in try await daemonClient.remoteProviders() }
     /// How `refreshRemote()` fetches the session mirror — injectable for the
     /// same reason as `remoteProvidersFetcher`.
-    lazy var remoteSessionsFetcher: @MainActor () async throws -> RemoteSessionsResult =
+    @ObservationIgnored lazy var remoteSessionsFetcher: @MainActor () async throws -> RemoteSessionsResult =
         { [daemonClient] in try await daemonClient.remoteSessions() }
     /// How `pushRemoteRenameIfSupported` pushes a rename to the provider —
     /// injectable for the same reason as `remoteProvidersFetcher` (`DaemonClient`
     /// is concrete, no protocol), so tests can assert whether it fires per
     /// capability without a real daemon.
-    lazy var remoteRenamePusher: @MainActor (String, String, String) async throws -> Void =
+    @ObservationIgnored lazy var remoteRenamePusher: @MainActor (String, String, String) async throws -> Void =
         { [daemonClient] provider, sessionID, title in
             try await daemonClient.remoteRename(provider: provider, sessionID: sessionID, title: title)
         }
@@ -1468,13 +1492,13 @@ final class AppState: ObservableObject {
     /// switch — injectable for the same reason as `controlModeSetter`
     /// (`DaemonClient` is concrete, no protocol), so the Settings toggle
     /// tests can exercise the success branch without a real daemon.
-    lazy var remoteBackendsSetter: @MainActor (Bool) async throws -> Void =
+    @ObservationIgnored lazy var remoteBackendsSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setRemoteBackends(enabled: enabled) }
     /// How `setRemoteSessionPinned` pins/unpins a remote session for the
     /// sidebar dock — injectable for the same reason as `remoteRenamePusher`,
     /// so the pin action's success and failure branches are testable without
     /// a real daemon.
-    lazy var remoteSessionPinSetter: @MainActor (String, String, Bool) async throws -> Void =
+    @ObservationIgnored lazy var remoteSessionPinSetter: @MainActor (String, String, Bool) async throws -> Void =
         { [daemonClient] provider, sessionID, pinned in
             try await daemonClient.setRemoteSessionPin(
                 provider: provider, sessionID: sessionID, pinned: pinned)
@@ -1484,7 +1508,7 @@ final class AppState: ObservableObject {
     /// same reason as `remoteRenamePusher` (`DaemonClient` is concrete, no
     /// protocol), so the optimistic-placeholder paths are testable without a
     /// real daemon (tests must never touch `~/tbd`).
-    lazy var remoteSessionCreator: @MainActor (String, String, UUID?) async throws -> RemoteSessionPayload =
+    @ObservationIgnored lazy var remoteSessionCreator: @MainActor (String, String, UUID?) async throws -> RemoteSessionPayload =
         { [daemonClient] provider, paramsJSON, parentWorktreeID in
             try await daemonClient.remoteCreate(
                 provider: provider, paramsJSON: paramsJSON, parentWorktreeID: parentWorktreeID)
@@ -1493,7 +1517,7 @@ final class AppState: ObservableObject {
     /// has answered. A plain refresh in production; a seam because a test that
     /// exercises the placeholder swap must be able to decide whether the
     /// adopted row shows up, without a daemon to adopt anything.
-    lazy var remoteLaneRowsRefresher: @MainActor () async -> Void =
+    @ObservationIgnored lazy var remoteLaneRowsRefresher: @MainActor () async -> Void =
         { [weak self] in await self?.refreshWorktrees() }
 
     /// How `reportRemoteAttachExit` tells the daemon an app-spawned `attach`
@@ -1501,7 +1525,7 @@ final class AppState: ObservableObject {
     /// (`DaemonClient` is concrete, no protocol), so the auth-exit routing
     /// tests can assert the report fires without a real daemon (tests must
     /// never touch `~/tbd`).
-    lazy var remoteAttachExitReporter: @MainActor (String, String, Int32) async throws -> Void =
+    @ObservationIgnored lazy var remoteAttachExitReporter: @MainActor (String, String, Int32) async throws -> Void =
         { [daemonClient] provider, sessionID, exitCode in
             try await daemonClient.reportRemoteAttachExit(
                 provider: provider, sessionID: sessionID, exitCode: exitCode)
@@ -1518,18 +1542,18 @@ final class AppState: ObservableObject {
             daemonCapabilities = capabilities
         }
     }
-    lazy var cliInstallerCoordinator = CLIInstallerCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
-    lazy var legacyHooksCoordinator = LegacyHooksCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
-    private var pollTimer: Timer?
-    private var pollCycle = 0
+    @ObservationIgnored lazy var cliInstallerCoordinator = CLIInstallerCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
+    @ObservationIgnored lazy var legacyHooksCoordinator = LegacyHooksCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
+    @ObservationIgnored private var pollTimer: Timer?
+    @ObservationIgnored private var pollCycle = 0
     /// True while a poll refresh cycle (the list RPCs) is running. The 2s poll
     /// timer skips its refresh when this is set, so overlapping cycles can't
     /// stack into an RPC storm when the daemon is slow (Layer A guard).
-    private var pollCycleInFlight = false
+    @ObservationIgnored private var pollCycleInFlight = false
     /// Count of poll ticks skipped because a previous cycle was still in flight.
     /// Storm indicator for observability and tests.
-    private(set) var skippedPollCycles = 0
-    private var subscriptionTask: Task<Void, Never>?
+    @ObservationIgnored private(set) var skippedPollCycles = 0
+    @ObservationIgnored private var subscriptionTask: Task<Void, Never>?
     let notificationSoundPlayer = NotificationSoundPlayer()
     let macNotificationManager = MacNotificationManager()
 
@@ -1540,8 +1564,8 @@ final class AppState: ObservableObject {
     private static let skipAccountPickerKey = "com.tbd.app.accountPicker.useDefaultWithoutAsking"
     private static let remoteSessionDisplayNamesKey = "com.tbd.app.remoteSessionDisplayNames"
 
-    private var memoryPressureSource: DispatchSourceMemoryPressure?
-    private var focusObservers: [NSObjectProtocol] = []
+    @ObservationIgnored private var memoryPressureSource: DispatchSourceMemoryPressure?
+    @ObservationIgnored private var focusObservers: [NSObjectProtocol] = []
 
     /// UserDefaults domain this AppState reads instance-level preferences from.
     /// Production uses `.standard`; tests inject a per-suite `UserDefaults(suiteName:)`
@@ -2384,9 +2408,10 @@ final class AppState: ObservableObject {
             || terminal.awaitingInputObservedAt != delta.observedAt else { return }
         terminal.awaitingInputReason = delta.reason
         terminal.awaitingInputObservedAt = delta.observedAt
-        // One write-back through the `@Published` dictionary, not two: each
-        // assignment is a full copy-on-write plus an `objectWillChange`, and
-        // this delta arrives on every `Notification` hook of every class.
+        // One write-back through the tracked dictionary, not two: each
+        // assignment is a full copy-on-write plus a notification to every view
+        // that read `terminals`, and this delta arrives on every
+        // `Notification` hook of every class.
         terminals[delta.worktreeID]?[idx] = terminal
     }
 
@@ -2574,6 +2599,10 @@ final class AppState: ObservableObject {
     /// `scratchWorktrees` `didSet`s): `SidebarView` reads it twice per body
     /// evaluation, and each read was a full copy of every row.
     var allWorktrees: [Worktree] {
+        // Re-register both dependencies on every read, including cache hits —
+        // see "THE WARM-CACHE DEPENDENCY TRAP" above.
+        _ = worktrees
+        _ = scratchWorktrees
         if let cached = allWorktreesCache { return cached }
         let flattened = worktrees.values.flatMap { $0 } + scratchWorktrees
         allWorktreesCache = flattened
@@ -3377,10 +3406,11 @@ final class AppState: ObservableObject {
     /// caption shown alongside it. Non-scratch worktrees never dim here.
     ///
     /// `directoryExists` is an autoclosure so the caller's `stat()` is only
-    /// paid for un-promoted scratch rows: every sidebar row re-evaluates its
-    /// body on any AppState `@Published` change, and an eager argument would
-    /// charge every regular row a synchronous disk hit per render for a flag
-    /// this rule ignores.
+    /// paid for un-promoted scratch rows: a sidebar row re-evaluates its body
+    /// on any change to the `AppState` properties it reads — `worktrees` among
+    /// them, which every poll touches — and an eager argument would charge
+    /// every regular row a synchronous disk hit per render for a flag this
+    /// rule ignores.
     nonisolated static func scratchRowIsDimmed(
         _ worktree: Worktree,
         directoryExists: @autoclosure () -> Bool

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -156,7 +156,7 @@ enum ArchivedHideEmptyFilter {
 
 struct ArchivedWorktreesView: View {
     let repoID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var listWidth: CGFloat = 280
     @State private var dragStartWidth: CGFloat? = nil
@@ -715,7 +715,6 @@ private struct ArchivedRow: Identifiable {
 private struct ArchivedWorktreeRow: View {
     let row: ArchivedRow
     let isSelected: Bool
-    @EnvironmentObject var appState: AppState
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {

--- a/Sources/TBDApp/Components/ToastOverlay.swift
+++ b/Sources/TBDApp/Components/ToastOverlay.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// transitions and auto-dismiss timing are owned by the AppState toast state
 /// machine (AppState+Toast.swift).
 struct ToastOverlay: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         Group {

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -8,7 +8,7 @@ private enum FilePanelStorageKey {
 }
 
 struct ContentView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
     @AppStorage(FilePanelStorageKey.isVisible) private var showFilePanel = true
     @AppStorage(FilePanelStorageKey.width) private var filePanelWidth: Double = 280
@@ -36,6 +36,7 @@ struct ContentView: View {
     }
 
     var body: some View {
+        @Bindable var appState = appState
         VStack(spacing: 0) {
             // Persistent, non-blocking cross-build warning: the shared daemon
             // was started from a different worktree's build than this app.
@@ -61,7 +62,19 @@ struct ContentView: View {
                 SidebarView()
                     .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 400)
             } detail: {
-                DetailSectionHostPager()
+                // The tab choice is resolved HERE, in a real `body`, and handed
+                // down as a value. Reading these three properties inside
+                // `updateNSViewController` instead would register no
+                // dependency — Observation tracks what a `body` evaluation
+                // reads — so a selection change that touched nothing else this
+                // body reads would leave the detail area on the previous tab.
+                DetailSectionHostPager(
+                    targetTab: DetailSectionHostPager.targetTab(
+                        isConnected: appState.isConnected,
+                        selectedRemoteSession: appState.selectedRemoteSession,
+                        selectedRemoteProvider: appState.selectedRemoteProvider
+                    )
+                )
             }
             .toolbar(removing: .sidebarToggle)
             .toolbar {
@@ -311,9 +324,9 @@ struct ContentView: View {
         ) { sheet in
             switch sheet {
             case .compose(let target):
-                QueuedPromptModal(target: target).environmentObject(appState)
+                QueuedPromptModal(target: target).environment(appState)
             case .readback(let readback):
-                ParkedPromptReadbackView(readback: readback).environmentObject(appState)
+                ParkedPromptReadbackView(readback: readback).environment(appState)
             }
         }
         .alert(
@@ -554,7 +567,7 @@ struct ContentView: View {
 /// the `tv.window != nil` guards in `TerminalPanelView`).
 ///
 /// Each tab's content is a small internally-reactive wrapper — it reads
-/// `@EnvironmentObject`/`@AppStorage` state itself rather than being handed a
+/// `@Environment`/`@AppStorage` state itself rather than being handed a
 /// fresh value on every `updateNSViewController` — so its
 /// `NSHostingController` is created exactly once and its `rootView` is
 /// never reassigned: the same "stable identity, reactive interior" shape
@@ -567,7 +580,12 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
         case other
     }
 
-    @EnvironmentObject var appState: AppState
+    /// Resolved by the caller's `body` rather than read from `appState` here —
+    /// see the call site in `ContentView.body` for why. Changing it is what
+    /// drives `updateNSViewController` to bring a different tab forward.
+    let targetTab: DetailTab
+
+    @Environment(AppState.self) var appState
     @EnvironmentObject var appearance: AppearanceSettings
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
 
@@ -588,7 +606,7 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
         if !currentIDs.contains(Self.remoteTabID) {
             let host = NSHostingController(
                 rootView: RemoteSessionHostSlot()
-                    .environmentObject(appState)
+                    .environment(appState)
                     .environmentObject(appearance)
             )
             let item = NSTabViewItem(viewController: host)
@@ -599,7 +617,7 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
         if !currentIDs.contains(Self.providerDeskTabID) {
             let host = NSHostingController(
                 rootView: ProviderDeskHostSlot()
-                    .environmentObject(appState)
+                    .environment(appState)
                     .environmentObject(appearance)
             )
             let item = NSTabViewItem(viewController: host)
@@ -610,7 +628,7 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
         if !currentIDs.contains(Self.otherTabID) {
             let host = NSHostingController(
                 rootView: OtherSectionContent()
-                    .environmentObject(appState)
+                    .environment(appState)
                     .environmentObject(overlayCoordinator)
             )
             let item = NSTabViewItem(viewController: host)
@@ -618,11 +636,7 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
             vc.addTabViewItem(item)
         }
 
-        let targetID = Self.targetTab(
-            isConnected: appState.isConnected,
-            selectedRemoteSession: appState.selectedRemoteSession,
-            selectedRemoteProvider: appState.selectedRemoteProvider
-        ).rawValue
+        let targetID = targetTab.rawValue
         if let idx = vc.tabViewItems.firstIndex(where: { $0.identifier as? String == targetID }),
            vc.selectedTabViewItemIndex != idx {
             vc.selectedTabViewItemIndex = idx
@@ -660,7 +674,7 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
 /// already built to handle (see its own doc comment on why it's not
 /// `.id()`-keyed).
 private struct RemoteSessionHostSlot: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         if let selection = appState.remoteSessionHostSelection {
@@ -681,7 +695,7 @@ private struct RemoteSessionHostSlot: View {
 /// window rather than a resting state — and the desk has no honest content
 /// to show for a provider TBD no longer knows about.
 private struct ProviderDeskHostSlot: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         if let name = appState.selectedRemoteProvider,
@@ -702,7 +716,7 @@ private struct OtherSectionContent: View {
     @AppStorage(FilePanelStorageKey.isVisible) private var showFilePanel = true
     @AppStorage(FilePanelStorageKey.width) private var filePanelWidth: Double = 280
 
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
 
     var body: some View {
@@ -808,7 +822,7 @@ private struct OtherSectionContent: View {
 /// `contentAreaHeight` moves in as this view's own `@State` instead: nothing
 /// outside this branch ever read it in `ContentView`.
 private struct WorktreeDetailAreaView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
     @Binding var showFilePanel: Bool
     @Binding var filePanelWidth: Double

--- a/Sources/TBDApp/FileViewer/FileViewerPanel.swift
+++ b/Sources/TBDApp/FileViewer/FileViewerPanel.swift
@@ -147,7 +147,7 @@ struct FileViewerPanel: View {
     /// Every read below is of a directory on this disk, so the panel takes the
     /// proven-local wrapper rather than a bare `Worktree`.
     let worktree: LocalWorktree
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var staged: [GitFileStatus] = []
     @State private var unstaged: [GitFileStatus] = []

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -54,7 +54,7 @@ enum TextFinderCommand {
 
 /// Menu commands providing keyboard shortcuts for the app.
 struct TBDCommands: Commands {
-    @ObservedObject var appState: AppState
+    var appState: AppState
 
     var body: some Commands {
         CommandGroup(after: .appInfo) {
@@ -91,39 +91,12 @@ struct TBDCommands: Commands {
 
         // Worktree commands
         CommandMenu("Worktree") {
-            Button("New Worktree") {
-                Task { @MainActor in
-                    appState.newWorktreeInFocusedRepo()
-                }
-            }
-            .keyboardShortcut("n", modifiers: .command)
-
-            Button("Archive Worktree") {
-                Task { @MainActor in
-                    appState.archiveSelectedWorktree()
-                }
-            }
-            .keyboardShortcut("a", modifiers: [.command, .shift])
-            .disabled(appState.selectedWorktreeIDs.isEmpty)
+            WorktreeCommandsContent().environment(appState)
         }
 
         // Terminal commands
         CommandMenu("Terminal") {
-            Button("New Tab") {
-                Task { @MainActor in
-                    appState.newTerminalTab()
-                }
-            }
-            .keyboardShortcut("t", modifiers: .command)
-            .disabled(appState.selectedWorktreeIDs.isEmpty)
-
-            Button("Close Tab") {
-                Task { @MainActor in
-                    appState.closeFocusedTab()
-                }
-            }
-            .keyboardShortcut("w", modifiers: .command)
-            .disabled(!appState.canCloseFocusedTab)
+            TerminalCommandsContent().environment(appState)
         }
 
         // Worktree selection by index (Cmd-1 through Cmd-9)
@@ -146,5 +119,58 @@ struct TBDCommands: Commands {
                 .keyboardShortcut(KeyEquivalent(Character("\(index)")), modifiers: .command)
             }
         }
+    }
+}
+
+/// The two menus whose items are *gated* on `AppState` live in nested `View`s,
+/// not directly in the `Commands` body above — the same shape
+/// `ModelProfileMenu` and `NightwatchStatusItem` use, and for the same reason:
+/// a `Commands` body does not reliably re-evaluate when the state it reads
+/// changes, so a `.disabled(…)` computed there can be captured once and never
+/// re-computed. Selection is empty at launch, so a captured value would leave
+/// ⌘⇧A, ⌘T and ⌘W permanently disabled.
+///
+/// The ungated items stay in the `Commands` body: their closures only *call*
+/// `AppState`, and a closure that runs later needs no dependency.
+private struct WorktreeCommandsContent: View {
+    @Environment(AppState.self) var appState
+
+    var body: some View {
+        Button("New Worktree") {
+            Task { @MainActor in
+                appState.newWorktreeInFocusedRepo()
+            }
+        }
+        .keyboardShortcut("n", modifiers: .command)
+
+        Button("Archive Worktree") {
+            Task { @MainActor in
+                appState.archiveSelectedWorktree()
+            }
+        }
+        .keyboardShortcut("a", modifiers: [.command, .shift])
+        .disabled(appState.selectedWorktreeIDs.isEmpty)
+    }
+}
+
+private struct TerminalCommandsContent: View {
+    @Environment(AppState.self) var appState
+
+    var body: some View {
+        Button("New Tab") {
+            Task { @MainActor in
+                appState.newTerminalTab()
+            }
+        }
+        .keyboardShortcut("t", modifiers: .command)
+        .disabled(appState.selectedWorktreeIDs.isEmpty)
+
+        Button("Close Tab") {
+            Task { @MainActor in
+                appState.closeFocusedTab()
+            }
+        }
+        .keyboardShortcut("w", modifiers: .command)
+        .disabled(!appState.canCloseFocusedTab)
     }
 }

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import TBDShared
 
 struct StatusBarView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     /// Path + repo of the resolved single-selected worktree. Taking a
     /// `LocalWorktree?` is what makes "nil when it has no path yet" true —
@@ -553,7 +553,7 @@ private struct PRChipCluster: View {
 /// *glyph*, so a click always does what the slot is drawing: an xmark untracks,
 /// a status dot opens the PR exactly as it did before this control existed.
 private struct PRChipView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     let chip: StatusBarView.PRChip
 
     @State private var isHovering = false
@@ -798,7 +798,7 @@ private struct PRChipOverflowMenu: View {
 /// `StatusBarHoverAffordance` rather than wiring `onHover` by hand, so its
 /// cursor push can never lose its matching pop.
 private struct ParkedPromptStatusItem: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     let worktree: Worktree
 
     @State private var isHovering = false
@@ -861,7 +861,7 @@ private struct ParkedPromptStatusItem: View {
 /// close cannot arise here. Adopting it would add three constants and an
 /// overlay that resolve an ambiguity this chip does not have.
 private struct AutoArchiveChipView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     let worktreeID: UUID
     let chip: StatusBarView.AutoArchiveChip
 
@@ -942,7 +942,7 @@ private struct AutoArchiveChipView: View {
 /// cursor are the whole affordance, and the toast is what confirms the copy
 /// landed (the label itself is too small to flash a "Copied" state legibly).
 private struct CopyableStatusText: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     /// Optional leading glyph naming what the value is. Part of the same click
     /// target and hover affordance as the text.

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -21,7 +21,7 @@ final class JumpMenuController {
 
     /// Wire AppState once at app launch. Called from TBDApp.swift after
     /// the AppState instance is created. Keeping this out of the
-    /// initializer avoids a chicken-and-egg with @StateObject AppState.
+    /// initializer avoids a chicken-and-egg with the root-owned AppState.
     func configure(appState: AppState) {
         self.appState = appState
     }

--- a/Sources/TBDApp/MenuBar/ModelProfileMenu.swift
+++ b/Sources/TBDApp/MenuBar/ModelProfileMenu.swift
@@ -11,21 +11,23 @@ import TBDShared
 /// Tab pre-selection in Settings is deferred — "Manage profiles…" simply
 /// opens the Settings window and the user clicks the Model Profiles tab.
 struct ModelProfileMenu: Commands {
-    @ObservedObject var appState: AppState
+    var appState: AppState
 
     var body: some Commands {
         CommandMenu("Model Profile") {
             ModelProfileMenuContent()
-                .environmentObject(appState)
+                .environment(appState)
         }
     }
 }
 
-/// Extracted into a `View` so SwiftUI re-renders the menu body when
-/// `@Published` properties on `AppState` change. `Commands` bodies do not
-/// always observe `@ObservedObject` mutations reliably for nested content.
+/// Extracted into a `View` so SwiftUI re-renders the menu body when the
+/// `AppState` properties it reads change. A `Commands` body does not reliably
+/// re-evaluate on state changes — that was true of `@ObservedObject` before and
+/// is true of Observation now — so anything whose *rendering* depends on
+/// `AppState` belongs in a nested `View` like this one.
 private struct ModelProfileMenuContent: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         Button(action: {

--- a/Sources/TBDApp/MenuBar/NightwatchStatusItem.swift
+++ b/Sources/TBDApp/MenuBar/NightwatchStatusItem.swift
@@ -9,7 +9,7 @@ import TBDShared
 /// The menu TITLE carries the active mode (🌙 / ◐) so "am I being watched?"
 /// is answerable at a glance without opening the menu.
 struct NightwatchStatusItem: Commands {
-    @ObservedObject var appState: AppState
+    var appState: AppState
     /// Gated behind the same Settings → Fleet Automation opt-in as the sidebar
     /// control, so the whole Nightwatch feature (both entry points) is off by
     /// default. Fail-closed to hidden when the user has never opted in.
@@ -27,17 +27,23 @@ struct NightwatchStatusItem: Commands {
         if experimentalEnabled {
             CommandMenu(title) {
                 NightwatchStatusContent()
-                    .environmentObject(appState)
+                    .environment(appState)
             }
         }
     }
 }
 
-/// Extracted into a `View` so SwiftUI re-renders the menu body when
-/// `@Published` properties on `AppState` change. `Commands` bodies do not
-/// always observe `@ObservedObject` mutations reliably for nested content.
+/// Extracted into a `View` so SwiftUI re-renders the menu body when the
+/// `AppState` properties it reads change. A `Commands` body does not reliably
+/// re-evaluate on state changes — that was true of `@ObservedObject` before and
+/// is true of Observation now — so anything whose *rendering* depends on
+/// `AppState` belongs in a nested `View` like this one.
+///
+/// The menu TITLE is the one read this cannot cover: `CommandMenu` needs the
+/// string at `Commands` level. It has therefore always been best-effort, and
+/// still is.
 private struct NightwatchStatusContent: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         modeButton("I'm back", mode: .off)

--- a/Sources/TBDApp/Notes/WorktreeTitleView.swift
+++ b/Sources/TBDApp/Notes/WorktreeTitleView.swift
@@ -7,7 +7,7 @@ import TBDShared
 /// action menu (Rename, Archive, …).
 ///
 /// `appState`/`worktree`/`repoName` are passed in (not read from the
-/// environment) so this view has no `@EnvironmentObject` dependency inside the
+/// environment) so this view has no `@Environment` dependency inside the
 /// `.principal` toolbar item — matching the `PRButtonLabel` convention.
 struct WorktreeTitleView: View {
     let appState: AppState

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -63,7 +63,7 @@ enum TranscriptHeaderActions {
 struct HistoryPaneView: View {
     let worktreeID: UUID
     var transcriptAction: TranscriptAction = .resume
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     private var loadState: HistoryLoadState {
         appState.historyLoadStates[worktreeID] ?? .idle
@@ -207,7 +207,7 @@ struct HistoryPaneView: View {
 private struct HistoryHeaderRow: View {
     let loadState: HistoryLoadState
     let worktreeID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var statusMessage: String? = nil
     @State private var statusClearTask: Task<Void, Never>? = nil
 
@@ -357,7 +357,7 @@ struct SessionTranscriptView: View {
     let worktreeID: UUID
     let summary: SessionSummary
     let action: TranscriptAction
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
 
     /// True when the visible viewport is within ~50pt of the bottom of
@@ -660,7 +660,7 @@ private struct ClosedTerminalRowView: View {
 private struct ClosedTerminalDetailView: View {
     let entry: TerminalHistoryEntry
     let worktreeID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     private var content: String? {
         appState.closedTerminalContents[entry.id]

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -5,7 +5,7 @@ import TBDShared
 struct NotePaneView: View {
     let noteID: UUID
     let worktreeID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var text: String = ""
     @State private var loaded = false
     @State private var saveTask: Task<Void, Never>?

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -49,7 +49,7 @@ struct PanePlaceholder: View {
     let worktree: LocalWorktree
     let tabID: UUID?
     @Binding var layout: LayoutNode
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
     @State private var isHeaderHovering = false
     @State private var showSourceCode = false
@@ -669,7 +669,7 @@ private extension View {
 struct EditableNoteTitle: View {
     let noteID: UUID
     let worktreeID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var isEditing = false
     @State private var editText = ""
     @FocusState private var isFocused: Bool

--- a/Sources/TBDApp/Panes/Transcript/AskUserQuestionCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/AskUserQuestionCard.swift
@@ -25,7 +25,7 @@ struct AskUserQuestionCard: View {
 
     @State private var fullResultText: String? = nil
     @State private var fullInputJSON: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     // MARK: - Decoded input shape
 

--- a/Sources/TBDApp/Panes/Transcript/BashCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/BashCardBody.swift
@@ -13,7 +13,7 @@ struct BashCardBody: View {
 
     @State private var fullResultText: String? = nil
     @State private var fullInputJSON: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     private struct Input: Decodable { let command: String; let description: String? }
     private static let decoder = JSONDecoder()

--- a/Sources/TBDApp/Panes/Transcript/EditCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/EditCardBody.swift
@@ -12,7 +12,7 @@ struct EditCardBody: View {
     let terminalID: UUID?
 
     @State private var fullInputJSON: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.openFilePreview) private var openFilePreview
 
     private struct EditHunk: Decodable, Equatable {

--- a/Sources/TBDApp/Panes/Transcript/GenericToolCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/GenericToolCardBody.swift
@@ -11,7 +11,7 @@ struct GenericToolCardBody: View {
 
     @State private var fullResultText: String? = nil
     @State private var fullInputJSON: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/Sources/TBDApp/Panes/Transcript/GlobCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/GlobCardBody.swift
@@ -8,7 +8,7 @@ struct GlobCardBody: View {
     let terminalID: UUID?
 
     @State private var fullResultText: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/Sources/TBDApp/Panes/Transcript/GrepCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/GrepCardBody.swift
@@ -8,7 +8,7 @@ struct GrepCardBody: View {
     let terminalID: UUID?
 
     @State private var fullResultText: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/Sources/TBDApp/Panes/Transcript/ReadCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/ReadCardBody.swift
@@ -9,7 +9,7 @@ struct ReadCardBody: View {
     let terminalID: UUID?
 
     @State private var fullResultText: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.openFilePreview) private var openFilePreview
 
     private struct Input: Decodable {

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
@@ -31,7 +31,7 @@ struct SystemReminderRowBody: View {
 
     @State private var fullText: String? = nil
     @State private var metadata: TranscriptAttachmentMetadata? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     /// Only hook output and injected file bodies come from `attachment` rows;
     /// every other reminder kind would round-trip for a guaranteed-nil result.

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -12,7 +12,7 @@ import os
 struct TableTranscriptPaneView: View {
     let terminalID: UUID
     let worktreeID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.openTranscriptOverlay) private var openTranscriptOverlay
     @Environment(\.openTranscriptLink) private var openTranscriptLink
 

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
@@ -759,7 +759,7 @@ struct TableTranscriptView: NSViewRepresentable {
                 .environment(\.transcriptStaticCards, true)
                 .environment(\.openTranscriptOverlay, context.openTranscriptOverlay)
                 .environment(\.toggleTranscriptActivityGroup, context.toggleActivityGroup)
-                .environmentObjectIfPresent(context.appState)
+                .environmentIfPresent(context.appState)
         }
 
         // MARK: Activity-row height
@@ -2090,14 +2090,14 @@ final class TranscriptHostingCellView: NSTableCellView {
 // MARK: - Environment helper
 
 private extension View {
-    /// Injects the `AppState` environment object only when present, so the
-    /// hosted row's `@EnvironmentObject var appState` resolves exactly as it does
-    /// in the SwiftUI pane. A nil appState (headless harness without a wired
+    /// Injects `AppState` into the environment only when present, so the
+    /// hosted row's `@Environment(AppState.self) var appState` resolves exactly
+    /// as it does in the SwiftUI pane. A nil appState (headless harness without a wired
     /// state) leaves the row to render its appState-independent content.
     @ViewBuilder
-    func environmentObjectIfPresent(_ appState: AppState?) -> some View {
+    func environmentIfPresent(_ appState: AppState?) -> some View {
         if let appState {
-            self.environmentObject(appState)
+            self.environment(appState)
         } else {
             self
         }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
@@ -15,7 +15,7 @@ struct TranscriptOverlayView: View {
     let onBack: () -> Void
     let onClose: () -> Void
 
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     private static let decoder = JSONDecoder()
 

--- a/Sources/TBDApp/Panes/Transcript/WriteCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCardBody.swift
@@ -9,7 +9,7 @@ struct WriteCardBody: View {
     let terminalID: UUID?
 
     @State private var fullInputJSON: String? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.openFilePreview) private var openFilePreview
 
     private struct Input: Decodable { let file_path: String; let content: String }

--- a/Sources/TBDApp/ReclaimedSectionView.swift
+++ b/Sources/TBDApp/ReclaimedSectionView.swift
@@ -9,7 +9,7 @@ import TBDShared
 /// `appState.reapRecords[repoID]` is non-empty.
 struct ReclaimedSectionView: View {
     let repoID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var isExpanded = false
 
@@ -189,7 +189,7 @@ private struct ReclaimedRow: View {
 struct ReclaimedDetailView: View {
     let record: ReapRecord
     let repoID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {

--- a/Sources/TBDApp/Remote/RemoteAttachPager.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachPager.swift
@@ -29,7 +29,7 @@ import TBDShared
 struct RemoteAttachPager: NSViewControllerRepresentable {
     let selections: [RemoteSessionSelection]
     let activeSelection: RemoteSessionSelection?
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var appearance: AppearanceSettings
 
     func makeNSViewController(context: Context) -> NSTabViewController {
@@ -65,7 +65,7 @@ struct RemoteAttachPager: NSViewControllerRepresentable {
                         appState?.markRemoteSessionDetached(selection, exitCode: exitCode)
                     }
                 )
-                .environmentObject(appState)
+                .environment(appState)
                 .environmentObject(appearance)
             )
             let item = NSTabViewItem(viewController: host)

--- a/Sources/TBDApp/Remote/RemoteCreateSheet.swift
+++ b/Sources/TBDApp/Remote/RemoteCreateSheet.swift
@@ -49,7 +49,7 @@ struct RemoteCreateSheet: View {
     /// sees; this one never leaves the app.
     var repoID: UUID?
 
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
 
     @State private var stringValues: [String: String] = [:]

--- a/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
@@ -7,7 +7,7 @@ import TBDShared
 struct RemoteProviderDeskView: View {
     let provider: RemoteProviderStatus
 
-    @EnvironmentObject private var appState: AppState
+    @Environment(AppState.self) private var appState
     @State private var isRefreshing = false
     @State private var runningRemediation: RemoteRemediationRun?
 

--- a/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
@@ -102,7 +102,7 @@ enum RemoteSessionSendPayload {
 /// `.onChange(of: selection)`.
 struct RemoteSessionDetailView: View {
     let selection: RemoteSessionSelection
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     /// Behavior seam for `performSend`'s post-send delay (CLAUDE.md "New
     /// delays and timers take an injected clock"). Last property with a
     /// default so the synthesized memberwise init needs no call-site
@@ -609,7 +609,7 @@ private struct RemoteLogTabView: View {
     let sessionID: String
     var refreshToken: Int
 
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var text = ""
     @State private var isLoading = false
     @State private var errorMessage: String?

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -9,7 +9,7 @@ enum RepoDetailTab: String, CaseIterable {
 
 struct RepoDetailView: View {
     let repoID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var selectedTab: RepoDetailTab = .archived
     /// The repo whose pre-session hook editor should be revealed, pending
@@ -74,7 +74,7 @@ struct RepoSettingsView: View {
     /// Set by `RepoDetailView` when a pre-session-hook reveal targets this
     /// repo; consumed (set back to `nil`) the moment this view acts on it.
     @Binding var pendingHookReveal: UUID?
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     /// Drives focus into the pre-session TextEditor once scrolled.
     @FocusState private var focusedHook: RepoHooksSettingsView.HookField?
 

--- a/Sources/TBDApp/RepoInstructionsView.swift
+++ b/Sources/TBDApp/RepoInstructionsView.swift
@@ -3,7 +3,7 @@ import TBDShared
 
 struct RepoInstructionsView: View {
     let repoID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var renamePromptDraft: String = ""
     @State private var customInstructionsDraft: String = ""

--- a/Sources/TBDApp/ScratchArchivedView.swift
+++ b/Sources/TBDApp/ScratchArchivedView.swift
@@ -8,7 +8,7 @@ import TBDShared
 /// `scratch.delete`, so there are no Claude sessions to browse. No split
 /// pane, no pagination — scratch archive volume is expected to be low.
 struct ScratchArchivedView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var pendingDeleteID: UUID?
 
     private var rows: [Worktree] {

--- a/Sources/TBDApp/ScratchDetailView.swift
+++ b/Sources/TBDApp/ScratchDetailView.swift
@@ -46,7 +46,7 @@ struct ScratchDetailView: View {
 /// `@State` rather than read from a live in-memory array entry. No env
 /// overrides / hooks sections — out of scope for scratch settings.
 struct ScratchSettingsView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var scratchProfileOverrideID: UUID?
     @State private var isLoaded = false

--- a/Sources/TBDApp/ScratchInstructionsTabView.swift
+++ b/Sources/TBDApp/ScratchInstructionsTabView.swift
@@ -17,7 +17,7 @@ import TBDShared
 /// consistent-looking markup here keeps both views simple and leaves the
 /// sheet's existing behavior/tests untouched.
 struct ScratchInstructionsTabView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var renamePromptDraft: String = ""
     @State private var instructionsDraft: String = ""

--- a/Sources/TBDApp/ScratchInstructionsView.swift
+++ b/Sources/TBDApp/ScratchInstructionsView.swift
@@ -7,7 +7,7 @@ import TBDShared
 /// rather than a persistent autosaving tab — see `EditEndpointSheet` in
 /// `Settings/ModelProfilesSettingsView.swift` for the sheet convention.
 struct ScratchInstructionsView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
 
     @State private var draft: String = ""

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -19,10 +19,11 @@ enum SettingsWindowCloser {
 }
 
 struct ModelProfilesSettingsView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var showAddSheet = false
 
     var body: some View {
+        @Bindable var appState = appState
         VStack(alignment: .leading, spacing: 12) {
             globalDefaultHeader
             // Same persisted flag the spawn-time account picker's checkbox
@@ -39,7 +40,7 @@ struct ModelProfilesSettingsView: View {
         .task { await appState.loadModelProfiles() }
         .sheet(isPresented: $showAddSheet) {
             AddModelProfileSheet()
-                .environmentObject(appState)
+                .environment(appState)
         }
     }
 
@@ -68,7 +69,7 @@ struct ModelProfilesSettingsView: View {
         List {
             ForEach(appState.modelProfiles, id: \.profile.id) { entry in
                 ModelProfileRow(entry: entry)
-                    .environmentObject(appState)
+                    .environment(appState)
             }
             .onMove { source, destination in
                 appState.reorderModelProfiles(fromOffsets: source, toOffset: destination)
@@ -90,7 +91,7 @@ struct ModelProfilesSettingsView: View {
 // MARK: - Row
 
 struct ModelProfileRow: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     let entry: ModelProfileWithUsage
 
     @State private var isEditingName = false
@@ -165,15 +166,15 @@ struct ModelProfileRow: View {
         }
         .sheet(isPresented: $showEditEndpoint) {
             EditEndpointSheet(profile: profile)
-                .environmentObject(appState)
+                .environment(appState)
         }
         .sheet(isPresented: $showEditBedrock) {
             EditBedrockSheet(profile: profile)
-                .environmentObject(appState)
+                .environment(appState)
         }
         .sheet(isPresented: $showEditClaudeDirect) {
             EditClaudeDirectSheet(profile: profile)
-                .environmentObject(appState)
+                .environment(appState)
         }
     }
 
@@ -519,7 +520,7 @@ private func modelDiscoveryStatus(profile: String, discovery: BedrockModels.Disc
 }
 
 struct AddModelProfileSheet: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
 
     @State private var preset: AddPreset = .claudeDirect
@@ -882,7 +883,7 @@ struct AddModelProfileSheet: View {
 // MARK: - Edit endpoint sheet
 
 struct EditEndpointSheet: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
     let profile: ModelProfile
 
@@ -1032,7 +1033,7 @@ struct EditEndpointSheet: View {
 // MARK: - Edit Bedrock sheet
 
 struct EditBedrockSheet: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
     let profile: ModelProfile
 
@@ -1211,7 +1212,7 @@ struct EditBedrockSheet: View {
 // MARK: - Edit Claude (direct) sheet
 
 struct EditClaudeDirectSheet: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
     let profile: ModelProfile
 

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -35,7 +35,7 @@ struct GeneralSettingsTab: View {
         "Turn this off to skip empty Notes tabs in ordinary new worktrees. " +
         "Conversations revived on a fresh branch still receive their populated provenance note."
 
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @AppStorage("enableNotifications") private var enableNotifications: Bool = true
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
     @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
@@ -674,7 +674,7 @@ struct GeneralSettingsTab: View {
 // MARK: - Repositories Tab
 
 struct RepositoriesSettingsTab: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -703,7 +703,7 @@ struct RepositoriesSettingsTab: View {
 
 struct RepoSettingsRow: View {
     let repo: Repo
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var editingName: String = ""
     @State private var isEditing: Bool = false
 

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -30,7 +30,7 @@ struct TmuxConfigurationPathPresentation: Equatable {
 
 struct TerminalSettingsView: View {
     @EnvironmentObject var appearance: AppearanceSettings
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @AppStorage(AppState.terminalAutoResizeKey) private var enableTerminalAutoResize: Bool = false
 
     @StateObject private var editorVM = TerminalThemeEditorViewModel()

--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -30,7 +30,7 @@ struct BranchListView: View {
     /// `WorktreeProfilePickerView`. The standalone `BranchPickerView` wrapper
     /// is currently unused, so its default empty closure is harmless.
     var onClose: () -> Void = {}
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
 
     @State private var branches: [BranchInfo] = []

--- a/Sources/TBDApp/Sidebar/NightwatchModeToggle.swift
+++ b/Sources/TBDApp/Sidebar/NightwatchModeToggle.swift
@@ -60,7 +60,7 @@ enum NightwatchModePresentation {
 /// segment calls `setNightwatchMode`. Always visible so the mode is never lost
 /// in the menu bar.
 struct NightwatchModeToggle: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         HStack(spacing: 0) {

--- a/Sources/TBDApp/Sidebar/PinnedDockDeskSlot.swift
+++ b/Sources/TBDApp/Sidebar/PinnedDockDeskSlot.swift
@@ -13,9 +13,10 @@ import TBDShared
 /// respond to clicks — and `.onTapGesture` would kill its `.contextMenu`.
 struct PinnedDockDeskSlot: View {
     let desk: Worktree?
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
+        @Bindable var appState = appState
         if let desk {
             List(selection: $appState.selectedWorktreeIDs) {
                 WorktreeRowView(worktree: desk)

--- a/Sources/TBDApp/Sidebar/PinnedDockView.swift
+++ b/Sources/TBDApp/Sidebar/PinnedDockView.swift
@@ -18,7 +18,7 @@ struct PinnedDockView: View {
     /// interleaved.
     let remoteRows: [PinnedDockRemoteRow]
     let availableHeight: CGFloat
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     /// The pinned roots, in display order — the elements `.onMove` addresses.
     private var roots: [PinnedDockRow] {
@@ -59,6 +59,7 @@ struct PinnedDockView: View {
     }
 
     var body: some View {
+        @Bindable var appState = appState
         if !rows.isEmpty || !remoteRows.isEmpty {
             ScrollViewReader { proxy in
                 List(selection: $appState.selectedWorktreeIDs) {

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -22,7 +22,7 @@ private let remoteRowLogger = Logger(subsystem: "com.tbd.app", category: "remote
 /// its Provider Desk. The whole section renders nothing when no providers are
 /// registered — see `AppState.remoteSectionVisible(providers:)`.
 struct RemoteSectionView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     /// Read only to place the session rows under their provider's title —
     /// see `SidebarHeaderMetrics.childRowLeadingInset`.
     @AppStorage(AppState.chevronBeforeProjectNameKey)
@@ -176,7 +176,7 @@ enum RemoteProviderStatusPresentation {
 /// painted onto every row.
 struct RemoteProviderHeaderRow: View {
     let provider: RemoteProviderStatus
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var showingCreateSheet = false
     /// Whether the auth CTA popover (opened from the `.needsAuth` indicator)
     /// is showing.
@@ -393,7 +393,7 @@ struct RemoteProviderHeaderRow: View {
 /// below) or by keyboard.
 struct RemoteSessionRowView: View {
     let session: RemoteSessionInfo
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var isEditing = false
     @State private var isRowHovered = false
     @State private var isNameTruncated = false

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -27,7 +27,7 @@ struct HoverPressButtonStyle: ButtonStyle {
 
 struct RepoSectionView: View {
     let repo: Repo
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     @State private var isEditing = false
     @State private var isSectionHovered = false
@@ -132,7 +132,13 @@ struct RepoSectionView: View {
     /// A plain `static var` rather than `@State`: it is written from inside a
     /// `body` evaluation, and SwiftUI state written during a view update
     /// faults with "Modifying state during view update" (the same hazard that
-    /// keeps `AppState`'s derived caches off `@Published`). `RepoSectionView`
+    /// keeps `AppState`'s derived caches `@ObservationIgnored`).
+    ///
+    /// Note the getter above reads both `remoteSessions` and `worktrees`
+    /// *before* consulting this cache. It has to: they are the cache key, but
+    /// they are also what registers this view's dependency on them, and a body
+    /// served from a cache hit that read neither would drop both — see "THE
+    /// WARM-CACHE DEPENDENCY TRAP" in `AppState.swift`. `RepoSectionView`
     /// is inferred `@MainActor` from `View`, so this storage is
     /// main-actor-isolated and race-free; the `nonisolated` statics below
     /// deliberately never touch it, which keeps them callable — and pure —
@@ -361,7 +367,7 @@ struct RepoSectionView: View {
                             // outright or present the sheet this view owns.
                             onStartRemoteSession: { startRemoteSession(with: $0) }
                         )
-                        .environmentObject(appState)
+                        .environment(appState)
                         .background(.ultraThickMaterial)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                         .onHover { newWorktreeMenu.menuHover($0) }

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -7,7 +7,7 @@ import TBDShared
 /// hover `+` to create a new scratch space, followed by the scratch worktree
 /// rows when the section is expanded.
 struct ScratchSectionView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var isHeaderHovered = false
     @State private var isChevronHovered = false
     @State private var showingScratchInstructions = false
@@ -96,7 +96,7 @@ struct ScratchSectionView: View {
             }
         }
         .sheet(isPresented: $showingScratchInstructions) {
-            ScratchInstructionsView().environmentObject(appState)
+            ScratchInstructionsView().environment(appState)
         }
         .listRowInsets(EdgeInsets(top: 0, leading: SidebarHeaderMetrics.headerRowLeadingInset,
                                   bottom: 0, trailing: 0))

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -7,7 +7,7 @@ import TBDShared
 struct SidebarContextMenu: View {
     let worktree: Worktree
     var onRename: () -> Void
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         RowActionMenuItemsView(

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import TBDShared
 
 struct SidebarView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @AppStorage("sidebar.showHiddenRepos") private var showHiddenRepos: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
     @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
@@ -24,6 +24,7 @@ struct SidebarView: View {
     }
 
     var body: some View {
+        @Bindable var appState = appState
         ScrollViewReader { proxy in
             List(selection: $appState.selectedWorktreeIDs) {
                 if AppState.scratchSectionVisible(setting: showScratchSection, spaces: appState.scratchWorktrees) {

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -67,7 +67,7 @@ struct WorktreeProfilePickerView: View {
     /// it is one registered provider among the others, so it needs no row of
     /// its own — only the gate `offerableProviders` applies to it.
     var onStartRemoteSession: (RemoteProviderStatus) -> Void = { _ in }
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
 
     private enum Page {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -21,7 +21,7 @@ struct WorktreeRowView: View {
     var isMain: Bool = false
     var indentLevel: Int = 0
     var sectionRepoID: UUID? = nil
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @State private var isEditing = false
     @State private var isRowHovered: Bool = false
     @State private var isPRIconHovered: Bool = false
@@ -166,7 +166,7 @@ struct WorktreeRowView: View {
                     // present the sheet — same division as `RepoSectionView`.
                     onStartRemoteSession: { startRemoteSession(with: $0) }
                 )
-                .environmentObject(appState)
+                .environment(appState)
                 .background(.ultraThickMaterial)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .onHover { newChildMenu.menuHover($0) }
@@ -686,8 +686,8 @@ struct WorktreeRowView: View {
     /// Cache for sidebar PR status icons, keyed by icon name. The returned
     /// NSImage must be identity-stable across body evaluations:
     /// `Image(nsImage:)` diffs by object identity, so a fresh instance per
-    /// render made every row's icon layer rebuild at once whenever an
-    /// AppState-wide @Published reassignment re-evaluated all rows (visible
+    /// render made every row's icon layer rebuild at once whenever a write to
+    /// an `AppState` property the rows read re-evaluated all of them (visible
     /// mass flicker). Also skips the disk I/O (`Bundle.module.url` +
     /// `NSImage(contentsOf:)`) per evaluation. MainActor confinement
     /// (SwiftUI body runs on main) makes this safe without locks.

--- a/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
@@ -19,7 +19,7 @@ struct WorktreeSubtreeView: View {
     let worktree: Worktree
     let depth: Int
     let sectionRepoID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     /// Read only to place the row: the project chevron's position decides
     /// which column every section title sits in, and rows follow their title.
     /// See `SidebarHeaderMetrics.childRowLeadingInset`.

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -426,7 +426,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct TBDAppMain: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @StateObject private var appState = AppState(userDefaults: TBDAppMain.resolveUserDefaults())
+    /// `@State`, not `@StateObject`: `AppState` is `@Observable`.
+    ///
+    /// The swap is not purely notational and was audited rather than assumed.
+    /// `StateObject.init(wrappedValue:)` takes an `@autoclosure @escaping`, so
+    /// this expression used to run lazily, on the first body evaluation;
+    /// `State.init(wrappedValue:)` takes the value directly, so it now runs when
+    /// this struct is constructed, inside `App.main()`. `AppState.init` does
+    /// real work — a tmux-executable resolve, three `UserDefaults` restores, a
+    /// memory-pressure source, focus observers, a theme-file watcher and a
+    /// connect/poll `Task` — so *when* it runs matters.
+    ///
+    /// It is safe here for a reason that does not generalise to views: this is
+    /// the `@main` `App`, which `App.main()` instantiates exactly once. The
+    /// separate trap the repo has already been bitten by — a `@State` default
+    /// expression re-running on every memberwise init — needs a struct SwiftUI
+    /// recreates, and an `App` is not one. Do not copy this pattern into a
+    /// `View`.
+    @State private var appState = AppState(userDefaults: TBDAppMain.resolveUserDefaults())
     @StateObject private var appearance = AppearanceSettings()
     @StateObject private var overlayCoordinator = TranscriptOverlayCoordinator()
 
@@ -453,7 +470,7 @@ struct TBDAppMain: App {
     var body: some Scene {
         Window("TBD", id: "main") {
             ContentView()
-                .environmentObject(appState)
+                .environment(appState)
                 .environmentObject(appearance)
                 .environmentObject(overlayCoordinator)
                 .onAppear {
@@ -462,9 +479,10 @@ struct TBDAppMain: App {
                     // Hand AppState a reference to the appearance settings so
                     // `mainAreaTerminalSize()` can compute pre-spawn tmux pane
                     // dimensions using the user's current font. Done in
-                    // `onAppear` rather than `init` because `@StateObject`
-                    // values aren't guaranteed to be initialized when the
-                    // App's `init` runs.
+                    // `onAppear` rather than `init` because the two objects
+                    // are separate `@State`/`@StateObject` properties and
+                    // nothing orders their construction against each other;
+                    // by first appearance both exist.
                     appState.appearance = appearance
                 }
                 .onOpenURL { url in
@@ -494,7 +512,7 @@ struct TBDAppMain: App {
 
         Settings {
             SettingsView()
-                .environmentObject(appState)
+                .environment(appState)
                 .environmentObject(appearance)
                 .environmentObject(overlayCoordinator)
         }

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -443,6 +443,13 @@ struct TBDAppMain: App {
     /// expression re-running on every memberwise init — needs a struct SwiftUI
     /// recreates, and an `App` is not one. Do not copy this pattern into a
     /// `View`.
+    ///
+    /// That "exactly once" is an undocumented SwiftUI behaviour, and it is what
+    /// this line rests on, so it is worth naming what would break without it:
+    /// `AppState` has no `deinit` unregistering its observers, so a second
+    /// construction would silently leave behind a second memory-pressure
+    /// source, a second set of focus observers, a second theme-file watcher and
+    /// a second connect/poll `Task` — extra RPC traffic with no visible cause.
     @State private var appState = AppState(userDefaults: TBDAppMain.resolveUserDefaults())
     @StateObject private var appearance = AppearanceSettings()
     @StateObject private var overlayCoordinator = TranscriptOverlayCoordinator()
@@ -479,10 +486,12 @@ struct TBDAppMain: App {
                     // Hand AppState a reference to the appearance settings so
                     // `mainAreaTerminalSize()` can compute pre-spawn tmux pane
                     // dimensions using the user's current font. Done in
-                    // `onAppear` rather than `init` because the two objects
-                    // are separate `@State`/`@StateObject` properties and
-                    // nothing orders their construction against each other;
-                    // by first appearance both exist.
+                    // `onAppear` rather than `init` because `appearance` is a
+                    // `@StateObject`, whose value is not guaranteed to be
+                    // installed when the App's `init` runs. By first appearance
+                    // both objects exist. (`appState` is eager now that it is
+                    // `@State`, but that only removes half the ordering
+                    // problem, so the hook stays where it is.)
                     appState.appearance = appearance
                 }
                 .onOpenURL { url in

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -84,7 +84,7 @@ private struct TabDropDelegate: DropDelegate {
 struct TabBar: View {
     let tabs: [TBDShared.Tab]
     let worktreeID: UUID
-    @EnvironmentObject private var appState: AppState
+    @Environment(AppState.self) private var appState
     @Binding var activeTabIndex: Int
     var onAddShell: () -> Void = {}
     var onAddClaude: () -> Void = {}
@@ -164,10 +164,9 @@ private struct AddTabButton: View {
     /// mount, it does not stop the expression from re-evaluating. `AddTabButton`
     /// is built inside `TabBar.body`, itself built inside `SingleWorktreeView.body`,
     /// and `WorktreePager` keeps one of those mounted per kept-alive worktree, all
-    /// observing `AppState` — so any `@Published` change (the 2 s poll, terminal
-    /// churn, `mainAreaSize` during a window resize) re-ran `detect()` for every
-    /// mounted worktree, each doing `2 × (PATH dirs + 8)` synchronous `stat`s on
-    /// the main thread. The two real refresh paths below cover the value: `.task`
+    /// reading `AppState` — so a change to any property they read (the 2 s poll,
+    /// terminal churn) re-ran `detect()` for every mounted worktree, each doing
+    /// `2 × (PATH dirs + 8)` synchronous `stat`s on the main thread. The two real refresh paths below cover the value: `.task`
     /// on appear, and a synchronous re-detect in `showMenu()`.
     @State private var availability = AgentExecutableAvailability.allAvailable
 
@@ -556,7 +555,7 @@ private struct TabBarItem: View {
     private var showClaudeTabUsageTooltip: Bool = true
     @AppStorage(AppState.usageResetTimeStyleKey)
     private var usageResetTimeStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset
-    @EnvironmentObject private var appState: AppState
+    @Environment(AppState.self) private var appState
 
     private var showClose: Bool {
         isSelected || isHovering
@@ -766,7 +765,7 @@ private struct TabBarItem: View {
             .background(Color(nsColor: .controlBackgroundColor))
             .cornerRadius(4)
             .opacity(0.85)
-            // Defer the @Published write off SwiftUI's view-graph update pass.
+            // Defer the tracked write off SwiftUI's view-graph update pass.
             // Writing it synchronously here re-invalidates the body that owns
             // this preview, causing a runaway re-render loop. The equality
             // guard also keeps a redundant same-value write (the catch-all

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -6,7 +6,6 @@ import TBDShared
 /// When multiple terminals are docked, draggable dividers between cells allow vertical resizing.
 struct PinnedTerminalDock: View {
     let terminals: [Terminal]
-    @EnvironmentObject var appState: AppState
     @State private var ratios: [CGFloat] = []
 
     var body: some View {
@@ -102,7 +101,7 @@ private struct DockCellDivider: View {
 /// A single cell in the pinned terminal dock.
 private struct PinnedTerminalCell: View {
     let terminal: Terminal
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
         // Bind ONCE per render — findWorktree is a linear scan, and both the

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -27,9 +27,10 @@ struct MainAreaSizeKey: PreferenceKey {
 }
 
 struct TerminalContainerView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     var body: some View {
+        @Bindable var appState = appState
         // `dockedTerminalIDs` (on AppState) is the single source of truth for
         // which pinned terminals fall to the dock; the keep-alive pager dedups
         // against the same set so a docked terminal is never mounted twice.
@@ -87,7 +88,7 @@ struct TerminalContainerView: View {
 /// Shows the tab bar and split layout for a single selected worktree.
 struct SingleWorktreeView: View {
     let worktreeID: UUID
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     /// Spawn-time account picker (AccountPickerSheet). Opened by the plain
     /// "Claude" action (unless "Use default without asking" is on) and by the
     /// "+"-menu "Choose account…" item.
@@ -252,7 +253,7 @@ struct SingleWorktreeView: View {
                         selectLastTab()
                     }
                 }
-                .environmentObject(appState)
+                .environment(appState)
             }
             // TmuxBridge sessions are created on-demand by TerminalPanelView
             .task(id: worktreeID) {
@@ -506,7 +507,7 @@ enum QueuedPromptBannerModel {
 /// target, opening the same composer the status bar does, so editing, Copy,
 /// Discard and the send-immediately bit all live in one place.
 private struct QueuedPromptBanner: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     let worktree: Worktree
 
     @State private var isHovered = false
@@ -573,7 +574,6 @@ private struct PreSessionSetupBanner: View {
 /// Each panel displays the worktree name and its primary terminal.
 private struct MultiWorktreeView: View {
     let worktreeIDs: [UUID]
-    @EnvironmentObject var appState: AppState
 
     private var columns: Int {
         let count = worktreeIDs.count
@@ -629,7 +629,7 @@ private struct MultiWorktreeCell: View {
     /// SwiftTerm pane area (excludes the per-cell header bar + divider).
     /// All cells are equal size so a single publisher suffices.
     let isPrimary: Bool
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     private var worktree: Worktree? {
         // Routes through findWorktree so scratch spaces (which live in

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -47,7 +47,7 @@ struct TerminalPanelView: View {
     var remoteURL: String?
     var onFilePathClicked: ((String) -> Void)?
     var onTerminalNotification: ((String, String) -> Void)?
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var appearance: AppearanceSettings
     /// Called only after tmux positively confirms the requested window is absent.
     /// The callback owns the persistent automatic-recovery budget and recreation.
@@ -241,7 +241,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
     var remoteURL: String?
     var onFilePathClicked: ((String) -> Void)?
     var onTerminalNotification: ((String, String) -> Void)?
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @EnvironmentObject var appearance: AppearanceSettings
     var onMissingWindow: (@MainActor () async -> AutomaticTerminalRecreationOutcome)?
     var onRecoveryGuidance: (@MainActor (String) -> Void)?

--- a/Sources/TBDApp/Terminal/WorktreePager.swift
+++ b/Sources/TBDApp/Terminal/WorktreePager.swift
@@ -15,7 +15,7 @@ import AppKit
 struct WorktreePager: NSViewControllerRepresentable {
     let worktreeIDs: [UUID]
     let activeID: UUID?
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
 
     static func mountedWorktreeIDs(recentIDs: [UUID], activeID: UUID?) -> [UUID] {
         guard let activeID else { return recentIDs }
@@ -46,7 +46,7 @@ struct WorktreePager: NSViewControllerRepresentable {
         for id in mountedIDs where !currentIDs.contains(id) {
             let host = NSHostingController(
                 rootView: SingleWorktreeView(worktreeID: id)
-                    .environmentObject(appState)
+                    .environment(appState)
             )
             let item = NSTabViewItem(viewController: host)
             item.identifier = id

--- a/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
+++ b/Sources/TBDApp/Worktree/ParkedPromptReadbackView.swift
@@ -205,7 +205,7 @@ enum ParkedPromptUndeliverable: Equatable {
 /// understood. Copy works when nothing else does, Discard throws the message
 /// away, and Deliver stays honestly disabled where delivery cannot happen.
 struct ParkedPromptReadbackView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
     let readback: ParkedPromptReadback
 

--- a/Sources/TBDApp/Worktree/QueuedPromptModal.swift
+++ b/Sources/TBDApp/Worktree/QueuedPromptModal.swift
@@ -133,7 +133,7 @@ enum QueuedPromptComposer {
 /// running with an idle agent, exactly as before the feature existed. Follows
 /// the sheet convention of `ScratchInstructionsView`.
 struct QueuedPromptModal: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
     @ObservedObject var target: QueuedPromptTarget
 

--- a/Tests/TBDAppTests/ActiveTabResolutionTests.swift
+++ b/Tests/TBDAppTests/ActiveTabResolutionTests.swift
@@ -525,9 +525,9 @@ struct ActiveTabResolutionTests {
         }
     }
 
-    /// A retry that changes nothing must also *publish* nothing: every write to
-    /// an `@Published` dictionary fires a full `AppState.objectWillChange`, and
-    /// this path is on a repeat timer by construction.
+    /// A retry that changes nothing must also *notify* nothing: every write to
+    /// a tracked dictionary notifies every view that read it, and this path is
+    /// on a repeat timer by construction.
     @Test("a repeat fetch that changes nothing publishes nothing")
     func idempotentTabStateFetchDoesNotRepublish() async {
         await withState { state in
@@ -541,14 +541,12 @@ struct ActiveTabResolutionTests {
 
             await state.loadTabStates(worktreeID: worktreeID)
 
-            var publishes = 0
-            let token = state.objectWillChange.sink { _ in publishes += 1 }
-            defer { token.cancel() }
-
-            await state.loadTabStates(worktreeID: worktreeID)
+            let publishes = await countEmissions(of: state, duringAsync: {
+                await state.loadTabStates(worktreeID: worktreeID)
+            })
 
             #expect(publishes == 0,
-                    "an identical response must not fan out an objectWillChange")
+                    "an identical response must not notify anyone")
         }
     }
 

--- a/Tests/TBDAppTests/AppStateEmissionCounter.swift
+++ b/Tests/TBDAppTests/AppStateEmissionCounter.swift
@@ -27,13 +27,22 @@ import Testing
 /// - **`onChange` fires in `willSet` position**, before the write commits. That
 ///   is irrelevant to a counter, which never reads the new value.
 ///
-/// The subtlety this whole file exists to expose survives the migration intact:
+/// The subtlety this whole file exists to expose mostly survives the migration:
 /// Observation notifies on **assignment**, not on change. A guard inside a
 /// property's `didSet` suppresses the downstream work but not the notification.
 /// To spare a render pass, the equality guard has to sit at the *assignment
 /// site*. What per-property tracking changed is *who* pays for a redundant
 /// notification — every reader of that one property, rather than every view
 /// observing the object — not whether one is sent.
+///
+/// The one carve-out, because reading the paragraph above without it leads
+/// straight to a wrong conclusion about the counts in
+/// `AppStatePublishFrequencyTests`: Swift 6.2's macro *does* drop the
+/// notification for a whole-property assignment of an equal value when the
+/// property's type is `Equatable`. It does not do so for anything reached
+/// through `_modify` — `dict[k] = v`, `rows[i].field = x`, `set.insert(…)` —
+/// nor for a property whose type is not `Equatable`.
+/// ``AppStateObservationContractTests`` pins both halves of that rule.
 ///
 /// ``AppStateTrackedPropertyCoverageTests`` pins the read list against the
 /// class, so a property added to `AppState` without being added here fails a

--- a/Tests/TBDAppTests/AppStateEmissionCounter.swift
+++ b/Tests/TBDAppTests/AppStateEmissionCounter.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import Testing
 @testable import TBDApp
@@ -8,35 +7,303 @@ import Testing
 
 // MARK: - The instrument
 
-/// Counts `objectWillChange` emissions from `state` across `body`.
+/// Counts observer notifications from every tracked property of `state` across
+/// `body` — the object-wide emission count.
 ///
-/// `AppState` is an `ObservableObject`, so `objectWillChange` is **object-wide**:
-/// one emission re-runs the body of every view observing the object, regardless
-/// of which of its ~107 `@Published` properties changed. Readership is therefore
-/// irrelevant to invalidation — only *writer frequency* is. This helper turns
-/// that frequency into a number a test can assert on.
+/// `AppState` is `@Observable`, so there is no `objectWillChange` to subscribe
+/// to: notification is per-property, and a consumer hears only about the
+/// properties it read. To keep measuring the *object-wide* rate this file was
+/// built around, ``AppStateEmissionTracker`` arms a `withObservationTracking`
+/// whose `apply` closure reads all of `AppState`'s tracked stored properties,
+/// so any one of them firing is a notification this counter hears.
 ///
-/// The subtlety it exists to expose: `@Published` fires on **assignment**, not on
-/// change. A guard inside a property's `didSet` suppresses the downstream work
-/// but NOT the SwiftUI invalidation, because `objectWillChange` has already been
-/// sent by `willSet` before `didSet` ever runs. To spare a render pass, the
-/// equality guard has to sit at the *assignment site*.
+/// Two sharp edges of the primitive it is built on:
 ///
-/// The cancellable is held for exactly the closure's duration and cancelled on
-/// the way out, so a later emission from an unrelated test can't be attributed
-/// to this one.
+/// - **`onChange` is one-shot.** It must re-arm after every fire or the counter
+///   silently stops at 1. The re-arm here is *synchronous*, inside the callback,
+///   because these tests write several properties back-to-back within one
+///   synchronous call and a hop to a later turn would drop everything in
+///   between.
+/// - **`onChange` fires in `willSet` position**, before the write commits. That
+///   is irrelevant to a counter, which never reads the new value.
+///
+/// The subtlety this whole file exists to expose survives the migration intact:
+/// Observation notifies on **assignment**, not on change. A guard inside a
+/// property's `didSet` suppresses the downstream work but not the notification.
+/// To spare a render pass, the equality guard has to sit at the *assignment
+/// site*. What per-property tracking changed is *who* pays for a redundant
+/// notification — every reader of that one property, rather than every view
+/// observing the object — not whether one is sent.
+///
+/// ``AppStateTrackedPropertyCoverageTests`` pins the read list against the
+/// class, so a property added to `AppState` without being added here fails a
+/// test rather than quietly going uncounted.
+@MainActor
+final class AppStateEmissionTracker {
+    private let state: AppState
+    private var isLive = true
+    private(set) var count = 0
+
+    init(_ state: AppState) {
+        self.state = state
+        arm()
+    }
+
+    /// Stop counting. Idempotent, and required on the way out of a measurement
+    /// so a later emission from an unrelated test cannot be attributed to this
+    /// one — the Observation equivalent of cancelling a Combine subscription.
+    func stop() {
+        isLive = false
+    }
+
+    private func arm() {
+        withObservationTracking {
+            Self.readAllTrackedProperties(of: state)
+        } onChange: { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, self.isLive else { return }
+                self.count += 1
+                self.arm()
+            }
+        }
+    }
+
+    /// Every tracked stored property of `AppState`, read once, so that
+    /// `withObservationTracking` registers a dependency on all of them.
+    ///
+    /// Deliberately reads only *stored* properties: a computed one such as
+    /// `allWorktrees` would fill a memo cache as a side effect of measuring.
+    static func readAllTrackedProperties(of state: AppState) {
+        _ = state.repos
+        _ = state.worktrees
+        _ = state.scratchWorktrees
+        _ = state.terminals
+        _ = state.notes
+        _ = state.focusedTabCloseContext
+        _ = state.unreadByWorktree
+        _ = state.unreadByRemoteSession
+        _ = state.unreadTerminals
+        _ = state.selectedWorktreeIDs
+        _ = state.selectionOrder
+        _ = state.repoDetailReveal
+        _ = state.selectedRepoID
+        _ = state.pendingRepoDetailTab
+        _ = state.selectedScratchSection
+        _ = state.selectedRemoteProvider
+        _ = state.selectedRemoteSession
+        _ = state.remoteSessionRequestedTab
+        _ = state.canGoBack
+        _ = state.canGoForward
+        _ = state.archivedWorktrees
+        _ = state.archivedScratchWorktrees
+        _ = state.archivedWorktreesHasMore
+        _ = state.isLoadingMoreArchived
+        _ = state.archivedSearchQuery
+        _ = state.archivedSearchResults
+        _ = state.archivedSearchFailed
+        _ = state.isLoadingMoreArchivedSearch
+        _ = state.reapRecords
+        _ = state.remoteProviders
+        _ = state.remoteSessions
+        _ = state.remoteSessionDisplayNames
+        _ = state.highlightedArchivedWorktreeID
+        _ = state.activeToast
+        _ = state.pendingScrollToWorktreeID
+        _ = state.isInitialStateLoaded
+        _ = state.dockRatio
+        _ = state.skipAccountPicker
+        _ = state.mainAreaSize
+        _ = state.isConnected
+        _ = state.layouts
+        _ = state.gridLayouts
+        _ = state.paneHistories
+        _ = state.tabs
+        _ = state.activeTabIndices
+        _ = state.worktreeTabOrders
+        _ = state.draggingTabID
+        _ = state.repoFilter
+        _ = state.pendingWorktreeIDs
+        _ = state.suspendingTerminalIDs
+        _ = state.suspendingSnapshots
+        _ = state.editingWorktreeID
+        _ = state.isRenamingWorktree
+        _ = state.prStatuses
+        _ = state.prObservations
+        _ = state.prBindings
+        _ = state.prDetachedCounts
+        _ = state.modelProfiles
+        _ = state.defaultProfileID
+        _ = state.codexUsage
+        _ = state.isLoadingCodexUsage
+        _ = state.primaryAgentPreference
+        _ = state.globalEnvOverrides
+        _ = state.globalRemoteCreateDefaults
+        _ = state.autoArchiveOnMergeDefault
+        _ = state.autoHibernateOnMergeDefault
+        _ = state.gcEnabled
+        _ = state.autoCreateNotesEnabled
+        _ = state.nightwatchMode
+        _ = state.autoHibernateEnabled
+        _ = state.hibernateIdleMinutes
+        _ = state.supervisionEnabled
+        _ = state.autoResumeOnLimitReset
+        _ = state.autoResumeOnApiError
+        _ = state.dismissedProxyWarnings
+        _ = state.daemonBuildMismatchMessage
+        _ = state.daemonBuildMismatchDismissed
+        _ = state.controlModeAttachedPanes
+        _ = state.controlModeFailingInputPanes
+        _ = state.historyActiveWorktrees
+        _ = state.historyLoadStates
+        _ = state.selectedSessionIDs
+        _ = state.sessionTranscripts
+        _ = state.sessionTranscriptLoading
+        _ = state.closedTerminalHistories
+        _ = state.selectedClosedTerminalIDs
+        _ = state.closedTerminalContents
+        _ = state.recentlyVisitedWorktreeIDs
+        _ = state.recentWorktreeIDs
+        _ = state.recentlyAttachedRemoteSessions
+        _ = state.explicitlyDetachedRemoteSessions
+        _ = state.pendingReconnectRemoteSessions
+        _ = state.selectedArchivedWorktreeIDs
+        _ = state.selectedReapRecordIDs
+        _ = state.revivingArchived
+        _ = state.alertMessage
+        _ = state.alertIsError
+        _ = state.tmuxExecutableResolution
+        _ = state.savedTmuxExecutablePath
+        _ = state.isTmuxLocationPromptPresented
+        _ = state.daemonCapabilities
+        _ = state.queuedPromptTarget
+        _ = state.parkedPromptReadback
+        _ = state.parkedPromptDeliveryInFlight
+    }
+
+    /// The read list above, as data, for the coverage test.
+    static let trackedPropertyNames: Set<String> = [
+        "repos",
+        "worktrees",
+        "scratchWorktrees",
+        "terminals",
+        "notes",
+        "focusedTabCloseContext",
+        "unreadByWorktree",
+        "unreadByRemoteSession",
+        "unreadTerminals",
+        "selectedWorktreeIDs",
+        "selectionOrder",
+        "repoDetailReveal",
+        "selectedRepoID",
+        "pendingRepoDetailTab",
+        "selectedScratchSection",
+        "selectedRemoteProvider",
+        "selectedRemoteSession",
+        "remoteSessionRequestedTab",
+        "canGoBack",
+        "canGoForward",
+        "archivedWorktrees",
+        "archivedScratchWorktrees",
+        "archivedWorktreesHasMore",
+        "isLoadingMoreArchived",
+        "archivedSearchQuery",
+        "archivedSearchResults",
+        "archivedSearchFailed",
+        "isLoadingMoreArchivedSearch",
+        "reapRecords",
+        "remoteProviders",
+        "remoteSessions",
+        "remoteSessionDisplayNames",
+        "highlightedArchivedWorktreeID",
+        "activeToast",
+        "pendingScrollToWorktreeID",
+        "isInitialStateLoaded",
+        "dockRatio",
+        "skipAccountPicker",
+        "mainAreaSize",
+        "isConnected",
+        "layouts",
+        "gridLayouts",
+        "paneHistories",
+        "tabs",
+        "activeTabIndices",
+        "worktreeTabOrders",
+        "draggingTabID",
+        "repoFilter",
+        "pendingWorktreeIDs",
+        "suspendingTerminalIDs",
+        "suspendingSnapshots",
+        "editingWorktreeID",
+        "isRenamingWorktree",
+        "prStatuses",
+        "prObservations",
+        "prBindings",
+        "prDetachedCounts",
+        "modelProfiles",
+        "defaultProfileID",
+        "codexUsage",
+        "isLoadingCodexUsage",
+        "primaryAgentPreference",
+        "globalEnvOverrides",
+        "globalRemoteCreateDefaults",
+        "autoArchiveOnMergeDefault",
+        "autoHibernateOnMergeDefault",
+        "gcEnabled",
+        "autoCreateNotesEnabled",
+        "nightwatchMode",
+        "autoHibernateEnabled",
+        "hibernateIdleMinutes",
+        "supervisionEnabled",
+        "autoResumeOnLimitReset",
+        "autoResumeOnApiError",
+        "dismissedProxyWarnings",
+        "daemonBuildMismatchMessage",
+        "daemonBuildMismatchDismissed",
+        "controlModeAttachedPanes",
+        "controlModeFailingInputPanes",
+        "historyActiveWorktrees",
+        "historyLoadStates",
+        "selectedSessionIDs",
+        "sessionTranscripts",
+        "sessionTranscriptLoading",
+        "closedTerminalHistories",
+        "selectedClosedTerminalIDs",
+        "closedTerminalContents",
+        "recentlyVisitedWorktreeIDs",
+        "recentWorktreeIDs",
+        "recentlyAttachedRemoteSessions",
+        "explicitlyDetachedRemoteSessions",
+        "pendingReconnectRemoteSessions",
+        "selectedArchivedWorktreeIDs",
+        "selectedReapRecordIDs",
+        "revivingArchived",
+        "alertMessage",
+        "alertIsError",
+        "tmuxExecutableResolution",
+        "savedTmuxExecutablePath",
+        "isTmuxLocationPromptPresented",
+        "daemonCapabilities",
+        "queuedPromptTarget",
+        "parkedPromptReadback",
+        "parkedPromptDeliveryInFlight",
+    ]
+}
+
+/// Counts observer notifications from `state` across `body`.
+///
+/// The tracker is live for exactly the closure's duration and stopped on the
+/// way out.
 @MainActor
 func countEmissions(of state: AppState, during body: () -> Void) -> Int {
-    var count = 0
-    let token = state.objectWillChange.sink { _ in count += 1 }
-    defer { token.cancel() }
+    let tracker = AppStateEmissionTracker(state)
+    defer { tracker.stop() }
     body()
-    return count
+    return tracker.count
 }
 
 /// `async` twin of ``countEmissions(of:during:)``, for driving a production path
-/// that suspends. Same contract: the subscription is live for the whole
-/// operation, including across every suspension point inside it.
+/// that suspends. Same contract: the tracker is live for the whole operation,
+/// including across every suspension point inside it.
 ///
 /// Deliberately a separate argument label rather than an overload. A trailing
 /// closure that happens to be synchronous binds to whichever overload the
@@ -45,11 +312,10 @@ func countEmissions(of state: AppState, during body: () -> Void) -> Int {
 /// well-behaved property.
 @MainActor
 func countEmissions(of state: AppState, duringAsync body: () async -> Void) async -> Int {
-    var count = 0
-    let token = state.objectWillChange.sink { _ in count += 1 }
-    defer { token.cancel() }
+    let tracker = AppStateEmissionTracker(state)
+    defer { tracker.stop() }
     await body()
-    return count
+    return tracker.count
 }
 
 // MARK: - Fixtures

--- a/Tests/TBDAppTests/AppStateObservationTests.swift
+++ b/Tests/TBDAppTests/AppStateObservationTests.swift
@@ -1,0 +1,518 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// Tier 2: hosts real SwiftUI in an `NSHostingView` and pumps the run loop in
+// bounded slices. No subprocesses, no `~/tbd`; every `AppState` and every
+// `@AppStorage` store is a throwaway `UserDefaults` suite.
+//
+// WHAT THIS FILE PINS
+//
+// `AppState` is `@Observable`, so a view re-evaluates only when a property it
+// actually read changes. Two things have to hold for that to be true in
+// practice, and neither is visible to a model-layer assertion:
+//
+//   1. A write to a property a view does not read must not re-evaluate it.
+//      Under `ObservableObject` this was false by construction —
+//      `objectWillChange` was object-wide — so this file's first suite fails
+//      against the pre-migration tree.
+//   2. A view served from one of `AppState`'s memo caches must keep its
+//      dependency on the cache's tracked source. SwiftUI rebuilds a view's
+//      dependency set from what each `body` evaluation actually read, so a
+//      body served entirely from a warm cache reads nothing tracked and drops
+//      the dependency — after which a real change does not reach it. A naive
+//      conversion has exactly this bug; `AppStateWarmCacheDependencySourceTests`
+//      at the foot of this file fails against it.
+//
+// Counts are compared before-and-after, never against an exact number: SwiftUI
+// may legitimately evaluate a body more than once for one change.
+
+// MARK: - Instruments
+
+/// Body evaluations of one probe view. A reference type so the count survives
+/// the view struct being recreated.
+@MainActor
+final class BodyEvaluationCounter {
+    private(set) var count = 0
+    /// Returns a value so the call can sit in a `@ViewBuilder` as `let _ = `.
+    @discardableResult
+    func bump() -> Int {
+        count += 1
+        return count
+    }
+}
+
+/// Reads exactly one `AppState` property, directly.
+private struct DirectReadProbe: View {
+    let counter: BodyEvaluationCounter
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        let _ = counter.bump()
+        Text("repos: \(appState.repos.count)")
+    }
+}
+
+/// Reads `AppState` only through a *method* backed by a memo cache, and
+/// composes a child view from the result — the shape the sidebar actually has,
+/// and the one a `withObservationTracking` assertion over the model cannot see.
+private struct ComposedReadProbe: View {
+    let parentID: UUID
+    let counter: BodyEvaluationCounter
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        let _ = counter.bump()
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(appState.children(of: parentID)) { child in
+                Text(child.displayName)
+            }
+        }
+    }
+}
+
+/// Reads one tracked property directly AND one only through the memo-cached
+/// `children(of:)`. The direct read is the lever: writing it forces a
+/// re-evaluation whose `children(of:)` call is served from the warm cache, and
+/// the counter proves that re-evaluation happened rather than assuming it.
+private struct CacheTrapProbe: View {
+    let parentID: UUID
+    let counter: BodyEvaluationCounter
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        let _ = counter.bump()
+        VStack(alignment: .leading, spacing: 0) {
+            Text(appState.alertMessage ?? "-")
+            ForEach(appState.children(of: parentID)) { child in
+                Text(child.displayName)
+            }
+        }
+    }
+}
+
+/// Reads only `@AppStorage`. Used as the vacuity guard in the cache suite: it
+/// proves a defaults flip really did invalidate the views that read that key,
+/// so a passing cache assertion cannot be one where nothing re-evaluated.
+private struct AppStorageProbe: View {
+    let counter: BodyEvaluationCounter
+    @AppStorage(AppState.chevronBeforeProjectNameKey)
+    private var chevronBeforeProjectName: Bool = AppState.chevronBeforeProjectNameDefault
+
+    var body: some View {
+        let _ = counter.bump()
+        Text(chevronBeforeProjectName ? "before" : "after")
+    }
+}
+
+// MARK: - Harness
+
+@MainActor
+private struct HostedProbe {
+    let state: AppState
+    let defaults: UserDefaults
+    let host: NSHostingView<AnyView>
+    private let window: NSWindow
+
+    init(state: AppState, defaults: UserDefaults, content: AnyView) {
+        self.state = state
+        self.defaults = defaults
+        self.host = NSHostingView(rootView: content)
+        host.frame = NSRect(x: 0, y: 0, width: 420, height: 600)
+        window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+    }
+
+    /// Let SwiftUI's scheduled update land, then force layout so any pending
+    /// body evaluation actually runs. Bounded slices — never an unbounded wait.
+    func pump() {
+        for _ in 0..<5 {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        host.layoutSubtreeIfNeeded()
+    }
+
+    func tearDown() {
+        window.contentView = nil
+    }
+}
+
+/// One `AppState` and one `@AppStorage` store, both throwaway suites, hosting
+/// `content` in a borderless window. `UserDefaults.standard` on this unbundled
+/// executable is the developer's real `TBDApp.plist` — see the root `CLAUDE.md`
+/// — so the `.defaultAppStorage` leg matters as much as the `AppState` one.
+@MainActor
+private func withHostedProbe(
+    _ content: @MainActor (AppState) -> AnyView,
+    _ body: (HostedProbe) -> Void
+) {
+    let suiteName = "TBDAppTests.AppStateObservation.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let state = AppState(userDefaults: defaults)
+
+    // `.defaultAppStorage` on the whole tree, not per view: an `@AppStorage`
+    // that fell through to `UserDefaults.standard` would read — and a test
+    // that flips one would write — the developer's real `TBDApp.plist`.
+    let probe = HostedProbe(
+        state: state,
+        defaults: defaults,
+        content: AnyView(content(state).defaultAppStorage(defaults))
+    )
+    defer { probe.tearDown() }
+    probe.pump()
+    body(probe)
+}
+
+@MainActor
+private func makeWorktree(
+    id: UUID = UUID(),
+    repoID: UUID?,
+    parentWorktreeID: UUID? = nil,
+    name: String,
+    sortOrder: Int = 0
+) -> Worktree {
+    Worktree(
+        id: id,
+        repoID: repoID,
+        name: name,
+        displayName: name,
+        branch: "main",
+        path: "/tmp/\(name)",
+        status: .active,
+        tmuxServer: "test-server",
+        sortOrder: sortOrder,
+        parentWorktreeID: parentWorktreeID
+    )
+}
+
+// MARK: - Per-property tracking
+
+@MainActor
+@Suite("A write reaches only the views that read that property")
+struct AppStatePerPropertyTrackingTests {
+
+    /// The core discriminator. Under `ObservableObject` every write to any of
+    /// `AppState`'s ~104 published properties re-ran the body of every view
+    /// observing the object, so the first assertion below could not hold. It is
+    /// what this migration is for.
+    ///
+    /// The second half is the positive control: without it, a harness that had
+    /// simply stopped detecting re-evaluation at all would pass the first half.
+    @Test("an unrelated write leaves the body alone; a read one does not")
+    func unrelatedWriteDoesNotReEvaluate() {
+        let counter = BodyEvaluationCounter()
+        withHostedProbe({ state in
+            AnyView(DirectReadProbe(counter: counter).environment(state))
+        }, { probe in
+            let baseline = counter.count
+            #expect(baseline > 0, "the probe never evaluated; the harness is not measuring anything")
+
+            // `isConnected` is not read by `DirectReadProbe`.
+            probe.state.isConnected = !probe.state.isConnected
+            probe.pump()
+            #expect(counter.count == baseline,
+                    "a write to a property this view does not read re-evaluated it")
+
+            // `repos` is.
+            probe.state.repos = [Repo(id: UUID(), path: "/tmp/acme", displayName: "acme")]
+            probe.pump()
+            #expect(counter.count > baseline,
+                    "a write to a property this view DOES read did not re-evaluate it")
+        })
+    }
+
+    /// Same claim, but for a view whose only `AppState` read is through a
+    /// method backed by a memo cache and composed into a child `ForEach`. The
+    /// read-set as actually composed is the thing per-property tracking has to
+    /// get right, and it is not inspectable from the model side.
+    @Test("a composed, cache-served read-set tracks the same way")
+    func composedReadSetTracksTheSameWay() {
+        let counter = BodyEvaluationCounter()
+        let repoID = UUID()
+        let parentID = UUID()
+
+        withHostedProbe({ state in
+            state.worktrees = [repoID: [
+                makeWorktree(id: parentID, repoID: repoID, name: "parent")
+            ]]
+            return AnyView(
+                ComposedReadProbe(parentID: parentID, counter: counter).environment(state)
+            )
+        }, { probe in
+            let baseline = counter.count
+            #expect(baseline > 0, "the probe never evaluated; the harness is not measuring anything")
+
+            probe.state.isConnected = !probe.state.isConnected
+            probe.pump()
+            #expect(counter.count == baseline,
+                    "a write to a property this view does not read re-evaluated it")
+
+            probe.state.worktrees[repoID]?.append(
+                makeWorktree(repoID: repoID, parentWorktreeID: parentID, name: "child")
+            )
+            probe.pump()
+            #expect(counter.count > baseline,
+                    "adding a child did not re-evaluate the view that renders children")
+        })
+    }
+}
+
+// MARK: - The production sidebar composition
+
+@MainActor
+@Suite("The real sidebar subtree renders through the memo cache")
+struct AppStateCacheDependencyTests {
+
+    /// End-to-end shape: the production sidebar composition —
+    /// `WorktreeSubtreeView`, which renders `WorktreeRowView` and recurses
+    /// through `AppState.children(of:)` — grows a row when a child is added
+    /// through the memo cache. Asserted on rendered height, because the bug
+    /// class this guards against is stale UI and height is what a user sees.
+    ///
+    /// `WorktreeSubtreeView` is the interesting subject because `children(of:)`
+    /// is its *only* route to `worktrees`; `RepoSectionView`, by contrast,
+    /// indexes `appState.worktrees` directly in four computed properties, so it
+    /// re-registers that dependency whatever the cache does.
+    ///
+    /// It does NOT discriminate against the missing `_ = worktrees` touch: the
+    /// `@AppStorage` flip below is included as the unrelated re-evaluation the
+    /// trap needs, and measurably does not force one on this view — the test
+    /// passes either way. The discriminating assertion lives in
+    /// ``AppStateWarmCacheDependencySourceTests``, which forces the
+    /// re-evaluation through a tracked property and proves it happened.
+    @Test("the real sidebar subtree renders a child added after its cache was warmed")
+    func realSidebarSubtreeRendersAChildAddedThroughTheCache() {
+        let storageCounter = BodyEvaluationCounter()
+        let repoID = UUID()
+        let parentID = UUID()
+
+        withHostedProbe({ state in
+            state.worktrees = [repoID: [
+                makeWorktree(id: parentID, repoID: repoID, name: "parent")
+            ]]
+            return AnyView(
+                VStack(alignment: .leading, spacing: 0) {
+                    WorktreeSubtreeView(worktree: state.worktrees[repoID]![0],
+                                        depth: 0,
+                                        sectionRepoID: repoID)
+                    AppStorageProbe(counter: storageCounter)
+                }
+                .frame(width: 420, alignment: .leading)
+                .environment(state)
+            )
+        }, { probe in
+            let coldHeight = probe.host.fittingSize.height
+            #expect(coldHeight > 0, "the subtree never laid out; the harness is not measuring anything")
+
+            // (2) Re-evaluate while the cache is warm, for a reason that has
+            // nothing to do with `worktrees`.
+            let beforeFlip = storageCounter.count
+            probe.defaults.set(
+                !AppState.chevronBeforeProjectNameDefault,
+                forKey: AppState.chevronBeforeProjectNameKey
+            )
+            probe.pump()
+            #expect(storageCounter.count > beforeFlip,
+                    "the defaults flip invalidated nothing, so the cache was never re-served")
+
+            // (3) A real change to the source the cache is derived from.
+            probe.state.worktrees[repoID]?.append(
+                makeWorktree(repoID: repoID, parentWorktreeID: parentID, name: "child")
+            )
+            probe.pump()
+
+            #expect(probe.host.fittingSize.height > coldHeight,
+                    "the new child row never appeared: the warm cache severed the worktrees dependency")
+        })
+    }
+}
+
+// MARK: - The warm-cache dependency trap, measured
+
+@MainActor
+@Suite("A cache-served evaluation would sever the worktrees dependency")
+struct AppStateWarmCacheDependencySourceTests {
+
+    /// The discriminating test for the `_ = worktrees` touch in
+    /// `AppState.childrenIndex()`. Remove that line and this fails.
+    ///
+    /// Sequence, with every step proved rather than assumed: evaluate cold
+    /// (fills `childrenIndexCache` and reads `worktrees`); write a property the
+    /// probe reads *directly*, asserting the body count moved — so an
+    /// evaluation demonstrably ran while the cache was warm, and its
+    /// `children(of:)` call read nothing tracked; then write `worktrees`.
+    ///
+    /// Without the touch, that last write does not arrive: SwiftUI rebuilt the
+    /// view's dependency set from the cache-served evaluation, which registered
+    /// nothing. The view keeps rendering the old subtree — stale sidebar, no
+    /// error anywhere.
+    ///
+    /// The lever matters. A re-evaluation forced through `@AppStorage` instead
+    /// of through a tracked `AppState` property does *not* reproduce this, which
+    /// is why the probe below reads `alertMessage` directly rather than relying
+    /// on a defaults flip.
+    @Test("a cache-warm re-evaluation costs the view its worktrees dependency without the fix")
+    func warmReEvaluationKeepsTheDependency() {
+        let counter = BodyEvaluationCounter()
+        let repoID = UUID()
+        let parentID = UUID()
+
+        withHostedProbe({ state in
+            state.worktrees = [repoID: [
+                makeWorktree(id: parentID, repoID: repoID, name: "parent")
+            ]]
+            return AnyView(
+                CacheTrapProbe(parentID: parentID, counter: counter).environment(state)
+            )
+        }, { probe in
+            let cold = counter.count
+            #expect(cold > 0, "the probe never evaluated; the harness is not measuring anything")
+
+            probe.state.alertMessage = "forced"
+            probe.pump()
+            let warm = counter.count
+            #expect(warm > cold,
+                    "the forced re-evaluation did not happen, so the cache was never re-served")
+
+            probe.state.worktrees[repoID]?.append(
+                makeWorktree(repoID: repoID, parentWorktreeID: parentID, name: "child")
+            )
+            probe.pump()
+            #expect(counter.count > warm,
+                    "a worktrees write did not reach a view whose last evaluation was cache-served")
+        })
+    }
+
+    /// The same claim at the primitive level, with no SwiftUI involved:
+    /// `withObservationTracking` replaces its access list per call, so a
+    /// cache-served read leaves it with nothing registered. Asserted separately
+    /// from the hosted test so a future failure says which layer moved.
+    @Test("withObservationTracking registers the dependency on a warm cache too")
+    func rawTrackingKeepsTheDependencyOnAWarmCache() {
+        withEmissionState { state in
+            let repoID = UUID()
+            let parentID = UUID()
+            state.worktrees = [repoID: [
+                makeWorktree(id: parentID, repoID: repoID, name: "parent")
+            ]]
+
+            // Cold: the fill reads `worktrees`, so the tracker fires.
+            // `onChange` is `@Sendable`, so the flag lives in a reference box.
+            let coldFired = BodyEvaluationCounter()
+            withObservationTracking {
+                _ = state.children(of: parentID)
+            } onChange: {
+                MainActor.assumeIsolated { _ = coldFired.bump() }
+            }
+            state.worktrees[repoID]?.append(
+                makeWorktree(repoID: repoID, parentWorktreeID: parentID, name: "a")
+            )
+            #expect(coldFired.count > 0, "a cold-cache read did not register a dependency on worktrees")
+
+            // Warm: re-read to refill, then arm again against the warm cache.
+            _ = state.children(of: parentID)
+            let warmFired = BodyEvaluationCounter()
+            withObservationTracking {
+                _ = state.children(of: parentID)
+            } onChange: {
+                MainActor.assumeIsolated { _ = warmFired.bump() }
+            }
+            state.worktrees[repoID]?.append(
+                makeWorktree(repoID: repoID, parentWorktreeID: parentID, name: "b")
+            )
+            #expect(warmFired.count > 0,
+                    "a warm-cache read registered no dependency on worktrees")
+        }
+    }
+
+    /// `allWorktrees` is the other memoized getter and carries the same touch,
+    /// over both of its sources. Asserted separately because its cache is
+    /// invalidated by two `didSet`s, and a touch that covered only one of them
+    /// would leave scratch-space churn silently undeliverable.
+    @Test("allWorktrees keeps both dependencies on a warm cache")
+    func allWorktreesKeepsBothDependenciesWarm() {
+        withEmissionState { state in
+            let repoID = UUID()
+            state.worktrees = [repoID: [makeWorktree(repoID: repoID, name: "parent")]]
+            state.scratchWorktrees = []
+
+            for (label, mutate) in [
+                ("worktrees", { state.worktrees[repoID]?.append(makeWorktree(repoID: repoID, name: "w")) }),
+                ("scratchWorktrees", { state.scratchWorktrees.append(makeWorktree(repoID: nil, name: "s")) })
+            ] as [(String, () -> Void)] {
+                _ = state.allWorktrees  // warm the cache
+                let fired = BodyEvaluationCounter()
+                withObservationTracking {
+                    _ = state.allWorktrees
+                } onChange: {
+                    MainActor.assumeIsolated { _ = fired.bump() }
+                }
+                mutate()
+                #expect(fired.count > 0,
+                        "a warm allWorktrees read registered no dependency on \(label)")
+            }
+        }
+    }
+}
+
+// MARK: - Untracked bookkeeping behind a tracked question
+
+@MainActor
+@Suite("canCloseFocusedTab tracks the property that moves when focus does")
+struct AppStateFocusedTabTrackingTests {
+
+    /// `resolvedFocusedTabCloseContext()` answers "which tab would ⌘W close?"
+    /// from three things Observation cannot see: `terminalFocusTargets` and
+    /// `terminalTabCloseContexts` (both `@ObservationIgnored`) and
+    /// `NSApp.keyWindow?.firstResponder` (not observable at all). Its one
+    /// observable input is `focusedTabCloseContext`, which `TerminalPanelView`
+    /// writes on every focus in and out — so that property is the proxy for a
+    /// first-responder change, and the function has to read it on every path
+    /// or the File ▸ Close Tab item registers no dependency on focus moving.
+    ///
+    /// The discriminator is a NON-EMPTY `terminalFocusTargets`: on the empty
+    /// path the function returns `focusedTabCloseContext` anyway, so a test
+    /// that left it empty would pass with the read removed. Remove the
+    /// `let lastFocused = focusedTabCloseContext` line and this fails.
+    @Test("a focus change still reaches canCloseFocusedTab once a terminal view has registered")
+    func focusChangeReachesTheMenuItemWithRegisteredTerminals() {
+        let suiteName = "TBDAppTests.FocusedTabTracking.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+
+        let view = TBDTerminalView(
+            frame: CGRect(x: 0, y: 0, width: 320, height: 240),
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: defaults)
+        )
+        view.resize(cols: 10, rows: 5)
+        let terminalID = UUID()
+        state.registerTerminalView(view, for: terminalID)
+        #expect(!state.terminalFocusTargets.isEmpty,
+                "the discriminating path needs a registered terminal view")
+
+        let fired = BodyEvaluationCounter()
+        withObservationTracking {
+            _ = state.canCloseFocusedTab
+        } onChange: {
+            MainActor.assumeIsolated { _ = fired.bump() }
+        }
+
+        // What TerminalPanelView does when a terminal takes focus.
+        state.focusedTabCloseContext = TabCloseContext(worktreeID: UUID(), tabID: UUID())
+
+        #expect(fired.count > 0,
+                "a focus change did not reach canCloseFocusedTab, so Close Tab can stay stale")
+    }
+}
+

--- a/Tests/TBDAppTests/AppStateObservationTests.swift
+++ b/Tests/TBDAppTests/AppStateObservationTests.swift
@@ -490,6 +490,15 @@ struct AppStateFocusedTabTrackingTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let state = AppState(userDefaults: defaults)
 
+        // `resolvedFocusedTabCloseContext()` reaches `NSApp.keyWindow` on the
+        // path this test drives, and `NSApp` is an implicitly-unwrapped global
+        // that stays nil until an application object exists — so without this
+        // the force-unwrap takes the whole test process down rather than
+        // failing one test. Same guard, same reason, as
+        // `ComposerTextOwnershipTests`. Suites run in parallel across one
+        // process, so relying on another suite having done it first is luck.
+        _ = NSApplication.shared
+
         let view = TBDTerminalView(
             frame: CGRect(x: 0, y: 0, width: 320, height: 240),
             font: TBDTerminalView.defaultMonospaceFont,

--- a/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
+++ b/Tests/TBDAppTests/AppStatePublishFrequencyTests.swift
@@ -9,17 +9,43 @@ import TBDShared
 //
 // WHAT THIS FILE MEASURES, AND WHY IT IS SHAPED THIS WAY
 //
-// `AppState` is an `ObservableObject` with ~107 `@Published` properties, read by
-// ~56 view files through `@EnvironmentObject`. `objectWillChange` is object-wide,
-// so one write to one property re-runs the body of every observing view. A
-// property nobody reads costs exactly as much as one everybody reads; only how
-// often it is *written* matters.
+// `AppState` is `@Observable` with ~104 tracked properties, read by ~60 view
+// files through `@Environment(AppState.self)`. Notification is per-property, so
+// a redundant write now costs only the views that read *that* property rather
+// than every view observing the object. What it does not do is stop the
+// notification being sent.
 //
-// The second mechanic is the one these tests are built around: `@Published`
-// publishes on ASSIGNMENT, not on change. `willSet` sends `objectWillChange`
-// before `didSet` runs, so an equality guard inside `didSet` suppresses the
-// downstream work and none of the SwiftUI invalidation. Only a guard at the
-// *assignment site* — or not being `@Published` at all — spares a render pass.
+// That is the mechanic these tests are built around, and it mostly survived
+// the migration from `ObservableObject`: Observation notifies on ASSIGNMENT,
+// not on change. The notification is sent from `willSet`, before `didSet` runs,
+// so an equality guard inside `didSet` suppresses the downstream work and none
+// of the SwiftUI invalidation. Only a guard at the *assignment site* — or the
+// property not being tracked at all — spares a render pass.
+//
+// ONE EXCEPTION, AND IT IS THE TOOLCHAIN'S, NOT OURS. Swift 6.2's `@Observable`
+// macro drops the notification for a **whole-property assignment of an equal
+// value** when the property's type is `Equatable`. Two large classes of write
+// are NOT covered and still notify unconditionally:
+//
+//   - anything reached through the `_modify` accessor — `dict[k] = v`,
+//     `rows[i].field = x`, `set.insert(…)`, `array.removeAll(where:)` — because
+//     `_modify` yields storage `inout` and never sees a before-and-after pair;
+//   - any property whose type is not `Equatable`, e.g. `remoteProviders`
+//     (`[RemoteProviderStatus]`, which has no `Equatable` conformance).
+//
+// Every count below is a consequence of that rule, so a count that moves
+// without a code change is the first sign the toolchain's behaviour did.
+// `AppStateObservationContractTests` pins the rule itself in one place, so
+// such a change fails there by name instead of scattering across this file.
+//
+// It is a floor, not the fix. The assignment-site guard audit tracked in #667
+// stays open: it is what stops the notification being *sent* on the two paths
+// above, which is most of what this file measures.
+//
+// The counts below are still object-wide: `countEmissions` arms a tracker that
+// reads every tracked property, so one unit is one notification from any of
+// them. That keeps a multi-property path (a `didSet` tail that clears four
+// other properties, say) measurable as the single number it costs.
 //
 // So each significant writer is measured twice: once re-applying what is already
 // there (the ideal is 0 emissions) and once applying a genuine change (the ideal
@@ -97,15 +123,18 @@ private func seatOneTerminal(
 
 /// Direct re-assignment of an unchanged value. These are not exotic: they are
 /// what a resize tick, a heartbeat, or a poll that found nothing new does when
-/// its call site has no equality guard. The ideal for every one of them is 0.
+/// its call site has no equality guard. The ideal for every one of them is 0,
+/// and all three reach it — but by the toolchain's equal-value exemption for
+/// whole-property assignments, not by a guard at the call site. The suites
+/// below are where that exemption stops applying.
 @MainActor
-@Suite("A @Published re-assignment publishes even when nothing changed")
+@Suite("A whole-property re-assignment of an equal value notifies nobody")
 struct IdempotentReassignmentTests {
 
     /// `mainAreaSize` is the known instance of the bug shape. Its `didSet`
     /// guards (`guard mainAreaSize != oldValue else { return }`,
     /// `AppState.swift:671`) — but that guard only suppresses the daemon
-    /// broadcast, because `objectWillChange` was already sent by `willSet`. The
+    /// broadcast, because the notification was already sent by `willSet`. The
     /// single writer is `TerminalContainerView.swift:68`, inside
     /// `.onPreferenceChange(MainAreaSizeKey.self)`, which AppKit fires on every
     /// layout pass of a window-resize drag.
@@ -117,13 +146,12 @@ struct IdempotentReassignmentTests {
 
             let count = countEmissions(of: state) { state.mainAreaSize = size }
 
-            // KNOWN ISSUE — `AppState.mainAreaSize`. Ideal 0, observed 1.
-            // The `didSet` guard cannot help; the fix is an equality guard at
-            // the assignment site in `TerminalContainerView.onPreferenceChange`
-            // (or dropping `@Published` and republishing manually).
-            withKnownIssue("mainAreaSize republishes on every resize tick (#667)") {
-                #expect(count == 0)
-            }
+            // Whole-property assignment of an equal `CGSize`, so the macro
+            // drops it. The `didSet` guard still cannot help — it runs after
+            // the notification would have been sent — and an assignment-site
+            // guard in `TerminalContainerView.onPreferenceChange` would be
+            // what spared this if the property's type were not `Equatable`.
+            #expect(count == 0)
         }
     }
 
@@ -136,11 +164,8 @@ struct IdempotentReassignmentTests {
 
             let count = countEmissions(of: state) { state.isConnected = true }
 
-            // KNOWN ISSUE — `AppState.isConnected`. Ideal 0, observed 1.
-            // Fix: guard at the assignment site.
-            withKnownIssue("isConnected republishes on an unchanged liveness result (#667)") {
-                #expect(count == 0)
-            }
+            // Whole-property assignment of an equal `Bool`.
+            #expect(count == 0)
         }
     }
 
@@ -162,11 +187,11 @@ struct IdempotentReassignmentTests {
 
             let count = countEmissions(of: state) { state.tabs = snapshot }
 
-            // KNOWN ISSUE — `AppState.tabs`. Ideal 0, observed 1.
-            // Fix: guard at the assignment site (`reconcileTabs`, below).
-            withKnownIssue("tabs republishes on an identical dictionary (#667)") {
-                #expect(count == 0)
-            }
+            // Whole-property assignment of an equal dictionary. Note this is
+            // the *only* shape of `tabs` write that gets the exemption:
+            // `reconcileTabs` below assigns through a subscript and still
+            // notifies on an identical response.
+            #expect(count == 0)
         }
     }
 }
@@ -473,11 +498,15 @@ struct DeltaIngestionTests {
 
             #expect(state.terminals[worktreeID]?.first?.hibernatedAt != nil)
             // KNOWN ISSUE — `AppState.terminals`, via
-            // `applyTerminalHibernationDelta` (AppState.swift:2224). Ideal 1
-            // (one logical park), observed 7 — one per field written through
-            // the subscript. Fix: mutate a local copy of the row and assign it
+            // `applyTerminalHibernationDelta`. Ideal 1 (one logical park),
+            // observed 9 — one per field written through the subscript
+            // (`tmuxWindowID`, `tmuxPaneID`, `hibernatedAt`, `keepWarm`,
+            // `suspendedSnapshot`, `hibernateReason`, `pendingResumeAt`,
+            // `awaitingInputReason`, `awaitingInputObservedAt`). Every one is a
+            // `_modify`, so none of them is eligible for the equal-value
+            // exemption. Fix: mutate a local copy of the row and assign it
             // back once.
-            withKnownIssue("one park costs one publish per field written (#667)") {
+            withKnownIssue("one park costs one notification per field written (#667)") {
                 #expect(count == 1)
             }
         }
@@ -500,7 +529,7 @@ struct DeltaIngestionTests {
             // KNOWN ISSUE — `AppState.controlModeFailingInputPanes`, via
             // `applyControlModeInputHealthDelta` (AppState.swift:2101).
             // `Set.remove` on an absent member is still a get-modify-set of the
-            // `@Published` property, so it publishes. Ideal 0, observed 1.
+            // tracked property, so it notifies. Ideal 0, observed 1.
             // Fix: `guard controlModeFailingInputPanes.contains(key)`.
             withKnownIssue("a redundant recovery still republishes (#667)") {
                 #expect(count == 0)
@@ -592,7 +621,7 @@ struct NotificationDeltaTests {
             }
 
             // KNOWN ISSUE — `AppState.unreadTerminals` (AppState.swift:2331).
-            // `Set.insert` is a get-modify-set of the `@Published` property, so
+            // `Set.insert` is a get-modify-set of the tracked property, so
             // an already-unread terminal republishes. Ideal 0, observed 1.
             // Fix: `guard !unreadTerminals.contains(tid)` at the assignment site.
             withKnownIssue("a repeat arrival for an unread terminal republishes (#667)") {
@@ -634,23 +663,32 @@ struct RemoteRefreshTests {
             await state.refreshRemote()
         }
 
-        // KNOWN ISSUE — ideal 0, observed 7, from five properties across three
-        // functions, none of them guarded:
-        //   `remoteProviders`, `remoteSessions`     — AppState+Remote.swift:44–45
+        // KNOWN ISSUE — ideal 0, observed 1. Seven properties across three
+        // functions are written unguarded by an idle refresh:
+        //   `remoteProviders`, `remoteSessions`     — AppState+Remote.swift
         //   `unreadByRemoteSession`,
-        //   `remoteSessionDisplayNames`             — AppState+Remote.swift:84–85
+        //   `remoteSessionDisplayNames`             — AppState+Remote.swift
         //   `explicitlyDetachedRemoteSessions`,
         //   `pendingReconnectRemoteSessions`,
-        //   `recentlyAttachedRemoteSessions`        — AppState.swift:1067–1069
-        // The five prunes are `x = x.filter { … }`, which is unconditional by
-        // construction: `filter` always returns a fresh collection, so the
-        // assignment always publishes even when nothing was dropped. And
-        // `remoteSessionDisplayNames` has a `didSet` that re-encodes and
-        // re-writes UserDefaults (AppState.swift:485), so an idle refresh also
-        // costs a disk write.
+        //   `recentlyAttachedRemoteSessions`        — AppState.swift
+        // All seven are `x = x.filter { … }` or a wholesale replace, which is
+        // unconditional by construction: `filter` always returns a fresh
+        // collection, so the assignment is made even when nothing was dropped.
+        // Six of them are spared by the equal-value exemption. The seventh,
+        // `remoteProviders`, is not: `RemoteProviderStatus` has no `Equatable`
+        // conformance, so the macro cannot compare and always notifies.
+        //
+        // That asymmetry is the argument for the guard rather than against it:
+        // whether an idle refresh costs a render pass currently depends on
+        // whether somebody remembered to conform an unrelated model type.
         // Fix: compare before assigning in all three functions — the shape
         // every sibling refresher already uses.
-        withKnownIssue("an unchanged remote refresh publishes 7 times (#667)") {
+        //
+        // `remoteSessionDisplayNames` additionally has a `didSet` that
+        // re-encodes and re-writes UserDefaults, and `didSet` runs whether or
+        // not the notification was dropped — so an idle refresh still costs a
+        // disk write regardless.
+        withKnownIssue("an unchanged remote refresh still notifies (#667)") {
             #expect(count == 0)
         }
     }
@@ -824,7 +862,7 @@ struct TerminalPollTickTests {
 // MARK: - Selection
 
 /// Selection is a user gesture, so its frequency is bounded by clicks — but the
-/// `didSet` cascade at `AppState.swift:192` writes five further `@Published`
+/// `didSet` cascade at `AppState.swift:192` writes five further tracked
 /// properties unconditionally, so one click costs many invalidations, and
 /// re-clicking the already-selected row costs the same as a real move.
 @MainActor
@@ -844,16 +882,22 @@ struct SelectionCascadeTests {
                 state.selectedWorktreeIDs = [row.id]
             }
 
-            // KNOWN ISSUE — ideal 0, observed 7: `selectedWorktreeIDs` itself
-            // (1), the four unconditional clears in its own `didSet` tail —
-            // `selectedRepoID`, `selectedScratchSection`,
-            // `selectedRemoteProvider`, `selectedRemoteSession`
-            // (AppState.swift:303–306) — and the `recentWorktreeIDs`
-            // `removeAll`/`insert` pair (:316–:317), which rewrites the LRU to
-            // the arrangement it already had.
-            // `selectionOrder` contributes nothing: its write IS guarded
-            // (:292), which is the model the other six should follow.
-            withKnownIssue("re-selecting the current worktree costs 7 publishes (#667)") {
+            // KNOWN ISSUE — ideal 0, observed 2: the `recentWorktreeIDs`
+            // `removeAll`/`insert` pair, which rewrites the LRU to the
+            // arrangement it already had. Both are `_modify` writes, so
+            // neither is eligible for the equal-value exemption.
+            //
+            // Five further unguarded writes on this path cost nothing *here*
+            // only because the exemption covers them — `selectedWorktreeIDs`
+            // itself, re-assigned to an equal set, and the four unconditional
+            // clears in its own `didSet` tail (`selectedRepoID`,
+            // `selectedScratchSection`, `selectedRemoteProvider`,
+            // `selectedRemoteSession`), each already nil or false. They are
+            // still unguarded; see the sibling test for what they cost when
+            // the values do differ.
+            // `selectionOrder` contributes nothing for the right reason: its
+            // write IS guarded, which is the model the other six should follow.
+            withKnownIssue("re-selecting the current worktree still notifies twice (#667)") {
                 #expect(count == 0)
             }
         }
@@ -862,12 +906,18 @@ struct SelectionCascadeTests {
     /// A real selection change. Not zero, and not one either — the number is the
     /// finding. Pinned as a live assertion so the cascade cannot silently grow.
     ///
-    /// The 9 accounted for in full, because an unattributed total invites a
+    /// The 5 accounted for in full, because an unattributed total invites a
     /// reader to "fix" the wrong line: `selectedWorktreeIDs` (1) +
-    /// `selectionOrder` (1) + the four unconditional clears at
-    /// `AppState.swift:303`–`:306` (4) + `canGoBack`, flipped to true by
-    /// `recordNavigation` because this is the second entry in the history (1) +
-    /// the `recentWorktreeIDs` `removeAll`/`insert` pair at `:316`–`:317` (2).
+    /// `selectionOrder` (1) + `canGoBack`, flipped to true by `recordNavigation`
+    /// because this is the second entry in the history (1) + the
+    /// `recentWorktreeIDs` `removeAll`/`insert` pair (2).
+    ///
+    /// The four unconditional clears in the `didSet` tail (`selectedRepoID`,
+    /// `selectedScratchSection`, `selectedRemoteProvider`,
+    /// `selectedRemoteSession`) contribute nothing: each is a whole-property
+    /// assignment of the nil or false it already held, so the equal-value
+    /// exemption drops them. They remain unguarded, and cost four notifications
+    /// each time the selection actually moves off a repo or remote row.
     @Test("selecting a different worktree")
     func realSelectionChange() {
         withEmissionState { state in
@@ -882,7 +932,7 @@ struct SelectionCascadeTests {
             }
 
             #expect(state.selectionOrder == [rows[1].id])
-            #expect(count == 9)
+            #expect(count == 5)
         }
     }
 
@@ -891,10 +941,10 @@ struct SelectionCascadeTests {
     /// regression back to the per-id mutation `SelectionOrderWriteCoalescingTests`
     /// removed.
     ///
-    /// 8, one fewer than the test above, and the missing one is `canGoBack`:
+    /// 4, one fewer than the test above, and the missing one is `canGoBack`:
     /// this is the FIRST navigation entry, so there is nothing to go back to
-    /// and `updateNavigationFlags` leaves the flag alone. That guard
-    /// (`AppState.swift:413`) is one of the few already in the right place.
+    /// and `updateNavigationFlags` leaves the flag alone. That guard is one of
+    /// the few already in the right place.
     @Test("selecting five worktrees in one gesture")
     func multiSelection() {
         withEmissionState { state in
@@ -908,7 +958,7 @@ struct SelectionCascadeTests {
             }
 
             #expect(state.selectedWorktreeIDs.count == 5)
-            #expect(count == 8)
+            #expect(count == 4)
         }
     }
 }

--- a/Tests/TBDAppTests/AppStateTrackedPropertyCoverageTests.swift
+++ b/Tests/TBDAppTests/AppStateTrackedPropertyCoverageTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+// Tier 1: deterministic, in-process state only.
+
+/// Pins ``AppStateEmissionTracker/readAllTrackedProperties(of:)`` against the
+/// class it measures.
+///
+/// That read list is what makes the object-wide emission count in
+/// `AppStatePublishFrequencyTests` possible: Observation notifies only the
+/// readers of a property, so a property the tracker never reads is a property
+/// whose writes go uncounted — and an uncounted writer looks exactly like a
+/// well-behaved one. Under `ObservableObject` this could not happen, because
+/// `objectWillChange` was object-wide and needed no list.
+///
+/// The check reads the shape the `@Observable` macro leaves behind. The macro
+/// rewrites each tracked stored property into a computed pair over storage it
+/// renames with a leading underscore, and leaves `@ObservationIgnored`
+/// properties as plain storage under their own name. So the underscored
+/// children of a reflected `AppState` — minus the registrar the macro adds —
+/// are exactly its tracked stored properties.
+@MainActor
+@Suite("The emission tracker reads every tracked property of AppState")
+struct AppStateTrackedPropertyCoverageTests {
+
+    /// Tracked stored property names, recovered from the macro's storage.
+    private static func trackedPropertyNames(of state: AppState) -> Set<String> {
+        var found: Set<String> = []
+        for child in Mirror(reflecting: state).children {
+            guard let label = child.label, label.hasPrefix("_") else { continue }
+            if label.hasPrefix("_$") { continue }  // `_$observationRegistrar`
+            found.insert(String(label.dropFirst()))
+        }
+        return found
+    }
+
+    @Test("the read list covers every tracked property, and nothing else")
+    func readListMatchesTheClass() {
+        withEmissionState { state in
+            let actual = Self.trackedPropertyNames(of: state)
+
+            // Guards the guard: if the macro ever stops using underscored
+            // storage, `actual` goes empty and every comparison below passes
+            // vacuously. Assert it found something first.
+            #expect(actual.count > 50,
+                    "expected to recover AppState's tracked storage by reflection, found \(actual.count)")
+
+            let listed = AppStateEmissionTracker.trackedPropertyNames
+            let missing = actual.subtracting(listed)
+            let stale = listed.subtracting(actual)
+
+            #expect(missing.isEmpty,
+                    "tracked but uncounted — add to readAllTrackedProperties: \(missing.sorted())")
+            #expect(stale.isEmpty,
+                    "listed but no longer tracked — remove from readAllTrackedProperties: \(stale.sorted())")
+        }
+    }
+
+    /// The other half of the audit: a property that was deliberately left
+    /// unpublished under `ObservableObject` must stay untracked under
+    /// `@Observable`, where the default inverted. The memo caches are the
+    /// load-bearing case — tracking them would make a cache fill an observable
+    /// mutation during view update — so they are asserted by name.
+    @Test("the derived-worktree memo caches are not tracked")
+    func memoCachesStayUntracked() {
+        withEmissionState { state in
+            let tracked = Self.trackedPropertyNames(of: state)
+            #expect(!tracked.contains("childrenIndexCache"))
+            #expect(!tracked.contains("allWorktreesCache"))
+        }
+    }
+}
+
+/// Pins the one toolchain behaviour every count in
+/// `AppStatePublishFrequencyTests` now rests on.
+///
+/// Swift 6.2's `@Observable` macro drops the notification for a whole-property
+/// assignment of an equal value when the property's type is `Equatable`, and
+/// keeps it for everything reached through `_modify`. That is an optimisation,
+/// not a language guarantee — the migration design explicitly declines to build
+/// a contract on it — so it is asserted here, once, by name. If a toolchain
+/// change reverts or extends it, this fails and says which half moved, instead
+/// of a dozen counts drifting across the frequency file with no stated cause.
+///
+/// It is emphatically not a substitute for the assignment-site guard audit
+/// (#667): it spares only the narrow whole-property case, and the two shapes
+/// below are both live in production paths.
+@MainActor
+@Suite("Observation's equal-value exemption covers assignment, not mutation")
+struct AppStateObservationContractTests {
+
+    @Test("a whole-property assignment of an equal Equatable value notifies nobody")
+    func equalAssignmentIsExempt() {
+        withEmissionState { state in
+            state.isConnected = true
+            #expect(countEmissions(of: state) { state.isConnected = true } == 0)
+            // Positive control: a genuine change still notifies, so the
+            // assertion above cannot be passing because nothing is measured.
+            #expect(countEmissions(of: state) { state.isConnected = false } == 1)
+        }
+    }
+
+    @Test("an in-place mutation notifies even when the value does not change")
+    func inPlaceMutationIsNotExempt() {
+        withEmissionState { state in
+            let terminalID = UUID()
+            state.unreadTerminals = [terminalID]
+            // `insert` of a member already present: the set is unchanged, but
+            // it is reached through `_modify`, which never sees a
+            // before-and-after pair to compare.
+            #expect(countEmissions(of: state) { state.unreadTerminals.insert(terminalID) } == 1)
+        }
+    }
+}

--- a/Tests/TBDAppTests/TabBarHitAreaTests.swift
+++ b/Tests/TBDAppTests/TabBarHitAreaTests.swift
@@ -35,7 +35,7 @@ struct TabBarHitAreaTests {
                     activeTabIndex: .constant(0),
                     onCloseTab: { _ in }
                 )
-                .environmentObject(appState)
+                .environment(appState)
                 .frame(width: 220, height: 30)
             )
             let labelOnlyWidth = keyViewProxyMaxWidth(

--- a/Tests/TBDAppTests/TableTranscriptHarness.swift
+++ b/Tests/TBDAppTests/TableTranscriptHarness.swift
@@ -1754,7 +1754,7 @@ struct TableTranscriptHarness {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 8)
                 .fixedSize(horizontal: false, vertical: true)
-                .environmentObject(appState)
+                .environment(appState)
         ))
         host.translatesAutoresizingMaskIntoConstraints = false
         let container = NSView(frame: frame)

--- a/Tests/TBDAppTests/TranscriptCardAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptCardAttachmentTests.swift
@@ -60,7 +60,7 @@ struct TranscriptCardAttachmentTests {
                 .fixedSize(horizontal: false, vertical: true)
                 .environment(\.transcriptStaticCards, true)
                 .environment(\.openTranscriptOverlay, { _ in })
-                .environmentObject(appState)
+                .environment(appState)
         )
 
         let width = TranscriptCardSizing.width(forLineFragmentWidth: 680)

--- a/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
+++ b/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
@@ -176,7 +176,7 @@ struct WorkbenchSnapshotTests {
             let host = NSHostingView(rootView: AnyView(
                 workbenchView
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .environmentObject(appState)
+                    .environment(appState)
             ))
             host.translatesAutoresizingMaskIntoConstraints = false
             if let appearance = appearance {


### PR DESCRIPTION
## Summary

TBD's sidebar, tab bar and pane placeholders re-render constantly while a terminal
scrolls, even though nothing they display has changed. The reason is structural rather
than accidental: `AppState` was an `ObservableObject` with 104 `@Published` properties
consumed through `@EnvironmentObject` by 88 declarations across 56 view files, and
`objectWillChange` is object-wide. One write to one property re-ran the body of *every*
view observing the object. Readership was irrelevant to invalidation — only writer
frequency mattered, so a property nobody read cost exactly as much as one everybody read.

This PR converts `AppState` to `@Observable`, which replaces object-wide notification
with per-property dependency tracking: a view re-evaluates only when a property it
actually read changes. It is step 1 of 9; the eight sibling observable classes convert in
later PRs and are untouched here.

## Why this shape

The design is `docs/specs/2026-08-25-appstate-observable-migration-design.md`, which
lands separately — it is committed on another worktree's branch, and copying it here
would put the same document on two branches. It records the decision to override the
tracking issue's (#667) deferral of this migration, the nine-PR landing order, the four
hazards, and the no-feature-flag waiver.

**Atomic by necessity.** The class declaration and all 88 `@EnvironmentObject` binding
sites have to flip together — the choice between `@EnvironmentObject` and `@Environment`
is made at compile time. That is also why this ships without a feature flag: a runtime
flag would require every affected view body to exist twice. The revert path is the branch
plus `scripts/restart.sh`.

**Mixed-mode is expected.** The root scenes now inject `.environment(appState)` alongside
`.environmentObject(appearance)` and `.environmentObject(overlayCoordinator)` until those
classes convert.

## What this PR does

- `AppState` becomes `@MainActor @Observable final class`; 104 `@Published` markers are
  dropped.
- **A property-by-property audit, not a find-replace.** The macro inverts the tracking
  default: under `ObservableObject` a property participated only if marked `@Published`;
  under `@Observable` *every* stored property is tracked unless marked
  `@ObservationIgnored`. 76 stored properties whose unpublished status was a deliberate,
  documented decision — memo caches, the two ordering watermarks whose doc comments exist
  precisely to keep a same-value poll from publishing, sequence counters, in-flight `Task`
  handles, `AnyCancellable`s, and 29 `lazy var` injection seams — are each marked
  `@ObservationIgnored`. Every one was checked for view-layer readers first; none has any.
- The two memo-cache getters (`childrenIndex()`, `allWorktrees`) touch their tracked
  source before consulting the cache — see hazard (b) below.
- 88 `@EnvironmentObject var appState: AppState` → `@Environment(AppState.self)`,
  25 `.environmentObject(appState)` → `.environment(appState)`, 1 `@StateObject` →
  `@State`, 3 `@ObservedObject` → a plain stored property, and 7 `$appState.foo` binding
  sites gain a local `@Bindable` shadow.
- The test-side emission counter is rebuilt on `withObservationTracking`, keeping the
  object-wide counts that `AppStatePublishFrequencyTests`' ratchet is built on. **This
  was unenumerated scope**: `AppState` no longer has an `objectWillChange`, and a
  914-line ratchet file plus its helper were built entirely on subscribing to it. Rather
  than convert those 29 assertions to per-property counting — which would have discarded
  the multi-property totals that are the whole point of several of them — the counter now
  arms a tracker that reads every tracked property and re-arms on each fire, so one unit
  is still one notification from any of them. The re-arm is synchronous, because these
  tests write several properties back-to-back inside one synchronous call and a hop to a
  later runloop turn would drop everything in between.

## Hazards, and what actually happened

The spec named four. Two behaved as specified, one was confirmed but only after the
prescribed test shape failed to reproduce it, and one turned out not to apply to this PR.

**(a) Combine consumers — does not apply to PR 1.** The briefing for this work said the
`themeStore.$userThemes` subscription in `AppState.setupAppearanceSubscriptions` was
`AppState`'s to rebuild here. It is not: the site *lives* in `AppState.swift`, but the
publisher belongs to `ThemeStore`, which is still an `ObservableObject` after this PR, so
`$userThemes` keeps compiling and keeps working. The spec agrees — it assigns that bridge
to `ThemeStore`'s PR and the `$schemeID` one to `AppearanceSettings`'. **No Combine
rewiring was needed in this PR**, and none was done; `import Combine` stays in
`AppState.swift` for exactly those two still-live bridges.

**(b) The warm-cache dependency trap — confirmed, and it is a real stale-UI bug.**
The caches behind `childrenIndex()` and `allWorktrees` are `@ObservationIgnored` — they
have to be, since they are filled from inside `body` — so a cache *hit* reads nothing
observable. SwiftUI rebuilds a view's dependency set from what each body
evaluation actually read, so a body served entirely from a warm cache drops its
dependency on `worktrees` — and the next write to it does not invalidate that view. Under
`ObservableObject` the memo was safe because invalidation was object-wide; per-property
tracking removes the net the memo was leaning on. Fixed as the spec prescribes: an
unconditional `_ = worktrees` (and `_ = scratchWorktrees` in `allWorktrees`) before the
cache check, so every evaluation re-registers the dependency. Verified both ways — see
Evidence.

**(c) `@StateObject` → `@State`.** One site, `TBDAppMain.appState`, and the spec was
right to demand an audit — there are *two* differences, not one.

The one the spec names is re-running: a `@State` default-value expression re-runs on every
memberwise init of the declaring struct. Safe here, because `TBDAppMain` is the `@main`
`App` and `App.main()` instantiates it exactly once; the trap needs a struct SwiftUI
recreates, and an `App` is not one.

The one it does not name, and which I initially missed, is *timing*.
`StateObject.init(wrappedValue:)` takes an `@autoclosure @escaping`, so the expression ran
lazily on first body evaluation; `State.init(wrappedValue:)` takes the value directly, so
it now runs when the struct is constructed, inside `App.main()`. `AppState.init` does real
work at that moment — a tmux-executable resolve, three `UserDefaults` restores, a
memory-pressure `DispatchSource`, focus observers, a theme-file watcher, and a
connect/poll `Task`. The app launches and runs correctly with the construction moved, and
the reasoning is recorded at the declaration so the next reader does not have to
rediscover it, but this is the one change in the PR resting on a dogfood observation
rather than a test.

The two per-row/per-pane `@StateObject`s the spec flags (`HoverMenuModel`, `WebviewState`)
belong to later PRs and are untouched.

**(d) Reads outside `body` — this is where the real bugs were.** The spec called this a
review checklist item rather than something the compiler surfaces, and that was exactly
right: an independent review pass over the finished diff found two live regressions here,
both now fixed. Details in the next section, because they matter more than the rest of
this PR.

The rest of the sweep came back clean. The failure shape that matters is a view that
*displays* state cached from a closure read; three candidate sites exist and all three are
one-shot side effects, not display state. `TerminalSettingsView` seeds a draft in
`.onAppear` but also carries `.onChange(of: appState.savedTmuxExecutablePath)`, whose
argument is a body read and therefore registers the dependency correctly.

## Two regressions the review caught, and what they teach

Both were introduced by this commit, both are hazard (d), and neither would have shown up
in a test I had thought to write.

**The remote-session detail pane could fail to switch tabs.**
`DetailSectionHostPager.updateNSViewController` chose the front tab by reading
`isConnected`, `selectedRemoteSession` and `selectedRemoteProvider` — in a representable
update method, not a `body`, and `ContentView.body` reads none of the three. Whether
SwiftUI applies observation tracking to representable update methods is undocumented, so
rather than depend on the answer, the tab choice is now resolved in `ContentView.body` and
passed down as a plain `DetailTab` value. The representable updates because its input
changed, which needs no undocumented behaviour to work.

What makes this one worth reading twice is *why* it was reachable. `activateRemoteSession`
clears five properties and then sets `selectedRemoteSession`. Click a remote-session row
while nothing local is selected and all five clears assign the value already held — so the
equal-value exemption drops all five, and the only surviving notification is for a
property nothing in that body reads. **Two safety nets were removed in the same commit**:
object-wide invalidation, and the redundant-write noise that used to stand in for it. Any
site reading `AppState` outside a `body` now has neither.

**⌘W could stay disabled after clicking into a terminal.**
`resolvedFocusedTabCloseContext()` — behind `canCloseFocusedTab`, behind
`.disabled(!appState.canCloseFocusedTab)` — answers its question from three things
Observation cannot see: `terminalFocusTargets` and `terminalTabCloseContexts` (both
correctly `@ObservationIgnored`) and `NSApp.keyWindow?.firstResponder` (not observable at
all). It touched the tracked `focusedTabCloseContext` only on the branch taken before any
terminal view has registered — i.e. never, in a running app. `TerminalPanelView` writes
that property on every focus in and out, so it is the correct observable proxy for a
first-responder change; it is now read unconditionally, the same shape as the memo-cache
fix. Covered by a discriminating test whose whole point is a *non-empty*
`terminalFocusTargets`, since the empty path returns the property anyway and would pass
either way.

**And one hardening, not a bug.** `TBDCommands` lost its `@ObservedObject`, which was its
only (already-unreliable) subscription, while still computing `.disabled(…)` from
`selectedWorktreeIDs` and `canCloseFocusedTab` in a `Commands` body. Since selection is
empty at launch, a captured value would leave ⌘⇧A, ⌘T and ⌘W permanently disabled. The two
gated menus now put their items in nested `View`s — the same workaround
`ModelProfileMenu` and `NightwatchStatusItem` already use, and for the reason their doc
comments already give. The ungated items stay in the `Commands` body: their closures only
*call* `AppState`, and a closure that runs later needs no dependency.

Three unused `@Environment(AppState.self)` declarations (`PinnedTerminalDock`,
`MultiWorktreeView`, `ArchivedWorktreeRow`) were also removed. They were load-bearing by
accident under `@EnvironmentObject` — declaring it re-rendered the view on any write — and
are inert now, so leaving them would advertise a dependency that no longer exists.

## Assumptions

- Assumes SwiftUI's `Commands` bodies observe no better and no worse than before. The
  existing doc comments already record that they observe unreliably, which is why menu
  *content* lives in nested `View`s — a workaround this PR extends to `TBDCommands`. The
  one read it cannot cover is `NightwatchStatusItem`'s menu title, because `CommandMenu`
  needs the string at `Commands` level: the 🌙/◐ glyph may lag a mode change. That was
  best-effort before this PR and still is, and it is worth a glance while dogfooding.
- Assumes the emission tracker's hand-written read list stays in step with `AppState`.
  Enforced rather than assumed: `AppStateTrackedPropertyCoverageTests` recovers the
  tracked set by reflection and fails if the list drifts either way.
- **`focusedTabCloseContext` is a proxy for focus, not a mirror of it.** It is written on
  mouse-driven focus changes, which is what makes the ⌘W fix work, but programmatic
  `makeFirstResponder` moves (the webview find bar, an inline rename field, a submitting
  text editor) do not write it. Close Tab can therefore stay *enabled* after focus leaves
  a terminal that way; ⌘W then re-resolves and no-ops, so the consequence is a stale menu
  state rather than a wrong close. Closing the gap properly means writing nil on
  resign-first-responder — a change to the focus bookkeeping, not to this read — and is
  left out of this PR deliberately. Recorded at the call site too.
- **Two other representable update methods read tracked state, surveyed and left alone.**
  `RemoteAttachPager.updateNSViewController` reads `remoteProviders`, but its parent
  reads the same property in a body-used computed property, so a late-arriving provider
  re-runs the parent and the pager updates — it self-heals. `TerminalPanelView.updateNSView`
  reads `terminals` to set `isCodexTerminal`, which is computed from `kind` and `label` —
  both fixed when the terminal is spawned — so that read is defensive rather than a live
  transition. Passing the flag down instead would put a `terminals` dependency on
  `PanePlaceholder` and `PinnedTerminalDock`, two of the hottest views in the app, which
  is the churn this PR exists to remove. If `kind` or `label` ever become mutable
  post-spawn, that read needs revisiting.

## An unplanned finding: three ratchet entries retired

Swift 6.2's `@Observable` macro drops the notification for a **whole-property assignment
of an equal value** when the property's type is `Equatable`. Writes reached through
`_modify` (`dict[k] = v`, `rows[i].field = x`, `set.insert(…)`) and properties whose type
is not `Equatable` are not covered and still notify unconditionally.

That silently fixed three of the `withKnownIssue` markers in
`AppStatePublishFrequencyTests` — `mainAreaSize`, `isConnected` and a whole-dictionary
`tabs` re-assign now cost 0 — so per that file's own ratchet convention they are promoted
to live assertions. Four other counts moved and are re-attributed in place; each new
number reconciles exactly with the mechanism (e.g. re-selecting the already-selected
worktree drops 7 → 2: the four unconditional `didSet` clears are equal-value assignments
and are dropped, leaving only the `recentWorktreeIDs` `removeAll`/`insert` pair, which is
`_modify`).

The spec warns this optimisation is "not something to build a contract on". Every count in
that file now rests on it, so rather than leave the dependency implicit, it is asserted
once by name in `AppStateObservationContractTests`: if a toolchain change reverts or
extends it, one test fails and says which half moved instead of a dozen counts drifting
with no stated cause. **It does not retire the assignment-site guard audit**, which stays
open in #667 — it spares only the narrow whole-property case, and both uncovered shapes
are live in production paths.

## The measured gate was deliberately not run, and neither was the diagnostic capture

The spec defines a measured performance gate (graph-flush share of main-thread samples,
before and after). **It was not attempted and this PR claims no performance result.** The
baseline it names is about to move: a separate fix removes wheel-event amplification in
TBD's terminal, which reduces run-loop turns — and because SwiftUI's graph flush is a
run-loop observer, its frequency drops as a direct consequence. Measuring against today's
baseline would either credit this migration with that fix's win or hide its own. The
spec's own acceptance section says as much: "If the amplification fix lands first, this
baseline must be re-measured before the gate is applied." The gate gets applied later,
against a re-taken baseline, by whoever holds both halves.

The spec also asks for a diagnostic capture before this lands — a dogfood session with
temporary instrumentation naming which property fires during a scroll. It is explicitly
non-gating, and its purpose is to make the *after*-measurement interpretable (it tells us
in advance whether the sidebar reads the firing property, which is the difference between
expecting a large win and expecting a null result). Since the measurement it serves is not
being taken here, the capture belongs with the re-taken baseline rather than with this
diff. It has not been done.

This PR therefore stands on the structural argument and on the correctness tests below.

## Evidence & verification

**Three discriminating tests, all mutation-checked** — each was run against the tree
without its fix and observed to fail, not merely asserted to be discriminating.

- *Per-property tracking* (`AppStatePerPropertyTrackingTests`). Hosts a view in an
  `NSHostingView` inside a borderless window, pumps the run loop in bounded slices, and
  counts body evaluations. A write to a property the view does not read leaves the count
  alone; a write to one it does read moves it (the positive control, without which a
  harness that had stopped detecting re-evaluation would pass the first half). The first
  assertion cannot hold under `ObservableObject`. Asserted as before/after comparisons,
  never exact counts. A second case covers a read-set composed the way the sidebar's is —
  through a memo-cached *method*, into a child `ForEach`.
- *The warm-cache trap* (`AppStateWarmCacheDependencySourceTests`). Evaluates cold,
  forces a re-evaluation through a tracked property **and asserts the body count moved**,
  so the cache is provably re-served, then writes `worktrees`. With `_ = worktrees`
  removed from `childrenIndex()`, this fails: `counter.count → 2` did not exceed
  `warm → 2` — the write never reached the view. Restored, it passes. The same claim is
  asserted at the primitive level (`withObservationTracking` registers nothing on a warm
  cache without the touch) and for `allWorktrees` over both of its sources.
- *The focus proxy* (`AppStateFocusedTabTrackingTests`), covering the ⌘W regression above.
  Registers a real `TBDTerminalView` so `terminalFocusTargets` is non-empty — which is the
  whole point, since the empty path returns `focusedTabCloseContext` anyway and would pass
  without the fix — then tracks `canCloseFocusedTab` and writes `focusedTabCloseContext`
  the way `TerminalPanelView` does on focus. With the unconditional read removed:
  `fired.count → 0`.

**A note on where the spec's prescribed test shape did not work.** The spec asks for the
cache test to force its unrelated re-evaluation on a production sidebar view. I hosted the
real `WorktreeSubtreeView` (the right subject — `children(of:)` is its only route to
`worktrees`, unlike `RepoSectionView`, which indexes `appState.worktrees` directly in four
computed properties) and used the `@AppStorage` key it reads to force the re-evaluation.
That test passes with the fix *and without it*: the defaults flip measurably does not
force the re-evaluation the trap needs on that view. Rather than leave a test that guards
nothing while looking like it guards this, it is retained and renamed for what it does
assert — that the real sidebar composition renders a child added after its cache was
warmed — with its doc stating plainly that it does not discriminate and pointing at the
test that does. The discriminating version forces the re-evaluation through a tracked
property instead, and proves the forced evaluation happened rather than assuming it.

**Coverage of the `@ObservationIgnored` audit.** `AppStateTrackedPropertyCoverageTests`
recovers `AppState`'s tracked set by reflection (the macro renames tracked storage with a
leading underscore and leaves ignored properties under their own name) and asserts the
emission tracker's read list matches it exactly in both directions, plus that the two memo
caches are not tracked. It guards its own guard: if reflection stops recovering the
storage the comparisons would pass vacuously, so it first asserts it found something.

**Two independent review passes.** The finished diff was reviewed cold by a separate agent
at high effort, which is where the two hazard-(d) regressions came from; a second, narrower
pass then reviewed the fixes themselves, and produced the two Assumptions entries above
plus a real one: the new focus test drives the path that reaches `NSApp.keyWindow`, and
`NSApp` is an implicitly-unwrapped global that is nil until an application object exists —
so the test now does `_ = NSApplication.shared` first, the same guard
`ComposerTextOwnershipTests` documents, rather than relying on a parallel suite having
created one. The first pass also
independently recomputed the 104/76 property partition and confirmed it is exact, verified
that `_ = worktrees` survives optimisation (the macro's getter calls
`_$observationRegistrar.access`, which mutates a thread-local the optimiser cannot prove
pure), and read the setter/`_modify` templates out of the toolchain's
`libObservationMacros.dylib` to confirm the equal-value exemption is on the setter and
absent from `_modify` rather than inferred from test counts. Every finding it raised is
either fixed above or recorded in Assumptions.

**Suite and lint.** `scripts/test.sh`: 8167 tests in 795 suites, 83 issues of which 82 are
the `withKnownIssue` ratchet markers described above. The remaining one is a
`TerminalActivityEventHandlerTests` case in daemon code this diff does not touch, which a
session working in another worktree independently bisected to cross-suite pollution and
confirmed is not a regression; it passes on a solo rerun. (An earlier run of the same tree
also caught `CodexUsageFetcherLifecycleTests` and a `ReplayLiveIntegrationMatrixTests`
case whose own failure message reads "harness/load, not production" — both timeouts under
concurrent load, both green solo. This machine is running ~9 agent sessions and a load
average near 200.) `swiftlint --strict`: 0 violations in 826 files.

**Live verification, and its limits.** Built and installed through `scripts/restart.sh`
and run against the live daemon. The app launches, the sidebar and tab bar render,
terminal panes stream and repaint, and a live-transcript pane mounts and lays out — which
between them exercise most of the 88 converted binding sites. A missing injection would
not be subtle: `@Environment(AppState.self)`, like `@EnvironmentObject`, traps at runtime
when the object was never injected.

Two caveats, both worth stating rather than glossing:

- **That run predates the review fixes.** The `DetailSectionHostPager(targetTab:)` change,
  the `TBDCommands` restructure and the focus-proxy read went in afterwards, and they
  compile and test green but have not been exercised in a running app. Another worktree
  has since taken the shared daemon and `/Applications/TBD.app` for its own verification,
  so re-taking them would have voided that session's work for a smoke test I had already
  run once. First dogfood should watch three things: the remote-session detail pane
  switching tabs, ⌘W enabling after clicking into a terminal, and the Nightwatch menu-bar
  glyph following a mode change.
- **No screenshot or accessibility read** was possible from this session (neither Screen
  Recording nor assistive access is granted to it), so visual confirmation of sidebar
  reactivity is left to dogfooding rather than claimed here.

One observation worth recording without overclaiming: SwiftUI's
"Publishing changes from within view updates is not allowed" fault is **bursty** in the
pre-change build — across three four-minute windows of the outgoing process I counted 0,
0, and ~5,000. The converted build logged none of it, and none of the `@Observable`
equivalent ("Modifying state during view update") either, over the windows observed. That
is a few minutes of smoke, not a soak, and the burst's trigger was never isolated — so it
is not offered as proof. It is worth stating only because the second of those two messages
is the exact fault the memo caches' `@ObservationIgnored` annotations exist to prevent,
and because the first one can no longer originate from `AppState` at all: it has no
`objectWillChange` any more.

[20260825-mutual-cheetah](https://cheapsteak.github.io/tbd/open/?worktree=6400D927-EA9A-4461-BDE5-62163C94850C)
