### PR TITLE
Fix: A provider added while the daemon is running never gets described, so attach and logs stay hidden

### DIFF
--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -32,6 +32,14 @@ public actor RemoteProviderManager {
     /// §"Never silent").
     private let actuationLog: ActuationLog?
     static let pollInterval: TimeInterval = 60
+    /// How many times one provider may be enrolled post-boot before this
+    /// actor stops trying. More than one because a describe failure is
+    /// routinely transient (the provider is mid-deploy, or a credential is
+    /// being refreshed); bounded because nothing clears the count, so an
+    /// unbounded retry would become a describe subprocess per RPC for a
+    /// provider that is permanently unreachable. A daemon restart resets it,
+    /// as it resets every other in-memory enrollment fact.
+    static let maxEnrollmentAttempts = 3
 
     private var providers: [String: RemoteProviderConfig] = [:]
     private var describes: [String: ProviderDescribe] = [:]
@@ -54,16 +62,27 @@ public actor RemoteProviderManager {
     private var snapshotFreshnessUnreadable: Set<String> = []
     private var loops: [String: Task<Void, Never>] = [:]
     private var supervisors: [String: ProviderEventsSupervisor] = [:]
-    /// One entry per provider this actor has enrolled post-boot — see
-    /// `enrollIfNeeded`. The stored `Task` IS the idempotency record: entries
-    /// are never removed, so a completed one is what stops a later `invoke`
-    /// from re-describing a provider boot never saw.
+    /// The most recent post-boot enrollment task per provider — see
+    /// `enrollIfNeeded`. Retained after completion so `shutdown()` can cancel
+    /// AND await it; the burst guard is `enrollmentsInFlight` and the retry
+    /// budget is `enrollmentAttempts`.
     ///
     /// "Enrollment" is deliberately not "adoption": in this actor adoption
     /// already means `RemoteSessionAdopter` pulling a provider's SESSIONS
     /// into the local mirror, which is a different thing happening to a
     /// different noun.
     private var enrollments: [String: Task<Void, Never>] = [:]
+    /// Names with an enrollment currently running. Separate from
+    /// `enrollments`, which retains the last task handle so `shutdown()` can
+    /// drain it: this is the burst guard, and it is cleared when the
+    /// enrollment finishes so a FAILED one can be retried.
+    private var enrollmentsInFlight: Set<String> = []
+    /// Enrollment attempts spent per provider, capped by
+    /// `maxEnrollmentAttempts`. A describe that fails leaves no `describes`
+    /// entry, so without a budget the retry would fire on every single
+    /// `invoke` and roster refresh for a provider that is simply down — a
+    /// describe subprocess per RPC, forever.
+    private var enrollmentAttempts: [String: Int] = [:]
     /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
     /// against a second concurrent call to the same sequence (e.g. two
     /// overlapping `start()`s). See the comment on `spawnPollLoops` for the
@@ -295,11 +314,27 @@ public actor RemoteProviderManager {
     /// believes is torn down. `shuttingDown` (set here, before `stopAll()`,
     /// and never cleared) makes shutdown terminal: every `spawnPollLoops()`
     /// call that resumes after this one — queued or future — is a no-op.
+    /// Enrollment is drained FIRST, and deliberately BEFORE the reconfigure
+    /// lock is taken. Cancelling an in-flight `describe` without awaiting it
+    /// orphans the child process — the interruption still runs on the
+    /// cancelled task, so the process must stay alive to finish unwinding it,
+    /// which is exactly why `Daemon.stop()` pairs `remoteStartTask?.cancel()`
+    /// with `await remoteStartTask?.value`. Draining inside the lock would
+    /// deadlock instead: `enroll` acquires that same lock to arm its poll
+    /// loop, so awaiting it while holding the lock would wait on a task that
+    /// is waiting on us. Setting `shuttingDown` before the drain (it is
+    /// actor-isolated with no `await` ahead of it, and never cleared) closes
+    /// the window: an enrollment scheduled between here and the lock is
+    /// refused by `enrollIfNeeded`, and one already past that point finds
+    /// `shuttingDown` true under the lock and arms nothing.
     func shutdown() async {
+        shuttingDown = true
+        let pending = Array(enrollments.values)
+        for task in pending { task.cancel() }
+        for task in pending { await task.value }
+
         await acquireReconfigureLock()
         defer { releaseReconfigureLock() }
-        shuttingDown = true
-        for task in enrollments.values { task.cancel() }
         await stopAll()
     }
 
@@ -976,6 +1011,13 @@ public actor RemoteProviderManager {
         for task in enrollments.values { await task.value }
     }
 
+    /// Test seam: whether an enrollment is still running for `name` — the
+    /// only way to observe that `shutdown()` awaited what it cancelled
+    /// rather than leaving a describe subprocess unwinding behind it.
+    func hasEnrollmentInFlight(named name: String) -> Bool {
+        enrollmentsInFlight.contains(name)
+    }
+
     /// Test seam: how many post-boot enrollments have been scheduled for
     /// `name` — 0 or 1 by construction. Makes the "a burst of invokes must
     /// not spawn N describes" invariant assertable at the source rather than
@@ -1033,19 +1075,26 @@ public actor RemoteProviderManager {
     /// describe's 10s timeout.
     ///
     /// Idempotent by construction, which matters because `invoke` reaches
-    /// here on EVERY call: the `enrollments` entry is written with no `await`
-    /// between the check and the insert, so actor isolation makes it atomic,
-    /// and it is never removed. A burst of invokes therefore spawns exactly
-    /// one describe, and `enroll`'s own `loops` check keeps it to at most one
-    /// poll loop.
+    /// here on EVERY call: `enrollmentsInFlight` is written with no `await`
+    /// between the check and the insert, so actor isolation makes it atomic.
+    /// A burst of invokes therefore spawns exactly one describe, and
+    /// `enroll`'s own `loops` check keeps it to at most one poll loop.
+    ///
+    /// A FAILED enrollment is retryable, which is why the burst guard is that
+    /// separate set rather than the presence of an `enrollments` entry. A
+    /// describe can fail transiently, and treating one failure as final would
+    /// strand the provider in exactly the state this method exists to
+    /// prevent — no describe, capability gates closed, no poll loop — until a
+    /// daemon restart. `enrollmentAttempts` bounds that retry.
     ///
     /// Three ways to be skipped, all deliberate:
     /// - **before `registrySwept`** — `start()` hasn't finished its sweep
     ///   yet, and it will describe every registry entry itself; enrolling
     ///   here would just race it to the same describe.
     /// - **a describe already on file** — boot handled this provider. Note a
-    ///   FAILED boot describe leaves none, so the first post-boot invoke buys
-    ///   one retry; the `enrollments` record keeps it to exactly one.
+    ///   FAILED boot describe leaves none, so post-boot invokes may still
+    ///   enroll it, bounded by `maxEnrollmentAttempts`.
+    /// - **the attempt budget is spent** — see `maxEnrollmentAttempts`.
     /// - **shutting down** — `enroll` re-checks under the reconfigure lock
     ///   too, since it can be scheduled just before `shutdown()` runs.
     ///
@@ -1057,14 +1106,23 @@ public actor RemoteProviderManager {
     /// `recordFailure` spell out at length.
     private func enrollIfNeeded(_ config: RemoteProviderConfig) {
         guard registrySwept, !shuttingDown,
-            enrollments[config.name] == nil,
-            describes[config.name] == nil
+            !enrollmentsInFlight.contains(config.name),
+            describes[config.name] == nil,
+            (enrollmentAttempts[config.name] ?? 0) < Self.maxEnrollmentAttempts
         else { return }
+        enrollmentsInFlight.insert(config.name)
+        enrollmentAttempts[config.name, default: 0] += 1
         remoteLogger.debug("enrolling post-boot provider \(config.name, privacy: .public)")
         enrollments[config.name] = Task { [weak self] in await self?.enroll(config) }
     }
 
     private func enroll(_ config: RemoteProviderConfig) async {
+        // Released on EVERY exit, including the failure returns below — that
+        // is what lets a later `invoke` or roster refresh retry a describe
+        // that failed, up to `maxEnrollmentAttempts`. The `enrollments` entry
+        // itself is deliberately NOT cleared: `shutdown()` drains it, and a
+        // handle removed on completion could not be awaited.
+        defer { enrollmentsInFlight.remove(config.name) }
         guard !Task.isCancelled else { return }
         // Same order the boot sweep uses: recover persisted freshness before
         // the describe, so this provider's first status read reports what the

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -33,12 +33,34 @@ public actor RemoteProviderManager {
     private let actuationLog: ActuationLog?
     static let pollInterval: TimeInterval = 60
     /// How many times one provider may be enrolled post-boot before this
-    /// actor stops trying. More than one because a describe failure is
-    /// routinely transient (the provider is mid-deploy, or a credential is
-    /// being refreshed); bounded because nothing clears the count, so an
-    /// unbounded retry would become a describe subprocess per RPC for a
-    /// provider that is permanently unreachable. A daemon restart resets it,
-    /// as it resets every other in-memory enrollment fact.
+    /// actor stops trying.
+    ///
+    /// This is a chosen policy, not an inherited one, so it is stated rather
+    /// than left implicit in a constant (`docs/theory-placement.md`). Boot
+    /// does not retry at all: a `describe` that fails during the boot sweep
+    /// leaves no `describes` entry until the daemon restarts. Enrollment
+    /// deliberately differs, because its trigger differs — boot runs once at
+    /// a moment nobody chose, while enrollment runs when somebody actually
+    /// addresses the provider, and answering "no describe, and never again"
+    /// to a user who just invoked a verb against a provider that has since
+    /// come back is the bug this whole path exists to remove.
+    ///
+    /// Why more than one: a describe failure is routinely transient — the
+    /// provider mid-deploy, a credential being refreshed. Why bounded at all:
+    /// nothing clears the count, and the retry is driven by traffic rather
+    /// than a timer, so an unbounded budget would spend a describe subprocess
+    /// on every `invoke` and every roster refresh, forever, for a provider
+    /// that is simply gone. Why three rather than two or ten: it is the
+    /// smallest budget that survives more than a single unlucky moment while
+    /// staying negligible if the provider never comes back. A daemon restart
+    /// resets it, as it resets every other in-memory enrollment fact.
+    ///
+    /// No spec accompanies this: the enclosing change is a bug fix, adding no
+    /// subsystem, flag, or migration, and the constant tunes a retry inside
+    /// it rather than revising TBD's theory of remote providers (root
+    /// `CLAUDE.md`, "Work starts with a brainstormed spec"). If the retry
+    /// ever grows a timer, a backoff, or a persisted count, that is a new
+    /// theory and it needs one.
     static let maxEnrollmentAttempts = 3
 
     private var providers: [String: RemoteProviderConfig] = [:]

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -54,6 +54,16 @@ public actor RemoteProviderManager {
     private var snapshotFreshnessUnreadable: Set<String> = []
     private var loops: [String: Task<Void, Never>] = [:]
     private var supervisors: [String: ProviderEventsSupervisor] = [:]
+    /// One entry per provider this actor has enrolled post-boot — see
+    /// `enrollIfNeeded`. The stored `Task` IS the idempotency record: entries
+    /// are never removed, so a completed one is what stops a later `invoke`
+    /// from re-describing a provider boot never saw.
+    ///
+    /// "Enrollment" is deliberately not "adoption": in this actor adoption
+    /// already means `RemoteSessionAdopter` pulling a provider's SESSIONS
+    /// into the local mirror, which is a different thing happening to a
+    /// different noun.
+    private var enrollments: [String: Task<Void, Never>] = [:]
     /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
     /// against a second concurrent call to the same sequence (e.g. two
     /// overlapping `start()`s). See the comment on `spawnPollLoops` for the
@@ -77,6 +87,10 @@ public actor RemoteProviderManager {
     /// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Stale
     /// snapshots"). Swept on every apply so it cannot grow without bound.
     private var filingDecisions: [UUID: Date] = [:]
+    /// True once `loadRegistryAndDescribe()` has swept the registry. It is
+    /// the line between "boot will describe this provider" and "nothing ever
+    /// will" — see `enrollIfNeeded`, which is a no-op before it flips.
+    private var registrySwept = false
 
     init(
         db: TBDDatabase, subscriptions: StateSubscriptionManager,
@@ -152,6 +166,7 @@ public actor RemoteProviderManager {
             await recoverLastSuccessfulSnapshotAtIfNeeded(provider: config.name, markStale: true)
             await describeProvider(config)
         }
+        registrySwept = true
         subscriptions.broadcast(delta: .remoteSessionsChanged)
     }
 
@@ -284,6 +299,7 @@ public actor RemoteProviderManager {
         await acquireReconfigureLock()
         defer { releaseReconfigureLock() }
         shuttingDown = true
+        for task in enrollments.values { task.cancel() }
         await stopAll()
     }
 
@@ -945,6 +961,29 @@ public actor RemoteProviderManager {
         }
     }
 
+    /// Test seam: whether a 60s poll loop is currently armed for `name`.
+    /// Same rationale as `hasSupervisor` — the post-boot enrollment path is
+    /// only observable through the loop it arms.
+    func hasPollLoop(named name: String) -> Bool {
+        loops[name] != nil
+    }
+
+    /// Test seam: awaits the post-boot enrollments `invoke`/`refreshRegistry`
+    /// schedule, so tests can assert on describe/poll-loop state
+    /// deterministically instead of bound-polling a fire-and-forget `Task`.
+    /// Returns immediately when nothing has been enrolled.
+    func awaitEnrollments() async {
+        for task in enrollments.values { await task.value }
+    }
+
+    /// Test seam: how many post-boot enrollments have been scheduled for
+    /// `name` — 0 or 1 by construction. Makes the "a burst of invokes must
+    /// not spawn N describes" invariant assertable at the source rather than
+    /// only through its side effects.
+    func enrollmentCount(named name: String) -> Int {
+        enrollments[name] == nil ? 0 : 1
+    }
+
     func invoke(
         providerName: String, verb: [String], stdin: Data?,
         timeout: TimeInterval
@@ -952,6 +991,10 @@ public actor RemoteProviderManager {
         guard let config = providers[providerName] ?? loadAdHoc(named: providerName) else {
             throw RemoteProviderError.unknownProvider(providerName)
         }
+        // Synchronous, so it runs to completion before the first `await`
+        // below — that's what makes a burst of concurrent invokes schedule
+        // exactly one enrollment.
+        enrollIfNeeded(config)
         let result = try await runner.run(
             config, verb: verb, stdin: stdin, timeout: timeout,
             contractVersion: contractMajor(for: providerName))
@@ -962,13 +1005,91 @@ public actor RemoteProviderManager {
     }
 
     /// Tests (and a pre-`start()` RPC call) can address providers straight
-    /// from the registry file.
+    /// from the registry file. This is also how a provider APPENDED to the
+    /// registry while the daemon runs first reaches this actor — `invoke`
+    /// turns that into a full enrollment, see `enrollIfNeeded`.
     private func loadAdHoc(named name: String) -> RemoteProviderConfig? {
         guard let configs = try? RemoteProviderRegistry.load(from: registryURL),
             let config = configs.first(where: { $0.name == name })
         else { return nil }
         registerIfNeeded(config)
         return config
+    }
+
+    /// Gives a provider first invoked AFTER the boot sweep the same treatment
+    /// `loadRegistryAndDescribe()` + `spawnPollLoops()` give a boot-time one:
+    /// a `describe` — without which `describes[name]` stays empty,
+    /// `declaredCapabilities` returns the empty set, and every capability
+    /// gate that reads it fails closed, so the detail pane says the provider
+    /// "doesn't support attach or a log view" while the provider is answering
+    /// perfectly well — and then its 60s poll loop, without which the mirror
+    /// stays at zero sessions. Before this, a provider added to
+    /// `agent-providers.json` mid-run was reachable by direct verbs (`invoke`
+    /// falls back to `loadAdHoc`) and by nothing else until someone restarted
+    /// the daemon.
+    ///
+    /// Fire-and-forget on purpose: `invoke` calls this synchronously, and
+    /// describing inline would make an unrelated `remote.log` wait out a
+    /// describe's 10s timeout.
+    ///
+    /// Idempotent by construction, which matters because `invoke` reaches
+    /// here on EVERY call: the `enrollments` entry is written with no `await`
+    /// between the check and the insert, so actor isolation makes it atomic,
+    /// and it is never removed. A burst of invokes therefore spawns exactly
+    /// one describe, and `enroll`'s own `loops` check keeps it to at most one
+    /// poll loop.
+    ///
+    /// Three ways to be skipped, all deliberate:
+    /// - **before `registrySwept`** — `start()` hasn't finished its sweep
+    ///   yet, and it will describe every registry entry itself; enrolling
+    ///   here would just race it to the same describe.
+    /// - **a describe already on file** — boot handled this provider. Note a
+    ///   FAILED boot describe leaves none, so the first post-boot invoke buys
+    ///   one retry; the `enrollments` record keeps it to exactly one.
+    /// - **shutting down** — `enroll` re-checks under the reconfigure lock
+    ///   too, since it can be scheduled just before `shutdown()` runs.
+    ///
+    /// Called from `invoke` rather than from `loadAdHoc`, which would also
+    /// cover `recordAttachExit`: an attach is gated app-side on declared
+    /// capabilities, so a provider with no describe can't be attached in the
+    /// first place, and slipping a describe into that path would race the
+    /// deliberately-ordered health inheritance `recordAttachExit` and
+    /// `recordFailure` spell out at length.
+    private func enrollIfNeeded(_ config: RemoteProviderConfig) {
+        guard registrySwept, !shuttingDown,
+            enrollments[config.name] == nil,
+            describes[config.name] == nil
+        else { return }
+        remoteLogger.debug("enrolling post-boot provider \(config.name, privacy: .public)")
+        enrollments[config.name] = Task { [weak self] in await self?.enroll(config) }
+    }
+
+    private func enroll(_ config: RemoteProviderConfig) async {
+        guard !Task.isCancelled else { return }
+        // Same order the boot sweep uses: recover persisted freshness before
+        // the describe, so this provider's first status read reports what the
+        // mirror actually knows rather than treating it as never-refreshed.
+        await recoverLastSuccessfulSnapshotAtIfNeeded(provider: config.name, markStale: true)
+        await describeProvider(config)
+        // A failed describe already recorded (and broadcast) its health via
+        // `recordFailure`/`setHealth`; there's no contract to poll against,
+        // so stop here exactly as `spawnPollLoops` would.
+        guard describes[config.name] != nil else { return }
+        // `describeProvider` doesn't broadcast on success — boot's
+        // `loadRegistryAndDescribe` does it once for the whole batch. This is
+        // the one-provider equivalent: every capability gate reads the
+        // describe, so the app has to hear about it.
+        subscriptions.broadcast(delta: .remoteSessionsChanged)
+        // Same lock the boot path takes, for the same reason (see
+        // `spawnPollLoops`) — an unlocked `startLoop` here could interleave
+        // with a concurrent `stopAll()` and orphan a supervisor. Deliberately
+        // NOT `spawnPollLoops()`: that stops and respawns every provider's
+        // loop, so adding one provider would blip the streams of all the
+        // others.
+        await acquireReconfigureLock()
+        defer { releaseReconfigureLock() }
+        guard !shuttingDown, loops[config.name] == nil else { return }
+        await startLoop(for: config)
     }
 
     /// Registers a provider config (if not already known) and seeds a
@@ -1012,6 +1133,37 @@ public actor RemoteProviderManager {
     /// What TBD announces before it has negotiated anything — the conservative
     /// reading, and the value the runner emitted unconditionally before.
     static let fallbackContractMajor = 1
+
+    /// Picks up registry entries added since the boot sweep: registers each
+    /// one and schedules its enrollment (describe + poll loop). Called by the
+    /// `remote.providers` RPC, which is how the app asks for the roster — so
+    /// a provider appended to `agent-providers.json` becomes fully live
+    /// without anyone having to invoke a verb against it first, and without
+    /// a daemon restart.
+    ///
+    /// Cheap enough to sit on that path: a small JSON read plus a dictionary
+    /// probe per entry, and `enrollIfNeeded` is a no-op for every provider
+    /// already on file, so the repeated calls the app's delta-driven refresh
+    /// makes cost one file read each. No broadcast of its own — a landing
+    /// enrollment broadcasts, which is what pulls the app back for the roster
+    /// that now carries the new provider's capabilities.
+    ///
+    /// Reads through `loadEntries` for the same reserved-name filtering the
+    /// boot sweep gets: a registry entry that shadows a built-in provider is
+    /// skipped there and must be skipped here too, or this path would be a
+    /// way around it. Built-ins themselves need nothing — `init` seeds them.
+    ///
+    /// Deliberately additive: an entry REMOVED from the registry keeps its
+    /// poll loop until the daemon restarts. Tearing loops down from a file
+    /// read would let a half-written registry (or a momentarily unreadable
+    /// one, which reports as "no providers") kill live streams.
+    func refreshRegistry() {
+        guard let loaded = try? RemoteProviderRegistry.loadEntries(from: registryURL) else { return }
+        for config in loaded.configs {
+            registerIfNeeded(config)
+            enrollIfNeeded(config)
+        }
+    }
 
     func providerStatuses() async -> [RemoteProviderStatus] {
         for name in providers.keys {

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -138,6 +138,10 @@ extension RPCRouter {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
+        // Re-read the registry first, so a provider added to
+        // `agent-providers.json` while the daemon runs is registered and
+        // enrolled rather than staying invisible until a restart.
+        await manager.refreshRegistry()
         return try RPCResponse(result: RemoteProvidersResult(providers: await manager.providerStatuses()))
     }
 

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -106,6 +106,52 @@ func providerOK(_ json: String) -> ProviderResult {
     ProviderResult(exitCode: 0, stdout: Data(json.utf8), stderr: "")
 }
 
+/// Provider-and-verb-keyed fake, keys shaped `"<provider>.<verb>"` (e.g.
+/// `"late.describe"`), each answering an unbounded number of calls.
+///
+/// The positional `FakeProviderInvoker` script cannot express the post-boot
+/// enrollment tests: enrollment's `describe` is deliberately fire-and-forget, so
+/// it runs CONCURRENTLY with the `invoke` that scheduled it and which of the
+/// two pops the script first is a scheduling detail. A positional script
+/// would hand the describe's JSON to the `log` call about a third of the
+/// time. Keying by provider+verb makes the assertions independent of that
+/// interleaving instead of quarantining a race.
+final class VerbKeyedProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
+    private let lock = NSLock()
+    private let results: [String: ProviderResult]
+    private var counts: [String: Int] = [:]
+
+    init(_ results: [String: ProviderResult]) {
+        self.results = results
+    }
+
+    func run(
+        _ config: RemoteProviderConfig, verb: [String], stdin: Data?,
+        timeout: TimeInterval, contractVersion: Int
+    ) async throws -> ProviderResult {
+        try lookup(provider: config.name, verb: verb)
+    }
+
+    /// Synchronous for the same reason `FakeProviderInvoker.popScript` is —
+    /// NSLock must not be taken from an `async` context.
+    private func lookup(provider: String, verb: [String]) throws -> ProviderResult {
+        lock.lock(); defer { lock.unlock() }
+        let key = "\(provider).\(verb.first ?? "?")"
+        counts[key, default: 0] += 1
+        guard let result = results[key] else {
+            preconditionFailure("VerbKeyedProviderInvoker has no result for \(key)")
+        }
+        return result
+    }
+
+    /// How many times `"<provider>.<verb>"` has been invoked. Locked, because
+    /// a manager's background poll `Task` may still be writing.
+    func count(_ key: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return counts[key] ?? 0
+    }
+}
+
 /// Thread-safe collector for broadcast StateDeltas, mirroring the pattern in
 /// `RPCRouterWorktreeCreateBroadcastTests` / `GCHandlersTests`.
 private final class BroadcastDeltas: @unchecked Sendable {
@@ -873,6 +919,256 @@ struct RemoteProviderManagerTests {
             "provider without events capability must still be covered by the 60s list poll; observed calls=\(invoker.callsSnapshot())"
         )
         await m.stopAll()
+    }
+
+    // MARK: - post-boot provider enrollment
+
+    /// Rewrites the registry to hold both `fake` and `late`, mimicking a user
+    /// appending a provider to `agent-providers.json` with the daemon already
+    /// running.
+    private func addLateProviderToRegistry() throws {
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}, {"name": "late", "exec": "/nonexistent/late"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
+    }
+
+    private func manager(_ invoker: VerbKeyedProviderInvoker) -> RemoteProviderManager {
+        RemoteProviderManager(db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+    }
+
+    /// The bug this path exists for: a provider added to the registry AFTER
+    /// boot used to be registered by `loadAdHoc` and nothing more. Direct
+    /// verbs worked, but `describes` stayed empty — so the app's capability
+    /// gate, which fails closed, rendered "doesn't support attach or a log
+    /// view" — and no poll loop ever ran, so the mirror stayed at zero
+    /// sessions, until someone restarted the daemon.
+    @Test func providerAddedAfterBootGetsDescribeAndPollLoop() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": providerOK(#"{"contract_versions": [1], "name": "late", "capabilities": ["log", "attach"]}"#),
+            "late.list": providerOK(#"{"sessions": []}"#),
+            "late.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+
+        _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+
+        let late = await m.providerStatuses().first { $0.config.name == "late" }
+        #expect(late?.describe?.capabilities == ["log", "attach"],
+                "a post-boot provider must be described, or the app's capability gate fails closed")
+        #expect(await m.hasPollLoop(named: "late"),
+                "a post-boot provider must get the same 60s poll loop a boot-time one gets")
+        await m.stopAll()
+    }
+
+    /// Enrollment arms one provider's loop rather than going through
+    /// `spawnPollLoops()`, which stops and respawns every provider's loop and
+    /// supervisor — adding one provider must not blip the others' streams.
+    @Test func enrollmentLeavesExistingProviderLoopsAlone() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": ["events"]}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": providerOK(#"{"contract_versions": [1], "name": "late"}"#),
+            "late.list": providerOK(#"{"sessions": []}"#),
+            "late.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        #expect(await m.hasSupervisor(named: "fake"))
+        try addLateProviderToRegistry()
+
+        _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+
+        #expect(await m.hasSupervisor(named: "fake"),
+                "enrolling a provider must not tear down an existing one's events supervisor")
+        #expect(await m.hasPollLoop(named: "fake"),
+                "enrolling a provider must not tear down an existing one's poll loop")
+        await m.stopAll()
+    }
+
+    /// `invoke` reaches `loadAdHoc` on every call for a provider that isn't in
+    /// `providers` yet, so without the `enrollments` record a burst of invokes
+    /// would spawn one describe each — and, worse, race N poll loops onto the
+    /// same provider.
+    @Test func repeatedInvokesEnrollOnlyOnce() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": providerOK(#"{"contract_versions": [1], "name": "late"}"#),
+            "late.list": providerOK(#"{"sessions": []}"#),
+            "late.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+
+        for _ in 0..<5 {
+            _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        }
+        await m.awaitEnrollments()
+
+        #expect(await m.enrollmentCount(named: "late") == 1)
+        #expect(invoker.count("late.describe") == 1,
+                "five invokes must share one describe; observed \(invoker.count("late.describe"))")
+        #expect(await m.hasPollLoop(named: "late"))
+        await m.stopAll()
+    }
+
+    /// The enrollment path's mirror of `versionMismatchNeverPolls`: a post-boot
+    /// provider that negotiates no usable contract gets its health surfaced
+    /// and no poll loop. `[3]` for the same reason that test uses it — it is
+    /// outside `supportedContractMajors`, which covers both 1 and 2.
+    @Test func enrollmentOfVersionMismatchedProviderArmsNoLoop() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": providerOK(#"{"contract_versions": [3], "name": "late"}"#),
+            "late.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+
+        _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+
+        let late = await m.providerStatuses().first { $0.config.name == "late" }
+        #expect(late?.health == .error)
+        #expect(late?.errorMessage == "no common contract version")
+        #expect(await !m.hasPollLoop(named: "late"),
+                "no negotiated contract means nothing to poll")
+        await m.stopAll()
+    }
+
+    /// A provider boot already described must not be re-described by an
+    /// `invoke` — the `describes` check in `enrollIfNeeded` is what keeps the
+    /// boot path authoritative and stops enrollment becoming a per-invoke
+    /// describe.
+    @Test func bootDescribedProviderIsNotReDescribedByInvoke() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.stop": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.loadRegistryAndDescribe()
+        _ = try await m.invoke(providerName: "fake", verb: ["stop", "a"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+        #expect(await m.enrollmentCount(named: "fake") == 0)
+        #expect(invoker.count("fake.describe") == 1)
+    }
+
+    /// Shutdown is terminal for this actor, and enrollment is no exception: an
+    /// invoke landing after `shutdown()` must not describe or arm a loop on a
+    /// manager the daemon believes it tore down.
+    @Test func enrollmentAfterShutdownArmsNothing() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+        await m.shutdown()
+
+        _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+
+        #expect(await m.enrollmentCount(named: "late") == 0)
+        #expect(await !m.hasPollLoop(named: "late"))
+        #expect(invoker.count("late.describe") == 0,
+                "a shut-down manager must not spawn a describe")
+    }
+
+    /// The `remote.providers` path: a provider appended to the registry must
+    /// go fully live off the app's own roster request, without anyone having
+    /// to invoke a verb against it first.
+    @Test func refreshRegistryEnrollsAProviderNobodyInvoked() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": providerOK(#"{"contract_versions": [1], "name": "late", "capabilities": ["log"]}"#),
+            "late.list": providerOK(#"{"sessions": []}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        #expect(await m.providerStatuses().count == 1)
+        try addLateProviderToRegistry()
+
+        await m.refreshRegistry()
+        await m.awaitEnrollments()
+
+        let late = await m.providerStatuses().first { $0.config.name == "late" }
+        #expect(late?.describe?.capabilities == ["log"])
+        #expect(await m.hasPollLoop(named: "late"))
+        await m.stopAll()
+    }
+
+    /// The app's refresh is delta-driven and fires repeatedly, so the roster
+    /// path must stay a no-op after the first enrollment rather than
+    /// re-describing every provider on every call.
+    @Test func repeatedRegistryRefreshesDescribeOnlyOnce() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": providerOK(#"{"contract_versions": [1], "name": "late"}"#),
+            "late.list": providerOK(#"{"sessions": []}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+
+        for _ in 0..<5 {
+            await m.refreshRegistry()
+            await m.awaitEnrollments()
+        }
+
+        #expect(invoker.count("late.describe") == 1,
+                "five roster refreshes must share one describe; observed \(invoker.count("late.describe"))")
+        #expect(invoker.count("fake.describe") == 1,
+                "an already-described provider must never be re-described by a refresh")
+        await m.stopAll()
+    }
+
+    /// Removal is deliberately not handled: a momentarily unreadable or
+    /// half-written registry reads as "no providers", and tearing loops down
+    /// from that would kill live streams.
+    @Test func refreshRegistryDoesNotTearDownRemovedProviders() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        #expect(await m.hasPollLoop(named: "fake"))
+
+        try "[]".write(to: registryURL, atomically: true, encoding: .utf8)
+        await m.refreshRegistry()
+
+        #expect(await m.hasPollLoop(named: "fake"),
+                "an empty or unreadable registry must not kill a live provider's poll loop")
+        await m.stopAll()
+    }
+
+    /// Before the boot sweep has run, `start()` is still coming and will
+    /// describe every registry entry itself — an invoke landing in that
+    /// window must not race it to the same describe. (This is also what
+    /// keeps a manager that never boots, as the RPC-router tests use, free of
+    /// unscripted describes.)
+    @Test func invokeBeforeBootSweepDoesNotEnroll() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        _ = try await m.invoke(providerName: "fake", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+        #expect(await m.enrollmentCount(named: "fake") == 0)
+        #expect(invoker.count("fake.describe") == 0,
+                "boot's own sweep describes registry entries; enrolling here would double up")
     }
 
     @Test func versionMismatchNeverPolls() async throws {

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -116,6 +116,47 @@ func providerOK(_ json: String) -> ProviderResult {
 /// would hand the describe's JSON to the `log` call about a third of the
 /// time. Keying by provider+verb makes the assertions independent of that
 /// interleaving instead of quarantining a race.
+/// Like `VerbKeyedProviderInvoker`, but each key holds a SEQUENCE of results
+/// consumed in order (the last one repeats once exhausted). Needed for the
+/// enrollment-retry tests, where the same `<provider>.describe` key must fail
+/// first and succeed second — still keyed by verb, so it stays independent of
+/// how the concurrent describe and invoke interleave.
+final class VerbKeyedSequenceInvoker: RemoteProviderInvoking, @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [String: [ProviderResult]]
+    private var counts: [String: Int] = [:]
+
+    init(_ results: [String: [ProviderResult]]) {
+        self.results = results
+    }
+
+    func run(
+        _ config: RemoteProviderConfig, verb: [String], stdin: Data?,
+        timeout: TimeInterval, contractVersion: Int
+    ) async throws -> ProviderResult {
+        try lookup(provider: config.name, verb: verb)
+    }
+
+    private func lookup(provider: String, verb: [String]) throws -> ProviderResult {
+        lock.lock(); defer { lock.unlock() }
+        let key = "\(provider).\(verb.first ?? "?")"
+        counts[key, default: 0] += 1
+        guard var queue = results[key], let next = queue.first else {
+            preconditionFailure("VerbKeyedSequenceInvoker has no result for \(key)")
+        }
+        if queue.count > 1 {
+            queue.removeFirst()
+            results[key] = queue
+        }
+        return next
+    }
+
+    func count(_ key: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return counts[key] ?? 0
+    }
+}
+
 final class VerbKeyedProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
     private let lock = NSLock()
     private let results: [String: ProviderResult]
@@ -935,6 +976,10 @@ struct RemoteProviderManagerTests {
         RemoteProviderManager(db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
     }
 
+    private func manager(_ invoker: VerbKeyedSequenceInvoker) -> RemoteProviderManager {
+        RemoteProviderManager(db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+    }
+
     /// The bug this path exists for: a provider added to the registry AFTER
     /// boot used to be registered by `loadAdHoc` and nothing more. Direct
     /// verbs worked, but `describes` stayed empty — so the app's capability
@@ -1006,8 +1051,18 @@ struct RemoteProviderManagerTests {
         await m.start()
         try addLateProviderToRegistry()
 
-        for _ in 0..<5 {
-            _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        // CONCURRENT on purpose. Awaiting five invokes one at a time would
+        // pass even if the `enrollmentsInFlight` insert sat behind an
+        // `await` — the very regression the burst guard exists to prevent.
+        // Firing them together is what puts five calls inside `invoke`
+        // before any enrollment completes.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    _ = try? await m.invoke(
+                        providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+                }
+            }
         }
         await m.awaitEnrollments()
 
@@ -1169,6 +1224,91 @@ struct RemoteProviderManagerTests {
         #expect(await m.enrollmentCount(named: "fake") == 0)
         #expect(invoker.count("fake.describe") == 0,
                 "boot's own sweep describes registry entries; enrolling here would double up")
+    }
+
+    /// Regression test for the review's HIGH finding: `shutdown()` used to
+    /// cancel enrollment tasks without awaiting them. Cancelling an in-flight
+    /// describe without awaiting orphans the child process, because the
+    /// interruption runs on the cancelled task — the same hazard
+    /// `Daemon.stop()` documents for `remoteStartTask`. After `shutdown()`
+    /// returns, no enrollment may still be running.
+    @Test func shutdownDrainsAnInFlightEnrollment() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": providerOK(#"{"contract_versions": [1], "name": "late"}"#),
+            "late.list": providerOK(#"{"sessions": []}"#),
+            "late.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+        _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+
+        await m.shutdown()
+
+        #expect(await !m.hasEnrollmentInFlight(named: "late"),
+                "shutdown must await the enrollment it cancelled, not leave it running")
+        #expect(await !m.hasPollLoop(named: "late"),
+                "a shut-down manager must arm nothing")
+    }
+
+    /// Regression test for the review's MEDIUM finding: one failed describe
+    /// used to strand a provider forever, since the `enrollments` entry was
+    /// never cleared. A transient failure must be retryable — otherwise the
+    /// provider sits in exactly the state this feature exists to fix.
+    @Test func aFailedEnrollmentCanBeRetried() async throws {
+        let invoker = VerbKeyedSequenceInvoker([
+            "fake.describe": [providerOK(#"{"contract_versions": [1], "name": "fake"}"#)],
+            "fake.list": [providerOK(#"{"sessions": []}"#)],
+            "late.log": [providerOK(#"{"ok": true}"#), providerOK(#"{"ok": true}"#)],
+            "late.describe": [
+                ProviderResult(exitCode: 3, stdout: Data(), stderr: "provider mid-deploy"),
+                providerOK(#"{"contract_versions": [1], "name": "late", "capabilities": ["log"]}"#),
+            ],
+            "late.list": [providerOK(#"{"sessions": []}"#)],
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+
+        _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+        #expect(await m.providerStatuses().first { $0.config.name == "late" }?.describe == nil,
+                "the first describe failed, so there is no contract on file yet")
+        #expect(await !m.hasPollLoop(named: "late"))
+
+        _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+        await m.awaitEnrollments()
+
+        let late = await m.providerStatuses().first { $0.config.name == "late" }
+        #expect(late?.describe?.capabilities == ["log"],
+                "a second invoke must retry the describe rather than stay stranded")
+        #expect(await m.hasPollLoop(named: "late"))
+        await m.stopAll()
+    }
+
+    /// The retry has to stop somewhere: a provider that is simply down must
+    /// not buy a describe subprocess on every RPC for the daemon's lifetime.
+    @Test func enrollmentRetriesAreBoundedByTheAttemptBudget() async throws {
+        let invoker = VerbKeyedProviderInvoker([
+            "fake.describe": providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            "fake.list": providerOK(#"{"sessions": []}"#),
+            "late.describe": ProviderResult(exitCode: 3, stdout: Data(), stderr: "unreachable"),
+            "late.log": providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        try addLateProviderToRegistry()
+
+        for _ in 0..<8 {
+            _ = try await m.invoke(providerName: "late", verb: ["log", "s1"], stdin: nil, timeout: 30)
+            await m.awaitEnrollments()
+        }
+
+        #expect(invoker.count("late.describe") == RemoteProviderManager.maxEnrollmentAttempts,
+                "eight invokes against a down provider must spend the budget and stop; observed \(invoker.count("late.describe"))")
+        await m.stopAll()
     }
 
     @Test func versionMismatchNeverPolls() async throws {


### PR DESCRIPTION
## What's broken

Add a provider to `~/tbd/agent-providers.json` while the daemon is already running and it comes up half-alive, permanently. The roster lists it and reports it healthy, but with no successful inventory and zero sessions, and opening one of its sessions says *"This provider doesn't support attach or a log view for this session"* — while `remote.log` and `remote.send` against that very provider work fine.

Nothing recovers it. Editing the file again does not help, and neither does anything the app can do. The only cure is restarting the daemon, which is a heavy thing to ask of someone who just added a line to a config file.

Anyone running more than one backend hits this the moment they add the second one, because the first was present at boot and the second never is.

## Why it happens

Two things only ever happen during daemon boot.

A provider's `describe` response — the thing that says which verbs it supports — is written by `describeProvider`, which is reached only from `loadRegistryAndDescribe()`, which is reached only from `start()`. Its 60-second poll loop, the thing that fills the session mirror, is armed only by `spawnPollLoops()`, also only from `start()`.

A provider that shows up later takes a different door. `invoke` falls back to `loadAdHoc`, which re-reads the registry and calls `registerIfNeeded` — enough to put the provider in the roster with a default-healthy entry, which is why it looks fine and why direct verbs work. But no describe is ever run for it, and no loop is ever armed.

The empty describe is what hides attach and logs. `declaredCapabilities` returns the capabilities from the stored describe, or the empty set when there is none, and every capability gate fails closed on it *by design* — an unknown capability set is not permission to try the verb and see. So a provider that never got described is indistinguishable, to every gate, from one that supports nothing.

## What this PR does

Gives a provider first seen after the boot sweep the same treatment boot gives: a describe, and then a poll loop if it negotiates a usable contract. One idempotent `enrollIfNeeded`, reached two ways:

- **`invoke`** enrolls the provider it just resolved — the path `log` and `send` already take.
- **`remote.providers`** re-reads the registry first, via a new `refreshRegistry()`, so a new provider lights up from the app's ordinary roster request even if nobody ever invokes a verb against it.

Enrollment is fire-and-forget, because `invoke` is on the RPC path and describing inline would make an unrelated `log` call wait out a describe's 10-second timeout.

It is idempotent by construction, which matters because `invoke` reaches it on every call: the `enrollments` entry is written with no `await` between the check and the insert, so actor isolation collapses a burst of invokes into exactly one describe, and `enroll`'s own `loops` check keeps it to at most one poll loop.

It arms that single loop under the existing reconfigure lock rather than calling `spawnPollLoops()`, which stops and respawns *every* provider's loop and supervisor — adding one provider should not blip everyone else's event stream. `shuttingDown` is re-checked under that lock, and a new `registrySwept` flag keeps enrollment from racing boot's own sweep to the same describe.

Called from `invoke` rather than from `loadAdHoc`, which would also cover `recordAttachExit` — attach is gated on declared capabilities anyway, so an undescribed provider cannot be attached in the first place, and slipping a describe into that path would race the deliberately-ordered health inheritance that `recordAttachExit` and `recordFailure` spell out at length.

Named *enrollment* rather than *adoption* because adoption already means something else here: `RemoteSessionAdopter` pulling a provider's sessions into the local mirror.

## Assumptions

**Registry removals are deliberately not handled.** An entry deleted from the file keeps its poll loop until the next restart. A momentarily unreadable or half-written registry reads as "no providers", and tearing loops down from a file read would kill live streams on a transient parse failure — a much worse outcome than a stale loop.

**Reading the registry on the roster path is cheap enough to be unconditional.** It is a small JSON read plus a dictionary probe per entry, and enrollment is a no-op for every provider already on file, so the app's delta-driven refresh costs one file read per call and nothing else.

**A failed enrollment is retryable, up to three attempts.** A describe can fail transiently — the provider mid-deploy, a credential being refreshed — and treating one failure as final would strand the provider in exactly the state this PR removes. So the burst guard (`enrollmentsInFlight`) is released on every exit, and a later invoke or roster refresh tries again; `maxEnrollmentAttempts` bounds it at three, because the retry is driven by traffic rather than a timer and an unbounded budget would spend a describe subprocess per RPC forever on a provider that is simply gone. A daemon restart resets the count.

This differs from boot deliberately: boot does not retry at all. The reasoning, and why three, is stated on the constant itself rather than left implicit — see `docs/theory-placement.md`. **No spec accompanies it**: this change adds no subsystem, flag, or migration, and the constant tunes a retry inside a bug fix rather than revising TBD's theory of remote providers. If the retry ever grows a timer, a backoff, or a persisted count, that is a new theory and needs one.

## Evidence & verification

Found on a live daemon, not constructed. A second provider added to the registry while the daemon ran showed no describe, no capabilities and no poll, while the provider executable itself answered `describe` correctly in well under its timeout from a stripped environment, and both `log` and `send` succeeded against it through the daemon. After a daemon restart, both providers described and polled normally — transport and registration were never the problem; describe and poll-loop arming were simply missing on that path.

Nine tests in `RemoteProviderManagerTests`, using a new provider-and-verb-keyed fake invoker. The positional `FakeProviderInvoker` cannot express these: enrollment's describe runs concurrently with the invoke that scheduled it, so which one pops the script first is a scheduling detail, and a positional script binds the describe's JSON to the `log` call a fraction of the time. Keying by provider and verb makes the assertions independent of the interleaving rather than quarantining a race.

Covered: a post-boot provider gets a describe and a poll loop; an existing provider's loop and events supervisor are untouched by a new enrollment; five **concurrent** invokes share one describe (fired through a task group — awaited one at a time, the test would pass even if the in-flight insert sat behind an `await`, which is the regression the burst guard exists to prevent); five roster refreshes share one describe; a provider negotiating no supported contract major arms no loop; nothing enrolls before the boot sweep; nothing enrolls after shutdown; a registry removal does not tear down a live loop; `shutdown()` leaves no enrollment running; a failed describe is retried and then succeeds; eight invokes against a down provider spend the attempt budget and stop.

```
scripts/swift-safe build          → Build complete!
swiftlint --strict                → 0 violations, 0 serious in 824 files
scripts/test.sh --filter 'RemoteProviderManager|RPCRouterRemote'
                                  → 105 tests in 3 suites passed
scripts/test.sh --filter '^TBDDaemonTests\.'
                                  → 4275 tests in 375 suites passed (71 known issues)
scripts/test.sh --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'
                                  → 3825 tests in 392 suites passed (14 known issues)
```

---

Authored by an AI agent (Claude Opus 5) in a TBD worktree, from a live reproduction on a running daemon, and reviewed by the repo owner before submission.

[20260825-secret-wallaby](https://cheapsteak.github.io/tbd/open/?worktree=CCEFA3B3-0332-492F-A21D-99F4FA8DE046)
