### PR TITLE
Feat: Enable SwiftTerm's Metal renderer behind a default-off flag

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3638,6 +3638,54 @@ final class AppState {
     /// "Experimental" section of the General settings tab.
     static let terminalAutoResizeKey = "enableTerminalAutoResize"
 
+    /// UserDefaults key for the experimental Metal terminal renderer. When on,
+    /// every terminal surface calls `applyMetalRendererPreference(enabled:)` on
+    /// the view it has just built, swapping SwiftTerm's CoreGraphics draw path
+    /// for its GPU one. Off by default: replacing a load-bearing rendering path is
+    /// exactly the category that ships default-off and soaks first.
+    ///
+    /// App-side `UserDefaults` rather than a daemon `config` column because the
+    /// behavior is entirely app-side rendering with no daemon participation —
+    /// the same placement as `enableTranscriptKey`, and on the same store as it:
+    /// the Settings toggle binds `@AppStorage`, which always targets
+    /// `UserDefaults.standard`, so every reader must land on `.standard` too or
+    /// the writer and the readers drift apart and the toggle stops doing
+    /// anything. Reads go through `metalTerminalRendererEnabled(defaults:)` —
+    /// never `bool(forKey:)` — so "nobody has chosen" stays distinguishable
+    /// from an explicit `false`.
+    static let useMetalTerminalRendererKey = "useMetalTerminalRenderer"
+
+    /// The one default for `useMetalTerminalRendererKey`, for the reason
+    /// spelled out on `enableTranscriptDefault`. Off until the A/B against a
+    /// standalone emulator says otherwise; graduation is a one-line change
+    /// here, which reaches everyone who never touched the toggle while
+    /// preserving every deliberate opt-out.
+    static let useMetalTerminalRendererDefault = false
+
+    /// Whether newly created terminal views should request SwiftTerm's Metal
+    /// renderer. Three-state read: an unset key takes the shipped default, and
+    /// an explicit `false` survives a change to that constant.
+    ///
+    /// Only `makeNSView` consults this, so flipping the toggle applies to
+    /// terminals opened afterwards — the Settings copy says so, and an app
+    /// restart is the way to move every already-open terminal at once.
+    static func metalTerminalRendererEnabled(defaults: UserDefaults = .standard) -> Bool {
+        metalTerminalRendererEnabled(stored: defaults.object(forKey: useMetalTerminalRendererKey) as? Bool)
+    }
+
+    /// The three-state decision on its own, with the shipped default injected.
+    ///
+    /// Split out so a test can prove the property that makes graduation safe:
+    /// `nil` — nobody chose — follows `shippedDefault`, while an explicit
+    /// `false` holds against a `shippedDefault` of `true`. Reading through
+    /// `bool(forKey:)` instead would collapse those two into one.
+    static func metalTerminalRendererEnabled(
+        stored: Bool?,
+        shippedDefault: Bool = useMetalTerminalRendererDefault
+    ) -> Bool {
+        stored ?? shippedDefault
+    }
+
     /// UserDefaults key for showing the sidebar's Scratch section (repo-less
     /// scratch spaces). Default on.
     static let showScratchSectionKey = "showScratchSection"

--- a/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
+++ b/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
@@ -52,6 +52,11 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
         // down whenever `allowMouseReporting` is true (see
         // `handleClickPassthrough`), so this doesn't double-forward.
         tv.allowMouseReporting = true
+        // The GPU draw path applies to every terminal surface, not just the
+        // tmux panes. Leaving this one out would silently mix renderers inside
+        // a single A/B — a user evaluating the flag would open a remote-attach
+        // terminal, find it still stutters, and blame the renderer.
+        tv.applyMetalRendererPreference(enabled: AppState.metalTerminalRendererEnabled())
         tv.terminalDelegate = context.coordinator
         context.coordinator.terminalView = tv
         context.coordinator.onExit = onExit

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -32,6 +32,8 @@ struct TerminalSettingsView: View {
     @EnvironmentObject var appearance: AppearanceSettings
     @Environment(AppState.self) var appState
     @AppStorage(AppState.terminalAutoResizeKey) private var enableTerminalAutoResize: Bool = false
+    @AppStorage(AppState.useMetalTerminalRendererKey) private var useMetalTerminalRenderer: Bool =
+        AppState.useMetalTerminalRendererDefault
 
     @StateObject private var editorVM = TerminalThemeEditorViewModel()
     @State private var showingSaveAsDialog = false
@@ -219,10 +221,15 @@ struct TerminalSettingsView: View {
             Section {
                 Toggle("Auto-resize tmux windows to match the app pane (WIP)", isOn: $enableTerminalAutoResize)
                     .help("When on, TBD broadcasts the live pane size to the daemon and resizes every tmux window on app resize. Currently unstable — can leave panes smaller than the visible area and clip the bottom rows.")
+                Toggle("GPU terminal rendering (Metal)", isOn: $useMetalTerminalRenderer)
+                    .help("Draws terminals through SwiftTerm's Metal renderer instead of its CoreGraphics path. If the GPU path is unavailable, terminals stay on CoreGraphics. While on, terminals already open keep the glyphs they have already drawn, so a Thin Strokes change reaches them only as new characters appear.")
+                Text("Takes effect for terminals opened after the change — restart the app to switch every open terminal at once.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             } header: {
                 Text("Experimental")
             } footer: {
-                Text("Off by default — under active development. Known bugs around tmux \"window-size manual\" lock-in can clip the bottom rows of a pane. To bail out, turn it off and restart the app.")
+                Text("Both off by default — under active development. Auto-resize has known bugs around tmux \"window-size manual\" lock-in that can clip the bottom rows of a pane; to bail out of either setting, turn it off and restart the app.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -1,6 +1,9 @@
 import AppKit
 import Combine
 import SwiftTerm
+import os
+
+private let terminalViewLogger = Logger(subsystem: "com.tbd.app", category: "terminalRenderer")
 
 private extension CharacterSet {
     /// Characters that require shell quoting when they appear in a file path.
@@ -181,6 +184,19 @@ class TBDTerminalView: TerminalView {
         // SwiftTerm's `fontSmoothing = false` is what produces iTerm's
         // "Thin Strokes" rendering, so we invert the user-facing toggle.
         self.fontSmoothing = !appearanceSettings.thinStrokes
+        // Known limitation under the Metal flag, and TBD cannot close it from
+        // here. `fontSmoothing`'s setter is a bare stored-property write, so
+        // this `needsDisplay` is the only repaint — and it is a no-op under
+        // Metal, where `draw(_:)` early-returns. Forcing a Metal frame instead
+        // would not help: the renderer re-reads `fontSmoothing` every frame,
+        // but the glyph atlas is keyed on (font, size, glyph) with smoothing
+        // absent from the key, and nothing flushes it on a smoothing change.
+        // So an already-open terminal keeps the glyphs it has drawn, and only
+        // characters it has not yet rasterized pick the new setting up — a mix,
+        // not a clean deferral. Rebuilding the renderer would fix it, at the
+        // cost of a runtime shader compile per view; not worth it for a taste
+        // toggle on an experimental flag. The Settings help says what happens,
+        // and the durable fix is an upstream atlas-invalidation hook.
         self.needsDisplay = true
     }
 
@@ -308,14 +324,174 @@ class TBDTerminalView: TerminalView {
         return (cellWidth, cellHeight)
     }
 
+    /// What a capture has to do about the renderer before it can read pixels.
+    enum CapturePreparation: Equatable {
+        /// CoreGraphics is already drawing into the backing store.
+        case captureDirectly
+        /// Metal owns the pixels; drop to CoreGraphics and put it back after.
+        case dropToCoreGraphicsThenRestore
+    }
+
+    /// The capture-time renderer decision, extracted so it can be asserted
+    /// without a GPU.
+    ///
+    /// It cannot be asserted *with* one under `scripts/test.sh`: SwiftTerm
+    /// resolves its shaders relative to `Bundle.main`, which in a test run is
+    /// the toolchain's xctest helper rather than the build directory, so
+    /// `setUseMetal(true)` throws `shaderSourceMissing` and the Metal branch is
+    /// unreachable in-process. Splitting the decision out is what keeps that
+    /// branch covered anyway — delete the drop-to-CoreGraphics and this goes
+    /// red, GPU or no GPU.
+    static func capturePreparation(isUsingMetalRenderer: Bool) -> CapturePreparation {
+        isUsingMetalRenderer ? .dropToCoreGraphicsThenRestore : .captureDirectly
+    }
+
+    /// Requests SwiftTerm's Metal renderer for this view when `enabled`.
+    ///
+    /// Returns whether the GPU path is actually active afterwards, which is
+    /// what tests assert on — `setUseMetal(_:)` throws on hardware without
+    /// Metal or when the pipeline cannot be built, and degrading to the
+    /// CoreGraphics path we shipped for years is always correct. The failure is
+    /// logged at `.error` once per terminal view — not once per app run — and
+    /// never retried: a per-frame retry would turn a hardware fact into a log
+    /// flood, while one line per view stays proportionate and tells you which
+    /// views degraded.
+    ///
+    /// With `enabled` false this makes no `setUseMetal` call at all, so the
+    /// default branch is byte-for-byte the path that existed before the flag.
+    @discardableResult
+    func applyMetalRendererPreference(enabled: Bool) -> Bool {
+        guard enabled else { return false }
+        // Wait for a window. Enabling Metal on a view SwiftUI has not attached
+        // yet stores `metalBoundWindow = nil`, and `viewDidMoveToWindow` then
+        // rebinds — building a SECOND MTKView, renderer, glyph atlas and
+        // pipeline set and discarding the first, synchronously on the main
+        // thread. Renderer construction runs a runtime compile of SwiftTerm's
+        // shader source (there is no `default.metallib` to short-circuit it)
+        // and `makeLibrary` has no cache, so opening a worktree with six tabs
+        // would pay twelve of those, half of them thrown away milliseconds
+        // later. That is exactly the cost this flag exists to measure, so
+        // paying it twice would contaminate the A/B it is here to inform.
+        switch Self.metalActivation(hasWindow: window != nil) {
+        case .deferUntilWindowed:
+            wantsMetalRendererOnWindow = true
+            return false
+        case .now:
+            return enableMetalRenderer()
+        }
+    }
+
+    /// When a Metal request can be honoured.
+    enum MetalActivation: Equatable {
+        case now
+        case deferUntilWindowed
+    }
+
+    /// Extracted so the deferral is assertable without a GPU — the same reason
+    /// `capturePreparation(isUsingMetalRenderer:)` is. Losing it costs one
+    /// wasted renderer build per terminal and nothing goes red, which is how
+    /// it got shipped the first time.
+    static func metalActivation(hasWindow: Bool) -> MetalActivation {
+        hasWindow ? .now : .deferUntilWindowed
+    }
+
+    /// Set when the flag was on but the view had no window yet;
+    /// `viewDidMoveToWindow` consumes it exactly once.
+    ///
+    /// Internal rather than `private` only so a test can watch that handoff.
+    /// Production takes the deferring branch every time — both call sites
+    /// request Metal from `makeNSView`, before SwiftUI has attached the view —
+    /// and `isUsingMetalRenderer` cannot stand in as the observable, because the
+    /// GPU path is unreachable in a test process. Nothing outside this file
+    /// reads it.
+    var wantsMetalRendererOnWindow = false
+
+    private func enableMetalRenderer() -> Bool {
+        do {
+            try setUseMetal(true)
+            // Positive confirmation. During the soak the question "is the GPU
+            // path actually on?" has to be answerable from the log:
+            // `setUseMetal` degrades silently by design, so the ABSENCE of the
+            // error below is not evidence that Metal engaged — only this line
+            // is.
+            //
+            // `.notice`, not `.info`, and the difference is the whole point.
+            // `.info` lives in a memory ring buffer that `log show` loses
+            // within minutes; this line was already unreadable ~15 minutes
+            // after the launch that wrote it. `.notice` persists to disk, so
+            // somebody can answer the question the next morning. It fires once
+            // per terminal view, which is rare enough to afford that.
+            terminalViewLogger.notice("Metal terminal renderer active for this terminal view")
+            return true
+        } catch {
+            terminalViewLogger.error(
+                "Metal terminal renderer unavailable; staying on CoreGraphics: \(String(describing: error), privacy: .public)"
+            )
+            return false
+        }
+    }
+
     /// Capture the current visible terminal content as an NSImage.
     /// Returns nil if the view has no dimensions yet.
+    ///
+    /// Runs the capture with the CoreGraphics renderer temporarily reinstated —
+    /// see `withCoreGraphicsRendering(_:)` for why a Metal-backed view would
+    /// otherwise hand back a blank image.
     func captureScreenshot() -> NSImage? {
         guard bounds.width > 0 && bounds.height > 0 else { return nil }
-        guard let bitmapRep = bitmapImageRepForCachingDisplay(in: bounds) else { return nil }
-        cacheDisplay(in: bounds, to: bitmapRep)
-        guard let cgImage = bitmapRep.cgImage else { return nil }
-        return NSImage(cgImage: cgImage, size: bounds.size)
+        return withCoreGraphicsRendering {
+            guard let bitmapRep = bitmapImageRepForCachingDisplay(in: bounds) else { return nil }
+            cacheDisplay(in: bounds, to: bitmapRep)
+            guard let cgImage = bitmapRep.cgImage else { return nil }
+            return NSImage(cgImage: cgImage, size: bounds.size)
+        }
+    }
+
+    /// Runs `body` with this view on SwiftTerm's CoreGraphics draw path,
+    /// restoring the Metal renderer afterwards if it was active.
+    ///
+    /// `bitmapImageRepForCachingDisplay` + `cacheDisplay` read the view's
+    /// backing store by re-running `draw(_:)` down the subview tree. A
+    /// Metal-backed `TerminalView` renders into a `CAMetalLayer` owned by an
+    /// `MTKView` subview, which draws through its layer rather than through
+    /// `draw(_:)` — so that capture path sees no glyphs and returns a blank
+    /// image. A blank image is a *silent* regression: it still renders as an
+    /// image, so nothing downstream reports the failure.
+    ///
+    /// `setUseMetal(_:)` is togglable in both directions at runtime, so the fix
+    /// is to drop to CoreGraphics for the duration of the capture. The whole
+    /// round trip happens inside one main-thread turn, so the compositor never
+    /// commits the intermediate hierarchy and the swap is not visible; the
+    /// `drawMetalFrameNow()` on the way back is belt and braces, forcing the
+    /// freshly built `MTKView` to produce a frame synchronously rather than
+    /// leaving it blank until the next runloop turn.
+    ///
+    /// Re-enabling rebuilds the `MTKView`, its renderer and its glyph atlas,
+    /// which is not free — acceptable because captures are user-gestured and
+    /// occasional, not per-frame.
+    private func withCoreGraphicsRendering<T>(_ body: () -> T) -> T {
+        guard Self.capturePreparation(isUsingMetalRenderer: isUsingMetalRenderer)
+            == .dropToCoreGraphicsThenRestore
+        else { return body() }
+        do {
+            try setUseMetal(false)
+        } catch {
+            terminalViewLogger.error(
+                "Could not drop to CoreGraphics for capture; snapshot may be blank: \(String(describing: error), privacy: .public)"
+            )
+            return body()
+        }
+        defer {
+            do {
+                try setUseMetal(true)
+                drawMetalFrameNow()
+            } catch {
+                terminalViewLogger.error(
+                    "Could not restore the Metal renderer after capture; staying on CoreGraphics: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+        return body()
     }
 
     /// Converts a window-coordinate point to terminal grid (col, row).
@@ -386,6 +562,14 @@ class TBDTerminalView: TerminalView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         if window != nil {
+            // Deferred from `applyMetalRendererPreference`, which could not run
+            // before the view had a window without costing a second renderer
+            // build. Consumed once: a later reparent is upstream's rebind to
+            // handle, not ours to re-request.
+            if wantsMetalRendererOnWindow {
+                wantsMetalRendererOnWindow = false
+                _ = enableMetalRenderer()
+            }
             installMouseMonitor()
             registerForDraggedTypes([.fileURL])
         } else {

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -314,6 +314,13 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         // instead of forwarding mouse events to tmux
         tv.allowMouseReporting = false
 
+        // Experimental GPU draw path (default off — Settings → Terminal →
+        // Experimental). Requested here rather than in `updateNSView` so a
+        // view never swaps renderers mid-life; flipping the toggle therefore
+        // reaches terminals opened afterwards, and an app restart moves them
+        // all. A throw leaves this view on CoreGraphics.
+        tv.applyMetalRendererPreference(enabled: AppState.metalTerminalRendererEnabled())
+
         // Wire up Cmd+Click file path detection
         tv.worktreePath = worktreePath
         tv.remoteURL = remoteURL

--- a/Tests/TBDAppTests/MetalTerminalRendererSettingTests.swift
+++ b/Tests/TBDAppTests/MetalTerminalRendererSettingTests.swift
@@ -1,0 +1,412 @@
+import AppKit
+import Foundation
+import Metal
+import SwiftTerm
+import Testing
+
+@testable import TBDApp
+
+/// Storage contract for the experimental Metal renderer flag. Three states,
+/// and the one that matters is `nil`: graduation is meant to be a one-line
+/// change to `useMetalTerminalRendererDefault` that reaches everyone who never
+/// touched the toggle *without* overriding anyone who deliberately turned it
+/// off. That only holds if "nobody chose" is distinguishable from an explicit
+/// `false`, which a `bool(forKey:)` read would destroy.
+@MainActor
+@Suite("useMetalTerminalRenderer setting")
+struct MetalTerminalRendererSettingTests {
+    @Test("ships off — replacing the draw path soaks behind a flag first")
+    func defaultsToOff() {
+        #expect(AppState.useMetalTerminalRendererDefault == false)
+    }
+
+    @Test("an unset key reads the shipped default")
+    func unsetReadsShippedDefault() {
+        let suiteName = "metal-renderer-unset-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(defaults.object(forKey: AppState.useMetalTerminalRendererKey) == nil)
+        #expect(
+            AppState.metalTerminalRendererEnabled(defaults: defaults)
+                == AppState.useMetalTerminalRendererDefault)
+    }
+
+    @Test("both explicit values round-trip through the read")
+    func explicitValuesRoundTrip() {
+        let suiteName = "metal-renderer-explicit-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: AppState.useMetalTerminalRendererKey)
+        #expect(AppState.metalTerminalRendererEnabled(defaults: defaults))
+        defaults.set(false, forKey: AppState.useMetalTerminalRendererKey)
+        #expect(!AppState.metalTerminalRendererEnabled(defaults: defaults))
+    }
+
+    /// The graduation rehearsal: flip the shipped default to `true` and check
+    /// that only the untouched state follows it.
+    @Test("an explicit false survives a change to the default constant; nil follows it")
+    func explicitFalseSurvivesGraduation() {
+        #expect(AppState.metalTerminalRendererEnabled(stored: nil, shippedDefault: true))
+        #expect(!AppState.metalTerminalRendererEnabled(stored: false, shippedDefault: true))
+        #expect(AppState.metalTerminalRendererEnabled(stored: true, shippedDefault: false))
+        #expect(!AppState.metalTerminalRendererEnabled(stored: nil, shippedDefault: false))
+    }
+
+    /// The gate reads whichever suite it is *given*, which is what lets a test
+    /// exercise it at all: `metalTerminalRendererEnabled()` defaults to
+    /// `.standard`, and on this unbundled executable `.standard` is the
+    /// developer's real plist. Production leaves the parameter off on purpose —
+    /// the Settings toggle writes `.standard` through `@AppStorage`, so every
+    /// reader has to resolve there or the toggle silently stops taking effect.
+    @Test("the gate reads the suite it is handed, not a store of its own")
+    func readerFollowsInjectedDefaults() {
+        let suiteName = "metal-renderer-injected-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(
+            AppState.metalTerminalRendererEnabled(defaults: defaults)
+                == AppState.useMetalTerminalRendererDefault)
+
+        defaults.set(true, forKey: AppState.useMetalTerminalRendererKey)
+        #expect(AppState.metalTerminalRendererEnabled(defaults: defaults))
+
+        defaults.set(false, forKey: AppState.useMetalTerminalRendererKey)
+        #expect(!AppState.metalTerminalRendererEnabled(defaults: defaults))
+    }
+}
+
+/// Both branches of the flag against a live `TBDTerminalView`, plus the hazard
+/// the flag introduces: a Metal-backed view renders into a `CAMetalLayer`, and
+/// the snapshot path reads the view's *backing store*. A blank snapshot is a
+/// silent regression — a blank image still renders as an image — so the
+/// non-blank assertion is the only thing standing between the flag and a
+/// wordlessly broken sidebar preview.
+@MainActor
+@Suite("Metal renderer: both branches, and snapshots survive")
+struct MetalTerminalRendererViewTests {
+    /// Hosts the view in a real off-screen `NSWindow`.
+    ///
+    /// **Note the ordering differs from production, deliberately.**
+    /// `TerminalPanelView.makeNSView` enables Metal on a view that has no
+    /// superview and no window yet — SwiftUI attaches it afterwards — which is
+    /// the ordering SwiftTerm's own documentation advises against. It works
+    /// because `metalBoundWindow` starts nil and `viewDidMoveToWindow` then
+    /// rebinds, tearing down the off-window `MTKView`, renderer and glyph atlas
+    /// and rebuilding them. So production pays one build-and-discard per
+    /// terminal opened, and relies on that rebind path rather than on the
+    /// documented ordering.
+    ///
+    /// This helper windows the view first because that is the *quieter* of the
+    /// two paths to test against: it exercises the renderer without also
+    /// exercising the rebind. Neither ordering is currently reachable in-process
+    /// anyway — see `flagOnEndToEnd` — so this is about not encoding a false
+    /// claim in a comment, not about coverage we have.
+    private func withView(_ body: (TBDTerminalView) -> Void) {
+        // AppearanceSettings must never read or write the developer's real
+        // TBDApp.plist (the UserDefaults twin of the ~/tbd fence).
+        let suiteName = "TBDAppTests.MetalRenderer.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let frame = CGRect(x: 0, y: 0, width: 400, height: 200)
+        let view = TBDTerminalView(
+            frame: frame,
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: defaults))
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.contentView?.addSubview(view)
+        view.layoutSubtreeIfNeeded()
+        defer { view.removeFromSuperview() }
+        body(view)
+    }
+
+    /// Writes enough text that a correct capture cannot be a single flat
+    /// color, whichever renderer produced it.
+    private func feedSampleText(_ view: TBDTerminalView) {
+        let line = String(repeating: "MW#@8", count: 40)
+        view.feed(text: "\(line)\r\n\(line)\r\n\(line)\r\n")
+        view.layoutSubtreeIfNeeded()
+    }
+
+    /// Whether a capture contains more than one distinct pixel. A blank
+    /// snapshot — the Metal failure mode — is uniformly the background color,
+    /// so "not all pixels equal" is the discriminating property, and it does
+    /// not depend on which renderer drew the glyphs.
+    private func hasVaryingPixels(_ image: NSImage) -> Bool {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return false
+        }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        guard rep.pixelsWide > 0, rep.pixelsHigh > 0 else { return false }
+        let first = rep.colorAt(x: 0, y: 0)
+        for y in stride(from: 0, to: rep.pixelsHigh, by: 2) {
+            for x in stride(from: 0, to: rep.pixelsWide, by: 2) {
+                if rep.colorAt(x: x, y: y) != first { return true }
+            }
+        }
+        return false
+    }
+
+    /// The outcome of asking for the GPU path, with the reason kept when it
+    /// could not be had.
+    private enum MetalOutcome {
+        case active
+        case unavailable(Error)
+    }
+
+    /// Turns Metal on, keeping the thrown `MetalError` instead of swallowing it.
+    ///
+    /// `applyMetalRendererPreference` deliberately swallows it — that is the
+    /// production contract, degrade and carry on. But a test that only sees
+    /// `false` cannot tell "this machine has no GPU" from "the shader library
+    /// did not resolve", and those want opposite responses.
+    private func enableMetal(_ view: TBDTerminalView) -> MetalOutcome {
+        do {
+            try view.setUseMetal(true)
+            return .active
+        } catch {
+            return .unavailable(error)
+        }
+    }
+
+    /// Where SwiftTerm probes for `Shaders.metal`, for the failure
+    /// text. Knowing *which* paths were searched is the difference between
+    /// "this machine has no GPU" and "the resource bundle was not staged next
+    /// to the binary" — the second is a packaging bug, not a hardware fact.
+    private static func shaderBundleCandidates() -> String {
+        let name = "SwiftTerm_SwiftTerm.bundle"
+        let probes: [(String, URL?)] = [
+            ("Bundle.main.resourceURL", Bundle.main.resourceURL?.appendingPathComponent(name)),
+            ("Bundle.main.bundleURL", Bundle.main.bundleURL.appendingPathComponent(name)),
+            ("Bundle(for: TBDTerminalView.self).resourceURL",
+             Bundle(for: TBDTerminalView.self).resourceURL),
+        ]
+        return probes.map { label, url in
+            guard let url else { return "\(label)=<nil>" }
+            let exists = FileManager.default.fileExists(atPath: url.path)
+            return "\(label)=\(url.path) [\(exists ? "present" : "absent")]"
+        }.joined(separator: ", ")
+    }
+
+    /// Carries a diagnosis onto the PRIMARY failure line. `#expect(_:_:)` and
+    /// `Issue.record(String)` both demote the text to a trailing `↳` that CI
+    /// summaries drop — Tests/CLAUDE.md assertion-hygiene rule 4.
+    private struct MetalDiagnosis: Error, CustomStringConvertible {
+        let what: String
+        let underlying: String
+        /// Captured at the call site: `description` is nonisolated, and the
+        /// probe that builds this reads main-actor state.
+        let bundles: String
+        var description: String {
+            "\(what): \(underlying); shader-bundle candidates were \(bundles)"
+        }
+    }
+
+    @Test("flag off: no setUseMetal call, the view stays on CoreGraphics")
+    func flagOffLeavesCoreGraphics() {
+        withView { view in
+            let active = view.applyMetalRendererPreference(enabled: false)
+            #expect(!active)
+            #expect(!view.isUsingMetalRenderer)
+        }
+    }
+
+    @Test("flag off: snapshots keep working, unchanged")
+    func flagOffSnapshotIsNonBlank() {
+        withView { view in
+            view.applyMetalRendererPreference(enabled: false)
+            feedSampleText(view)
+            let shot = view.captureScreenshot()
+            #expect(shot != nil)
+            #expect(shot.map(hasVaryingPixels) == true)
+        }
+    }
+
+    /// The capture-time renderer decision, both ways. This is the branch the
+    /// end-to-end test below cannot reach in-process, and it is discriminating
+    /// on its own: drop the Metal case and the terminal's snapshots go blank
+    /// with nothing else going red.
+    @Test("a Metal-backed view must not be captured through its backing store")
+    func capturePreparationCoversBothRenderers() {
+        #expect(
+            TBDTerminalView.capturePreparation(isUsingMetalRenderer: true)
+                == .dropToCoreGraphicsThenRestore)
+        #expect(
+            TBDTerminalView.capturePreparation(isUsingMetalRenderer: false)
+                == .captureDirectly)
+    }
+
+    /// Metal is requested only once the view has a window.
+    ///
+    /// Enabling it earlier "works" — upstream rebinds on `viewDidMoveToWindow` —
+    /// but the rebind builds a second `MTKView`, renderer, glyph atlas and
+    /// pipeline set and throws the first away, synchronously, including a
+    /// runtime shader compile that nothing caches. Nothing goes red when that
+    /// regresses; the terminals just cost twice as much to open, which would
+    /// quietly corrupt the very A/B this flag exists to serve.
+    @Test("a Metal request waits for the view to have a window")
+    func metalActivationWaitsForWindow() {
+        #expect(TBDTerminalView.metalActivation(hasWindow: true) == .now)
+        #expect(TBDTerminalView.metalActivation(hasWindow: false) == .deferUntilWindowed)
+    }
+
+    /// The whole flag-on path, end to end — Metal active, a non-blank capture,
+    /// and the view still on Metal afterwards.
+    ///
+    /// **It does not run here, and the `else` branch is why that is visible
+    /// rather than silent.** SwiftTerm resolves `Shaders.metal` against
+    /// `Bundle.main`, which in a test run is the toolchain's xctest helper, not
+    /// the build directory holding `SwiftTerm_SwiftTerm.bundle` — so
+    /// `setUseMetal(true)` throws `shaderSourceMissing` and the GPU path is
+    /// unreachable in-process. Rather than skip quietly, the test pins *that
+    /// diagnosis*: any other failure reason reds it, and the day the resource
+    /// resolves (a SwiftPM layout change, an upstream fix, a packaged runner)
+    /// the real assertions start running with no edit here.
+    ///
+    /// The live-app half of this is not optional — see the PR description.
+    @Test("flag on: Metal active, capture non-blank, renderer restored")
+    func flagOnEndToEnd() throws {
+        try #require(MTLCreateSystemDefaultDevice() != nil, "no Metal device on this machine")
+        withView { view in
+            switch enableMetal(view) {
+            case .active:
+                #expect(view.isUsingMetalRenderer)
+                // The production wrapper agrees with the raw call: a re-request
+                // is a no-op and still reports the GPU path as on.
+                #expect(view.applyMetalRendererPreference(enabled: true))
+
+                feedSampleText(view)
+                let shot = view.captureScreenshot()
+                #expect(shot != nil)
+                // A blank result here means the CoreGraphics round trip
+                // failed, NOT that the Metal drawable was unavailable: the
+                // capture deliberately disables Metal and draws through
+                // CoreGraphics, so it never reads a drawable. The
+                // `drawMetalFrameNow()` on the way back is the only part that
+                // wants one, and it cannot affect the bitmap already captured.
+                #expect(
+                    shot.map(hasVaryingPixels) == true,
+                    "Metal-backed capture came back blank — the CoreGraphics round trip in captureScreenshot() is not holding")
+                #expect(
+                    view.isUsingMetalRenderer,
+                    "the capture must not strand the view on CoreGraphics")
+
+            case .unavailable(let error):
+                // Pin the ONE case this is allowed to be unreachable for, by
+                // matching the case and not its prose. `MetalError`'s
+                // description strings share wording across five of its eleven
+                // cases — "shader source" alone also admits
+                // `shaderCompilationFailed`, and "Metal library" admits
+                // `shaderFunctionMissing` and `shaderLibraryLoadFailed`. A
+                // substring allowlist would therefore let a genuinely broken
+                // shader or a missing entry point pass as "expected" on the day
+                // the resource resolves in-process — which is precisely the day
+                // this test is supposed to start doing its job.
+                guard case MetalError.shaderSourceMissing = error else {
+                    Issue.record(
+                        MetalDiagnosis(
+                            what: "setUseMetal(true) failed for a reason other than the known "
+                                + "test-process shader-resolution gap",
+                            underlying: String(describing: error),
+                            bundles: Self.shaderBundleCandidates()))
+                    return
+                }
+                // Even unreachable, the capture path must still be sound on the
+                // CoreGraphics side it fell back to.
+                feedSampleText(view)
+                #expect(view.captureScreenshot().map(hasVaryingPixels) == true)
+                #expect(!view.isUsingMetalRenderer)
+            }
+        }
+    }
+
+    /// A view with **no** window, plus the means to give it one.
+    ///
+    /// This is the ordering production actually uses and `withView` above
+    /// deliberately does not: both `TerminalPanelView.makeNSView` and
+    /// `LocalPTYTerminalView.makeNSView` apply the preference before SwiftUI
+    /// attaches the view, so every shipped terminal takes the deferring branch
+    /// and the handoff to `viewDidMoveToWindow` is the only thing that makes
+    /// the flag mean anything.
+    private func withWindowlessView(
+        _ body: (TBDTerminalView, _ attachToWindow: () -> Void) -> Void
+    ) {
+        // Same reason as `withView`: AppearanceSettings must never reach the
+        // developer's real TBDApp.plist.
+        let suiteName = "TBDAppTests.MetalRendererDeferral.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let frame = CGRect(x: 0, y: 0, width: 400, height: 200)
+        let view = TBDTerminalView(
+            frame: frame,
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: defaults))
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        defer { view.removeFromSuperview() }
+        body(view) {
+            // `addSubview` into a windowed hierarchy drives
+            // `viewDidMoveToWindow` synchronously, which is the handoff itself.
+            window.contentView?.addSubview(view)
+            view.layoutSubtreeIfNeeded()
+        }
+    }
+
+    /// The branch production always takes. Returning `false` here is not a
+    /// refusal — it is "not yet" — and the difference is only observable in the
+    /// armed flag, so a deferral that silently dropped the request would look
+    /// identical to a machine without a GPU.
+    @Test("flag on before the view has a window: the request defers, it is not dropped")
+    func metalRequestDefersWhenWindowless() {
+        withWindowlessView { view, _ in
+            #expect(!view.applyMetalRendererPreference(enabled: true))
+            #expect(view.wantsMetalRendererOnWindow)
+        }
+    }
+
+    /// The other half of the handoff, and the half nothing else covers: drop
+    /// the consumption in `viewDidMoveToWindow` and the flag stops reaching any
+    /// terminal opened the normal way, with every other test still green.
+    ///
+    /// The consumed flag is the whole assertion on purpose — do not "fix" this
+    /// by also checking `isUsingMetalRenderer`. `setUseMetal(true)` throws
+    /// `shaderSourceMissing` in a test process (see `flagOnEndToEnd`), so the
+    /// view legitimately ends up back on CoreGraphics whether or not the
+    /// handoff ran, and asserting on it would either red permanently or say
+    /// nothing.
+    @Test("a window arriving consumes the deferred Metal request")
+    func windowArrivalConsumesDeferredRequest() {
+        withWindowlessView { view, attachToWindow in
+            view.applyMetalRendererPreference(enabled: true)
+            #expect(view.wantsMetalRendererOnWindow)
+
+            attachToWindow()
+            #expect(!view.wantsMetalRendererOnWindow)
+        }
+    }
+
+    /// The gate on the deferral, not just on the immediate call. A deferral
+    /// armed unconditionally would leave the off branch requesting Metal a
+    /// moment later, from `viewDidMoveToWindow` — the flag would read as off
+    /// and behave as on, which is the one outcome a default-off soak cannot
+    /// tolerate.
+    @Test("flag off arms no deferral, and a window arriving does not create one")
+    func flagOffNeverArmsDeferral() {
+        withWindowlessView { view, attachToWindow in
+            #expect(!view.applyMetalRendererPreference(enabled: false))
+            #expect(!view.wantsMetalRendererOnWindow)
+
+            attachToWindow()
+            #expect(!view.wantsMetalRendererOnWindow)
+        }
+    }
+}

--- a/docs/specs/2026-08-25-terminal-metal-renderer-design.md
+++ b/docs/specs/2026-08-25-terminal-metal-renderer-design.md
@@ -1,0 +1,291 @@
+# Enabling SwiftTerm's Metal renderer for embedded terminals
+
+TBD embeds SwiftTerm to draw its terminals. SwiftTerm ships two draw paths — a
+CoreGraphics one and a Metal one behind a public `setUseMetal(_:)` — and TBD had
+never called the second, so every terminal-render measurement TBD had ever taken
+was of the CoreGraphics path while a GPU path sat unused in the same binary.
+
+This design adds a default-off flag that selects between them, so the two can be
+compared from Settings on a real workload. It ships as an experiment with a
+recorded result, not as a performance fix.
+
+## Why the draw path was suspected
+
+Embedded terminals scrolled and typed noticeably slower than a standalone
+terminal emulator on the same machine. A control experiment isolates that to
+TBD's frontend rather than to the machine, the daemon, tmux, or the hosted
+agent's output volume:
+
+- A standalone emulator running a **plain shell** — smooth.
+- The same emulator running the **same agent TUI**, attached to the **same tmux
+  session** on the **same loaded machine** — smooth.
+- A TBD terminal running that TUI — laggy.
+
+Only the frontend differs across those three, so the frontend is the variable
+that matters. The daemon is separately excluded: with tmux control mode off,
+terminal I/O runs app to local PTY with no daemon participation, and daemon
+sampling during the same windows showed its main thread idle and its worker
+activity peaking in the window that captured no scrolling at all.
+
+Sampling the app across windows scored for containing actual scrolling put real
+cost in the CoreGraphics draw path. Percentages below are of main-thread samples,
+in two validated scroll windows against a quiet baseline:
+
+- **Terminal draw** — 20.7% and 11.6%, against 4.0% quiet.
+- **The per-row attributed-string rebuild inside it** — 12.8% and 7.5%, against
+  2.2%. That code rebuilds an attributed string for every row intersecting the
+  dirty rect on every draw, with no row-level cache of the built segments.
+- **The shaped-line cache alongside it** — value-keyed but capped at
+  eight-character segments, so ordinary text re-shapes every frame.
+- **Terminal feed and parse** — around 2.7%.
+
+Those are real inefficiencies in code that runs on every frame, and a GPU
+renderer covering exactly that stage existed and was unreachable. Enabling it
+behind a flag is an afternoon's work and reversible, so it was worth measuring
+rather than arguing about.
+
+## What the flag can and cannot reach
+
+Two facts bound the prize, and both were established by measurement rather than
+by reading code. They belong here because they decide how a flat result should be
+read.
+
+**The genuinely expensive path is upstream of drawing.** Deterministic
+benchmarking finds that the one costly workload — high-rate line-append while
+scrolling — spends its cost in `feed`, that is in parse and damage tracking,
+which sits *upstream* of the draw stage a GPU renderer replaces. A GPU renderer
+substitutes how a frame is drawn; it does not touch what produced the frame.
+
+**Drawing was already cheap in absolute terms.** A display pass costs single-digit
+milliseconds (median around 6 ms) and a parse a tenth of a millisecond. Under
+typing, display passes fall to 19.3 per second against a 60 per second budget,
+with a p90 gap of 101 ms and a worst gap of 846 ms — the render loop is *starved*,
+not slow. Making a cheap pass cheaper does not fix a pass that never gets to run.
+
+Neither fact makes the experiment worthless: the draw path is genuinely
+inefficient and the flag is cheap. Both mean the expected prize is small, and
+that a null result should be read as confirming the cost lies elsewhere rather
+than as a failure of the GPU path.
+
+## How this sits on SwiftTerm 2.0
+
+TBD pins a SwiftTerm 2.0 fork revision (`62d0be6d4c9641a4b27f311c55e1489b024271c3`).
+That revision moves parsing onto the PTY IO thread, puts `Terminal` access behind
+a public ticket lock, and replaces the fixed 16.67 ms paint floor with a
+display-link frame scheduler. Three consequences for this flag:
+
+- **The call survives the version unchanged.** `setUseMetal(_:)` is still the
+  entry point at the pinned revision; nothing about the 2.0 concurrency model
+  renames or retires it.
+- **Upstream's `usesMetalLayerSurface` is a different thing.** It is a separate,
+  additional surface-selection toggle, not a rename of `setUseMetal(_:)`, and
+  this flag does not set it.
+- **Both branches run the new scheduler and the lock.** Turning the flag off does
+  not restore a pre-2.0 terminal; it selects the CoreGraphics backend underneath
+  the same frame scheduling and the same locking. So this flag bounds
+  **rendering-backend** risk only. It cannot be used to A/B frame scheduling, and
+  a scheduling problem will look identical on both sides of it.
+
+Where measurements in this document were taken against the pre-2.0 CoreGraphics
+path, that is stated. They are evidence about how that path behaves and they
+stand; they are not claims about the current pin.
+
+## What ships
+
+A `UserDefaults` flag, `useMetalTerminalRenderer`, defaulting to **off**, with a
+toggle in Settings under Terminal. When set, the terminal view requests
+`setUseMetal(true)` after construction.
+
+`UserDefaults` rather than a `config` column because the behavior is entirely
+app-side rendering with no daemon participation — the same placement as the
+existing `enableTranscript` flag. It is read through the three-state form:
+
+```swift
+defaults.object(forKey: useMetalTerminalRendererKey) as? Bool ?? Self.useMetalTerminalRendererDefault
+```
+
+so "nobody has chosen" stays distinguishable from an explicit `false`. Graduation
+is then a one-line change to the default constant: it reaches everyone who never
+touched the toggle while preserving every deliberate opt-out.
+
+`setUseMetal(_:)` throws — on hardware without Metal support, or when the pipeline
+cannot be built. On a throw the view stays on CoreGraphics, the failure is logged
+once per terminal view at `.error`, and no retry is attempted. Degrading to the
+path that shipped for years is always correct here; crashing, or logging per
+frame, is not.
+
+**Activation is confirmed positively, not by absence of an error.** Because
+`setUseMetal(_:)` degrades silently by design, a missing error line is not
+evidence that Metal engaged. A `.notice` line is emitted per terminal view on
+success. `.notice` rather than `.info` because `.info` lives in a memory ring
+buffer that becomes unreadable within minutes of the launch that wrote it, and
+the question "was the GPU path actually on?" has to be answerable the next
+morning. One line per view is rare enough to afford that.
+
+**The request is deferred until the view has a window.** Enabling Metal on a view
+that is not yet attached leaves the renderer bound to no window, and attachment
+then rebinds — building a second Metal view, renderer, glyph atlas and pipeline
+set and discarding the first, synchronously on the main thread. Renderer
+construction runs a runtime compile of the shader source with no library cache,
+so opening a worktree with six tabs would pay twelve of those, half of them thrown
+away milliseconds later. That is exactly the cost the flag exists to measure, so
+paying it twice would contaminate the comparison.
+
+## Hazards
+
+**The shader resource must actually reach the app bundle.** SwiftTerm resolves
+its shader source relative to the main bundle. The app is assembled into a bundle
+at build time, and staging only TBD's own resource bundle leaves the shader
+source out — `setUseMetal(true)` then throws for a missing shader and the terminal
+silently stays on CoreGraphics. The failure mode is the worst possible one for an
+experiment: an A/B that compares two identical CoreGraphics terminals and reports
+"no difference". The bundling step stages every dependency resource bundle, and
+the per-view `.notice` line above is what proves the path is live.
+
+**Pane snapshots read the view backing store.** The screenshot path captures by
+re-running the view's draw down the subview tree. A Metal-backed view renders into
+a layer that path does not see, so snapshots come back blank — and a blank image
+is a *silent* regression, because it still renders as an image and nothing
+downstream reports it. Snapshots feed the sidebar context menu and pane
+placeholders.
+
+`setUseMetal(_:)` is togglable in both directions at runtime, so the capture drops
+to CoreGraphics for its duration and restores Metal afterwards. The whole round
+trip happens inside one main-thread turn, so the compositor never commits the
+intermediate hierarchy and the swap is not visible; a synchronous frame is forced
+on the way back so the rebuilt Metal view is not blank until the next runloop
+turn. Re-enabling rebuilds the renderer and glyph atlas, which is acceptable only
+because captures are user-gestured and occasional rather than per-frame.
+
+**Terminal views are reparented across windows.** The keep-alive pager retains up
+to eight terminal views and moves them between windows, which is precisely the
+Metal-layer device-and-drawable rebinding case SwiftTerm's own comments call out.
+The soak must demonstrate that handling holds under TBD's pager specifically.
+
+**Eight simultaneous GPU contexts is a new resource class.** Today the retained
+views cost only their backing stores. The soak watches for GPU memory growth
+across worktree switches, not only for correctness.
+
+## Field result
+
+The flag has been dogfooded with Metal confirmed active — 15 per-view activations
+observed with zero fallbacks to CoreGraphics. The by-feel A/B verdict is **no
+noticeable improvement**.
+
+Two verified mechanisms explain that, and both are findings in their own right.
+
+**In a fullscreen TUI there is nothing for a row cache to hit.** The primary
+workload is an agent TUI running in the alternate screen buffer, and the alt
+buffer is constructed with no scrollback at all (`Terminal.swift`: "The alt buffer
+should never have scrollback"). So what feels like scrolling is not scrolling: the
+TUI rewrites the entire screen each step, every line's generation stamp bumps, and
+a per-row render cache misses on every row no matter how it is keyed. Cache design
+is irrelevant when the content genuinely is new. What remains of Metal's edge is
+glyph rasterization — an atlas hit instead of a text-layout pass — which is real
+but the smaller share.
+
+This also reframes an upstream report that the Metal renderer keys its row cache
+on absolute row number and screen-relative coordinates, both invalidated by every
+scroll, and that fixing it takes a frame from 10.35 ms to 0.60 ms. That patch
+would help scrollback scrolling in a shell. It cannot help the fullscreen-TUI
+workload, because there the cache has nothing valid to retain.
+
+**TBD amplifies wheel input upstream of any renderer.** TBD's own terminal panel
+installs a local wheel-event monitor that emits `max(1, Int(abs(deltaY)))` mouse
+reports per event, with no momentum-phase filter and no fractional-delta
+accumulator, and it consumes the event — so it is the only thing forwarding wheel
+input, and SwiftTerm's own better handler never runs. A sub-line delta still sends
+a full report, and a trackpad flick's momentum tail arrives at 60-120 Hz. Each
+report makes the hosted TUI repaint and that repaint returns through the PTY as
+output. Measured: scrolling produces 634 chunks per second against 21.8 quiet and
+79.5 while typing, each chunk trivially small. Scrolling manufactures the output
+flood the terminal then pays for, and that amplification sits entirely upstream of
+the renderer, so no amount of GPU work can touch it.
+
+A third possibility is on record but not observed here: a separately reported case
+shows six streaming agent TUIs with Metal enabled still consuming 75-82% of a core,
+with cost relocating to text-layout glyph metrics rather than disappearing. That
+report is CJK-heavy and an ASCII agent TUI should hit the glyph atlas far better.
+
+**What the flag is worth, stated plainly.** Its value is that it makes the A/B
+available from Settings on a real workload, and that it bounds rendering-backend
+risk to one togglable switch. It is not a proven win. It ships default-off, and
+**graduation is not recommended on current evidence** — the two mechanisms above
+are where the work is, and neither is a rendering-backend problem.
+
+## Acceptance
+
+**Graduation requires closing the gap to a standalone emulator under realistic
+load.** The bar is that a TBD terminal hosting an agent TUI feels comparable to a
+standalone emulator hosting the same TUI, attached to the same tmux session, on
+the same machine — the control described above. The repository owner judges
+comparable. On the evidence recorded here that bar is not met, so the flag stays
+off.
+
+**The comparison must be made on a loaded machine, not a quiet one.** A browser
+open, agents running, memory under pressure: the conditions the app is actually
+used in. This is not incidental strictness. Field observation established that
+TBD's terminal is usable when the machine is quiet and degrades badly when it is
+not, while a standalone emulator stays smooth through both — so a gate applied to
+a quiet machine can pass while the defect that motivated the work is entirely
+intact. Closing a browser and freeing roughly 3 GB was measured to halve system
+load, stop paging, and produce a large subjective improvement while leaving TBD's
+own CPU unchanged. A gate that ambient relief can satisfy is measuring the
+machine, not the change.
+
+Feel is the bar rather than a threshold on the profile because the profile can
+improve while the terminal still feels slow — the relocating-cost report above is
+exactly that case. The profile keeps the judgment honest; it does not settle it.
+
+**Profiling protocol, if the profile is used to corroborate.** Score every window
+on both sides for an actual scroll or keystroke signature and discard the failures
+rather than averaging them in; take several short windows rather than one long
+one, so a mistimed window announces itself instead of becoming a finding. Ensure
+the quiet baseline is genuinely quiet — a session in which tooling is running
+commands streams output into the terminal and drives the very redraws under
+comparison. Compare subtree totals, never summed symbol occurrences: call-graph
+counts are inclusive of children, and summing a parent with its own callees
+inflated the draw path by roughly twofold on a first pass and made it look
+dominant.
+
+**Tests cover both branches of the flag.** With the flag off, no `setUseMetal`
+call is made and the CoreGraphics path is byte-for-byte what existed before. With
+it on, Metal is requested and a captured snapshot is non-blank. The three states
+of the default are distinguishable: an unset key reads the shipped default, and an
+explicit `false` survives a change to that constant. Two decisions are extracted
+into pure functions — the capture-time renderer swap and the wait-for-window
+deferral — because a test process resolves shaders against a helper binary rather
+than the build directory, so the Metal branch itself cannot be exercised
+in-process; deleting either decision then goes red anyway.
+
+## Rejected alternatives
+
+**Replacing the terminal engine.** A migration to a different terminal engine is
+not rejected, but it is sequenced behind this experiment, because the experiment
+discriminates between the two readings that decide it. If enabling the GPU
+renderer closed the gap, the difficulty was a rendering defect in a fallback path
+and a migration would be solving a solved problem at a cost measured in months. It
+did not close the gap, which supports the competing reading — that the difficulty
+is in how TBD drives the engine rather than in how the engine draws — and that
+reading is corroborated by both field mechanisms above, one of which is entirely
+TBD's own code. A migration also carries a hard constraint: tmux cannot be removed
+from TBD, because worktree reconciliation, cross-session agent messaging, the pane
+readers, and pane identity for the peer registry all run through tmux commands. An
+engine choice that assumes owning the process is unavailable regardless of its
+rendering merits.
+
+**Cherry-picking the upstream row-cache fix before measuring.** Applying it first
+would have avoided a possibly misleading flat scroll result, at the cost of fork
+setup before any evidence justified it and of mixing two changes into one
+measurement. Recording the expected readings in advance costs nothing and does the
+same job — and in the event the fullscreen-TUI finding shows that patch would not
+have changed the verdict anyway.
+
+**Moving painting off the main thread as part of this flag.** Out of scope by
+construction: at the pinned revision the frame scheduler and the off-main model
+apply to both branches, so this flag cannot deliver or withhold them. Scheduling
+work belongs to the dependency pin, not here.
+
+**Shipping without a flag.** Rejected: selecting a rendering backend is exactly
+the category that must ship default-off and soak. The flag is also what makes the
+A/B possible at all, since it can be toggled live from Settings.

--- a/scripts/restart-bundle-lib.sh
+++ b/scripts/restart-bundle-lib.sh
@@ -173,7 +173,7 @@ assemble_app_bundle() {
     local launch_path="${3-}"
     local bundle_dir bundle_macos bundle_plist source_plist
     local app_exec_path bundle_resources source_icon bundle_icon
-    local source_resource_bundle bundle_resource_bundle sidecar
+    local source_resource_bundle bundle_resource_bundle resource_bundle_name sidecar
 
     if [ -z "$repo_root" ] || [ -z "$build_dir" ]; then
         echo "error: assemble_app_bundle needs a repo root and a build dir" >&2
@@ -213,18 +213,52 @@ assemble_app_bundle() {
         cp "$source_icon" "$bundle_icon" || return 1
     fi
 
-    # The resource bundle with localized strings and assets. SPM produces it in
-    # .build/arm64-apple-macosx/<config>; it must be inside the .app or app
-    # launch fails with "could not load resource bundle". $build_dir is a
-    # symlink to that directory, so reach the bundle through it rather than
+    # Every SwiftPM resource bundle next to the built products goes into the
+    # .app. SPM produces them in .build/arm64-apple-macosx/<config>; $build_dir
+    # is a symlink to that directory, so reach them through it rather than
     # composing a path with ../arm64-apple-macosx/<config>.
-    source_resource_bundle="$build_dir/TBD_TBDApp.bundle"
-    bundle_resource_bundle="$bundle_resources/TBD_TBDApp.bundle"
-    if [ -d "$source_resource_bundle" ]; then
+    #
+    # TBD_TBDApp.bundle (localized strings and assets) has always been required
+    # — without it app launch fails outright with "could not load resource
+    # bundle". The dependencies' bundles matter for a subtler reason, and the
+    # failure they produce is silent rather than loud: a SwiftPM library's
+    # `Bundle.module` accessor falls back to the absolute
+    # `.build/.../<Pkg>_<Target>.bundle` path baked in at compile time, which
+    # happens to resolve on the machine that built the binary — so a missing
+    # bundle looks fine here and breaks anywhere else. Code that probes for its
+    # bundle by name instead (SwiftTerm's Metal renderer does, deliberately,
+    # because the generated accessor `fatalError`s) looks only at `Bundle.main`
+    # — its `resourceURL` and its `bundleURL` — and finds nothing when the
+    # bundle is staged nowhere. The app binary is hard-linked INTO the bundle,
+    # so `Bundle.main` is TBD.app, and `SwiftTerm_SwiftTerm.bundle`, which
+    # carries `Shaders.metal`, was not there. The result was `setUseMetal(true)`
+    # throwing `shaderSourceMissing` and the terminal quietly staying on
+    # CoreGraphics: a GPU renderer that reports itself unavailable on a machine
+    # with a GPU.
+    #
+    # Copying all of them is both shorter than naming two and the right
+    # invariant: an .app must carry every resource bundle its executable may
+    # look up at runtime. They are small, and a stale one is worse than a
+    # redundant one, so the staged set is cleared first and rebuilt from what
+    # the build actually produced — otherwise a dependency that is dropped or
+    # renamed leaves its bundle in the .app forever, and the next person
+    # debugging a resource lookup finds two plausible candidates.
+    rm -rf "$bundle_resources"/*.bundle
+    for source_resource_bundle in "$build_dir"/*.bundle; do
+        [ -d "$source_resource_bundle" ] || continue
+        resource_bundle_name="$(basename "$source_resource_bundle")"
+        # Test-target resource bundles are fixtures, not app resources. They can
+        # be large and they ship nothing the app reads, so keep them out.
+        case "$resource_bundle_name" in
+            *Tests.bundle) continue ;;
+        esac
+        bundle_resource_bundle="$bundle_resources/$resource_bundle_name"
         rm -rf "$bundle_resource_bundle"
         cp -R "$source_resource_bundle" "$bundle_resource_bundle" || return 1
-    else
-        echo "warning: TBD_TBDApp.bundle not found at $source_resource_bundle" >&2
+    done
+    # The app's own bundle is the one whose absence is fatal, so it keeps a check.
+    if [ ! -d "$bundle_resources/TBD_TBDApp.bundle" ]; then
+        echo "warning: TBD_TBDApp.bundle not found at $build_dir/TBD_TBDApp.bundle" >&2
     fi
 
     # Stash the source worktree path inside the bundle so the running app can

--- a/scripts/restart-bundle-lib.test.sh
+++ b/scripts/restart-bundle-lib.test.sh
@@ -51,6 +51,13 @@ assert_no_file() {
     if [ -f "$2" ]; then fail "$1: unexpected $2"; else pass "$1"; fi
 }
 
+# A resource bundle is a directory, so "it is gone" has to be asserted on the
+# directory itself — an emptied-but-surviving bundle is still an orphan the
+# next person debugging a resource lookup has to rule out.
+assert_no_dir() {
+    if [ -d "$2" ]; then fail "$1: unexpected $2"; else pass "$1"; fi
+}
+
 # Read one top-level field out of the sidecar without assuming jq is installed.
 sidecar_field() {
     python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2"
@@ -299,6 +306,76 @@ test_assemble_bundle_drops_a_stale_sidecar() {
         "$bundle/Contents/TBDBuildIdentity.json"
 }
 
+# The app binary is hard-linked into the .app, so `Bundle.main` is TBD.app and
+# a dependency that looks its own bundle up by name finds only what was staged
+# there. Staging just the app's own bundle is what left SwiftTerm's Metal
+# renderer without Shaders.metal and silently on CoreGraphics.
+test_assemble_bundle_stages_every_dependency_resource_bundle() {
+    local repo build bundle
+    repo="$(mkrepo)"
+    build="$repo/.build/release"
+    mkbuild "$build"
+    mkdir -p "$build/SwiftTerm_SwiftTerm.bundle" "$build/OtherDep_OtherDep.bundle"
+    printf 'shaders' > "$build/SwiftTerm_SwiftTerm.bundle/Shaders.metal"
+    printf 'asset' > "$build/OtherDep_OtherDep.bundle/Asset.txt"
+
+    assert_ok "assemble_app_bundle succeeds with several resource bundles" \
+        assemble_app_bundle "$repo" "$build" "/usr/bin:/bin"
+
+    bundle="$(bundle_dir_for_build "$build")"
+    assert_file "the bundle carrying the Metal shaders is staged" \
+        "$bundle/Contents/Resources/SwiftTerm_SwiftTerm.bundle/Shaders.metal"
+    assert_file "a second dependency bundle is staged too" \
+        "$bundle/Contents/Resources/OtherDep_OtherDep.bundle/Asset.txt"
+    # Copying everything must not come at the cost of the one bundle whose
+    # absence the assembly already warns about.
+    assert_file "the app's own resource bundle survives the wider copy" \
+        "$bundle/Contents/Resources/TBD_TBDApp.bundle/Localizable.strings"
+}
+
+test_assemble_bundle_skips_test_fixture_bundles() {
+    local repo build bundle
+    repo="$(mkrepo)"
+    build="$repo/.build/release"
+    mkbuild "$build"
+    mkdir -p "$build/TBD_TBDAppTests.bundle" "$build/SwiftTerm_SwiftTerm.bundle"
+    printf 'fixture' > "$build/TBD_TBDAppTests.bundle/Fixture.json"
+    printf 'shaders' > "$build/SwiftTerm_SwiftTerm.bundle/Shaders.metal"
+
+    assemble_app_bundle "$repo" "$build" "/usr/bin:/bin" >/dev/null 2>&1
+
+    bundle="$(bundle_dir_for_build "$build")"
+    assert_no_dir "test-target fixtures stay out of the shipped app" \
+        "$bundle/Contents/Resources/TBD_TBDAppTests.bundle"
+    # Paired with the exclusion so a copy loop that stages nothing at all
+    # cannot pass this case by accident.
+    assert_file "a real dependency bundle beside the fixture is still staged" \
+        "$bundle/Contents/Resources/SwiftTerm_SwiftTerm.bundle/Shaders.metal"
+}
+
+test_assemble_bundle_clears_a_dropped_resource_bundle() {
+    local repo build bundle
+    repo="$(mkrepo)"
+    build="$repo/.build/release"
+    mkbuild "$build"
+    mkdir -p "$build/OldDep_OldDep.bundle"
+    printf 'asset' > "$build/OldDep_OldDep.bundle/Asset.txt"
+    assemble_app_bundle "$repo" "$build" "/usr/bin:/bin" >/dev/null 2>&1
+
+    bundle="$(bundle_dir_for_build "$build")"
+    assert_file "the first assembly stages the dependency" \
+        "$bundle/Contents/Resources/OldDep_OldDep.bundle/Asset.txt"
+
+    # A dependency that is dropped or renamed must not leave its bundle in the
+    # .app forever: the staged set is rebuilt from what the build produced.
+    rm -rf "$build/OldDep_OldDep.bundle"
+    assemble_app_bundle "$repo" "$build" "/usr/bin:/bin" >/dev/null 2>&1
+    assert_no_dir "a bundle the build no longer produces is cleared" \
+        "$bundle/Contents/Resources/OldDep_OldDep.bundle"
+    assert_file "clearing the stale set keeps the bundles that remain" \
+        "$bundle/Contents/Resources/TBD_TBDApp.bundle/Localizable.strings"
+}
+
 # MARK: - Signing
 
 test_sign_prefers_the_stable_identity() {
@@ -453,6 +530,9 @@ test_json_escape_string
 test_assemble_bundle_produces_a_launchable_bundle
 test_assemble_bundle_rejects_an_empty_path
 test_assemble_bundle_drops_a_stale_sidecar
+test_assemble_bundle_stages_every_dependency_resource_bundle
+test_assemble_bundle_skips_test_fixture_bundles
+test_assemble_bundle_clears_a_dropped_resource_bundle
 test_sign_prefers_the_stable_identity
 test_sign_rejects_a_missing_bundle_argument
 test_install_replaces_the_previous_bundle


### PR DESCRIPTION
## Summary

Embedded terminals in TBD scroll and type noticeably slower than a standalone
emulator on the same machine, hosting the same agent TUI, attached to the same
tmux session. Only the frontend differs across that control, and profiling puts
the cost in SwiftTerm's CoreGraphics draw path.

SwiftTerm has shipped a Metal renderer this whole time, behind a public
`setUseMetal(_:)`. TBD has never called it. Every performance number we have was
taken of a fallback path while a GPU path sat unused in the same binary.

This adds a default-off toggle — **Settings → Terminal → Experimental → "GPU
terminal rendering (Metal)"** — so the two paths can be A/B'd by feel.

**It has now been dogfooded, and the by-feel verdict is no noticeable
improvement.** That is a real result rather than a missing one, and the spec
records the two verified mechanisms behind it. The flag ships anyway because it
makes the A/B available on a real workload from Settings and bounds
rendering-backend risk to one switch — not because it is a proven win.
Graduation is explicitly **not** recommended on current evidence.

Rebased onto `main` at SwiftTerm 2.0 (the `62d0be6d` pin, with the parser on the
PTY IO thread, locked terminal access, and the FrameDriver replacing the fixed
16.67 ms paint floor). `setUseMetal(_:)` survives that bump unchanged, exactly as
`docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md` predicted it
would; `usesMetalLayerSurface` is a separate additional surface-selection toggle,
not a rename, and this PR does not touch it. That is not taken on faith: the
three APIs this PR calls — `setUseMetal(_:)`, `isUsingMetalRenderer`,
`drawMetalFrameNow()` — were located in the resolved checkout at the new
revision, and `scripts/swift-safe build --build-tests` compiles both the app and
the test targets against it, which is what the `test` check re-proves here. Both branches of this flag run the
new frame scheduler and lock, so it bounds rendering-backend risk only.

## Why this shape

Spec: `docs/specs/2026-08-25-terminal-metal-renderer-design.md`, **committed in
this PR**. It was previously carried on a branch whose PR was closed without
merging, so it was committed nowhere; it now lands with the code it describes,
brought current with SwiftTerm 2.0 and carrying the field result below.

`UserDefaults` rather than a `config` column because the behavior is entirely
app-side rendering with no daemon participation — the same placement as
`enableTranscript`. Read through the three-state form so "nobody chose" stays
distinguishable from an explicit `false`, which is what makes graduation a
one-line change to `useMetalTerminalRendererDefault` that reaches everyone who
never touched the toggle while preserving every deliberate opt-out.

The call sits in `makeNSView`, not `updateNSView`, so a view never swaps
renderers mid-life. Flipping the toggle therefore reaches terminals opened
afterwards, and an app restart moves them all — the Settings row says so.

## What this PR does

- `AppState`: `useMetalTerminalRendererKey`, `useMetalTerminalRendererDefault`
  (false), and the three-state read, split into a pure
  `metalTerminalRendererEnabled(stored:shippedDefault:)` so the graduation
  property is directly assertable.
- `TerminalPanelView.makeNSView` and `LocalPTYTerminalView.makeNSView`: both
  terminal surfaces request the GPU path when the flag is on. Covering only the
  first would silently mix renderers inside one A/B. Both read through the same
  static `AppState.metalTerminalRendererEnabled()`, on `UserDefaults.standard`,
  which is also where the `@AppStorage` Settings toggle writes.

  **On which store this flag lives in.** An earlier revision routed the two
  readers through the `AppState` instance's injected suite, so that `TBD_MOCK`'s
  isolated defaults would reach them. The gate correctly pointed out that this
  left the *writer* behind: `@AppStorage` targets `UserDefaults.standard` unless
  an ancestor applies `.defaultAppStorage(_:)`, and nothing in `Sources/TBDApp`
  does. Under the mock harness the toggle would then write one store while the
  terminals read another — the toggle appearing to do nothing, and the write
  landing in exactly the plist `TBD_MOCK` exists to protect.

  Both sides now sit on `.standard`, which is the convention every sibling flag
  already follows: `enableTranscript` — the precedent this flag was modeled on —
  is `@AppStorage` in `SettingsView` and `PanePlaceholder`, with a static
  `transcriptFeatureEnabled(defaults:)` for non-View callers. Routing one flag
  through the instance is what manufactured the split. If `@AppStorage`-backed
  settings should honour the mock suite, the fix is `.defaultAppStorage(_:)` at
  the Settings root for *all* of them; that is a separate change and not
  something this experimental flag should do unilaterally for itself.
- `TBDTerminalView.applyMetalRendererPreference(enabled:)`: wraps the throwing
  call. On throw it logs once at `.error` and leaves the view on CoreGraphics;
  it never retries. On success it logs once at `.notice` — see "Flag & rollout".
- `TBDTerminalView.captureScreenshot()`: drops to CoreGraphics for the duration
  of a capture and restores Metal after. See "The snapshot hazard".
- `docs/specs/2026-08-25-terminal-metal-renderer-design.md`: the spec, as
  required for anything shipping behind a flag.
- `scripts/restart-bundle-lib.sh`: stages **every** dependency resource bundle
  into `TBD.app`, not just `TBD_TBDApp.bundle`. Without this the feature is inert —
  see "The bug that would have faked a null result".
- Tests in `Tests/TBDAppTests/MetalTerminalRendererSettingTests.swift`.

## Flag & rollout

- **Flag:** `useMetalTerminalRenderer` (`UserDefaults`), default **OFF**.
- **Enable for the soak:** Settings → Terminal → Experimental → "GPU terminal
  rendering (Metal)". Applies to terminals opened after the change; restart the
  app to move every open terminal at once. Equivalent CLI:
  `defaults write com.github.cheapsteak.tbd useMetalTerminalRenderer -bool true`.
  That is the bundle identifier, and it is the right domain because
  `scripts/restart.sh` launches TBD from an `.app`. The `TBDApp` domain reaches
  only an unbundled launch of the executable — verified here by watching which
  plist the running app rewrote on relaunch.
- **Confirm it engaged** (do not infer from the absence of an error — the
  fallback is silent by design):
  `log show --last 1h --predicate 'subsystem == "com.tbd.app" AND category == "terminalRenderer"'`
  should show `Metal terminal renderer active for this terminal view`, once per
  terminal view. It is logged at `.notice` deliberately — `.info` lives in a
  memory ring buffer that `log show` loses within minutes, which made the line
  unreadable ~15 minutes after the launch that wrote it during this PR's own
  verification.
- **Graduation: not recommended on current evidence.** The mechanism would be a
  one-line flip of `AppState.useMetalTerminalRendererDefault` to `true`, which
  reaches everyone who never touched the toggle while preserving every explicit
  opt-out. The evidence does not support taking it: the A/B has been run and came
  back flat, for two reasons that are not rendering-backend problems (see "The
  field result"). The flag stays default-off and available. If the two upstream
  causes are ever addressed, re-run the comparison before flipping — do not flip
  on the strength of this PR.

## The bug that would have faked a null result

`scripts/restart.sh` copied exactly one SwiftPM resource bundle into `TBD.app`:
`TBD_TBDApp.bundle`. SwiftTerm loads `Shaders.metal` from
`SwiftTerm_SwiftTerm.bundle`, and because the app binary is hard-linked *into*
the bundle, `Bundle.main` is `TBD.app` — where that bundle has never existed.

So `setUseMetal(true)` threw `shaderSourceMissing`, the new code caught it,
logged, and left the terminal on CoreGraphics. Exactly as designed, and exactly
wrong: the A/B would have compared two identical CoreGraphics terminals and
concluded that Metal makes no difference.

The general form is worth knowing beyond this PR. A SwiftPM library's generated
`Bundle.module` accessor falls back to the absolute `.build/…` path baked in at
compile time, so a resource bundle missing from an `.app` still resolves **on
the machine that built the binary** and breaks anywhere else. Every dependency
resource in this app has been riding that fallback. SwiftTerm's Metal renderer
is the one that noticed, because it deliberately avoids `Bundle.module` (the
generated accessor `fatalError`s rather than returning nil) and probes by name
under `Bundle.main` instead.

The staging now copies every `*.bundle` from the build directory into
`Contents/Resources`, excluding test fixtures. On this rebase it moved with the
rest of bundle assembly into `scripts/restart-bundle-lib.sh`, which `main`
extracted so `scripts/update.sh` produces the same bundle — and which still
staged only `TBD_TBDApp.bundle`, so the hazard was live there too.

## What review found, and what turned out to be true

Two review rounds ran over this branch. The first reported that appearance
changes never repaint under Metal, because `applyScheme` and
`applyFontSmoothing` ended in `needsDisplay = true` and SwiftTerm's `draw(_:)`
early-returns whenever a Metal view exists. That premise is correct. The
conclusion was half right, and the fix it prompted was wrong — worth recording,
because the wrong fix looked convincing.

**Theme changes were never broken.** `installColors` calls SwiftTerm's
`colorsChanged()`, which clears the attribute caches, calls `updateFullScreen()`
and queues a display. That deferred pass rebuilds every visible row against the
new palette on both renderers. Round one missed it; round two found it.

**And the "fix" was actively wrong.** Forcing a synchronous `drawMetalFrameNow()`
after a scheme change draws the *old* colours: the Metal renderer caches per-row
vertex data keyed on `BufferLine.generation`, `installPalette` does not bump it,
and `metalDirtyRange` is still nil at that moment because it is only assigned
inside the deferred `updateDisplay()`. So the immediate frame is a wasted GPU
pass that can put one stale frame *ahead* of the correct one. Removed.

**Thin strokes, however, really is inert under Metal, and TBD cannot fix it
from here.** `fontSmoothing`'s setter is a bare stored-property write with no
scheduling, so `needsDisplay` is the only repaint and it is a no-op under Metal.
Forcing a frame would not help: the renderer re-reads `fontSmoothing` every
frame, but glyphs already in its atlas are never re-rasterized and nothing
invalidates the atlas on a smoothing change — an ASCII terminal keeps every
glyph it has. Rebuilding the renderer would work, at the cost of recompiling the
shader library once per terminal view.

Not worth that. Thin strokes now takes effect for terminals opened afterwards,
which is the same envelope the flag itself already has, and the Settings help
text says so. If the soak makes this annoying, the real fix is an upstream atlas
invalidation hook, not a rebuild here.

**One earlier change here was wrong, and the merge gate caught it.** A previous
revision of this branch deleted `applyScheme`'s `layer.backgroundColor = bg.cgColor`
write, on the theory that upstream's `nativeBackgroundColor` setter already
painted the layer and that the extra write would cover the transparency a
`CAMetalLayer` needs. The gate flagged it as HIGH precisely because it could not
check that theory against the dependency from its sandbox, and it was right to:
the theory does not hold, and the write affects the **default** CoreGraphics path
that every install runs.

Checked directly against the pinned SwiftTerm 2.0 source rather than reasoned
about: `makeMetalView` returns an `NSView` either way — a `TerminalMetalLayerView`
owning a `CAMetalLayer`, or an `MTKView` — and in both cases the Metal surface is
a **subview**. The `TerminalView`'s own layer therefore sits *behind* it and
cannot paint over it. Worse for the original theory, `TerminalMetalLayerView` sets
`metalLayer.isOpaque = backgroundOpacity >= 1.0`, so at reduced opacity the parent
layer's background is exactly what should show through. The write is both safe
under Metal and load-bearing without it.

`applyScheme` is therefore byte-for-byte `main`'s version in this PR — this diff
does not touch it at all.

Also from review: the staging clears the staged bundle set before rebuilding it,
so a dropped or renamed dependency cannot leave an orphan in the `.app`.

**And one that would have corrupted the measurement itself.** Requesting Metal
inside `makeNSView` means requesting it on a view SwiftUI has not attached yet,
so `metalBoundWindow` is nil and `viewDidMoveToWindow` immediately rebinds —
building a *second* `MTKView`, renderer, glyph atlas and pipeline set and
discarding the first, synchronously on the main thread. Renderer construction
runs a runtime compile of SwiftTerm's shader source (there is no
`default.metallib` to short-circuit it) and `makeLibrary` has no cache. Opening
a worktree with six tabs paid twelve of those, six of them thrown away
milliseconds later.

It "worked", and nothing would have gone red. It would simply have made
terminals with the flag on cost about twice as much to open — and a
terminal-open A/B would have charged that to the Metal renderer. The request now
waits for the view to have a window, which still never swaps renderers mid-life
because it happens before any content is fed. The decision is extracted as
`metalActivation(hasWindow:)` and tested both ways.

## The snapshot hazard

`captureScreenshot()` reads the view's backing store via
`bitmapImageRepForCachingDisplay` + `cacheDisplay`, which re-runs `draw(_:)`
down the subview tree. A Metal-backed `TerminalView` renders into a
`CAMetalLayer` owned by an `MTKView` subview, which draws through its layer and
not through `draw(_:)` — so the capture sees no glyphs.

The spec's candidate fix was to drop to CoreGraphics for the duration of the
capture and restore after, flagged as a candidate rather than a decision
because it might flicker. **It does not flicker, and it is what shipped.** The
whole round trip happens inside one main-thread turn, so the compositor never
commits the intermediate hierarchy; `drawMetalFrameNow()` on the way back
forces the rebuilt `MTKView` to produce a frame synchronously rather than
leaving it blank until the next runloop turn. Re-enabling rebuilds the
`MTKView`, its renderer and its glyph atlas, which is acceptable only because
captures are user-gestured and occasional — this would be indefensible per
frame.

**The capture path is unreachable in production *and* in CI, so read the soak
accordingly.** `captureScreenshot()` has one registration site and zero
invocation sites, and `flagOnEndToEnd` takes its unavailable branch under the
test harness. A clean soak is therefore **not** evidence that this hazard is
closed — the only evidence is the manual run recorded below.

**Finding worth recording: nothing currently reads these snapshots.**
`AppState.snapshotProviders` is populated in `makeNSView` and cleared in
`PanePlaceholder`, but no code invokes the closures; the last consumer went in
#362, and `suspendingSnapshots` has no writer either. So the regression this
guards against is presently unobservable — the fix protects a future reader
rather than a current one. Ripping the orphaned machinery out is a separate
change and not this PR's business.

## Assumptions

- Assumes SwiftTerm keeps resolving `Shaders.metal` under `Bundle.main`. If
  upstream switches to `Bundle.module`, the `restart.sh` staging becomes
  unnecessary but harmless; if it changes the bundle *name*, the staging keeps
  working because it copies everything.
- Assumes SwiftUI attaches the view to a window shortly after `makeNSView`
  returns. Metal is enabled on a view that has no window yet — the ordering
  SwiftTerm's docs advise against — and it works because `viewDidMoveToWindow`
  rebinds. Consequence worth knowing: each terminal opened builds an `MTKView`,
  renderer and glyph atlas off-window and immediately discards them for a
  rebound set. Correct, but one build-and-discard per terminal.
- Assumes terminal `NSView`s are never reparented across `NSWindow`s. Verified:
  the keep-alive pager is an `NSTabViewController` with `.unspecified` style,
  which hides and shows views inside one window, and nothing else hosts a
  terminal in a separate window. The spec expected this to be the
  `CAMetalLayer` device-rebinding case; it is not. SwiftTerm carries handling
  for it regardless (`viewDidMoveToWindow` → `rebindMetalRendererToWindow`), so
  if TBD ever gains a detached terminal window the path exists.

## Evidence & verification

**Tests.** `Tests/TBDAppTests/MetalTerminalRendererSettingTests.swift` — 13
tests, plus three cases in `scripts/restart-bundle-lib.test.sh`. The suite
verdict for this rebase is CI's, not a local run: see the checks on this PR.

Three of those cover the branch production always takes and CI otherwise could
not see. Both call sites request Metal from `makeNSView`, before SwiftUI has
attached the view, so the deferral is the live path: a windowless view arms
`wantsMetalRendererOnWindow` and reports not-yet-active, a window arriving
consumes it, and with the flag off nothing is armed before or after windowing.
The observable is the deferral flag rather than `isUsingMetalRenderer`, because
`setUseMetal` always throws in a test process — which is exactly why this
handoff was invisible to the suite before, and why a refactor that dropped the
consumption would have left the flag silently inert for every terminal while
everything stayed green.

Every new test in this PR was mutation-checked rather than assumed to
discriminate. Removing the consumption in `viewDidMoveToWindow` fails exactly
the consumption test; ungating the deferral fails exactly the flag-off test;
reverting the bundle staging to its old single-bundle form fails exactly the
three staging cases. Each mutation was reverted and the suite re-run green.

- Flag off: no `setUseMetal` call is made, the view stays on CoreGraphics, and
  captures are unchanged.
- Three states: an unset key reads the shipped default; both explicit values
  round-trip; and the graduation rehearsal — `nil` follows a `shippedDefault`
  of `true` while an explicit `false` holds against it.
- The instance gate reads its own injected `UserDefaults`, so the suite never
  touches the developer's real `TBDApp.plist`.
- The capture-time renderer decision, both ways.

**One branch cannot be exercised in-process, and the test says so rather than
skipping.** SwiftTerm resolves its shaders against `Bundle.main`, which in a
test run is the toolchain's xctest helper —
`…/usr/libexec/swift/pm/` — not the build directory holding
`SwiftTerm_SwiftTerm.bundle`. Unlike the app, there is nowhere legitimate to
stage it: that path is inside the Xcode toolchain. So `setUseMetal(true)` throws
`shaderSourceMissing` and the GPU path is unreachable under
`scripts/test.sh`.

Rather than let that become a permanently-green hole, `flagOnEndToEnd` pins the
diagnosis: it runs the real assertions when Metal initializes, and otherwise
asserts that the failure was *specifically* the shader-resolution gap. Any
other reason — a pipeline failure, a missing device — reds it, and the day the
resource resolves the real assertions start running with no edit. The
capture-policy decision is tested separately and is discriminating on its own:
delete the drop-to-CoreGraphics and it goes red with or without a GPU.

**This is a real gap and it is closed by the live check below, not by the
suite.** A reviewer should treat "snapshots survive with the flag on" as
verified by observation, not by CI.

**Live verification.**

Done on this machine against `/Applications/TBD.app`, daemon and app restarted
from this worktree.

*The flag is on and the GPU path is really running.* Positive confirmation in
the log, not inferred from the absence of an error:

    [com.tbd.app:terminalRenderer] Metal terminal renderer active for this terminal view

*The off branch is really off.* The app instance launched with the flag `false`
produced **zero** `terminalRenderer` lines — no `setUseMetal` call at all.

*The staging fix is what makes it work.*
`/Applications/TBD.app/Contents/Resources/SwiftTerm_SwiftTerm.bundle/Shaders.metal`
is present after the change and was absent before it.

*Snapshots survive, and this is the part CI cannot show you.* A temporary probe
(added, observed, reverted — not in this diff) called `captureScreenshot()`
inside the running app and measured the returned bitmap. **15 captures across 5
terminal views at two pane sizes, every one non-blank with the renderer
restored:**

    METALPROBE t=3.0:  metalBefore=true metalAfter=true size=1186x1616 distinctColors=12
    METALPROBE t=10.0: metalBefore=true metalAfter=true size=1186x1616 distinctColors=12
    METALPROBE t=25.0: metalBefore=true metalAfter=true size=1186x1616 distinctColors=12
    (and the same three at 2379x1616)

`distinctColors` counts distinct sampled pixel colours and stops at 12, so every
capture hit the cap — richly non-blank, not a uniform background. No flicker was
introduced: the round trip completes inside one main-thread turn.

*GPU memory, measured rather than guessed.* Same clean binary, one restart
apart, `footprint` on the app process:

- flag OFF: **2528 KB** IOAccelerator (graphics), phys_footprint ~190 MB
- flag ON, one Metal terminal view: **6800 KB** IOAccelerator (graphics),
  phys_footprint ~192-204 MB (three samples)

So roughly **4.3 MB of GPU-accelerator memory per Metal terminal view**.
Extrapolated to the keep-alive pager's limit of 8 retained views that is about
**+34 MB** — modest, and not the resource class the spec worried it might be.
Stated as an extrapolation on purpose: only one or two terminal views were ever
constructed during these runs, so eight simultaneous contexts were **not**
directly observed. Anyone soaking this should re-check `footprint` after
switching between eight worktrees.

*What I could not verify, so that nobody reads more into the above than it
supports.* `screencapture` and cua-driver's window capture both fail on this
machine (`could not create image from display`) and the accessibility tree comes
back empty, so there is **no pixel-level confirmation that the terminal looks
right** — only that the bitmap the app itself produces is non-blank and varied.
Someone with a working display should glance at a terminal with the flag on
before graduating it.

*One thing that briefly looked like a hang and was not,* recorded because it
will mislead the next person: with the app backgrounded and the display asleep,
App Nap coalesced three `DispatchQueue.main.asyncAfter` blocks scheduled 3, 10
and 25 seconds out so that all three fired together **91 seconds late**. The
main thread was healthy throughout (5-second heartbeats never missed). If you
probe a backgrounded TBDApp with delayed work, expect that.

**Not verified here.** Two things, stated so nobody over-reads the above.
`screencapture` and the accessibility tree are both blocked by missing TCC
grants on this machine, so the appearance-path conclusions above are read from
SwiftTerm's source at the pinned revision — **not** from watching a theme switch
repaint. Someone with a working display should switch terminal theme once with
the flag on, and toggle Thin Strokes once, before graduating it. And:

**A soak note that is not a defect but will be noticed.** SwiftTerm's Metal
renderer carries a `#if DEBUG` FPS `print`, and `scripts/restart.sh` builds and
runs `.build/debug`, so with the flag on each actively redrawing terminal writes
one `Metal FPS: …` line per second into `/tmp/tbdapp.log`. Across a fleet of
streaming agent terminals that is a steady multi-line-per-second write for the
whole soak. It is in the dependency, not in `Sources/`, so no repo rule is
broken — but expect the log to grow and do not mistake it for TBD logging.

## The field result, and why it is not a reason to hold the PR

The by-feel A/B has now been run by the repository owner with Metal confirmed
active. **No noticeable improvement.** Two mechanisms explain it, both verified
in source rather than inferred, and both recorded in the spec:

- **A fullscreen TUI gives a row cache nothing to hit.** The primary workload
  runs in the alternate screen buffer, which SwiftTerm constructs with no
  scrollback at all (`Terminal.swift`: "The alt buffer should never have
  scrollback"). So what feels like scrolling is not scrolling — the TUI rewrites
  the whole screen each step, every line's generation stamp bumps, and a per-row
  cache misses on every row however it is keyed. This also reframes the upstream
  report that fixing the Metal row cache's scroll invalidation takes a frame from
  10.35 ms to 0.60 ms: that patch would help scrollback scrolling in a shell, and
  cannot help here, because here the cache has nothing valid to retain.
- **TBD amplifies wheel input upstream of any renderer.** `TerminalPanelView`
  installs a local wheel monitor that emits `max(1, Int(abs(deltaY)))` mouse
  reports per event with no momentum-phase filter and no fractional-delta
  accumulator, and it *consumes* the event — so it is the only thing forwarding
  wheel input, and SwiftTerm's own accumulating handler never runs. Each report
  makes the hosted TUI repaint, and that repaint returns through the PTY as
  output. Scrolling manufactures the flood the terminal then pays for, entirely
  upstream of the draw stage.

Neither is a rendering-backend problem, so neither is fixed by this PR and
neither should block it. The flag's value is that it makes this comparison
available from Settings on a real workload — which is how the two mechanisms
above got identified — and that it keeps the GPU path behind one switch. It stays
default-off.


[Metal terminal renderer](https://cheapsteak.github.io/tbd/open/?worktree=B3D0662F-4668-4ED8-903A-F6B26C353592)

https://claude.ai/code/session_01Tpo4r47Dzwp9m4tVDrLueR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental Metal terminal renderer toggle in Terminal Settings, disabled by default.
  * Newly opened terminals can use Metal, with automatic Core Graphics fallback if activation fails.
  * Existing terminals retain their current renderer; screenshot capture temporarily uses Core Graphics when needed.
* **Bug Fixes**
  * App packaging now includes required SwiftPM resource bundles and removes stale bundles.
* **Documentation**
  * Added documentation covering renderer behavior, limitations, activation timing, fallback handling, and performance findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->