### PR TITLE
Fix: a failed tmux read reported a live pane as gone, stranding terminals as unclosable ghosts

### DIFF
--- a/.claude/skills/tbd-project/references/architecture.md
+++ b/.claude/skills/tbd-project/references/architecture.md
@@ -124,7 +124,7 @@ tmux server: tbd-<djb2-hash-of-repo-path>
 - `sendKeys` — literal text (tmux `-l`); `sendKey` — a key name like "Enter"; `sendCommand` — text + Enter
 - `capturePaneOutput` / `capturePaneWithAnsi` — plain or ANSI-escaped snapshot
 - `paneCurrentCommand` / `panePID` — used by `ClaudeStateDetector`
-- `windowExists` — reconcile check; `dryRun` mode for tests
+- `windowPresence` / `serverPresence` — reconcile checks, three-valued (`.present` / `.absent` / `.unreachable`) so a failed read is never read as absence; `dryRun` mode for tests
 
 ## Worktree Lifecycle
 

--- a/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
@@ -51,6 +51,11 @@ extension ActuationOutcome {
             case .paneBelongsToAnotherTerminal: return .refused(.targetMismatch)
             case .paneMissing, .processExited: return .refused(.notFound)
             }
+        // The pane could not be READ — no tmux server answered. No refusal
+        // reason can say that without asserting something false about the
+        // target, and `notFound` in particular would put "the terminal is gone"
+        // on the permanent record on the strength of a failed read.
+        case .paneUnreadable: return .transportFailed
         // The row is there but cannot be woken as asked: nothing to resume, or
         // the profile it was pinned to no longer exists.
         case .noSessionID, .profileMissing: return .refused(.notEligible)
@@ -73,6 +78,8 @@ extension ActuationOutcome {
             case .paneBelongsToAnotherTerminal(let actual):
                 return "Pane \(paneID) answers with a different terminal: \(actual)"
             }
+        case .paneUnreadable(let paneID, let server):
+            return "Could not reach tmux server \(server) to check pane \(paneID)"
         case .profileMissing(let profileID):
             return "Profile no longer exists: \(profileID.uuidString)"
         }

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -10,7 +10,7 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "limitResume"
 /// without a user gesture, behind the SAME target consultation
 /// (`paneSendTarget`) that `handleTerminalSend` runs before it types.
 public protocol ResumeSendingTmux: Sendable {
-    func windowExists(server: String, windowID: String) async -> Bool
+    func windowPresence(server: String, windowID: String) async -> TmuxResourcePresence
     func paneInMode(server: String, paneID: String) async throws -> Bool
     func panePID(server: String, paneID: String) async throws -> String
     func paneSendTarget(server: String, paneID: String) async throws -> PaneSendTarget
@@ -262,12 +262,30 @@ public struct LimitResumeActuator: LimitResumeActuating {
               let worktree = ((try? await db.worktrees.getLocal(id: terminal.worktreeID)) ?? nil)
         else { return .notEligible(.terminalGone) }
         let server = worktree.tmuxServer
-        guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
+        switch await tmux.windowPresence(server: server, windowID: terminal.tmuxWindowID) {
+        case .present:
+            break
+        case .absent:
+            // tmux answered on a reachable server: the window is gone. Cancel
+            // silently, as this check has always done.
             return .notEligible(.terminalGone)
+        case .unreachable:
+            // The window read failed, so nothing is known about it.
+            // `.terminalGone` ends the scheduled resume, so concluding it from
+            // a failed read would throw away a resume for a session that is
+            // very likely still running. `.failed` ends the row too — see
+            // `paneTargetVerdict` — but says so out loud, naming the reason.
+            logger.warning("""
+                actuate: could not reach tmux server \(server, privacy: .public) to check \
+                window \(terminal.tmuxWindowID, privacy: .public) for terminal \
+                \(terminal.id.uuidString, privacy: .public) — not cancelling on a failed read
+                """)
+            return .notEligible(.failed(
+                "could not reach tmux server \(server) to verify the target window"))
         }
 
         // 1a. Ask the pane who it is, before any key is typed into it.
-        //     `windowExists` above proves a window id resolves to SOME window;
+        //     `windowPresence` above proves a window id resolves to SOME window;
         //     it cannot prove the pane still belongs to THIS terminal. tmux
         //     reuses pane ids, so a stale `tmuxPaneID` names a live stranger
         //     that passes every remaining check — window alive, Claude
@@ -342,14 +360,20 @@ public struct LimitResumeActuator: LimitResumeActuating {
     /// Classify one `paneSendTarget` consultation into an eligibility verdict.
     ///
     /// The outcomes mirror how this actuator already treats the same facts:
-    /// a pane that is gone or whose process has exited is the `windowExists`
+    /// a pane that is gone or whose process has exited is the `windowPresence`
     /// case one level finer, so it cancels silently as `.terminalGone`. A pane
-    /// that answers with a DIFFERENT terminal is not "gone" and not a
-    /// transient state to retry — the row's coordinate is stale and will stay
-    /// stale until something respawns the window, so retrying would only aim
-    /// at the same stranger again. It fails the row with a message naming both
-    /// ids, the way step 3's not-foreground check fails a row a retry cannot
-    /// help either.
+    /// that answers with a DIFFERENT terminal is not "gone": the row's
+    /// coordinate is stale and will stay stale until something respawns the
+    /// window, so it fails the row with a message naming both ids, the way
+    /// step 3's not-foreground check does.
+    ///
+    /// `.failed` versus `.terminalGone` is a choice about what the user is
+    /// TOLD, not about whether anything runs again. A row that leaves `pending`
+    /// never re-fires under either status (`ScheduledResumeStore.setStatus`
+    /// refuses to write `pending` back, and `reschedule` only moves rows that
+    /// are still pending), and only `.paneInCopyMode` reschedules. `.failed`
+    /// surfaces a notification carrying its reason; `.terminalGone` cancels
+    /// silently on the claim that the terminal is gone.
     private func paneTargetVerdict(
         server: String, terminal: Terminal
     ) async -> PaneTargetVerdict {
@@ -374,9 +398,14 @@ public struct LimitResumeActuator: LimitResumeActuating {
             return .notEligible(.terminalGone)
         case .unreachable:
             // The consultation reached no server, so nothing is known about the
-            // pane. `.terminalGone` would CANCEL the scheduled resume on the
-            // strength of a failed read; `.failed` leaves the row for a later
-            // attempt, matching the throwing branch above.
+            // pane. Both verdicts end this scheduled resume — nothing re-fires
+            // a row once it leaves `pending`, for `.cancelled` or `.failed`
+            // alike — so the difference is not retryability, it is what the
+            // user is told: `.terminalGone` cancels SILENTLY, asserting the
+            // terminal is gone, while `.failed` surfaces a notification
+            // carrying the reason. On a failed read the silent assertion is
+            // the one that is wrong, and the reason is the thing worth saying.
+            // Matches the throwing branch above.
             logger.warning("""
                 actuate: could not reach tmux server \(server, privacy: .public) to consult \
                 pane \(terminal.tmuxPaneID, privacy: .public) for terminal \

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -366,12 +366,24 @@ public struct LimitResumeActuator: LimitResumeActuating {
         }
 
         switch target {
-        case .missing:
+        case .absent:
             logger.info("""
                 actuate: pane \(terminal.tmuxPaneID, privacy: .public) for terminal \
                 \(terminal.id.uuidString, privacy: .public) no longer exists — cancelling
                 """)
             return .notEligible(.terminalGone)
+        case .unreachable:
+            // The consultation reached no server, so nothing is known about the
+            // pane. `.terminalGone` would CANCEL the scheduled resume on the
+            // strength of a failed read; `.failed` leaves the row for a later
+            // attempt, matching the throwing branch above.
+            logger.warning("""
+                actuate: could not reach tmux server \(server, privacy: .public) to consult \
+                pane \(terminal.tmuxPaneID, privacy: .public) for terminal \
+                \(terminal.id.uuidString, privacy: .public) — not cancelling on a failed read
+                """)
+            return .notEligible(.failed(
+                "could not reach tmux server \(server) to verify the target pane"))
         case .dead:
             logger.info("""
                 actuate: pane \(terminal.tmuxPaneID, privacy: .public) for terminal \

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -806,7 +806,7 @@ public actor HibernationCoordinator {
         let liveServer: String
 
         // The whole decide-then-mutate tmux section (ownership check +
-        // windowExists + respawn/create/kill/persist) runs under the
+        // windowPresence + respawn/create/kill/persist) runs under the
         // per-server lock: `wakesInFlight` above only dedupes wakes for the
         // SAME terminal, while this closes the cross-terminal TOCTOU on a
         // shared server (see `TmuxManager.withWorktreeServerLock`). The lock
@@ -880,7 +880,7 @@ public actor HibernationCoordinator {
     }
 
     /// The decide-then-mutate tmux section of `wake()` — ownership check,
-    /// `windowExists`, and the in-place respawn OR recreate mutations. Must
+    /// `windowPresence`, and the in-place respawn OR recreate mutations. Must
     /// only be entered under `TmuxManager.withWorktreeServerLock` (see the call
     /// site in `wake()`), otherwise two concurrent wakes on the same server can
     /// interleave across the awaits below and hijack each other's windows.
@@ -898,7 +898,7 @@ public actor HibernationCoordinator {
     ) async -> WakeTmuxOutcome {
         // Post-reboot a fresh tmux server reissues window ids from @1 again,
         // so a stale parked row's window id can equal a window that ANOTHER
-        // terminal's wake just created on the same server. `windowExists`
+        // terminal's wake just created on the same server. `windowPresence`
         // alone is therefore not ownership: if any other terminal currently
         // claims this id, ours is necessarily the stale claim (it predates
         // the reboot) and respawning in place would hijack that terminal's
@@ -910,7 +910,25 @@ public actor HibernationCoordinator {
             logger.info("wake: window \(windowID, privacy: .public) on \(server, privacy: .public) is claimed by another terminal — recreating instead of respawning in place for terminal \(terminal.id, privacy: .public)")
         }
 
-        if !claimedByOther, await tmux.windowExists(server: server, windowID: windowID) {
+        // A failed READ here is not "the window is gone": both branches below
+        // MUTATE (one respawns over whatever is in the window, the other kills
+        // it and creates a replacement), so an unanswered question must reach
+        // neither. The row stays parked and a later wake asks again — the same
+        // contract `.respawnFailed` already carries.
+        let windowPresence = claimedByOther
+            ? TmuxResourcePresence.absent
+            : await tmux.windowPresence(server: server, windowID: windowID)
+        if windowPresence == .unreachable {
+            logger.warning("""
+                wake: could not reach tmux server \(server, privacy: .public) to check window \
+                \(windowID, privacy: .public) for terminal \(terminal.id, privacy: .public) — \
+                leaving the row parked rather than respawning or recreating on a failed read
+                """)
+            return .failed(.respawnFailed(
+                reason: "could not reach tmux server \(server) to check window \(windowID)"))
+        }
+
+        if windowPresence == .present {
             do {
                 try await tmux.respawnWindow(
                     server: server,
@@ -929,12 +947,13 @@ public actor HibernationCoordinator {
                 return .failed(.respawnFailed(reason: "failed to respawn claude in window \(windowID): \(error.localizedDescription)"))
             }
         } else {
-            // The window is GONE — killed, the whole tmux server died (a
-            // machine reboot destroys every server; `windowExists` returns
-            // false on any tmux error, covering both), or its id is owned by
-            // another terminal (see above). Recreate the window and spawn the
-            // same `claude --resume` there: transcripts live on disk, so
-            // resume works fine in a fresh window. Mirrors
+            // The window is positively GONE — tmux answered on a reachable
+            // server and this id is not on it — or its id is owned by another
+            // terminal (see above). A read that FAILED never arrives here; it
+            // returned `.respawnFailed` above, because "I could not ask" is not
+            // a licence to kill a window and spawn a replacement. Recreate the
+            // window and spawn the same `claude --resume` there: transcripts
+            // live on disk, so resume works fine in a fresh window. Mirrors
             // `handleTerminalRecreateWindow`. Tabs are keyed by terminal id,
             // so keeping the same terminal row preserves the tab.
             do {
@@ -959,7 +978,7 @@ public actor HibernationCoordinator {
                     rows: resolvedRows
                 )
                 // Clean up the old window if it somehow still exists (a
-                // transient windowExists misclassification must not leak a
+                // transient windowPresence misclassification must not leak a
                 // live window; usually it's already dead so this no-ops).
                 // Skip when another terminal owns the id — killing it would
                 // tear down THEIR live window. This must happen AFTER
@@ -1117,16 +1136,36 @@ public actor HibernationCoordinator {
     public func reconcileOnStartup() async {
         guard let allTerminals = try? await db.terminals.list() else { return }
 
+        // Cached per server name, the same way `reconcileTerminalsWhileLocked`
+        // does it: rows overwhelmingly share a handful of servers, and a server
+        // that did not answer makes `serverPresence` reach for a `/bin/ps`
+        // snapshot to tell "gone" from "unreachable". After a reboot every
+        // server is in exactly that state, so an uncached probe would pay one
+        // full process-table read per parked row.
+        var serverPresenceByName: [String: TmuxResourcePresence] = [:]
+
         for terminal in allTerminals where terminal.isParked {
             guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else { continue }
             let server = worktree.tmuxServer
 
-            // Check if the window still exists AND is running claude
-            let serverAlive = await tmux.serverExists(server: server)
-            guard serverAlive else { continue }
-
-            let windowAlive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
-            guard windowAlive else { continue }
+            // Check if the window still exists AND is running claude. Both
+            // probes must answer POSITIVELY: this pass clears a parked flag, so
+            // `.absent` and `.unreachable` lead to the same place — leave the
+            // row parked, which is already what it says — but for different
+            // reasons, and neither is a reason to un-park. A row whose window
+            // could not be read stays parked and resumable, and the next
+            // startup (or a wake) asks again.
+            let presence: TmuxResourcePresence
+            if let cached = serverPresenceByName[server] {
+                presence = cached
+            } else {
+                presence = await tmux.serverPresence(server: server)
+                serverPresenceByName[server] = presence
+            }
+            guard presence == .present else { continue }
+            guard await tmux.windowPresence(
+                server: server, windowID: terminal.tmuxWindowID) == .present
+            else { continue }
 
             // Verify the pane is still running a Claude process
             guard let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -15,7 +15,9 @@ public enum HibernateResult: Equatable, Sendable {
 /// awake. Only states tmux gave a positive answer for appear here; "the probe
 /// failed" is deliberately not a case, because it is not a disagreement.
 public enum UnparkedPaneDisagreement: Equatable, Sendable {
-    /// tmux cannot find the pane — it, its window, or the whole server is gone.
+    /// tmux answered about a reachable server and the pane is not on it — it,
+    /// or its window, is gone. A server that could not be REACHED is not this
+    /// case and never becomes a disagreement; it is `WakeResult.paneUnreadable`.
     case paneMissing
     /// The pane object survives (`remain-on-exit`) but its process has exited,
     /// so the row's "awake" refers to a shell, not a session.
@@ -38,6 +40,14 @@ public enum WakeResult: Equatable, Sendable {
     /// rather than silently discarded. Nothing is respawned — see
     /// `classifyUnparkedWake` for why repair is a separate change.
     case sessionGone(paneID: String, detail: UnparkedPaneDisagreement)
+    /// The row is NOT parked and its pane could not be READ: no tmux server
+    /// answered on the socket the daemon resolved. Distinct from `.sessionGone`
+    /// because nothing disagreed — the question was never answered — and
+    /// distinct from `.notHibernated` because the caller must learn the check
+    /// failed rather than be told "already awake, nothing to do". Nothing was
+    /// woken and any `initialPrompt` was NOT delivered, so an autonomous caller
+    /// has to know it should retry rather than assume delivery.
+    case paneUnreadable(paneID: String, server: String)
     case notFound        // terminal/worktree DB row missing — NOT tmux failures
     case noSessionID
     case inFlight        // a wake for this terminal is already respawning
@@ -527,11 +537,18 @@ public actor HibernationCoordinator {
     /// primitive that would drift from it. That probe already answers both
     /// halves of the question: is a process there, and is the pane still ours.
     ///
-    /// Only a POSITIVE disagreement downgrades the answer, exactly as on the
-    /// send path. A probe that merely threw keeps the benign historical no-op:
-    /// a failed tmux call proves nothing, and tmux calls fail spuriously
-    /// precisely when the machine is loaded enough for the session to be alive.
-    /// A pane carrying no identity at all is likewise left alone.
+    /// Only a POSITIVE disagreement downgrades the answer to `.sessionGone`,
+    /// exactly as on the send path. A probe that merely threw keeps the benign
+    /// historical no-op: a failed tmux call proves nothing, and tmux calls fail
+    /// spuriously precisely when the machine is loaded enough for the session
+    /// to be alive. A pane carrying no identity at all is likewise left alone.
+    ///
+    /// A probe that ran and reached no server is the third answer,
+    /// `.paneUnreadable`: like a throw it is not a disagreement, but unlike a
+    /// throw it is a fact the caller can act on — it names the server and pane
+    /// that could not be consulted, so an autonomous caller learns its prompt
+    /// was not delivered instead of reading "already awake" off a check that
+    /// never happened.
     ///
     /// This reports; it deliberately does NOT repair. Respawning an unparked
     /// row would make tmux authoritative over the parked flag, and then one
@@ -573,10 +590,23 @@ public actor HibernationCoordinator {
                   paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame
             else { return .notHibernated }
             disagreement = .paneBelongsToAnotherTerminal(actualTerminalID: paneTerminalID)
-        case .missing:
+        case .absent:
             disagreement = .paneMissing
         case .dead:
             disagreement = .processExited
+        case .unreachable:
+            // The probe ran and reached no server. That is not a
+            // disagreement — nothing answered to disagree — so it must not
+            // become `.sessionGone`, which asserts the session is gone. Report
+            // the failed read as itself so the caller knows its prompt was not
+            // delivered and a retry is the right move.
+            logger.warning("""
+                wake: could not reach tmux server \(worktree.tmuxServer, privacy: .public) to \
+                consult pane \(terminal.tmuxPaneID, privacy: .public) for unparked terminal \
+                \(terminal.id, privacy: .public) — reporting the failed read, not sessionGone
+                """)
+            return .paneUnreadable(
+                paneID: terminal.tmuxPaneID, server: worktree.tmuxServer)
         }
 
         logger.warning("""

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -244,13 +244,20 @@ extension WorktreeLifecycle {
             if let outcome = Self.consumeMarker(atPath: preSession.markerPath) {
                 return outcome
             }
-            let windowAlive = await tmux.windowExists(
+            // Only a positive absence ends the wait early. `.unreachable` keeps
+            // polling: reporting `.paneKilled` abandons a hook that may still
+            // be running (and, on the create path, notifies the user that their
+            // pre-session was killed), and a read that failed is no evidence
+            // the pane died. If the server really is gone the marker never
+            // lands and the deadline below reports `.timedOut`, which is the
+            // honest answer for a window nobody could read.
+            let windowPresence = await tmux.windowPresence(
                 server: tmuxServer, windowID: preSession.windowID
             )
-            if !windowAlive {
+            if windowPresence == .absent {
                 // Same-iteration race: the hook can write the marker after the
                 // fileExists check above and exit (closing the pane) before the
-                // windowExists check. Re-check the marker once so a hook that
+                // windowPresence check. Re-check the marker once so a hook that
                 // actually finished isn't misreported as a killed pane.
                 if let outcome = Self.consumeMarker(atPath: preSession.markerPath) {
                     return outcome

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -600,8 +600,23 @@ extension WorktreeLifecycle {
                                 // attributed for backward compatibility.
                                 continue
                             }
-                        case .missing:
+                        case .absent:
                             break
+                        case .unreachable:
+                            // A failed READ, not evidence the pane is gone.
+                            // This is the destructive path — the next lines
+                            // park a session or delete its row — so an "I don't
+                            // know" must leave the row exactly as it is and let
+                            // a later sweep ask again. Treated identically to
+                            // the thrown-consultation case below, because it is
+                            // the same fact arriving by a different route.
+                            logger.warning("""
+                                reconcile: could not reach tmux server \
+                                \(wt.tmuxServer, privacy: .public) to consult pane \
+                                \(terminal.tmuxPaneID, privacy: .public) for terminal \
+                                \(terminal.id, privacy: .public) — leaving the row untouched
+                                """)
+                            continue
                         }
                     } catch {
                         // An unreadable identity is not evidence of staleness.
@@ -613,7 +628,7 @@ extension WorktreeLifecycle {
 
                 // Preserve the existing extra safety when the window probe
                 // itself says a Claude window is gone: if Claude is still
-                // running, retain the row. A pane that answered `.missing` or
+                // running, retain the row. A pane that answered `.absent` or
                 // with another terminal's identity is already definitive, so
                 // never inspect its current command. An owned dead pane
                 // continued above because remain-on-exit makes it an intended

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -195,9 +195,16 @@ extension WorktreeLifecycle {
                 // while we waited. Only judge the server whose lock we hold.
                 guard let current = try await db.worktrees.getLocal(id: wt.id),
                       current.tmuxServer == wt.tmuxServer else { return }
-                if await hasLiveWindow(server: current.tmuxServer, worktreeID: current.id) {
+                switch await liveWindowPresence(
+                    server: current.tmuxServer, worktreeID: current.id) {
+                case .present:
                     logger.info("reconcile: keeping non-canonical tmux server \(current.tmuxServer, privacy: .public) for worktree \(current.id, privacy: .public) — it has live windows (promoted-scratch inheritance)")
                     return
+                case .unreachable:
+                    logger.warning("reconcile: keeping non-canonical tmux server \(current.tmuxServer, privacy: .public) for worktree \(current.id, privacy: .public) — its windows could not be read, and a failed read is not evidence the server is stale")
+                    return
+                case .absent:
+                    break
                 }
                 do {
                     try await db.worktrees.updateTmuxServer(
@@ -448,10 +455,14 @@ extension WorktreeLifecycle {
                 let liveRowsOnServer = globalLiveRows.filter { $0.tmuxServer == server }
                 if liveRowsOnServer.isEmpty {
                     // Nothing references this server anymore. Skip silently
-                    // when it isn't running (nothing to reap or kill — and
-                    // archived rows keep pointing here forever, so this is
-                    // the steady state on every later reconcile).
-                    guard await tmux.serverExists(server: server) else { return }
+                    // unless tmux positively answers that it is running
+                    // (nothing to reap or kill — and archived rows keep
+                    // pointing here forever, so this is the steady state on
+                    // every later reconcile). `.unreachable` skips too: killing
+                    // a server is irreversible and takes every pane on it with
+                    // it, so it needs a server that answered, not merely one
+                    // that did not.
+                    guard await tmux.serverPresence(server: server) == .present else { return }
                     // Nothing left names this server — that is why it is being
                     // killed — so the row is identified by what IS known: the
                     // server, and the repo whose sweep found it when there is
@@ -563,14 +574,14 @@ extension WorktreeLifecycle {
         // Probe the server each worktree row actually stores, not a canonical
         // name. Promoted scratch worktrees keep their inherited scratch server.
         // Cached per server name — rows overwhelmingly share one server.
-        var serverAliveByName: [String: Bool] = [:]
+        var serverPresenceByName: [String: TmuxResourcePresence] = [:]
         for wt in worktrees {
-            let serverAlive: Bool
-            if let cached = serverAliveByName[wt.tmuxServer] {
-                serverAlive = cached
+            let serverPresence: TmuxResourcePresence
+            if let cached = serverPresenceByName[wt.tmuxServer] {
+                serverPresence = cached
             } else {
-                serverAlive = await tmux.serverExists(server: wt.tmuxServer)
-                serverAliveByName[wt.tmuxServer] = serverAlive
+                serverPresence = await tmux.serverPresence(server: wt.tmuxServer)
+                serverPresenceByName[wt.tmuxServer] = serverPresence
             }
             let terminals = try await db.terminals.list(worktreeID: wt.id)
             // Parked rows (`hibernatedAt` OR legacy `suspendedAt` — see
@@ -578,12 +589,41 @@ extension WorktreeLifecycle {
             // is expected, and the row is already exactly what this pass would
             // produce.
             for terminal in terminals where !terminal.isParked {
-                var windowAlive = false
-                if serverAlive {
-                    windowAlive = await tmux.windowExists(
+                // Everything below this probe is the destructive half of
+                // reconcile — it parks a session or deletes its row — so the
+                // question it asks is not "did a read succeed" but "did tmux
+                // ANSWER that this window is gone". A server or window that
+                // could not be read leaves the row exactly as it is; the next
+                // sweep asks again. That distinction is the whole point of the
+                // presence tri-state: a `Bool` probe ending in `catch { false }`
+                // put a failed read on the same footing as a vanished window,
+                // and the destructive branches then fired on a socket mismatch.
+                let windowPresence: TmuxResourcePresence
+                switch serverPresence {
+                case .present:
+                    windowPresence = await tmux.windowPresence(
                         server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
+                case .absent:
+                    // Positive evidence that the server is not there — after a
+                    // reboot, that no tmux server process exists for this uid
+                    // at all — so neither is any window on it. Probing the
+                    // window would be asking a server nothing is listening for.
+                    windowPresence = .absent
+                case .unreachable:
+                    windowPresence = .unreachable
                 }
 
+                if windowPresence == .unreachable {
+                    logger.warning("""
+                        reconcile: could not read tmux window \
+                        \(terminal.tmuxWindowID, privacy: .public) on server \
+                        \(wt.tmuxServer, privacy: .public) for terminal \
+                        \(terminal.id, privacy: .public) — leaving the row untouched
+                        """)
+                    continue
+                }
+
+                let windowAlive = windowPresence == .present
                 if windowAlive {
                     do {
                         switch try await tmux.paneSendTarget(
@@ -672,19 +712,44 @@ extension WorktreeLifecycle {
         }
     }
 
-    /// True when `server` is up AND hosts a live tmux window for at least one
-    /// of `worktreeID`'s terminal rows. Used by the stale-server self-heal to
-    /// distinguish a genuinely dead/renamed server (safe to canonicalize)
-    /// from a deliberately inherited one whose sessions are still running
-    /// (promoted scratch space). Early-exits on the first live window.
-    private func hasLiveWindow(server: String, worktreeID: UUID) async -> Bool {
-        guard await tmux.serverExists(server: server) else { return false }
+    /// Whether `server` hosts a live tmux window for any of `worktreeID`'s
+    /// terminal rows — as three facts, not two. Used by the stale-server
+    /// self-heal to distinguish a genuinely dead/renamed server (safe to
+    /// canonicalize) from a deliberately inherited one whose sessions are still
+    /// running (promoted scratch space). Early-exits on the first live window.
+    ///
+    /// `.absent` is the only verdict that licenses the rewrite, and it must
+    /// mean "tmux answered, and none of these windows is on this server".
+    /// Rewriting the row on a read that merely failed would point it at the
+    /// canonical (empty) server while the inherited one still runs the
+    /// sessions — orphaning live windows and handing the next pass an empty
+    /// server to conclude everything is dead from. So a single unreadable
+    /// window makes the whole answer `.unreachable`, even if other windows
+    /// answered `.absent`: "some of the windows are not here" is not "none of
+    /// them is".
+    private func liveWindowPresence(
+        server: String, worktreeID: UUID
+    ) async -> TmuxResourcePresence {
+        switch await tmux.serverPresence(server: server) {
+        case .present:
+            break
+        case .absent:
+            return .absent
+        case .unreachable:
+            return .unreachable
+        }
         let terminals = (try? await db.terminals.list(worktreeID: worktreeID)) ?? []
+        var anyUnreadable = false
         for terminal in terminals {
-            if await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) {
-                return true
+            switch await tmux.windowPresence(server: server, windowID: terminal.tmuxWindowID) {
+            case .present:
+                return .present
+            case .absent:
+                continue
+            case .unreachable:
+                anyUnreadable = true
             }
         }
-        return false
+        return anyUnreadable ? .unreachable : .absent
     }
 }

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -20,6 +20,29 @@ public extension DeskSessionManaging {
     func maintainJudgeLease(worktreeID: UUID) async {}
 }
 
+/// A Watch Desk candidate's pane could not be consulted because no tmux server
+/// answered on the socket the daemon resolved (`PaneSendTarget.unreachable`).
+///
+/// Thrown rather than folded into "not a live candidate" because on this rail an
+/// empty candidate list is an ACTION, not a silence: it spawns a replacement
+/// desk terminal and revokes a valid judge lease. A failed read must produce
+/// neither, so the whole pass aborts and the next tick asks again.
+/// `LocalizedError`, not merely `Error`: the callers that catch this log
+/// `error.localizedDescription`, and a bare `Error` bridges to NSError there —
+/// rendering "The operation couldn't be completed" with the server and pane
+/// stripped out, which is exactly the diagnostic this case exists to leave
+/// behind.
+public struct DeskPaneUnreachable: LocalizedError, Equatable, CustomStringConvertible {
+    public let server: String
+    public let paneID: String
+
+    public var description: String {
+        "Watch Desk pane \(paneID) could not be consulted: tmux server \(server) did not answer"
+    }
+
+    public var errorDescription: String? { description }
+}
+
 /// Manages the persistent "Watch Desk" scratch space for daywatch/nightwatch operations.
 /// Idempotent creation: mode switches reuse the existing desk session.
 /// Nudges the session when judgment items are queued (tick exit code 10).
@@ -303,7 +326,8 @@ public actor DeskSessionManager: DeskSessionManaging {
                     """)
                 continue
             }
-            guard await paneIdentityPermitsSend(server: server, terminal: terminal) else { continue }
+            guard try await paneIdentityPermitsSend(server: server, terminal: terminal)
+            else { continue }
             if tmux.verifiesPaneCurrentCommand {
                 guard let command = try? await tmux.paneCurrentCommand(
                     server: server,
@@ -338,15 +362,24 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// would not merely receive a stray keystroke, it would read and act on
     /// instructions addressed to another session, with permissions bypassed.
     ///
-    /// Excluding rather than throwing is what makes the outcome safe by
-    /// default. A dropped candidate is simply not live, so the callers'
+    /// Excluding rather than throwing is what makes a POSITIVE disagreement
+    /// safe by default. A dropped candidate is simply not live, so the callers'
     /// existing "no uniquely owned live terminal … skipping" path handles it,
     /// and `leasedJudgeTerminal` gets *more* correct: a stranger can no longer
     /// masquerade as the lease owner, nor pad the candidate count into a
     /// spurious fail-closed contention report.
     ///
+    /// "Could not reach the server" is the case exclusion gets wrong, and it
+    /// throws instead — see the `.unreachable` arm below for why an empty
+    /// candidate list is an action on this rail rather than a silence.
+    ///
     /// - Returns: `true` when this pane may be sent to.
-    private func paneIdentityPermitsSend(server: String, terminal: Terminal) async -> Bool {
+    /// - Throws: `DeskPaneUnreachable` when the consultation reached no server
+    ///   at all, so the caller aborts rather than treating an unread pane as an
+    ///   absent one.
+    private func paneIdentityPermitsSend(
+        server: String, terminal: Terminal
+    ) async throws -> Bool {
         let target: PaneSendTarget
         do {
             target = try await tmux.paneSendTarget(server: server, paneID: terminal.tmuxPaneID)
@@ -367,12 +400,29 @@ public actor DeskSessionManager: DeskSessionManaging {
         }
 
         switch target {
-        case .missing:
+        case .absent:
             logger.notice("""
                 Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
                 pane \(terminal.tmuxPaneID, privacy: .public) no longer exists
                 """)
             return false
+        case .unreachable:
+            // Not an answer about the pane, and on this rail "not a candidate"
+            // is destructive rather than merely quiet: an empty candidate list
+            // makes `ensureDeskSession` and `nudgeDeskSession` SPAWN a
+            // replacement agent, and makes `leasedJudgeTerminal` REVOKE a valid
+            // lease. Doing either because a read failed would duplicate a live
+            // desk. So this does not answer the question at all — it throws,
+            // which aborts the whole pass before any of those act, and the
+            // callers' existing `catch` logs and skips the tick.
+            logger.warning("""
+                Watch Desk pass aborted: could not reach tmux server \
+                \(server, privacy: .public) to consult pane \
+                \(terminal.tmuxPaneID, privacy: .public) for terminal \
+                \(terminal.id, privacy: .public) — no desk terminal will be spawned, \
+                replaced or revoked on a failed read
+                """)
+            throw DeskPaneUnreachable(server: server, paneID: terminal.tmuxPaneID)
         case .dead:
             logger.notice("""
                 Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -290,7 +290,7 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// is issue #384, and picking the newest row alone would not prevent it.
     ///
     /// Neither guard is sufficient on its own, and neither proves *ownership*.
-    /// `windowExists` proves a window id resolves to SOME window;
+    /// `windowPresence` proves a window id resolves to SOME window;
     /// `paneCurrentCommand` proves an agent of the right kind is in the
     /// foreground of SOME pane. A recycled pane id running a stranger's Claude
     /// satisfies both. So each surviving candidate is asked who it is
@@ -319,12 +319,31 @@ public actor DeskSessionManager: DeskSessionManaging {
 
         var live: [Terminal] = []
         for terminal in candidates {
-            guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
+            switch await tmux.windowPresence(server: server, windowID: terminal.tmuxWindowID) {
+            case .present:
+                break
+            case .absent:
                 logger.notice("""
                     Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
                     window \(terminal.tmuxWindowID, privacy: .public) no longer exists
                     """)
                 continue
+            case .unreachable:
+                // Same rule, and the same reasoning, as the `.unreachable` arm
+                // of `paneIdentityPermitsSend`: on this rail dropping a
+                // candidate is itself an action. An empty candidate list makes
+                // `ensureDeskSession`/`nudgeDeskSession` SPAWN a replacement
+                // agent and makes `leasedJudgeTerminal` REVOKE a valid lease, so
+                // a window read that failed must abort the pass rather than
+                // quietly shrink the list.
+                logger.warning("""
+                    Watch Desk pass aborted: could not reach tmux server \
+                    \(server, privacy: .public) to check window \
+                    \(terminal.tmuxWindowID, privacy: .public) for terminal \
+                    \(terminal.id, privacy: .public) — no desk terminal will be spawned, \
+                    replaced or revoked on a failed read
+                    """)
+                throw DeskPaneUnreachable(server: server, paneID: terminal.tmuxPaneID)
             }
             guard try await paneIdentityPermitsSend(server: server, terminal: terminal)
             else { continue }

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -43,6 +43,43 @@ public struct DeskPaneUnreachable: LocalizedError, Equatable, CustomStringConver
     public var errorDescription: String? { description }
 }
 
+/// A Watch Desk candidate's pane could not be consulted because the
+/// consultation itself failed to run — a wedged tmux tripping the subprocess
+/// timeout, a query that exited non-zero, a binary that could not be spawned.
+///
+/// The same category of non-answer as `DeskPaneUnreachable`, thrown for exactly
+/// the same reason: on this rail an empty candidate list is an ACTION, so a read
+/// that learned nothing about the pane must abort the pass rather than shrink
+/// the list.
+///
+/// Kept distinct from `DeskPaneUnreachable` rather than folded into it because
+/// the two describe different facts and point an operator at different remedies.
+/// `DeskPaneUnreachable` asserts that a query ran and no server answered on the
+/// socket the daemon resolved — a claim that would be simply false for a query
+/// that exited 1, or one that never started. This type asserts only that the
+/// consultation failed, and carries the underlying failure so the log says which
+/// one it was. `LocalizedError` for the same reason as its sibling: the callers
+/// that catch this log `error.localizedDescription`, and a bare `Error` bridges
+/// to NSError there, rendering "The operation couldn't be completed" with the
+/// whole diagnostic stripped out.
+public struct DeskPaneConsultationFailed: LocalizedError, Equatable, CustomStringConvertible {
+    public let server: String
+    public let paneID: String
+    /// The underlying failure, rendered at the throw site. A `String` rather
+    /// than the `Error` itself so this type stays `Equatable`, matching its
+    /// sibling and keeping it assertable from a test.
+    public let reason: String
+
+    public var description: String {
+        """
+        Watch Desk pane \(paneID) could not be consulted: querying tmux server \
+        \(server) failed: \(reason)
+        """
+    }
+
+    public var errorDescription: String? { description }
+}
+
 /// Manages the persistent "Watch Desk" scratch space for daywatch/nightwatch operations.
 /// Idempotent creation: mode switches reuse the existing desk session.
 /// Nudges the session when judgment items are queued (tick exit code 10).
@@ -388,13 +425,15 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// masquerade as the lease owner, nor pad the candidate count into a
     /// spurious fail-closed contention report.
     ///
-    /// "Could not reach the server" is the case exclusion gets wrong, and it
-    /// throws instead — see the `.unreachable` arm below for why an empty
-    /// candidate list is an action on this rail rather than a silence.
+    /// A consultation that produced no answer at all is the case exclusion gets
+    /// wrong, and both of its shapes throw instead — the server unreachable, and
+    /// the query failing outright. See the `.unreachable` arm below for why an
+    /// empty candidate list is an action on this rail rather than a silence.
     ///
     /// - Returns: `true` when this pane may be sent to.
     /// - Throws: `DeskPaneUnreachable` when the consultation reached no server
-    ///   at all, so the caller aborts rather than treating an unread pane as an
+    ///   at all, or `DeskPaneConsultationFailed` when it could not be run at
+    ///   all, so the caller aborts rather than treating an unread pane as an
     ///   absent one.
     private func paneIdentityPermitsSend(
         server: String, terminal: Terminal
@@ -404,18 +443,27 @@ public actor DeskSessionManager: DeskSessionManaging {
             target = try await tmux.paneSendTarget(server: server, paneID: terminal.tmuxPaneID)
         } catch {
             // The consultation could not be RUN at all (a wedged tmux tripping
-            // the subprocess timeout) — no answer about the pane either way.
-            // Dropped, matching how the `paneCurrentCommand` check below already
-            // treats the same wedged server: `try?` there turns a failed query
-            // into a skipped candidate. Pasting a judge prompt into a pane we
-            // could not look at is exactly what this check exists to stop, and
-            // the cost of being wrong is only a skipped tick.
-            logger.notice("""
-                Skipping Watch Desk terminal \(terminal.id, privacy: .public): could not verify \
-                pane \(terminal.tmuxPaneID, privacy: .public) belongs to it: \
-                \(String(describing: error), privacy: .public)
+            // the subprocess timeout) — no answer about the pane either way,
+            // which is the same non-answer the `.unreachable` arm below gets,
+            // and it gets the same treatment. Quietly excluding the candidate is
+            // not the cheap option on this rail: an empty candidate list makes
+            // `ensureDeskSession`/`nudgeDeskSession` SPAWN a replacement agent
+            // and makes `leasedJudgeTerminal` REVOKE a valid lease, so a read
+            // that failed would buy a duplicated desk on a live one, not a
+            // skipped tick. Throwing aborts the pass before any of those act;
+            // the callers' existing `catch` logs and skips the tick, and the
+            // next tick asks again.
+            logger.warning("""
+                Watch Desk pass aborted: could not consult pane \
+                \(terminal.tmuxPaneID, privacy: .public) for terminal \
+                \(terminal.id, privacy: .public) on tmux server \
+                \(server, privacy: .public): \(String(describing: error), privacy: .public) \
+                — no desk terminal will be spawned, replaced or revoked on a failed read
                 """)
-            return false
+            throw DeskPaneConsultationFailed(
+                server: server,
+                paneID: terminal.tmuxPaneID,
+                reason: String(describing: error))
         }
 
         switch target {

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -27,6 +27,25 @@ extension RPCRouter {
             """
     }
 
+    /// The message for a wake whose pane consultation could not reach the tmux
+    /// server. Shared by `terminal.wake` and `terminal.resume` for the same
+    /// reason `unparkedWakeMessage` is.
+    ///
+    /// Deliberately says nothing about whether the session is alive, and
+    /// carries no `terminalSessionGone` code: that code's contract is a pane
+    /// that POSITIVELY disagreed, and this is a read that never happened. The
+    /// text is retryable on purpose — the failure mode this exists to stop is a
+    /// caller reading a failed read as a dead session and giving up on live
+    /// work.
+    static func unreadablePaneWakeMessage(paneID: String, server: String) -> String {
+        """
+        Could not reach tmux server \(server) to check pane \(paneID), so nothing was woken \
+        and any prompt was NOT delivered. This is a failed read, not a missing session — the \
+        terminal may well be running. Retry; if it persists, check that the daemon and your \
+        shell resolve the same tmux socket.
+        """
+    }
+
     /// `terminal.hibernate` — manually hibernate one Claude terminal (kill its
     /// process, keep the tmux window). Honors the running/permission rails.
     func handleTerminalHibernate(
@@ -90,6 +109,12 @@ extension RPCRouter {
             return RPCResponse(
                 error: RPCRouter.unparkedWakeMessage(paneID: paneID, detail: detail),
                 code: RPCErrorCode.terminalSessionGone.rawValue)
+        case .paneUnreadable(let paneID, let server):
+            // An error, so the caller knows its prompt went nowhere — but
+            // pointedly NOT `terminalSessionGone`, which claims the session is
+            // gone. Nothing established that.
+            return RPCResponse(
+                error: RPCRouter.unreadablePaneWakeMessage(paneID: paneID, server: server))
         case .notFound:
             return RPCResponse(error: "Terminal not found")
         case .noSessionID:

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -66,6 +66,12 @@ extension RPCRouter {
             return RPCResponse(
                 error: RPCRouter.unparkedWakeMessage(paneID: paneID, detail: detail),
                 code: RPCErrorCode.terminalSessionGone.rawValue)
+        case .paneUnreadable(let paneID, let server):
+            // The read failed; nothing is known about the session. Same honest
+            // answer as `terminal.wake`, and the same refusal to claim it is
+            // gone.
+            return RPCResponse(
+                error: RPCRouter.unreadablePaneWakeMessage(paneID: paneID, server: server))
         case .notFound:
             return RPCResponse(error: "Terminal not found")
         case .noSessionID:

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -686,13 +686,14 @@ extension RPCRouter {
         // does). Refuse to kill an in-flight turn or a raised permission hand,
         // matching `isManuallyHibernatable`'s rails.
         //
-        // Qualified on the window actually being ALIVE. `activityState` is
-        // hook-fed and carries no timestamp, so a session that died mid-turn
-        // (crash, OOM, killed pane) stays `.working` forever. An unqualified
-        // rail would then refuse forever on exactly the wedged terminal a
-        // caller most needs to close — turning the safety rail into a trap for
-        // this command's primary cleanup use case. A dead-window row cannot be
-        // mid-turn, so it stays closeable without --force.
+        // Qualified on tmux positively answering that the window is GONE.
+        // `activityState` is hook-fed and carries no timestamp, so a session
+        // that died mid-turn (crash, OOM, killed pane) stays `.working`
+        // forever. An unqualified rail would then refuse forever on exactly the
+        // wedged terminal a caller most needs to close — turning the safety
+        // rail into a trap for this command's primary cleanup use case. A
+        // dead-window row cannot be mid-turn, so it stays closeable without
+        // --force.
         if params.respectActivityRails == true,
            terminal.activityState == .working || terminal.activityState == .waitingForUser {
             // Resolved inside the rails branch, not in the condition list, so
@@ -702,9 +703,17 @@ extension RPCRouter {
             let railWorktree = try await actuating(actuationID) {
                 try await db.worktrees.getLocal(id: terminal.worktreeID)
             }
+            // Only a POSITIVE absence lowers the rail. It is lowered so a wedged
+            // terminal whose window really died stays closeable without
+            // `--force`; a window read that FAILED is not that fact, and
+            // lowering the rail on it would let a close kill an in-flight turn
+            // in a live session the daemon merely could not see. `.unreachable`
+            // therefore keeps the rail up exactly as `.present` does — refusing
+            // is reversible, `--force` is still there, and the next call asks
+            // tmux again.
             if let railWorktree,
-               await tmux.windowExists(
-                server: railWorktree.tmuxServer, windowID: terminal.tmuxWindowID) {
+               await tmux.windowPresence(
+                server: railWorktree.tmuxServer, windowID: terminal.tmuxWindowID) != .absent {
                 let what = terminal.activityState == .working
                     ? "mid-turn"
                     : "waiting on a permission prompt"
@@ -1074,8 +1083,17 @@ extension RPCRouter {
             // and updated the row's ids. Killing it here would tear down the
             // freshly-spawned claude and re-park the row (wake flap). Leave
             // the row untouched.
-            if await tmux.windowExists(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID) {
-                logger.info("recreateWindow: window \(terminal.tmuxWindowID, privacy: .public) for claude terminal \(terminal.id, privacy: .public) is alive — ignoring stale recreate request")
+            // `.unreachable` declines with `.present`, and deliberately: the
+            // branch below KILLS this window and re-parks the row, so a read
+            // that failed must not reach it. Returning the row untouched is the
+            // same answer a live window gets, and the caller can ask again.
+            let recreatePresence = await tmux.windowPresence(
+                server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
+            if recreatePresence != .absent {
+                let why = recreatePresence == .present
+                    ? "is alive — ignoring stale recreate request"
+                    : "could not be read (no tmux server answered) — declining to recreate on a failed read"
+                logger.info("recreateWindow: window \(terminal.tmuxWindowID, privacy: .public) for claude terminal \(terminal.id, privacy: .public) \(why, privacy: .public)")
                 return try RPCResponse(result: terminal)
             }
             // This branch actuates too, and differently: it kills a window the

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -72,8 +72,14 @@ actor TranscriptParseCache {
 /// record gets and the message the caller sees.
 ///
 /// One type for both typing paths — the send handler and the verifier's
-/// retry — so a refusal cannot be classified two ways depending on which one
+/// retry — so a decline cannot be classified two ways depending on which one
 /// asked.
+///
+/// `outcome` is the full `ActuationOutcome` rather than a `RefusedReason`
+/// because not every "do not type here" is a refusal: a consultation that could
+/// not reach the server declined nothing about the target, and carries
+/// `.transportFailed` instead. Collapsing that into a refusal reason would make
+/// the record claim the daemon decided something it never learned.
 struct PaneSendRefusal: Sendable {
     let outcome: ActuationOutcome
     let message: String
@@ -2309,10 +2315,11 @@ extension RPCRouter {
         }
 
         // Ask the pane about itself before typing into it — the honest-transport
-        // check of issue #384 and the dead-pane class beside it. A decline here
-        // is a refusal, never a transport failure: the daemon declined without
-        // touching the transport. The consultation itself failing is the
-        // opposite, and is classified as such.
+        // check of issue #384 and the dead-pane class beside it. A decline made
+        // on an ANSWER is a refusal: the daemon declined without touching the
+        // transport. A consultation that could not be completed — thrown here,
+        // or answered `.unreachable` — is the opposite, and carries
+        // `.transportFailed` on the record instead of a refusal reason.
         let refusal: PaneSendRefusal?
         do {
             refusal = try await consultPaneBeforeTyping(
@@ -2437,8 +2444,9 @@ extension RPCRouter {
     /// Consult the pane the send names, and classify the answer.
     ///
     /// `nil` means "proceed" — the pane is alive and either agrees it is this
-    /// terminal or claims no identity at all. Anything else is a refusal the
-    /// caller records and returns, with the message a human reads.
+    /// terminal or claims no identity at all. Anything else is a decline the
+    /// caller records and returns, with the message a human reads: a refusal
+    /// when tmux answered, a transport failure when it could not be reached.
     ///
     /// tmux's own exit status cannot carry this: `send-keys` into a
     /// `remain-on-exit` dead pane exits 0, and keys sent to a reused pane id
@@ -2454,10 +2462,29 @@ extension RPCRouter {
         terminal: Terminal, server: String
     ) async throws -> PaneSendRefusal? {
         switch try await tmux.paneSendTarget(server: server, paneID: terminal.tmuxPaneID) {
-        case .missing:
+        case .absent:
             return PaneSendRefusal(outcome: .refused(.notFound), message: """
                 tmux pane \(terminal.tmuxPaneID) for terminal \(terminal.id.uuidString) \
                 no longer exists on server \(server) — nothing was sent
+                """)
+        case .unreachable:
+            // NOT a refusal, and above all not "no longer exists": the daemon
+            // could not reach the server, so it knows nothing about the pane.
+            // `transportFailed` is the honest classification — the daemon
+            // reached for the transport and the transport did not answer — and
+            // it is what keeps this out of the refusal reasons, none of which
+            // can describe a failed read without asserting something false
+            // about the target.
+            logger.warning("""
+                terminal.send: could not reach tmux server \(server, privacy: .public) to \
+                consult pane \(terminal.tmuxPaneID, privacy: .public) for terminal \
+                \(terminal.id.uuidString, privacy: .public); nothing was sent
+                """)
+            return PaneSendRefusal(outcome: .transportFailed, message: """
+                could not reach tmux server \(server) to check pane \(terminal.tmuxPaneID) \
+                for terminal \(terminal.id.uuidString) — nothing was sent, and the pane's \
+                state is unknown (this is a failed read, not a missing pane). Retry; if it \
+                persists, check that the daemon and your shell resolve the same tmux socket.
                 """)
         case .dead:
             return PaneSendRefusal(outcome: .refused(.notEligible), message: """

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -6,9 +6,27 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "TmuxManager"
 
 /// What one read-only `list-panes` consultation says about a pane that a send
 /// is aimed at. Read before anything is typed; see `paneSendTargetQuery`.
+///
+/// The two negative cases are deliberately separate facts, and conflating them
+/// was a real defect: a reachable server answering "no such pane" is positive
+/// evidence of absence, while a server that could not be reached at all is a
+/// failed READ that says nothing about the pane. The daemon spawns tmux with
+/// `environment: nil`, so its `TMUX_TMPDIR` can differ from the user's shell
+/// and `-L <name>` can resolve to a different socket file — the second case
+/// happens in the field, and reporting it as absence refuses sends to (and,
+/// worse, parks) perfectly live sessions. Affirmative evidence of absence is
+/// what `docs/specs/2026-08-11-bounded-terminal-recovery-design.md` requires;
+/// the app layer already honours it (`TmuxPreparationFailure.windowMissing`
+/// versus `.commandFailed`).
 public enum PaneSendTarget: Sendable, Equatable {
-    /// tmux cannot find the pane — it, its window, or the whole server is gone.
-    case missing
+    /// tmux answered about a reachable server and this pane is not on it — it,
+    /// or its window, is gone. Positive evidence of absence.
+    case absent
+    /// The consultation could not be completed: the server did not answer on
+    /// the socket this daemon resolved. NOT evidence about the pane, and never
+    /// to be reported as "gone" — the pane may well be alive and typed into by
+    /// a shell that resolves the same `-L` name to a different socket.
+    case unreachable
     /// The pane object exists (`remain-on-exit` kept it) but its process has
     /// exited. `send-keys` into it still exits 0 and the keys go nowhere.
     /// `terminalID` carries the same ownership stamp as a live pane so
@@ -132,7 +150,10 @@ public struct TmuxManager: Sendable {
     /// Throwing, because "the consultation could not be run at all" is one of
     /// the answers: it is the wedged-tmux path the send classifies as a
     /// transport failure rather than a refusal, and a non-throwing hook would
-    /// leave that branch with no way to be exercised.
+    /// leave that branch with no way to be exercised. Returning `.unreachable`
+    /// is the neighbouring case — the consultation ran and could not reach the
+    /// server — and every consumer must treat it as "I don't know", never as
+    /// "gone".
     public let dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)?
     /// Optional test hook consulted by `pasteText` in dryRun mode:
     /// `(server, paneID, bytes)` — the payload that would have been written to
@@ -605,13 +626,62 @@ public struct TmuxManager: Sendable {
          + "#{pane_start_command}"]
     }
 
+    /// The reachability probe run after a failed `paneSendTargetQuery`: one
+    /// read-only, server-wide inventory of pane identities.
+    ///
+    /// Server-wide (`-a`) rather than `-t <pane>` deliberately. The whole point
+    /// is to separate "tmux answered" from "tmux could not be reached", and a
+    /// second target-scoped query would fail for BOTH reasons exactly as the
+    /// first one did. `list-panes -a` names no target, so its exit status is
+    /// about the SERVER: it exits 0 with the inventory when the server answers
+    /// and non-zero when nothing is listening on that socket.
+    ///
+    /// It reports `#{pane_id}` and nothing else — no prose, no stderr parsing.
+    /// The bounded-recovery spec rejects reading tmux's human-facing text
+    /// ("rendered and human-facing text is not a stable machine interface. Exit
+    /// status and formatted identity inventories are"), so absence is concluded
+    /// from a formatted inventory that does not contain the id, never from an
+    /// error message that says so.
+    public static func allPaneIDsQuery(server: String) -> [String] {
+        ["-L", server, "list-panes", "-a", "-F", "#{pane_id}"]
+    }
+
+    /// Whether a server-wide `allPaneIDsQuery` inventory names `paneID`.
+    static func paneInventoryLists(_ output: String, paneID: String) -> Bool {
+        output.split(separator: "\n").contains {
+            $0.trimmingCharacters(in: .whitespaces) == paneID
+        }
+    }
+
+    /// Turn a failed `paneSendTargetQuery` into a verdict, given what the
+    /// reachability probe saw. Pure, so all three branches are unit-testable
+    /// without a tmux server.
+    ///
+    /// - Parameter paneInventory: `allPaneIDsQuery`'s stdout, or `nil` when the
+    ///   probe itself failed.
+    ///
+    /// Three cases, and only one of them is evidence:
+    /// - probe failed → `.unreachable`. Two failed reads in a row still say
+    ///   nothing about the pane.
+    /// - probe answered and the inventory does NOT name the pane → `.absent`.
+    ///   The server is reachable and does not have this pane: positive absence.
+    /// - probe answered and the inventory DOES name the pane → `.unreachable`.
+    ///   The first failure was transient or anomalous, and the one thing this
+    ///   function must never do is report a pane tmux just listed as gone.
+    static func classifyFailedConsultation(
+        paneInventory: String?, paneID: String
+    ) -> PaneSendTarget {
+        guard let paneInventory else { return .unreachable }
+        return paneInventoryLists(paneInventory, paneID: paneID) ? .unreachable : .absent
+    }
+
     /// Classify `paneSendTargetQuery`'s stdout for the pane the send named.
     /// Pure, so the classification is unit-testable without a tmux server.
     ///
     /// Only the line whose `#{pane_id}` is `paneID` counts — the query returns
     /// one line per pane in the target's window. A run with no such line means
-    /// tmux answered about a window that no longer holds this pane, which is
-    /// the same fact as `can't find pane`: `.missing`.
+    /// tmux answered — exit 0, on a reachable server — about a window that no
+    /// longer holds this pane: positive evidence of absence, `.absent`.
     static func parsePaneSendTarget(_ output: String, paneID: String) -> PaneSendTarget {
         for line in output.split(separator: "\n") {
             let fields = line.split(
@@ -625,9 +695,10 @@ public struct TmuxManager: Sendable {
             }
             return .live(terminalID: terminalID)
         }
-        // rc 0 but no line for this pane (including no output at all): nothing
-        // answered for the coordinate the send named.
-        return .missing
+        // rc 0 but no line for this pane (including no output at all): the
+        // server answered, and nothing on it holds the coordinate the send
+        // named.
+        return .absent
     }
 
     /// The exact assignment shape `newWindowCommand` and `respawnWindowCommand`
@@ -1048,19 +1119,46 @@ public struct TmuxManager: Sendable {
     /// Read-only — a query, not an actuation. Throws only when the query itself
     /// could not be *run*: a wedged server tripping the subprocess timeout
     /// (`TmuxError.timedOut`) or a tmux that would not spawn at all, neither of
-    /// which this catch matches. A non-zero *exit* is read as an answer instead,
-    /// because the only way this fixed argv can exit non-zero is tmux failing to
-    /// resolve the target — `can't find pane`, or no server on that socket, both
-    /// of which mean the same thing for a send. (`paneSendTargetQuery`'s exact
-    /// argv is pinned by a unit test, so it cannot drift into a usage error that
-    /// would arrive here wearing the same clothes.)
+    /// which this catch matches.
+    ///
+    /// A non-zero *exit* is ambiguous and is NOT read as an answer on its own.
+    /// This fixed argv can exit non-zero for two unrelated reasons — the pane
+    /// could not be resolved on a server that answered, or no server answered on
+    /// that socket at all — and only the first is evidence about the pane. The
+    /// second is a failed read: the daemon spawns tmux with `environment: nil`,
+    /// so a `TMUX_TMPDIR` that differs from the user's shell puts the same
+    /// `-L <name>` on a different socket file, and a live pane then wears the
+    /// clothes of a vanished one. So a failure is disambiguated by a positive
+    /// server-reachability probe (`allPaneIDsQuery`) rather than by reading
+    /// tmux's error prose; see `classifyFailedConsultation`.
+    /// (`paneSendTargetQuery`'s exact argv is pinned by a unit test, so it
+    /// cannot drift into a usage error that would arrive here wearing the same
+    /// clothes.)
     public func paneSendTarget(server: String, paneID: String) async throws -> PaneSendTarget {
         if dryRun { return try dryRunPaneSendTarget?(server, paneID) ?? .live(terminalID: nil) }
         let args = Self.paneSendTargetQuery(server: server, paneID: paneID)
         do {
             return Self.parsePaneSendTarget(try await runTmux(args), paneID: paneID)
         } catch TmuxError.commandFailed {
-            return .missing
+            let inventory = try? await runTmux(Self.allPaneIDsQuery(server: server))
+            let verdict = Self.classifyFailedConsultation(
+                paneInventory: inventory, paneID: paneID)
+            if verdict == .unreachable {
+                // The one drift this whole split exists to make diagnosable in
+                // the field: which server name, and which pane, could not be
+                // consulted — and whether the reachability probe itself
+                // answered (transient failure) or not (socket mismatch / dead
+                // server).
+                let probeOutcome = inventory == nil
+                    ? "the reachability probe also failed"
+                    : "the reachability probe still lists the pane"
+                logger.warning("""
+                    paneSendTarget: could not establish whether pane \(paneID, privacy: .public) \
+                    exists on server \(server, privacy: .public) — the consultation failed and \
+                    \(probeOutcome, privacy: .public); reporting unreachable rather than absent
+                    """)
+            }
+            return verdict
         }
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -234,6 +234,18 @@ public struct TmuxManager: Sendable {
     /// — is not something a test on a shared developer box or a CI runner can
     /// arrange, and certainly not one that starts real tmux servers of its own.
     public let tmuxServerProcessProbe: (@Sendable () async -> Bool?)?
+    /// Collapses the production `/bin/ps` reading behind `serverPresence` onto
+    /// one in-flight call plus a seconds-long memo, because the question it
+    /// answers is machine-global and does not vary with the server name — see
+    /// `TmuxServerProcessProbeCache`. Shared by every value-copy of this
+    /// manager, the same way `resourceCoordinator` is, so the daemon's one
+    /// manager gives the whole process one probe per sweep.
+    ///
+    /// Deliberately NOT applied to `tmuxServerProcessProbe`: an injected probe
+    /// is a fixture, and a fixture that silently answered from a memo would
+    /// make a test's second call unable to see a changed answer. The memo's own
+    /// behavior is pinned directly in `TmuxServerPresenceTests`.
+    private let serverProcessProbeCache = TmuxServerProcessProbeCache()
 
     /// Whether callers should treat `paneCurrentCommand` as a meaningful
     /// process-liveness signal. Plain dry-run fixtures intentionally return a
@@ -862,9 +874,15 @@ public struct TmuxManager: Sendable {
     /// (never a partial picture) for a timeout, a non-zero exit or non-UTF-8
     /// output, which is precisely the "the probe itself failed" case.
     ///
-    /// Only ever reached after a `list-sessions` that did not answer, and
-    /// `reconcileTerminalsWhileLocked` caches `serverPresence` per server name,
-    /// so a sweep pays at most one `ps` per unanswered server.
+    /// Only ever reached after a `list-sessions` that did not answer, and never
+    /// reached directly: `serverPresence` routes it through
+    /// `serverProcessProbeCache`, so concurrent askers share one reading and a
+    /// sweep over many unanswered servers pays for one `ps` rather than one per
+    /// server. The per-server `serverPresence` memos in
+    /// `reconcileTerminalsWhileLocked` and `HibernationCoordinator` are a
+    /// complement, not a substitute — they save the `list-sessions` too, but
+    /// each covers only its own pass and neither reaches the other's, nor
+    /// `liveWindowPresence`'s once-per-noncanonical-row consultation.
     static func probeTmuxServerProcesses() async -> Bool? {
         guard let snapshot = await OrphanProcessCollector.realProcessSnapshot() else {
             return nil
@@ -1573,7 +1591,12 @@ public struct TmuxManager: Sendable {
             if let injectedProbe = tmuxServerProcessProbe {
                 probe = await injectedProbe()
             } else {
-                probe = await Self.probeTmuxServerProcesses()
+                // Memoized: the reading is about the machine, not about
+                // `server`, so a sweep that finds many unanswered servers pays
+                // for one `ps` rather than one per server.
+                probe = await serverProcessProbeCache.reading {
+                    await Self.probeTmuxServerProcesses()
+                }
             }
             let verdict = Self.classifyFailedServerConsultation(
                 tmuxServerProcessesExist: probe)

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -39,6 +39,31 @@ public enum PaneSendTarget: Sendable, Equatable {
     case live(terminalID: String?)
 }
 
+/// What one read-only consultation says about a tmux resource a caller is
+/// about to act on: a window, or a whole server.
+///
+/// The same three-way split as `PaneSendTarget`, and for the same reason. A
+/// `Bool` probe has to spend its one bit on "yes" and then fold both "tmux
+/// answered: not here" and "tmux was never reached" into "no" — which is the
+/// conflation `docs/specs/2026-08-11-bounded-terminal-recovery-design.md`
+/// forbids, because every destructive rail in the daemon (park, delete, kill,
+/// respawn, spawn-a-replacement, revoke-a-lease, cancel-a-resume) is gated on
+/// that single bit. Making the third case a separate value is what forces each
+/// of those rails to decide, at the compiler's insistence, what a FAILED READ
+/// means for it — and the answer is always "decline and let a later pass ask
+/// again".
+public enum TmuxResourcePresence: Sendable, Equatable {
+    /// tmux answered and the resource is there.
+    case present
+    /// tmux answered on a reachable server and the resource is NOT there.
+    /// Positive evidence of absence — the only verdict that may license a
+    /// destructive or irreversible action.
+    case absent
+    /// The consultation could not be completed, so nothing is known about the
+    /// resource. Never to be reported or treated as absence.
+    case unreachable
+}
+
 /// Serializes tmux resource ownership transitions per server.
 ///
 /// A tmux window becomes externally visible before the database row that owns
@@ -102,11 +127,33 @@ public struct TmuxManager: Sendable {
     /// have been passed to tmux. Used by spawn / swap integration tests to assert
     /// command shapes without spawning an actual tmux server.
     public let dryRunRecorder: (@Sendable ([String]) -> Void)?
-    /// Optional test hook consulted by `windowExists` in dryRun mode: return
+    /// Optional test hook consulted by `windowPresence` in dryRun mode: return
     /// `true` for a window ID to simulate that window having been killed.
     /// Without it, dryRun reports every window as alive, which makes paths
     /// like the pre-session `.paneKilled` short-circuit untestable.
+    ///
+    /// Two-state by construction, so it can only say `.present` or `.absent`:
+    /// `true` means tmux ANSWERED that the window is gone. A fixture that needs
+    /// the third fact — the read itself failed — uses `dryRunWindowPresence`,
+    /// which takes precedence over this hook when both are set.
     public let dryRunWindowIsDead: (@Sendable (String) -> Bool)?
+    /// Optional test hook consulted by `windowPresence` in dryRun mode:
+    /// `(server, windowID)` → the full three-way verdict. Consulted before
+    /// `dryRunWindowIsDead`, which stays as the two-state shorthand the
+    /// existing fixtures are written against.
+    ///
+    /// This exists because a two-state hook cannot express `.unreachable`, and
+    /// `.unreachable` is precisely the state every destructive rail must be
+    /// tested against: a fixture that can only say "alive" or "gone" leaves the
+    /// failed-read branch — the one that must NOT park, delete, kill, respawn
+    /// or revoke — with no way to be exercised, which is how the daemon shipped
+    /// a `catch { return false }` in front of the very check that was meant to
+    /// stop it.
+    public let dryRunWindowPresence: (@Sendable (String, String) -> TmuxResourcePresence)?
+    /// Optional test hook consulted by `serverPresence` in dryRun mode:
+    /// `server` → the three-way verdict. Without it, dryRun reports every
+    /// server `.present`, which is what every pre-existing fixture assumes.
+    public let dryRunServerPresence: (@Sendable (String) -> TmuxResourcePresence)?
     /// Optional test hook consulted by `capturePaneOutput` and
     /// `capturePaneWithAnsi` in dryRun mode:
     /// (server, paneID) → pane text. Without it, dryRun captures return "",
@@ -163,14 +210,30 @@ public struct TmuxManager: Sendable {
     /// dispatch envelope, for one — need the bytes themselves.
     public let dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)?
     /// Optional test hook for real (non-dryRun) mode: override the result of
-    /// `windowExists(server:windowID:)`. Allows tests to force a window as dead
-    /// while still having a live process running in the pane (for testing the
-    /// safety check in reconcile).
-    public let realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)?
+    /// `windowPresence(server:windowID:)`. Allows tests to force a window as
+    /// positively absent while still having a live process running in the pane
+    /// (for testing the safety check in reconcile), or to force the failed-read
+    /// verdict against a real server.
+    public let realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxResourcePresence?)?
     /// Optional test hook for real (non-dryRun) mode: override the result of
     /// `paneCurrentCommand(server:paneID:)`. Allows tests to return a specific
     /// command string without relying on tmux's actual pane_current_command.
     public let realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)?
+    /// Seam for the out-of-tmux evidence `serverPresence` consults after a
+    /// `list-sessions` that did not answer: does ANY tmux server process exist
+    /// for this uid?
+    ///
+    /// Two nils, deliberately, and they mean different things:
+    /// - the **property** being nil ⇒ use the production `/bin/ps` probe.
+    /// - the closure **returning** nil ⇒ the probe itself could not be taken,
+    ///   which is never evidence of absence (see `serverPresence`).
+    ///
+    /// Consulted in real mode only; dryRun answers from `dryRunServerPresence`
+    /// long before this is reached. It exists because the condition that makes
+    /// the probe interesting — a machine with no tmux process running anywhere
+    /// — is not something a test on a shared developer box or a CI runner can
+    /// arrange, and certainly not one that starts real tmux servers of its own.
+    public let tmuxServerProcessProbe: (@Sendable () async -> Bool?)?
 
     /// Whether callers should treat `paneCurrentCommand` as a meaningful
     /// process-liveness signal. Plain dry-run fixtures intentionally return a
@@ -193,13 +256,15 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunWindowPresence: (@Sendable (String, String) -> TmuxResourcePresence)? = nil, dryRunServerPresence: (@Sendable (String) -> TmuxResourcePresence)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxResourcePresence?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, tmuxServerProcessProbe: (@Sendable () async -> Bool?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
         self.resourceCoordinator = TmuxServerResourceCoordinator()
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
+        self.dryRunWindowPresence = dryRunWindowPresence
+        self.dryRunServerPresence = dryRunServerPresence
         self.dryRunListWindows = dryRunListWindows
         self.dryRunCapturePane = dryRunCapturePane
         self.dryRunPaneCurrentCommand = dryRunPaneCurrentCommand
@@ -208,8 +273,9 @@ public struct TmuxManager: Sendable {
         self.dryRunKillWindowError = dryRunKillWindowError
         self.dryRunPaneSendTarget = dryRunPaneSendTarget
         self.dryRunPasteBytes = dryRunPasteBytes
-        self.realModeWindowExistsOverride = realModeWindowExistsOverride
+        self.realModeWindowPresenceOverride = realModeWindowPresenceOverride
         self.realModePaneCurrentCommandOverride = realModePaneCurrentCommandOverride
+        self.tmuxServerProcessProbe = tmuxServerProcessProbe
     }
 
     /// Runs one ownership transition while exclusively holding `server`.
@@ -646,11 +712,165 @@ public struct TmuxManager: Sendable {
         ["-L", server, "list-panes", "-a", "-F", "#{pane_id}"]
     }
 
+    /// The reachability probe run after a failed window consultation: one
+    /// read-only, server-wide inventory of window identities.
+    ///
+    /// The window-space twin of `allPaneIDsQuery`, and server-wide (`-a`) for
+    /// the identical reason: naming no target makes its exit status a fact
+    /// about the SERVER rather than about the window that just failed, which is
+    /// the only way to tell "tmux answered" from "tmux was never reached". It
+    /// reports `#{window_id}` and nothing else — an identity inventory, never
+    /// tmux's error prose.
+    public static func allWindowIDsQuery(server: String) -> [String] {
+        ["-L", server, "list-windows", "-a", "-F", "#{window_id}"]
+    }
+
+    /// Whether a server-wide `-F` identity inventory names `id`. One line per
+    /// resource, so membership is an exact match on the trimmed line.
+    static func inventoryLists(_ output: String, id: String) -> Bool {
+        output.split(separator: "\n").contains {
+            $0.trimmingCharacters(in: .whitespaces) == id
+        }
+    }
+
     /// Whether a server-wide `allPaneIDsQuery` inventory names `paneID`.
     static func paneInventoryLists(_ output: String, paneID: String) -> Bool {
-        output.split(separator: "\n").contains {
-            $0.trimmingCharacters(in: .whitespaces) == paneID
+        inventoryLists(output, id: paneID)
+    }
+
+    /// Turn a failed window consultation into a verdict, given what the
+    /// window-inventory reachability probe saw. Pure, so all three branches are
+    /// unit-testable without a tmux server.
+    ///
+    /// - Parameter windowInventory: `allWindowIDsQuery`'s stdout, or `nil` when
+    ///   the probe itself failed.
+    ///
+    /// The same three cases as `classifyFailedConsultation`, in the window's
+    /// identity space:
+    /// - probe failed → `.unreachable`. Two failed reads still say nothing.
+    /// - probe answered and the inventory does NOT name the window → `.absent`.
+    /// - probe answered and the inventory DOES name the window → `.unreachable`.
+    ///   Never report a window tmux just listed as gone.
+    static func classifyFailedWindowConsultation(
+        windowInventory: String?, windowID: String
+    ) -> TmuxResourcePresence {
+        guard let windowInventory else { return .unreachable }
+        return inventoryLists(windowInventory, id: windowID) ? .unreachable : .absent
+    }
+
+    /// Turn a failed `list-sessions` into a verdict, given what the process
+    /// table said about tmux servers. Pure, so all three branches are
+    /// unit-testable without a tmux server and without shelling out to `ps`.
+    ///
+    /// - Parameter tmuxServerProcessesExist: whether the process table holds at
+    ///   least one tmux server process for this uid, or `nil` when the probe
+    ///   itself could not be taken.
+    ///
+    /// The distinction tmux cannot draw — "no server is running under this
+    /// name" versus "this process resolved a socket the server is not listening
+    /// on" — is drawn from OUTSIDE tmux, where it does exist:
+    /// - probe failed → `.unreachable`. A failed probe is never evidence of
+    ///   absence; two failed reads still say nothing.
+    /// - probe answered and NO tmux server process exists → `.absent`. Nothing
+    ///   is running, so nothing can be listening on any socket, whatever
+    ///   `TMUX_TMPDIR` resolves to for whoever asks. This is the post-reboot
+    ///   case, and the reason it must reclaim: otherwise every row on every
+    ///   pre-reboot server accumulates forever.
+    /// - probe answered and a tmux server process DOES exist → `.unreachable`.
+    ///   Something is running and our socket resolution did not reach it, which
+    ///   is exactly the field bug, so the rows are protected.
+    static func classifyFailedServerConsultation(
+        tmuxServerProcessesExist: Bool?
+    ) -> TmuxResourcePresence {
+        guard let exists = tmuxServerProcessesExist else { return .unreachable }
+        return exists ? .unreachable : .absent
+    }
+
+    /// Whether a `/bin/ps` snapshot holds a tmux server process for `uid`.
+    ///
+    /// **The matching rule, and why it is deliberately name-agnostic.** A row
+    /// counts when all of these hold:
+    /// 1. `entry.uid == uid` — another user's tmux server cannot be ours and
+    ///    cannot be reached on our socket directory either.
+    /// 2. `entry.ppid != daemonPID` — this daemon's own in-flight `tmux …` CLI
+    ///    invocations are excluded. Those are clients, never servers: tmux's
+    ///    server `daemon()`s itself away from its spawning process, so a real
+    ///    server's ppid is 1 and never the daemon's.
+    /// 3. `isTmuxProcessCommand(entry.command)` — argv[0]'s basename is `tmux`,
+    ///    or the command carries the rewritten `tmux: …` process title.
+    ///
+    /// Rule 3 does NOT try to match `-L <our server name>`, and that is the
+    /// point rather than an omission. The thing under suspicion here is our own
+    /// *name → socket* resolution: the daemon spawns tmux with `environment:
+    /// nil`, so the same `-L <name>` can land on a different socket file than
+    /// the shell that started the server used. Deciding "is this our server?"
+    /// by re-reading the name from argv would assume the very resolution the
+    /// probe exists to doubt, and would miss a server that IS ours under a name
+    /// we can no longer resolve. The question asked is the weaker, sounder one:
+    /// *is any tmux server at all running for this uid?* Only "no" is used, and
+    /// only to license `.absent`.
+    ///
+    /// Rule 3 also does not try to separate servers from clients, because on
+    /// macOS it cannot: tmux rewrites its process title to `tmux: server (…)`
+    /// only where `setproctitle` is available, so elsewhere a server keeps the
+    /// original argv (`tmux -L … new-session …`) and is indistinguishable from
+    /// a client by argv alone. Matching both is sound in the direction that
+    /// matters — a tmux *client* only exists while attached to a server, so it
+    /// is evidence FOR a running server — and every remaining over-match (a
+    /// stranger's short-lived `tmux` CLI) can only produce `.unreachable`, the
+    /// verdict that protects rows. An under-match, by contrast, would produce a
+    /// wrong `.absent` and park or delete live sessions, so the matcher is
+    /// broad on purpose.
+    static func tmuxServerProcessesExist(
+        in snapshot: [ProcessSnapshotEntry], uid: uid_t, daemonPID: Int32
+    ) -> Bool {
+        snapshot.contains { entry in
+            entry.uid == uid
+                && entry.ppid != daemonPID
+                && isTmuxProcessCommand(entry.command)
         }
+    }
+
+    /// Whether one `ps -o command=` line names a tmux process (server or
+    /// client). See `tmuxServerProcessesExist` for why both count.
+    ///
+    /// Two accepted shapes, and nothing else:
+    /// - argv[0]'s last path component is exactly `tmux`, so
+    ///   `/opt/homebrew/bin/tmux -L x new-session` matches while a path merely
+    ///   containing "tmux" (`/Users/x/tmux-notes/bin/editor`) does not — the
+    ///   same basename discipline `AgentReaper.isAgentBinary` uses.
+    /// - argv[0] begins `tmux:`, the rewritten title (`tmux: server (…)`,
+    ///   `tmux: client (…)`).
+    ///
+    /// This reads the process table, which is a machine interface — not tmux's
+    /// stderr prose, which stays forbidden.
+    static func isTmuxProcessCommand(_ command: String) -> Bool {
+        guard let arg0 = command.split(
+            whereSeparator: { $0 == " " || $0 == "\t" }
+        ).first else { return false }
+        if arg0.hasPrefix("tmux:") { return true }
+        let basename = arg0.split(separator: "/").last.map(String.init) ?? String(arg0)
+        return basename == "tmux"
+    }
+
+    /// The production out-of-tmux probe: one `/bin/ps` snapshot, classified by
+    /// `tmuxServerProcessesExist`. `nil` when the snapshot could not be taken.
+    ///
+    /// Reuses `OrphanProcessCollector.realProcessSnapshot()` rather than adding
+    /// a second way to read the process table — it already carries uid, ppid
+    /// and full argv, already bounds the subprocess, and already returns `nil`
+    /// (never a partial picture) for a timeout, a non-zero exit or non-UTF-8
+    /// output, which is precisely the "the probe itself failed" case.
+    ///
+    /// Only ever reached after a `list-sessions` that did not answer, and
+    /// `reconcileTerminalsWhileLocked` caches `serverPresence` per server name,
+    /// so a sweep pays at most one `ps` per unanswered server.
+    static func probeTmuxServerProcesses() async -> Bool? {
+        guard let snapshot = await OrphanProcessCollector.realProcessSnapshot() else {
+            return nil
+        }
+        return tmuxServerProcessesExist(
+            in: snapshot, uid: getuid(), daemonPID: getpid())
     }
 
     /// Turn a failed `paneSendTargetQuery` into a verdict, given what the
@@ -1271,30 +1491,111 @@ public struct TmuxManager: Sendable {
             }
     }
 
-    /// Check whether a tmux window exists by querying list-panes.
-    public func windowExists(server: String, windowID: String) async -> Bool {
-        if dryRun { return !(dryRunWindowIsDead?(windowID) ?? false) }
-        if let override = realModeWindowExistsOverride?(server, windowID) {
+    /// What one read-only `list-panes -t <window>` consultation says about a
+    /// window: it is there, tmux answered that it is not, or the read failed.
+    ///
+    /// A failure is disambiguated exactly the way `paneSendTarget` does it — by
+    /// a positive, server-wide identity inventory (`allWindowIDsQuery`), never
+    /// by reading tmux's error text. `can't find window` and `no server running
+    /// on …` are the same exit status and differ only in prose, and prose is
+    /// not a machine interface; the inventory's exit status, on the other hand,
+    /// is a fact about the server, and its contents are a fact about the
+    /// window. So: probe failed → `.unreachable`; probe answered without this
+    /// window → `.absent`; probe answered WITH it → `.unreachable`, because a
+    /// window tmux just listed must never be reported gone.
+    public func windowPresence(server: String, windowID: String) async -> TmuxResourcePresence {
+        if dryRun {
+            if let hook = dryRunWindowPresence { return hook(server, windowID) }
+            return (dryRunWindowIsDead?(windowID) ?? false) ? .absent : .present
+        }
+        if let override = realModeWindowPresenceOverride?(server, windowID) {
             return override
         }
         do {
             let args = ["-L", server, "list-panes", "-t", windowID]
             _ = try await runTmux(args)
-            return true
+            return .present
         } catch {
-            return false
+            let inventory = try? await runTmux(Self.allWindowIDsQuery(server: server))
+            let verdict = Self.classifyFailedWindowConsultation(
+                windowInventory: inventory, windowID: windowID)
+            if verdict == .unreachable {
+                let probeOutcome = inventory == nil
+                    ? "the reachability probe also failed"
+                    : "the reachability probe still lists the window"
+                logger.warning("""
+                    windowPresence: could not establish whether window \
+                    \(windowID, privacy: .public) exists on server \(server, privacy: .public) — \
+                    the consultation failed and \(probeOutcome, privacy: .public); reporting \
+                    unreachable rather than absent
+                    """)
+            }
+            return verdict
         }
     }
 
-    /// Check whether a tmux server is running by querying list-sessions.
-    public func serverExists(server: String) async -> Bool {
-        if dryRun { return true }
+    /// What one read-only `list-sessions` consultation says about a tmux
+    /// server, with the failed half decided from outside tmux.
+    ///
+    /// tmux itself offers no way to tell "no server is running under this
+    /// socket name" from "this process resolved a socket path the server is not
+    /// listening on". Both exit 1 from the same command and differ only in the
+    /// prose on stderr, which the bounded-recovery spec forbids reading — and
+    /// the mismatch is not hypothetical: the daemon spawns tmux with
+    /// `environment: nil`, so a `TMUX_TMPDIR` that differs from the shell that
+    /// started the server puts the same `-L <name>` on a different socket file.
+    /// There is no positive probe inside tmux to fall back on the way
+    /// `windowPresence` has one: a server-wide inventory IS this same question,
+    /// and the only command that would answer affirmatively (`start-server`)
+    /// answers by creating the thing it was asked about.
+    ///
+    /// The **process table** is where the distinction does exist, so that is
+    /// what a failed `list-sessions` consults. If no tmux server process is
+    /// running for this uid at all, then nothing is listening on any socket —
+    /// no resolution mismatch can hide a server that does not exist — and the
+    /// verdict is `.absent`. That is the post-reboot case, and it has to
+    /// reclaim: without it every row on every pre-reboot server is parked-proof
+    /// and delete-proof forever, accumulating without bound. If tmux processes
+    /// DO exist, or if the probe could not be taken at all, the verdict is
+    /// `.unreachable` and every destructive rail declines. A failed probe is
+    /// never evidence of absence — that is the whole doctrine here.
+    ///
+    /// See `tmuxServerProcessesExist` for the matching rule and why it is
+    /// deliberately name-agnostic.
+    public func serverPresence(server: String) async -> TmuxResourcePresence {
+        if dryRun { return dryRunServerPresence?(server) ?? .present }
         do {
             let args = ["-L", server, "list-sessions"]
             _ = try await runTmux(args)
-            return true
+            return .present
         } catch {
-            return false
+            let probe: Bool?
+            if let injectedProbe = tmuxServerProcessProbe {
+                probe = await injectedProbe()
+            } else {
+                probe = await Self.probeTmuxServerProcesses()
+            }
+            let verdict = Self.classifyFailedServerConsultation(
+                tmuxServerProcessesExist: probe)
+            switch verdict {
+            case .absent:
+                logger.info("""
+                    serverPresence: no answer from tmux server \(server, privacy: .public) and \
+                    no tmux server process is running for this uid — reporting absent
+                    """)
+            case .unreachable:
+                let reason = probe == nil
+                    ? "the process probe itself failed"
+                    : "tmux server processes are running for this uid"
+                logger.warning("""
+                    serverPresence: no answer from tmux server \(server, privacy: .public) but \
+                    \(reason, privacy: .public) — reporting unreachable rather than absent, so \
+                    nothing is parked or deleted on a read that proved nothing
+                    """)
+            case .present:
+                break
+            }
+            return verdict
         }
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxServerProcessProbeCache.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxServerProcessProbeCache.swift
@@ -1,0 +1,108 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "TmuxServerProcessProbe")
+
+/// One short-lived memo of the machine-global "is any tmux server running for
+/// this uid?" reading, with concurrent askers collapsed onto a single in-flight
+/// reading.
+///
+/// **The answer is a fact about the machine, not about a server.**
+/// `TmuxManager.serverPresence` consults the process table only after a
+/// `list-sessions` that did not answer, and what it asks there is deliberately
+/// name-agnostic — see `TmuxManager.tmuxServerProcessesExist` for why keying on
+/// `-L <name>` would assume the very name-to-socket resolution the probe exists
+/// to doubt. So N unanswered servers in one sweep is one question asked N
+/// times, and each asking is a `/bin/ps -axww` over every process on the box,
+/// bounded at 60 seconds and subject to no concurrency limit of its own. The
+/// post-reboot sweep — where every server is unanswered at once, and which is
+/// the whole reason the probe exists — is precisely when that multiplies.
+///
+/// Two collapses, covering different shapes of the same waste:
+///
+/// - **In flight.** An asker that arrives while a reading is being taken awaits
+///   that reading rather than spawning a second `ps` beside it. This is the arm
+///   that matters under a sweep, where the askers arrive together.
+/// - **Just taken.** An asker that arrives within `freshness` of a completed
+///   reading reuses it.
+///
+/// **Why the window is short, and why the residual risk is closed.** The only
+/// verdict this probe licenses is `.absent`, which is what lets reconcile park
+/// sessions and delete rows, so a memo that outlived the truth of "no tmux
+/// anywhere" would reclaim rows on a machine where tmux had since come back.
+/// For a stale "no tmux processes" to cause harm, ALL of these would have to
+/// hold at once: a tmux server is running, a terminal row points at a window on
+/// it, `list-sessions` for that row's server name still fails, and that server
+/// started within the last `freshness` seconds. A row pointing at a server that
+/// young was created by TBD's own `ensureServer` moments earlier, resolving the
+/// same name the same way in the same process — so its `list-sessions` answers
+/// and the probe is never reached for it. `freshness` is nonetheless kept an
+/// order of magnitude below the interval between reclaiming sweeps
+/// (`AgentReaper` at 60 s, `OrphanGC` hourly), so nothing is ever carried from
+/// one sweep into the next.
+///
+/// **The stamp is taken when the reading LANDS, not when it was asked for.** A
+/// `ps` that took 40 seconds to come back describes a machine 40 seconds ago;
+/// measuring the window from the request would hand that reading a full
+/// `freshness` of additional life on top of however long it was in the air.
+///
+/// `now` is the date seam (`CLAUDE.md`: `Duration` is behavior, `Date` is
+/// data). This type never sleeps, debounces or times out — it stamps a reading
+/// and compares stamps — so it takes a date source rather than a clock.
+actor TmuxServerProcessProbeCache {
+    /// How long a completed reading may stand in for a fresh one.
+    ///
+    /// Sized to cover one sweep of a machine whose servers are all gone (where
+    /// `list-sessions` fails immediately rather than burning its 15 s timeout),
+    /// and to expire many times over between the sweeps that could act on it.
+    static let freshness: TimeInterval = 10
+
+    /// A completed reading and when it landed.
+    ///
+    /// `answer` carries the probe's own optional: `nil` means *the reading could
+    /// not be taken*, which `TmuxManager` maps to `.unreachable` and which is
+    /// never evidence of absence. A failed reading is memoized like any other —
+    /// re-running a `ps` that just failed is no more likely to answer, and the
+    /// verdict it produces protects rows either way.
+    private struct Reading {
+        let answer: Bool?
+        let takenAt: Date
+    }
+
+    private let now: @Sendable () -> Date
+    private var last: Reading?
+    private var inFlight: Task<Bool?, Never>?
+
+    init(now: @escaping @Sendable () -> Date = Date.init) {
+        self.now = now
+    }
+
+    /// The current reading, taking a fresh one with `take` only when neither
+    /// collapse above applies.
+    func reading(taking take: @escaping @Sendable () async -> Bool?) async -> Bool? {
+        if let last {
+            let age = now().timeIntervalSince(last.takenAt)
+            if age < Self.freshness {
+                logger.debug(
+                    "tmux server process probe: reusing a reading \(age, privacy: .public)s old")
+                return last.answer
+            }
+        }
+        if let inFlight {
+            logger.debug("tmux server process probe: joining the reading already in flight")
+            return await inFlight.value
+        }
+
+        // Detached so that one asker's cancellation cannot cancel a reading
+        // every other asker is waiting on, and so the reading does not inherit
+        // whatever priority the first asker happened to have.
+        let pending = Task.detached { await take() }
+        inFlight = pending
+        let answer = await pending.value
+        // Only the task still holding the slot may clear it: a newer reading
+        // may already have replaced this one while this one was in the air.
+        if inFlight == pending { inFlight = nil }
+        last = Reading(answer: answer, takenAt: now())
+        return answer
+    }
+}

--- a/Tests/TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift
@@ -12,21 +12,36 @@ import Testing
 // and touches nothing outside the process.
 
 /// Reboot path (whole tmux server gone) driven end-to-end through
-/// `reconcile(repoID:)`. Proves the #284 fix: terminals are PARKED as
-/// suspended (resumable Claude) or deleted (plain shell) — NOT eagerly
-/// recreated. Recovery is the on-demand Resume button (see #285), so reconcile
-/// must leave the dead server dead.
+/// `reconcile(repoID:)`, against a real tmux. Proves the #284 fix: terminals
+/// are PARKED as suspended (resumable Claude) or deleted (plain shell) — NOT
+/// eagerly recreated. Recovery is the on-demand Resume button (see #285), so
+/// reconcile must leave the dead server dead.
 ///
 /// This needs a REAL `TmuxManager`: `TmuxManager(dryRun: true)` always reports
-/// `serverExists → true`, so it cannot model the post-reboot `serverExists →
-/// false` state this test depends on. We start a real server, capture live
-/// window/pane IDs, then kill the server to simulate the reboot.
+/// the server `.present`, so it cannot model the post-reboot state this test
+/// depends on. We start a real server, capture live window/pane IDs, then kill
+/// the server to simulate the reboot.
+///
+/// **Why the process probe is injected rather than left to run for real.**
+/// `serverPresence` may only answer `.absent` for a server that did not respond
+/// when no tmux server process exists for this uid at all — tmux itself cannot
+/// tell "gone" from "this process resolved a different socket", and the process
+/// table is the only place that distinction exists. A reboot makes that
+/// condition true; a test cannot. This suite starts real tmux servers of its
+/// own, sibling worktrees on a shared box run more, and CI runners are not
+/// guaranteed bare either, so a real probe here would answer "yes, tmux is
+/// running" for reasons that have nothing to do with the server under test and
+/// the assertion would flip with the machine's mood. `tmuxServerProcessProbe`
+/// pins it to the post-reboot fact — no tmux process anywhere — while every
+/// other step, including the kill and the `list-sessions` that fails after it,
+/// stays real. The probe's own three branches are pinned deterministically in
+/// `TBDDaemonTests/TmuxServerPresenceTests`.
 @Test func testReconcileRebootParksClaudeAndDeletesShell() async throws {
     let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
     defer { try? FileManager.default.removeItem(at: tempDir) }
 
     let db = try TBDDatabase(inMemory: true)
-    let realTmux = TmuxManager()
+    let realTmux = TmuxManager(tmuxServerProcessProbe: { false })
     let lifecycle = WorktreeLifecycle(
         db: db, git: GitManager(), tmux: realTmux, hooks: HookResolver()
     )
@@ -35,7 +50,7 @@ import Testing
         path: repoDir.path, displayName: "test", defaultBranch: "main"
     )
     // reconcile derives the server name from the repo path, so the worktree row
-    // must use the same name for the serverExists probe to match.
+    // must use the same name for the serverPresence probe to match.
     let serverName = TmuxManager.serverName(forRepoPath: repo.path)
 
     // A worktree whose path == the repo path is reported by `git worktree
@@ -66,10 +81,14 @@ import Testing
         tmuxWindowID: shellWindow.windowID, tmuxPaneID: shellWindow.paneID
     )
 
-    // Simulate the reboot: the whole server is gone, so serverExists → false.
+    // Simulate the reboot: the whole server is gone. `list-sessions` really
+    // fails; the pinned probe supplies the out-of-tmux half — no tmux server
+    // process exists — which is what makes the verdict `.absent` rather than
+    // the row-protecting `.unreachable`.
     try await realTmux.killServer(server: serverName)
-    let aliveAfterKill = await realTmux.serverExists(server: serverName)
-    #expect(!aliveAfterKill, "precondition: server must be gone to model a reboot")
+    let presenceAfterKill = await realTmux.serverPresence(server: serverName)
+    #expect(presenceAfterKill == .absent,
+            "precondition: a killed server with no tmux process left must read as absent")
 
     do {
         try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
@@ -81,13 +100,14 @@ import Testing
     let claudeAfter = try await db.terminals.get(id: claudeTerminal.id)
     let shellAfter = try await db.terminals.get(id: shellTerminal.id)
     // Was the dead server resurrected by an eager recreate? (The bug.)
-    let serverAliveAfter = await realTmux.serverExists(server: serverName)
+    let serverPresenceAfter = await realTmux.serverPresence(server: serverName)
     try? await realTmux.killServer(server: serverName)
 
     // Resumable Claude session: parked, not recreated, not deleted.
     #expect(claudeAfter != nil, "claude terminal must NOT be deleted on reboot")
     #expect(claudeAfter?.isParked == true, "claude terminal must be parked (resumable via wake)")
-    #expect(claudeAfter?.claudeSessionID == sessionID, "session ID must be preserved for on-demand resume")
+    #expect(claudeAfter?.claudeSessionID == sessionID,
+            "session ID must be preserved for on-demand resume")
     // The window/pane IDs must NOT have been replaced — reconcile does not spawn
     // a new window on the reboot path anymore.
     #expect(claudeAfter?.tmuxWindowID == claudeWindow.windowID,
@@ -98,7 +118,7 @@ import Testing
 
     // CRUCIAL #284 invariant: reconcile must not have bootstrapped the dead
     // server to recreate windows. No mass `claude --resume` storm on reboot.
-    #expect(!serverAliveAfter,
+    #expect(serverPresenceAfter != .present,
             "reconcile must leave the dead server dead — no eager mass-recreate (#284)")
 }
 
@@ -239,14 +259,17 @@ func testReconcileDeadWindowLiveClaudeNotParked() async throws {
     let db = try TBDDatabase(inMemory: true)
 
     // Create a TmuxManager with seams to:
-    // 1. Force windowExists to return false for the test window
+    // 1. Force the window probe to report the test window POSITIVELY absent —
+    //    tmux answered on a reachable server — which is the only verdict that
+    //    reaches the park path at all
     // 2. Return a Claude version string when paneCurrentCommand is called
-    // This simulates the safety check scenario: window reports dead, but
+    // This simulates the safety check scenario: window reports gone, but
     // Claude process is still running.
     let tmux = TmuxManager(
-        realModeWindowExistsOverride: { server, windowID in
+        realModeWindowPresenceOverride: { server, windowID in
             if windowID == "@live-claude-window" {
-                return false  // Simulate dead window
+                // Simulate a window tmux answered about and does not have.
+                return TmuxResourcePresence.absent
             }
             return nil
         },
@@ -292,7 +315,7 @@ func testReconcileDeadWindowLiveClaudeNotParked() async throws {
     try? await tmux.killServer(server: serverName)
 
     // The safety check at WorktreeLifecycle+Reconcile.swift:272-279 should detect
-    // that a Claude process is still running in the pane despite windowExists returning false.
+    // that a Claude process is still running in the pane despite the window probe reporting absence.
     // Result: the terminal should NOT be parked (the safety check skips parking).
     #expect(afterReconcile != nil, "Claude terminal must NOT be deleted or parked when live claude is detected")
     #expect(afterReconcile?.isParked == false, "Claude terminal must NOT be parked — the safety check detected live claude process")

--- a/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
@@ -316,7 +316,7 @@ struct ActuationLogWiringTests {
     /// what the daemon actually did.
     @Test("a wake at a vanished pane records not-found, not the benign no-op")
     func wakeAtMissingPaneRecordsNotFound() async throws {
-        let fixture = try makeFixture(paneTarget: { _, _ in .missing })
+        let fixture = try makeFixture(paneTarget: { _, _ in .absent })
         let worktree = try await makeWorktree(in: fixture.db)
         let terminal = try await fixture.db.terminals.create(
             worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")

--- a/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
@@ -98,7 +98,7 @@ import TestSupport
     /// successful no-op. It carries a machine-readable code so an autonomous
     /// caller can branch without matching message text.
     @Test func wakeOnUnparkedRowWithNoPaneIsAnErrorNotASilentNoOp() async throws {
-        let (router, db) = try makeRouter(paneTarget: { _, _ in .missing })
+        let (router, db) = try makeRouter(paneTarget: { _, _ in .absent })
         let terminal = try await makeUnparkedTerminal(db, tag: "repoW")
 
         let req = try RPCRequest(
@@ -155,7 +155,7 @@ import TestSupport
     /// routes through the same coordinator, so a silent no-op here would be the
     /// original bug surviving at the other entry point.
     @Test func legacyResumeOnUnparkedRowWithNoPaneIsAnErrorNotASilentNoOp() async throws {
-        let (router, db) = try makeRouter(paneTarget: { _, _ in .missing })
+        let (router, db) = try makeRouter(paneTarget: { _, _ in .absent })
         let terminal = try await makeUnparkedTerminal(db, tag: "repoW5")
 
         let req = try RPCRequest(

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -1130,12 +1130,19 @@ extension TBDHomeSerialized {
                 "a pane that agrees it is this terminal must be nudged")
         }
 
-        /// A consultation that cannot be RUN at all is not an answer about the
-        /// pane. The candidate is dropped, matching how the sibling
-        /// `paneCurrentCommand` check already treats a wedged server (`try?` →
-        /// skip). Skipping costs one tick; pasting into a pane nobody could
-        /// look at is the thing the check exists to stop.
-        @Test("a pane whose identity cannot be read is not nudged")
+        /// The thrown twin of `testUnreachableServerDoesNotReplaceTheDeskAgent`,
+        /// below — same rail, same verdict, different way of learning nothing. A
+        /// consultation that could not be RUN at all (a wedged tmux tripping the
+        /// subprocess timeout) is no more an answer about the pane than one that
+        /// ran and reached no server, and on this rail dropping a candidate is
+        /// destructive rather than merely quiet. With this row the SOLE
+        /// candidate, excluding it makes `nudgeDeskSession` spawn a replacement
+        /// agent onto a desk that may be perfectly alive, and
+        /// `leasedJudgeTerminal` revoke the live judge's lease. So the pass
+        /// aborts instead, and spawn recovery is deliberately left ENABLED here
+        /// (unlike the exclusion tests above) because "the desk was never
+        /// touched" is the whole property under test.
+        @Test("a pane whose identity cannot be read is not nudged, replaced, or unleased")
         func testNudgeSkipsPaneWhoseIdentityCannotBeRead() async throws {
             let f = try makeDeskFixture(tag: "nudge-wedged")
             defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
@@ -1143,15 +1150,35 @@ extension TBDHomeSerialized {
             let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
             let seeded = try await f.db.terminals.list(worktreeID: desk.id)
             let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+            let rowsBefore = seeded.count
+
+            // A live judge holds the lease, so "the lease survived" is a fact
+            // the pass could destroy rather than one that was never true.
+            let acquiredAt = Date()
+            let lease = try await f.db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: claude.id, now: acquiredAt)
 
             f.identities.markUnreachable(claude.tmuxPaneID)
-            f.spawnFailures.setFailing(true)
 
             let before = f.recorder.pastedPanes.count
             await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
 
             let targets = Array(f.recorder.pastedPanes.dropFirst(before))
             #expect(targets.isEmpty, "an unverifiable pane must receive nothing, got \(targets)")
+
+            let rowsAfter = try await f.db.terminals.list(worktreeID: desk.id)
+            #expect(rowsAfter.count == rowsBefore,
+                    "a failed read must not spawn a replacement desk agent")
+            // And the row it could not read is left exactly where it was.
+            #expect(rowsAfter.contains { $0.id == claude.id })
+
+            let after = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+            #expect(after.terminalID == claude.id,
+                    "a failed read must not fence the lease owner")
+            #expect(after.generation == lease.generation,
+                    "a failed read must not bump the lease generation")
+            #expect(after.isValid(at: acquiredAt),
+                    "a failed read must not revoke a valid lease")
         }
 
         /// The defect, on the rail where "not a candidate" is destructive. A

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -27,21 +27,35 @@ private final class DeskTmuxRecorder: @unchecked Sendable {
     }
 }
 
-/// Mutable set of tmux windows that `windowExists` should report as gone. Mutable rather
-/// than a fixed closure because one test has to *revive* a desk mid-flight to prove a
-/// failed nudge didn't start the overlap cooldown.
+/// Mutable set of tmux windows `windowPresence` should report as gone, plus the
+/// separate set whose READ fails. Mutable rather than a fixed closure because
+/// one test has to *revive* a desk mid-flight to prove a failed nudge didn't
+/// start the overlap cooldown.
+///
+/// The two sets are deliberately different facts: a dead window is tmux
+/// answering, an unreadable one is tmux never being reached — and on this rail
+/// they must produce opposite behaviour (reclaim versus abort the pass).
 private final class DeadWindows: @unchecked Sendable {
     private let lock = NSLock()
     private var dead: Set<String> = []
+    private var unreadable: Set<String> = []
 
     func markDead(_ windowID: String) {
         lock.lock(); defer { lock.unlock() }
         dead.insert(windowID)
     }
 
-    func isDead(_ windowID: String) -> Bool {
+    /// The window's probe fails to reach any server — nothing is learned about
+    /// the window, which may well still be running an agent.
+    func markUnreadable(_ windowID: String) {
         lock.lock(); defer { lock.unlock() }
-        return dead.contains(windowID)
+        unreadable.insert(windowID)
+    }
+
+    func presence(for windowID: String) -> TmuxResourcePresence {
+        lock.lock(); defer { lock.unlock() }
+        if unreadable.contains(windowID) { return .unreachable }
+        return dead.contains(windowID) ? .absent : .present
     }
 }
 
@@ -911,7 +925,7 @@ extension TBDHomeSerialized {
                 tmux: TmuxManager(
                     dryRun: true,
                     dryRunRecorder: { recorder.record($0) },
-                    dryRunWindowIsDead: { dead.isDead($0) },
+                    dryRunWindowPresence: { _, windowID in dead.presence(for: windowID) },
                     dryRunPaneCurrentCommand: { _, paneID in commands.command(for: paneID) },
                     dryRunPaneSendTarget: { _, paneID in try identities.answer(for: paneID) }
                 ),
@@ -1337,7 +1351,7 @@ extension TBDHomeSerialized {
                 tmux: TmuxManager(
                     dryRun: true,
                     dryRunRecorder: { f.recorder.record($0) },
-                    dryRunWindowIsDead: { f.dead.isDead($0) },
+                    dryRunWindowPresence: { _, windowID in f.dead.presence(for: windowID) },
                     dryRunPaneCurrentCommand: { _, pane in f.commands.command(for: pane) }),
                 skillDir: f.home.appendingPathComponent("skills/nightwatch").path, actuationLog: makeTestActuationLog())
             _ = try await laterManager.ensureDeskSession(mode: .nightwatch)
@@ -1375,7 +1389,7 @@ extension TBDHomeSerialized {
                 tmux: TmuxManager(
                     dryRun: true,
                     dryRunRecorder: { f.recorder.record($0) },
-                    dryRunWindowIsDead: { f.dead.isDead($0) },
+                    dryRunWindowPresence: { _, windowID in f.dead.presence(for: windowID) },
                     dryRunPaneCurrentCommand: { _, pane in f.commands.command(for: pane) }),
                 skillDir: f.home.appendingPathComponent("skills/nightwatch").path, actuationLog: makeTestActuationLog())
             _ = try await laterManager.ensureDeskSession(mode: .nightwatch)
@@ -1384,6 +1398,61 @@ extension TBDHomeSerialized {
             let recovered = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
             #expect(recovered.terminalID == successor.id)
             #expect(recovered.generation == first.generation + 1)
+        }
+
+        /// The same setup as `deadOwnerRecovery` with one fact changed: the
+        /// owner's window is UNREADABLE rather than dead. Nothing about that
+        /// window has been established, so none of the actions that recovery
+        /// performs may fire — the lease must not move to the successor, its
+        /// generation must not bump, and the judge prompt must not be pasted
+        /// anywhere. Fencing a live judge and anointing a second one on the
+        /// strength of a failed read is exactly the duplicate-desk incident this
+        /// rail exists to avoid, and it is the destructive twin of the assertion
+        /// above: same fixture, opposite verdict.
+        @Test("an unreadable owner window neither moves the judge lease nor pastes")
+        func unreadableOwnerWindowKeepsTheLease() async throws {
+            let f = try makeDeskFixture(tag: "judge-owner-unreadable")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .nightwatch)
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            let first = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+            let owner = try #require(try await f.db.terminals.get(id: first.terminalID))
+            f.dead.markUnreadable(owner.tmuxWindowID)
+            let successor = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@successor", tmuxPaneID: "%successor",
+                label: TerminalLabel.claudeCode, kind: .claude)
+            let rowsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
+
+            // A second manager, as in the sibling test, so the ten-minute nudge
+            // overlap does not hide the behaviour. It deliberately does NOT run
+            // `ensureDeskSession` first: that call would itself abort on the
+            // unreadable window, which is the same property under test one
+            // surface earlier, and `nudgeDeskSession` takes its worktree by id.
+            let laterManager = DeskSessionManager(
+                db: f.db,
+                lifecycle: WorktreeLifecycle(
+                    db: f.db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+                tmux: TmuxManager(
+                    dryRun: true,
+                    dryRunRecorder: { f.recorder.record($0) },
+                    dryRunWindowPresence: { _, windowID in f.dead.presence(for: windowID) },
+                    dryRunPaneCurrentCommand: { _, pane in f.commands.command(for: pane) }),
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path,
+                actuationLog: makeTestActuationLog())
+            let pastedBefore = f.recorder.pastedPanes.count
+            await laterManager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            let after = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+            #expect(after.terminalID == owner.id,
+                    "a failed read must not fence the lease owner")
+            #expect(after.terminalID != successor.id)
+            #expect(after.generation == first.generation,
+                    "a failed read must not bump the lease generation")
+            #expect(Array(f.recorder.pastedPanes.dropFirst(pastedBefore)).isEmpty,
+                    "nothing may be pasted on a pass that could not read its candidates")
+            #expect(try await f.db.terminals.list(worktreeID: desk.id).count == rowsBefore,
+                    "a failed read must not spawn a replacement desk agent")
         }
     }
 }

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -84,8 +84,10 @@ private final class PaneIdentities: @unchecked Sendable {
         answers[paneID] = target
     }
 
-    /// Make the consultation itself fail for a pane — a wedged tmux, not an
-    /// answer about the pane.
+    /// Make the consultation itself fail for a pane — a wedged tmux tripping
+    /// the subprocess timeout, not an answer about the pane. Distinct from
+    /// `set(.unreachable, for:)`, where the consultation RAN and reached no
+    /// server; both are non-answers, and the rail must survive either.
     func markUnreachable(_ paneID: String) {
         lock.lock(); defer { lock.unlock() }
         unreachable.insert(paneID)
@@ -1136,6 +1138,38 @@ extension TBDHomeSerialized {
 
             let targets = Array(f.recorder.pastedPanes.dropFirst(before))
             #expect(targets.isEmpty, "an unverifiable pane must receive nothing, got \(targets)")
+        }
+
+        /// The defect, on the rail where "not a candidate" is destructive. A
+        /// consultation that RAN and reached no tmux server says nothing about
+        /// the pane — but an empty candidate list here is an ACTION, not a
+        /// silence: `nudgeDeskSession` spawns a replacement agent onto what may
+        /// be a perfectly live desk. So the pass aborts instead of concluding
+        /// absence, and spawn recovery is deliberately left ENABLED here (unlike
+        /// the sibling tests above) because "it was never reached" is the whole
+        /// property under test.
+        @Test("an unreachable server neither nudges nor replaces the desk agent")
+        func testUnreachableServerDoesNotReplaceTheDeskAgent() async throws {
+            let f = try makeDeskFixture(tag: "nudge-unreachable")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+            let rowsBefore = seeded.count
+
+            f.identities.set(.unreachable, for: claude.tmuxPaneID)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            let targets = Array(f.recorder.pastedPanes.dropFirst(before))
+            #expect(targets.isEmpty, "an unreadable pane must receive nothing, got \(targets)")
+            let rowsAfter = try await f.db.terminals.list(worktreeID: desk.id)
+            #expect(rowsAfter.count == rowsBefore,
+                    "a failed read must not spawn a replacement desk agent")
+            // And the row it could not read is left exactly where it was.
+            #expect(rowsAfter.contains { $0.id == claude.id })
         }
 
         /// `postShiftWrapUp` reaches the same candidate list on the same timer,

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -387,7 +387,7 @@ struct HibernationCoordinatorTests {
     /// live session made without ever asking tmux.
     @Test func wakeOnUnparkedRowWithMissingPaneReportsSessionGone() async throws {
         let (db, _, terminalID) = try await setup()
-        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in .missing })
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in .absent })
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
@@ -431,7 +431,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) },
-                               dryRunPaneSendTarget: { _, _ in .missing })
+                               dryRunPaneSendTarget: { _, _ in .absent })
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
@@ -457,6 +457,38 @@ struct HibernationCoordinatorTests {
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
         #expect(await coord.wake(terminalID: terminalID) == .notHibernated)
+    }
+
+    /// A consultation that RAN and reached no tmux server is not a
+    /// disagreement: nothing answered, so nothing disagreed. Reporting
+    /// `.sessionGone` would tell the caller its live session is gone on the
+    /// strength of a failed read — the exact conflation this change removes.
+    @Test func unreachableServerIsNotReportedAsSessionGone() async throws {
+        let (db, _, terminalID) = try await setup()
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in .unreachable })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let result = await coord.wake(terminalID: terminalID)
+        #expect(result == .paneUnreadable(paneID: "%0", server: "tbd-hib"))
+        // Named explicitly, because "not sessionGone" is the whole property and
+        // a future refactor could reintroduce it through a different detail.
+        if case .sessionGone = result {
+            Issue.record("an unreachable server must never be reported as sessionGone")
+        }
+        // And the row is left exactly as it was — reporting, never repairing.
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == false)
+        #expect(after?.tmuxPaneID == "%0")
+    }
+
+    /// The record must not claim a refusal either: nothing was decided, the
+    /// transport simply did not answer.
+    @Test func unreachableServerWakeIsRecordedAsTransportFailure() {
+        #expect(ActuationOutcome.classify(
+            WakeResult.paneUnreadable(paneID: "%0", server: "tbd-hib")) == .transportFailed)
+        #expect(ActuationOutcome.classify(
+            WakeResult.paneUnreadable(paneID: "%0", server: "tbd-hib")).reason == nil)
     }
 
     /// A live pane carrying no identity is left alone — refusal requires
@@ -490,7 +522,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
         let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true },
-                               dryRunPaneSendTarget: { _, _ in .missing })
+                               dryRunPaneSendTarget: { _, _ in .absent })
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
@@ -1426,6 +1458,35 @@ struct RPCRouterWakePromptDeliveryTests {
         #expect(try resp.decodeResult(TerminalWakeResult.self).woken == false)
         #expect(recorded.snapshot().isEmpty,
                 "a no-op wake must not touch tmux at all; got: \(recorded.snapshot())")
+    }
+
+    /// An unreachable tmux server: the RPC must report an error (the prompt
+    /// went nowhere, so `woken: false` would let an autonomous caller believe
+    /// it was merely already awake) WITHOUT claiming the session is gone. In
+    /// particular it must not carry `terminalSessionGone`, whose contract is a
+    /// pane that positively disagreed.
+    @Test func wakeOnUnreachableServerErrorsWithoutClaimingSessionGone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true, dryRunRecorder: { recorded.append($0) },
+            dryRunPaneSendTarget: { _, _ in .unreachable })
+        let terminal = try await makeTerminal(db: db)  // NOT hibernated
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id, prompt: "must never appear"))
+        let resp = await makeRouter(db: db, tmux: tmux).handle(req)
+
+        #expect(!resp.success)
+        let error = try #require(resp.error)
+        #expect(error.contains("Could not reach tmux server"))
+        #expect(error.contains("tbd-wake-prompt"))
+        #expect(error.contains("%0"))
+        #expect(!error.contains("is gone"))
+        #expect(resp.errorCode != RPCErrorCode.terminalSessionGone.rawValue)
+        #expect(recorded.snapshot().isEmpty,
+                "a failed read must not touch tmux; got: \(recorded.snapshot())")
     }
 }
 

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -591,7 +591,7 @@ struct HibernationCoordinatorTests {
     // A reboot destroys every tmux server, leaving parked rows pointing at
     // dead windows. Wake must detect the dead window and RECREATE it (server +
     // window) instead of failing "Terminal not found". Both sides of the
-    // `windowExists` gate are covered.
+    // `windowPresence` gate are covered.
 
     /// Window ALIVE (dryRun default): the existing respawn-in-place path runs
     /// unchanged — same window/pane ids, `respawn-window` issued, never
@@ -651,7 +651,7 @@ struct HibernationCoordinatorTests {
                 "expected new-window in the worktree cwd carrying claude --resume; got: \(joined)")
         #expect(!joined.contains { $0.contains("respawn-window") },
                 "a dead window must NOT be respawned into; got: \(joined)")
-        // Old-window cleanup: a transient windowExists misclassification must
+        // Old-window cleanup: a transient windowPresence misclassification must
         // not leak a live old window (usually already dead — kill no-ops).
         #expect(joined.contains { $0.contains("kill-window") && $0.contains("@0") },
                 "expected a best-effort kill of the old window; got: \(joined)")
@@ -659,14 +659,50 @@ struct HibernationCoordinatorTests {
                 "onServerCreated must fire once with the recreated server name")
     }
 
+    /// Window UNREADABLE: neither branch may run. Respawn-in-place would fire
+    /// `respawn-window -k` into a window nobody could look at — killing whatever
+    /// is running there — and the recreate branch would kill it outright and
+    /// spawn a duplicate `claude --resume` beside the live one. So wake mutates
+    /// nothing, leaves the row parked, and reports the failure so a later retry
+    /// can ask again.
+    @Test func wakeLeavesTheRowParkedWhenTheWindowCannotBeRead() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorded.append($0) },
+            dryRunWindowPresence: { _, windowID in windowID == "@0" ? .unreachable : .present }
+        )
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
+
+        let wake = await coord.wake(terminalID: terminalID)
+        guard case .respawnFailed(let reason) = wake else {
+            Issue.record("expected .respawnFailed, got \(wake) — an unreadable window must not wake")
+            return
+        }
+        #expect(reason.contains("could not reach tmux server"))
+
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == true, "the row must stay parked and resumable")
+        #expect(after?.tmuxWindowID == "@0", "no coordinate may be rewritten on a failed read")
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(!joined.contains { $0.contains("respawn-window") },
+                "an unreadable window must not be respawned into; got: \(joined)")
+        #expect(!joined.contains { $0.contains("new-window") },
+                "an unreadable window must not be replaced; got: \(joined)")
+        #expect(!joined.contains { $0.contains("kill-window") },
+                "an unreadable window must not be killed; got: \(joined)")
+    }
+
     // MARK: - Wake: window-id ownership (post-reboot id recycling)
     //
     // A fresh tmux server reissues window ids from @1, so a stale parked
     // row's id can equal a window ANOTHER terminal's wake just created.
-    // `windowExists` alone is not ownership — both sides of the claim gate
+    // `windowPresence` alone is not ownership — both sides of the claim gate
     // are covered.
 
-    /// Collision + windowExists true: another terminal on the same server
+    /// Collision + a present window: another terminal on the same server
     /// claims this row's window id, so respawning in place would hijack that
     /// terminal's live session. Wake must take the RECREATE branch — and must
     /// NOT kill the other terminal's window.
@@ -1061,7 +1097,7 @@ struct HibernationCoordinatorTests {
 
     /// `reconcileOnStartup` clears a stale parked timestamp for a terminal whose
     /// claude is actually still alive (daemon crashed mid-park). Uses the
-    /// paneCurrentCommand hook to report a live claude and windowExists (default
+    /// paneCurrentCommand hook to report a live claude and windowPresence (default
     /// dryRun = alive). Covers BOTH the authoritative and legacy columns via
     /// `clearHibernated` nulling both.
     @Test func reconcileOnStartupClearsStaleParkedForLiveClaude() async throws {

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -184,7 +184,7 @@ struct FakeInspector: PaneProcessInspecting {
     }
 
     @Test func vanishedPaneIsTerminalGone() async throws {
-        tmux.paneTarget = .missing
+        tmux.paneTarget = .absent
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .terminalGone)
         #expect(tmux.sends.isEmpty)
@@ -196,6 +196,22 @@ struct FakeInspector: PaneProcessInspecting {
         tmux.paneTarget = .dead(terminalID: terminalID.uuidString)
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .terminalGone)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    /// `.terminalGone` CANCELS the scheduled resume, permanently. Doing that
+    /// because no tmux server answered would throw away a pending resume for a
+    /// session that is very likely still running, so an unreachable server
+    /// fails the attempt (retryable) instead of cancelling the row.
+    @Test func unreachableServerDoesNotCancelTheResume() async throws {
+        tmux.paneTarget = .unreachable
+        let outcome = await makeActuator().actuate(row)
+        guard case .failed(let message) = outcome else {
+            Issue.record("expected .failed, got \(outcome) — an unreachable server must not cancel")
+            return
+        }
+        #expect(message.contains("could not reach tmux server"))
+        #expect(outcome != .terminalGone)
         #expect(tmux.sends.isEmpty)
     }
 

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -10,7 +10,10 @@ struct FakeTmuxSendError: Error {}
 /// Records every tmux call; scriptable pane state.
 final class FakeResumeTmux: ResumeSendingTmux, @unchecked Sendable {
     private let queue = DispatchQueue(label: "FakeResumeTmux")
-    var windowAlive = true
+    /// What the window probe answers. Three-valued, because the actuator has
+    /// three different behaviours: fire, cancel the row, and refuse to touch
+    /// the row at all.
+    var windowPresenceValue: TmuxResourcePresence = .present
     var inMode = false
     /// When non-empty, `paneInMode` pops values off the front (in call
     /// order) before falling back to `inMode` — scripts a value that
@@ -25,7 +28,9 @@ final class FakeResumeTmux: ResumeSendingTmux, @unchecked Sendable {
     private var _escapeCount = 0
     var sends: [String] { queue.sync { _sends } }
 
-    func windowExists(server: String, windowID: String) async -> Bool { windowAlive }
+    func windowPresence(server: String, windowID: String) async -> TmuxResourcePresence {
+        windowPresenceValue
+    }
     func paneInMode(server: String, paneID: String) async throws -> Bool {
         queue.sync {
             if !inModeSequence.isEmpty { return inModeSequence.removeFirst() }
@@ -142,15 +147,33 @@ struct FakeInspector: PaneProcessInspecting {
     }
 
     @Test func deadWindowIsTerminalGone() async throws {
-        tmux.windowAlive = false
+        tmux.windowPresenceValue = .absent
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .terminalGone)
+    }
+
+    /// `.terminalGone` cancels the row SILENTLY, on the claim that the terminal
+    /// is gone. A window probe that could not reach any tmux server has not
+    /// established that, and this actuator types unattended, so the failed read
+    /// must not be the thing that ends a resume without a word. `.failed`
+    /// carries the reason to the user instead.
+    @Test func unreachableWindowProbeDoesNotCancelSilently() async throws {
+        tmux.windowPresenceValue = .unreachable
+        let outcome = await makeActuator().actuate(row)
+        guard case .failed(let message) = outcome else {
+            Issue.record(
+                "expected .failed, got \(outcome) — an unreadable window must not cancel silently")
+            return
+        }
+        #expect(message.contains("could not reach tmux server"))
+        #expect(message.contains("window"))
+        #expect(tmux.sends.isEmpty)
     }
 
     // MARK: - Pane target consultation (eligibility step 1a)
     //
     // The auto-resume actuator is the component issue #384 caught typing into
-    // a stranger: `windowExists` proves a window id resolves, never that the
+    // a stranger: `windowPresence` proves a window id resolves, never that the
     // pane still belongs to this terminal. Same rule as `terminal.send` —
     // only a POSITIVE disagreement refuses.
 
@@ -199,15 +222,19 @@ struct FakeInspector: PaneProcessInspecting {
         #expect(tmux.sends.isEmpty)
     }
 
-    /// `.terminalGone` CANCELS the scheduled resume, permanently. Doing that
-    /// because no tmux server answered would throw away a pending resume for a
-    /// session that is very likely still running, so an unreachable server
-    /// fails the attempt (retryable) instead of cancelling the row.
-    @Test func unreachableServerDoesNotCancelTheResume() async throws {
+    /// `.terminalGone` cancels the scheduled resume SILENTLY, asserting the
+    /// terminal is gone. An unreachable server has asserted nothing, and the
+    /// session is very likely still running. Both statuses end the row —
+    /// nothing re-fires a resume once it leaves `pending` — so what changes is
+    /// the honesty of the record and the notification the user gets: `.failed`
+    /// says why, where a silent cancellation would claim a terminal died on the
+    /// strength of a read that never landed.
+    @Test func unreachableServerDoesNotCancelSilently() async throws {
         tmux.paneTarget = .unreachable
         let outcome = await makeActuator().actuate(row)
         guard case .failed(let message) = outcome else {
-            Issue.record("expected .failed, got \(outcome) — an unreachable server must not cancel")
+            Issue.record(
+                "expected .failed, got \(outcome) — an unreachable server must not cancel silently")
             return
         }
         #expect(message.contains("could not reach tmux server"))

--- a/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
@@ -27,7 +27,16 @@ struct OrphanGCDeletionQueueTests {
             liveCWDsProvider: { [] },
             scratchpadBase: nil,
             now: now,
-            beforeInterruptedArchiveReap: beforeInterruptedArchiveReap
+            beforeInterruptedArchiveReap: beforeInterruptedArchiveReap,
+            // Injected empty rather than defaulted. `sweep(dryRun: true)`
+            // reaches the orphan-process phase regardless of
+            // `gcOrphanProcessesEnabled`, and the default provider is the real
+            // `/bin/ps -axww` over every process on the machine — a subprocess
+            // this suite has no business spawning (`Tests/CLAUDE.md`: prefer the
+            // injection seam). Behaviour-preserving: `liveCWDsProvider` is empty
+            // too, so every pid's cwd is unreadable and the phase already plans
+            // nothing.
+            processSnapshotProvider: { [] }
         )
     }
 

--- a/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCProfileDirTests.swift
@@ -80,7 +80,16 @@ struct OrphanGCProfileDirTests: ~Copyable {
             beforeInterruptedArchiveReap: nil,
             profileDirBase: profileBase,
             credentialsKeychain: keychain,
-            beforeProfileDirReap: beforeProfileDirReap
+            beforeProfileDirReap: beforeProfileDirReap,
+            // Injected empty rather than defaulted. `sweep(dryRun: true)`
+            // reaches the orphan-process phase regardless of
+            // `gcOrphanProcessesEnabled`, and the default provider is the real
+            // `/bin/ps -axww` over every process on the machine — a subprocess
+            // this suite has no business spawning (`Tests/CLAUDE.md`: prefer the
+            // injection seam). Behaviour-preserving: `liveCWDsProvider` is empty
+            // too, so every pid's cwd is unreadable and the phase already plans
+            // nothing.
+            processSnapshotProvider: { [] }
         )
     }
 

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -51,9 +51,18 @@ struct OrphanGCTests {
             db: db,
             git: git,
             broadcast: { broadcaster.append($0) },
-            lsofProvider: { [] },
+            liveCWDsProvider: { [] },
             scratchpadBase: scratchpadBase,
-            now: now
+            now: now,
+            // Injected empty rather than defaulted. `sweep(dryRun: true)`
+            // reaches the orphan-process phase regardless of
+            // `gcOrphanProcessesEnabled`, and the default provider is the real
+            // `/bin/ps -axww` over every process on the machine — a subprocess
+            // this suite has no business spawning (`Tests/CLAUDE.md`: prefer the
+            // injection seam). Behaviour-preserving: `liveCWDsProvider` is empty
+            // too, so every pid's cwd is unreadable and the phase already plans
+            // nothing.
+            processSnapshotProvider: { [] }
         )
     }
 

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -39,12 +39,77 @@ struct PaneSendTargetQueryTests {
     /// `display-message -p` prints an empty line and exits 0 for a pane that is
     /// gone, so it cannot distinguish "vanished" from "healthy". `list-panes`
     /// exits non-zero with `can't find pane`. The builder must stay on
-    /// `list-panes` for the missing-pane branch to exist at all.
+    /// `list-panes` for the absent-pane branch to exist at all.
     @Test("the target query uses list-panes, not display-message")
     func queryUsesListPanes() {
         let args = TmuxManager.paneSendTargetQuery(server: "tbd-acme", paneID: "%7")
         #expect(args.contains("list-panes"))
         #expect(!args.contains("display-message"))
+    }
+
+    // MARK: - The reachability probe
+
+    /// Pinned exactly, like `paneSendTargetQuery` above and for the same
+    /// reason: this argv is the whole basis on which a failed consultation is
+    /// allowed to conclude "the pane is gone". A drift into a usage error would
+    /// make the probe fail for a reason unrelated to reachability, and every
+    /// failed consultation would silently become `.unreachable`.
+    @Test("the reachability probe asks one server-wide list-panes for pane ids")
+    func probeShape() {
+        #expect(TmuxManager.allPaneIDsQuery(server: "tbd-acme")
+            == ["-L", "tbd-acme", "list-panes", "-a", "-F", "#{pane_id}"])
+    }
+
+    /// `-a` is load-bearing: a target-scoped probe would fail for both of the
+    /// reasons this split exists to tell apart, and would prove nothing.
+    @Test("the reachability probe names no target")
+    func probeIsServerWide() {
+        let args = TmuxManager.allPaneIDsQuery(server: "tbd-acme")
+        #expect(args.contains("-a"))
+        #expect(!args.contains("-t"))
+    }
+
+    /// THE REGRESSION: a live pane must never be reported missing. The
+    /// consultation failed, but the server answered the probe and listed the
+    /// pane — so the failure was transient, and the one verdict that must not
+    /// come out of it is absence.
+    @Test("a pane the probe still lists is never reported as absent")
+    func failedConsultationWithLivePaneIsUnreachable() {
+        #expect(TmuxManager.classifyFailedConsultation(
+            paneInventory: "%1\n%265\n%9\n", paneID: "%265") == .unreachable)
+    }
+
+    /// The other half: the reconciler must still be able to reclaim. A server
+    /// that answered and does not list the pane is positive evidence of absence.
+    @Test("a pane a reachable server does not list is absent")
+    func failedConsultationWithReachableServerIsAbsent() {
+        #expect(TmuxManager.classifyFailedConsultation(
+            paneInventory: "%1\n%9\n", paneID: "%265") == .absent)
+        // A server with no panes at all still ANSWERED, so this is still
+        // absence rather than a failed read.
+        #expect(TmuxManager.classifyFailedConsultation(
+            paneInventory: "", paneID: "%265") == .absent)
+    }
+
+    /// Two failed reads in a row are still two failed reads. Nothing about the
+    /// pane has been established, so nothing may be claimed about it — this is
+    /// the "no server on that socket" case the old code called `.missing`.
+    @Test("a probe that also fails proves nothing and stays unreachable")
+    func failedProbeIsUnreachable() {
+        #expect(TmuxManager.classifyFailedConsultation(
+            paneInventory: nil, paneID: "%265") == .unreachable)
+    }
+
+    /// The inventory is matched whole, exactly as `parsePaneSendTarget` matches
+    /// its lines: `%1` listed must not answer for `%12`, or a genuinely absent
+    /// pane would be excused as unreachable forever and never reclaimed.
+    @Test("the probe's inventory is matched whole, not by prefix")
+    func probeInventoryMatchIsExact() {
+        #expect(TmuxManager.paneInventoryLists("%12\n", paneID: "%1") == false)
+        #expect(TmuxManager.paneInventoryLists("%12\n", paneID: "%12"))
+        #expect(TmuxManager.paneInventoryLists("  %12  \n", paneID: "%12"))
+        #expect(TmuxManager.classifyFailedConsultation(
+            paneInventory: "%12\n", paneID: "%1") == .absent)
     }
 
     @Test("the stamp command sets the pane-scoped option on the given target")
@@ -137,14 +202,14 @@ struct PaneSendTargetQueryTests {
     @Test("pane ids are compared whole, not by prefix")
     func parsePaneIDMatchIsExact() {
         let output = "%12\t0\tMINE\tclaude\n"
-        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%1") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%1") == .absent)
         #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%12") == .live(terminalID: "MINE"))
     }
 
     /// A pane started without an explicit command — `tmux new-session -d` with
     /// no argument — reports an empty `#{pane_start_command}`, so the last
     /// field is genuinely empty rather than absent. It must still parse as four
-    /// fields, not fall through to `.missing`.
+    /// fields, not fall through to `.absent`.
     @Test("an empty trailing start command is still a complete answer")
     func parseEmptyStartCommand() {
         #expect(TmuxManager.parsePaneSendTarget("%0\t0\t\t\n", paneID: "%0")
@@ -155,9 +220,9 @@ struct PaneSendTargetQueryTests {
 
     @Test("empty or malformed output names nothing")
     func parseEmpty() {
-        #expect(TmuxManager.parsePaneSendTarget("", paneID: "%7") == .missing)
-        #expect(TmuxManager.parsePaneSendTarget("\n", paneID: "%7") == .missing)
-        #expect(TmuxManager.parsePaneSendTarget("%7\t0\tonly-three\n", paneID: "%7") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget("", paneID: "%7") == .absent)
+        #expect(TmuxManager.parsePaneSendTarget("\n", paneID: "%7") == .absent)
+        #expect(TmuxManager.parsePaneSendTarget("%7\t0\tonly-three\n", paneID: "%7") == .absent)
     }
 
     // MARK: - Identity resolution

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -112,6 +112,60 @@ struct PaneSendTargetQueryTests {
             paneInventory: "%12\n", paneID: "%1") == .absent)
     }
 
+    // MARK: - The window probe, on the same rule
+
+    /// The window-space twin of `probeShape`/`probeIsServerWide`. It has to be
+    /// server-wide for the identical reason: a target-scoped window query fails
+    /// for both of the reasons the split exists to tell apart, so it could never
+    /// disambiguate its own failure. It also reports one formatted identity per
+    /// line and nothing else — the alternative, reading `can't find window` off
+    /// stderr, is the prose-parsing the bounded-recovery spec rejects.
+    @Test("the window reachability probe asks one server-wide list-windows for window ids")
+    func windowProbeShape() {
+        let args = TmuxManager.allWindowIDsQuery(server: "tbd-acme")
+        #expect(args == ["-L", "tbd-acme", "list-windows", "-a", "-F", "#{window_id}"])
+        #expect(args.contains("-a"))
+        #expect(!args.contains("-t"))
+    }
+
+    /// THE REGRESSION, in the window's identity space: the consultation failed,
+    /// but the server answered the probe and listed the window. A window tmux
+    /// just named must never be reported gone — that verdict parks live
+    /// sessions and deletes their rows.
+    @Test("a window the probe still lists is never reported as absent")
+    func failedWindowConsultationWithLiveWindowIsUnreachable() {
+        #expect(TmuxManager.classifyFailedWindowConsultation(
+            windowInventory: "@1\n@7\n@9\n", windowID: "@7") == .unreachable)
+    }
+
+    /// The reclaim half: a server that answered and does not list the window is
+    /// positive evidence of absence, and reconcile still acts on it.
+    @Test("a window a reachable server does not list is absent")
+    func failedWindowConsultationWithReachableServerIsAbsent() {
+        #expect(TmuxManager.classifyFailedWindowConsultation(
+            windowInventory: "@1\n@9\n", windowID: "@7") == .absent)
+        #expect(TmuxManager.classifyFailedWindowConsultation(
+            windowInventory: "", windowID: "@7") == .absent)
+    }
+
+    /// Two failed reads in a row still say nothing about the window.
+    @Test("a window probe that also fails proves nothing and stays unreachable")
+    func failedWindowProbeIsUnreachable() {
+        #expect(TmuxManager.classifyFailedWindowConsultation(
+            windowInventory: nil, windowID: "@7") == .unreachable)
+    }
+
+    /// Matched whole, so `@1` listed does not answer for `@12` — otherwise a
+    /// genuinely absent window would be excused as unreadable forever and never
+    /// reclaimed.
+    @Test("the window probe's inventory is matched whole, not by prefix")
+    func windowProbeInventoryMatchIsExact() {
+        #expect(TmuxManager.classifyFailedWindowConsultation(
+            windowInventory: "@12\n", windowID: "@1") == .absent)
+        #expect(TmuxManager.classifyFailedWindowConsultation(
+            windowInventory: "  @12  \n", windowID: "@12") == .unreachable)
+    }
+
     @Test("the stamp command sets the pane-scoped option on the given target")
     func stampShape() {
         let args = TmuxManager.setPaneTerminalIDCommand(

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -374,7 +374,7 @@ struct PreSessionHookTests {
 
         let db = try TBDDatabase(inMemory: true)
         // Short injected timeout; the marker is never written. (The killed-pane
-        // short-circuit can't fire under dryRun tmux — windowExists is always
+        // short-circuit can't fire under dryRun tmux — windowPresence is always
         // true — so the timeout path covers the no-completion case here.)
         let lifecycle = makeLifecycle(db: db, timeout: 0.3)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
@@ -599,7 +599,7 @@ struct PreSessionHookTests {
         let db = try TBDDatabase(inMemory: true)
 
         // The dead-window check fires AFTER the marker check in each poll
-        // iteration. Simulate the race deterministically: the windowExists
+        // iteration. Simulate the race deterministically: the windowPresence
         // probe itself writes the marker (hook finished + pane closed between
         // the two checks) and reports the window dead. The wait must re-check
         // the marker and honor its exit code instead of returning .paneKilled.
@@ -668,6 +668,34 @@ struct PreSessionHookTests {
             preSession: spawn, tmuxServer: "tbd-test"
         )
         #expect(outcome == .paneKilled)
+    }
+
+    /// The other branch of the same probe. `.paneKilled` is a claim — the user
+    /// closed the hook terminal — that the create path acts on and notifies
+    /// about, so a window read that reached no server must not produce it. The
+    /// wait keeps polling and ends on its own deadline instead, which is the
+    /// honest outcome for a window nobody could read.
+    @Test func unreadableWindowIsTimedOutNotPaneKilled() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+
+        let worktreeID = UUID()
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
+        // Short timeout so the poll loop reaches its deadline quickly; the
+        // point is which outcome it reports, not how long it waits.
+        let lifecycle = makeLifecycle(
+            db: db, timeout: 0.2, windowPresence: { _, _ in .unreachable })
+        let spawn = PreSessionSpawn(
+            terminalID: UUID(), tmuxServer: "test-server",
+            windowID: "@mock-0", paneID: "%mock-0",
+            markerPath: markerPath, hookPath: "/dev/null"
+        )
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: spawn, tmuxServer: "tbd-test"
+        )
+        #expect(outcome == .timedOut,
+                "an unreadable window must not be reported as a killed pane")
     }
 
     // MARK: - Killed pane (end-to-end)

--- a/Tests/TBDDaemonTests/PreSessionTestSupport.swift
+++ b/Tests/TBDDaemonTests/PreSessionTestSupport.swift
@@ -59,6 +59,10 @@ func makeLifecycle(
     subscriptions: StateSubscriptionManager? = nil,
     timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
     windowIsDead: (@Sendable (String) -> Bool)? = nil,
+    /// The three-valued window probe, for the fixtures that need to say "the
+    /// read failed" — which `windowIsDead` cannot express. Takes precedence
+    /// over `windowIsDead` when both are given.
+    windowPresence: (@Sendable (String, String) -> TmuxResourcePresence)? = nil,
     listWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil
 ) -> WorktreeLifecycle {
     var dryRunRecorder: (@Sendable ([String]) -> Void)?
@@ -72,6 +76,7 @@ func makeLifecycle(
             dryRun: true,
             dryRunRecorder: dryRunRecorder,
             dryRunWindowIsDead: windowIsDead,
+            dryRunWindowPresence: windowPresence,
             dryRunListWindows: listWindows
         ),
         hooks: HookResolver(),

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -97,7 +97,7 @@ struct ScratchPromoteReconcileTests {
         #expect(promoted.mainWorktree.tmuxServer != canonical)
         #expect(promoted.mainWorktree.tmuxServer == promoted.scratch.tmuxServer)
 
-        // dryRun tmux without dryRunWindowIsDead reports every window ALIVE —
+        // dryRun tmux without a window-presence hook reports every window ALIVE —
         // the live-session case reconcile must leave alone.
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())

--- a/Tests/TBDDaemonTests/SessionStatesRPCTests.swift
+++ b/Tests/TBDDaemonTests/SessionStatesRPCTests.swift
@@ -11,7 +11,7 @@ import TestSupport
 /// `dryRunRecorder` alone is **not** enough, and the gap matters here more than
 /// anywhere: it fires on the mutating commands, while `capturePaneOutput`,
 /// `capturePaneWithAnsi`, `capturePaneScrollback`, `paneCurrentCommand`,
-/// `paneSendTarget`, `listWindows` and `windowExists` short-circuit on their own
+/// `paneSendTarget`, `listWindows` and `windowPresence` short-circuit on their own
 /// dryRun hooks and never reach it. A pane *read* is exactly what this method
 /// must never do, so the fixture wires every one of those hooks into the same
 /// recorder and the assertion covers the composed set rather than one arm of it.

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -286,7 +286,7 @@ private func actuationRows(at path: String) throws -> [[String: Any]] {
 }
 
 /// The re-park branch kills a window it read as dead and parks the session. It
-/// is an actuation, not a DB-only edit — the `windowExists` read one line
+/// is an actuation, not a DB-only edit — the `windowPresence` read one line
 /// earlier can be stale — so it writes its own `hibernate` row through
 /// `terminal.recreateWindow`'s door, the same act reconcile's recovery park
 /// records.
@@ -347,6 +347,60 @@ func testRecreateWindowReparkWritesHibernateRow() async throws {
 
     let updated = try #require(try await db.terminals.get(id: terminal.id))
     #expect(updated.isParked, "the park itself must still happen")
+}
+
+/// The same branch's other gate. `recreateWindow` re-parks only a window it
+/// read as GONE — and that read kills the window on the way. A probe that
+/// reached no tmux server has read nothing, so the request is declined
+/// (successfully, with the row returned unchanged) instead of tearing down a
+/// window that may be running a live agent.
+@Test("recreateWindow declines rather than re-parking when the window cannot be read")
+func testRecreateWindowDeclinesOnUnreadableWindow() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(
+        dryRun: true,
+        dryRunRecorder: { recorded.append($0) },
+        dryRunWindowPresence: { _, _ in .unreachable })
+    let (log, logPath) = try makeReadableActuationLog()
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+        tmux: tmux,
+        actuationLog: log
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-repark-unreadable", displayName: "test", defaultBranch: "main")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-repark-unreadable",
+        branch: "tbd/wt-repark-unreadable",
+        path: "/tmp/fake-repo-repark-unreadable/wt",
+        tmuxServer: "tbd-4e9a4c02"
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@unreadable-claude",
+        tmuxPaneID: "%unreadable-claude",
+        label: "claude",
+        claudeSessionID: "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff",
+        kind: .claude
+    )
+
+    let response = await router.handle(try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id),
+        actor: ActuationActor.app))
+
+    #expect(response.success, "declining is a no-op success, not an error")
+    let updated = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(!updated.isParked, "a failed read must not park the session")
+    #expect(updated.tmuxWindowID == "@unreadable-claude")
+    #expect(!recorded.snapshot().contains { $0.contains("kill-window") },
+            "a failed read must not kill the window")
+    let rows = try actuationRows(at: logPath)
+    #expect(rows.isEmpty, "nothing was actuated, so nothing may be recorded as actuated")
 }
 
 /// Fail-closed: an unwritable record refuses the re-park before the kill. The

--- a/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
+++ b/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
@@ -36,12 +36,14 @@ struct TerminalCloseRailsTests {
         return Fixture(db: db, worktree: wt, terminal: terminal)
     }
 
-    /// `windowIsDead: true` forces the row's window to read as gone, which is
-    /// what a crashed-mid-turn session looks like.
-    private func makeRouter(db: TBDDatabase, windowIsDead: Bool = false) -> RPCRouter {
-        var deadHook: (@Sendable (String) -> Bool)?
-        if windowIsDead { deadHook = { _ in true } }
-        let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: deadHook)
+    /// `windowPresence` scripts what the row's window probe answers. `.absent`
+    /// is what a crashed-mid-turn session looks like; `.unreachable` is a read
+    /// that never reached a server and says nothing about the window.
+    private func makeRouter(
+        db: TBDDatabase, windowPresence: TmuxResourcePresence = .present
+    ) -> RPCRouter {
+        let tmux = TmuxManager(
+            dryRun: true, dryRunWindowPresence: { _, _ in windowPresence })
         return RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
@@ -126,12 +128,34 @@ struct TerminalCloseRailsTests {
     @Test("rails on: a mid-turn terminal whose window is DEAD still closes")
     func railsOnClosesBusyTerminalWithDeadWindow() async throws {
         let fx = try await makeFixture(activityState: .working)
-        let router = makeRouter(db: fx.db, windowIsDead: true)
+        let router = makeRouter(db: fx.db, windowPresence: .absent)
 
         let resp = try await close(router, fx.terminal.id, rails: true)
 
         #expect(resp.success, "a dead-window row cannot be mid-turn")
         #expect(resp.errorCode == nil)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+    }
+
+    /// The third state, and the one the qualification must NOT extend to. A
+    /// window read that reached no server has not established that the session
+    /// died, so lowering the rail on it would let a close kill an in-flight turn
+    /// the daemon merely could not see. `--force` still closes it, which is what
+    /// makes keeping the rail up the reversible choice.
+    @Test("rails on: a mid-turn terminal whose window could not be READ is still refused")
+    func railsOnRefusesBusyTerminalWithUnreadableWindow() async throws {
+        let fx = try await makeFixture(activityState: .working)
+        let router = makeRouter(db: fx.db, windowPresence: .unreachable)
+
+        let resp = try await close(router, fx.terminal.id, rails: true)
+
+        #expect(!resp.success, "a failed read must not lower the rail")
+        #expect(resp.errorCode == RPCErrorCode.terminalBusy.rawValue)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) != nil)
+
+        // And the escape hatch still works, so the refusal is never a trap.
+        let forced = try await close(router, fx.terminal.id, rails: false)
+        #expect(forced.success)
         #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
     }
 

--- a/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
@@ -32,7 +32,7 @@ struct TerminalSendTargetCheckTests {
     /// the terminal rather than as a literal, because the interesting cases are
     /// agreement and disagreement with an id the fixture only mints later.
     private enum PaneAnswer: Sendable {
-        case missing
+        case absent
         case dead
         /// Alive, carrying no identity at all.
         case unresolvable
@@ -44,10 +44,13 @@ struct TerminalSendTargetCheckTests {
         case stranger(String)
         /// The consultation could not be run at all — a wedged tmux tripping
         /// the subprocess timeout. Not an answer about the pane.
+        case wedged
+        /// The consultation ran and reached no server. Also not an answer about
+        /// the pane, and the case the daemon used to conflate with `.absent`.
         case unreachable
     }
 
-    /// The error a `.unreachable` consultation fails with, so the test can
+    /// The error a `.wedged` consultation fails with, so the test can
     /// assert the handler propagated *that* error rather than inventing one.
     private struct WedgedTmux: Error {}
 
@@ -82,13 +85,14 @@ struct TerminalSendTargetCheckTests {
             dryRunRecorder: { recorder.record($0) },
             dryRunPaneSendTarget: { _, _ in
                 switch answer {
-                case .missing: return .missing
+                case .absent: return .absent
                 case .dead: return .dead(terminalID: box.id)
                 case .unresolvable: return .live(terminalID: nil)
                 case .matching: return .live(terminalID: box.id)
                 case .matchingLowercased: return .live(terminalID: box.id.lowercased())
                 case .stranger(let other): return .live(terminalID: other)
-                case .unreachable: throw WedgedTmux()
+                case .wedged: throw WedgedTmux()
+                case .unreachable: return .unreachable
                 }
             })
         let db = try TBDDatabase(inMemory: true)
@@ -158,7 +162,7 @@ struct TerminalSendTargetCheckTests {
 
     @Test("a pane tmux cannot find is refused as not-found")
     func missingPaneRefused() async throws {
-        let fixture = try await makeFixture(answer: .missing)
+        let fixture = try await makeFixture(answer: .absent)
         let response = try await send(fixture)
 
         #expect(!response.success)
@@ -200,7 +204,7 @@ struct TerminalSendTargetCheckTests {
     /// its target, and the record says `transport-failed`.
     @Test("a consultation that cannot be run is a transport failure, not a refusal")
     func unreachableConsultationIsTransportFailure() async throws {
-        let fixture = try await makeFixture(answer: .unreachable)
+        let fixture = try await makeFixture(answer: .wedged)
 
         // The handler rethrows; the router turns that into an error response.
         let response = try await send(fixture)
@@ -215,6 +219,62 @@ struct TerminalSendTargetCheckTests {
         // Not misfiled as any flavour of refusal.
         #expect(outcome["reason"] == nil)
         #expect(!written.contains { $0["result"] as? String == "dispatched" })
+    }
+
+    /// The field defect this suite grew for: the daemon could not reach the
+    /// server (its `TMUX_TMPDIR` differs from the user's shell, so the same
+    /// `-L <name>` resolved elsewhere) and the send refused with "no longer
+    /// exists on server …" while the pane was demonstrably alive and accepting
+    /// `send-keys` from a shell. A failed read must not wear the words of a
+    /// missing pane, and must not be filed as a refusal.
+    @Test("an unreachable server is a transport failure, and never says the pane is gone")
+    func unreachableServerIsNotReportedAsMissing() async throws {
+        let fixture = try await makeFixture(answer: .unreachable)
+        let response = try await send(fixture)
+
+        #expect(!response.success)
+        let error = try #require(response.error)
+        // The exact phrase the old code produced for this state.
+        #expect(!error.contains("no longer exists"))
+        // It says what actually happened, and that it is worth retrying.
+        #expect(error.contains("could not reach tmux server"))
+        #expect(error.contains("tbd-acme"))
+        #expect(error.contains("%7"))
+        #expect(error.lowercased().contains("retry"))
+        // Nothing was typed.
+        #expect(fixture.recorder.calls.isEmpty)
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        let outcome = try #require(written.last)
+        #expect(outcome["result"] as? String == "transport-failed")
+        // Emphatically not filed as any flavour of refusal — least of all
+        // `not-found`, which would put "the pane is gone" on the record.
+        #expect(outcome["reason"] == nil)
+        #expect(!written.contains { $0["result"] as? String == "dispatched" })
+    }
+
+    /// Liveness comes from what tmux answered, never from the row's own
+    /// bookkeeping. A terminal the DB still calls `working` whose pane is dead
+    /// is dead — stale activity metadata must not soften the verdict into
+    /// "unknown", nor harden an unreachable read into a verdict.
+    @Test("stale working activity does not change a dead pane's verdict")
+    func staleActivityDoesNotChangeLivenessVerdict() async throws {
+        for state in [TerminalActivityState.working, .waitingForUser] {
+            let fixture = try await makeFixture(answer: .dead)
+            try await fixture.router.db.terminals.setActivityState(
+                id: fixture.terminal.id, activityState: state,
+                source: .hookEvent("UserPromptSubmit"))
+            let stamped = try await fixture.router.db.terminals.get(id: fixture.terminal.id)
+            #expect(stamped?.activityState == state)
+
+            let response = try await send(fixture)
+            #expect(!response.success)
+            #expect(response.error?.contains("dead") == true)
+            let outcome = try lastOutcome(at: fixture.logPath)
+            #expect(outcome["result"] as? String == "refused")
+            #expect(outcome["reason"] as? String == "not-eligible")
+        }
     }
 
     // MARK: - The branches that still send

--- a/Tests/TBDDaemonTests/TmuxServerPresenceTests.swift
+++ b/Tests/TBDDaemonTests/TmuxServerPresenceTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Tier 1 — the out-of-tmux evidence `serverPresence` uses to decide what a
+/// `list-sessions` that did not answer means, with no tmux server anywhere and
+/// no `ps` subprocess. Both halves are pure functions for exactly that reason:
+/// the interesting condition (a machine with no tmux process running at all) is
+/// not something a test on a shared box can arrange.
+@Suite("Tmux server presence")
+struct TmuxServerPresenceTests {
+
+    // MARK: - The verdict
+
+    /// The reboot case, and the regression this whole seam exists to fix. Every
+    /// tmux server is genuinely gone, so nothing can be listening on any socket
+    /// whatever `TMUX_TMPDIR` resolves to — and reconcile must reclaim, or the
+    /// rows of every pre-reboot server accumulate forever.
+    @Test("no tmux server process anywhere makes a failed list-sessions absent")
+    func noTmuxProcessesIsAbsent() {
+        #expect(TmuxManager.classifyFailedServerConsultation(
+            tmuxServerProcessesExist: false) == .absent)
+    }
+
+    /// The field bug: something IS running and our `-L <name>` did not reach
+    /// it, which says nothing about whether it is ours. Protect the rows.
+    @Test("a running tmux server process keeps a failed list-sessions unreachable")
+    func tmuxProcessesPresentIsUnreachable() {
+        #expect(TmuxManager.classifyFailedServerConsultation(
+            tmuxServerProcessesExist: true) == .unreachable)
+    }
+
+    /// The doctrine of this change in one assertion: a probe that could not be
+    /// taken is not evidence of absence. Two failed reads still say nothing,
+    /// and `.absent` is the only verdict that licenses parking or deleting.
+    @Test("a probe that itself failed is unreachable, never absent")
+    func failedProbeIsUnreachable() {
+        #expect(TmuxManager.classifyFailedServerConsultation(
+            tmuxServerProcessesExist: nil) == .unreachable)
+        #expect(TmuxManager.classifyFailedServerConsultation(
+            tmuxServerProcessesExist: nil) != .absent)
+    }
+
+    // MARK: - The matching rule
+
+    @Test("a tmux invocation matches by argv[0] basename, absolute or bare")
+    func matchesTmuxBasename() {
+        #expect(TmuxManager.isTmuxProcessCommand("tmux -L tbd-acme new-session -d -s main"))
+        #expect(TmuxManager.isTmuxProcessCommand("/opt/homebrew/bin/tmux -L tbd-acme attach"))
+        #expect(TmuxManager.isTmuxProcessCommand("tmux"))
+    }
+
+    /// The rewritten process title, which is what a tmux server shows wherever
+    /// `setproctitle` is available.
+    @Test("the rewritten tmux: title matches for server and client alike")
+    func matchesRewrittenTitle() {
+        #expect(TmuxManager.isTmuxProcessCommand("tmux: server (/tmp/tmux-501/tbd-acme)"))
+        #expect(TmuxManager.isTmuxProcessCommand("tmux: client (/tmp/tmux-501/tbd-acme)"))
+    }
+
+    /// Basename discipline, the same one `AgentReaper.isAgentBinary` keeps: a
+    /// path that merely CONTAINS "tmux" is not a tmux process. Over-matching
+    /// here would pin `.unreachable` forever on any box that happens to hold a
+    /// tmux-ish path, and nothing would ever be reclaimed after a reboot.
+    @Test("a path that merely contains tmux does not match")
+    func doesNotMatchIncidentalPaths() {
+        #expect(!TmuxManager.isTmuxProcessCommand("/Users/me/tmux-notes/bin/editor --flag"))
+        #expect(!TmuxManager.isTmuxProcessCommand("tmuxinator start acme"))
+        #expect(!TmuxManager.isTmuxProcessCommand("/bin/zsh -ic \"sleep 300\""))
+        #expect(!TmuxManager.isTmuxProcessCommand(""))
+        #expect(!TmuxManager.isTmuxProcessCommand("   "))
+    }
+
+    // MARK: - The snapshot gate
+
+    private static func entry(
+        pid: Int32, ppid: Int32, uid: uid_t, command: String
+    ) -> ProcessSnapshotEntry {
+        ProcessSnapshotEntry(
+            pid: pid, ppid: ppid, pgid: pid, uid: uid,
+            elapsedSeconds: 120, command: command)
+    }
+
+    /// A machine with no tmux anywhere. The reboot state, and the one that must
+    /// answer "no".
+    @Test("a snapshot with no tmux row reports no server processes")
+    func emptyOfTmuxReportsFalse() {
+        let snapshot = [
+            Self.entry(pid: 10, ppid: 1, uid: 501, command: "/bin/zsh -l"),
+            Self.entry(pid: 11, ppid: 1, uid: 501, command: "/usr/bin/ssh-agent -l"),
+        ]
+        #expect(!TmuxManager.tmuxServerProcessesExist(
+            in: snapshot, uid: 501, daemonPID: 99))
+        #expect(!TmuxManager.tmuxServerProcessesExist(
+            in: [], uid: 501, daemonPID: 99))
+    }
+
+    /// A tmux server daemonizes away from whoever started it, so its ppid is 1
+    /// — never the daemon's. Name-agnostic on purpose: the socket name is what
+    /// is under suspicion, so a server under ANY name counts.
+    @Test("a daemonized tmux server under any name reports as present")
+    func daemonizedServerReportsTrue() {
+        let snapshot = [
+            Self.entry(pid: 10, ppid: 1, uid: 501, command: "/bin/zsh -l"),
+            Self.entry(
+                pid: 42, ppid: 1, uid: 501,
+                command: "tmux -L someone-elses-name new-session -d -s main"),
+        ]
+        #expect(TmuxManager.tmuxServerProcessesExist(
+            in: snapshot, uid: 501, daemonPID: 99))
+    }
+
+    /// Another user's tmux server cannot be ours and is not reachable on our
+    /// socket directory either, so it must not veto the reclaim.
+    @Test("another uid's tmux server does not count")
+    func foreignUIDDoesNotCount() {
+        let snapshot = [
+            Self.entry(pid: 42, ppid: 1, uid: 502, command: "tmux: server (/tmp/tmux-502/default)"),
+        ]
+        #expect(!TmuxManager.tmuxServerProcessesExist(
+            in: snapshot, uid: 501, daemonPID: 99))
+    }
+
+    /// The daemon's own in-flight `tmux …` CLI calls are clients, not servers.
+    /// Counting them would let a concurrent reconcile probe veto its own
+    /// reclaim, and the post-reboot sweep — which runs many tmux commands —
+    /// would be exactly when that happens.
+    @Test("this daemon's own tmux CLI children do not count")
+    func ownCLIChildrenDoNotCount() {
+        let snapshot = [
+            Self.entry(pid: 43, ppid: 99, uid: 501, command: "tmux -L tbd-acme list-windows -a"),
+        ]
+        #expect(!TmuxManager.tmuxServerProcessesExist(
+            in: snapshot, uid: 501, daemonPID: 99))
+
+        // …but a real server that happens to sit next to one still counts.
+        let withServer = snapshot + [
+            Self.entry(pid: 44, ppid: 1, uid: 501, command: "tmux: server (/tmp/tmux-501/tbd-acme)"),
+        ]
+        #expect(TmuxManager.tmuxServerProcessesExist(
+            in: withServer, uid: 501, daemonPID: 99))
+    }
+
+    /// A tmux client only exists while attached to a server, so it is evidence
+    /// FOR one — and on platforms where tmux does not rewrite its title a
+    /// server is indistinguishable from a client by argv anyway. Counting both
+    /// errs toward `.unreachable`, the verdict that protects rows.
+    @Test("a tmux client counts as evidence that a server is running")
+    func clientCountsAsEvidence() {
+        let snapshot = [
+            Self.entry(pid: 45, ppid: 30, uid: 501, command: "tmux -L tbd-acme attach -t main"),
+        ]
+        #expect(TmuxManager.tmuxServerProcessesExist(
+            in: snapshot, uid: 501, daemonPID: 99))
+    }
+}

--- a/Tests/TBDDaemonTests/TmuxServerPresenceTests.swift
+++ b/Tests/TBDDaemonTests/TmuxServerPresenceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 @testable import TBDDaemonLib
 
@@ -152,5 +153,137 @@ struct TmuxServerPresenceTests {
         ]
         #expect(TmuxManager.tmuxServerProcessesExist(
             in: snapshot, uid: 501, daemonPID: 99))
+    }
+}
+
+/// A one-shot async gate. `wait()` suspends until `open()` is called and
+/// returns immediately after that.
+///
+/// Deliberately not a `DispatchSemaphore`: nothing here needs to hold a thread,
+/// and parking cooperative threads on a 3-core runner is the hazard
+/// `Tests/CLAUDE.md` documents under "Thread-blocking gates run off the
+/// cooperative pool".
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pending = waiters
+        waiters = []
+        for continuation in pending { continuation.resume() }
+    }
+}
+
+/// How many times the memo actually took a reading.
+private actor ReadingCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
+}
+
+/// Tier 1 — the memo in front of the machine-global process probe, driven
+/// entirely through injected closures: no `ps`, no subprocess, no wall-clock
+/// wait. The behaviour under test is "how many readings were taken", and the
+/// window is compared against an injected date source rather than measured.
+@Suite("Tmux server process probe memo")
+struct TmuxServerProcessProbeCacheTests {
+
+    /// The point of the whole type. `serverPresence` asks this question once per
+    /// server that did not answer, and the answer does not depend on the server
+    /// — so a post-reboot sweep over N dead servers must cost one `ps`, not N.
+    @Test("a reading inside the freshness window is reused rather than retaken")
+    func readingInsideTheWindowIsReused() async {
+        let date = TestDateSource()
+        let counter = ReadingCounter()
+        let cache = TmuxServerProcessProbeCache(now: date.provider)
+        let take: @Sendable () async -> Bool? = { await counter.bump(); return false }
+
+        #expect(await cache.reading(taking: take) == false)
+        date.advance(by: TmuxServerProcessProbeCache.freshness - 1)
+        #expect(await cache.reading(taking: take) == false)
+
+        #expect(await counter.count == 1,
+                "a reading still inside its window must not be retaken")
+    }
+
+    /// The other half, and the one that keeps the memo honest: `.absent` is the
+    /// verdict that licenses parking and deleting rows, so a reading may not
+    /// outlive its window. The boundary is pinned exactly — at `freshness` the
+    /// reading is already stale — so shortening or lengthening the window is a
+    /// deliberate edit rather than a silent drift.
+    @Test("a reading older than the freshness window is retaken")
+    func staleReadingIsRetaken() async {
+        let date = TestDateSource()
+        let counter = ReadingCounter()
+        let cache = TmuxServerProcessProbeCache(now: date.provider)
+        let take: @Sendable () async -> Bool? = { await counter.bump(); return false }
+
+        #expect(await cache.reading(taking: take) == false)
+        date.advance(by: TmuxServerProcessProbeCache.freshness)
+        #expect(await cache.reading(taking: take) == false)
+
+        #expect(await counter.count == 2,
+                "a reading at or past its window must be taken again")
+    }
+
+    /// A reading that could not be taken is memoized like any other — rerunning
+    /// a `ps` that just failed is no more likely to answer — and it still means
+    /// `.unreachable`, never absence. Memoizing must not turn "I don't know"
+    /// into a licence to reclaim.
+    @Test("a reading that could not be taken is memoized and still never means absence")
+    func failedReadingIsMemoizedAndNeverAbsent() async {
+        let date = TestDateSource()
+        let counter = ReadingCounter()
+        let cache = TmuxServerProcessProbeCache(now: date.provider)
+        let take: @Sendable () async -> Bool? = { await counter.bump(); return nil }
+
+        #expect(await cache.reading(taking: take) == nil)
+        #expect(await cache.reading(taking: take) == nil)
+        #expect(await counter.count == 1, "a failed reading is memoized like any other")
+        #expect(TmuxManager.classifyFailedServerConsultation(
+            tmuxServerProcessesExist: nil) == .unreachable)
+    }
+
+    /// The arm that matters under a sweep, where the askers arrive together
+    /// rather than one after another: a second asker that arrives while a
+    /// reading is in the air joins it instead of spawning a second `ps`
+    /// alongside. `runBoundedProcess` has no concurrency limit of its own, so
+    /// without this the machine takes N simultaneous full process-table scans.
+    ///
+    /// No wall-clock wait anywhere: the first reading is held open on a gate
+    /// until the second asker has been launched.
+    @Test("concurrent askers join one reading instead of each taking their own")
+    func concurrentAskersJoinOneReading() async {
+        let entered = AsyncGate()
+        let release = AsyncGate()
+        let counter = ReadingCounter()
+        let cache = TmuxServerProcessProbeCache()
+        let take: @Sendable () async -> Bool? = {
+            await counter.bump()
+            await entered.open()
+            await release.wait()
+            return false
+        }
+
+        let first = Task { await cache.reading(taking: take) }
+        // The reading is now in the air, and `reading` claims the in-flight slot
+        // with no suspension after starting it, so the actor cannot hand a
+        // second asker an empty slot.
+        await entered.wait()
+        let second = Task { await cache.reading(taking: take) }
+        await release.open()
+
+        #expect(await first.value == false)
+        #expect(await second.value == false)
+        #expect(await counter.count == 1,
+                "the second asker must join the reading in flight, not take one")
     }
 }

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -810,6 +810,114 @@ import Testing
     #expect(!recorded.snapshot().contains { $0.contains("kill-window") })
 }
 
+// MARK: - Reconcile and the pane consultation's two negative answers
+
+/// Both arms below share this: a main worktree on a live (dryRun) server with
+/// one live window, holding one resumable Claude terminal. The only variable is
+/// what the pane consultation answers.
+private func makeReconcileFixture(
+    tempDir: URL, repoDir: URL, paneTarget: @escaping @Sendable (String, String) throws -> PaneSendTarget
+) async throws -> (TBDDatabase, WorktreeLifecycle, Repo, Terminal) {
+    let db = try TBDDatabase(inMemory: true)
+    let server = TmuxManager.serverName(forRepoPath: repoDir.path)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true, dryRunPaneSendTarget: paneTarget),
+        hooks: HookResolver())
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let main = try await db.worktrees.createMain(
+        repoID: repo.id, name: "main", branch: "main",
+        path: repoDir.path, tmuxServer: server)
+    let terminal = try await db.terminals.create(
+        worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+        label: "claude", claudeSessionID: "sess-reconcile", kind: .claude)
+    return (db, lifecycle, repo, terminal)
+}
+
+/// Encoded with sorted keys so the comparison is over the whole row rather
+/// than the fields a reader thought to name.
+private func encodedRow(_ terminal: Terminal) throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    return try encoder.encode(terminal)
+}
+
+/// The destructive half of the defect. Reconcile parks resumable sessions and
+/// deletes the rest, so a consultation that reached no tmux server must leave
+/// the row alone: "I could not read the pane" is not "the pane is gone", and
+/// getting it wrong here loses a live agent's in-flight work rather than merely
+/// refusing one send.
+@Test func testReconcileLeavesRowUntouchedWhenServerIsUnreachable() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let (db, lifecycle, repo, terminal) = try await makeReconcileFixture(
+        tempDir: tempDir, repoDir: repoDir, paneTarget: { _, _ in .unreachable })
+    let before = try encodedRow(try #require(try await db.terminals.get(id: terminal.id)))
+
+    try await lifecycle.reconcile(
+        repoID: repo.id, actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    let after = try #require(try await db.terminals.get(id: terminal.id))
+    let afterEncoded = try encodedRow(after)
+    #expect(afterEncoded == before,
+            "an unreachable server must leave the row byte-identical; got \(after)")
+    // Spelled out too, because these are the three specific mutations this pass
+    // makes and a reader should see them refused by name.
+    #expect(after.hibernatedAt == nil, "must not park on a failed read")
+    #expect(after.tmuxPaneID == "%1", "must not rewrite the coordinate on a failed read")
+    #expect(after.tmuxWindowID == "@1")
+}
+
+/// The over-correction guard: a reconciler that never reclaims anything is its
+/// own bug. A server that ANSWERED and does not hold the pane is positive
+/// evidence of absence, and a resumable session there is still parked.
+@Test func testReconcileStillParksWhenThePaneIsPositivelyAbsent() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let (db, lifecycle, repo, terminal) = try await makeReconcileFixture(
+        tempDir: tempDir, repoDir: repoDir, paneTarget: { _, _ in .absent })
+
+    try await lifecycle.reconcile(
+        repoID: repo.id, actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    let after = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(after.hibernatedAt != nil, "an absent pane must still park its resumable session")
+    #expect(after.claudeSessionID == "sess-reconcile", "the session must be preserved for wake")
+}
+
+/// The same absence on a NON-resumable row still deletes, so the two halves of
+/// the reclaim path are both proven live.
+@Test func testReconcileStillDeletesNonResumableRowWhenThePaneIsPositivelyAbsent() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let server = TmuxManager.serverName(forRepoPath: repoDir.path)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in .absent }),
+        hooks: HookResolver())
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let main = try await db.worktrees.createMain(
+        repoID: repo.id, name: "main", branch: "main",
+        path: repoDir.path, tmuxServer: server)
+    let terminal = try await db.terminals.create(
+        worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+        label: "Shell", kind: .shell)
+
+    try await lifecycle.reconcile(
+        repoID: repo.id, actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    let after = try await db.terminals.get(id: terminal.id)
+    #expect(after == nil, "an absent pane on a non-resumable row must still be reclaimed")
+}
+
 /// Suspended terminals must not be touched during reconcile, regardless of server/window state.
 /// dryRun mode exercises the serverAlive=true branch; suspended terminals are skipped
 /// before the windowExists check, so this works with dryRun=true.

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -718,13 +718,13 @@ import Testing
 // MARK: - Reconcile Tests
 
 /// Alive server + alive windows: no terminals are deleted, window IDs unchanged.
-/// (dryRun makes serverExists → true and windowExists → true, so this exercises
+/// (dryRun makes serverPresence → .present and windowPresence → .present, so this exercises
 /// the "server alive, window alive → keep terminal" branch.)
 ///
 /// This also serves as a regression guard for the dead-window deletion path: any
 /// bug that incorrectly triggers dead-window deletion would drop terminals here,
 /// because the setup is identical to what a "dead window" scenario looks like
-/// before the windowExists check. The dead-window path itself (windowExists → false)
+/// before the window probe. The positively-absent window path
 /// requires a non-dryRun integration test against a real tmux server with stale IDs.
 @Test func testReconcileAliveTerminalUntouched() async throws {
     let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
@@ -751,12 +751,12 @@ import Testing
     let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
     #expect(terminalsAfter.count == 2, "Alive terminals must not be deleted during reconcile")
 
-    // In dryRun mode, serverExists → true → windowExists path is taken.
-    // windowExists → true → terminals are kept with their original IDs.
+    // In dryRun mode, serverPresence → .present → the window probe runs.
+    // windowPresence → .present → terminals are kept with their original IDs.
     // The important invariant: terminal COUNT must not drop.
     let windowIDsAfter = Set(terminalsAfter.map { $0.tmuxWindowID })
     #expect(!windowIDsAfter.isEmpty, "Terminal window IDs must be present after reconcile")
-    // Since serverExists → true and windowExists → true, the alive-window branch
+    // Since both probes report presence, the alive-window branch
     // is taken and IDs are NOT touched (the terminal is left running as-is).
     #expect(windowIDsAfter == windowIDsBefore, "Window IDs must be unchanged when server and windows are alive")
 }
@@ -810,20 +810,29 @@ import Testing
     #expect(!recorded.snapshot().contains { $0.contains("kill-window") })
 }
 
-// MARK: - Reconcile and the pane consultation's two negative answers
+// MARK: - Reconcile and the three probes' two negative answers
 
 /// Both arms below share this: a main worktree on a live (dryRun) server with
-/// one live window, holding one resumable Claude terminal. The only variable is
-/// what the pane consultation answers.
+/// one live window, holding one resumable Claude terminal. The variables are
+/// what the server, window and pane probes answer.
 private func makeReconcileFixture(
-    tempDir: URL, repoDir: URL, paneTarget: @escaping @Sendable (String, String) throws -> PaneSendTarget
+    tempDir: URL, repoDir: URL,
+    paneTarget: @escaping @Sendable (String, String) throws -> PaneSendTarget = { _, _ in
+        .live(terminalID: nil)
+    },
+    windowPresence: (@Sendable (String, String) -> TmuxResourcePresence)? = nil,
+    serverPresence: (@Sendable (String) -> TmuxResourcePresence)? = nil
 ) async throws -> (TBDDatabase, WorktreeLifecycle, Repo, Terminal) {
     let db = try TBDDatabase(inMemory: true)
     let server = TmuxManager.serverName(forRepoPath: repoDir.path)
     let lifecycle = WorktreeLifecycle(
         db: db,
         git: GitManager(),
-        tmux: TmuxManager(dryRun: true, dryRunPaneSendTarget: paneTarget),
+        tmux: TmuxManager(
+            dryRun: true,
+            dryRunWindowPresence: windowPresence,
+            dryRunServerPresence: serverPresence,
+            dryRunPaneSendTarget: paneTarget),
         hooks: HookResolver())
     let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let main = try await db.worktrees.createMain(
@@ -918,9 +927,194 @@ private func encodedRow(_ terminal: Terminal) throws -> Data {
     #expect(after == nil, "an absent pane on a non-resumable row must still be reclaimed")
 }
 
+// MARK: - Reconcile and the window/server probes' two negative answers
+//
+// The pane consultation above is the LAST of three probes reconcile runs, and
+// for a while it was the only one that could say "I could not read this". The
+// server and window probes returned `Bool` and ended in `catch { return false }`,
+// so the socket mismatch that motivated the whole split short-circuited into
+// "gone" one and two probes EARLIER — and the destructive branches fired
+// without the fixed pane path ever being consulted. The tests below pin each
+// probe's failed read to "leave the row alone", and pair it with the positive
+// absence that must still reclaim.
+
+/// The finding this suite exists for: the server probe fails, and nothing may
+/// be parked or deleted on the strength of it.
+@Test func testReconcileLeavesRowUntouchedWhenTheServerProbeIsUnreachable() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let (db, lifecycle, repo, terminal) = try await makeReconcileFixture(
+        tempDir: tempDir, repoDir: repoDir,
+        // Reached only if the gate above it wrongly lets the pass continue.
+        paneTarget: { _, _ in .absent },
+        serverPresence: { _ in .unreachable })
+    let before = try encodedRow(try #require(try await db.terminals.get(id: terminal.id)))
+
+    try await lifecycle.reconcile(
+        repoID: repo.id, actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    let after = try #require(try await db.terminals.get(id: terminal.id))
+    let afterEncoded = try encodedRow(after)
+    #expect(afterEncoded == before,
+            "an unreachable SERVER must leave the row byte-identical; got \(after)")
+    #expect(after.hibernatedAt == nil, "must not park when the server probe failed")
+}
+
+/// The same rule one probe later: the server answered, the window read did not.
+@Test func testReconcileLeavesRowUntouchedWhenTheWindowProbeIsUnreachable() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let (db, lifecycle, repo, terminal) = try await makeReconcileFixture(
+        tempDir: tempDir, repoDir: repoDir,
+        paneTarget: { _, _ in .absent },
+        windowPresence: { _, _ in .unreachable },
+        serverPresence: { _ in .present })
+    let before = try encodedRow(try #require(try await db.terminals.get(id: terminal.id)))
+
+    try await lifecycle.reconcile(
+        repoID: repo.id, actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    let after = try #require(try await db.terminals.get(id: terminal.id))
+    let afterEncoded = try encodedRow(after)
+    #expect(afterEncoded == before,
+            "an unreadable WINDOW must leave the row byte-identical; got \(after)")
+    #expect(after.hibernatedAt == nil, "must not park when the window probe failed")
+}
+
+/// The over-correction guard for the window probe: tmux ANSWERED that the
+/// window is not there, so the resumable session is still parked. Without this,
+/// "never act on a failed read" could quietly become "never act".
+@Test func testReconcileStillParksWhenTheWindowIsPositivelyAbsent() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let (db, lifecycle, repo, terminal) = try await makeReconcileFixture(
+        tempDir: tempDir, repoDir: repoDir,
+        windowPresence: { _, _ in .absent },
+        serverPresence: { _ in .present })
+
+    try await lifecycle.reconcile(
+        repoID: repo.id, actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    let after = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(after.hibernatedAt != nil, "an absent window must still park its resumable session")
+    #expect(after.claudeSessionID == "sess-reconcile", "the session must be preserved for wake")
+}
+
+/// The over-correction guard one probe EARLIER, and the reboot contract itself:
+/// the server probe answered `.absent` — nothing at all is running, so no
+/// socket-resolution mismatch can be hiding a live server — and both halves of
+/// the reclaim must fire. Resumable Claude parks (the session survives for
+/// wake); a plain shell, which has nothing to resume, is deleted.
+///
+/// Without this, "never act on a failed read" quietly becomes "never act after
+/// a reboot", and every row on every pre-reboot server accumulates forever.
+/// `serverPresence` gets the `.absent` verdict from the process table rather
+/// than from tmux — see `TmuxServerPresenceTests` for that classification and
+/// `WorktreeLifecycleLiveTests.testReconcileRebootParksClaudeAndDeletesShell`
+/// for the same contract against a real killed tmux server.
+@Test func testReconcileReclaimsBothRowKindsWhenTheServerIsPositivelyAbsent() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let server = TmuxManager.serverName(forRepoPath: repoDir.path)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true, dryRunServerPresence: { _ in .absent }),
+        hooks: HookResolver())
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let main = try await db.worktrees.createMain(
+        repoID: repo.id, name: "main", branch: "main",
+        path: repoDir.path, tmuxServer: server)
+    let claude = try await db.terminals.create(
+        worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+        label: "claude", claudeSessionID: "sess-reboot", kind: .claude)
+    let shell = try await db.terminals.create(
+        worktreeID: main.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+        label: "Shell", kind: .shell)
+
+    try await lifecycle.reconcile(
+        repoID: repo.id, actuationLog: makeTestActuationLog(),
+        reapSharedScratchTmuxResources: true)
+
+    let claudeAfter = try #require(try await db.terminals.get(id: claude.id))
+    #expect(claudeAfter.hibernatedAt != nil,
+            "an absent server must park its resumable session, not leave it live-looking")
+    #expect(claudeAfter.claudeSessionID == "sess-reboot",
+            "the session must be preserved for wake")
+    #expect(claudeAfter.tmuxWindowID == "@1",
+            "reboot must not recreate the window (no eager mass `claude --resume`, #284)")
+
+    let shellAfter = try await db.terminals.get(id: shell.id)
+    #expect(shellAfter == nil,
+            "a shell row on an absent server has nothing to resume and must be deleted")
+}
+
+/// `reconcileTmuxResources` is destructive in the other direction: it KILLS a
+/// tmux server no row references any more. A server that did not answer has not
+/// told us it is unreferenced-and-alive — and killing takes every pane on it
+/// with it — so the sweep must require a positive answer.
+///
+/// Driven through the scratch sweep because its visit set is exactly "every
+/// server a scratch row names", archived rows included, while ownership is read
+/// from live rows only: one archived scratch row is therefore a server with no
+/// live owner, which is the branch under test.
+@Test func testResourceSweepDoesNotKillAnUnreachableUnreferencedServer() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = LockedCommandRecorder()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunServerPresence: { _ in .unreachable }),
+        hooks: HookResolver())
+    let scratch = try await db.worktrees.createScratch(
+        name: "s", displayName: "S", path: "/tmp/scratch-unreachable",
+        tmuxServer: "tbd-unreachable-sweep")
+    try await db.worktrees.archive(id: scratch.id)
+
+    try await lifecycle.reconcileScratchTerminals(
+        actuationLog: makeTestActuationLog(), reapOrphanTmuxResources: true)
+
+    #expect(!recorded.snapshot().contains { $0.contains("kill-server") },
+            "a server that did not answer must not be killed")
+    #expect(!recorded.snapshot().contains { $0.contains("kill-window") },
+            "nor may its windows be swept on a failed read")
+}
+
+/// The paired positive control: the same unreferenced server, answering.
+@Test func testResourceSweepStillKillsAnAnsweringUnreferencedServer() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = LockedCommandRecorder()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunServerPresence: { _ in .present }),
+        hooks: HookResolver())
+    let scratch = try await db.worktrees.createScratch(
+        name: "s", displayName: "S", path: "/tmp/scratch-present",
+        tmuxServer: "tbd-present-sweep")
+    try await db.worktrees.archive(id: scratch.id)
+
+    try await lifecycle.reconcileScratchTerminals(
+        actuationLog: makeTestActuationLog(), reapOrphanTmuxResources: true)
+
+    #expect(recorded.snapshot().contains { $0.contains("kill-server") },
+            "an unreferenced server that answers is still reclaimed")
+}
+
 /// Suspended terminals must not be touched during reconcile, regardless of server/window state.
 /// dryRun mode exercises the serverAlive=true branch; suspended terminals are skipped
-/// before the windowExists check, so this works with dryRun=true.
+/// before the window probe, so this works with dryRun=true.
 @Test func testReconcileSuspendedTerminalSkippedOnReboot() async throws {
     let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
     defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -1016,10 +1210,10 @@ private func encodedRow(_ terminal: Terminal) throws -> Data {
     #expect(codexAfter?.hibernatedAt != nil)
 }
 
-/// Server gone path (reboot): in dryRun mode serverExists → true, so this path
+/// Server gone path (reboot): in dryRun mode serverPresence → .present, so this path
 /// cannot be directly triggered. Instead, this test seeds a stale windowID and
 /// verifies that when the server IS alive (dryRun), the stale window is treated
-/// as alive (windowExists → true in dryRun) and NOT deleted.
+/// as alive (windowPresence → .present in dryRun) and NOT deleted.
 /// This is the inverse regression guard: ensures dryRun never triggers reboot recreation.
 @Test func testReconcileDryRunDoesNotTriggerRebootRecreation() async throws {
     let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
@@ -1044,9 +1238,9 @@ private func encodedRow(_ terminal: Terminal) throws -> Data {
     let staleWindowID = "@stale-99"
     try await db.terminals.updateTmuxIDs(id: terminal.id, windowID: staleWindowID, paneID: "%stale-99")
 
-    // In dryRun mode, serverExists → true (not the reboot path).
-    // windowExists → true for any ID, so the stale window is treated as alive.
-    // Result: the terminal record must NOT be deleted (no dead-window deletion).
+    // In dryRun mode, serverPresence → .present (not the reboot path), and
+    // windowPresence → .present for any ID, so the stale window is treated as
+    // alive. Result: the terminal record must NOT be deleted.
     try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog(), reapSharedScratchTmuxResources: true)
 
     let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
@@ -1057,11 +1251,11 @@ private func encodedRow(_ terminal: Terminal) throws -> Data {
     #expect(terminalAfter?.tmuxWindowID == staleWindowID,
             "dryRun: stale window ID must not be replaced when server reports alive")
 
-    // NOTE: The actual reboot path (serverExists → false) cannot be tested with
-    // dryRun=true. See testReconcileRebootParksClaudeAndDeletesShell in
-    // TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift, which drives it with a
-    // real tmux server and verifies terminals are parked as suspended (not
-    // recreated) when the server is gone.
+    // NOTE: a real killed server is exercised by
+    // testReconcileRebootParksClaudeAndDeletesShell in
+    // TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift, which drives it
+    // against real tmux; the server-probe verdicts themselves are injected
+    // above in `makeReconcileFixture`-based tests.
 }
 
 @Test func testCreateWorktreeTrapBugScenario() async throws {


### PR DESCRIPTION
## What's broken

`tbd terminal send` refuses to type into a terminal that is perfectly healthy, reporting that its pane is gone:

```
tmux pane %265 for terminal <uuid> no longer exists on server tbd-c1d9f56d — nothing was sent
```

At that same moment, `tmux -L tbd-c1d9f56d list-panes` lists `@265 %265` with `pane_dead=0`, and a direct `send-keys` to that pane works. The pane the daemon says is gone is one you can type into by hand.

It gets worse than a refused send. `tbd terminal list` never consults tmux at all — it is a pure database read — so the row keeps rendering as a live, non-hibernated terminal while every daemon-mediated operation against it fails. The activity state stays `working` or `waiting_for_user`, which is exactly the state the close rails treat as "busy, don't touch". The terminal becomes a ghost: it cannot be used, and it cannot be closed without `--force`. During a bulk closeout that repeats across every affected worktree, and `--force` is being demanded on the strength of activity metadata that nothing has been able to refresh.

## Why it happens

`TmuxManager.paneSendTarget` asked one question and accepted two very different answers as though they were the same. Its own comment made the claim explicit — that this argv can only exit non-zero for

> `can't find pane`, or no server on that socket, both of which mean the same thing for a send.

They do not mean the same thing. "tmux answered, and there is no such pane" is evidence about the pane. "No server answered on that socket" is a failed read, and a failed read is evidence about nothing at all. Both arrived as `TmuxError.commandFailed`, and both became `.missing`.

The second case is reachable in ordinary use. tmux resolves every `-L <name>` under `$TMUX_TMPDIR/tmux-<uid>/`, and the daemon spawns tmux with `environment: nil` — it inherits whatever environment it was launched with. When that differs from the environment of the shell a person types in, the identical `-L tbd-c1d9f56d` names two different socket files. The daemon looks at a socket where nothing is running, gets a non-zero exit, and reports the difference between the two environments as the death of a pane that never stopped running.

This is precisely the inference [`docs/specs/2026-08-11-bounded-terminal-recovery-design.md`](docs/specs/2026-08-11-bounded-terminal-recovery-design.md) exists to forbid — recover only on affirmative evidence of absence, never on an ambiguous command failure, because "transient server, process, and configuration failures are ambiguous". The app layer already honors that rule, splitting `windowMissing` from `commandFailed` and probing a server-wide inventory before it believes in absence. The daemon had no equivalent. The rule was written down, and only half the system followed it.

## What this PR does

`PaneSendTarget.missing` becomes two cases that mean different things:

- **`.absent`** — tmux answered, on a server that is reachable, and this pane is not there. Positive evidence.
- **`.unreachable`** — the consultation could not be completed. Not an answer about the pane.

A failure is sorted between them by a **positive server-wide inventory probe** (`list-panes -a -F '#{pane_id}'`), which is how the bounded-recovery design already does it in the app. Deliberately not by reading tmux's error text: that design rejects it ("rendered and human-facing text is not a stable machine interface. Exit status and formatted identity inventories are"), and `no_tui_scraping_literals` enforces it. The probe's argv is pinned by a test so it cannot drift into a usage error wearing the same clothes.

The asymmetry is the point. If the probe *lists* the pane, the verdict is `.unreachable`, never `.absent` — a pane tmux just named cannot be reported gone. If the probe itself fails, that is a second failed read, and two failed reads still say nothing.

Every consumer handles the new case deliberately. There is no `default:` anywhere that would quietly absorb `.unreachable` back into absence:

- **send** — refuses as a transport failure with a message that says the server could not be reached and the pane's state is unknown, instead of asserting it is gone.
- **reconcile** — leaves the row byte-identical and lets a later sweep ask again. This is the destructive path, where the next lines park a session or delete its row, so "I don't know" must change nothing. `.absent` still parks and deletes exactly as before.
- **wake** — reports a new `paneUnreadable` rather than `sessionGone`, and deliberately carries no `terminalSessionGone` wire code, whose contract is a positive disagreement.
- **`LimitResumeActuator`** — records a failed read as `failed` carrying the reason, rather than `cancelled`, which asserts the terminal died. **This does not make the resume retryable, and an earlier draft of this description wrongly implied it did.** A row leaving `pending` never re-fires under either status (`setStatus` refuses `pending`, `reschedule` moves only pending rows, and copy-mode is the sole re-arm path), so the auto-resume ends either way. What changes is that the user is told why, instead of the record silently claiming a terminal was gone when nobody could tell.
- **Watch Desk** — throws and aborts the pass, for **both** shapes of non-answer: a server that did not answer, and a consultation that could not be run at all. Excluding an unreadable candidate looks conservative but is the opposite: an empty candidate list makes `ensureDeskSession` spawn a replacement agent and makes `leasedJudgeTerminal` revoke a valid lease. A failed read must cause neither, and the thrown-consultation branch — which predates this branch and still returned `false` — is fixed here too, because the guarantee is worthless if only one of the two routes honors it.

### The boolean probes had the same bug one level up

Review caught that the pane fix was landing too deep to help. `windowExists` and `serverExists` both returned `Bool` and both ended `catch { return false }` — the same conflation — and they gate *ahead* of the pane consultation. In reconcile an unreachable server left `windowAlive` false, so the repaired switch was never reached and park/delete ran anyway. No test could catch it: the window test double was a two-state boolean with no way to say "unreachable".

Both are now `TmuxResourcePresence` (`.present`/`.absent`/`.unreachable`), with the boolean entry points **deleted rather than kept as wrappers**, so the compiler forced all thirteen call sites to be re-decided. The rule applied at each: a failed read may never cause a destructive or irreversible action — park, delete, kill-server, respawn, spawn-a-replacement-desk, revoke-a-lease, cancel-a-resume all decline and let a later pass retry, while positive absence still reclaims, with tests pinning that half so this does not become a reconciler that never reclaims.

`windowPresence` disambiguates via the same positive `list-windows -a` inventory. `serverPresence` cannot — tmux answers a missing server and a mis-resolved socket identically — so its evidence comes from outside tmux: one bounded `/bin/ps` snapshot, reusing `OrphanProcessCollector` rather than adding a second process-table reader. No tmux process for this uid means nothing can be listening on any socket, whatever the socket directory resolves to; that is positive absence, and it is the reboot case that must reclaim. Processes present means something is running that we failed to reach, so rows are protected. A probe that cannot run is never absence. The match is deliberately name-agnostic: keying on `-L <name>` would assume the very name-to-socket resolution under suspicion.

**Known limit of that probe.** It asks "is *any* tmux running for this uid", so post-reboot reclamation only fires while no tmux at all is running — usually true when reconcile runs at daemon startup, but a personal tmux session left alive will hold those rows until it exits. It fails toward keeping rows. Tightening it (matching the server name in argv, or reading the socket path out of tmux's rewritten `tmux: server (<path>)` title, which would answer the drift question directly) is deliberately left for the follow-up.

**Socket-path resolution is deliberately untouched.** Pinning `TMUX_TMPDIR`, or moving from `-L` to an explicit `-S`, changes where every server name resolves and can orphan live tmux servers — the failure mode `CLAUDE.md` warns about, and not something to bundle into a fix that is otherwise purely about not lying. This PR makes the drift *diagnosable* — an `.unreachable` verdict logs the server, the pane, and whether the probe answered — and leaves closing it to the follow-up.

### Why this needed no spec

It restores the system to a theory it already holds, rather than revising one. The rule that absence requires affirmative evidence is already written down and already implemented on the app side; this extends it to the daemon that was violating it. No flag, no migration, no config column, no new RPC method, no schema change.

The parts of this investigation that *do* revise the theory — reconciling rows against live window+pane tuples transactionally, a repair or successor path that preserves scrollback, a read-only repair audit, and teaching the archive gate to consume a liveness verdict — are **not** in this PR. They get their own design doc and their own review.

## Assumptions

- Assumes the daemon's tmux and a user's tmux may resolve the same `-L` name to different sockets. That is what this PR stops mis-reporting; it does **not** prevent it. If the environments are aligned by other means, this change is inert rather than wrong.
- Assumes a server-wide `list-panes -a` is cheap enough to run on a failed consultation. Failed consultations are rare, and it runs only after one.
- Assumes an aborted Watch Desk pass is safer than a partial one. One unreadable pane now ends the whole tick rather than dropping a single candidate; the next tick retries. Named because a finer tri-state result is possible if that trade turns out wrong.

## Evidence & verification

The repro is the discriminating test. `failedConsultationWithLivePaneIsUnreachable` drives a failed consultation whose reachability probe *does* list the pane and asserts the verdict is `.unreachable` — it fails against the old code, which returned `.missing`, and it is the exact shape of the field report.

Also covered, per branch:

- probe answers without the pane → `.absent`; probe also fails → `.unreachable`; whole-line vs prefix matching; the probe's argv pinned exactly.
- `unreachableServerIsNotReportedAsMissing` — the send message does **not** contain "no longer exists", is recorded as `transport-failed`, and nothing is typed.
- `testReconcileLeavesRowUntouchedWhenServerIsUnreachable` — row JSON byte-identical before and after. This is the one protecting live work.
- `testReconcileStillParksWhenThePaneIsPositivelyAbsent` and `…StillDeletesNonResumableRow…` — the guard against over-correcting into a reconciler that never reclaims anything.
- `staleActivityDoesNotChangeLivenessVerdict` — a dead pane whose row still says `working`/`waiting_for_user` still classifies dead; stale metadata does not bend the verdict.
- `unreachableServerIsNotReportedAsSessionGone` and an RPC-level assertion that wake errors without the `terminalSessionGone` code.
- `testUnreachableServerDoesNotReplaceTheDeskAgent` — spawn recovery left enabled, and nothing is pasted and no terminal row is created.
- `unreachableServerDoesNotCancelTheResume`.

**Not verified locally.** This was authored on a Linux host with no Swift toolchain, so `scripts/swift-safe build` and `scripts/test.sh` could not run and were not run. Compile risk is concentrated in the new and edited test files. Opened as a draft so macOS CI performs the build and suite; I'll drive failures to green on this branch before marking it ready.

## Follow-ups this deliberately leaves open

- Closing the socket-resolution drift itself, rather than only reporting it honestly.
- `tbd terminal list` prints `ID | WINDOW | PANE | LABEL` and no server, and `tmuxServer` lives only on `Worktree` — so an operator cannot cross-check a pane against direct tmux without a join they cannot see. Small additive CLI output, kept out of a bug fix.
- `liveAgentTerminals`' `try? await tmux.paneCurrentCommand(...)` silently excludes a candidate when the query fails — the same defect class again, third member of the family. Not fixed here because it is not a mechanical swap: "the pane is running zsh" is a *real* answer that must keep excluding, so the fix has to split query-failure from a negative verdict, which is a behavior change past this rail.
