### PR TITLE
Fix: The daemon binds its socket before running the archived-worktree repair pass

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -90,8 +90,8 @@ public final class Daemon: Sendable {
     /// after `shutdown()` has already torn down the manager, orphaning them.
     public nonisolated(unsafe) var remoteStartTask: Task<Void, Never>?
     /// Deferred archived-worktree backfill task (step 11a-backfill). Stored so
-    /// `stop()` can cancel and await it — the pass spawns one `git` child per
-    /// archived row, so a SIGTERM mid-pass has a child to reap.
+    /// `stop()` can cancel and await it — the pass spawns `git` children, so a
+    /// SIGTERM mid-pass has an in-flight child to signal on the way out.
     public nonisolated(unsafe) var archivedBackfillTask: Task<Void, Never>?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
@@ -1261,19 +1261,28 @@ public final class Daemon: Sendable {
         // in-flight `describe` immediately rather than only being observed
         // between providers in `loadRegistryAndDescribe`'s loop — but that
         // interruption still runs ON this task, so it needs the daemon
-        // process (and the `SubprocessWatchdog` thread that reaps the killed
-        // child) to still be alive to finish unwinding. Awaiting `.value`
+        // process (and the `SubprocessWatchdog` thread the SIGKILL escalation
+        // is scheduled on) to still be alive to finish unwinding. Awaiting `.value`
         // here, before `Foundation.exit(0)` below, is what guarantees that;
         // without it the process could tear down mid-unwind and orphan the
         // child exactly as before.
+        //
+        // The archived-worktree backfill is cancelled here too, and awaited
+        // just below, for the same reason: it can be mid `runBoundedProcess`,
+        // and the cancellation relay's interruption unwinds ON this task, so
+        // the process must stay alive for that unwind to finish. What awaiting
+        // buys is the unwind, not a reap — the relay signals the `git` child
+        // with SIGTERM and the continuation resumes immediately after, while
+        // the +500 ms SIGKILL escalation is scheduled on the watchdog thread
+        // and does not survive the `Foundation.exit(0)` below.
+        //
+        // Both cancels go out before either await, so the two unwinds overlap
+        // rather than sum. Nothing above this bounds `stop()`'s latency —
+        // `main.swift` has no shutdown watchdog — and both must still complete
+        // before the manager teardown below.
         remoteStartTask?.cancel()
-        await remoteStartTask?.value
-
-        // Cancel-and-await for the same reason as `remoteStartTask` above: the
-        // backfill can be mid `runBoundedProcess`, and the cancellation relay's
-        // interruption unwinds ON this task, so the process must stay alive to
-        // reap the killed `git` child.
         archivedBackfillTask?.cancel()
+        await remoteStartTask?.value
         await archivedBackfillTask?.value
 
         // Stop remote-backends poll loops / events supervisors. Required,

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -89,6 +89,10 @@ public final class Daemon: Sendable {
     /// leaves `loadRegistryAndDescribe` spawning `describe` child processes
     /// after `shutdown()` has already torn down the manager, orphaning them.
     public nonisolated(unsafe) var remoteStartTask: Task<Void, Never>?
+    /// Deferred archived-worktree backfill task (step 11a-backfill). Stored so
+    /// `stop()` can cancel and await it — the pass spawns one `git` child per
+    /// archived row, so a SIGTERM mid-pass has a child to reap.
+    public nonisolated(unsafe) var archivedBackfillTask: Task<Void, Never>?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
     /// Session-limit auto-resume scheduler. Owned here so it can be stopped
@@ -247,10 +251,6 @@ public final class Daemon: Sendable {
         } catch {
             reconcileLogger.warning("Failed to reconcile scratch terminals: \(error.localizedDescription, privacy: .public)")
         }
-        // Backfill archived worktrees whose branch is missing — repairs
-        // rows whose branch was renamed before archive captured the new name.
-        // Idempotent and best-effort; never throws.
-        await ArchivedWorktreeBackfill(db: database, git: git).run()
         // Validate repo health — flips repos with stale paths to .missing.
         // Must come *after* reconcile so newly-discovered worktrees see the
         // correct status, and *before* the periodic tasks so users get accurate
@@ -330,6 +330,33 @@ public final class Daemon: Sendable {
         rpcRouter.deliveryVerifier = verifier
         await verifier.replayMissedObservations(activeSegmentPath: actuationLog.path)
         return verifier
+    }
+
+    /// Start the archived-worktree branch backfill as a background task.
+    ///
+    /// **Ordering contract: this runs only AFTER the RPC listener is bound
+    /// (step 9), never inside `performStartupReconciliation` (step 8d).** The
+    /// pass spawns one `git` subprocess per archived row; measured on a box
+    /// with 1,825 archived worktrees it ran for ~3 minutes, during which the
+    /// daemon had bound no socket, written no port file, and the app's connect
+    /// retries each spawned a daemon that exited "Another daemon is already
+    /// running". Nothing the backfill does needs to precede serving: it repairs
+    /// archived (inactive) rows, is idempotent, never deletes a row and never
+    /// throws.
+    ///
+    /// Returns `nil` in mock mode, where the backfill is a total no-op like
+    /// every other background rail.
+    @discardableResult
+    static func startArchivedWorktreeBackfill(
+        mockMode: MockMode?, database: TBDDatabase, git: GitManager
+    ) -> Task<Void, Never>? {
+        guard mockMode == nil else {
+            daemonLogger.info("Mock mode: skipping archived worktree backfill")
+            return nil
+        }
+        return Task {
+            await ArchivedWorktreeBackfill(db: database, git: git).run()
+        }
     }
 
     /// The construction behind `remote_backends_enabled` / `claude_cloud_enabled`
@@ -911,6 +938,15 @@ public final class Daemon: Sendable {
                 }
             }
 
+            // 11a-backfill. Repair archived worktree rows whose branch was
+            // renamed before archive captured the new name. Deferred off the
+            // boot critical path for the same reason as the tasks above — one
+            // `git` subprocess per archived row is minutes of work on a large
+            // fleet, and the listener must not wait on it. See
+            // `startArchivedWorktreeBackfill` for the ordering contract.
+            self.archivedBackfillTask = Daemon.startArchivedWorktreeBackfill(
+                mockMode: mockMode, database: database, git: git)
+
             // 11a-pre. Prune per-session Claude `fallbackModel` overlay files
             // orphaned by crashes or teardown paths that didn't clean up. Keep only
             // files whose key matches a live terminal. Best-effort.
@@ -1232,6 +1268,13 @@ public final class Daemon: Sendable {
         // child exactly as before.
         remoteStartTask?.cancel()
         await remoteStartTask?.value
+
+        // Cancel-and-await for the same reason as `remoteStartTask` above: the
+        // backfill can be mid `runBoundedProcess`, and the cancellation relay's
+        // interruption unwinds ON this task, so the process must stay alive to
+        // reap the killed `git` child.
+        archivedBackfillTask?.cancel()
+        await archivedBackfillTask?.value
 
         // Stop remote-backends poll loops / events supervisors. Required,
         // not optional: the events supervisor's supervision task retains

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -800,6 +800,45 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Repair an archived worktree's stale branch — but only if the row is
+    /// still the one the caller decided to repair.
+    ///
+    /// This is the compare-and-swap `ArchivedWorktreeBackfill` writes through.
+    /// Its pass runs while the daemon is serving, so an RPC can revive,
+    /// re-archive, rename or forget a row between the snapshot that decided on
+    /// a repair and this write. The write is therefore conditional on the row
+    /// still being `.archived` AND still carrying `expectedBranch`.
+    ///
+    /// Returns `false` when the row changed under the caller (revived,
+    /// re-archived under a different branch, or deleted) and nothing was
+    /// written. That is an expected outcome, not an error: the repair is
+    /// idempotent and best-effort, so losing the race costs nothing — the next
+    /// daemon start either picks the row up again or finds it no longer needs
+    /// repair.
+    ///
+    /// `archivedHeadSHA` is written only when it is non-nil AND the record has
+    /// none: this populates a missing value and never overwrites one.
+    public func repairArchivedBranch(
+        id: UUID, expectedBranch: String, newBranch: String, archivedHeadSHA: String?
+    ) async throws -> Bool {
+        try await writer.write { db -> Bool in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+                return false
+            }
+            guard record.status == WorktreeStatus.archived.rawValue,
+                  record.branch == expectedBranch
+            else {
+                return false
+            }
+            record.branch = newBranch
+            if let sha = archivedHeadSHA, record.archivedHeadSHA == nil {
+                record.archivedHeadSHA = sha
+            }
+            try record.update(db)
+            return true
+        }
+    }
+
     /// Record that this worktree's contents were checked out from an unvetted
     /// ref (a PR head, whose commits may come from a third-party fork).
     /// One-way: only ever sets the flag to `true`. Nothing clears it, because

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -800,18 +800,28 @@ public struct WorktreeStore: Sendable {
         }
     }
 
-    /// Repair an archived worktree's stale branch — but only if the row is
-    /// still the one the caller decided to repair.
+    /// Repair an archived worktree's stale branch, writing only if the row
+    /// still matches the three fields the caller's decision rested on: it is
+    /// still `.archived`, still carries `expectedBranch`, and still has
+    /// `expectedArchivedAt` as its archive timestamp.
     ///
     /// This is the compare-and-swap `ArchivedWorktreeBackfill` writes through.
     /// Its pass runs while the daemon is serving, so an RPC can revive,
-    /// re-archive, rename or forget a row between the snapshot that decided on
-    /// a repair and this write. The write is therefore conditional on the row
-    /// still being `.archived` AND still carrying `expectedBranch`.
+    /// re-archive or forget a row between the snapshot that decided on a repair
+    /// and this write.
     ///
-    /// Returns `false` when the row changed under the caller (revived,
-    /// re-archived under a different branch, or deleted) and nothing was
-    /// written. That is an expected outcome, not an error: the repair is
+    /// The three fields are checked rather than the row's identity of state,
+    /// which SQLite gives no handle on. Status and branch alone are not enough:
+    /// the revive path recreates the *stale* branch name from `archivedHeadSHA`
+    /// (`WorktreeLifecycle+Archive.swift`), so a row revived and archived again
+    /// comes back `.archived` on `expectedBranch` and would otherwise pass.
+    /// `archivedAt` closes that: `archive` stamps `Date()` on every archive and
+    /// `revive` clears it to nil, so a revive/re-archive cycle necessarily
+    /// changes it.
+    ///
+    /// Returns `false` when any of the three no longer matches (the row was
+    /// revived, re-archived, moved to another branch, or deleted) and nothing
+    /// was written. That is an expected outcome, not an error: the repair is
     /// idempotent and best-effort, so losing the race costs nothing — the next
     /// daemon start either picks the row up again or finds it no longer needs
     /// repair.
@@ -819,14 +829,16 @@ public struct WorktreeStore: Sendable {
     /// `archivedHeadSHA` is written only when it is non-nil AND the record has
     /// none: this populates a missing value and never overwrites one.
     public func repairArchivedBranch(
-        id: UUID, expectedBranch: String, newBranch: String, archivedHeadSHA: String?
+        id: UUID, expectedBranch: String, newBranch: String, expectedArchivedAt: Date?,
+        archivedHeadSHA: String?
     ) async throws -> Bool {
         try await writer.write { db -> Bool in
             guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
                 return false
             }
             guard record.status == WorktreeStatus.archived.rawValue,
-                  record.branch == expectedBranch
+                  record.branch == expectedBranch,
+                  record.archivedAt == expectedArchivedAt
             else {
                 return false
             }

--- a/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
+++ b/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
@@ -19,9 +19,10 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "archivedBack
 ///
 /// The pass runs *while the daemon serves RPCs* (see
 /// `Daemon.startArchivedWorktreeBackfill`), so every write goes through
-/// `WorktreeStore.repairArchivedBranch`, which refuses a row that changed under
-/// the pass, and every loop checks `Task.isCancelled` so shutdown does not have
-/// to wait out one `git` subprocess per archived row.
+/// `WorktreeStore.repairArchivedBranch`, which refuses a row whose status,
+/// branch or `archivedAt` no longer matches the snapshot the repair was decided
+/// from, and every loop checks `Task.isCancelled` so shutdown does not have to
+/// wait out the `git` subprocesses still ahead of it.
 public struct ArchivedWorktreeBackfill: Sendable {
     public let db: TBDDatabase
     public let git: GitManager
@@ -43,7 +44,7 @@ public struct ArchivedWorktreeBackfill: Sendable {
 
         for repo in repos where repo.status != .missing {
             // The pass now runs alongside a serving daemon, so a SIGTERM must
-            // not have to wait out one `git` subprocess per archived row.
+            // not have to wait out the remaining repos' `git` subprocesses.
             guard !Task.isCancelled else {
                 logger.debug("backfill: cancelled before repo \(repo.displayName, privacy: .public)")
                 return
@@ -52,8 +53,23 @@ public struct ArchivedWorktreeBackfill: Sendable {
         }
     }
 
+    /// What one repo's pass did, in counts. Returned so tests can assert the
+    /// two things the repo-wide ref map is about, neither of which shows up in
+    /// the DB: that a branch the map names costs no `git` subprocess, and that
+    /// a branch it does *not* name still gets a real `refExists` before the row
+    /// is called broken. Nothing in production reads this.
+    struct RepoPassStats: Equatable {
+        /// Rows whose branch the ref map did not name, and which therefore
+        /// reached a real `git rev-parse` probe.
+        var refExistsProbes = 0
+        /// Rows the pass judged broken and handed to `attemptRepair`.
+        var repairAttempts = 0
+    }
+
     /// Run the backfill for a single repo. `internal` so tests can drive it directly.
-    func runForRepo(repo: Repo) async {
+    @discardableResult
+    func runForRepo(repo: Repo) async -> RepoPassStats {
+        var stats = RepoPassStats()
         // `listLocal`, not `list`: this pass probes each row's branch against
         // the repo's checkout on THIS disk, so a remote lane — which has no
         // checkout here — is not broken, it is out of scope. Probing one would
@@ -66,10 +82,31 @@ public struct ArchivedWorktreeBackfill: Sendable {
             archived = try await db.worktrees.listLocal(repoID: repo.id, status: .archived)
         } catch {
             logger.warning("backfill: failed to list archived worktrees for \(repo.displayName, privacy: .public): \(error, privacy: .public)")
-            return
+            return stats
         }
 
-        guard !archived.isEmpty else { return }
+        guard !archived.isEmpty else { return stats }
+
+        // One `for-each-ref` for the whole repo, used as a fast *negative*
+        // filter — never as a replacement for `refExists`. `refExists` resolves
+        // a ref by git's own rules; `refTips` covers only `refs/heads` and
+        // `refs/remotes/origin`. A name present in the map certainly resolves,
+        // so the row is fine and costs no subprocess (the overwhelmingly common
+        // case on a healthy fleet). A name *absent* from the map may still
+        // resolve some other way, so it falls through to the real `refExists`
+        // before the row is treated as broken — treating absence as authority
+        // would reclassify rows as broken and trigger repairs that never used
+        // to happen.
+        //
+        // A failed `refTips` leaves this nil, which degrades to exactly the
+        // per-row behavior that predates it: one `refExists` per archived row.
+        let tips: [String: String]?
+        do {
+            tips = try await git.refTips(repoPath: repo.path)
+        } catch {
+            logger.warning("backfill: refTips failed in \(repo.displayName, privacy: .public), falling back to per-row probes: \(error, privacy: .public)")
+            tips = nil
+        }
 
         // Lazily mine the reflog only if at least one row needs repair —
         // skip the git call entirely on the common (no-broken-rows) path.
@@ -80,8 +117,10 @@ public struct ArchivedWorktreeBackfill: Sendable {
         for wt in archived {
             guard !Task.isCancelled else {
                 logger.debug("backfill: cancelled mid-repo \(repo.displayName, privacy: .public)")
-                return
+                return stats
             }
+            if tips?[wt.branch] != nil { continue }
+            stats.refExistsProbes += 1
             let branchOK = await git.refExists(repoPath: repo.path, ref: wt.branch)
             logger.debug("backfill:   wt=\(wt.name, privacy: .public) branch=\(wt.branch, privacy: .public) exists=\(branchOK, privacy: .public)")
             if branchOK {
@@ -93,14 +132,26 @@ public struct ArchivedWorktreeBackfill: Sendable {
                 renameMap = await mineReflogRenames(repoPath: repo.path)
             }
 
-            await attemptRepair(worktree: wt.worktree, repo: repo, renameMap: renameMap ?? [:])
+            stats.repairAttempts += 1
+            await attemptRepair(
+                worktree: wt.worktree, repo: repo, renameMap: renameMap ?? [:], refTips: tips)
         }
+        return stats
     }
 
     /// Repair one row. `internal` (like `runForRepo`) so tests can drive it
     /// with a deliberately stale snapshot — the race this pass has to survive
     /// now that it runs alongside a serving daemon.
-    func attemptRepair(worktree: Worktree, repo: Repo, renameMap: [String: String]) async {
+    ///
+    /// `refTips` is the repo-wide ref map `runForRepo` already paid for, used
+    /// here on the same positive-only terms: a name found in it resolves and
+    /// carries its SHA, a name absent from it falls back to `refExists` /
+    /// `headSHA`. Nil means the map was unavailable and every probe is a
+    /// subprocess.
+    func attemptRepair(
+        worktree: Worktree, repo: Repo, renameMap: [String: String],
+        refTips: [String: String]? = nil
+    ) async {
         // Walk the rename chain (a → b → c) until we hit a branch that no
         // longer appears as a key (i.e. the latest known name).
         var current = worktree.branch
@@ -115,7 +166,23 @@ public struct ArchivedWorktreeBackfill: Sendable {
             return
         }
 
-        let newExists = await git.refExists(repoPath: repo.path, ref: current)
+        // `refs/heads/<name>` short-names to `<name>`; a remote-tracking ref
+        // short-names to `origin/<name>`. `current` came out of a
+        // `refs/heads/… → refs/heads/…` reflog entry, so an `origin/` prefix
+        // here would mean a local branch literally named `origin/…`, whose key
+        // in the map is ambiguous with the remote-tracking ref of the same
+        // name. Refuse the shortcut in that case and let git answer.
+        let tipSHA: String? = current.hasPrefix("origin/") ? nil : refTips?[current]
+        // Spelled out rather than `tipSHA != nil || await refExists(…)`:
+        // `||` takes its right operand as an autoclosure, which cannot be
+        // `async`. The short-circuit is the point — a name the map already
+        // resolved must not cost a subprocess.
+        let newExists: Bool
+        if tipSHA != nil {
+            newExists = true
+        } else {
+            newExists = await git.refExists(repoPath: repo.path, ref: current)
+        }
         guard newExists else {
             logger.warning("backfill: worktree \(worktree.id, privacy: .public) reflog suggests rename '\(worktree.branch, privacy: .public)' → '\(current, privacy: .public)' but renamed branch is also missing")
             return
@@ -135,34 +202,61 @@ public struct ArchivedWorktreeBackfill: Sendable {
             // land on the newer commit. Acceptable: the fallback only fires
             // when the branch is also gone, and a slightly newer starting point
             // beats outright failure.
-            do {
-                headSHA = try await git.headSHA(repoPath: repo.path, ref: current)
-            } catch {
-                logger.warning("backfill: failed to resolve archivedHeadSHA for \(worktree.id, privacy: .public) (branch \(current, privacy: .public)): \(error, privacy: .public)")
+            if let tipSHA {
+                headSHA = tipSHA
+            } else {
+                do {
+                    headSHA = try await git.headSHA(repoPath: repo.path, ref: current)
+                } catch {
+                    logger.warning("backfill: failed to resolve archivedHeadSHA for \(worktree.id, privacy: .public) (branch \(current, privacy: .public)): \(error, privacy: .public)")
+                }
             }
         }
 
+        // Re-verify the premise the repair rests on — "`worktree.branch` does
+        // not resolve" — immediately before the write. Between the probe that
+        // decided this row was broken and now, a revive can have recreated that
+        // exact branch: `beginReviveWorktree` runs `git worktree add` on
+        // `worktree.branch` at `archivedHeadSHA` while leaving the row
+        // `.archived` on the old branch for the whole of its work
+        // (`WorktreeLifecycle+Archive.swift`), so the CAS below sees nothing
+        // amiss and would rewrite the branch out from under a live checkout.
+        // One subprocess, paid only on rows that are about to be repaired.
+        //
+        // This narrows the window; it does not close it. The probe cannot run
+        // inside the DB transaction, so a revive landing between these two
+        // lines still slips through — with the row's `archivedAt` unchanged,
+        // the CAS cannot see it either. What the CAS *does* close durably is
+        // the aftermath: once that revive completes and the worktree is
+        // archived again, `archivedAt` differs and the row is never rewritten.
+        if await git.refExists(repoPath: repo.path, ref: worktree.branch) {
+            logger.debug("backfill: worktree \(worktree.id, privacy: .public) branch '\(worktree.branch, privacy: .public)' resolves again (likely revived under the pass) — repair abandoned")
+            return
+        }
+
         // The snapshot this decision came from can be stale: the daemon is
-        // serving, so an RPC may have revived, re-archived, renamed or deleted
-        // this row since. `repairArchivedBranch` writes only if the row is
-        // still archived and still carries the branch we decided to repair.
-        // Losing that race is expected and costs nothing — the repair is
-        // idempotent, so the next daemon start picks the row up again if it
-        // still needs one. No lock and no generation column: a lock held
-        // across one `git` subprocess per archived row would block exactly the
-        // RPCs this deferral exists to unblock.
+        // serving, so an RPC may have revived, re-archived or deleted this row
+        // since. `repairArchivedBranch` writes only if the row is still
+        // archived, still carries the branch we decided to repair, and still
+        // has the `archivedAt` the snapshot was taken with. Losing that race is
+        // expected and costs nothing — the repair is idempotent, so the next
+        // daemon start picks the row up again if it still needs one. No lock
+        // and no generation column: a lock held across the pass's `git`
+        // subprocesses would block exactly the RPCs this deferral exists to
+        // unblock.
         let repaired: Bool
         do {
             repaired = try await db.worktrees.repairArchivedBranch(
                 id: worktree.id, expectedBranch: worktree.branch,
-                newBranch: current, archivedHeadSHA: headSHA)
+                newBranch: current, expectedArchivedAt: worktree.archivedAt,
+                archivedHeadSHA: headSHA)
         } catch {
             logger.warning("backfill: failed to update branch for \(worktree.id, privacy: .public): \(error, privacy: .public)")
             return
         }
 
         guard repaired else {
-            logger.debug("backfill: worktree \(worktree.id, privacy: .public) changed under the pass (no longer archived on '\(worktree.branch, privacy: .public)') — skipped")
+            logger.debug("backfill: worktree \(worktree.id, privacy: .public) no longer matches the snapshot (status, branch '\(worktree.branch, privacy: .public)', or archivedAt changed) — skipped")
             return
         }
 

--- a/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
+++ b/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
@@ -16,6 +16,12 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "archivedBack
 ///
 /// Idempotent: rows with a resolvable branch are skipped — running twice is a
 /// no-op for already-fixed rows. Never deletes rows; never throws to the caller.
+///
+/// The pass runs *while the daemon serves RPCs* (see
+/// `Daemon.startArchivedWorktreeBackfill`), so every write goes through
+/// `WorktreeStore.repairArchivedBranch`, which refuses a row that changed under
+/// the pass, and every loop checks `Task.isCancelled` so shutdown does not have
+/// to wait out one `git` subprocess per archived row.
 public struct ArchivedWorktreeBackfill: Sendable {
     public let db: TBDDatabase
     public let git: GitManager
@@ -36,6 +42,12 @@ public struct ArchivedWorktreeBackfill: Sendable {
         }
 
         for repo in repos where repo.status != .missing {
+            // The pass now runs alongside a serving daemon, so a SIGTERM must
+            // not have to wait out one `git` subprocess per archived row.
+            guard !Task.isCancelled else {
+                logger.debug("backfill: cancelled before repo \(repo.displayName, privacy: .public)")
+                return
+            }
             await runForRepo(repo: repo)
         }
     }
@@ -66,6 +78,10 @@ public struct ArchivedWorktreeBackfill: Sendable {
         logger.debug("backfill: repo=\(repo.displayName, privacy: .public) archivedCount=\(archived.count, privacy: .public)")
 
         for wt in archived {
+            guard !Task.isCancelled else {
+                logger.debug("backfill: cancelled mid-repo \(repo.displayName, privacy: .public)")
+                return
+            }
             let branchOK = await git.refExists(repoPath: repo.path, ref: wt.branch)
             logger.debug("backfill:   wt=\(wt.name, privacy: .public) branch=\(wt.branch, privacy: .public) exists=\(branchOK, privacy: .public)")
             if branchOK {
@@ -81,7 +97,10 @@ public struct ArchivedWorktreeBackfill: Sendable {
         }
     }
 
-    private func attemptRepair(worktree: Worktree, repo: Repo, renameMap: [String: String]) async {
+    /// Repair one row. `internal` (like `runForRepo`) so tests can drive it
+    /// with a deliberately stale snapshot — the race this pass has to survive
+    /// now that it runs alongside a serving daemon.
+    func attemptRepair(worktree: Worktree, repo: Repo, renameMap: [String: String]) async {
         // Walk the rename chain (a → b → c) until we hit a branch that no
         // longer appears as a key (i.e. the latest known name).
         var current = worktree.branch
@@ -102,26 +121,49 @@ public struct ArchivedWorktreeBackfill: Sendable {
             return
         }
 
+        // Resolve everything the write needs BEFORE touching the row, so the
+        // repair lands as one compare-and-swap rather than two unguarded
+        // writes. A SHA lookup that fails still must not block the branch
+        // repair, so it degrades to `nil` — which the store reads as "leave
+        // archivedHeadSHA alone".
+        var headSHA: String? = nil
+        if worktree.archivedHeadSHA == nil {
+            // Populate archivedHeadSHA from the renamed branch's *current*
+            // HEAD — not the commit the worktree was on at archive time, which
+            // we can't recover after the fact. If the user committed on the
+            // renamed branch post-archive, a later SHA-fallback revive will
+            // land on the newer commit. Acceptable: the fallback only fires
+            // when the branch is also gone, and a slightly newer starting point
+            // beats outright failure.
+            do {
+                headSHA = try await git.headSHA(repoPath: repo.path, ref: current)
+            } catch {
+                logger.warning("backfill: failed to resolve archivedHeadSHA for \(worktree.id, privacy: .public) (branch \(current, privacy: .public)): \(error, privacy: .public)")
+            }
+        }
+
+        // The snapshot this decision came from can be stale: the daemon is
+        // serving, so an RPC may have revived, re-archived, renamed or deleted
+        // this row since. `repairArchivedBranch` writes only if the row is
+        // still archived and still carries the branch we decided to repair.
+        // Losing that race is expected and costs nothing — the repair is
+        // idempotent, so the next daemon start picks the row up again if it
+        // still needs one. No lock and no generation column: a lock held
+        // across one `git` subprocess per archived row would block exactly the
+        // RPCs this deferral exists to unblock.
+        let repaired: Bool
         do {
-            try await db.worktrees.updateBranch(id: worktree.id, branch: current)
+            repaired = try await db.worktrees.repairArchivedBranch(
+                id: worktree.id, expectedBranch: worktree.branch,
+                newBranch: current, archivedHeadSHA: headSHA)
         } catch {
             logger.warning("backfill: failed to update branch for \(worktree.id, privacy: .public): \(error, privacy: .public)")
             return
         }
 
-        // Populate archivedHeadSHA from the renamed branch's *current* HEAD —
-        // not the commit the worktree was on at archive time, which we can't
-        // recover after the fact. If the user committed on the renamed branch
-        // post-archive, a later SHA-fallback revive will land on the newer
-        // commit. Acceptable: the fallback only fires when the branch is also
-        // gone, and a slightly newer starting point beats outright failure.
-        if worktree.archivedHeadSHA == nil {
-            do {
-                let sha = try await git.headSHA(repoPath: repo.path, ref: current)
-                try await db.worktrees.updateArchivedHeadSHA(id: worktree.id, sha: sha)
-            } catch {
-                logger.warning("backfill: failed to populate archivedHeadSHA for \(worktree.id, privacy: .public) (branch \(current, privacy: .public)): \(error, privacy: .public)")
-            }
+        guard repaired else {
+            logger.debug("backfill: worktree \(worktree.id, privacy: .public) changed under the pass (no longer archived on '\(worktree.branch, privacy: .public)') — skipped")
+            return
         }
 
         logger.info("backfill: repaired worktree \(worktree.id, privacy: .public) branch '\(worktree.branch, privacy: .public)' → '\(current, privacy: .public)'")

--- a/Tests/TBDDaemonTests/ArchivedBackfillDeferralTests.swift
+++ b/Tests/TBDDaemonTests/ArchivedBackfillDeferralTests.swift
@@ -139,6 +139,230 @@ struct ArchivedBackfillDeferralTests {
         #expect(after.archivedHeadSHA == nil)
     }
 
+    // MARK: - The premise is re-verified immediately before the write
+
+    /// A1: `beginReviveWorktree` recreates the *stale* branch name from
+    /// `archivedHeadSHA` and leaves the row `.archived` on that name for the
+    /// whole of its work, so status and branch alone cannot tell a mid-revive
+    /// row from an untouched one. What can is the premise the repair rests on:
+    /// the branch does not resolve. `attemptRepair` re-probes it right before
+    /// the write, and abandons the repair when it resolves again.
+    @Test("a row whose branch resolves again by write time is not repaired")
+    func branchResolvingAgainAbandonsTheRepair() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+        let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+
+        // The snapshot the pass decided from, taken while the branch is gone.
+        let snapshot = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        let renameMap = await backfill.mineReflogRenames(repoPath: broken.repo.path)
+        #expect(renameMap[broken.staleBranch] == broken.renamedBranch)
+
+        // ... and then a revive recreates the stale branch at the archived SHA,
+        // leaving the row `.archived` on that same branch while it works.
+        let sha = try await git.headSHA(repoPath: broken.repo.path, ref: broken.renamedBranch)
+        try await shell("git branch \(broken.staleBranch) \(sha)", at: URL(fileURLWithPath: broken.repo.path))
+
+        await backfill.attemptRepair(
+            worktree: snapshot, repo: broken.repo, renameMap: renameMap)
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(
+            after.branch == broken.staleBranch,
+            "the branch resolves again, so the premise of the repair no longer holds")
+        #expect(after.archivedHeadSHA == nil)
+    }
+
+    /// A2, end to end: revive recreates the stale branch, the user re-archives,
+    /// and the row comes back `.archived` on that same branch name. A stale
+    /// write here is durable — `refreshGitStatuses` only syncs branches for
+    /// `.active` rows, so nothing would ever correct it and the next revive
+    /// would check out the wrong branch.
+    @Test("a row revived and re-archived under the pass is not repaired")
+    func revivedAndReArchivedRowIsNotRepaired() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+        let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+
+        let snapshot = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        let renameMap = await backfill.mineReflogRenames(repoPath: broken.repo.path)
+
+        // Revive: the stale branch is recreated at the archived SHA and the row
+        // goes active. Then the user archives again on that same branch.
+        let sha = try await git.headSHA(repoPath: broken.repo.path, ref: broken.renamedBranch)
+        try await shell("git branch \(broken.staleBranch) \(sha)", at: URL(fileURLWithPath: broken.repo.path))
+        try await db.worktrees.revive(id: broken.worktreeID)
+        try await db.worktrees.archive(id: broken.worktreeID, archivedHeadSHA: sha)
+
+        await backfill.attemptRepair(
+            worktree: snapshot, repo: broken.repo, renameMap: renameMap)
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(after.status == .archived)
+        #expect(after.branch == broken.staleBranch, "a re-archived row must not be rewritten")
+        #expect(after.archivedAt != snapshot.archivedAt)
+    }
+
+    /// A2, isolated on `archivedAt`: the revive/re-archive cycle happened and
+    /// the branch is missing again by the time the pass writes (the user
+    /// renamed or deleted it after re-archiving), so the re-probe above finds
+    /// nothing wrong. Only the changed `archivedAt` distinguishes this row from
+    /// the one the snapshot described.
+    @Test("a re-archived row is refused even when its branch is missing again")
+    func reArchivedRowWithMissingBranchIsNotRepaired() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+        let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+
+        let snapshot = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        let renameMap = await backfill.mineReflogRenames(repoPath: broken.repo.path)
+
+        // A full revive / re-archive cycle at the row level. The branch stays
+        // missing in the repo, so the pre-write re-probe has nothing to catch.
+        try await db.worktrees.revive(id: broken.worktreeID)
+        try await db.worktrees.archive(id: broken.worktreeID)
+        #expect(await git.refExists(repoPath: broken.repo.path, ref: broken.staleBranch) == false)
+
+        await backfill.attemptRepair(
+            worktree: snapshot, repo: broken.repo, renameMap: renameMap)
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(after.branch == broken.staleBranch)
+        #expect(after.archivedHeadSHA == nil)
+    }
+
+    // MARK: - The repo-wide ref map is a negative filter, not an authority
+
+    /// `runForRepo` hoists one `git for-each-ref` per repo and skips any row
+    /// whose branch it names, which spares a subprocess per row on a healthy
+    /// fleet. The map covers only `refs/heads` and `refs/remotes/origin`, so a
+    /// branch *absent* from it must still be confirmed with `refExists` before
+    /// the row counts as broken — otherwise rows git resolves fine get
+    /// reclassified and repaired for the first time.
+    ///
+    /// Here the DB's branch name resolves as a **tag**: outside both namespaces
+    /// the map covers, and with a rename for that same name sitting in the
+    /// reflog, so a map treated as authoritative would classify the row broken
+    /// and hand it to `attemptRepair`.
+    ///
+    /// The assertion is on the pass's own counts, not just the row. An
+    /// authoritative map does not in fact corrupt this row — `attemptRepair`'s
+    /// pre-write re-probe of the same branch catches it a moment later and
+    /// abandons the repair — so the DB looks identical either way and only the
+    /// counts tell the two apart. Two guards covering one outcome is the
+    /// intent, not an accident; this pins the outer one so it cannot rot behind
+    /// the inner one.
+    @Test("a branch resolving outside the ref map's namespaces is left alone")
+    func refMapAbsenceFallsBackToRefExists() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+
+        let sha = try await git.headSHA(repoPath: broken.repo.path, ref: broken.renamedBranch)
+        try await shell("git tag \(broken.staleBranch) \(sha)", at: URL(fileURLWithPath: broken.repo.path))
+        let tips = try await git.refTips(repoPath: broken.repo.path)
+        #expect(tips[broken.staleBranch] == nil, "a tag is outside refs/heads and refs/remotes/origin")
+        #expect(await git.refExists(repoPath: broken.repo.path, ref: broken.staleBranch))
+
+        let stats = await ArchivedWorktreeBackfill(db: db, git: git)
+            .runForRepo(repo: broken.repo)
+
+        #expect(
+            stats.refExistsProbes == 1,
+            "a branch the map does not name must still be confirmed with refExists")
+        #expect(
+            stats.repairAttempts == 0,
+            "the ref map is a fast negative filter; git decides what actually resolves")
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(after.branch == broken.staleBranch)
+        #expect(after.archivedHeadSHA == nil)
+    }
+
+    /// The map's positive leg, and the saving that motivated it: every archived
+    /// row resolves through `refs/heads`, so one `for-each-ref` answers all of
+    /// them, not one `rev-parse` each, and every row is left as it was found.
+    @Test("a repo whose archived branches all resolve costs no per-row probe")
+    func healthyRepoIsLeftUntouched() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        var ids: [UUID: String] = [:]
+        for _ in 0..<3 {
+            let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+            try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+            ids[wt.id] = wt.branch
+        }
+
+        // The premise: every archived row's branch is named by the repo-wide
+        // ref map, so the fast path answers all of them and no row ever reaches
+        // a `refExists` probe or the reflog.
+        let tips = try await git.refTips(repoPath: repo.path)
+        for branch in ids.values {
+            #expect(tips[branch] != nil, "archive keeps the branch, so the ref map names it")
+        }
+
+        let stats = await ArchivedWorktreeBackfill(db: db, git: git).runForRepo(repo: repo)
+        #expect(
+            stats == .init(refExistsProbes: 0, repairAttempts: 0),
+            "the repo-wide ref map answered every row; no row cost a subprocess")
+
+        for (id, branch) in ids {
+            let after = try #require(try await db.worktrees.get(id: id))
+            #expect(after.branch == branch)
+        }
+    }
+
+    /// The degraded leg: when `refTips` is unavailable the pass must behave
+    /// exactly as it did before the map existed — every probe a subprocess,
+    /// every repairable row still repaired. `nil` is what a failed
+    /// `for-each-ref` leaves behind.
+    @Test("a nil ref map still repairs a broken row")
+    func nilRefMapStillRepairs() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+        let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+
+        let snapshot = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        let renameMap = await backfill.mineReflogRenames(repoPath: broken.repo.path)
+        await backfill.attemptRepair(
+            worktree: snapshot, repo: broken.repo, renameMap: renameMap, refTips: nil)
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(after.branch == broken.renamedBranch)
+        #expect(after.archivedHeadSHA?.isEmpty == false)
+    }
+
     // MARK: - Cancellation
 
     /// A gate that lets the test cancel the backfill task before its pass
@@ -169,11 +393,12 @@ struct ArchivedBackfillDeferralTests {
     ///
     /// This test does **not** discriminate the `Task.isCancelled` guards on
     /// its own: `runBoundedProcess`'s `CancellationRelay` already kills every
-    /// `git` child of a cancelled task, so `refExists` answers false, the
+    /// `git` child of a cancelled task, so `refTips` and `refExists` fail, the
     /// reflog read comes back empty, and no repair is reachable whether or not
     /// the loops check cancellation. What the guards buy is the *early return*
-    /// — not spawning one doomed subprocess per archived row on the way out —
-    /// and that is a subprocess count, which this tree has no seam to observe.
+    /// — not spawning the doomed subprocesses still ahead of the pass on the
+    /// way out — and that is a subprocess count, which this tree has no seam to
+    /// observe.
     @Test("a cancelled pass repairs nothing; the same fixture repairs when not cancelled")
     func cancelledPassRepairsNothing() async throws {
         let (tempDir, repoDir) = try await createTestRepo()
@@ -208,8 +433,9 @@ struct ArchivedBackfillDeferralTests {
 // MARK: - The compare-and-swap write itself
 
 /// `WorktreeStore.repairArchivedBranch` is the whole concurrency position of
-/// the deferred backfill: the write lands only if the row is still the one the
-/// caller decided to repair. Tier 1 — in-memory DB, no subprocesses.
+/// the deferred backfill: the write lands only if the row still matches the
+/// three fields the caller's decision rested on — status, branch, and the
+/// archive timestamp. Tier 1 — in-memory DB, no subprocesses.
 @Suite("RepairArchivedBranchTests")
 struct RepairArchivedBranchTests {
 
@@ -227,13 +453,44 @@ struct RepairArchivedBranchTests {
         return wt
     }
 
+    /// The row's archive timestamp as the backfill reads it: through
+    /// `listLocal(repoID:status:)`, the same query `runForRepo` snapshots from.
+    private func listedArchivedAt(db: TBDDatabase, wt: Worktree) async throws -> Date? {
+        let listed = try await db.worktrees.listLocal(repoID: wt.repoID, status: .archived)
+        return try #require(listed.first { $0.id == wt.id }).archivedAt
+    }
+
+    /// The `archivedAt` half of the CAS is only worth anything if a `Date`
+    /// survives the write-read-compare round trip through GRDB unchanged. If it
+    /// did not, the guard would silently refuse every repair — a vacuous guard
+    /// that looks like a working one. So: seed a row, read the timestamp back
+    /// the way the pass reads it, and compare-and-swap with exactly that value.
+    @Test("round trip: an archivedAt read back through listLocal() satisfies the CAS")
+    func archivedAtSurvivesTheRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await seedArchivedWorktree(db: db, branch: "old")
+
+        let readBack = try await listedArchivedAt(db: db, wt: wt)
+        #expect(readBack != nil, "an archived row carries an archive timestamp")
+
+        let repaired = try await db.worktrees.repairArchivedBranch(
+            id: wt.id, expectedBranch: "old", newBranch: "new",
+            expectedArchivedAt: readBack, archivedHeadSHA: "deadbeef")
+        #expect(repaired, "a Date read back through listLocal() must still match the stored row")
+
+        let after = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(after.branch == "new")
+    }
+
     @Test("success: an unchanged archived row is repaired and gets its missing SHA")
     func repairsUnchangedRow() async throws {
         let db = try TBDDatabase(inMemory: true)
         let wt = try await seedArchivedWorktree(db: db, branch: "old")
+        let archivedAt = try await listedArchivedAt(db: db, wt: wt)
 
         let repaired = try await db.worktrees.repairArchivedBranch(
-            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "deadbeef")
+            id: wt.id, expectedBranch: "old", newBranch: "new",
+            expectedArchivedAt: archivedAt, archivedHeadSHA: "deadbeef")
         #expect(repaired)
 
         let after = try #require(try await db.worktrees.get(id: wt.id))
@@ -245,9 +502,11 @@ struct RepairArchivedBranchTests {
     func preservesExistingHeadSHA() async throws {
         let db = try TBDDatabase(inMemory: true)
         let wt = try await seedArchivedWorktree(db: db, branch: "old", archivedHeadSHA: "original")
+        let archivedAt = try await listedArchivedAt(db: db, wt: wt)
 
         let repaired = try await db.worktrees.repairArchivedBranch(
-            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "replacement")
+            id: wt.id, expectedBranch: "old", newBranch: "new",
+            expectedArchivedAt: archivedAt, archivedHeadSHA: "replacement")
         #expect(repaired)
 
         let after = try #require(try await db.worktrees.get(id: wt.id))
@@ -259,7 +518,8 @@ struct RepairArchivedBranchTests {
     func refusesMissingRow() async throws {
         let db = try TBDDatabase(inMemory: true)
         let repaired = try await db.worktrees.repairArchivedBranch(
-            id: UUID(), expectedBranch: "old", newBranch: "new", archivedHeadSHA: nil)
+            id: UUID(), expectedBranch: "old", newBranch: "new",
+            expectedArchivedAt: Date(), archivedHeadSHA: nil)
         #expect(!repaired)
     }
 
@@ -267,10 +527,12 @@ struct RepairArchivedBranchTests {
     func refusesRevivedRow() async throws {
         let db = try TBDDatabase(inMemory: true)
         let wt = try await seedArchivedWorktree(db: db, branch: "old")
+        let archivedAt = try await listedArchivedAt(db: db, wt: wt)
         try await db.worktrees.revive(id: wt.id)
 
         let repaired = try await db.worktrees.repairArchivedBranch(
-            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "deadbeef")
+            id: wt.id, expectedBranch: "old", newBranch: "new",
+            expectedArchivedAt: archivedAt, archivedHeadSHA: "deadbeef")
         #expect(!repaired)
 
         let after = try #require(try await db.worktrees.get(id: wt.id))
@@ -282,14 +544,44 @@ struct RepairArchivedBranchTests {
     func refusesChangedBranch() async throws {
         let db = try TBDDatabase(inMemory: true)
         let wt = try await seedArchivedWorktree(db: db, branch: "old")
+        let archivedAt = try await listedArchivedAt(db: db, wt: wt)
         try await db.worktrees.updateBranch(id: wt.id, branch: "someone-elses-branch")
 
         let repaired = try await db.worktrees.repairArchivedBranch(
-            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "deadbeef")
+            id: wt.id, expectedBranch: "old", newBranch: "new",
+            expectedArchivedAt: archivedAt, archivedHeadSHA: "deadbeef")
         #expect(!repaired)
 
         let after = try #require(try await db.worktrees.get(id: wt.id))
         #expect(after.branch == "someone-elses-branch")
         #expect(after.archivedHeadSHA == nil)
+    }
+
+    /// The revive path recreates the *stale* branch name from
+    /// `archivedHeadSHA`, so a row revived and archived again comes back
+    /// `.archived` on exactly the branch the pass expected: status and branch
+    /// agree, and only the archive timestamp says the row is not the one the
+    /// snapshot described. Without that third field this write lands, and
+    /// nothing corrects it afterwards — `refreshGitStatuses` syncs branches for
+    /// `.active` rows only.
+    @Test("archivedAt changed: a row revived and re-archived on the same branch is refused")
+    func refusesReArchivedRowOnTheSameBranch() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await seedArchivedWorktree(db: db, branch: "old")
+        let archivedAt = try await listedArchivedAt(db: db, wt: wt)
+
+        try await db.worktrees.revive(id: wt.id)
+        try await db.worktrees.archive(id: wt.id, archivedHeadSHA: "post-revive-sha")
+        let reArchivedAt = try await listedArchivedAt(db: db, wt: wt)
+        #expect(reArchivedAt != archivedAt, "every archive stamps a fresh timestamp")
+
+        let repaired = try await db.worktrees.repairArchivedBranch(
+            id: wt.id, expectedBranch: "old", newBranch: "new",
+            expectedArchivedAt: archivedAt, archivedHeadSHA: "deadbeef")
+        #expect(!repaired)
+
+        let after = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(after.branch == "old")
+        #expect(after.archivedHeadSHA == "post-revive-sha")
     }
 }

--- a/Tests/TBDDaemonTests/ArchivedBackfillDeferralTests.swift
+++ b/Tests/TBDDaemonTests/ArchivedBackfillDeferralTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The archived-worktree backfill runs *after* the RPC listener binds, and
+/// therefore alongside RPCs that can mutate the rows it is repairing.
+///
+/// Tier 2 (real git subprocesses, real in-memory DB, no wall-clock waits).
+@Suite("ArchivedBackfillDeferralTests")
+struct ArchivedBackfillDeferralTests {
+
+    /// A repairable broken row: an archived worktree whose DB branch is the
+    /// pre-rename name, with the rename recorded in the repo's reflog. Built
+    /// exactly the way `testBackfillRepairsRenamedBranch` builds it.
+    private struct BrokenRow {
+        let repo: Repo
+        let worktreeID: UUID
+        let staleBranch: String
+        let renamedBranch: String
+    }
+
+    private func makeBrokenArchivedRow(
+        db: TBDDatabase, git: GitManager, tempDir: URL, repoDir: URL
+    ) async throws -> BrokenRow {
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        let staleBranch = wt.branch
+        let renamedBranch = "renamed-\(UUID().uuidString.prefix(6))"
+        try await shell("git branch -m \(renamedBranch)", at: URL(fileURLWithPath: wt.localPath))
+        try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+        // Roll the DB row back to the pre-rename name — the legacy state the
+        // backfill exists to repair.
+        try await db.worktrees.updateBranch(id: wt.id, branch: staleBranch)
+        try await db.worktrees.updateArchivedHeadSHA(id: wt.id, sha: nil)
+
+        return BrokenRow(
+            repo: repo, worktreeID: wt.id,
+            staleBranch: staleBranch, renamedBranch: renamedBranch)
+    }
+
+    // MARK: - Ordering: the backfill is not in the pre-bind phase
+
+    /// `Daemon.start()` runs `performStartupReconciliation` at step 8d and
+    /// binds the RPC listener with `sock.start()` at step 9 — so anything
+    /// inside that method is work the socket waits on. On a box with 1,825
+    /// archived rows the backfill's one-`git`-subprocess-per-row pass held the
+    /// bind for ~3 minutes. This test pins the backfill *out* of that method:
+    /// a repairable row must still be broken when startup reconciliation
+    /// returns, and repaired only once the deferred task (step 11a-backfill,
+    /// after the bind) has run.
+    @Test("startup reconciliation does not repair archived rows; the deferred task does")
+    func backfillIsDeferredPastTheListenerBind() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+
+        await Daemon().performStartupReconciliation(
+            mockMode: nil, database: db, git: git, lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
+
+        let afterReconcile = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(
+            afterReconcile.branch == broken.staleBranch,
+            "the backfill must not run inside performStartupReconciliation — the socket bind waits on it")
+        #expect(afterReconcile.archivedHeadSHA == nil)
+
+        let task = try #require(
+            Daemon.startArchivedWorktreeBackfill(mockMode: nil, database: db, git: git),
+            "live mode must start the deferred backfill task")
+        await task.value
+
+        let afterBackfill = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(afterBackfill.branch == broken.renamedBranch)
+        #expect(afterBackfill.archivedHeadSHA?.isEmpty == false)
+    }
+
+    // MARK: - Mock gate: both branches
+
+    @Test("mock ON: no backfill task is started and nothing is repaired")
+    func mockModeStartsNoBackfill() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+
+        let task = Daemon.startArchivedWorktreeBackfill(
+            mockMode: .enabled(fixturePath: "/tmp/does-not-exist.json"),
+            database: db, git: git)
+        #expect(task == nil)
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(after.branch == broken.staleBranch)
+        #expect(after.archivedHeadSHA == nil)
+    }
+
+    // MARK: - Compare-and-swap: a row that changed under the pass is not clobbered
+
+    @Test("a row revived under the pass keeps its branch")
+    func revivedRowIsNotClobberedMidPass() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+        let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+
+        // The snapshot `runForRepo` would have taken, ...
+        let snapshot = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        let renameMap = await backfill.mineReflogRenames(repoPath: broken.repo.path)
+        #expect(renameMap[broken.staleBranch] == broken.renamedBranch)
+
+        // ... and then an RPC revives the row before the write lands.
+        try await db.worktrees.revive(id: broken.worktreeID)
+
+        await backfill.attemptRepair(
+            worktree: snapshot, repo: broken.repo, renameMap: renameMap)
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(after.status == .active)
+        #expect(after.branch == broken.staleBranch, "a revived row must not be rewritten by the pass")
+        #expect(after.archivedHeadSHA == nil)
+    }
+
+    // MARK: - Cancellation
+
+    /// A gate that lets the test cancel the backfill task before its pass
+    /// begins, with no wall-clock race: the task parks here, the test cancels,
+    /// and only then is the gate opened.
+    private actor Gate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var opened = false
+
+        func wait() async {
+            if opened { return }
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func open() {
+            opened = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    /// Cancellation contract: a cancelled pass returns without repairing and
+    /// without hanging, and the same fixture is genuinely repairable when the
+    /// pass is not cancelled (the control arm — without it this assertion
+    /// would pass just as happily against a fixture nothing could repair).
+    ///
+    /// This test does **not** discriminate the `Task.isCancelled` guards on
+    /// its own: `runBoundedProcess`'s `CancellationRelay` already kills every
+    /// `git` child of a cancelled task, so `refExists` answers false, the
+    /// reflog read comes back empty, and no repair is reachable whether or not
+    /// the loops check cancellation. What the guards buy is the *early return*
+    /// — not spawning one doomed subprocess per archived row on the way out —
+    /// and that is a subprocess count, which this tree has no seam to observe.
+    @Test("a cancelled pass repairs nothing; the same fixture repairs when not cancelled")
+    func cancelledPassRepairsNothing() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let git = GitManager()
+        let broken = try await makeBrokenArchivedRow(
+            db: db, git: git, tempDir: tempDir, repoDir: repoDir)
+        let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+
+        let gate = Gate()
+        let task = Task {
+            await gate.wait()
+            await backfill.run()
+        }
+        task.cancel()
+        await gate.open()
+        await task.value
+
+        let after = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(after.branch == broken.staleBranch)
+        #expect(after.archivedHeadSHA == nil)
+
+        // Control arm: the fixture really was repairable.
+        await backfill.run()
+        let control = try #require(try await db.worktrees.get(id: broken.worktreeID))
+        #expect(control.branch == broken.renamedBranch)
+    }
+}
+
+// MARK: - The compare-and-swap write itself
+
+/// `WorktreeStore.repairArchivedBranch` is the whole concurrency position of
+/// the deferred backfill: the write lands only if the row is still the one the
+/// caller decided to repair. Tier 1 — in-memory DB, no subprocesses.
+@Suite("RepairArchivedBranchTests")
+struct RepairArchivedBranchTests {
+
+    private func seedArchivedWorktree(
+        db: TBDDatabase, branch: String, archivedHeadSHA: String? = nil
+    ) async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/tbd-repair-cas-\(UUID().uuidString)",
+            displayName: "cas-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", displayName: "WT", branch: branch,
+            path: "/tmp/tbd-repair-cas-wt-\(UUID().uuidString)",
+            tmuxServer: "cas-server")
+        try await db.worktrees.archive(id: wt.id, archivedHeadSHA: archivedHeadSHA)
+        return wt
+    }
+
+    @Test("success: an unchanged archived row is repaired and gets its missing SHA")
+    func repairsUnchangedRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await seedArchivedWorktree(db: db, branch: "old")
+
+        let repaired = try await db.worktrees.repairArchivedBranch(
+            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "deadbeef")
+        #expect(repaired)
+
+        let after = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(after.branch == "new")
+        #expect(after.archivedHeadSHA == "deadbeef")
+    }
+
+    @Test("success: an existing archivedHeadSHA is preserved, never overwritten")
+    func preservesExistingHeadSHA() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await seedArchivedWorktree(db: db, branch: "old", archivedHeadSHA: "original")
+
+        let repaired = try await db.worktrees.repairArchivedBranch(
+            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "replacement")
+        #expect(repaired)
+
+        let after = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(after.branch == "new")
+        #expect(after.archivedHeadSHA == "original")
+    }
+
+    @Test("missing row: returns false")
+    func refusesMissingRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repaired = try await db.worktrees.repairArchivedBranch(
+            id: UUID(), expectedBranch: "old", newBranch: "new", archivedHeadSHA: nil)
+        #expect(!repaired)
+    }
+
+    @Test("status changed: a revived row is refused and left untouched")
+    func refusesRevivedRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await seedArchivedWorktree(db: db, branch: "old")
+        try await db.worktrees.revive(id: wt.id)
+
+        let repaired = try await db.worktrees.repairArchivedBranch(
+            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "deadbeef")
+        #expect(!repaired)
+
+        let after = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(after.branch == "old")
+        #expect(after.archivedHeadSHA == nil)
+    }
+
+    @Test("branch changed: a re-archived row on another branch is refused")
+    func refusesChangedBranch() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await seedArchivedWorktree(db: db, branch: "old")
+        try await db.worktrees.updateBranch(id: wt.id, branch: "someone-elses-branch")
+
+        let repaired = try await db.worktrees.repairArchivedBranch(
+            id: wt.id, expectedBranch: "old", newBranch: "new", archivedHeadSHA: "deadbeef")
+        #expect(!repaired)
+
+        let after = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(after.branch == "someone-elses-branch")
+        #expect(after.archivedHeadSHA == nil)
+    }
+}


### PR DESCRIPTION
## What's broken

Restart TBD on a machine with a lot of archived worktrees and the daemon appears not to come up. The app sits retrying, and every retry launches a daemon that immediately exits with `startup: Another daemon is already running (PID …). Exiting.` while the app logs `Daemon launched but could not connect`. From the outside this is indistinguishable from a crashed daemon — the natural reaction is to kill things and try again, which only spawns more doomed daemons.

The daemon is alive and healthy the whole time. It simply has not bound its socket yet. On the machine where this was measured it recovered on its own after roughly three minutes.

Measured directly on the live daemon while it was in this state:

- `~/tbd/sock`, `~/tbd/port` and `~/tbd/vend.sock` all absent, with the daemon process running normally.
- `lsof` on the daemon showed zero unix sockets — the listener was not bound at all, as opposed to bound somewhere unexpected.
- A `sample` of the daemon put the entire stack in `ArchivedWorktreeBackfill.runForRepo` → `GitManager.run` → `runBoundedProcess`.
- The socket appeared the instant that pass finished, and RPC then answered in 39–49 ms.

How often it hits scales with how many archived worktrees you have accumulated, so it gets worse over time and it is worst for the heaviest users. At 1,825 archived rows it was ~3 minutes.

## Why it happens

The daemon's startup does its reconciliation work before it starts serving. One item in that work is a one-shot repair pass over **archived** worktree rows whose branch no longer resolves — the case where someone renamed a branch inside a worktree before archiving it, and the rename never reached the database.

To find those rows the pass asked git about each archived branch, one `git` subprocess per archived row, and it did all of that before the listener was bound. Throughput was ~682 rows/min, so the socket bind waited on the entire pass.

Nothing about that work needs to precede serving. It repairs rows that are archived — inactive by definition. The pass is idempotent, never deletes a row, and never throws. It was simply sequenced in front of the listener rather than behind it.

## What this PR does

**Binds the listener first.** The backfill moves out of `performStartupReconciliation` (which the bind waits on) into a task started after `sock.start()`, alongside the other deferred boot tasks. `stop()` cancels and awaits it, and both of its loops check for cancellation so a shutdown mid-pass doesn't wait out the remaining subprocesses.

The rest of startup reconciliation stays *before* the bind deliberately. The per-repo reconcile and the scratch-terminal sweep can destructively reap shared tmux servers, which stops being safe once a terminal-create RPC can be in flight; repo health validation stays early so `[missing]` tags are correct as soon as the app connects.

**Makes the pass cheap.** It now takes one `git for-each-ref` per repo (`GitManager.refTips`, already used by the conflict sweep) instead of one `rev-parse` per row. The map is used strictly as a *negative* filter, never as an authority: a branch present in it certainly resolves, so the row is skipped with no subprocess; a branch absent from it still falls through to the real `refExists` before the row is treated as broken. That matters because `refExists` resolves by git's full rules while the map covers only `refs/heads` and `refs/remotes/origin` — treating absence as authority would reclassify rows as broken and trigger repairs that never used to happen. A failed `refTips` degrades to the old per-row behavior.

**Handles the concurrency this creates.** Serving RPCs while a pass mutates worktree rows is a race that did not exist when the pass ran before the bind, and it needs a position rather than an assumption.

The position is compare-and-swap, not a lock. The per-repo snapshot of archived rows can go stale, so every write goes through `WorktreeStore.repairArchivedBranch`, which writes only if the row is still archived, still on the branch the pass decided to repair, and still carries the same `archivedAt`. A lock held across a whole repo's pass would block exactly the RPCs this change exists to unblock, and losing the race costs nothing: the repair is idempotent, so the next start either picks the row up again or finds it no longer needs one.

Status and branch alone are **not** sufficient, which is the subtle part. The revive path recreates the *stale* branch name from `archivedHeadSHA`, and it leaves the row `.archived` on the old branch for the whole of its work. So a row that was revived and archived again comes back archived, on the same branch name, with that branch now genuinely existing — and a status+branch CAS would happily rewrite it, pointing the row at an unrelated branch while the user's work sat on the original. `archivedAt` closes that durably (archive stamps it, revive clears it), and nothing else would have: `refreshGitStatuses` only syncs branches for active rows, so the corruption would never have been self-corrected.

`attemptRepair` also re-probes the branch immediately before writing, because the CAS proves the *row* did not change but not that the *premise* — "this branch does not resolve" — still holds.

## Why no spec

The deferral restores a property the system already claimed: the daemon is supposed to serve promptly, and the backfill's own contract describes it as best-effort, idempotent, one-shot recovery over inactive rows. The `refTips` change is semantics-preserving — same rows examined, same repairs, same outcomes, fewer subprocesses.

The compare-and-swap position is the arguable part, and it is stated here rather than in `docs/specs/` because it is a consequence forced by the fix rather than a new capability. Reviewers who disagree should say so — it is a deliberate call, not an oversight.

**No feature flag, also deliberately.** The flag rule targets newly-autonomous or newly-destructive behavior. This pass already ran unattended and already mutated persisted state at every boot; the only new exposure is concurrency, and the CAS narrows the write surface rather than widening it — two previously unguarded writes became one guarded transaction. A default-off flag would mean the shipped default keeps the multi-minute stall this PR exists to remove, which inverts the risk instead of containing it.

## Assumptions

- **`archivedAt` changes across a revive/re-archive cycle.** `archive` stamps `Date()` and `revive` clears it to nil. If a future path ever re-archives a row while preserving its old timestamp, the CAS stops distinguishing that case and the revive-then-re-archive corruption returns. A test pins that the value survives its round-trip through the store, so the guard cannot silently become vacuous.
- **The reflog rename message keeps its current wording.** Pre-existing: the parser matches git's `Branch: renamed …` text and silently returns nothing if git ever rewords it, leaving rows untouched — consistent with the never-throws contract.

## Evidence & verification

**The stall, before and after.** Measured at the seam with 200 archived rows in a real temporary repo, timing the phase the socket bind waits on: **9.12 s with the backfill inline, 0.32 s without it** — ~44 ms/row of pure bind delay, which extrapolates to ~80 s at the 1,825 rows on the machine that reported this (against ~3 min observed there under real load). Measured under an isolated `TBD_HOME`; no live daemon was restarted, so no other session's work was disturbed.

**Discriminating tests.** Every guard was mutation-checked — the mutation applied, the suite run, the failing test recorded, the mutation reverted — and re-checked *after* the rebase, since a rebase is where a guard quietly stops being exercised:

- Restoring the backfill into `performStartupReconciliation` → `backfillIsDeferredPastTheListenerBind` fails.
- Removing `archivedAt` from the CAS → `refusesReArchivedRowOnTheSameBranch` and `reArchivedRowWithMissingBranchIsNotRepaired` fail.
- Removing the pre-write re-probe → `branchResolvingAgainAbandonsTheRepair` fails.
- Making `refTips` authoritative → `refMapAbsenceFallsBackToRefExists` fails.

Each mutation reddened *only* its named tests.

**One guard ships unasserted, stated plainly.** The `Task.isCancelled` checks have no discriminating test. `runBoundedProcess`'s cancellation relay already kills the `git` child of a cancelled task, so no repair is reachable either way — the outcome is over-determined. What the checks actually buy is not spawning the remaining subprocesses on the way out. The test says so in its comment rather than implying coverage it doesn't have.

**Suites.** Targeted run 52 tests / 3 suites green, including `testBackfillIgnoresRemoteLanes` from #718, which this branch's rebase could have broken. `swiftlint --strict` clean across 824 files.

Full suite on this branch reported failures, and they are load, not this change — established rather than asserted: every failure was a time-limit or bounded-wait deadline with zero logic assertions (the run took 2041 s, and one *passing* test took 913 s). All 18 affected suites re-run in isolation: **199 tests / 20 suites pass in 61 s**. Same tests, same tree; the only variable was machine population. This box was running ~9 concurrent agent sessions with load average peaking around 197.

## Related

Builds on #718, which stopped this same pass probing archived *remote* lanes against local refs. The two are orthogonal — #718 narrows which rows the pass sees, this narrows what it does per row — and the rebase keeps both intact.

[🚦 Daemon startup blocked by backfill](https://cheapsteak.github.io/tbd/open/?worktree=DB9D1621-AB32-4B85-9FA8-81B7538292E3)
