### PR TITLE
Feat: name which provider a remote surface is talking about

### DIFF
--- a/Sources/TBDApp/Remote/RemoteAgentAttention.swift
+++ b/Sources/TBDApp/Remote/RemoteAgentAttention.swift
@@ -1,0 +1,94 @@
+import Foundation
+import TBDShared
+
+/// One mirror row, read for the question "does a human need to do something,
+/// and what?" — the attention axis, stated in words.
+///
+/// Pure policy with no SwiftUI or `AppState` dependency, like
+/// `RemoteAttachExitClass` and `RemoteSessionDetailGates` beside it.
+///
+/// Two rules it never breaks, both from the provider contract:
+///
+/// - **Blockage is read off `agent_state`, never off `pending_question`.**
+///   The contract says so normatively, so every path here checks
+///   `waitingInput` first and reaches for the question block second, as
+///   detail. A provider that leaves a stale question block behind can make
+///   TBD's explanation wrong; it can never make TBD claim a session is
+///   blocked that the agent axis says is working.
+/// - **`state: running` with `agent_state: unknown` is not progress.** It
+///   means the terminal exists and nothing machine-readable reported what the
+///   agent is doing. It is a distinct, named reading here for exactly that
+///   reason: it used to render as the same green as real work.
+enum RemoteAgentAttention {
+    /// Why a human is being asked to look, in one sentence, or nil when
+    /// nothing about this row asks for a human.
+    ///
+    /// Ordered most specific source first: the structured question block, the
+    /// provider's own reason string, then the bare state.
+    static func explanation(for session: RemoteSessionInfo) -> String? {
+        guard !session.gone else { return nil }
+        switch session.payload.agentState {
+        case .waitingInput:
+            if let question = questionSummary(session.payload.pendingQuestion) { return question }
+            if let reason = humanizedReason(session.payload.agentStateReason) { return reason }
+            return "Waiting for input."
+        case .unknown where session.payload.state == .running:
+            return unattributedRunningExplanation
+        case .idle where session.payload.state == .running:
+            return "Agent is idle — it reported no work in progress."
+        case .working, .idle, .exited, .unknown:
+            return nil
+        }
+    }
+
+    /// The sentence for a live terminal whose agent says nothing. Named
+    /// rather than inlined because the desk states it both per row and once
+    /// in aggregate, and the two must not drift into saying different things.
+    static let unattributedRunningExplanation =
+        "Terminal is running and no agent state was reported — terminal liveness is not agent progress."
+
+    /// Rows a human has to act on. The agent axis alone decides this; a
+    /// terminal that happens to be running or exited underneath does not
+    /// change whether the agent is blocked.
+    static func needsAttention(_ session: RemoteSessionInfo) -> Bool {
+        !session.gone && session.payload.agentState == .waitingInput
+    }
+
+    /// Rows with a live terminal and no reported agent state — counted
+    /// separately from both "working" and "waiting" because it is neither.
+    static func isUnattributedRunning(_ session: RemoteSessionInfo) -> Bool {
+        !session.gone && session.payload.state == .running && session.payload.agentState == .unknown
+    }
+
+    /// The provider's free-form `agent_state_reason`, made readable.
+    ///
+    /// Exactly one value is translated: `permission_prompt`, the contract's
+    /// own worked example. Everything else is passed through verbatim rather
+    /// than pattern-matched — the field is provider-defined, and a caller
+    /// that invents meanings for strings it was never promised will
+    /// eventually put a confident sentence over a value that meant something
+    /// else.
+    static func humanizedReason(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed == "permission_prompt" { return "Blocked on a permission prompt." }
+        return trimmed
+    }
+
+    /// The structured question block as one line: the first question's
+    /// prompt, plus its option labels when it has any, plus a count when more
+    /// than one question is pending.
+    static func questionSummary(_ question: RemotePendingQuestion?) -> String? {
+        guard let question, let first = question.questions.first else { return nil }
+        var line = "Blocked on a question: \(first.prompt)"
+        let options = first.options.map(\.label).filter { !$0.isEmpty }
+        if !options.isEmpty {
+            line += " (\(options.joined(separator: " / ")))"
+        }
+        if question.questions.count > 1 {
+            line += " — and \(question.questions.count - 1) more."
+        }
+        return line
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteAttachDiagnosisView.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachDiagnosisView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import TBDShared
+
+/// What the attach pane shows when `RemoteAttachPreflight` could not resolve
+/// a selection to a spawnable command.
+///
+/// Deliberately in the pane rather than an alert or a log line: the user is
+/// looking here, so the reason belongs here. `RemoteAttachPager` used to
+/// `continue` past an unresolvable selection — no tab, no error, and a blank
+/// rectangle where the terminal should have been, which reads as "attach is
+/// broken" whatever the actual cause was.
+///
+/// Every string comes from the pure diagnosis, so what a user reads is
+/// exactly what `RemoteAttachPreflightTests` asserts.
+struct RemoteAttachDiagnosisView: View {
+    let selection: RemoteSessionSelection
+    let diagnosis: RemoteAttachPreflight.Diagnosis
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(SuffixRowIndicator.attention.color)
+                Text(diagnosis.title)
+                    .font(.headline)
+            }
+            Text(diagnosis.detail)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+            // The selection verbatim: which provider was asked, for which
+            // session. The failure class this view exists for is "I thought I
+            // was talking to the other provider", so the pane never leaves
+            // that implicit.
+            Text("\(selection.provider) · \(selection.sessionID)")
+                .font(.caption.monospaced())
+                .foregroundStyle(.tertiary)
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(nsColor: .textBackgroundColor))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(diagnosis.title). \(diagnosis.detail)")
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteAttachDiagnosisView.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachDiagnosisView.swift
@@ -37,6 +37,14 @@ struct RemoteAttachDiagnosisView: View {
                 .font(.caption.monospaced())
                 .foregroundStyle(.tertiary)
                 .textSelection(.enabled)
+            // Every diagnosis but one describes something a person can fix
+            // while looking at this pane, so the pane must not read as a
+            // dead end: `RemoteAttachPager` re-runs the preflight on each
+            // render and replaces this view with the terminal the moment it
+            // passes.
+            Text("TBD re-checks this automatically — no need to reopen the session.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
             Spacer(minLength: 0)
         }
         .padding(20)

--- a/Sources/TBDApp/Remote/RemoteAttachPager.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachPager.swift
@@ -32,6 +32,22 @@ struct RemoteAttachPager: NSViewControllerRepresentable {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var appearance: AppearanceSettings
 
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    /// Which mounted tabs are showing a preflight diagnosis rather than a
+    /// live terminal, and which diagnosis each is showing.
+    ///
+    /// A tab is created once per selection and then kept — that is the whole
+    /// point of the pager — so without this record a failed preflight would
+    /// freeze at whatever it concluded on first mount. Several diagnoses
+    /// describe conditions a user fixes while looking at them (`chmod +x`,
+    /// re-registering a provider), and before the preflight existed an
+    /// unresolvable selection was simply skipped and therefore retried on
+    /// every render. Keeping that self-healing is what this exists for.
+    final class Coordinator {
+        var diagnosed: [RemoteSessionSelection: RemoteAttachPreflight.Diagnosis] = [:]
+    }
+
     func makeNSViewController(context: Context) -> NSTabViewController {
         let vc = NSTabViewController()
         vc.tabStyle = .unspecified
@@ -41,7 +57,7 @@ struct RemoteAttachPager: NSViewControllerRepresentable {
 
     func updateNSViewController(_ vc: NSTabViewController, context: Context) {
         let mountedSelections = Set(selections)
-        let currentSelections = vc.tabViewItems.compactMap { $0.identifier as? RemoteSessionSelection }
+        var currentSelections = vc.tabViewItems.compactMap { $0.identifier as? RemoteSessionSelection }
 
         // 1. Remove tab items for selections no longer in the mount set
         //    (cap eviction, explicit detach, or the session vanishing from
@@ -50,7 +66,29 @@ struct RemoteAttachPager: NSViewControllerRepresentable {
         for (idx, selection) in currentSelections.enumerated().reversed() {
             if !mountedSelections.contains(selection) {
                 vc.removeTabViewItem(vc.tabViewItems[idx])
+                context.coordinator.diagnosed[selection] = nil
             }
+        }
+
+        // 1a. Re-resolve every tab that is currently showing a diagnosis, and
+        //     drop it when the answer has changed — the add loop below then
+        //     rebuilds it, as a live terminal once the preflight passes. Only
+        //     diagnosis tabs are re-resolved: a mounted terminal owns a live
+        //     PTY, and tearing it down because a provider's registration
+        //     momentarily looked different would kill the connection this
+        //     pager exists to keep alive.
+        for (selection, shown) in context.coordinator.diagnosed {
+            let current = RemoteAttachPreflight.resolve(
+                selection: selection,
+                providers: appState.remoteProviders,
+                sessions: appState.remoteSessions)
+            guard current != shown else { continue }
+            if let idx = vc.tabViewItems.firstIndex(
+                where: { $0.identifier as? RemoteSessionSelection == selection }) {
+                vc.removeTabViewItem(vc.tabViewItems[idx])
+            }
+            context.coordinator.diagnosed[selection] = nil
+            currentSelections.removeAll { $0 == selection }
         }
 
         // 2. Add tab items for newly-mounted selections.
@@ -83,6 +121,10 @@ struct RemoteAttachPager: NSViewControllerRepresentable {
                 host = NSHostingController(rootView: AnyView(
                     RemoteAttachDiagnosisView(selection: selection, diagnosis: diagnosis)
                 ))
+                // Recorded so 1a re-resolves it on every later render: this
+                // pane is a report about conditions that change, not a
+                // permanent verdict.
+                context.coordinator.diagnosed[selection] = diagnosis
             }
             let item = NSTabViewItem(viewController: host)
             item.identifier = selection

--- a/Sources/TBDApp/Remote/RemoteAttachPager.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachPager.swift
@@ -54,20 +54,36 @@ struct RemoteAttachPager: NSViewControllerRepresentable {
         }
 
         // 2. Add tab items for newly-mounted selections.
+        //
+        //    Resolution goes through `RemoteAttachPreflight`, which matches
+        //    the registry key exactly or fails by name — it has no expression
+        //    for attaching through a provider other than the selected one.
+        //    An unresolvable selection used to `continue` here: no tab, no
+        //    error, and a blank pane where the terminal should be. Now the
+        //    pane says which provider was asked and what stopped it.
         for selection in selections where !currentSelections.contains(selection) {
-            guard let config = appState.remoteProviders.first(where: { $0.config.name == selection.provider })?.config
-            else { continue } // provider unregistered/unknown — nothing to spawn against
-            let host = NSHostingController(
-                rootView: RemoteAttachTerminalView(
-                    provider: config,
-                    sessionID: selection.sessionID,
-                    onDetached: { [weak appState] exitCode in
-                        appState?.markRemoteSessionDetached(selection, exitCode: exitCode)
-                    }
-                )
-                .environmentObject(appState)
-                .environmentObject(appearance)
-            )
+            let diagnosis = RemoteAttachPreflight.resolve(
+                selection: selection,
+                providers: appState.remoteProviders,
+                sessions: appState.remoteSessions)
+            let host: NSHostingController<AnyView>
+            if let config = diagnosis.readyConfig {
+                host = NSHostingController(rootView: AnyView(
+                    RemoteAttachTerminalView(
+                        provider: config,
+                        sessionID: selection.sessionID,
+                        onDetached: { [weak appState] exitCode in
+                            appState?.markRemoteSessionDetached(selection, exitCode: exitCode)
+                        }
+                    )
+                    .environmentObject(appState)
+                    .environmentObject(appearance)
+                ))
+            } else {
+                host = NSHostingController(rootView: AnyView(
+                    RemoteAttachDiagnosisView(selection: selection, diagnosis: diagnosis)
+                ))
+            }
             let item = NSTabViewItem(viewController: host)
             item.identifier = selection
             vc.addTabViewItem(item)

--- a/Sources/TBDApp/Remote/RemoteAttachPreflight.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachPreflight.swift
@@ -1,0 +1,189 @@
+import Foundation
+import TBDShared
+
+/// Resolves a remote-session selection to the exact command that will attach
+/// to it — or to a named reason it cannot.
+///
+/// **Exact match on the registry key, or nothing.** The resolution has no
+/// expression for a fallback: there is no "closest provider", no match on
+/// `describe.name`, no single-registered-provider shortcut. That is
+/// deliberate. A caller that quietly attaches to a different backend than the
+/// one the user selected produces the worst failure this subsystem has —
+/// work done confidently against the wrong control plane — and the cheapest
+/// way to make it impossible is to give the code no way to say it.
+///
+/// It also replaces a silent skip. `RemoteAttachPager` used to `continue`
+/// past a selection whose provider it couldn't resolve: no tab, no error, no
+/// log line, and a blank pane where the terminal should be. Every branch here
+/// ends in something a user can read and act on.
+///
+/// Pure, with the filesystem behind an injected probe, so every diagnosis is
+/// assertable without spawning anything.
+enum RemoteAttachPreflight {
+    enum Diagnosis: Equatable {
+        /// Attachable: spawn `config.argv + ["attach", sessionID]`.
+        case ready(RemoteProviderConfig)
+        /// No registry entry by that name. A renamed or removed entry, or a
+        /// mirror row that outlived the registration it came from.
+        case providerNotRegistered(provider: String)
+        /// The session id exists — under a different registry entry. Names
+        /// both, because this is the failure a user is most likely to be
+        /// misreading as "attach is broken".
+        case sessionBelongsToAnotherProvider(requested: String, actual: String, sessionID: String)
+        /// The provider does not declare the `attach` capability.
+        case attachUnsupported(provider: String)
+        /// The registry entry's executable isn't there — the missing
+        /// local-transport-dependency case.
+        case executableMissing(provider: String, command: String)
+        /// It is there and is not executable by this user.
+        case executableNotRunnable(provider: String, command: String)
+
+        /// The provider config to spawn, or nil for every diagnosis that
+        /// isn't `.ready`.
+        var readyConfig: RemoteProviderConfig? {
+            if case .ready(let config) = self { return config }
+            return nil
+        }
+
+        var title: String {
+            switch self {
+            case .ready: return "Ready to attach"
+            case .providerNotRegistered: return "Provider not registered"
+            case .sessionBelongsToAnotherProvider: return "Session belongs to another provider"
+            case .attachUnsupported: return "Attach not supported"
+            case .executableMissing: return "Attach command not found"
+            case .executableNotRunnable: return "Attach command not executable"
+            }
+        }
+
+        /// One actionable sentence. Every one names the provider, because the
+        /// motivating confusion is precisely not knowing which provider a
+        /// surface is talking about.
+        var detail: String {
+            switch self {
+            case .ready(let config):
+                return "Attaching through \(config.name)."
+            case .providerNotRegistered(let provider):
+                return "No provider named \"\(provider)\" is registered in "
+                    + "~/tbd/agent-providers.json. TBD will not attach through a different "
+                    + "provider on its behalf. Re-register it under that exact name, or dismiss "
+                    + "the session."
+            case .sessionBelongsToAnotherProvider(let requested, let actual, let sessionID):
+                return "Session \"\(sessionID)\" is reported by \"\(actual)\", not \"\(requested)\". "
+                    + "Open it under \(actual); TBD will not attach to another provider's session."
+            case .attachUnsupported(let provider):
+                return "\"\(provider)\" does not declare the attach capability, so TBD never "
+                    + "invokes its attach verb. Use the log view, or send input, if those are "
+                    + "declared."
+            case .executableMissing(let provider, let command):
+                return "\"\(provider)\" is registered to run \(command), which does not exist on "
+                    + "this machine. Install the provider (or its transport helper), or correct "
+                    + "the exec path in ~/tbd/agent-providers.json."
+            case .executableNotRunnable(let provider, let command):
+                return "\"\(provider)\" is registered to run \(command), which exists but is not "
+                    + "executable by this user. Fix its permissions (chmod +x) and try again."
+            }
+        }
+    }
+
+    /// Whether the registry entry's executable can be run, and if not, why.
+    enum ExecutableStatus: Equatable {
+        case runnable
+        case missing
+        case notExecutable
+    }
+
+    /// Resolves `selection` against the registry and the mirror.
+    ///
+    /// `sessions` is used for ONE thing: to tell "no such provider" apart
+    /// from "that session lives somewhere else". It never contributes a
+    /// provider to attach through.
+    static func resolve(
+        selection: RemoteSessionSelection,
+        providers: [RemoteProviderStatus],
+        sessions: [RemoteSessionInfo],
+        probe: (RemoteProviderConfig) -> ExecutableStatus = { RemoteAttachPreflight.probeExecutable($0.exec) }
+    ) -> Diagnosis {
+        guard let provider = providers.first(where: { $0.config.name == selection.provider }) else {
+            // Say the more useful of the two things: if some OTHER registered
+            // provider reports this session id, the user is one click from
+            // the session they wanted.
+            if let owner = sessions.first(where: {
+                $0.payload.id == selection.sessionID && $0.provider != selection.provider
+            }) {
+                return .sessionBelongsToAnotherProvider(
+                    requested: selection.provider, actual: owner.provider,
+                    sessionID: selection.sessionID)
+            }
+            return .providerNotRegistered(provider: selection.provider)
+        }
+
+        // The session id is not in this provider's mirror, but is in
+        // another's. Registered-and-healthy is no excuse to attach: the
+        // provider would be asked for an id it never reported.
+        let mineHasSession = sessions.contains {
+            $0.provider == selection.provider && $0.payload.id == selection.sessionID
+        }
+        if !mineHasSession,
+           let owner = sessions.first(where: {
+               $0.payload.id == selection.sessionID && $0.provider != selection.provider
+           }) {
+            return .sessionBelongsToAnotherProvider(
+                requested: selection.provider, actual: owner.provider,
+                sessionID: selection.sessionID)
+        }
+
+        guard provider.describe?.capabilities.contains("attach") == true else {
+            return .attachUnsupported(provider: provider.config.name)
+        }
+
+        let command = RemoteProviderIdentityPresentation.commandLine(provider.config)
+        switch probe(provider.config) {
+        case .missing:
+            return .executableMissing(provider: provider.config.name, command: command)
+        case .notExecutable:
+            return .executableNotRunnable(provider: provider.config.name, command: command)
+        case .runnable:
+            return .ready(provider.config)
+        }
+    }
+
+    /// The default filesystem probe.
+    ///
+    /// A registry `exec` may be an absolute or relative path, or a bare
+    /// command name the login shell resolves on `PATH` — the contract only
+    /// says TBD execs it. Both are checked the way the spawn itself will
+    /// resolve them, so this never reports missing for a provider that would
+    /// in fact have run.
+    static func probeExecutable(
+        _ exec: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> ExecutableStatus {
+        guard !exec.isEmpty else { return .missing }
+        if exec.contains("/") {
+            return probePath(exec, fileManager: fileManager)
+        }
+        let searchPath = (environment["PATH"] ?? "").split(separator: ":").map(String.init)
+        var sawFile = false
+        for directory in searchPath where !directory.isEmpty {
+            let candidate = (directory as NSString).appendingPathComponent(exec)
+            switch probePath(candidate, fileManager: fileManager) {
+            case .runnable: return .runnable
+            case .notExecutable: sawFile = true
+            case .missing: continue
+            }
+        }
+        // A name found on PATH but never executable is a permissions problem;
+        // a name found nowhere is an installation problem.
+        return sawFile ? .notExecutable : .missing
+    }
+
+    private static func probePath(_ path: String, fileManager: FileManager) -> ExecutableStatus {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+            return .missing
+        }
+        return fileManager.isExecutableFile(atPath: path) ? .runnable : .notExecutable
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteCreateSheet.swift
+++ b/Sources/TBDApp/Remote/RemoteCreateSheet.swift
@@ -63,7 +63,10 @@ struct RemoteCreateSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("New \(describe?.name ?? provider.name) session")
+            // The registry key, not `describe.name`: two entries of the same
+            // kind report the same kind, and the sheet must say which entry
+            // this session will be created under.
+            Text("New \(provider.name) session")
                 .font(.headline)
 
             if fields.isEmpty {

--- a/Sources/TBDApp/Remote/RemoteProviderAuthPresentation.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderAuthPresentation.swift
@@ -73,8 +73,11 @@ struct RemoteProviderAuthPresentation: Equatable {
         localAuthExit: Bool = false
     ) -> RemoteProviderAuthPresentation? {
         guard status?.health == .needsAuth || localAuthExit else { return nil }
-        guard let providerName = nonBlank(status?.describe?.name)
-            ?? nonBlank(status?.config.name)
+        // Registry key first: the remedy a user has to run is scoped to the
+        // registered entry, and two entries of the same kind share a
+        // `describe.name` that cannot say which one needs re-authenticating.
+        guard let providerName = nonBlank(status?.config.name)
+            ?? nonBlank(status?.describe?.name)
             ?? nonBlank(fallbackProviderName) else { return nil }
         return RemoteProviderAuthPresentation(
             providerName: providerName,

--- a/Sources/TBDApp/Remote/RemoteProviderAuthPresentation.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderAuthPresentation.swift
@@ -16,8 +16,12 @@ import TBDShared
 /// opaque: it gets displayed and, on request, executed as text — never
 /// parsed, split, or rewritten.
 struct RemoteProviderAuthPresentation: Equatable {
-    /// The provider's display name (its `describe.name` when it has one,
-    /// otherwise the registry name).
+    /// How the provider is named to the user: its REGISTRY key, which is
+    /// unique by construction, falling back to `describe.name` and then to
+    /// the caller's own fallback. The remedy a user has to run is scoped to
+    /// the registered entry, and two registrations of the same provider kind
+    /// share a `describe.name` that cannot say which one needs
+    /// re-authenticating — see `RemoteProviderIdentityPresentation`.
     let providerName: String
     /// The explanatory line. The provider's `errorMessage` when it supplied
     /// one, else `fallbackMessage`.
@@ -63,10 +67,12 @@ struct RemoteProviderAuthPresentation: Equatable {
     /// the app knows the provider couldn't authenticate without yet knowing
     /// anything the provider had to say about it.
     ///
-    /// `providerName` resolves `describe.name` → registry name →
+    /// `providerName` resolves registry name → `describe.name` →
     /// `fallbackProviderName` (the caller's own name for the provider, e.g.
     /// a selection's `provider`). `nil` when none of the three exists, since
-    /// a CTA with nothing to name isn't worth showing.
+    /// a CTA with nothing to name isn't worth showing. The registry key
+    /// leads because it is what identifies the registration a user has to go
+    /// and re-authenticate.
     static func make(
         from status: RemoteProviderStatus?,
         fallbackProviderName: String? = nil,

--- a/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
@@ -25,6 +25,15 @@ struct RemoteProviderDeskSummary: Equatable {
     let terminal: TerminalCounts
     let agent: AgentCounts
     let latestMirrorUpdate: Date?
+    /// Rows whose agent axis says a human has to act (`waiting_input`), in
+    /// the same order as `sessions`. Held as rows rather than a count
+    /// because the desk names them and states WHY each is blocked —
+    /// a digit in a strip is not an explanation.
+    let needsAttention: [RemoteSessionInfo]
+    /// Rows with a live terminal and no reported agent state. Counted apart
+    /// from both working and waiting because it is neither: it means only
+    /// that a terminal exists (`RemoteAgentAttention.isUnattributedRunning`).
+    let unattributedRunning: [RemoteSessionInfo]
 
     var total: Int { sessions.count }
 
@@ -102,5 +111,18 @@ struct RemoteProviderDeskSummary: Equatable {
         self.terminal = terminal
         self.agent = agent
         latestMirrorUpdate = sessions.first?.lastSeen
+        needsAttention = sessions.filter(RemoteAgentAttention.needsAttention)
+        unattributedRunning = sessions.filter(RemoteAgentAttention.isUnattributedRunning)
+    }
+
+    /// The one-line aggregate the desk states when live terminals are
+    /// reporting no agent state at all. Nil when none are.
+    var unattributedRunningNotice: String? {
+        let count = unattributedRunning.count
+        guard count > 0 else { return nil }
+        let subject = count == 1
+            ? "1 running session reports no agent state"
+            : "\(count) running sessions report no agent state"
+        return "\(subject) — terminal liveness is not agent progress."
     }
 }

--- a/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
@@ -11,7 +11,23 @@ struct RemoteProviderDeskView: View {
     @State private var isRefreshing = false
     @State private var runningRemediation: RemoteRemediationRun?
 
-    private var displayName: String { provider.describe?.name ?? provider.config.name }
+    /// The registry key, never `describe.name` — see
+    /// `RemoteProviderIdentityPresentation` for why the desk must not lead
+    /// with the provider's KIND.
+    private var displayName: String { RemoteProviderIdentityPresentation.headline(provider) }
+
+    private var identityRows: [RemoteProviderIdentityPresentation.Row] {
+        RemoteProviderIdentityPresentation.rows(provider)
+    }
+
+    private var inventoryState: RemoteProviderInventoryState {
+        RemoteProviderInventoryState.make(provider: provider, sessionCount: summary.total)
+    }
+
+    private var crossProviderNote: String? {
+        RemoteProviderInventoryState.crossProviderNote(
+            currentProvider: provider.config.name, sessions: appState.remoteSessions)
+    }
 
     private var summary: RemoteProviderDeskSummary {
         RemoteProviderDeskSummary(provider: provider.config.name, sessions: appState.remoteSessions)
@@ -21,7 +37,9 @@ struct RemoteProviderDeskView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 masthead
+                identityBlock
                 healthNotice
+                attentionNotices
                 stateStrips
                 sessionLedger
             }
@@ -49,8 +67,19 @@ struct RemoteProviderDeskView: View {
             .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(displayName)
-                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(displayName)
+                        .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    // Only when it says something the registry key doesn't:
+                    // two entries running the same binary report the same
+                    // kind, so showing it unconditionally is what made them
+                    // look like the same provider.
+                    if let kind = RemoteProviderIdentityPresentation.kindSubtitle(provider) {
+                        Text(kind)
+                            .font(.callout)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
                 HStack(spacing: 7) {
                     Text(healthTitle)
                     Text("·")
@@ -72,6 +101,93 @@ struct RemoteProviderDeskView: View {
             .keyboardShortcut("r", modifiers: .command)
             .help("Refresh provider and mirrored session state")
             .accessibilityLabel(isRefreshing ? "Refreshing provider" : "Refresh provider")
+        }
+    }
+
+    /// Which backend this registry entry is pointed at, as far as TBD can
+    /// honestly say: the provider's own `describe.identity` pairs when it
+    /// sends them, and the locally-derivable command line and versions
+    /// regardless.
+    private var identityBlock: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(identityRows) { row in
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Text(row.label)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 108, alignment: .leading)
+                    Text(row.value)
+                        .font(.callout.monospaced())
+                        .foregroundStyle(row.isDistinguishing ? .primary : .secondary)
+                        .textSelection(.enabled)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+                .accessibilityElement(children: .combine)
+            }
+            if provider.describe?.identity?.hasDisplayablePairs != true {
+                Text("This provider reports no backend identity, so TBD can only show the "
+                     + "command it runs. Two entries pointing at different backends are "
+                     + "distinguishable here only by that command.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    /// The attention axis, in words: which sessions are blocked and on what,
+    /// and how many live terminals are reporting nothing about their agent.
+    @ViewBuilder
+    private var attentionNotices: some View {
+        if !summary.needsAttention.isEmpty || summary.unattributedRunningNotice != nil {
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(summary.needsAttention) { session in
+                    Button {
+                        appState.selectRemoteSession(
+                            provider: session.provider, sessionID: session.payload.id)
+                    } label: {
+                        HStack(alignment: .top, spacing: 10) {
+                            Image(systemName: "hand.raised.fill")
+                                .foregroundStyle(SuffixRowIndicator.attention.color)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(session.payload.title ?? session.payload.id)
+                                    .fontWeight(.semibold)
+                                Text(RemoteAgentAttention.explanation(for: session) ?? "Waiting for input.")
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            Spacer(minLength: 0)
+                        }
+                        .font(.callout)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+                if let notice = summary.unattributedRunningNotice {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "questionmark.circle")
+                            .foregroundStyle(.secondary)
+                        Text(notice)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .font(.callout)
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                SuffixRowIndicator.attention.color.opacity(summary.needsAttention.isEmpty ? 0 : 0.08),
+                in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.09))
+            }
         }
     }
 
@@ -131,7 +247,10 @@ struct RemoteProviderDeskView: View {
             subtitle: "Process state",
             metrics: [
                 .init(label: "Starting", value: summary.terminal.starting, tint: .secondary),
-                .init(label: "Running", value: summary.terminal.running, tint: .green),
+                // Not green. Green is the colour a reader takes for progress,
+                // and a running terminal is not progress — the agent strip
+                // beside this one is the only place that can say so.
+                .init(label: "Running", value: summary.terminal.running, tint: .primary),
                 .init(label: "Exited", value: summary.terminal.exited, tint: .secondary),
                 .init(label: "Gone", value: summary.terminal.gone, tint: .orange),
                 .init(label: "Unknown", value: summary.terminal.unknown, tint: .secondary),
@@ -144,8 +263,8 @@ struct RemoteProviderDeskView: View {
             title: "Agent",
             subtitle: "Attention state",
             metrics: [
-                .init(label: "Working", value: summary.agent.working, tint: .blue),
-                .init(label: "Waiting", value: summary.agent.waitingInput, tint: .orange),
+                .init(label: "Working", value: summary.agent.working, tint: .green),
+                .init(label: "Waiting", value: summary.agent.waitingInput, tint: SuffixRowIndicator.attention.color),
                 .init(label: "Idle", value: summary.agent.idle, tint: .secondary),
                 .init(label: "Exited", value: summary.agent.exited, tint: .secondary),
                 .init(label: "Unknown", value: summary.agent.unknown, tint: .secondary),
@@ -166,19 +285,19 @@ struct RemoteProviderDeskView: View {
                     .foregroundStyle(.tertiary)
             }
 
+            if inventoryState.warrantsNotice {
+                inventoryNotice
+            }
+
             if summary.sessions.isEmpty {
                 VStack(spacing: 10) {
                     Image(systemName: "rectangle.stack.badge.minus")
                         .font(.system(size: 28))
                         .foregroundStyle(.tertiary)
-                    Text(provider.hasStaleSnapshot ? "No sessions in the last good inventory" : "No mirrored sessions")
+                    Text(inventoryState.title)
                         .font(.headline)
-                    // Don't send the user to a control this provider's own
-                    // state has disabled: `RemoteProviderHeaderRow` gates `+`
-                    // on `hasStaleSnapshot` until a full inventory recovers.
-                    Text(provider.hasStaleSnapshot
-                         ? "This provider's inventory is stale, so creating sessions is unavailable until a refresh succeeds."
-                         : "Use the + button beside \(displayName) in the sidebar to create one.")
+                        .multilineTextAlignment(.center)
+                    Text(emptyStateGuidance)
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -204,6 +323,50 @@ struct RemoteProviderDeskView: View {
                 }
             }
         }
+    }
+
+    /// The four not-simply-current readings of this provider's inventory,
+    /// each stated as itself. A stale list, a list TBD has never populated,
+    /// a list whose freshness is unreadable, and a successfully EMPTY list
+    /// are four different facts, and only the last is evidence about the
+    /// backend.
+    private var inventoryNotice: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: inventoryState.isCurrent ? "tray" : "clock.badge.questionmark")
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(inventoryState.title).fontWeight(.semibold)
+                Text(inventoryState.detail())
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                // The direct answer to "did I just look at the wrong
+                // provider" — the confusion this whole surface exists to end.
+                if let crossProviderNote {
+                    Text(crossProviderNote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .font(.callout)
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    /// What to do next when the list is empty, which depends on whether the
+    /// emptiness is a fact about the provider or about TBD's knowledge of it.
+    private var emptyStateGuidance: String {
+        // Don't send the user to a control this provider's own state has
+        // disabled: `RemoteProviderHeaderRow` gates `+` on `hasStaleSnapshot`
+        // until a full inventory recovers.
+        if provider.hasStaleSnapshot {
+            return "Creating sessions is unavailable until a refresh succeeds."
+        }
+        if case .emptySuccess = inventoryState {
+            return "Use the + button beside \(displayName) in the sidebar to create one."
+        }
+        return "Refresh to ask \(displayName) for its inventory."
     }
 
     private var freshnessLabel: String {
@@ -400,11 +563,15 @@ private struct ProviderSessionLedgerRow: View {
                 Text(RemoteSessionStatePresentation.agentLabel(session.payload.agentState))
             }
             .lineLimit(1)
-            if let reason = session.payload.agentStateReason, !reason.isEmpty {
-                Text(reason)
+            // `RemoteAgentAttention` supersedes the bare reason string: it
+            // prefers the structured question block when there is one, and
+            // it also speaks for the running-but-unattributed row, which has
+            // no reason string at all and used to say only "Updated 3m ago".
+            if let explanation = RemoteAgentAttention.explanation(for: session) {
+                Text(explanation)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                    .lineLimit(2)
             } else {
                 Text("Updated \(RemoteProviderDeskSummary.agePhrase(since: session.lastSeen))")
                     .font(.caption)
@@ -429,7 +596,10 @@ private struct ProviderSessionLedgerRow: View {
         case .idle: return .secondary
         case .exited: return .secondary
         case .unknown:
-            return session.payload.state == .running ? .green : .secondary
+            // A running terminal with no agent state was green here, which
+            // read as "this session is working" — the exact claim the
+            // contract says this combination cannot support.
+            return .secondary
         }
     }
 

--- a/Sources/TBDApp/Remote/RemoteProviderIdentityPresentation.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderIdentityPresentation.swift
@@ -1,0 +1,148 @@
+import Foundation
+import TBDShared
+
+/// What a provider header says about WHICH provider it is.
+///
+/// The one rule everything here follows: **the registry key is the
+/// identity.** `RemoteProviderConfig.name` is unique by construction
+/// (`RemoteProviderRegistry.loadEntries` rejects duplicates) and is what
+/// every other part of TBD keys on — the mirror's primary key, an attach
+/// selection, a notification's route. `ProviderDescribe.name` identifies the
+/// provider's KIND, so two registry entries running the same binary against
+/// different backends report the same one. Leading with the latter is how a
+/// user comes to inspect one backend while believing they inspected the
+/// other, and it is why `headline` is not `describe?.name ?? config.name`.
+///
+/// Pure and view-free so the exact strings a header renders can be asserted
+/// without a view hierarchy.
+enum RemoteProviderIdentityPresentation {
+    struct Row: Equatable, Identifiable {
+        let label: String
+        let value: String
+        /// Whether this row is what distinguishes two same-kind entries —
+        /// used only to decide emphasis, never content.
+        let isDistinguishing: Bool
+        var id: String { label }
+
+        init(label: String, value: String, isDistinguishing: Bool = false) {
+            self.label = label
+            self.value = value
+            self.isDistinguishing = isDistinguishing
+        }
+    }
+
+    /// The name a header leads with: always the registry key.
+    static func headline(_ provider: RemoteProviderStatus) -> String {
+        provider.config.name
+    }
+
+    /// The provider's kind, when it says anything the headline doesn't
+    /// already. Nil when `describe.name` matches the registry key (nothing to
+    /// add) or is missing (`describe` hasn't succeeded).
+    static func kindSubtitle(_ provider: RemoteProviderStatus) -> String? {
+        guard let kind = provider.describe?.name, !kind.isEmpty, kind != provider.config.name else {
+            return nil
+        }
+        return "reports as \(kind)"
+    }
+
+    /// The identity block under the headline, most identifying first.
+    ///
+    /// Every row is omitted when its source is absent, so a provider that
+    /// sends no `identity` still gets the two rows TBD can always derive
+    /// locally — the command it runs and, when `describe` succeeded, its
+    /// versions.
+    static func rows(
+        _ provider: RemoteProviderStatus,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> [Row] {
+        var rows: [Row] = []
+        for pair in provider.describe?.identity?.displayPairs ?? [] {
+            rows.append(Row(label: humanizedKey(pair.key), value: pair.value, isDistinguishing: true))
+        }
+        rows.append(Row(
+            label: "Command",
+            value: commandLine(provider.config, homeDirectory: homeDirectory),
+            // The command line is the disambiguator that needs no contract
+            // change: two entries of the same kind nearly always differ in
+            // their flags, and when they don't, the identity pairs above are
+            // the only thing that can tell them apart.
+            isDistinguishing: provider.describe?.identity?.hasDisplayablePairs != true))
+        if let version = versionLine(provider) {
+            rows.append(Row(label: "Version", value: version))
+        }
+        return rows
+    }
+
+    /// The registry entry's argv as one displayable line: the executable
+    /// tilde-abbreviated, the arguments redacted (the registry file is
+    /// user-authored, so nothing in it is contract-guaranteed to be
+    /// non-secret), and the whole thing shown verbatim otherwise.
+    ///
+    /// Deliberately NOT parsed. Reading an environment out of a flag list is
+    /// a guess that is wrong exactly when it matters most — an entry named
+    /// `…-staging` pointed by a stale flag at production — so the line is
+    /// put in front of a human instead.
+    static func commandLine(
+        _ config: RemoteProviderConfig,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> String {
+        let exec = abbreviatingHome(config.exec, homeDirectory: homeDirectory)
+        let args = ProviderIdentityRedaction.redactArguments(config.args ?? [])
+        return ([exec] + args).joined(separator: " ")
+    }
+
+    /// `provider_version` and the negotiated contract major, whichever are
+    /// known. Nil before `describe` has ever succeeded.
+    static func versionLine(_ provider: RemoteProviderStatus) -> String? {
+        var parts: [String] = []
+        if let version = provider.describe?.providerVersion, !version.isEmpty {
+            parts.append(version)
+        }
+        if provider.describe != nil {
+            // Absent from a daemon that predates negotiation; 1 is what every
+            // emitter announced unconditionally before, per
+            // `RemoteProviderStatus.contractVersion`.
+            parts.append("contract v\(provider.contractVersion ?? 1)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// A one-line identity for accessibility and for anywhere a block of rows
+    /// doesn't fit: the registry key, then its kind when that differs, then
+    /// the first identity pair.
+    static func compactSummary(_ provider: RemoteProviderStatus) -> String {
+        var parts = [headline(provider)]
+        if let kind = kindSubtitle(provider) { parts.append(kind) }
+        if let first = provider.describe?.identity?.displayPairs.first {
+            parts.append("\(humanizedKey(first.key)) \(first.value)")
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    /// `snake_case` or `kebab-case` provider key as a display label. No
+    /// dictionary of known keys: the map is provider-defined, and inventing
+    /// prettier names for the handful TBD happens to recognize would make
+    /// every other key look second-class.
+    static func humanizedKey(_ key: String) -> String {
+        let words = key
+            .split(whereSeparator: { $0 == "_" || $0 == "-" || $0 == " " })
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        guard let first = words.first else { return key }
+        let rest = words.dropFirst()
+        let capitalized = first.prefix(1).uppercased() + String(first.dropFirst())
+        return ([capitalized] + rest).joined(separator: " ")
+    }
+
+    /// `NSString.abbreviatingWithTildeInPath` with the home directory
+    /// injected, so a test asserts against a fixed home rather than the
+    /// machine's.
+    static func abbreviatingHome(_ path: String, homeDirectory: String) -> String {
+        let home = homeDirectory.hasSuffix("/") ? String(homeDirectory.dropLast()) : homeDirectory
+        guard !home.isEmpty else { return path }
+        if path == home { return "~" }
+        guard path.hasPrefix(home + "/") else { return path }
+        return "~" + String(path.dropFirst(home.count))
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteProviderInventoryState.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderInventoryState.swift
@@ -1,0 +1,132 @@
+import Foundation
+import TBDShared
+
+/// What a provider's session list currently IS — five readings that used to
+/// collapse into two empty-state strings.
+///
+/// The distinction that motivates the type: **"this provider reports no
+/// sessions" and "TBD has no inventory to show" are different facts**, and
+/// only the first is evidence about the backend. A registered-but-never-
+/// polled provider, a provider whose freshness record the daemon couldn't
+/// read, a provider whose last good inventory is going stale, and a provider
+/// that successfully reported nothing all produced roughly the same reassuring
+/// blank page — under a green badge, since none of them is unhealthy.
+///
+/// Pure and view-free: every sentence the desk renders is asserted here.
+enum RemoteProviderInventoryState: Equatable {
+    /// A successful inventory with rows in it.
+    case populated(count: Int, at: Date?)
+    /// A successful inventory that reported nothing. The only one of these
+    /// five that is evidence the backend really has no sessions.
+    case emptySuccess(at: Date?)
+    /// No successful inventory has ever been accepted for this provider.
+    case noInventoryYet
+    /// The daemon could not read the freshness record, so it cannot say
+    /// whether anything on screen is current — distinct from never having
+    /// snapshotted, because here TBD doesn't even know which of the two it is.
+    case freshnessUnknown
+    /// A prior good inventory that is no longer being refreshed. Rows may
+    /// still be on screen; they are history, not current state.
+    case stale(since: Date?, cachedCount: Int)
+
+    /// `sessionCount` is the number of mirror rows the desk is about to
+    /// render for this provider — the caller's own filtered count, so this
+    /// type never re-derives (and never disagrees with) what is on screen.
+    static func make(provider: RemoteProviderStatus, sessionCount: Int) -> RemoteProviderInventoryState {
+        if provider.hasStaleSnapshot {
+            // `hasStaleSnapshot` is true for an unreadable freshness row even
+            // with no known snapshot; say what is actually unknown rather
+            // than quoting an age TBD doesn't have.
+            if provider.lastSuccessfulSnapshotAt == nil { return .freshnessUnknown }
+            return .stale(since: provider.lastSuccessfulSnapshotAt, cachedCount: sessionCount)
+        }
+        guard let at = provider.lastSuccessfulSnapshotAt else {
+            return provider.freshnessUnreadable ? .freshnessUnknown : .noInventoryYet
+        }
+        return sessionCount == 0 ? .emptySuccess(at: at) : .populated(count: sessionCount, at: at)
+    }
+
+    /// The headline a reader sees in place of (or above) the session list.
+    var title: String {
+        switch self {
+        case .populated: return "Inventory current"
+        case .emptySuccess: return "This provider reports no sessions"
+        case .noInventoryYet: return "No inventory yet"
+        case .freshnessUnknown: return "Inventory freshness unknown"
+        case .stale: return "Showing the last good inventory"
+        }
+    }
+
+    /// The sentence under the headline. `now` is injected so the age it
+    /// quotes is deterministic in a test.
+    func detail(now: Date = Date()) -> String {
+        switch self {
+        case .populated(let count, let at):
+            let rows = count == 1 ? "1 session" : "\(count) sessions"
+            guard let at else { return "\(rows) reported." }
+            return "\(rows) reported \(RemoteProviderDeskSummary.agePhrase(since: at, now: now))."
+        case .emptySuccess(let at):
+            let base = "The provider answered and its inventory was empty"
+            guard let at else { return base + "." }
+            return base + " \(RemoteProviderDeskSummary.agePhrase(since: at, now: now))."
+        case .noInventoryYet:
+            return "TBD has not yet accepted a complete inventory from this provider, "
+                + "so an empty list here is not evidence that the provider has no sessions."
+        case .freshnessUnknown:
+            return "TBD could not read this provider's freshness record, so it cannot say whether "
+                + "anything shown here is current."
+        case .stale(let since, let cachedCount):
+            let rows = cachedCount == 1 ? "1 cached row" : "\(cachedCount) cached rows"
+            guard let since else {
+                return "\(rows) from an earlier inventory. Their states are history, not current."
+            }
+            return "\(rows) from the inventory of "
+                + "\(RemoteProviderDeskSummary.agePhrase(since: since, now: now)). "
+                + "Their states are history, not current."
+        }
+    }
+
+    /// Whether what the user is looking at may be presented as current.
+    var isCurrent: Bool {
+        switch self {
+        case .populated, .emptySuccess: return true
+        case .noInventoryYet, .freshnessUnknown, .stale: return false
+        }
+    }
+
+    /// Whether the desk should say anything at all beyond the list — a
+    /// populated, current inventory speaks for itself.
+    var warrantsNotice: Bool {
+        switch self {
+        case .populated: return false
+        case .emptySuccess, .noInventoryYet, .freshnessUnknown, .stale: return true
+        }
+    }
+
+    /// "3 sessions are registered under other providers (agentbox-staging: 3)."
+    ///
+    /// The direct answer to "did I just inspect the wrong provider" — stated
+    /// by TBD at the moment the question arises, rather than left to a user
+    /// to reconstruct by clicking every other header. Nil when no other
+    /// provider holds anything, which is the common case and would otherwise
+    /// be noise.
+    ///
+    /// Counts the same rows the desk counts: not dismissed, and keyed on the
+    /// registry name, so two entries of the same KIND are two different
+    /// providers here exactly as they are everywhere else.
+    static func crossProviderNote(
+        currentProvider: String,
+        sessions: [RemoteSessionInfo]
+    ) -> String? {
+        var counts: [String: Int] = [:]
+        for session in sessions where !session.dismissed && session.provider != currentProvider {
+            counts[session.provider, default: 0] += 1
+        }
+        guard !counts.isEmpty else { return nil }
+        let total = counts.values.reduce(0, +)
+        let breakdown = counts.keys.sorted().map { "\($0): \(counts[$0] ?? 0)" }.joined(separator: ", ")
+        let noun = total == 1 ? "session is" : "sessions are"
+        let where_ = counts.count == 1 ? "another provider" : "other providers"
+        return "\(total) \(noun) registered under \(where_) (\(breakdown))."
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
@@ -303,7 +303,10 @@ struct RemoteSessionDetailView: View {
             }
 
             HStack(spacing: 8) {
-                Text(providerStatus?.describe?.name ?? selection.provider)
+                // The selection's own registry key: the identity every other
+                // subsystem keys on, and the one that differs between two
+                // entries of the same kind.
+                Text(selection.provider)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 if let session {

--- a/Sources/TBDApp/Settings/RemoteCreateDefaultsEditor.swift
+++ b/Sources/TBDApp/Settings/RemoteCreateDefaultsEditor.swift
@@ -97,7 +97,7 @@ struct RemoteCreateDefaultsEditor: View {
     private func providerSection(_ provider: RemoteProviderStatus) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             if editableProviders.count > 1 {
-                Text(provider.describe?.name ?? provider.config.name)
+                Text(RemoteProviderIdentityPresentation.headline(provider))
                     .font(.caption)
                     .fontWeight(.medium)
                     .foregroundStyle(.secondary)

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -239,7 +239,11 @@ struct RemoteProviderHeaderRow: View {
                 Button {
                     appState.selectRemoteProvider(provider.config.name)
                 } label: {
-                    Text(provider.describe?.name ?? provider.config.name)
+                    // The registry key. `describe.name` names the provider's
+                    // KIND, so two entries running the same binary against
+                    // different backends rendered as two identical rows —
+                    // see `RemoteProviderIdentityPresentation`.
+                    Text(RemoteProviderIdentityPresentation.headline(provider))
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(
                             appState.selectedRemoteProvider == provider.config.name
@@ -253,7 +257,8 @@ struct RemoteProviderHeaderRow: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Open \(provider.describe?.name ?? provider.config.name) provider desk")
+                .accessibilityLabel("Open \(RemoteProviderIdentityPresentation.headline(provider)) provider desk")
+                .help(RemoteProviderIdentityPresentation.compactSummary(provider))
                 healthSuffix
                 if canCreate {
                     Button {
@@ -269,7 +274,7 @@ struct RemoteProviderHeaderRow: View {
                     .disabled(provider.hasStaleSnapshot)
                     .help(provider.hasStaleSnapshot
                           ? "Inventory is stale; refresh must recover before creating sessions"
-                          : "New \(provider.describe?.name ?? provider.config.name) session")
+                          : "New \(RemoteProviderIdentityPresentation.headline(provider)) session")
                 }
             }
             if let issueSummary {

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -612,7 +612,7 @@ struct RepoSectionView: View {
             } else {
                 Menu("New Remote Session…") {
                     ForEach(providers, id: \.config.name) { provider in
-                        Button(provider.describe?.name ?? provider.config.name) {
+                        Button(RemoteProviderIdentityPresentation.headline(provider)) {
                             openRemoteCreateSheet(for: provider)
                         }
                         .disabled(provider.hasStaleSnapshot)

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -452,11 +452,12 @@ struct WorktreeProfilePickerView: View {
         }
     }
 
-    /// Display name for a provider — the negotiated `describe` name when the
-    /// provider supplied one, else its configured name (same precedence as
-    /// `RepoSectionView.newRemoteSessionMenuItem`).
+    /// Display name for a provider: its REGISTRY key, which is unique by
+    /// construction — never `describe.name`, which names the provider's kind
+    /// and is therefore identical across two entries running the same binary
+    /// against different backends. See `RemoteProviderIdentityPresentation`.
     nonisolated static func providerLabel(_ provider: RemoteProviderStatus) -> String {
-        provider.describe?.name ?? provider.config.name
+        RemoteProviderIdentityPresentation.headline(provider)
     }
 
     /// Why a provider's row is unselectable, or nil when it is selectable.

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -287,7 +287,7 @@ struct WorktreeRowView: View {
             } else {
                 Menu("New Remote Session…") {
                     ForEach(providers, id: \.config.name) { provider in
-                        Button(provider.describe?.name ?? provider.config.name) {
+                        Button(RemoteProviderIdentityPresentation.headline(provider)) {
                             remoteCreateSheetProvider = provider
                         }
                         .disabled(provider.hasStaleSnapshot)

--- a/Sources/TBDShared/RemotePendingQuestion.swift
+++ b/Sources/TBDShared/RemotePendingQuestion.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// The Session object's optional `pending_question`
+/// (`docs/remote-provider-contract.md` § Pending question) — the structured
+/// choice an agent is currently blocked on.
+///
+/// **Display detail layered on `agent_state`, never a substitute for it.**
+/// The contract is explicit that a caller MUST NOT conclude a session is
+/// blocked from this field's presence: blocking is read off `agent_state`
+/// like every other session's, and this field only ever says WHAT the
+/// blocked session is blocked on. Every consumer in TBD gates on
+/// `agentState == .waitingInput` first and reaches for this second.
+///
+/// Decoded on the same terms as the rest of the Session object: leniently,
+/// and never fatally. A malformed question block costs the explanation, never
+/// the session.
+public struct RemotePendingQuestion: Codable, Sendable, Equatable {
+    /// Stable while the same question is pending, per the contract — so a
+    /// caller can tell "still the same question" from "a new one arrived"
+    /// without diffing prompt text. Optional here because a provider that
+    /// omits it still leaves a question worth showing.
+    public let id: String?
+    public let questions: [RemotePendingQuestionItem]
+
+    public init(id: String? = nil, questions: [RemotePendingQuestionItem]) {
+        self.id = id
+        self.questions = questions
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, questions
+    }
+
+    /// A block whose every question was undecodable decodes as absent rather
+    /// than as an empty question set: an explanation with nothing in it is
+    /// not an explanation, and a caller that has to check `questions.isEmpty`
+    /// everywhere will eventually forget somewhere.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = (try? c.decodeIfPresent(String.self, forKey: .id)).flatMap { $0 }
+        let decoded: [LenientQuestion] =
+            (try? c.decodeIfPresent([LenientQuestion].self, forKey: .questions)).flatMap { $0 } ?? []
+        questions = decoded.compactMap(\.item)
+        guard !questions.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .questions, in: c,
+                debugDescription: "pending_question carried no decodable question")
+        }
+    }
+
+    /// One element of `questions`, decoded without the power to fail the
+    /// array — the same shape `LenientSessionArray` uses for sessions.
+    private struct LenientQuestion: Decodable {
+        let item: RemotePendingQuestionItem?
+        init(from decoder: any Decoder) throws {
+            item = try? RemotePendingQuestionItem(from: decoder)
+        }
+    }
+}
+
+public struct RemotePendingQuestionItem: Codable, Sendable, Equatable {
+    /// Required by the contract, and required here: a question with no text
+    /// has nothing to explain.
+    public let prompt: String
+    /// Short form for compact rendering where the full prompt doesn't fit.
+    public let label: String?
+    public let multi: Bool
+    public let options: [RemotePendingQuestionOption]
+
+    public init(prompt: String, label: String? = nil, multi: Bool = false,
+                options: [RemotePendingQuestionOption] = []) {
+        self.prompt = prompt
+        self.label = label
+        self.multi = multi
+        self.options = options
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prompt, label, multi, options
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        prompt = try c.decode(String.self, forKey: .prompt)
+        label = (try? c.decodeIfPresent(String.self, forKey: .label)).flatMap { $0 }
+        multi = (try? c.decodeIfPresent(Bool.self, forKey: .multi)).flatMap { $0 } ?? false
+        let decoded: [LenientOption] =
+            (try? c.decodeIfPresent([LenientOption].self, forKey: .options)).flatMap { $0 } ?? []
+        options = decoded.compactMap(\.option)
+    }
+
+    private struct LenientOption: Decodable {
+        let option: RemotePendingQuestionOption?
+        init(from decoder: any Decoder) throws {
+            option = try? RemotePendingQuestionOption(from: decoder)
+        }
+    }
+}
+
+public struct RemotePendingQuestionOption: Codable, Sendable, Equatable {
+    public let label: String
+    public let description: String?
+
+    public init(label: String, description: String? = nil) {
+        self.label = label
+        self.description = description
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case label, description
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        label = try c.decode(String.self, forKey: .label)
+        description = (try? c.decodeIfPresent(String.self, forKey: .description)).flatMap { $0 }
+    }
+}

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -154,9 +154,14 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
     /// `isArchived` for display, which supplies the contract's
     /// absent-reads-as-false semantics.
     public let archived: Bool?
+    /// The contract's optional `pending_question` — WHAT a `waiting_input`
+    /// session is blocked on. Liveness axis, not filing: a snapshot that has
+    /// gone stale can no longer assert it (see `projectedForStaleSnapshot`).
+    public let pendingQuestion: RemotePendingQuestion?
 
     enum CodingKeys: String, CodingKey {
         case id, title, state, meta, archived
+        case pendingQuestion = "pending_question"
         case createdAt = "created_at"
         case exitCode = "exit_code"
         case agentState = "agent_state"
@@ -168,11 +173,13 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
                 state: RemoteProcessState, exitCode: Int? = nil,
                 agentState: RemoteAgentState = .unknown,
                 agentStateReason: String? = nil, agentStateAt: String? = nil,
-                meta: [String: String]? = nil, archived: Bool? = nil) {
+                meta: [String: String]? = nil, archived: Bool? = nil,
+                pendingQuestion: RemotePendingQuestion? = nil) {
         self.id = id; self.title = title; self.createdAt = createdAt
         self.state = state; self.exitCode = exitCode
         self.agentState = agentState; self.agentStateReason = agentStateReason
         self.agentStateAt = agentStateAt; self.meta = meta; self.archived = archived
+        self.pendingQuestion = pendingQuestion
     }
 
     /// Decoded leniently, field by field, and fatal on exactly one thing.
@@ -210,6 +217,10 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
         agentStateReason = lenient(String.self, .agentStateReason)
         agentStateAt = lenient(String.self, .agentStateAt)
         archived = lenient(Bool.self, .archived)
+        // Absent whenever it is anything other than a question block TBD can
+        // read: the contract forbids inferring blockage from this field, so
+        // its loss costs an explanation and never a state.
+        pendingQuestion = lenient(RemotePendingQuestion.self, .pendingQuestion)
         let provider = decoder.userInfo[.remoteProviderName] as? String
         meta = Self.decodeMeta(from: c, sessionID: id, provider: provider)
         if !dropped.isEmpty {
@@ -254,9 +265,9 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
     private static func decodeMeta(
         from c: KeyedDecodingContainer<CodingKeys>, sessionID: String, provider: String?
     ) -> [String: String]? {
-        let raw: [String: MetaValue]?
+        let raw: [String: LenientDisplayScalar]?
         do {
-            raw = try c.decodeIfPresent([String: MetaValue].self, forKey: .meta)
+            raw = try c.decodeIfPresent([String: LenientDisplayScalar].self, forKey: .meta)
         } catch {
             // `meta` present but not an object — the one case that costs the
             // WHOLE map rather than a key, including `repo`, which is what
@@ -297,26 +308,6 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
         return kept
     }
 
-    /// One `meta` value, decoded down to the string a display map can show.
-    /// `literal` is nil for anything with no unambiguous literal form — an
-    /// object, an array, or an explicit null.
-    private struct MetaValue: Decodable {
-        let literal: String?
-
-        init(from decoder: any Decoder) throws {
-            guard let c = try? decoder.singleValueContainer(), !c.decodeNil() else {
-                literal = nil
-                return
-            }
-            if let s = try? c.decode(String.self) { literal = s; return }
-            if let b = try? c.decode(Bool.self) { literal = b ? "true" : "false"; return }
-            // Int before Double so a whole number reads as `42`, not `42.0`.
-            if let i = try? c.decode(Int.self) { literal = String(i); return }
-            if let d = try? c.decode(Double.self) { literal = String(d); return }
-            literal = nil
-        }
-    }
-
     /// The contract's absent-reads-as-`false` display semantics. The sync
     /// path must NOT use this — it needs to distinguish "no claim" (nil) from
     /// an explicit `false`, so it reads `archived` directly.
@@ -346,7 +337,11 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
             id: id, title: title, createdAt: createdAt,
             state: .unknown, exitCode: exitCode, agentState: .unknown,
             agentStateReason: nil, agentStateAt: agentStateAt, meta: meta,
-            archived: archived)
+            archived: archived,
+            // Liveness axis: "blocked on this question" is a claim about
+            // right now, and a provider that has stopped answering leaves
+            // TBD no standing to make it.
+            pendingQuestion: nil)
     }
 }
 
@@ -449,9 +444,19 @@ public struct ProviderDescribe: Codable, Sendable {
     public let providerVersion: String?
     public let capabilities: [String]
     public let createParams: [ProviderCreateParamField]
+    /// Which BACKEND this registry entry is pointed at, as non-secret display
+    /// pairs (`docs/remote-provider-contract.md` § `describe`). Nil from any
+    /// provider that doesn't send it, which is every provider written before
+    /// the field existed — TBD then shows only the identity it can derive
+    /// locally (the registry key and the command it runs).
+    ///
+    /// Note what `name` is and is not: it identifies the provider's KIND, so
+    /// two registry entries running the same binary against different control
+    /// planes report the same one. It is never sufficient identity on its own.
+    public let identity: ProviderIdentity?
 
     enum CodingKeys: String, CodingKey {
-        case name, capabilities
+        case name, capabilities, identity
         case contractVersions = "contract_versions"
         case providerVersion = "provider_version"
         case createParams = "create_params"
@@ -462,12 +467,14 @@ public struct ProviderDescribe: Codable, Sendable {
     /// memberwise init, so without this the only way to build one was a
     /// round-trip through `JSONDecoder`.
     public init(contractVersions: [Int] = [1], name: String, providerVersion: String? = nil,
-                capabilities: [String] = [], createParams: [ProviderCreateParamField] = []) {
+                capabilities: [String] = [], createParams: [ProviderCreateParamField] = [],
+                identity: ProviderIdentity? = nil) {
         self.contractVersions = contractVersions
         self.name = name
         self.providerVersion = providerVersion
         self.capabilities = capabilities
         self.createParams = createParams
+        self.identity = identity
     }
 
     public init(from decoder: Decoder) throws {
@@ -477,6 +484,9 @@ public struct ProviderDescribe: Codable, Sendable {
         providerVersion = try c.decodeIfPresent(String.self, forKey: .providerVersion)
         capabilities = try c.decodeIfPresent([String].self, forKey: .capabilities) ?? []
         createParams = try c.decodeIfPresent([ProviderCreateParamField].self, forKey: .createParams) ?? []
+        // Never fatal: an identity block TBD can't read costs the identity
+        // rows, never the provider's registration.
+        identity = (try? c.decodeIfPresent(ProviderIdentity.self, forKey: .identity)).flatMap { $0 }
     }
 }
 

--- a/Sources/TBDShared/RemoteProviderIdentity.swift
+++ b/Sources/TBDShared/RemoteProviderIdentity.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+// MARK: - Lenient display scalars
+
+/// One value from a provider-defined display map, decoded down to the string
+/// a display map can show. `literal` is nil for anything with no unambiguous
+/// literal form — an object, an array, or an explicit null.
+///
+/// Shared by the two flat string-to-string maps the provider contract
+/// defines: the Session object's `meta` and `describe`'s `identity`. Both
+/// carry provider-chosen display pairs, and both degrade the same way, so
+/// they coerce the same way from one implementation rather than two that can
+/// drift.
+struct LenientDisplayScalar: Decodable {
+    let literal: String?
+
+    init(from decoder: any Decoder) throws {
+        guard let c = try? decoder.singleValueContainer(), !c.decodeNil() else {
+            literal = nil
+            return
+        }
+        if let s = try? c.decode(String.self) { literal = s; return }
+        if let b = try? c.decode(Bool.self) { literal = b ? "true" : "false"; return }
+        // Int before Double so a whole number reads as `42`, not `42.0`.
+        if let i = try? c.decode(Int.self) { literal = String(i); return }
+        if let d = try? c.decode(Double.self) { literal = String(d); return }
+        literal = nil
+    }
+}
+
+// MARK: - Provider identity
+
+/// `describe.identity` — the non-secret display identity of the BACKEND a
+/// registry entry is pointed at (`docs/remote-provider-contract.md` §
+/// `describe`).
+///
+/// TBD cannot derive this itself. A registry entry is an executable path and
+/// a flag list, and the mapping from those flags to a control plane is the
+/// provider's private business — which is exactly why two entries running the
+/// same binary against different backends are indistinguishable to a caller
+/// that only reads `describe.name`. This field is what closes that gap.
+///
+/// A flat string-to-string map with a well-known key ORDER, not a schema:
+/// every vendor's notion of identity has a different shape, and a fixed set
+/// of typed fields forces a provider to either leave them empty or stretch
+/// them. TBD interprets nothing here beyond the ordering — the values are
+/// display text, on the same terms as the Session object's `meta`.
+public struct ProviderIdentity: Codable, Sendable, Equatable {
+    /// Every pair the provider sent that survived decoding, unredacted and
+    /// unordered. Callers that DISPLAY these must go through
+    /// `displayPairs` rather than reading this directly — it applies the
+    /// secret filter.
+    public let pairs: [String: String]
+
+    /// Keys TBD knows how to order, most identifying first. Everything else
+    /// sorts alphabetically after them. Order only — no key here is
+    /// interpreted, required, or given special rendering.
+    public static let wellKnownKeyOrder: [String] = [
+        "account", "environment", "region", "box", "host", "endpoint",
+    ]
+
+    public init(pairs: [String: String]) {
+        self.pairs = pairs
+    }
+
+    /// Decoded leniently and never fatally, exactly like `meta`: a value with
+    /// no literal form costs its own key and nothing else, and an `identity`
+    /// that is not an object at all costs the whole map rather than the
+    /// `describe` response that carries it. A provider's identity block is
+    /// display sugar — it must never be able to stop TBD from registering the
+    /// provider.
+    public init(from decoder: any Decoder) throws {
+        let raw = try [String: LenientDisplayScalar](from: decoder)
+        var kept: [String: String] = [:]
+        for (key, value) in raw {
+            if let literal = value.literal { kept[key] = literal }
+        }
+        pairs = kept
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        try pairs.encode(to: encoder)
+    }
+
+    /// The pairs as they may be shown: secret-looking keys dropped, values
+    /// truncated, well-known keys first and the rest alphabetical.
+    public var displayPairs: [ProviderIdentityPair] {
+        let safe = ProviderIdentityRedaction.filter(pairs)
+        let wellKnown = Self.wellKnownKeyOrder.compactMap { key -> ProviderIdentityPair? in
+            guard let value = safe[key] else { return nil }
+            return ProviderIdentityPair(key: key, value: value)
+        }
+        let rest = safe.keys
+            .filter { !Self.wellKnownKeyOrder.contains($0) }
+            .sorted()
+            .map { ProviderIdentityPair(key: $0, value: safe[$0] ?? "") }
+        return wellKnown + rest
+    }
+
+    /// Whether there is anything at all to show after redaction — the gate a
+    /// view uses to decide between an identity block and nothing.
+    public var hasDisplayablePairs: Bool { !displayPairs.isEmpty }
+}
+
+/// One identity pair as it reaches a view: already filtered and ordered by
+/// `ProviderIdentity.displayPairs`. A named type rather than a tuple so a
+/// `ForEach` can key on it directly.
+public struct ProviderIdentityPair: Sendable, Equatable, Identifiable {
+    public let key: String
+    public let value: String
+    public var id: String { key }
+
+    public init(key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+}
+
+/// What TBD refuses to put on screen from provider- or user-authored text.
+///
+/// The contract already says `describe.identity` carries display identity and
+/// never credential material, and this filter does not exist because that
+/// rule is doubted — it exists because the rule cannot be enforced from
+/// TBD's side of the process boundary, and because the SAME filter runs over
+/// the registry entry's own argv, which is user-authored and outside the
+/// contract's reach altogether.
+///
+/// Fail-safe by design: a key is dropped on a substring match, so `monkey`
+/// loses to `key`. Losing a display pair costs one line of context; showing a
+/// bearer token costs the token.
+public enum ProviderIdentityRedaction {
+    /// Substrings that make a key secret-bearing. Matched against the key
+    /// lowercased and stripped of separators, so `AWS_Session-Token` and
+    /// `awssessiontoken` are the same key to this check.
+    public static let secretKeySubstrings: [String] = [
+        "token", "secret", "password", "passwd", "credential", "cred",
+        "signature", "cookie", "auth", "key",
+    ]
+
+    // `session` is deliberately NOT in that list, though `session_token` is a
+    // real secret shape: this domain calls its ordinary, non-secret unit of
+    // work a session, and a filter that drops every key containing the word
+    // would redact the identity it exists to show. `token` already covers the
+    // secret-bearing compound.
+
+    /// The longest a rendered identity value may be. Identity values are
+    /// account ids, region names, and box handles; anything longer is either
+    /// not identity or not readable, and truncating bounds the damage from
+    /// both.
+    public static let maximumValueLength = 96
+
+    /// What a redacted value renders as. Deliberately not the value's own
+    /// prefix: a prefix of a secret is still a piece of a secret.
+    public static let redactedPlaceholder = "‹redacted›"
+
+    public static func isSecretKey(_ key: String) -> Bool {
+        let normalized = key.lowercased().filter { $0.isLetter || $0.isNumber }
+        return secretKeySubstrings.contains { normalized.contains($0) }
+    }
+
+    /// `value` bounded to `maximumValueLength`, with an ellipsis marking that
+    /// it was cut. Never used to shorten a secret — a secret-keyed pair is
+    /// dropped, not truncated.
+    public static func truncated(_ value: String) -> String {
+        guard value.count > maximumValueLength else { return value }
+        return String(value.prefix(maximumValueLength)) + "…"
+    }
+
+    /// Display pairs with secret-keyed entries removed and the rest bounded.
+    public static func filter(_ pairs: [String: String]) -> [String: String] {
+        var kept: [String: String] = [:]
+        for (key, value) in pairs where !isSecretKey(key) {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            kept[key] = truncated(trimmed)
+        }
+        return kept
+    }
+
+    /// A registry entry's argv, safe to show.
+    ///
+    /// Two shapes carry a secret on a command line, and both are handled:
+    /// `--token=abc` (the value rides the same argument as the flag) and
+    /// `--token abc` (the value is the NEXT argument). The second is why this
+    /// takes the whole list rather than mapping over it — an argument is only
+    /// judged in the company of the one before it.
+    ///
+    /// Never used to decide anything; the result is display text only.
+    public static func redactArguments(_ args: [String]) -> [String] {
+        var out: [String] = []
+        var redactNext = false
+        for arg in args {
+            if redactNext {
+                redactNext = false
+                // A flag never counts as the previous flag's value: `--token
+                // --verbose` means the token was simply not supplied here.
+                if arg.hasPrefix("-") {
+                    out.append(arg)
+                    continue
+                }
+                out.append(redactedPlaceholder)
+                continue
+            }
+            if let separator = arg.firstIndex(of: "="), arg.hasPrefix("-") {
+                let flag = String(arg[arg.startIndex..<separator])
+                if isSecretKey(flag) {
+                    out.append("\(flag)=\(redactedPlaceholder)")
+                    continue
+                }
+                out.append(arg)
+                continue
+            }
+            if arg.hasPrefix("-"), isSecretKey(arg) {
+                out.append(arg)
+                redactNext = true
+                continue
+            }
+            out.append(arg)
+        }
+        return out
+    }
+}

--- a/Tests/TBDAppTests/ProviderDisambiguationScenarioTests.swift
+++ b/Tests/TBDAppTests/ProviderDisambiguationScenarioTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// The reproduced confusion, pinned end to end.
+///
+/// Two registrations of the SAME provider kind, reporting the SAME box
+/// handle: `agentbox` (management, zero sessions) and `agentbox-staging`
+/// (three sessions, one of them blocked at a prompt). Everything a user reads
+/// while deciding "which one am I looking at, and is anything happening" is
+/// asserted here against that one fixture, because the failure was never in
+/// any single surface — it was that every surface answered a slightly
+/// different question and none of them answered this one.
+@Suite("Provider disambiguation scenario")
+struct ProviderDisambiguationScenarioTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000)
+    private let managementName = "agentbox"
+    private let stagingName = "agentbox-staging"
+
+    /// Both registrations run the same binary and report the same kind and
+    /// the same box handle — the worst case, where only the registry key and
+    /// the identity pairs can tell them apart.
+    private var management: RemoteProviderStatus {
+        provider(
+            registryName: managementName,
+            args: ["--control-plane", "management"],
+            identity: ["box": "i-0abc123", "environment": "management", "account": "acme-1234"],
+            snapshotAt: now.addingTimeInterval(-30))
+    }
+
+    private var staging: RemoteProviderStatus {
+        provider(
+            registryName: stagingName,
+            args: ["--control-plane", "staging"],
+            identity: ["box": "i-0abc123", "environment": "staging", "account": "acme-1234"],
+            snapshotAt: now.addingTimeInterval(-45))
+    }
+
+    private var sessions: [RemoteSessionInfo] {
+        [
+            session(provider: stagingName, id: "fix-flaky-ci", terminal: .running, agent: .working),
+            session(
+                provider: stagingName, id: "deploy-checks", terminal: .running, agent: .waitingInput,
+                question: RemotePendingQuestion(id: "q-4f2a1c", questions: [
+                    RemotePendingQuestionItem(
+                        prompt: "Which environment should this deploy to?",
+                        options: [
+                            RemotePendingQuestionOption(label: "staging"),
+                            RemotePendingQuestionOption(label: "production"),
+                        ]),
+                ])),
+            session(provider: stagingName, id: "opaque-build", terminal: .running, agent: .unknown),
+        ]
+    }
+
+    // MARK: - Which provider am I looking at
+
+    @Test("two registrations of the same kind never render as the same provider")
+    func registrationsAreDistinguishable() {
+        #expect(RemoteProviderIdentityPresentation.headline(management) == "agentbox")
+        #expect(RemoteProviderIdentityPresentation.headline(staging) == "agentbox-staging")
+
+        let managementRows = RemoteProviderIdentityPresentation.rows(management, homeDirectory: "/Users/dev")
+        let stagingRows = RemoteProviderIdentityPresentation.rows(staging, homeDirectory: "/Users/dev")
+
+        // The shared box handle is shown — it is true of both — but it is
+        // never the only thing shown, which is what made the two look alike.
+        #expect(managementRows.first { $0.label == "Box" }?.value == "i-0abc123")
+        #expect(stagingRows.first { $0.label == "Box" }?.value == "i-0abc123")
+        #expect(managementRows.first { $0.label == "Environment" }?.value == "management")
+        #expect(stagingRows.first { $0.label == "Environment" }?.value == "staging")
+        #expect(managementRows != stagingRows)
+    }
+
+    @Test("the shared kind is stated as a kind, beside the registry key")
+    func kindIsSubordinateToTheRegistryKey() {
+        #expect(RemoteProviderIdentityPresentation.kindSubtitle(management) == nil)
+        #expect(RemoteProviderIdentityPresentation.kindSubtitle(staging) == "reports as agentbox")
+    }
+
+    @Test("no credential ever reaches the identity block")
+    func identityCarriesNoCredentials() {
+        let leaky = provider(
+            registryName: managementName,
+            args: ["--token", "sk-live-1"],
+            identity: ["account": "acme-1234", "session_token": "AQoDYXdz", "api_key": "sk-live-2"],
+            snapshotAt: now)
+
+        let rendered = RemoteProviderIdentityPresentation.rows(leaky, homeDirectory: "/Users/dev")
+            .map(\.value).joined(separator: " ")
+
+        #expect(rendered.contains("AQoDYXdz") == false)
+        #expect(rendered.contains("sk-live-1") == false)
+        #expect(rendered.contains("sk-live-2") == false)
+        #expect(rendered.contains("acme-1234"))
+    }
+
+    // MARK: - Zero inventory here, live sessions there
+
+    @Test("the empty provider says it is empty AND says where the sessions are")
+    func emptyProviderPointsAtTheOtherOne() {
+        let summary = RemoteProviderDeskSummary(provider: managementName, sessions: sessions)
+        let state = RemoteProviderInventoryState.make(provider: management, sessionCount: summary.total)
+
+        #expect(summary.total == 0)
+        // A green badge over an empty list is what made this read as "staging
+        // is idle". Both halves of the sentence now exist.
+        #expect(state == .emptySuccess(at: now.addingTimeInterval(-30)))
+        #expect(state.title == "This provider reports no sessions")
+        #expect(RemoteProviderInventoryState.crossProviderNote(
+            currentProvider: managementName, sessions: sessions)
+            == "3 sessions are registered under another provider (agentbox-staging: 3).")
+    }
+
+    @Test("the populated provider needs no notice and no cross-reference")
+    func populatedProviderIsSilent() {
+        let summary = RemoteProviderDeskSummary(provider: stagingName, sessions: sessions)
+        let state = RemoteProviderInventoryState.make(provider: staging, sessionCount: summary.total)
+
+        #expect(state == .populated(count: 3, at: now.addingTimeInterval(-45)))
+        #expect(state.warrantsNotice == false)
+        #expect(RemoteProviderInventoryState.crossProviderNote(
+            currentProvider: stagingName, sessions: sessions) == nil)
+    }
+
+    @Test("a stale management provider is not confused with an empty one")
+    func staleIsNotEmpty() {
+        let unreachable = provider(
+            registryName: managementName, args: [], identity: nil,
+            snapshotAt: now.addingTimeInterval(-3 * 3600), health: .stale)
+
+        let state = RemoteProviderInventoryState.make(provider: unreachable, sessionCount: 0)
+
+        #expect(state == .stale(since: now.addingTimeInterval(-3 * 3600), cachedCount: 0))
+        #expect(state.isCurrent == false)
+    }
+
+    // MARK: - Terminal liveness vs agent progress
+
+    @Test("three running terminals are not three working agents")
+    func liveTerminalsAreNotProgress() {
+        let summary = RemoteProviderDeskSummary(provider: stagingName, sessions: sessions)
+
+        #expect(summary.terminal.running == 3)
+        #expect(summary.agent.working == 1)
+        #expect(summary.agent.waitingInput == 1)
+        #expect(summary.agent.unknown == 1)
+        #expect(summary.unattributedRunningNotice
+            == "1 running session reports no agent state — terminal liveness is not agent progress.")
+    }
+
+    @Test("the blocked session is named with what it is blocked on")
+    func theBlockedSessionExplainsItself() {
+        let summary = RemoteProviderDeskSummary(provider: stagingName, sessions: sessions)
+
+        #expect(summary.needsAttention.map(\.payload.id) == ["deploy-checks"])
+        #expect(summary.needsAttention.first.flatMap(RemoteAgentAttention.explanation(for:))
+            == "Blocked on a question: Which environment should this deploy to? (staging / production)")
+    }
+
+    // MARK: - Attach
+
+    @Test("attach to a staging session never routes through management")
+    func attachRoutesThroughTheSelectedRegistration() {
+        let ready = RemoteAttachPreflight.resolve(
+            selection: RemoteSessionSelection(provider: stagingName, sessionID: "deploy-checks"),
+            providers: [management, staging], sessions: sessions, probe: { _ in .runnable })
+
+        #expect(ready.readyConfig?.name == stagingName)
+        #expect(ready.readyConfig?.args == ["--control-plane", "staging"])
+
+        // Same session id, asked of the wrong registration: named, refused.
+        let wrong = RemoteAttachPreflight.resolve(
+            selection: RemoteSessionSelection(provider: managementName, sessionID: "deploy-checks"),
+            providers: [management, staging], sessions: sessions, probe: { _ in .runnable })
+
+        #expect(wrong == .sessionBelongsToAnotherProvider(
+            requested: managementName, actual: stagingName, sessionID: "deploy-checks"))
+    }
+
+    @Test("a missing local transport dependency is named instead of failing blank")
+    func missingDependencyIsNamed() {
+        let diagnosis = RemoteAttachPreflight.resolve(
+            selection: RemoteSessionSelection(provider: stagingName, sessionID: "deploy-checks"),
+            providers: [management, staging], sessions: sessions,
+            probe: { config in config.name == stagingName ? .missing : .runnable })
+
+        #expect(diagnosis == .executableMissing(
+            provider: stagingName,
+            command: "/opt/agentbox/bin/agentbox --control-plane staging"))
+        #expect(diagnosis.detail.contains("does not exist on this machine"))
+        // And it does not quietly attach through the registration that IS
+        // installed.
+        #expect(diagnosis.readyConfig == nil)
+    }
+
+    // MARK: - Fixtures
+
+    private func provider(
+        registryName: String,
+        args: [String],
+        identity: [String: String]?,
+        snapshotAt: Date?,
+        health: ProviderHealth = .ok
+    ) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(
+                name: registryName, exec: "/opt/agentbox/bin/agentbox", args: args),
+            describe: ProviderDescribe(
+                name: "agentbox", providerVersion: "0.4.2", capabilities: ["attach", "log", "send"],
+                identity: identity.map(ProviderIdentity.init(pairs:))),
+            health: health, errorMessage: nil, remediationLabel: nil, remediationCommand: nil,
+            lastSuccessfulSnapshotAt: snapshotAt, contractVersion: 2)
+    }
+
+    private func session(
+        provider: String,
+        id: String,
+        terminal: RemoteProcessState,
+        agent: RemoteAgentState,
+        question: RemotePendingQuestion? = nil
+    ) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider,
+            payload: RemoteSessionPayload(
+                id: id, title: id, createdAt: "2026-08-26T07:00:00Z",
+                state: terminal, agentState: agent,
+                meta: ["repo": "acme/api", "branch": id], pendingQuestion: question),
+            gone: false, dismissed: false, lastSeen: now.addingTimeInterval(-60))
+    }
+}

--- a/Tests/TBDAppTests/ProviderDisambiguationScenarioTests.swift
+++ b/Tests/TBDAppTests/ProviderDisambiguationScenarioTests.swift
@@ -61,8 +61,8 @@ struct ProviderDisambiguationScenarioTests {
         #expect(RemoteProviderIdentityPresentation.headline(management) == "agentbox")
         #expect(RemoteProviderIdentityPresentation.headline(staging) == "agentbox-staging")
 
-        let managementRows = RemoteProviderIdentityPresentation.rows(management, homeDirectory: "/Users/dev")
-        let stagingRows = RemoteProviderIdentityPresentation.rows(staging, homeDirectory: "/Users/dev")
+        let managementRows = RemoteProviderIdentityPresentation.rows(management, homeDirectory: "/Users/me")
+        let stagingRows = RemoteProviderIdentityPresentation.rows(staging, homeDirectory: "/Users/me")
 
         // The shared box handle is shown — it is true of both — but it is
         // never the only thing shown, which is what made the two look alike.
@@ -87,7 +87,7 @@ struct ProviderDisambiguationScenarioTests {
             identity: ["account": "acme-1234", "session_token": "AQoDYXdz", "api_key": "sk-live-2"],
             snapshotAt: now)
 
-        let rendered = RemoteProviderIdentityPresentation.rows(leaky, homeDirectory: "/Users/dev")
+        let rendered = RemoteProviderIdentityPresentation.rows(leaky, homeDirectory: "/Users/me")
             .map(\.value).joined(separator: " ")
 
         #expect(rendered.contains("AQoDYXdz") == false)

--- a/Tests/TBDAppTests/RemoteAgentAttentionTests.swift
+++ b/Tests/TBDAppTests/RemoteAgentAttentionTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+@Suite("Remote agent attention")
+struct RemoteAgentAttentionTests {
+    // MARK: - What blocks a session
+
+    @Test("a structured question is quoted, with its options")
+    func explainsAPendingQuestion() {
+        let session = session(
+            terminal: .running, agent: .waitingInput,
+            question: RemotePendingQuestion(id: "q1", questions: [
+                RemotePendingQuestionItem(
+                    prompt: "Which environment should this deploy to?",
+                    options: [
+                        RemotePendingQuestionOption(label: "staging"),
+                        RemotePendingQuestionOption(label: "production"),
+                    ]),
+            ]))
+
+        #expect(RemoteAgentAttention.explanation(for: session)
+            == "Blocked on a question: Which environment should this deploy to? (staging / production)")
+    }
+
+    @Test("more than one pending question is counted, not concatenated")
+    func countsAdditionalQuestions() {
+        let session = session(
+            terminal: .running, agent: .waitingInput,
+            question: RemotePendingQuestion(questions: [
+                RemotePendingQuestionItem(prompt: "First?"),
+                RemotePendingQuestionItem(prompt: "Second?"),
+            ]))
+
+        #expect(RemoteAgentAttention.explanation(for: session)
+            == "Blocked on a question: First? — and 1 more.")
+    }
+
+    @Test("the contract's own reason value is humanized and every other passes through")
+    func humanizesTheKnownReason() {
+        #expect(RemoteAgentAttention.humanizedReason("permission_prompt")
+            == "Blocked on a permission prompt.")
+        // Provider-defined; TBD invents no meaning for a value it was never
+        // promised.
+        #expect(RemoteAgentAttention.humanizedReason("awaiting_reviewer") == "awaiting_reviewer")
+        #expect(RemoteAgentAttention.humanizedReason("   ") == nil)
+        #expect(RemoteAgentAttention.humanizedReason(nil) == nil)
+    }
+
+    @Test("a question outranks a reason string, and a reason outranks the bare state")
+    func prefersTheMostSpecificSource() {
+        let both = session(
+            terminal: .running, agent: .waitingInput, reason: "permission_prompt",
+            question: RemotePendingQuestion(questions: [RemotePendingQuestionItem(prompt: "Go on?")]))
+        #expect(RemoteAgentAttention.explanation(for: both) == "Blocked on a question: Go on?")
+
+        let reasonOnly = session(terminal: .running, agent: .waitingInput, reason: "permission_prompt")
+        #expect(RemoteAgentAttention.explanation(for: reasonOnly) == "Blocked on a permission prompt.")
+
+        let bare = session(terminal: .running, agent: .waitingInput)
+        #expect(RemoteAgentAttention.explanation(for: bare) == "Waiting for input.")
+    }
+
+    // MARK: - Liveness is not progress
+
+    @Test("a running terminal with no agent state is stated as such, not as work")
+    func namesTheUnattributedRunningRow() {
+        let session = session(terminal: .running, agent: .unknown)
+
+        #expect(RemoteAgentAttention.isUnattributedRunning(session))
+        #expect(RemoteAgentAttention.explanation(for: session)
+            == RemoteAgentAttention.unattributedRunningExplanation)
+        // It is neither working nor waiting, and must not be counted as either.
+        #expect(RemoteAgentAttention.needsAttention(session) == false)
+    }
+
+    @Test("an idle agent under a live terminal says it is idle")
+    func namesTheIdleRow() {
+        #expect(RemoteAgentAttention.explanation(for: session(terminal: .running, agent: .idle))
+            == "Agent is idle — it reported no work in progress.")
+    }
+
+    @Test("a working session asks nothing of a human")
+    func workingSessionsAreSilent() {
+        let working = session(terminal: .running, agent: .working)
+
+        #expect(RemoteAgentAttention.explanation(for: working) == nil)
+        #expect(RemoteAgentAttention.needsAttention(working) == false)
+        #expect(RemoteAgentAttention.isUnattributedRunning(working) == false)
+    }
+
+    @Test("a tombstoned row asks nothing of a human either")
+    func goneRowsAreSilent() {
+        let gone = session(terminal: .running, agent: .waitingInput, gone: true)
+
+        #expect(RemoteAgentAttention.explanation(for: gone) == nil)
+        #expect(RemoteAgentAttention.needsAttention(gone) == false)
+        #expect(RemoteAgentAttention.isUnattributedRunning(gone) == false)
+    }
+
+    @Test("blockage is read off the agent axis, never off the question block")
+    func neverInfersBlockageFromAQuestion() {
+        // The contract forbids concluding a session is blocked from
+        // `pending_question` alone. A provider that leaves a stale block
+        // behind can make the explanation wrong; it must never make TBD
+        // claim a working session needs a human.
+        let working = session(
+            terminal: .running, agent: .working,
+            question: RemotePendingQuestion(questions: [RemotePendingQuestionItem(prompt: "Stale?")]))
+
+        #expect(RemoteAgentAttention.needsAttention(working) == false)
+        #expect(RemoteAgentAttention.explanation(for: working) == nil)
+    }
+
+    // MARK: - The desk's aggregate
+
+    @Test("the desk separates blocked rows from unattributed running ones")
+    func summarySeparatesTheTwoReadings() {
+        let sessions = [
+            session(id: "blocked", terminal: .running, agent: .waitingInput, reason: "permission_prompt"),
+            session(id: "opaque", terminal: .running, agent: .unknown),
+            session(id: "busy", terminal: .running, agent: .working),
+        ]
+
+        let summary = RemoteProviderDeskSummary(provider: "agentbox", sessions: sessions)
+
+        #expect(summary.needsAttention.map(\.payload.id) == ["blocked"])
+        #expect(summary.unattributedRunning.map(\.payload.id) == ["opaque"])
+        #expect(summary.unattributedRunningNotice
+            == "1 running session reports no agent state — terminal liveness is not agent progress.")
+        // Terminal liveness still counts all three: the axes stay separate.
+        #expect(summary.terminal.running == 3)
+    }
+
+    @Test("no unattributed rows means no notice")
+    func noNoticeWhenEverythingIsAttributed() {
+        let summary = RemoteProviderDeskSummary(
+            provider: "agentbox",
+            sessions: [session(terminal: .running, agent: .working)])
+
+        #expect(summary.unattributedRunningNotice == nil)
+        #expect(summary.needsAttention.isEmpty)
+    }
+
+    private func session(
+        id: String = "s1",
+        provider: String = "agentbox",
+        terminal: RemoteProcessState,
+        agent: RemoteAgentState,
+        reason: String? = nil,
+        question: RemotePendingQuestion? = nil,
+        gone: Bool = false
+    ) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider,
+            payload: RemoteSessionPayload(
+                id: id, title: id, state: terminal, agentState: agent,
+                agentStateReason: reason, pendingQuestion: question),
+            gone: gone, dismissed: false,
+            lastSeen: Date(timeIntervalSince1970: 1_000))
+    }
+}

--- a/Tests/TBDAppTests/RemoteAttachPreflightTests.swift
+++ b/Tests/TBDAppTests/RemoteAttachPreflightTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+@Suite("Remote attach preflight")
+struct RemoteAttachPreflightTests {
+    private func provider(
+        _ name: String,
+        exec: String = "/opt/agentbox/bin/agentbox",
+        capabilities: [String] = ["attach", "log"]
+    ) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: name, exec: exec),
+            describe: ProviderDescribe(name: "agentbox", capabilities: capabilities),
+            health: .ok, errorMessage: nil, remediationLabel: nil, remediationCommand: nil)
+    }
+
+    private func session(provider: String, id: String) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider,
+            payload: RemoteSessionPayload(id: id, state: .running, agentState: .working),
+            gone: false, dismissed: false, lastSeen: Date(timeIntervalSince1970: 1_000))
+    }
+
+    private func resolve(
+        provider selected: String,
+        sessionID: String = "s1",
+        providers: [RemoteProviderStatus],
+        sessions: [RemoteSessionInfo],
+        probe: @escaping (RemoteProviderConfig) -> RemoteAttachPreflight.ExecutableStatus = { _ in .runnable }
+    ) -> RemoteAttachPreflight.Diagnosis {
+        RemoteAttachPreflight.resolve(
+            selection: RemoteSessionSelection(provider: selected, sessionID: sessionID),
+            providers: providers, sessions: sessions, probe: probe)
+    }
+
+    // MARK: - Routing
+
+    @Test("attach resolves through the selected provider and no other")
+    func resolvesThroughTheSelectedProvider() {
+        // Two registrations of the same kind, both healthy, both declaring
+        // attach. Only the selected one may ever be spawned.
+        let diagnosis = resolve(
+            provider: "agentbox-staging",
+            providers: [provider("agentbox"), provider("agentbox-staging", exec: "/opt/staging/agentbox")],
+            sessions: [session(provider: "agentbox-staging", id: "s1")])
+
+        #expect(diagnosis.readyConfig?.name == "agentbox-staging")
+        #expect(diagnosis.readyConfig?.exec == "/opt/staging/agentbox")
+    }
+
+    @Test("a session belonging to another provider is named, never silently attached")
+    func neverFallsBackToAnotherProvider() {
+        // The failure this whole type exists to make impossible: the session
+        // is right there under a sibling registration, and one healthy
+        // provider is registered — a "helpful" fallback would attach to the
+        // wrong control plane.
+        let diagnosis = resolve(
+            provider: "agentbox",
+            providers: [provider("agentbox")],
+            sessions: [session(provider: "agentbox-staging", id: "s1")])
+
+        #expect(diagnosis == .sessionBelongsToAnotherProvider(
+            requested: "agentbox", actual: "agentbox-staging", sessionID: "s1"))
+        #expect(diagnosis.readyConfig == nil)
+        #expect(diagnosis.detail.contains("agentbox-staging"))
+        #expect(diagnosis.detail.contains("will not attach to another provider's session"))
+    }
+
+    @Test("an unregistered provider is reported by name, with no substitute offered")
+    func reportsAnUnregisteredProvider() {
+        let diagnosis = resolve(
+            provider: "agentbox-staging",
+            providers: [provider("agentbox")],
+            sessions: [session(provider: "agentbox-staging", id: "s1")])
+
+        // The session is only in the mirror, its registration is gone: name
+        // the registration, not the sibling.
+        #expect(diagnosis == .providerNotRegistered(provider: "agentbox-staging"))
+        #expect(diagnosis.detail.contains("agent-providers.json"))
+    }
+
+    @Test("no provider and no other owner still names the provider that was asked for")
+    func reportsAnUnknownProviderWithNoOwner() {
+        let diagnosis = resolve(
+            provider: "ghost", providers: [provider("agentbox")], sessions: [])
+
+        #expect(diagnosis == .providerNotRegistered(provider: "ghost"))
+    }
+
+    @Test("a provider that does not declare attach is not invoked for it")
+    func respectsTheAttachCapability() {
+        let diagnosis = resolve(
+            provider: "agentbox",
+            providers: [provider("agentbox", capabilities: ["log"])],
+            sessions: [session(provider: "agentbox", id: "s1")])
+
+        #expect(diagnosis == .attachUnsupported(provider: "agentbox"))
+        #expect(diagnosis.detail.contains("log view"))
+    }
+
+    // MARK: - Local transport dependency
+
+    @Test("a missing local executable is an actionable diagnosis, not a blank pane")
+    func reportsAMissingExecutable() {
+        let diagnosis = resolve(
+            provider: "agentbox",
+            providers: [provider("agentbox", exec: "/opt/agentbox/bin/agentbox")],
+            sessions: [session(provider: "agentbox", id: "s1")],
+            probe: { _ in .missing })
+
+        #expect(diagnosis == .executableMissing(
+            provider: "agentbox", command: "/opt/agentbox/bin/agentbox"))
+        #expect(diagnosis.title == "Attach command not found")
+        #expect(diagnosis.detail.contains("/opt/agentbox/bin/agentbox"))
+        #expect(diagnosis.detail.contains("agent-providers.json"))
+    }
+
+    @Test("a present but non-executable command is a different diagnosis")
+    func reportsANonExecutableCommand() {
+        let diagnosis = resolve(
+            provider: "agentbox",
+            providers: [provider("agentbox")],
+            sessions: [session(provider: "agentbox", id: "s1")],
+            probe: { _ in .notExecutable })
+
+        #expect(diagnosis == .executableNotRunnable(
+            provider: "agentbox", command: "/opt/agentbox/bin/agentbox"))
+        #expect(diagnosis.detail.contains("chmod +x"))
+    }
+
+    @Test("a secret-looking registry argument never reaches an error message")
+    func redactsArgumentsInDiagnostics() {
+        let status = RemoteProviderStatus(
+            config: RemoteProviderConfig(
+                name: "agentbox", exec: "/opt/agentbox/bin/agentbox",
+                args: ["--token=sk-live-1"]),
+            describe: ProviderDescribe(name: "agentbox", capabilities: ["attach"]),
+            health: .ok, errorMessage: nil, remediationLabel: nil, remediationCommand: nil)
+
+        let diagnosis = resolve(
+            provider: "agentbox", providers: [status],
+            sessions: [session(provider: "agentbox", id: "s1")],
+            probe: { _ in .missing })
+
+        #expect(diagnosis.detail.contains("sk-live-1") == false)
+    }
+
+    // MARK: - The filesystem probe
+
+    @Test("an absolute path is probed as a file")
+    func probesAbsolutePaths() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("preflight-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let runnable = directory.appendingPathComponent("provider")
+        try Data("#!/bin/sh\n".utf8).write(to: runnable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: runnable.path)
+        let plain = directory.appendingPathComponent("not-executable")
+        try Data("x".utf8).write(to: plain)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: plain.path)
+
+        #expect(RemoteAttachPreflight.probeExecutable(runnable.path) == .runnable)
+        #expect(RemoteAttachPreflight.probeExecutable(plain.path) == .notExecutable)
+        #expect(RemoteAttachPreflight.probeExecutable(directory.appendingPathComponent("absent").path)
+            == .missing)
+        // A directory is not a command, however much it exists.
+        #expect(RemoteAttachPreflight.probeExecutable(directory.path) == .missing)
+        #expect(RemoteAttachPreflight.probeExecutable("") == .missing)
+    }
+
+    @Test("a bare command name is resolved on PATH, the way the spawn will resolve it")
+    func probesBareNamesOnPath() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("preflight-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let onPath = directory.appendingPathComponent("agentbox")
+        try Data("#!/bin/sh\n".utf8).write(to: onPath)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: onPath.path)
+
+        // Never report "missing" for a provider that would in fact have run.
+        #expect(RemoteAttachPreflight.probeExecutable(
+            "agentbox", environment: ["PATH": "/nonexistent:\(directory.path)"]) == .runnable)
+        #expect(RemoteAttachPreflight.probeExecutable(
+            "agentbox", environment: ["PATH": "/nonexistent"]) == .missing)
+        #expect(RemoteAttachPreflight.probeExecutable("agentbox", environment: [:]) == .missing)
+    }
+}

--- a/Tests/TBDAppTests/RemoteProviderAuthPresentationTests.swift
+++ b/Tests/TBDAppTests/RemoteProviderAuthPresentationTests.swift
@@ -156,9 +156,14 @@ struct RemoteProviderAuthPresentationTests {
 
     // MARK: - Provider name
 
-    @Test func describeNameWinsOverTheRegistryName() throws {
+    /// The registry key leads, even when `describe` supplied a prettier
+    /// name. `describe.name` identifies the provider's KIND, so two
+    /// registrations running the same binary against different backends
+    /// report the same one — and this CTA's whole job is to send a user to
+    /// re-authenticate a specific registration.
+    @Test func registryNameWinsOverTheDescribeName() throws {
         let cta = try #require(RemoteProviderAuthPresentation.make(from: status(describeName: "Acme Cloud")))
-        #expect(cta.providerName == "Acme Cloud")
+        #expect(cta.providerName == "acme")
     }
 
     @Test func registryNameIsUsedWhenDescribeIsMissing() throws {
@@ -171,7 +176,7 @@ struct RemoteProviderAuthPresentationTests {
     @Test func fallbackNameLosesToBothNamesOnTheStatus() throws {
         let fromDescribe = try #require(RemoteProviderAuthPresentation.make(
             from: status(describeName: "Acme Cloud"), fallbackProviderName: "raw-name"))
-        #expect(fromDescribe.providerName == "Acme Cloud")
+        #expect(fromDescribe.providerName == "acme")
 
         let fromRegistry = try #require(RemoteProviderAuthPresentation.make(
             from: status(), fallbackProviderName: "raw-name"))
@@ -185,7 +190,7 @@ struct RemoteProviderAuthPresentationTests {
             describeName: "Acme Cloud", message: "credentials expired",
             label: "Sign in", command: "acme-provider login")))
         #expect(cta == RemoteProviderAuthPresentation(
-            providerName: "Acme Cloud", message: "credentials expired",
+            providerName: "acme", message: "credentials expired",
             actionLabel: "Sign in", command: "acme-provider login"))
     }
 }

--- a/Tests/TBDAppTests/RemoteProviderIdentityPresentationTests.swift
+++ b/Tests/TBDAppTests/RemoteProviderIdentityPresentationTests.swift
@@ -67,7 +67,7 @@ struct RemoteProviderIdentityPresentationTests {
             identity: ["environment": "staging", "account": "acme-1234", "tenant_slug": "acme"],
             providerVersion: "0.4.2", contractVersion: 2)
 
-        let rows = RemoteProviderIdentityPresentation.rows(provider, homeDirectory: "/Users/dev")
+        let rows = RemoteProviderIdentityPresentation.rows(provider, homeDirectory: "/Users/me")
 
         #expect(rows.map(\.label) == ["Account", "Environment", "Tenant slug", "Command", "Version"])
         #expect(rows[0].value == "acme-1234")
@@ -82,8 +82,8 @@ struct RemoteProviderIdentityPresentationTests {
         let staging = status(
             registryName: "agentbox-staging", kind: "agentbox", args: ["--control-plane", "staging"])
 
-        let managementRows = RemoteProviderIdentityPresentation.rows(management, homeDirectory: "/Users/dev")
-        let stagingRows = RemoteProviderIdentityPresentation.rows(staging, homeDirectory: "/Users/dev")
+        let managementRows = RemoteProviderIdentityPresentation.rows(management, homeDirectory: "/Users/me")
+        let stagingRows = RemoteProviderIdentityPresentation.rows(staging, homeDirectory: "/Users/me")
 
         #expect(managementRows.map(\.label) == ["Command", "Version"])
         #expect(managementRows[0].value == "/opt/agentbox/bin/agentbox --control-plane management")
@@ -94,13 +94,13 @@ struct RemoteProviderIdentityPresentationTests {
 
     @Test("the command line is tilde-abbreviated against an injected home")
     func abbreviatesHome() {
-        let provider = status(registryName: "agentbox", exec: "/Users/dev/bin/agentbox")
+        let provider = status(registryName: "agentbox", exec: "/Users/me/bin/agentbox")
 
         #expect(RemoteProviderIdentityPresentation.commandLine(
-            provider.config, homeDirectory: "/Users/dev") == "~/bin/agentbox")
+            provider.config, homeDirectory: "/Users/me") == "~/bin/agentbox")
         // A different user's home never gets abbreviated away.
         #expect(RemoteProviderIdentityPresentation.commandLine(
-            provider.config, homeDirectory: "/Users/other") == "/Users/dev/bin/agentbox")
+            provider.config, homeDirectory: "/Users/acme") == "/Users/me/bin/agentbox")
     }
 
     @Test("a secret-looking registry argument never reaches the screen")
@@ -110,7 +110,7 @@ struct RemoteProviderIdentityPresentationTests {
             args: ["--token=sk-live-1", "--profile", "acme"])
 
         let command = RemoteProviderIdentityPresentation.commandLine(
-            provider.config, homeDirectory: "/Users/dev")
+            provider.config, homeDirectory: "/Users/me")
 
         #expect(command.contains("sk-live-1") == false)
         #expect(command.contains(ProviderIdentityRedaction.redactedPlaceholder))
@@ -123,7 +123,7 @@ struct RemoteProviderIdentityPresentationTests {
             registryName: "agentbox", kind: "agentbox",
             identity: ["account": "acme-1234", "session_token": "AQoDYXdz"])
 
-        let rows = RemoteProviderIdentityPresentation.rows(provider, homeDirectory: "/Users/dev")
+        let rows = RemoteProviderIdentityPresentation.rows(provider, homeDirectory: "/Users/me")
 
         #expect(rows.contains { $0.value.contains("AQoDYXdz") } == false)
         #expect(rows.first?.label == "Account")
@@ -132,7 +132,7 @@ struct RemoteProviderIdentityPresentationTests {
     @Test("version is omitted entirely before describe has ever succeeded")
     func noVersionWithoutDescribe() {
         let rows = RemoteProviderIdentityPresentation.rows(
-            status(registryName: "agentbox"), homeDirectory: "/Users/dev")
+            status(registryName: "agentbox"), homeDirectory: "/Users/me")
 
         #expect(rows.map(\.label) == ["Command"])
     }

--- a/Tests/TBDAppTests/RemoteProviderIdentityPresentationTests.swift
+++ b/Tests/TBDAppTests/RemoteProviderIdentityPresentationTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+@Suite("Provider identity presentation")
+struct RemoteProviderIdentityPresentationTests {
+    private func status(
+        registryName: String,
+        kind: String? = nil,
+        exec: String = "/opt/agentbox/bin/agentbox",
+        args: [String]? = nil,
+        identity: [String: String]? = nil,
+        providerVersion: String? = nil,
+        contractVersion: Int? = nil
+    ) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: registryName, exec: exec, args: args),
+            describe: kind.map {
+                ProviderDescribe(
+                    name: $0, providerVersion: providerVersion,
+                    capabilities: ["attach"],
+                    identity: identity.map(ProviderIdentity.init(pairs:)))
+            },
+            health: .ok, errorMessage: nil, remediationLabel: nil, remediationCommand: nil,
+            contractVersion: contractVersion)
+    }
+
+    // MARK: - The headline
+
+    @Test("the headline is the registry key, never the provider kind")
+    func headlineIsTheRegistryKey() {
+        // The reproduced failure: two registrations of the same binary both
+        // rendered as "agentbox", so a user inspected one believing it was
+        // the other.
+        let management = status(registryName: "agentbox", kind: "agentbox")
+        let staging = status(registryName: "agentbox-staging", kind: "agentbox")
+
+        #expect(RemoteProviderIdentityPresentation.headline(management) == "agentbox")
+        #expect(RemoteProviderIdentityPresentation.headline(staging) == "agentbox-staging")
+        #expect(RemoteProviderIdentityPresentation.headline(management)
+            != RemoteProviderIdentityPresentation.headline(staging))
+    }
+
+    @Test("the headline survives a provider whose describe has never succeeded")
+    func headlineWithoutDescribe() {
+        #expect(RemoteProviderIdentityPresentation.headline(status(registryName: "agentbox-staging"))
+            == "agentbox-staging")
+    }
+
+    @Test("the kind is shown only when it adds something")
+    func kindSubtitleOnlyWhenDistinct() {
+        #expect(RemoteProviderIdentityPresentation.kindSubtitle(
+            status(registryName: "agentbox", kind: "agentbox")) == nil)
+        #expect(RemoteProviderIdentityPresentation.kindSubtitle(
+            status(registryName: "agentbox-staging", kind: "agentbox")) == "reports as agentbox")
+        #expect(RemoteProviderIdentityPresentation.kindSubtitle(
+            status(registryName: "agentbox-staging")) == nil)
+    }
+
+    // MARK: - Identity rows
+
+    @Test("identity pairs lead the block, well-known keys first")
+    func identityRowsLeadTheBlock() {
+        let provider = status(
+            registryName: "agentbox-staging", kind: "agentbox",
+            identity: ["environment": "staging", "account": "acme-1234", "tenant_slug": "acme"],
+            providerVersion: "0.4.2", contractVersion: 2)
+
+        let rows = RemoteProviderIdentityPresentation.rows(provider, homeDirectory: "/Users/dev")
+
+        #expect(rows.map(\.label) == ["Account", "Environment", "Tenant slug", "Command", "Version"])
+        #expect(rows[0].value == "acme-1234")
+        #expect(rows[1].value == "staging")
+        #expect(rows.last?.value == "0.4.2 · contract v2")
+    }
+
+    @Test("without an identity block the command line is what distinguishes two registrations")
+    func commandCarriesTheDistinctionWithoutIdentity() {
+        let management = status(
+            registryName: "agentbox", kind: "agentbox", args: ["--control-plane", "management"])
+        let staging = status(
+            registryName: "agentbox-staging", kind: "agentbox", args: ["--control-plane", "staging"])
+
+        let managementRows = RemoteProviderIdentityPresentation.rows(management, homeDirectory: "/Users/dev")
+        let stagingRows = RemoteProviderIdentityPresentation.rows(staging, homeDirectory: "/Users/dev")
+
+        #expect(managementRows.map(\.label) == ["Command", "Version"])
+        #expect(managementRows[0].value == "/opt/agentbox/bin/agentbox --control-plane management")
+        #expect(stagingRows[0].value == "/opt/agentbox/bin/agentbox --control-plane staging")
+        // Emphasised only while nothing better exists to tell them apart.
+        #expect(managementRows[0].isDistinguishing == true)
+    }
+
+    @Test("the command line is tilde-abbreviated against an injected home")
+    func abbreviatesHome() {
+        let provider = status(registryName: "agentbox", exec: "/Users/dev/bin/agentbox")
+
+        #expect(RemoteProviderIdentityPresentation.commandLine(
+            provider.config, homeDirectory: "/Users/dev") == "~/bin/agentbox")
+        // A different user's home never gets abbreviated away.
+        #expect(RemoteProviderIdentityPresentation.commandLine(
+            provider.config, homeDirectory: "/Users/other") == "/Users/dev/bin/agentbox")
+    }
+
+    @Test("a secret-looking registry argument never reaches the screen")
+    func redactsRegistryArguments() {
+        let provider = status(
+            registryName: "agentbox", exec: "/opt/agentbox/bin/agentbox",
+            args: ["--token=sk-live-1", "--profile", "acme"])
+
+        let command = RemoteProviderIdentityPresentation.commandLine(
+            provider.config, homeDirectory: "/Users/dev")
+
+        #expect(command.contains("sk-live-1") == false)
+        #expect(command.contains(ProviderIdentityRedaction.redactedPlaceholder))
+        #expect(command.hasSuffix("--profile acme"))
+    }
+
+    @Test("a credential-named identity pair is dropped rather than rendered")
+    func redactsIdentityPairs() {
+        let provider = status(
+            registryName: "agentbox", kind: "agentbox",
+            identity: ["account": "acme-1234", "session_token": "AQoDYXdz"])
+
+        let rows = RemoteProviderIdentityPresentation.rows(provider, homeDirectory: "/Users/dev")
+
+        #expect(rows.contains { $0.value.contains("AQoDYXdz") } == false)
+        #expect(rows.first?.label == "Account")
+    }
+
+    @Test("version is omitted entirely before describe has ever succeeded")
+    func noVersionWithoutDescribe() {
+        let rows = RemoteProviderIdentityPresentation.rows(
+            status(registryName: "agentbox"), homeDirectory: "/Users/dev")
+
+        #expect(rows.map(\.label) == ["Command"])
+    }
+
+    @Test("a daemon that sends no negotiated version still reports the contract major")
+    func versionFallsBackToMajorOne() {
+        let provider = status(registryName: "agentbox", kind: "agentbox", providerVersion: nil)
+
+        #expect(RemoteProviderIdentityPresentation.versionLine(provider) == "contract v1")
+    }
+
+    @Test("keys are humanized without inventing names for the ones TBD recognizes")
+    func humanizesKeys() {
+        #expect(RemoteProviderIdentityPresentation.humanizedKey("account") == "Account")
+        #expect(RemoteProviderIdentityPresentation.humanizedKey("aws_region") == "Aws region")
+        #expect(RemoteProviderIdentityPresentation.humanizedKey("control-plane") == "Control plane")
+        #expect(RemoteProviderIdentityPresentation.humanizedKey("") == "")
+    }
+
+    @Test("the compact summary leads with the registry key and adds the first identity pair")
+    func compactSummaryNamesTheRegistration() {
+        let provider = status(
+            registryName: "agentbox-staging", kind: "agentbox",
+            identity: ["environment": "staging"])
+
+        #expect(RemoteProviderIdentityPresentation.compactSummary(provider)
+            == "agentbox-staging, reports as agentbox, Environment staging")
+    }
+}

--- a/Tests/TBDAppTests/RemoteProviderInventoryStateTests.swift
+++ b/Tests/TBDAppTests/RemoteProviderInventoryStateTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+@Suite("Provider inventory state")
+struct RemoteProviderInventoryStateTests {
+    private let now = Date(timeIntervalSince1970: 100_000)
+
+    private func status(
+        name: String = "agentbox",
+        health: ProviderHealth = .ok,
+        snapshotAt: Date? = nil,
+        freshnessUnreadable: Bool = false
+    ) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: name, exec: "/opt/agentbox/bin/agentbox"),
+            describe: ProviderDescribe(name: "agentbox"),
+            health: health, errorMessage: nil, remediationLabel: nil, remediationCommand: nil,
+            lastSuccessfulSnapshotAt: snapshotAt, freshnessUnreadable: freshnessUnreadable)
+    }
+
+    // MARK: - The four not-simply-current readings
+
+    @Test("a successful empty inventory is its own state, not 'nothing to show'")
+    func emptySuccessIsDistinct() {
+        let state = RemoteProviderInventoryState.make(
+            provider: status(snapshotAt: now.addingTimeInterval(-30)), sessionCount: 0)
+
+        #expect(state == .emptySuccess(at: now.addingTimeInterval(-30)))
+        #expect(state.title == "This provider reports no sessions")
+        #expect(state.detail(now: now) == "The provider answered and its inventory was empty just now.")
+        // The only one of the empty readings that is evidence about the backend.
+        #expect(state.isCurrent)
+    }
+
+    @Test("never having snapshotted is not evidence that a provider has no sessions")
+    func noInventoryYetSaysSo() {
+        let state = RemoteProviderInventoryState.make(provider: status(), sessionCount: 0)
+
+        #expect(state == .noInventoryYet)
+        #expect(state.isCurrent == false)
+        #expect(state.detail(now: now).contains("not evidence"))
+    }
+
+    @Test("an unreadable freshness record is distinct from never having snapshotted")
+    func freshnessUnknownIsDistinct() {
+        let neverPolled = RemoteProviderInventoryState.make(
+            provider: status(freshnessUnreadable: true), sessionCount: 0)
+        #expect(neverPolled == .freshnessUnknown)
+
+        // `hasStaleSnapshot` is true here with no timestamp to quote; say
+        // what is unknown rather than invent an age.
+        let unhealthy = RemoteProviderInventoryState.make(
+            provider: status(health: .error, freshnessUnreadable: true), sessionCount: 3)
+        #expect(unhealthy == .freshnessUnknown)
+    }
+
+    @Test("a stale list is history, and says so with its age")
+    func staleQuotesItsAge() {
+        let state = RemoteProviderInventoryState.make(
+            provider: status(health: .stale, snapshotAt: now.addingTimeInterval(-2 * 3600)),
+            sessionCount: 2)
+
+        #expect(state == .stale(since: now.addingTimeInterval(-2 * 3600), cachedCount: 2))
+        #expect(state.isCurrent == false)
+        #expect(state.detail(now: now)
+            == "2 cached rows from the inventory of 2h ago. Their states are history, not current.")
+    }
+
+    @Test("a current populated inventory needs no notice at all")
+    func populatedIsSilent() {
+        let state = RemoteProviderInventoryState.make(
+            provider: status(snapshotAt: now.addingTimeInterval(-60)), sessionCount: 1)
+
+        #expect(state == .populated(count: 1, at: now.addingTimeInterval(-60)))
+        #expect(state.warrantsNotice == false)
+        #expect(state.detail(now: now) == "1 session reported 1m ago.")
+    }
+
+    @Test("every non-current reading warrants a notice")
+    func nonCurrentReadingsWarrantNotices() {
+        for state: RemoteProviderInventoryState in [
+            .emptySuccess(at: now), .noInventoryYet, .freshnessUnknown,
+            .stale(since: now, cachedCount: 0),
+        ] {
+            #expect(state.warrantsNotice, "\(state) must explain itself")
+        }
+    }
+
+    // MARK: - The wrong-provider cross-check
+
+    @Test("an empty provider names where the sessions actually are")
+    func crossProviderNoteNamesTheOtherProvider() {
+        let sessions = [
+            session(provider: "agentbox-staging", id: "a"),
+            session(provider: "agentbox-staging", id: "b"),
+            session(provider: "agentbox", id: "c"),
+        ]
+
+        #expect(RemoteProviderInventoryState.crossProviderNote(
+            currentProvider: "agentbox", sessions: sessions)
+            == "2 sessions are registered under another provider (agentbox-staging: 2).")
+    }
+
+    @Test("several other providers are listed, alphabetically")
+    func crossProviderNoteListsEachProvider() {
+        let sessions = [
+            session(provider: "zeta", id: "z"),
+            session(provider: "agentbox-staging", id: "a"),
+        ]
+
+        #expect(RemoteProviderInventoryState.crossProviderNote(
+            currentProvider: "agentbox", sessions: sessions)
+            == "2 sessions are registered under other providers (agentbox-staging: 1, zeta: 1).")
+    }
+
+    @Test("no note when nothing lives elsewhere, and dismissed rows never count")
+    func crossProviderNoteStaysQuiet() {
+        #expect(RemoteProviderInventoryState.crossProviderNote(
+            currentProvider: "agentbox",
+            sessions: [session(provider: "agentbox", id: "a")]) == nil)
+
+        #expect(RemoteProviderInventoryState.crossProviderNote(
+            currentProvider: "agentbox",
+            sessions: [session(provider: "agentbox-staging", id: "a", dismissed: true)]) == nil)
+    }
+
+    private func session(
+        provider: String, id: String, dismissed: Bool = false
+    ) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider,
+            payload: RemoteSessionPayload(id: id, state: .running, agentState: .working),
+            gone: false, dismissed: dismissed, lastSeen: now)
+    }
+}

--- a/Tests/TBDAppTests/WorktreeProfilePickerRemoteLaneTests.swift
+++ b/Tests/TBDAppTests/WorktreeProfilePickerRemoteLaneTests.swift
@@ -146,9 +146,14 @@ struct WorktreeProfilePickerRemoteLaneTests {
 
     // MARK: - provider display name
 
-    @Test func providerLabelPrefersTheNegotiatedDescribeName() {
+    /// The REGISTRY key, even when `describe` negotiated a prettier name:
+    /// `describe.name` names the provider's kind, so two registrations of the
+    /// same kind would appear in this picker under one label with no way to
+    /// tell which backend a new session would be created against. See
+    /// `RemoteProviderIdentityPresentation`.
+    @Test func providerLabelPrefersTheRegistryKey() {
         #expect(WorktreeProfilePickerView.providerLabel(
-            provider(name: "acme", describeName: "Acme Cloud")) == "Acme Cloud")
+            provider(name: "acme", describeName: "Acme Cloud")) == "acme")
     }
 
     @Test func providerLabelFallsBackToTheConfiguredName() {
@@ -226,12 +231,12 @@ struct WorktreeProfilePickerRemoteLaneTests {
     /// deliberately withholds has to land here or it lands nowhere.
     @Test func aProviderRowKeepsItsEllipsisWhenSelectingItOpensTheForm() {
         #expect(WorktreeProfilePickerView.providerRowTitle(
-            provider(name: "acme", describeName: "Acme Cloud"), opensForm: true) == "Acme Cloud…")
+            provider(name: "acme", describeName: "Acme Cloud"), opensForm: true) == "acme…")
     }
 
     @Test func aProviderRowDropsItsEllipsisWhenSelectingItCreatesOutright() {
         #expect(WorktreeProfilePickerView.providerRowTitle(
-            provider(name: "acme", describeName: "Acme Cloud"), opensForm: false) == "Acme Cloud")
+            provider(name: "acme", describeName: "Acme Cloud"), opensForm: false) == "acme")
     }
 
     /// The title still goes through `providerLabel`, so a provider that

--- a/Tests/TBDSharedTests/ProviderIdentityTests.swift
+++ b/Tests/TBDSharedTests/ProviderIdentityTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("describe.identity")
+struct ProviderIdentityTests {
+    private func decodeDescribe(_ json: String) throws -> ProviderDescribe {
+        try JSONDecoder().decode(ProviderDescribe.self, from: Data(json.utf8))
+    }
+
+    // MARK: - Decoding
+
+    @Test("identity pairs decode and order well-known keys first")
+    func decodesAndOrders() throws {
+        let describe = try decodeDescribe("""
+        {"contract_versions":[1],"name":"agentbox",
+         "identity":{"zone":"a","environment":"staging","account":"acme-1234","box":"i-0abc"}}
+        """)
+
+        let pairs = try #require(describe.identity).displayPairs
+        #expect(pairs.map(\.key) == ["account", "environment", "box", "zone"])
+        #expect(pairs.map(\.value) == ["acme-1234", "staging", "i-0abc", "a"])
+    }
+
+    @Test("a provider that sends no identity decodes to nil, not to an empty map")
+    func absentIdentityIsNil() throws {
+        // Every provider written before the field existed. The distinction
+        // matters: nil is what makes the UI say "this provider reports no
+        // backend identity" rather than silently showing nothing.
+        let describe = try decodeDescribe("""
+        {"contract_versions":[1],"name":"agentbox"}
+        """)
+
+        #expect(describe.identity == nil)
+    }
+
+    @Test("scalars are coerced and unrenderable values cost only their own key")
+    func coercesScalarsAndDropsStructures() throws {
+        let describe = try decodeDescribe("""
+        {"contract_versions":[1],"name":"agentbox",
+         "identity":{"account":1234,"multi_tenant":true,"ratio":1.5,
+                     "nested":{"a":1},"list":[1],"nothing":null,"environment":"prod"}}
+        """)
+
+        let identity = try #require(describe.identity)
+        #expect(identity.pairs["account"] == "1234")
+        #expect(identity.pairs["multi_tenant"] == "true")
+        #expect(identity.pairs["ratio"] == "1.5")
+        #expect(identity.pairs["environment"] == "prod")
+        #expect(identity.pairs["nested"] == nil)
+        #expect(identity.pairs["list"] == nil)
+        #expect(identity.pairs["nothing"] == nil)
+    }
+
+    @Test("an identity that is not an object costs the map, never the provider")
+    func malformedIdentityNeverFailsDescribe() throws {
+        // A provider whose identity block is garbage must still register:
+        // losing the display pairs costs context, losing `describe` costs the
+        // provider.
+        let describe = try decodeDescribe("""
+        {"contract_versions":[1],"name":"agentbox","capabilities":["attach"],
+         "identity":"acme-prod"}
+        """)
+
+        #expect(describe.identity == nil)
+        #expect(describe.name == "agentbox")
+        #expect(describe.capabilities == ["attach"])
+    }
+
+    @Test("identity round-trips through the daemon-to-app encode")
+    func roundTripsOverTheWire() throws {
+        // The app never invokes a provider; it reads `describe` off
+        // `RemoteProviderStatus`, which the daemon re-encodes. A field that
+        // decodes but doesn't encode would be invisible in the only place it
+        // is rendered.
+        let describe = try decodeDescribe("""
+        {"contract_versions":[1],"name":"agentbox","identity":{"environment":"staging"}}
+        """)
+        let status = RemoteProviderStatus(
+            config: RemoteProviderConfig(name: "agentbox-staging", exec: "/opt/agentbox/bin/agentbox"),
+            describe: describe, health: .ok, errorMessage: nil,
+            remediationLabel: nil, remediationCommand: nil)
+
+        let data = try JSONEncoder().encode(status)
+        let decoded = try JSONDecoder().decode(RemoteProviderStatus.self, from: data)
+
+        #expect(decoded.describe?.identity?.pairs["environment"] == "staging")
+    }
+
+    // MARK: - Redaction
+
+    @Test("secret-named keys are dropped rather than shown")
+    func dropsSecretKeys() {
+        let identity = ProviderIdentity(pairs: [
+            "account": "acme-1234",
+            "session_token": "AQoDYXdz…",
+            "api_key": "sk-live-1",
+            "aws_secret_access_key": "x",
+            "password": "hunter2",
+            "authorization": "Bearer abc",
+            "signature": "sig",
+            "cookie": "c",
+        ])
+
+        #expect(identity.displayPairs.map(\.key) == ["account"])
+    }
+
+    @Test("'session' alone is not treated as secret")
+    func sessionIsNotASecretWord() {
+        // This domain calls its ordinary unit of work a session; a filter
+        // that dropped every key containing the word would redact the
+        // identity it exists to show.
+        let identity = ProviderIdentity(pairs: ["session_host": "box-4", "session_token": "s3cr3t"])
+
+        #expect(identity.displayPairs.map(\.key) == ["session_host"])
+    }
+
+    @Test("long values are truncated and empty ones dropped")
+    func boundsValues() {
+        let long = String(repeating: "x", count: 200)
+        let identity = ProviderIdentity(pairs: ["account": long, "environment": "   "])
+
+        let pairs = identity.displayPairs
+        #expect(pairs.count == 1)
+        #expect(pairs[0].key == "account")
+        #expect(pairs[0].value.count == ProviderIdentityRedaction.maximumValueLength + 1)
+        #expect(pairs[0].value.hasSuffix("…"))
+    }
+
+    @Test("nothing displayable is reported as nothing displayable")
+    func reportsWhenEverythingWasRedacted() {
+        #expect(ProviderIdentity(pairs: ["api_key": "sk-1"]).hasDisplayablePairs == false)
+        #expect(ProviderIdentity(pairs: ["account": "a"]).hasDisplayablePairs == true)
+    }
+
+    @Test("secret-looking command arguments are redacted in both shapes")
+    func redactsRegistryArguments() {
+        // The registry file is user-authored and outside the contract's
+        // reach, so its argv gets the same filter as a provider's identity.
+        let redacted = ProviderIdentityRedaction.redactArguments(
+            ["--profile", "acme-staging", "--token=abc123", "--api-key", "sk-live", "--verbose"])
+
+        #expect(redacted == [
+            "--profile", "acme-staging",
+            "--token=\(ProviderIdentityRedaction.redactedPlaceholder)",
+            "--api-key", ProviderIdentityRedaction.redactedPlaceholder,
+            "--verbose",
+        ])
+    }
+
+    @Test("a flag following a secret flag is not mistaken for its value")
+    func doesNotSwallowTheNextFlag() {
+        let redacted = ProviderIdentityRedaction.redactArguments(["--token", "--staging"])
+
+        #expect(redacted == ["--token", "--staging"])
+    }
+}

--- a/Tests/TBDSharedTests/RemotePendingQuestionTests.swift
+++ b/Tests/TBDSharedTests/RemotePendingQuestionTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("Session pending_question")
+struct RemotePendingQuestionTests {
+    private func decode(_ json: String) throws -> RemoteSessionPayload {
+        try JSONDecoder().decode(RemoteSessionPayload.self, from: Data(json.utf8))
+    }
+
+    @Test("a full question block decodes")
+    func decodesFullBlock() throws {
+        let payload = try decode("""
+        {"id":"s1","state":"running","agent_state":"waiting_input",
+         "pending_question":{"id":"q-4f2a1c","questions":[
+           {"prompt":"Which environment should this deploy to?","label":"Environment","multi":false,
+            "options":[{"label":"staging","description":"the staging cluster"},{"label":"production"}]}]}}
+        """)
+
+        let question = try #require(payload.pendingQuestion)
+        #expect(question.id == "q-4f2a1c")
+        #expect(question.questions.count == 1)
+        #expect(question.questions[0].prompt == "Which environment should this deploy to?")
+        #expect(question.questions[0].label == "Environment")
+        #expect(question.questions[0].multi == false)
+        #expect(question.questions[0].options.map(\.label) == ["staging", "production"])
+        #expect(question.questions[0].options[0].description == "the staging cluster")
+        #expect(question.questions[0].options[1].description == nil)
+    }
+
+    @Test("a session without the field decodes exactly as before")
+    func absentFieldIsNil() throws {
+        let payload = try decode("""
+        {"id":"s1","state":"running","agent_state":"working"}
+        """)
+
+        #expect(payload.pendingQuestion == nil)
+        #expect(payload.agentState == .working)
+    }
+
+    @Test("a malformed question block costs the explanation, never the session")
+    func malformedBlockIsAbsent() throws {
+        let payload = try decode("""
+        {"id":"s1","title":"t","state":"running","agent_state":"waiting_input",
+         "pending_question":"blocked"}
+        """)
+
+        #expect(payload.pendingQuestion == nil)
+        #expect(payload.id == "s1")
+        #expect(payload.title == "t")
+        #expect(payload.agentState == .waitingInput)
+    }
+
+    @Test("a question with no readable prompt is skipped, and an empty block reads as absent")
+    func skipsUnreadableQuestions() throws {
+        let partial = try decode("""
+        {"id":"s1","state":"running","agent_state":"waiting_input",
+         "pending_question":{"questions":[{"options":[{"label":"a"}]},{"prompt":"Continue?"}]}}
+        """)
+        #expect(partial.pendingQuestion?.questions.map(\.prompt) == ["Continue?"])
+
+        let empty = try decode("""
+        {"id":"s1","state":"running","agent_state":"waiting_input",
+         "pending_question":{"questions":[{"options":[]}]}}
+        """)
+        // Not an empty question set: an explanation with nothing in it is not
+        // an explanation, and every caller would have to remember to check.
+        #expect(empty.pendingQuestion == nil)
+    }
+
+    @Test("an option with no label is skipped without costing the question")
+    func skipsUnlabelledOptions() throws {
+        let payload = try decode("""
+        {"id":"s1","state":"running","agent_state":"waiting_input",
+         "pending_question":{"questions":[{"prompt":"Pick","options":[{"description":"d"},{"label":"ok"}]}]}}
+        """)
+
+        #expect(payload.pendingQuestion?.questions[0].options.map(\.label) == ["ok"])
+    }
+
+    @Test("a stale snapshot cannot keep claiming what a session is blocked on")
+    func staleProjectionClearsTheQuestion() {
+        let payload = RemoteSessionPayload(
+            id: "s1", state: .running, agentState: .waitingInput,
+            agentStateReason: "permission_prompt", archived: true,
+            pendingQuestion: RemotePendingQuestion(
+                id: "q1", questions: [RemotePendingQuestionItem(prompt: "Continue?")]))
+
+        let projected = payload.projectedForStaleSnapshot()
+
+        // Liveness axis: cleared alongside agent state.
+        #expect(projected.pendingQuestion == nil)
+        #expect(projected.agentState == .unknown)
+        #expect(projected.agentStateReason == nil)
+        // Filing axis: untouched, as the projection's contract requires.
+        #expect(projected.archived == true)
+    }
+
+    @Test("an already-exited session keeps its question block untouched")
+    func staleProjectionLeavesTerminalRowsAlone() {
+        let payload = RemoteSessionPayload(
+            id: "s1", state: .exited, exitCode: 0, agentState: .exited,
+            pendingQuestion: RemotePendingQuestion(
+                id: "q1", questions: [RemotePendingQuestionItem(prompt: "Continue?")]))
+
+        #expect(payload.projectedForStaleSnapshot() == payload)
+    }
+
+    @Test("the field round-trips so a mirrored payload keeps its explanation")
+    func roundTripsThroughTheMirror() throws {
+        let payload = RemoteSessionPayload(
+            id: "s1", state: .running, agentState: .waitingInput,
+            pendingQuestion: RemotePendingQuestion(
+                id: "q1",
+                questions: [RemotePendingQuestionItem(
+                    prompt: "Continue?", multi: true,
+                    options: [RemotePendingQuestionOption(label: "yes")])]))
+
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(RemoteSessionPayload.self, from: data)
+
+        #expect(decoded == payload)
+        // The wire key is the contract's, not Swift's property name.
+        #expect(String(data: data, encoding: .utf8)?.contains("pending_question") == true)
+    }
+}

--- a/docs/remote-provider-contract.md
+++ b/docs/remote-provider-contract.md
@@ -204,15 +204,32 @@ Why credentials never travel, by kind:
     {"name": "size",   "type": "enum",   "label": "Size", "values": ["small","large"], "default": "small"}
   ],
   "profile_kinds": ["oauth", "api_key", "bedrock"],
-  "credential_ref_hint": "acme-vault path, e.g. acme-vault://oauth/<name>"
+  "credential_ref_hint": "acme-vault path, e.g. acme-vault://oauth/<name>",
+  "identity": {"account": "acme-prod-1234", "environment": "staging", "region": "us-east-1"}
 }
 ```
 
 - `contract_versions` — every contract major version this provider supports (see Versioning).
-- `name` — a stable machine identifier for the provider (used, along with each session id, as the caller's key for this provider's sessions).
+- `name` — a stable machine identifier for the provider's KIND, not for this registration of it. Two registry entries running the same executable against different backends report the same `name`, so a caller MUST NOT use it as the identity of a registration: the caller's own registry key is that identity, and is what it keys sessions, mirrors, and attach targets on.
+- `identity` (optional) — see Provider identity below.
 - `capabilities` — which optional verbs/features (`stop`, `log`, `transcript`, `send`, `attach`, `events`, `rename`, `profile`, `set-profile`, `archive`, `unarchive`, `land`) this provider implements. Every capability string except `profile` names the verb of the same name: declaring it means the verb is implemented, and omitting it means the caller never invokes it and never offers the corresponding action. `profile` is the exception — it gates whether `create`'s `profile` field is honored (see `create` and the Profile object above), while `set-profile` gates the verb of the same name.
 - `create_params` — a flat field list, not a JSON Schema, describing the form for `create`. Supported `type` values: `string`, `text`, `bool`, `int`, `enum`. The caller renders this generically (the most complex widget is an enum dropdown) and only does required/type checks client-side — the provider is the validator of record, via the error model below. The field names `repo`, `slug`, `branch`, `prompt`, and `title` are well-known: a caller may prefill them from ambient context (e.g. a currently selected repository) when present, and for `slug` a caller may generate a lane identifier of its own choosing. Well-known is a caller-side prefill convention and nothing more: it obliges a provider to nothing, changes no validation, and a provider that declares any of these names is simply one whose form a caller can fill in without asking. A caller that can answer every `required` field this way may skip the form entirely and create straight away; one that cannot must ask rather than guess.
 - `profile_kinds` and `credential_ref_hint` are meaningful only when `capabilities` includes `profile`; a provider without that capability SHOULD omit both, and a caller MUST ignore them if present without it. `profile_kinds` lists which `kind` values (from the Profile object above) this provider can actually realize. `credential_ref_hint` is placeholder text — not validation — describing the shape of a `credential_ref` this provider expects; a caller shows it as placeholder text in its credential-reference input.
+
+### Provider identity (optional)
+
+`identity` is a flat string-to-string map of **non-secret display pairs naming the backend this registration is pointed at** — the account, environment, region, box, or endpoint a human needs in order to tell two registrations apart. It answers the question `name` cannot: `name` identifies the provider's kind, so two registry entries running the same executable against a production and a staging control plane report the same `name`, and a caller that leads with it shows the same label for both.
+
+A caller cannot derive this itself. A registration is an executable path and a flag list, and the mapping from those flags to a control plane is the provider's private business, so a caller that inferred an environment from an argument would be guessing precisely where a wrong answer is most expensive.
+
+```json
+"identity": {"account": "acme-prod-1234", "environment": "staging", "box": "i-0abc123def"}
+```
+
+- **Entirely optional**, like every other additive field: a provider that omits it stays fully conformant, and a caller MUST degrade to whatever identity it can derive locally (its own registry key, and the command it runs).
+- **Answered from static local data, no network and no authentication**, on the same terms as the rest of `describe`. A provider that would have to call its backend to learn a value omits that key rather than making `describe` fall over on an expired credential.
+- **Values are display text and are never interpreted.** The keys `account`, `environment`, `region`, `box`, `host`, and `endpoint` are well-known only in the sense that a caller MAY order them first; no key is required, none changes any behavior, and every other key renders opaquely beside them. This mirrors `meta` on the Session object, and degrades the same way: a value that is not a string costs its own key, and an `identity` that is not an object costs the map without costing the `describe` response.
+- **It MUST NOT carry credential material** — no token, secret, password, session credential, or signature, whole or partial. Identity here means *which backend*, never *how to reach it*. A caller displays these pairs to a human, and a value that must not be displayed does not belong in the map. TBD additionally drops any pair whose key names credential material rather than trusting this rule alone, so a provider that violates it loses the pair rather than leaking it.
 
 `describe.capabilities` reports **interface capabilities**: which contract verbs TBD may call. It does not prove that a session has the external **task capabilities** a workload needs. A provider or workflow that claims ownership transfer or completion MUST preflight the concrete external capabilities required by that task and fail visibly before transfer when they are unavailable. Successful `create`, `state: "running"`, or `send` handoff proves only that the corresponding contract or transport step succeeded; it does not prove workload permission. The provider or higher-level workflow owns this preflight because TBD cannot infer vendor-specific permissions from the provider contract.
 

--- a/docs/specs/2026-08-26-provider-identity-and-connection-ergonomics-design.md
+++ b/docs/specs/2026-08-26-provider-identity-and-connection-ergonomics-design.md
@@ -1,0 +1,212 @@
+# Provider identity and connection ergonomics — design
+
+**Date:** 2026-08-26
+**Status:** Proposed; TBD half implemented, provider half filed as a dependency.
+**Scope:** TBD-side only — the remote-provider desk, sidebar header, attach
+resolution, and one optional additive field on the provider contract's
+`describe` response. No provider repository is edited by this work.
+
+## The problem
+
+TBD lets a user register several entries against the same provider binary — an
+`agentbox` pointed at one control plane and an `agentbox-staging` pointed at
+another are the motivating pair. Four things then go wrong, and all four share
+one root cause: **the surfaces answer a question the user did not ask.**
+
+1. **Which provider am I looking at?** The sidebar header and the desk masthead
+   both render `describe.name ?? config.name`. `describe.name` is the
+   provider's *machine identifier for its own kind* — two registry entries
+   running the same binary report the same one. Both rows therefore read
+   "agentbox", the desk title reads "agentbox", and the only unique identity in
+   the system, the registry key, is never on screen. A green badge over an
+   empty list then reads as "staging is idle" when it is in fact "you are
+   looking at management, which has no sessions."
+2. **Is that session working?** `state: running` and `agent_state: unknown` is
+   an explicitly specified combination in the contract, and it means *only*
+   that a terminal exists. The desk tinted terminal-Running green — the same
+   green the eye reads as progress — while the honest reading is "no machine
+   interface reported what the agent is doing." A session blocked at a
+   permission prompt and a session churning through a build are indistinguish-
+   able at a glance.
+3. **What did attach just do?** `RemoteAttachPager` resolves the provider
+   config by exact registry name and, when the lookup fails, `continue`s: no
+   tab, no error, no log line. A missing local transport dependency behaves
+   the same way one step later — the PTY opens, the exec fails, the pane is
+   blank. Both read as "attach is broken" rather than naming the cause.
+4. **Is this list current, empty, or the wrong list?** Stale, never-
+   snapshotted, successfully-empty and populated inventories collapsed into
+   two empty-state strings.
+
+## Principles this follows
+
+- **The registry key is the identity.** `config.name` is unique by
+  construction (`RemoteProviderRegistry.loadEntries` rejects duplicates) and
+  is what every other subsystem keys on — the mirror's primary key, the attach
+  selection, the notification route. It is therefore what the user must see.
+  `describe.name` is a *kind*, and is shown as such or not at all.
+- **The three axes stay separate.** Terminal liveness, agent attention, and
+  filing are independent in the contract and stay independent on screen. This
+  work adds a fourth reading — *attention explanation* — layered on the agent
+  axis, never substituted for it.
+- **A caller states what it knows, not what it hopes.** Every new string
+  distinguishes an observation from an absence: "reports no sessions" is a
+  different sentence from "no inventory yet", which is different again from
+  "showing the last good inventory."
+- **Never fall back to another provider.** Not for attach, not for identity,
+  not for diagnosis. Where a resolution fails, it fails by name.
+
+## Design
+
+### 1. Provider identity block
+
+The desk masthead leads with `config.name` — the registry key — and carries a
+secondary identity block beneath it. Rows, in order, each omitted when its
+source is absent:
+
+- **Registered as** — `config.name`. Always present.
+- **Provider kind** — `describe.name`, rendered **only when it differs** from
+  the registry key, as "reports as <kind>". Two entries of the same kind then
+  differ visibly on the line that matters and agree silently on the line that
+  does not.
+- **Identity pairs** — the new optional `describe.identity` map (below), well-
+  known keys first (`account`, `environment`, `region`, `box`, `host`,
+  `endpoint`) in that order, then every other key alphabetically. Rendered
+  opaquely: TBD interprets nothing but the ordering.
+- **Command** — the registry entry's `exec` (tilde-abbreviated) and args.
+  This is the disambiguator that is always available with no contract change:
+  two entries pointing at the same binary almost always differ in their flags.
+- **Version** — `provider_version` and the negotiated contract major.
+
+#### `describe.identity` (new, optional, additive)
+
+The contract has no field carrying *which backend account or environment a
+registry entry is pointed at*, and TBD cannot derive it: the registry entry is
+an executable path and a flag list, and the mapping from flags to control
+plane is the provider's private business. So the honest TBD half is to specify
+the field, decode it, render it, and degrade to the locally-derivable rows
+above when it is absent.
+
+Its shape deliberately reuses the pattern the contract already has for
+provider-defined display data — `meta`'s flat string-to-string map with a
+well-known key list — rather than inventing a rigid schema for facts that
+differ per vendor. A provider that has an account id and an environment name
+says so; one that has a box handle and a region says that instead.
+
+**Non-secret by construction, and by belt-and-braces.** The contract states
+the field carries display identity only and MUST NOT carry credential
+material. TBD additionally filters what it renders: a key whose name matches
+the secret vocabulary (`token`, `secret`, `password`, `passwd`, `key`,
+`credential`, `auth`, `session_token`, `signature`, `cookie`) is dropped
+entirely rather than shown, and a rendered value is truncated to 96
+characters. The filter is TBD's, not the contract's — a provider violating the
+contract should not be able to put a bearer token on a user's screen, and the
+same filter runs over registry args, which are user-authored and outside the
+contract's reach altogether.
+
+### 2. Attention, distinct from liveness
+
+`RemoteProviderDeskSummary` gains two derived readings over the mirror rows it
+already counts:
+
+- **`needsAttention`** — sessions whose agent axis is `waiting_input`. These
+  are the rows a human has to act on, and the desk lists them by name with
+  their explanation rather than leaving them as a digit in a strip.
+- **`unattributedRunning`** — sessions with a live terminal and `agent_state:
+  unknown`. The desk states the count in words: these are running terminals
+  whose agent progress is not reported, and terminal liveness is not agent
+  progress. Terminal-Running loses its green tint; green now means the agent
+  axis says `working`, and nothing else does.
+
+**The explanation.** `RemoteAgentAttention` turns one mirror row into one
+sentence, most specific source first:
+
+1. `pending_question` — the contract's structured blocked-on-a-question field,
+   now decoded TBD-side for the first time. "Blocked on a question: <prompt>"
+   plus the option labels.
+2. `agent_state_reason` — the free-form provider string, with the contract's
+   own example value `permission_prompt` humanized to "Blocked on a permission
+   prompt" and anything else rendered verbatim.
+3. The bare `waiting_input` state — "Waiting for input."
+
+`pending_question` belongs to the liveness axis, so `projectedForStaleSnapshot`
+clears it alongside `agent_state`: a cached "blocked on a question" over a
+provider that has stopped answering is a claim about right now that TBD cannot
+make.
+
+### 3. Attach preflight
+
+`RemoteAttachPreflight` resolves a selection to a spawnable command, or to a
+named diagnosis, as a pure function over the provider list, the mirror, and an
+executable-probe closure. Its resolution is exact-match-or-fail on the registry
+key — the type has no way to express a fallback, which is how "never silently
+fall back to another provider" becomes a property of the code rather than a
+rule someone must remember.
+
+Diagnoses, each with a title and an actionable sentence naming the provider:
+
+- `providerNotRegistered` — the selection names a provider no registry entry
+  matches (a renamed or removed entry, or a mirror row that outlived it).
+- `sessionBelongsToAnotherProvider` — this session id exists, under a
+  different registry entry. Names both.
+- `attachUnsupported` — the provider does not declare the `attach` capability.
+- `executableMissing` / `executableNotRunnable` — the registry entry's `exec`
+  is absent or not executable. This is the missing-local-transport-dependency
+  case, and it is the one that previously produced a blank pane.
+
+`RemoteAttachPager` renders the diagnosis in the pane instead of skipping the
+mount, so the failure appears where the user was looking.
+
+### 4. Inventory state
+
+`RemoteProviderInventoryState` collapses (health, snapshot timestamp,
+freshness readability, row count, other providers' row counts) into one of
+five readings, each with its own sentence:
+
+- **`noInventoryYet`** — no successful snapshot has ever been accepted.
+- **`freshnessUnknown`** — the daemon could not read the freshness record, so
+  it cannot say whether what is on screen is current.
+- **`stale`** — a prior good inventory, now unrefreshed; quotes its age.
+- **`emptySuccess`** — a snapshot succeeded and this provider reports nothing.
+  This is the reading that was missing, and it is the exact state the
+  motivating confusion produced.
+- **`populated`** — count and age.
+
+`emptySuccess` and `noInventoryYet` additionally carry a **cross-provider
+note** when other registered providers do hold sessions: "3 sessions are
+registered under other providers (agentbox-staging: 3)." That sentence is the
+direct answer to "did I just inspect the wrong provider", stated by TBD at the
+moment the question arises rather than left to the user to reconstruct.
+
+## What is deliberately not here
+
+- **No answering of pending questions.** The contract makes the field display
+  data with no answer verb; answering stays `attach`/`send`.
+- **No feature flag.** Nothing here acts autonomously, mutates persisted
+  state, or replaces a load-bearing path — the gate the repo's flag rule names.
+  The behavior changes are: additional read-only rows, changed wording, a
+  changed tint, and an error surfaced where a silent skip used to be.
+- **No provider-side work.** The `identity` field is specified and consumed;
+  emitting it is a provider dependency, filed separately.
+- **No new durable external resource**, so no reconciler question to answer:
+  every path here reads the existing mirror and spawns nothing that outlives
+  its pane.
+
+## Rejected alternatives
+
+- **Deriving environment from the exec path or args.** Pattern-matching
+  "staging" out of a flag list is a guess that is wrong precisely when it
+  matters (an entry named `agentbox-staging` pointed, by a stale flag, at
+  production). The command line is shown verbatim instead and left for a human
+  to read.
+- **A rigid `identity` schema (`account`/`environment`/`box` as typed
+  fields).** Every vendor's identity has a different shape; a fixed schema
+  forces providers to either lie or leave it empty. The flat map with a
+  well-known ordering matches what the contract already does for `meta`.
+- **Suppressing `describe.name` entirely.** It is genuinely useful when it
+  differs from the registry key (a registry entry named `staging` running the
+  `agentbox` binary), and useless noise when it matches. Conditional rendering
+  keeps the signal and drops the noise.
+- **Blocking attach when the provider looks unhealthy.** Already considered
+  and rejected in `AppState+RemoteAttach`: a failing `list` says nothing about
+  whether `attach` can connect. The preflight added here only reports facts
+  local to the laptop — registration, capability, and the executable itself.


### PR DESCRIPTION
## Summary

TBD lets you register several providers against the same provider binary — one pointed at a production control plane, one at staging, say. Until now every surface in the app labelled them with `describe.name`, which names the provider's *kind*: both registrations reported `agentbox`, so both sidebar rows read "agentbox", both desks were titled "agentbox", and both appeared under the same name in every create picker. The registry key — the thing that is unique by construction, and the thing the session mirror, attach, and notifications all key on — was never on screen.

The consequence is worse than a cosmetic label: a green provider badge over an empty session list reads as "staging is idle" when the truth is "you are looking at the other registration, which has no sessions." This PR makes each surface answer the question the reader actually has — *which* provider is this, is this list current, is that session working, and where will Attach connect?

## Why this shape

Spec: [`docs/specs/2026-08-26-provider-identity-and-connection-ergonomics-design.md`](docs/specs/2026-08-26-provider-identity-and-connection-ergonomics-design.md).

Four decisions worth naming:

- **The registry key is the identity.** `RemoteProviderRegistry` rejects duplicate names, so `config.name` is unique; `describe.name` is a kind and is now shown only when it differs ("reports as agentbox"). Rejected: suppressing `describe.name` entirely — it is genuinely useful when a registration is named something else.
- **`describe.identity` is a flat display map, not a schema.** Every vendor's identity has a different shape (account and environment for one, box handle and region for another), and a fixed set of typed fields forces a provider to leave them empty or stretch them. This reuses the pattern the contract already has for `meta`, with a well-known key *order* and no interpretation. Rejected: deriving an environment from the exec path or arguments — that guess is wrong precisely when it matters (an entry named `…-staging` pointed by a stale flag at production), so the command line is shown verbatim instead.
- **Attach cannot express a fallback.** `RemoteAttachPreflight` matches the registry key exactly or returns a named diagnosis. Making "attach through some other provider" unrepresentable is stronger than remembering not to do it.
- **No feature flag.** Nothing here acts autonomously, mutates persisted state, or replaces a load-bearing path. The changes are additional read-only rows, changed wording, one changed tint, and an error surfaced where a silent skip used to be.

## What this PR does

**Contract (TBD half only — no provider repository is touched)**

- `docs/remote-provider-contract.md`: adds the optional `describe.identity` map — non-secret display pairs naming the backend a registration points at — with its answer-locally, never-carry-credentials, and degrade-gracefully rules, and corrects the `describe.name` bullet to say it names a kind rather than a registration. Additive within contract major 2; every existing provider stays conformant.
- `ProviderIdentity` (new) decodes it leniently — a non-string value costs its key, a non-object costs the map, and neither can cost the provider its registration. `ProviderIdentityRedaction` drops credential-named keys and redacts secret-looking registry arguments before anything is displayed.
- `RemoteSessionPayload.pendingQuestion`: the contract's `pending_question` is decoded TBD-side for the first time (it has been riding the wire unread). Cleared by `projectedForStaleSnapshot` — it is a liveness-axis claim, and a provider that has stopped answering leaves TBD no standing to make it.

**App**

- `RemoteProviderIdentityPresentation` (new): headline, kind subtitle, and the desk's identity rows (identity pairs → command line → versions). Every provider-name display site now routes through it — sidebar header, desk masthead, session detail, both create pickers, the create sheet, the create-defaults editor, and the auth CTA.
- `RemoteAgentAttention` (new): one sentence per row — the structured question and its options, else the provider's reason string (`permission_prompt` humanized, everything else verbatim), else the bare state. Blockage is still read off `agent_state` only, per the contract.
- `RemoteProviderInventoryState` (new): five distinct readings — populated, empty-success, never-snapshotted, freshness-unreadable, stale — each with its own sentence, plus a cross-provider note ("3 sessions are registered under another provider (agentbox-staging: 3)") on an empty desk.
- `RemoteAttachPreflight` + `RemoteAttachDiagnosisView` (new): exact-match resolution with six named outcomes, rendered in the attach pane. `RemoteAttachPager` no longer `continue`s past an unresolvable selection.
- Desk: identity block, an attention section naming blocked sessions and what blocks them, and the aggregate "N running sessions report no agent state — terminal liveness is not agent progress". Terminal-Running loses its green tint; green now means the agent axis said `working`.

## Assumptions

- Assumes a provider that sends `identity` honours the contract's non-secret rule. TBD does not trust this alone — it drops credential-named keys — but a provider that puts a secret under an innocuous key would still display it.
- Assumes `config.exec` is resolved the way the preflight probes it (absolute/relative path, else `PATH`). If TBD ever spawns providers through a shell with a different resolution, the probe could report "missing" for something that would have run.

## Evidence & verification

Seven new suites, all tier 1 and deterministic:

- `ProviderDisambiguationScenarioTests` is the reproduced failure end to end: two registrations of the same kind reporting the **same box handle**, zero inventory on one, three live sessions on the other, one of them blocked at a prompt, and a missing attach dependency. It asserts the two registrations never render alike, that the empty desk names where the sessions are, that three running terminals are not three working agents, that attach routes through the selected registration and refuses the other, and that no credential reaches the screen.
- `ProviderIdentityTests`, `RemotePendingQuestionTests` (shared): decoding, lenient degradation, redaction, wire round-trip, and the stale projection clearing the question block.
- `RemoteProviderIdentityPresentationTests`, `RemoteProviderInventoryStateTests`, `RemoteAgentAttentionTests`, `RemoteAttachPreflightTests`: every string and every branch above.

**Not verified locally, and this needs a reviewer's attention:** the environment this branch was authored in has no Swift toolchain (Linux; TBD is macOS-only), so `scripts/swift-safe build` and `scripts/test.sh` could not be run — `swift-safe` exits 69 with "swift executable not found". The code is reviewed by eye against the existing types, but CI is the first actual compile. No live app verification for the same reason; the UI changes are asserted through the pure presentation types rather than the views, which is why every string lives outside the view layer.

A follow-up dependency issue is filed for the provider half (emitting `describe.identity`); TBD degrades to the registry key and command line until then.
