### PR TITLE
Fix: a cleared waiting_input left its attention hand behind

### DIFF
--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -468,16 +468,57 @@ struct RemoteSessionRowView: View {
     /// this reads `agentState` fresh every render rather than relying solely
     /// on the edge-triggered `unreadByRemoteSession` map (which clears the
     /// moment the session is selected, even if it's still waiting).
+    ///
+    /// The merge runs the unread half through `suffixContribution` first, so
+    /// the edge may only ADD what the steady axis cannot express. See that
+    /// function for what went wrong when it could also keep asserting
+    /// attention the steady axis had withdrawn.
     nonisolated static func suffixIndicator(
         agentState: RemoteAgentState, unreadType: NotificationType?
     ) -> SuffixRowIndicator? {
         let steadyType: NotificationType? = agentState == .waitingInput ? .attentionNeeded : nil
         return RowStatusIndicator.suffix(
-            notification: RemoteSessionRowView.higherSeverity(unreadType, steadyType),
+            notification: RemoteSessionRowView.higherSeverity(
+                suffixContribution(of: unreadType, agentState: agentState), steadyType),
             isWorking: agentState == .working,
             isSuspended: false,
             isHibernated: false
         )
+    }
+
+    /// What the row's unread entry may contribute to the SUFFIX slot, given
+    /// what the agent axis currently says.
+    ///
+    /// The unread map exists to add signals the steady axis cannot express —
+    /// an `.error` from a nonzero exit, a `.responseComplete`. It must never
+    /// keep asserting attention the steady axis has since withdrawn, and
+    /// `.attentionNeeded` is nothing but a restatement of `waiting_input`.
+    ///
+    /// Without this, the hand latched. `unreadByRemoteSession` is edge-
+    /// triggered and clears only when the user selects the session
+    /// (`AppState+Navigation`), while `.attentionNeeded` outranks `isWorking`
+    /// in `RowStatusIndicator.suffix` — so a session that asked for input
+    /// once, was answered elsewhere, and went back to work kept its hand
+    /// until somebody clicked it. Across a fleet that is a wall of hands over
+    /// sessions that are all working, which costs the glyph its meaning
+    /// exactly when a genuine one appears among them.
+    ///
+    /// The BOLD name is deliberately left latched: it says "you have not
+    /// looked since this happened", which stays true after the session
+    /// resumes, and it is cleared by looking. The suffix glyph says "this is
+    /// true right now", and that is the claim this function keeps honest.
+    nonisolated static func suffixContribution(
+        of unreadType: NotificationType?, agentState: RemoteAgentState
+    ) -> NotificationType? {
+        // The two types `RowStatusIndicator.suffix` renders as the hand.
+        // `.focusRequest` is not currently produced for remote rows
+        // (`AppState.remoteUnreadType` yields only `.attentionNeeded`,
+        // `.error` and `.responseComplete`), and is covered anyway so that a
+        // future edge cannot reintroduce the latch by another name.
+        guard unreadType == .attentionNeeded || unreadType == .focusRequest else {
+            return unreadType
+        }
+        return agentState == .waitingInput ? unreadType : nil
     }
 
     /// The higher-severity of two optional `NotificationType`s (nil sorts

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -1,5 +1,4 @@
 import AppKit
-import os
 import SwiftUI
 import TBDShared
 
@@ -484,64 +483,19 @@ struct RepoSectionView: View {
         }
     }
 
-    /// The two ISO 8601 profiles `parsedCreatedAt` accepts, built once and
-    /// reused. `ISO8601DateFormatter.init` bottoms out in ICU's `udat_open`,
-    /// and `isOrderedByCreation` parses both of its operands on every
-    /// comparison, so building them per call dominated the sort.
+    /// A session's `created_at`, in either ISO 8601 profile a conforming
+    /// provider may legally emit. `docs/remote-provider-contract.md` shows a
+    /// whole-second example but never pins a profile, and a default-options
+    /// formatter rejects the fractional form outright — which sorted every
+    /// such row as undated.
     ///
-    /// Two formatters and not one: `ISO8601DateFormatter` does not accept both
-    /// profiles in a single `formatOptions` value. `formatOptions` is set here
-    /// and never mutated afterwards.
-    ///
-    /// Deliberately NOT `Sendable`, which is what makes the confinement below
-    /// machine-checked rather than merely intended: `withLock` requires its
-    /// return type to be `Sendable`, so a body that handed a formatter back
-    /// out — `withLock { $0 }` — fails to compile.
-    private struct CreatedAtParsers {
-        let fractionalSeconds: ISO8601DateFormatter = {
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            return formatter
-        }()
-        let wholeSeconds = ISO8601DateFormatter()
-    }
-
-    /// Guards the shared parsers. `parsedCreatedAt` is `nonisolated` so a
-    /// plain test context can call it without hopping to `RepoSectionView`'s
-    /// inferred `@MainActor` isolation, and Swift Testing runs suites in
-    /// parallel — so two threads genuinely can reach one formatter at once,
-    /// even though every caller in the app is already on the main actor.
-    ///
-    /// A lock rather than `nonisolated(unsafe)` because the platform does not
-    /// promise what that would assume. Both `NSDateFormatter.h` and
-    /// `NSISO8601DateFormatter.h` are audited for sendability, and only
-    /// `DateFormatter` carries `NS_SWIFT_SENDABLE` ("All mutable state
-    /// protected by locks") — so the subclass's silence is a deliberate
-    /// withholding, not an oversight. An uncontended `os_unfair_lock` acquire
-    /// is nothing next to the ICU parse it wraps, so the guarantee is close to
-    /// free here.
-    ///
-    /// `uncheckedState:` rather than `initialState:` because the state is not
-    /// `Sendable` — see `CreatedAtParsers`. That is the point: it is the
-    /// unconstrained initializer that lets a non-`Sendable` value be locked,
-    /// and keeping the value non-`Sendable` is what makes escaping it a
-    /// compile error.
-    nonisolated private static let createdAtParsers =
-        OSAllocatedUnfairLock(uncheckedState: CreatedAtParsers())
-
+    /// The parsing (and the shared, lock-guarded formatters that make it
+    /// cheap enough to call from a sort comparator) lives in
+    /// `RemoteTimestamp`, alongside the ordering rule that reads the
+    /// contract's other timestamp. Two parsers for one wire format is one
+    /// too many.
     nonisolated static func parsedCreatedAt(_ raw: String?) -> Date? {
-        guard let raw else { return nil }
-        // `docs/remote-provider-contract.md` shows a whole-second
-        // `created_at` example but never pins a profile, so a conforming
-        // provider can legally emit fractional seconds
-        // (`2026-07-24T18:02:11.123Z`) — a default-options formatter rejects
-        // those outright, sorting every such row as undated. Try
-        // `.withFractionalSeconds` first, then fall back to the plain
-        // whole-second profile.
-        return RepoSectionView.createdAtParsers.withLock { parsers -> Date? in
-            if let date = parsers.fractionalSeconds.date(from: raw) { return date }
-            return parsers.wholeSeconds.date(from: raw)
-        }
+        RemoteTimestamp.parse(raw)
     }
 
     // MARK: - The cloud gate — pure, view-free forms of what the two owned

--- a/Sources/TBDDaemon/Database/RemoteSessionStore.swift
+++ b/Sources/TBDDaemon/Database/RemoteSessionStore.swift
@@ -103,8 +103,25 @@ public struct RemoteSessionStore: Sendable {
         _ session: RemoteSessionPayload, provider: String, existing: RemoteSessionRow?,
         now: Date, encoder: JSONEncoder, db: Database, repoCache: RepoCache
     ) throws -> (changed: Bool, attention: RemoteSessionPayload?) {
-        let payloadString = String(data: try encoder.encode(session), encoding: .utf8) ?? "{}"
         if var row = existing {
+            // Nothing serializes the `list` poll against the `events` stream
+            // against a one-off verb response, so a sighting can arrive after
+            // one that observed the same session LATER. Taking its agent
+            // state would reinstate a state the provider has moved on from —
+            // putting the attention hand back on a session that has been
+            // working for minutes, where only the next genuine transition
+            // could clear it again.
+            //
+            // Only the AGENT axis is withheld, because `agent_state_at` is
+            // the only thing the contract timestamps: it says when the agent
+            // state was determined and nothing about when the title, terminal
+            // state, or `meta` were. Withholding those too would drop a
+            // rename that arrived in the same response. Presence is never
+            // withheld either — the session was there to be reported,
+            // whenever the report was taken.
+            let session = Self.withFreshestAgentAxis(
+                incoming: session, storedPayload: row.payload, provider: provider, now: now)
+            let payloadString = String(data: try encoder.encode(session), encoding: .utf8) ?? "{}"
             let previousAgentState = row.agentState
             var changed = row.payload != payloadString || row.missingCount != 0 || row.gone
             var attention: RemoteSessionPayload?
@@ -135,6 +152,7 @@ public struct RemoteSessionStore: Sendable {
             // First sighting never notifies — otherwise the daemon would
             // fire a banner storm for every pre-existing session on startup.
             let resolvedRepoID = try self.resolveRepoID(metaRepo: session.meta?["repo"], repoCache: repoCache)
+            let payloadString = String(data: try encoder.encode(session), encoding: .utf8) ?? "{}"
             try RemoteSessionRow(
                 provider: provider, sessionID: session.id,
                 payload: payloadString, state: session.state.rawValue,
@@ -148,6 +166,78 @@ public struct RemoteSessionStore: Sendable {
                 pinnedAt: nil
             ).insert(db)
             return (true, nil)
+        }
+    }
+
+    /// `incoming`, with its agent axis replaced by the mirrored one whenever
+    /// the mirrored one is demonstrably newer.
+    ///
+    /// Returns `incoming` untouched in every other case, which is every case
+    /// for a provider that does not send `agent_state_at` — the ordering
+    /// check can only fire where the provider gave TBD something to order by.
+    ///
+    /// The whole payload is re-encoded from the result, so the mirror never
+    /// holds a payload whose `agent_state` and `agent_state_at` disagree:
+    /// both fields move together or neither does.
+    static func withFreshestAgentAxis(
+        incoming: RemoteSessionPayload, storedPayload: String, provider: String, now: Date
+    ) -> RemoteSessionPayload {
+        guard RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: incoming.agentStateAt,
+            storedAgentStateAt: storedAgentStateAt(storedPayload),
+            now: now) == .presenceOnly,
+            let stored = decodeStoredPayload(storedPayload)
+        else { return incoming }
+
+        remoteSessionStoreLogger.debug(
+            """
+            out-of-order sighting for \(provider, privacy: .public)/\
+            \(incoming.id, privacy: .public): agent_state \
+            \(incoming.agentState.rawValue, privacy: .public) at \
+            \(incoming.agentStateAt ?? "nil", privacy: .public) predates the mirrored \
+            \(stored.agentState.rawValue, privacy: .public) at \
+            \(stored.agentStateAt ?? "nil", privacy: .public); agent axis kept, rest applied
+            """)
+
+        return RemoteSessionPayload(
+            id: incoming.id, title: incoming.title, createdAt: incoming.createdAt,
+            state: incoming.state, exitCode: incoming.exitCode,
+            agentState: stored.agentState,
+            agentStateReason: stored.agentStateReason,
+            agentStateAt: stored.agentStateAt,
+            meta: incoming.meta, archived: incoming.archived)
+    }
+
+    /// The `agent_state_at` inside a mirrored payload string.
+    ///
+    /// Read back out of the stored JSON rather than kept in its own column:
+    /// the payload is already the mirror's record of what the provider last
+    /// said, and a column would be a second copy of one fact that a future
+    /// write path could forget to keep in step. Nil for a payload that
+    /// predates the field, is unparseable, or simply omitted it — all of
+    /// which mean the same thing here, which is that there is no ordering
+    /// information and the sighting applies.
+    ///
+    /// Decodes one field rather than the whole `RemoteSessionPayload`: this
+    /// runs once per session per sighting, and the full decode — with every
+    /// leniency rule and diagnostic in it — is paid only on the rare path
+    /// where a sighting actually is out of order.
+    static func storedAgentStateAt(_ payload: String) -> String? {
+        guard let data = payload.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(StoredAgentStateStamp.self, from: data).agentStateAt
+    }
+
+    private static func decodeStoredPayload(_ payload: String) -> RemoteSessionPayload? {
+        guard let data = payload.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(RemoteSessionPayload.self, from: data)
+    }
+
+    /// Just enough of the Session object to read one field back.
+    private struct StoredAgentStateStamp: Decodable {
+        let agentStateAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case agentStateAt = "agent_state_at"
         }
     }
 

--- a/Sources/TBDShared/RemoteSnapshotOrdering.swift
+++ b/Sources/TBDShared/RemoteSnapshotOrdering.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Parses the ISO-8601 timestamps the provider contract puts on the Session
 /// object (`created_at`, `agent_state_at`).
@@ -9,17 +10,45 @@ import Foundation
 /// provider-specific loss that makes a timestamp field useless for anything
 /// but display.
 public enum RemoteTimestamp {
-    private static let plain: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter
-    }()
+    /// The two ISO 8601 profiles `parse` accepts, built once and reused.
+    /// `ISO8601DateFormatter.init` bottoms out in ICU's `udat_open`, and this
+    /// runs once per session per sighting, so building them per call would
+    /// dominate the poll.
+    ///
+    /// Two formatters and not one: `ISO8601DateFormatter` does not accept
+    /// both profiles in a single `formatOptions` value. `formatOptions` is
+    /// set here and never mutated afterwards.
+    ///
+    /// Deliberately NOT `Sendable`, which is what makes the confinement below
+    /// machine-checked rather than merely intended: `withLock` requires its
+    /// return type to be `Sendable`, so a body that handed a formatter back
+    /// out — `withLock { $0 }` — fails to compile.
+    private struct Parsers {
+        let fractionalSeconds: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+        let wholeSeconds = ISO8601DateFormatter()
+    }
 
-    private static let fractional: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter
-    }()
+    /// Guards the shared parsers. Two threads genuinely can reach one
+    /// formatter at once — the daemon parses these on its poll actor while
+    /// the app parses them for display, and Swift Testing runs suites in
+    /// parallel.
+    ///
+    /// A lock rather than `nonisolated(unsafe)` because the platform does not
+    /// promise what that would assume: both `NSDateFormatter.h` and
+    /// `NSISO8601DateFormatter.h` are audited for sendability, and only
+    /// `DateFormatter` carries `NS_SWIFT_SENDABLE` — the subclass's silence
+    /// is a deliberate withholding, not an oversight. An uncontended
+    /// `os_unfair_lock` acquire is nothing next to the ICU parse it wraps.
+    ///
+    /// `uncheckedState:` rather than `initialState:` because the state is not
+    /// `Sendable` — see `Parsers`. That is the point: it is the unconstrained
+    /// initializer that lets a non-`Sendable` value be locked, and keeping
+    /// the value non-`Sendable` is what makes escaping it a compile error.
+    private static let parsers = OSAllocatedUnfairLock(uncheckedState: Parsers())
 
     /// The instant `value` names, or nil when it is absent or unparseable.
     /// Never throws and never guesses: an unparseable stamp is treated as no
@@ -27,7 +56,10 @@ public enum RemoteTimestamp {
     /// information rather than gaining a wrong instant.
     public static func parse(_ value: String?) -> Date? {
         guard let value, !value.isEmpty else { return nil }
-        return fractional.date(from: value) ?? plain.date(from: value)
+        return parsers.withLock { parsers -> Date? in
+            if let date = parsers.fractionalSeconds.date(from: value) { return date }
+            return parsers.wholeSeconds.date(from: value)
+        }
     }
 }
 

--- a/Sources/TBDShared/RemoteSnapshotOrdering.swift
+++ b/Sources/TBDShared/RemoteSnapshotOrdering.swift
@@ -78,8 +78,16 @@ public enum RemoteTimestamp {
 ///
 /// The contract already carries the fact needed to detect this —
 /// `agent_state_at`, the instant the agent state was determined — and TBD
-/// never read it. This is where it gets read.
+/// never read it. This is where it gets read. The rule, its conservatisms,
+/// and the alternatives weighed against it:
+/// `docs/specs/2026-08-26-remote-snapshot-ordering-design.md`.
 public enum RemoteSnapshotOrdering {
+    /// How far ahead of local time a mirrored stamp may be while still being
+    /// trusted to order sightings. Past this, the stored clock is treated as
+    /// wrong rather than merely skewed, and ordering is disabled for that
+    /// row — see `decide` for why that direction is the safe one.
+    public static let clockSkewTolerance: TimeInterval = 60
+
     public enum Decision: Equatable {
         /// Take the sighting as the session's current state.
         case apply
@@ -110,11 +118,22 @@ public enum RemoteSnapshotOrdering {
     ///   forever, freezing the row permanently — the one failure mode worse
     ///   than the bug being fixed. `tolerance` allows for ordinary skew
     ///   between the provider's clock and this machine's.
+    ///
+    /// `tolerance` is a **clock-skew allowance and nothing else**, which is
+    /// what sets its size: a minute is far more skew than an NTP-synced
+    /// machine ever shows and far less than a genuinely wrong clock, so it
+    /// separates the two without needing to be tuned. It is deliberately
+    /// NOT derived from the provider poll interval, which is also 60s today:
+    /// the two answer unrelated questions (how often TBD asks, versus how
+    /// wrong two clocks may be), and coupling them would make a change to
+    /// poll cadence silently change what counts as a broken clock. The
+    /// coincidence is worth naming precisely so nobody reads it as a
+    /// dependency.
     public static func decide(
         incomingAgentStateAt: String?,
         storedAgentStateAt: String?,
         now: Date,
-        tolerance: TimeInterval = 60
+        tolerance: TimeInterval = clockSkewTolerance
     ) -> Decision {
         guard let stored = RemoteTimestamp.parse(storedAgentStateAt),
               let incoming = RemoteTimestamp.parse(incomingAgentStateAt) else {

--- a/Sources/TBDShared/RemoteSnapshotOrdering.swift
+++ b/Sources/TBDShared/RemoteSnapshotOrdering.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Parses the ISO-8601 timestamps the provider contract puts on the Session
+/// object (`created_at`, `agent_state_at`).
+///
+/// Both spellings a conforming provider may emit are accepted: with and
+/// without fractional seconds. A default-options `ISO8601DateFormatter`
+/// rejects the fractional form outright, which is the kind of silent,
+/// provider-specific loss that makes a timestamp field useless for anything
+/// but display.
+public enum RemoteTimestamp {
+    private static let plain: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// The instant `value` names, or nil when it is absent or unparseable.
+    /// Never throws and never guesses: an unparseable stamp is treated as no
+    /// stamp at all, so a provider with a malformed timestamp loses ordering
+    /// information rather than gaining a wrong instant.
+    public static func parse(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        return fractional.date(from: value) ?? plain.date(from: value)
+    }
+}
+
+/// Whether a sighting of a session is fresh enough to overwrite what the
+/// mirror already holds.
+///
+/// The mirror is fed from two independent channels — the periodic `list`
+/// poll and the `events` stream — plus one-off verb responses, and nothing
+/// serializes them against each other. A `list` response that spent four
+/// seconds in flight can therefore land *after* an `events` line that
+/// observed the same session later, and last-writer-wins then reinstates the
+/// older state. For the agent axis that is not a cosmetic problem: it
+/// restores a `waiting_input` a human already dealt with, and the sidebar
+/// puts the attention hand back on a session that has been working for
+/// minutes.
+///
+/// The contract already carries the fact needed to detect this —
+/// `agent_state_at`, the instant the agent state was determined — and TBD
+/// never read it. This is where it gets read.
+public enum RemoteSnapshotOrdering {
+    public enum Decision: Equatable {
+        /// Take the sighting as the session's current state.
+        case apply
+        /// The sighting is demonstrably older than what the mirror holds.
+        /// It is still evidence the session EXISTS — presence bookkeeping
+        /// (last-seen, absence counting, `gone`) must be refreshed from it —
+        /// but its state must not overwrite newer state.
+        case presenceOnly
+    }
+
+    /// The decision for one session.
+    ///
+    /// Deliberately conservative, in three ways, because the cost of wrongly
+    /// rejecting a sighting (a row frozen at a state the provider has moved
+    /// on from) is worse than the cost of wrongly accepting one (the
+    /// pre-existing behavior):
+    ///
+    /// - **No stamp on either side means apply.** `agent_state_at` is
+    ///   optional, and most providers will never send it. Absent ordering
+    ///   information, last-writer-wins is exactly what TBD did before, and
+    ///   this function must not change behavior for those providers at all.
+    /// - **Equal stamps apply.** A provider stamping at second granularity
+    ///   would otherwise have every update after the first within the same
+    ///   second dropped, and re-applying an identical state is harmless.
+    /// - **A future-dated stored stamp disables the check.** A provider
+    ///   whose clock ran ahead (or that stamped a state it had not yet
+    ///   observed) would otherwise make every subsequent sighting "older"
+    ///   forever, freezing the row permanently — the one failure mode worse
+    ///   than the bug being fixed. `tolerance` allows for ordinary skew
+    ///   between the provider's clock and this machine's.
+    public static func decide(
+        incomingAgentStateAt: String?,
+        storedAgentStateAt: String?,
+        now: Date,
+        tolerance: TimeInterval = 60
+    ) -> Decision {
+        guard let stored = RemoteTimestamp.parse(storedAgentStateAt),
+              let incoming = RemoteTimestamp.parse(incomingAgentStateAt) else {
+            return .apply
+        }
+        guard stored <= now.addingTimeInterval(tolerance) else { return .apply }
+        return incoming < stored ? .presenceOnly : .apply
+    }
+}

--- a/Tests/TBDAppTests/RemoteSessionRowAttentionStalenessTests.swift
+++ b/Tests/TBDAppTests/RemoteSessionRowAttentionStalenessTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// The render half of the stale-hand failure.
+///
+/// `unreadByRemoteSession` is edge-triggered — written when the daemon
+/// broadcasts an attention delta, cleared only when the user selects that
+/// session — and `.attentionNeeded` outranks `isWorking` in
+/// `RowStatusIndicator.suffix`. So a session that asked for input once, was
+/// answered elsewhere, and went back to work kept its hand until somebody
+/// clicked it. With thirteen such sessions on screen the sidebar was a wall
+/// of hands, none of which meant anything, next to one that did.
+@Suite("Remote row attention staleness")
+struct RemoteSessionRowAttentionStalenessTests {
+    // MARK: - The steady axis withdraws what the edge asserted
+
+    @Test("a resumed session loses the hand a past waiting_input left behind")
+    func workingClearsALatchedHand() {
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .working, unreadType: .attentionNeeded) == .working)
+    }
+
+    @Test("every non-waiting agent state clears it, not just working")
+    func everyAdvancedStateClearsIt() {
+        // `tool_result`, an idle turn, a session whose state simply stopped
+        // being reported — none of them is "a human must act", and each
+        // arrived in the live failure.
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .idle, unreadType: .attentionNeeded) == nil)
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .unknown, unreadType: .attentionNeeded) == nil)
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .exited, unreadType: .attentionNeeded) == nil)
+    }
+
+    @Test("the genuinely waiting session keeps its hand")
+    func stillWaitingKeepsTheHand() {
+        // The one correct hand on screen must survive the fix, with or
+        // without an unread entry behind it.
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .waitingInput, unreadType: .attentionNeeded) == .attention)
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .waitingInput, unreadType: nil) == .attention)
+    }
+
+    @Test("signals the steady axis cannot express still come through")
+    func unreadStillAddsWhatItAloneKnows() {
+        // The unread map's job: an exited session's nonzero exit has no
+        // steady mapping at all, and must not be swept up by this gate.
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .exited, unreadType: .error) == .error)
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .working, unreadType: .error) == .error)
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .working, unreadType: .responseComplete) == .working)
+    }
+
+    @Test("the contribution gate names exactly the two types that render as a hand")
+    func gateCoversBothAttentionTypes() {
+        for type: NotificationType in [.attentionNeeded, .focusRequest] {
+            #expect(RemoteSessionRowView.suffixContribution(
+                of: type, agentState: .working) == nil)
+            #expect(RemoteSessionRowView.suffixContribution(
+                of: type, agentState: .waitingInput) == type)
+        }
+        // Everything else passes through untouched.
+        #expect(RemoteSessionRowView.suffixContribution(
+            of: .error, agentState: .working) == .error)
+        #expect(RemoteSessionRowView.suffixContribution(
+            of: nil, agentState: .working) == nil)
+    }
+
+    // MARK: - The sequences the failure was observed across
+
+    @Test("quota wait, credential rotation, then resumed working")
+    func quotaThenRotationThenResumed() {
+        // The unread entry is written once, at the first edge, and never
+        // rewritten by any of what follows — so every step here shares it.
+        let latched: NotificationType = .attentionNeeded
+
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .waitingInput, unreadType: latched) == .attention)
+        // Still blocked while a credential rotates: still a hand.
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .waitingInput, unreadType: latched) == .attention)
+        // Resumed: the hand goes, without anyone having to click the row.
+        #expect(RemoteSessionRowView.suffixIndicator(
+            agentState: .working, unreadType: latched) == .working)
+    }
+
+    @Test("a polling refresh alone clears it, with no selection change")
+    func pollingRefreshClearsIt() {
+        // What the daemon's next `list` produces is a new agent state on the
+        // same row, with the unread map untouched. That must be enough.
+        let beforeRefresh = RemoteSessionRowView.suffixIndicator(
+            agentState: .waitingInput, unreadType: .attentionNeeded)
+        let afterRefresh = RemoteSessionRowView.suffixIndicator(
+            agentState: .working, unreadType: .attentionNeeded)
+
+        #expect(beforeRefresh == .attention)
+        #expect(afterRefresh == .working)
+    }
+
+    @Test("selecting the session clears the unread entry without changing the verdict")
+    func selectionIsOrthogonal() {
+        // Selection clears `unreadByRemoteSession` (AppState+Navigation), so
+        // the row is then rendered with a nil unread type. The suffix must
+        // read the same either way — the glyph follows the agent axis, and
+        // selection is not evidence about it.
+        #expect(RemoteSessionRowView.suffixIndicator(agentState: .working, unreadType: nil)
+            == RemoteSessionRowView.suffixIndicator(agentState: .working, unreadType: .attentionNeeded))
+        #expect(RemoteSessionRowView.suffixIndicator(agentState: .waitingInput, unreadType: nil)
+            == RemoteSessionRowView.suffixIndicator(agentState: .waitingInput, unreadType: .attentionNeeded))
+    }
+
+    @Test("a relaunch starts with no unread entries and reaches the same verdict")
+    func foregroundOrReopenAgrees() {
+        // `unreadByRemoteSession` is in-memory, so a reopened app has none —
+        // which is exactly the state the fix makes a still-running app agree
+        // with. Before it, reopening the app was the only reliable way to
+        // clear a stale hand.
+        for state: RemoteAgentState in [.working, .idle, .unknown, .exited, .waitingInput] {
+            #expect(RemoteSessionRowView.suffixIndicator(agentState: state, unreadType: nil)
+                == RemoteSessionRowView.suffixIndicator(agentState: state, unreadType: .attentionNeeded),
+                "reopening the app must not be what fixes the glyph for \(state)")
+        }
+    }
+
+    // MARK: - The bold name is deliberately not part of this
+
+    @Test("the bold name stays latched until the row is looked at")
+    func boldNameRemainsEdgeTriggered() {
+        // "You have not looked since this happened" stays true after the
+        // session resumes, and looking is what clears it. Only the glyph —
+        // which claims something is true right now — is gated.
+        #expect(RowStatusIndicator.shouldBoldName(NotificationType.attentionNeeded))
+    }
+}

--- a/Tests/TBDDaemonTests/RemoteSessionOrderingTests.swift
+++ b/Tests/TBDDaemonTests/RemoteSessionOrderingTests.swift
@@ -1,0 +1,227 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2: in-memory GRDB only.
+///
+/// The live failure this pins: at 07:14Z the provider reported thirteen
+/// sessions working and one still waiting, and TBD's sidebar kept attention
+/// hands on the thirteen. Two independent defects produced that; this suite
+/// covers the mirror half — an out-of-order sighting reinstating an agent
+/// state the provider had already moved on from. The render half is
+/// `RemoteSessionRowAttentionStalenessTests` in `TBDAppTests`.
+@Suite("Remote session ordering")
+struct RemoteSessionOrderingTests {
+    let db: TBDDatabase
+    init() throws { db = try TBDDatabase(inMemory: true) }
+
+    private let earlier = "2026-08-26T07:10:00Z"
+    private let later = "2026-08-26T07:14:00Z"
+    /// Well after both stamps, so neither is future-dated relative to "now"
+    /// and the ordering check is armed.
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func payload(
+        _ id: String,
+        state: RemoteProcessState = .running,
+        agent: RemoteAgentState,
+        at stamp: String?,
+        reason: String? = nil,
+        title: String? = nil
+    ) -> RemoteSessionPayload {
+        RemoteSessionPayload(
+            id: id, title: title, state: state, agentState: agent,
+            agentStateReason: reason, agentStateAt: stamp)
+    }
+
+    private func row(_ id: String) async throws -> RemoteSessionRow? {
+        try await db.remoteSessions.list().first { $0.sessionID == id }
+    }
+
+    // MARK: - The reported failure
+
+    @Test("a late-arriving older snapshot cannot reinstate a cleared waiting_input")
+    func olderSightingDoesNotReinstateWaiting() async throws {
+        // The provider asked for input, then went back to work.
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("finish-pr-20974", agent: .waitingInput, at: earlier)], now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("finish-pr-20974", agent: .working, at: later)], now: now)
+
+        // A `list` response that was already in flight lands afterwards,
+        // carrying the older observation.
+        let outcome = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("finish-pr-20974", agent: .waitingInput, at: earlier)], now: now)
+
+        let mirrored = try await row("finish-pr-20974")
+        #expect(mirrored?.agentState == "working")
+        // And it must not re-notify: an edge TBD never observed going
+        // forward is not an edge to raise a banner for.
+        #expect(outcome.attention.isEmpty)
+        #expect(outcome.changed == false)
+    }
+
+    @Test("the genuinely waiting session keeps waiting")
+    func genuineWaitingSurvives() async throws {
+        // The one hand that was correct on screen: a session actually blocked
+        // on a question. Nothing here may clear it.
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("pdf-csv", agent: .working, at: earlier)], now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("pdf-csv", agent: .waitingInput, at: later, reason: "permission_prompt")],
+            now: now)
+        // A later poll that still reports waiting, with the same stamp.
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("pdf-csv", agent: .waitingInput, at: later, reason: "permission_prompt")],
+            now: now)
+
+        let mirrored = try await row("pdf-csv")
+        #expect(mirrored?.agentState == "waiting_input")
+    }
+
+    @Test("quota wait, then credential rotation, then resumed working")
+    func quotaWaitThenRotationThenWorking() async throws {
+        let stamps = [
+            "2026-08-26T07:00:00Z",   // blocked on quota
+            "2026-08-26T07:05:00Z",   // still blocked, credential being rotated
+            "2026-08-26T07:12:00Z",   // resumed
+        ]
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("workload-governor", agent: .working, at: "2026-08-26T06:00:00Z")],
+            now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("workload-governor", agent: .waitingInput, at: stamps[0], reason: "quota_exhausted")],
+            now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("workload-governor", agent: .waitingInput, at: stamps[1], reason: "credential_rotating")],
+            now: now)
+        let resumed = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("workload-governor", agent: .working, at: stamps[2])], now: now)
+
+        let mirrored = try await row("workload-governor")
+        #expect(mirrored?.agentState == "working")
+        #expect(resumed.changed)
+        // Every step moved forward, so none of them was withheld — and the
+        // reason string from the blocked phase is gone with it.
+        let stored = try #require(mirrored?.payload)
+        #expect(stored.contains("quota_exhausted") == false)
+        #expect(stored.contains("credential_rotating") == false)
+    }
+
+    // MARK: - What the rejection must not cost
+
+    @Test("an out-of-order sighting is still evidence the session exists")
+    func presenceSurvivesRejection() async throws {
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .waitingInput, at: earlier)], now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .working, at: later)], now: now)
+        // One absence: the session is now one snapshot from being called gone.
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [], now: now)
+        let afterAbsence = try await row("a")
+        #expect(afterAbsence?.missingCount == 1)
+
+        // An out-of-order sighting still says the session was there.
+        let outcome = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .waitingInput, at: earlier)], now: now)
+
+        let stored = try #require(await row("a"))
+        #expect(stored.missingCount == 0)
+        #expect(stored.gone == false)
+        #expect(stored.agentState == "working")
+        // The row genuinely changed (it was one absence from gone), so the
+        // UI is told — the withheld half is the state, never the presence.
+        #expect(outcome.changed)
+    }
+
+    @Test("an out-of-order response still delivers the fields it is authoritative about")
+    func nonAgentFieldsStillApply() async throws {
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .waitingInput, at: earlier, title: "old")],
+            now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .working, at: later, title: "old")], now: now)
+
+        // A `rename` response echoes the session with the new title and the
+        // agent stamp it happened to hold. `agent_state_at` timestamps the
+        // agent axis and nothing else, so the rename must land.
+        _ = try await db.remoteSessions.upsertOne(
+            provider: "p",
+            session: payload("a", agent: .waitingInput, at: earlier, title: "renamed"), now: now)
+
+        let stored = try #require(await row("a"))
+        #expect(stored.agentState == "working")
+        #expect(stored.payload.contains("renamed"))
+    }
+
+    @Test("a terminal exit reported alongside an older agent stamp still lands")
+    func terminalStateStillApplies() async throws {
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .waitingInput, at: earlier)], now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .working, at: later)], now: now)
+
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p",
+            sessions: [payload("a", state: .exited, agent: .waitingInput, at: earlier)], now: now)
+
+        let stored = try #require(await row("a"))
+        #expect(stored.state == "exited")
+        #expect(stored.agentState == "working")
+    }
+
+    // MARK: - Providers that send no stamp are untouched
+
+    @Test("without agent_state_at the mirror behaves exactly as before")
+    func noStampMeansLastWriterWins() async throws {
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .working, at: nil)], now: now)
+        let outcome = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .waitingInput, at: nil)], now: now)
+
+        let mirrored = try await row("a")
+        #expect(mirrored?.agentState == "waiting_input")
+        #expect(outcome.attention.map(\.id) == ["a"])
+    }
+
+    @Test("a stamp appearing for the first time is not treated as out of order")
+    func firstStampApplies() async throws {
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .waitingInput, at: nil)], now: now)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .working, at: earlier)], now: now)
+
+        let mirrored = try await row("a")
+        #expect(mirrored?.agentState == "working")
+    }
+
+    @Test("the merge helper leaves the agent state and its stamp consistent")
+    func mergedPayloadKeepsTheAxisTogether() throws {
+        let storedPayload = String(
+            data: try JSONEncoder().encode(
+                payload("a", agent: .working, at: later, reason: nil)),
+            encoding: .utf8) ?? "{}"
+
+        let merged = RemoteSessionStore.withFreshestAgentAxis(
+            incoming: payload("a", agent: .waitingInput, at: earlier, reason: "permission_prompt"),
+            storedPayload: storedPayload, provider: "p", now: now)
+
+        // Both halves of the axis move together or neither does — a payload
+        // whose `agent_state` and `agent_state_at` disagree would make the
+        // next ordering decision meaningless.
+        #expect(merged.agentState == .working)
+        #expect(merged.agentStateAt == later)
+        #expect(merged.agentStateReason == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/RemoteSessionOrderingTests.swift
+++ b/Tests/TBDDaemonTests/RemoteSessionOrderingTests.swift
@@ -5,12 +5,13 @@ import Foundation
 
 /// Tier 2: in-memory GRDB only.
 ///
-/// The live failure this pins: at 07:14Z the provider reported thirteen
-/// sessions working and one still waiting, and TBD's sidebar kept attention
-/// hands on the thirteen. Two independent defects produced that; this suite
-/// covers the mirror half — an out-of-order sighting reinstating an agent
-/// state the provider had already moved on from. The render half is
-/// `RemoteSessionRowAttentionStalenessTests` in `TBDAppTests`.
+/// The failure this pins, observed on a live fleet: a provider reported
+/// thirteen sessions working and one still waiting for input, and TBD's
+/// sidebar kept attention hands on all fourteen. Two independent defects
+/// produced that; this suite covers the mirror half — an out-of-order
+/// sighting reinstating an agent state the provider had already moved on
+/// from. The render half is `RemoteSessionRowAttentionStalenessTests` in
+/// `TBDAppTests`.
 @Suite("Remote session ordering")
 struct RemoteSessionOrderingTests {
     let db: TBDDatabase
@@ -46,18 +47,18 @@ struct RemoteSessionOrderingTests {
         // The provider asked for input, then went back to work.
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("finish-pr-20974", agent: .waitingInput, at: earlier)], now: now)
+            sessions: [payload("fix-flaky-ci", agent: .waitingInput, at: earlier)], now: now)
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("finish-pr-20974", agent: .working, at: later)], now: now)
+            sessions: [payload("fix-flaky-ci", agent: .working, at: later)], now: now)
 
         // A `list` response that was already in flight lands afterwards,
         // carrying the older observation.
         let outcome = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("finish-pr-20974", agent: .waitingInput, at: earlier)], now: now)
+            sessions: [payload("fix-flaky-ci", agent: .waitingInput, at: earlier)], now: now)
 
-        let mirrored = try await row("finish-pr-20974")
+        let mirrored = try await row("fix-flaky-ci")
         #expect(mirrored?.agentState == "working")
         // And it must not re-notify: an edge TBD never observed going
         // forward is not an edge to raise a banner for.
@@ -71,18 +72,18 @@ struct RemoteSessionOrderingTests {
         // on a question. Nothing here may clear it.
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("pdf-csv", agent: .working, at: earlier)], now: now)
+            sessions: [payload("export-report", agent: .working, at: earlier)], now: now)
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("pdf-csv", agent: .waitingInput, at: later, reason: "permission_prompt")],
+            sessions: [payload("export-report", agent: .waitingInput, at: later, reason: "permission_prompt")],
             now: now)
         // A later poll that still reports waiting, with the same stamp.
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("pdf-csv", agent: .waitingInput, at: later, reason: "permission_prompt")],
+            sessions: [payload("export-report", agent: .waitingInput, at: later, reason: "permission_prompt")],
             now: now)
 
-        let mirrored = try await row("pdf-csv")
+        let mirrored = try await row("export-report")
         #expect(mirrored?.agentState == "waiting_input")
     }
 
@@ -95,21 +96,21 @@ struct RemoteSessionOrderingTests {
         ]
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("workload-governor", agent: .working, at: "2026-08-26T06:00:00Z")],
+            sessions: [payload("build-indexer", agent: .working, at: "2026-08-26T06:00:00Z")],
             now: now)
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("workload-governor", agent: .waitingInput, at: stamps[0], reason: "quota_exhausted")],
+            sessions: [payload("build-indexer", agent: .waitingInput, at: stamps[0], reason: "quota_exhausted")],
             now: now)
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("workload-governor", agent: .waitingInput, at: stamps[1], reason: "credential_rotating")],
+            sessions: [payload("build-indexer", agent: .waitingInput, at: stamps[1], reason: "credential_rotating")],
             now: now)
         let resumed = try await db.remoteSessions.applySnapshot(
             provider: "p",
-            sessions: [payload("workload-governor", agent: .working, at: stamps[2])], now: now)
+            sessions: [payload("build-indexer", agent: .working, at: stamps[2])], now: now)
 
-        let mirrored = try await row("workload-governor")
+        let mirrored = try await row("build-indexer")
         #expect(mirrored?.agentState == "working")
         #expect(resumed.changed)
         // Every step moved forward, so none of them was withheld — and the

--- a/Tests/TBDSharedTests/RemoteSnapshotOrderingTests.swift
+++ b/Tests/TBDSharedTests/RemoteSnapshotOrderingTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("Remote snapshot ordering")
+struct RemoteSnapshotOrderingTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    // MARK: - Timestamp parsing
+
+    @Test("both ISO-8601 spellings a conforming provider may emit are read")
+    func parsesBothSpellings() {
+        let plain = RemoteTimestamp.parse("2026-08-26T07:14:00Z")
+        let fractional = RemoteTimestamp.parse("2026-08-26T07:14:00.250Z")
+
+        #expect(plain != nil)
+        #expect(fractional != nil)
+        // A default-options ISO8601DateFormatter rejects the fractional form
+        // outright; reading it as absent would silently disable ordering for
+        // every provider that emits it.
+        #expect(fractional.map { $0.timeIntervalSince(plain ?? $0) } == 0.25)
+    }
+
+    @Test("an absent or unparseable stamp is no stamp, never a guessed instant")
+    func parsesNothingIntoNothing() {
+        #expect(RemoteTimestamp.parse(nil) == nil)
+        #expect(RemoteTimestamp.parse("") == nil)
+        #expect(RemoteTimestamp.parse("yesterday") == nil)
+        #expect(RemoteTimestamp.parse("2026-08-26 07:14:00") == nil)
+    }
+
+    // MARK: - The decision
+
+    @Test("a sighting older than the mirrored state is presence-only")
+    func rejectsAnOlderSighting() {
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: "2026-08-26T07:10:00Z",
+            storedAgentStateAt: "2026-08-26T07:14:00Z",
+            now: now) == .presenceOnly)
+    }
+
+    @Test("a newer sighting applies")
+    func acceptsANewerSighting() {
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: "2026-08-26T07:14:00Z",
+            storedAgentStateAt: "2026-08-26T07:10:00Z",
+            now: now) == .apply)
+    }
+
+    @Test("an equal stamp applies")
+    func acceptsAnEqualStamp() {
+        // A provider stamping at second granularity would otherwise have
+        // every update after the first within the same second dropped, and
+        // re-applying an identical state costs nothing.
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: "2026-08-26T07:14:00Z",
+            storedAgentStateAt: "2026-08-26T07:14:00Z",
+            now: now) == .apply)
+    }
+
+    @Test("no ordering information means the previous behavior, unchanged")
+    func appliesWithoutStamps() {
+        // `agent_state_at` is optional and most providers will never send it.
+        // This check must not change anything for them.
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: nil, storedAgentStateAt: nil, now: now) == .apply)
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: nil,
+            storedAgentStateAt: "2026-08-26T07:14:00Z", now: now) == .apply)
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: "2026-08-26T07:10:00Z",
+            storedAgentStateAt: nil, now: now) == .apply)
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: "2026-08-26T07:10:00Z",
+            storedAgentStateAt: "not a date", now: now) == .apply)
+    }
+
+    @Test("a future-dated mirrored stamp disables the check rather than freezing the row")
+    func futureStoredStampFailsOpen() {
+        let stored = ISO8601DateFormatter().string(from: now.addingTimeInterval(3_600))
+        let incoming = ISO8601DateFormatter().string(from: now)
+
+        // Worse than the bug being fixed: a provider whose clock ran ahead
+        // would make every later sighting "older" forever, freezing the row
+        // at a state nothing could ever replace.
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: incoming, storedAgentStateAt: stored, now: now) == .apply)
+    }
+
+    @Test("ordinary clock skew stays inside the tolerance and still orders")
+    func toleratesSmallSkew() {
+        let stored = ISO8601DateFormatter().string(from: now.addingTimeInterval(30))
+        let incoming = ISO8601DateFormatter().string(from: now.addingTimeInterval(10))
+
+        // 30s ahead is skew, not a broken clock: the check still applies, so
+        // the older sighting is still rejected.
+        #expect(RemoteSnapshotOrdering.decide(
+            incomingAgentStateAt: incoming, storedAgentStateAt: stored, now: now) == .presenceOnly)
+    }
+}

--- a/docs/specs/2026-08-26-remote-snapshot-ordering-design.md
+++ b/docs/specs/2026-08-26-remote-snapshot-ordering-design.md
@@ -1,0 +1,105 @@
+# Remote snapshot ordering — design
+
+**Date:** 2026-08-26
+**Status:** Implemented.
+**Scope:** TBD-side only. No contract change: the field this reads,
+`agent_state_at`, has been in the provider contract since v1 and was simply
+never read.
+
+## The question this answers
+
+TBD's remote-session mirror is fed by three channels that nothing serializes
+against each other: the periodic `list` poll, the `events` stream, and the
+session objects that verb responses (`create`, `stop`, `rename`, `archive`)
+return. Each writes through the same upsert, which was last-writer-wins.
+
+So arrival order is not observation order. A `list` response that spent four
+seconds in flight lands after an `events` line that observed the same session
+later, and the mirror ends up holding the older reading. On the agent axis
+that is not cosmetic: it restores a `waiting_input` a human already dealt
+with, and the sidebar puts the attention hand back on a session that has been
+working for minutes — where, the state having already transitioned once,
+nothing short of the *next* genuine transition can clear it again.
+
+The contract already carries the fact that distinguishes the two orderings:
+`agent_state_at`, the instant the agent state was determined. This design is
+what TBD does with it.
+
+## The rule
+
+For each session in a sighting, compare the incoming `agent_state_at` against
+the one in the mirrored payload:
+
+- **Both parse, and incoming is strictly older** → the sighting's **agent
+  axis** is withheld; the mirrored `agent_state`, `agent_state_reason` and
+  `agent_state_at` are kept.
+- **Anything else** → apply, exactly as before.
+
+Three deliberate conservatisms, all in the same direction: the cost of
+wrongly *rejecting* a sighting is a row frozen at a state the provider has
+moved on from — precisely the bug being fixed, arrived at from the other
+side — while the cost of wrongly *accepting* one is the pre-existing
+behavior. So every ambiguity resolves toward applying.
+
+- **No stamp on either side applies.** `agent_state_at` is optional and most
+  providers will never send it. A provider that sends none must see byte-for-
+  byte the previous behavior.
+- **Equal stamps apply.** A provider stamping at second granularity would
+  otherwise have every update after the first within one second dropped, and
+  re-applying an identical state costs nothing.
+- **A future-dated *stored* stamp disables the check.** A provider whose
+  clock ran ahead, or that stamped a state before observing it, would
+  otherwise make every later sighting "older" forever. That freezes the row
+  permanently, with no path back — strictly worse than the bug. The
+  allowance is a clock-skew tolerance of one minute: far more skew than an
+  NTP-synced machine shows, far less than a genuinely wrong clock. It is
+  deliberately not derived from the 60-second poll interval it happens to
+  match; the two answer unrelated questions, and coupling them would make a
+  change in poll cadence silently redefine what counts as a broken clock.
+
+## Why only the agent axis
+
+`agent_state_at` timestamps the agent state. It says nothing about when the
+title, the terminal state, `meta`, or `archived` were determined, so
+withholding those on its evidence would be inventing a claim the provider
+never made — and would have a concrete cost: a `rename` response echoes the
+session object with a new title and whatever agent stamp it happens to hold,
+so rejecting the whole payload would silently drop renames.
+
+Both halves of the agent axis move together or neither does. A mirrored
+payload whose `agent_state` and `agent_state_at` disagreed would make the
+*next* ordering decision meaningless, so the merge takes state, reason and
+stamp from the same side.
+
+## What a withheld sighting still does
+
+- **Presence is never withheld.** The session was there to be reported,
+  whenever the report was taken, so `lastSeen`, `missingCount` and `gone` are
+  refreshed exactly as they would be. The contract's two-absence rule is
+  untouched, and a session cannot drift toward `gone` because its state was
+  stale.
+- **No attention edge fires.** The daemon raises a notification on an
+  observed transition into `waiting_input` or `exited`. An edge TBD did not
+  observe going forward is not one to notify about.
+- **`changed` reports honestly.** A sighting whose merged payload equals the
+  stored one is not a change, so it costs no UI broadcast; one that also
+  cleared a pending absence is.
+
+## Rejected alternatives
+
+- **Serializing the channels.** The push stream exists precisely so state
+  arrives without waiting for the next poll; funnelling both through one
+  queue would give back the latency the stream buys, and would still not
+  order a response against a poll that was already in flight.
+- **A monotonic sequence number added to the contract.** Stronger, and not
+  free: every provider would have to implement it before any of them
+  benefited, whereas `agent_state_at` is already specified, already emitted
+  by providers that have it, and degrades to today's behavior for the rest.
+  Worth revisiting only if a provider is found whose stamps are unusable.
+- **Storing the stamp in its own column.** The mirrored payload is already
+  the record of what the provider last said; a column would be a second copy
+  of one fact, which some future write path would forget to keep in step. The
+  common path decodes one field out of the stored JSON, and the full decode
+  is paid only on the rare sighting that actually is out of order.
+- **Trusting the local clock instead of the stamps.** Arrival time is what
+  produced the bug; ordering by it is the bug.


### PR DESCRIPTION
## What's broken

The sidebar keeps the attention hand on remote sessions that stopped needing attention.

Reproduced live on a fleet this morning: the provider's own `list` reported **13 sessions working, one waiting for input, one idle**, with newer `agent_state_at` stamps on all of them — and the TBD sidebar still showed attention hands on seven of the sessions that had moved on. The one genuinely blocked session had a hand too, and was indistinguishable from the false ones.

A wall of hands is worse than no hands: the glyph's whole job is to be scannable, and once most of them are stale the one that is real gets read as more of the same. Clicking each row cleared it, and so did quitting and reopening the app — which is what makes it look cosmetic and is exactly why it persisted.

## Why it happens

Two independent defects, one on each side of the RPC. Either alone reproduces the symptom.

**The app latches the glyph.** A remote row's suffix glyph is a merge of two inputs: the *steady* agent state, refreshed by every poll, and an *edge-triggered* unread entry recorded when the daemon broadcasts an attention delta. The merge exists for a good reason — a session that exits nonzero has an `.error` unread entry and an `agent_state` of `exited`, which has no steady glyph of its own, so without the merge the loudest case rendered as the quietest row.

But the unread entry is cleared in exactly one place: when the user selects that session. And `.attentionNeeded` outranks `isWorking` in `RowStatusIndicator.suffix`. So once a session had asked for input even once, its hand was pinned by the unread map, and a later `working` — however many polls confirmed it — could not outrank it. The row's own doc comment already drew the distinction the code did not honour: the bold name means "you have not looked since this happened", the glyph means "this is true right now".

**The daemon can reinstate an older state.** `RemoteSessionStore.upsert` is last-writer-wins with no ordering check. Nothing serializes the 60-second `list` poll against the `events` stream against a one-off verb response, so a `list` response that spent a few seconds in flight can be applied *after* an `events` line that observed the same session later — writing `waiting_input` back over a `working` that was already current. The contract has carried `agent_state_at` for exactly this purpose since v1, and TBD never read it.

## What this PR does

**App — the edge may add, never re-assert** (`RemoteSectionView`): a new `suffixContribution(of:agentState:)` gate passes every unread type through untouched except the two that render as a hand (`.attentionNeeded`, `.focusRequest`), which are dropped unless the agent axis *currently* says `waiting_input`. The hand now follows the axis every poll refreshes. `.error` and `.responseComplete` are unaffected, so the nonzero-exit case the merge was built for still works. The bold name is deliberately left edge-triggered.

**Daemon — reject out-of-order agent state** (`RemoteSessionStore`, `RemoteSnapshotOrdering`): the mirror compares the incoming `agent_state_at` against the stored one and, when the incoming is demonstrably older, keeps the mirrored agent axis instead. Four properties worth stating, each covered by a test:

- **Only the agent axis is withheld.** `agent_state_at` timestamps the agent state and nothing else, so the title, terminal state, `meta` and `archived` from the same sighting still apply — a `rename` response echoing a stale stamp must not lose its rename.
- **Presence is never withheld.** The session was there to be reported, whenever the report was taken, so `lastSeen`, `missingCount` and `gone` are refreshed either way. The two-absence rule is untouched.
- **No attention edge fires** from a withheld sighting — an edge TBD never observed going forward is not one to notify about.
- **Providers that send no stamp are byte-for-byte unaffected.** `agent_state_at` is optional; with no ordering information the previous last-writer-wins behavior is what runs. A *future-dated* stored stamp also disables the check, because a provider whose clock ran ahead would otherwise freeze the row permanently — the one failure worse than the bug.

`RemoteTimestamp` accepts both ISO-8601 spellings a conforming provider may emit; a default-options `ISO8601DateFormatter` rejects the fractional-seconds form, which would have silently disabled ordering for any provider that uses it.

**Spec:** [`docs/specs/2026-08-26-remote-snapshot-ordering-design.md`](docs/specs/2026-08-26-remote-snapshot-ordering-design.md). The app-side half is a plain bug fix — the code contradicted its own doc comment — but the daemon side had no ordering rule at all before this, so which axis a stale sighting withholds, what an ambiguous comparison does, and how a wrong clock is told from a skewed one are new decisions, and they are written down there with the alternatives weighed against them.

## Assumptions

- Assumes `agent_state_at` is monotonic per session for a given provider. Where it is not, the tolerance-guarded future-date check is the backstop: a stamp ahead of local time by more than 60s disables ordering for that row rather than freezing it.
- Assumes the app's `unreadByRemoteSession` remains the only latched input to the suffix slot. A future edge-triggered source would need the same gate.

## Evidence & verification

**The repro, before the fix:** a session observed at `waiting_input`, then at `working`, renders `.attention` — because the unread entry outranks the live state. `RemoteSessionRowAttentionStalenessTests.workingClearsALatchedHand` is that exact call and fails on the old code. On the daemon side, `RemoteSessionOrderingTests.olderSightingDoesNotReinstateWaiting` applies waiting → working → a late waiting, and the mirror ends at `waiting_input` without the fix.

**Discriminating tests**, covering the sequences the failure was seen across:

- quota wait → credential rotation → resumed working (both sides).
- a polling refresh alone, with no selection change — the case that was previously unfixable without clicking.
- selection changes, asserted to be *orthogonal* to the verdict rather than the remedy.
- app foreground/reopen: every agent state must reach the same glyph with an empty unread map as with a latched one, so reopening the app is never what fixes it.
- **the genuinely waiting session keeps its hand**, on both sides — the one correct hand from the live repro is the case a careless fix breaks.
- rejection costs: presence refreshed, absence counting intact, no attention edge, rename still applied, terminal exit still applied, no-stamp providers unchanged.

**Not verified locally, and a reviewer should know:** this branch was authored in an environment with no Swift toolchain (Linux; TBD is macOS-only), so `scripts/swift-safe build` and `scripts/test.sh` could not run — `swift-safe` exits 69, "swift executable not found". CI is the first compile, and there was no way to watch the sidebar clear its hands in a running app. The fix is therefore pinned entirely through pure functions and the in-memory mirror, which is where I would want it pinned regardless.

**Merge note:** #728 adds `pendingQuestion` to `RemoteSessionPayload`. When both land, `RemoteSessionStore.withFreshestAgentAxis` should carry `stored.pendingQuestion` rather than dropping it — the question block belongs to the agent axis, so it must move with it.
