### PR TITLE
Feat: See how long terminal output waits before it reaches the screen

### DIFF
--- a/Sources/TBDApp/Diagnostics/TerminalSignposts.swift
+++ b/Sources/TBDApp/Diagnostics/TerminalSignposts.swift
@@ -1,0 +1,59 @@
+import os
+
+/// Shared `OSSignposter` for `category: "perf-terminal"` — the path terminal
+/// output travels from the pty to the screen.
+///
+/// Signposts are silent unless a recording tool is attached, so these live in
+/// the code permanently rather than being added and deleted per investigation
+/// (see `docs/diagnostics-strategy.md`, and `TranscriptSignposts` for the
+/// sibling on `perf-transcript`).
+///
+/// Region names emitted today — **these are load-bearing**: the analysis
+/// scripts under `scripts/diag/` match on them verbatim, and
+/// `TerminalSignpostsTests` asserts them so a rename cannot silently break the
+/// tooling:
+///
+/// - `mainThreadHop` — begins on the pty reader thread immediately before the
+///   `DispatchQueue.main.async` in
+///   `TerminalPanelRepresentable.Coordinator.dataReceived(slice:)`, and ends
+///   inside that block. The duration *is* the main-thread queueing delay for
+///   terminal output — the thing average CPU utilisation cannot show, since a
+///   mostly-idle main thread still stalls output behind any long run-loop
+///   callout. Metadata: byte count of the chunk.
+///
+///   This interval also *defines* an analysis window: a period during which one
+///   is open is a period when terminal bytes were demonstrably sitting
+///   undelivered. That makes it a window derived from the symptom rather than
+///   from a suspect, which is what let the 2026-08-26 attribution rule the poll
+///   cycle out instead of assuming it in.
+///
+/// - `feed` — the nested `TerminalView.feed(byteArray:)` call, separating parse
+///   cost from queueing delay. Measured at 0.11 ms p50, which is what exonerates
+///   the parser.
+///
+/// Every chunk is instrumented rather than sampled: the median hop is 0.05 ms in
+/// every window measured, and the finding lives at the 99th percentile.
+///
+/// A third interval, `displayPass`, was deliberately **not** kept. Closing it
+/// required posting an extra block to the main queue on every display pass —
+/// the very queue whose delay `mainThreadHop` exists to measure. See
+/// `docs/specs/2026-08-26-terminal-latency-signposts-design.md`.
+enum TerminalSignposts {
+    /// Subsystem/category pair. Exposed so tests can assert it, since the
+    /// capture recipes and analysis scripts filter on it.
+    static let subsystem = "com.tbd.app"
+    static let category = "perf-terminal"
+
+    /// Interval names, referenced by the analysis scripts.
+    ///
+    /// `StaticString`, because `OSSignposter` requires it — the name is baked
+    /// into the binary at compile time rather than formatted at each emission,
+    /// which is a large part of why a signpost costs nothing when nobody is
+    /// recording.
+    enum Region {
+        static let mainThreadHop: StaticString = "mainThreadHop"
+        static let feed: StaticString = "feed"
+    }
+
+    nonisolated static let signposter = OSSignposter(subsystem: subsystem, category: category)
+}

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -1245,9 +1245,30 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         }
 
         func dataReceived(slice: ArraySlice<UInt8>) {
+            // `mainThreadHop` begins here, on the pty reader thread, and ends
+            // inside the block below once the main thread actually picks it up.
+            // That duration IS the main-thread queueing delay for terminal
+            // output — the quantity average CPU utilisation cannot show, and the
+            // one that identified the SwiftUI view-graph flush as the stall.
+            // See `TerminalSignposts` for why every chunk is instrumented.
+            let signposter = TerminalSignposts.signposter
+            let hop = signposter.beginInterval(
+                TerminalSignposts.Region.mainThreadHop,
+                id: signposter.makeSignpostID(),
+                "bytes=\(slice.count)"
+            )
             DispatchQueue.main.async { [weak self] in
+                signposter.endInterval(
+                    TerminalSignposts.Region.mainThreadHop, hop, "bytes=\(slice.count)"
+                )
                 self?.groupedViewerDidReceiveOutput()
+                let feedState = signposter.beginInterval(
+                    TerminalSignposts.Region.feed,
+                    id: signposter.makeSignpostID(),
+                    "bytes=\(slice.count)"
+                )
                 self?.terminalView?.feed(byteArray: slice)
+                signposter.endInterval(TerminalSignposts.Region.feed, feedState)
             }
         }
 

--- a/Tests/TBDAppTests/TerminalSignpostsTests.swift
+++ b/Tests/TBDAppTests/TerminalSignpostsTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import TBDApp
+
+/// The signpost region names and category are a published interface: the
+/// analysis scripts under `scripts/diag/` match on them verbatim, and the
+/// capture recipes in `docs/specs/2026-08-26-terminal-latency-signposts-design.md`
+/// filter on the category.
+///
+/// A rename would break that tooling without breaking a build, and the failure
+/// would surface only as "no intervals found" partway through a future
+/// investigation — at which point the natural reading is "the app must not be
+/// emitting", not "someone renamed a string". These assertions make the rename
+/// fail here instead.
+@Suite("TerminalSignposts identifiers are stable")
+struct TerminalSignpostsTests {
+    @Test("subsystem and category match the documented capture recipe")
+    func subsystemAndCategoryAreStable() {
+        #expect(TerminalSignposts.subsystem == "com.tbd.app")
+        #expect(TerminalSignposts.category == "perf-terminal")
+    }
+
+    @Test("region names match what the analysis scripts grep for")
+    func regionNamesAreStable() {
+        #expect("\(TerminalSignposts.Region.mainThreadHop)" == "mainThreadHop")
+        #expect("\(TerminalSignposts.Region.feed)" == "feed")
+    }
+
+}

--- a/docs/perf/2026-08-26-main-thread-burst-attribution.md
+++ b/docs/perf/2026-08-26-main-thread-burst-attribution.md
@@ -15,7 +15,25 @@ Both windows below are from pid 89137, `/Applications/TBD.app`, built from
 branch `tbd/diag-render-signposts` (commit `00c8ac35`). No restart occurred
 during or between them; the pid was verified stable rather than inferred.
 
-## Method, and what each instrument actually counts
+## Method: state what the instrument counts, and check it matches the claim
+
+This is the first rule, not a footnote. **Every wrong answer across this
+investigation came from an instrument measuring a superset or a subset of the
+claim being made — not once from bad reasoning over correct data.** A grep
+counted every observable rather than the one named. A compiler-process counter
+was blind to test processes. A round-trip probe measured process spawns. A
+profile summed a symbol with its own child and double-counted the subtree. A
+`pgrep -f` matched the investigator's own command lines. A line count over
+multi-line command text reported 457 processes where there were six. An XML
+export returned ref-compressed stack frames that read exactly like truncated
+ones.
+
+So: before reporting any number, say what the instrument actually counts, and
+check that it matches the claim. Treat *"the instrument cannot see what I am
+claiming"* as the first suspicion, not the last.
+
+The rest of this section applies that rule to each instrument used here.
+
 
 Three instruments were recorded into **one** `xctrace` trace, so they share a
 single timeline and correlation between them is exact rather than clock-matched:
@@ -172,6 +190,84 @@ flush and is recorded here so it is not rediscovered as a surprise.
   being copied and destroyed by value inside `ForEach` identity and view-list
   transforms (~4%), and generic-metadata lookup at ~11%, which is a symptom of
   deeply nested generic view types.
+
+## The fix, measured with the same instrument
+
+Per-property observation tracking (#724) landed while this was being written, so
+the same recipe was re-run against it: same window definition, same scripts, same
+machine, on an app verified built from `main` + #724 by the source paths baked
+into its binary.
+
+**Process age was tested rather than assumed.** Perceived lag had appeared to
+worsen with uptime, which would confound any comparison against a freshly
+restarted app, so the post-fix side was measured at three ages. It does not
+explain the effect: the 6-minute and 59-minute windows agree almost exactly.
+
+```
+                          stall%  | hop p99    max  | flush-s  >50ms callouts
+w2  before (50min uptime)  1.33%  |   187.9  227.7  |   19.4        105
+w3  before (60min uptime)  3.71%  |   257.9  325.2  |   22.2        118
+a1  after  ( 6min uptime)  0.26%  |    16.3  139.1  |    3.4         10
+a3  after  (59min uptime)  0.26%  |     5.3   58.4  |    6.3         50
+a4  after  (76min uptime)  0.83%  |   148.5  162.4  |   11.5         77
+```
+
+Stated conservatively, because the post-fix side is variable and a single window
+does not characterise it — `a3` reached p99 5.3 ms and `a4` 148.5 ms:
+
+- **Worst observed wait fell from 228–325 ms to 58–162 ms.**
+- **Stall load fell from 1.33–3.71% to 0.26–0.83%**, roughly 5x on the means.
+- Long callouts have not vanished. `a4` still shows 77 over 50 ms, up to 253 ms.
+  They far less often have terminal output waiting behind them, which is why the
+  symptom improved more than the flush count did.
+
+### A prediction this record made, and its falsification
+
+An earlier draft of this document predicted that #724 would cut the
+attribute-graph slice hardest and leave the `ForEach` view-list rebuild and the
+`Worktree` copying largely intact — reasoning that the rebuild runs whenever the
+list data changes, which the 2-second poll does regardless of how narrowly
+properties are tracked.
+
+That was wrong, and the correction is worth more than the prediction. In absolute
+CPU inside expensive flushes:
+
+- **`ForEach` view-list rebuild: 6,190 ms → 201 ms — a 31x cut, the largest.**
+- attribute-graph propagation: 7,922 ms → 1,066 ms (7.4x)
+- `View.body` evaluation: 4,677 ms → 1,642 ms (2.8x)
+- `Worktree` copy and destroy left the top entry points entirely.
+
+So the view-list rebuild was not independent of invalidation — it was *triggered*
+by it. Under object-wide notification any `AppState` write invalidated the
+observing views, forcing the whole nested `ForEach` list to be reconstructed, and
+the `Worktree` copies happened inside that reconstruction. Per-property tracking
+stops most of those reconstructions from being requested at all.
+
+The residual has a different shape: body evaluation is now the largest slice
+(54.5% in `a3`, 44.8% in `a4`), led by `WorktreeRowView.body`, `TabBarItem.body`
+and `PanePlaceholder.body`. That is the next target if anyone pursues the view
+graph — but at these latencies it is no longer what a user feels.
+
+## What this does not cover
+
+Every window in this record was taken during ordinary operation with agents
+streaming and **no user interaction**. Both intervals measure terminal output
+travelling *towards* the screen.
+
+- **Keystroke-to-echo was never measured**, here or anywhere. That gap predates
+  this work and survives it.
+- **Scrolling was not measured** in any window here either.
+
+Two named mechanisms target exactly those cases and are untouched by anything
+measured here: wheel-event amplification (#719), and the 150 ms window after each
+keystroke during which `interactiveInputDisplayWindowNs` disables the frame
+limiter so every output chunk forces a synchronous redraw. If typing or scrolling
+still feel slow, those are better suspects than the view graph.
+
+A window intended to cover typing or scrolling **must be checked for containing
+the action**. Four windows earlier in this investigation silently captured no
+scrolling and produced a confident, wrong conclusion that reached a committed
+spec before a validated re-run reversed it.
 
 ## Still open
 

--- a/docs/perf/2026-08-26-main-thread-burst-attribution.md
+++ b/docs/perf/2026-08-26-main-thread-burst-attribution.md
@@ -1,0 +1,185 @@
+# What occupies TBD's main thread while terminal output waits — 2026-08-26
+
+This is an evidence record, not a design. It answers the question left open by
+[`2026-08-25-terminal-render-cost-investigation.md`](2026-08-25-terminal-render-cost-investigation.md):
+*something* runs on the main thread in bursts long enough to stall terminal I/O
+by hundreds of milliseconds, and nothing had named it.
+
+It names it: **SwiftUI's own runloop observer, `Update.end`, flushing the view
+graph.** That callout is the only class of main-thread work in TBD that ever
+runs longer than about 35 ms without returning to the runloop, and terminal
+output — dispatched to the main queue by `TerminalPanelView.dataReceived` —
+cannot be delivered until it does.
+
+Both windows below are from pid 89137, `/Applications/TBD.app`, built from
+branch `tbd/diag-render-signposts` (commit `00c8ac35`). No restart occurred
+during or between them; the pid was verified stable rather than inferred.
+
+## Method, and what each instrument actually counts
+
+Three instruments were recorded into **one** `xctrace` trace, so they share a
+single timeline and correlation between them is exact rather than clock-matched:
+
+- **`potential-hangs`** — Instruments' own main-thread unresponsiveness
+  intervals (threshold 100 ms), derived from system responsiveness events. It
+  knows nothing about TBD's code, so selecting windows with it presupposes no
+  culprit. It is used here only as a cross-check; the primary window definition
+  is the next one.
+- **`time-profile`** — a 1 ms sampling profiler. Each row is one sample of one
+  thread with a full symbolicated backtrace. **Every sample is counted once,
+  into exactly one bucket.** A parent is therefore never summed with its own
+  child — the double-counting that inflated the draw path roughly 2x in the
+  earlier `sample`-based rounds is structurally impossible in this form.
+- **`os-signpost-interval`** — the temporary `mainThreadHop` / `feed` /
+  `displayPass` intervals from `00c8ac35`.
+
+**Windows are defined by the symptom, not by a suspect.** A *stall window* is a
+period during which at least one `mainThreadHop` interval was open — that is, a
+chunk of terminal bytes was demonstrably sitting on the main queue undelivered.
+Merged, kept when ≥ 50 ms. Nothing about the poll cycle, the renderer, or
+SwiftUI enters that definition.
+
+Recording is `xcrun xctrace record --instrument 'Time Profiler' --instrument
+'os_signpost' --instrument 'Hangs' --attach <pid> --time-limit 150s`. Analysis
+scripts are single-purpose and were checked against each other; the frame-ref
+trap below cost one wrong intermediate reading.
+
+### Two instrument traps hit while building this
+
+- **`xctrace export` ref-compresses backtrace frames.** A row's stack is a
+  mixture of `<frame id=…>` and `<frame ref=…>`; resolving only the
+  `<backtrace>` element and not each frame yields a stack with one named frame
+  and *N* unknowns, which reads exactly like a legitimately truncated stack and
+  is not. The first attribution pass reported "100% no TBDApp frame on stack"
+  purely from this.
+- **A 21-second pilot window disagreed with the 150-second ones**, showing zero
+  hop stalls beginning inside hang windows against 24 expected. It was a
+  small-sample artifact: at 150 s the same measurement gives 94.6% overlap.
+  Short windows are for catching mistimed captures, not for concluding.
+
+## The finding
+
+Two independent 150-second windows, `w2` and `w3`:
+
+- Stall windows (terminal bytes undelivered ≥ 50 ms): **10 totalling 2,016 ms**
+  in w2; **30 totalling 5,611 ms** in w3.
+- Inside them the main thread is **97–98% on-CPU** — against 21% (w2) and 27%
+  (w3) outside. The stall is a busy burst, not a block or a wait.
+- Of that in-stall CPU, **92.3% (w2) and 86.9% (w3) sits inside a runloop
+  observer callout**.
+- Over the same windows, CPU spent **servicing the main dispatch queue falls to
+  0.2% (w2) and 5.1% (w3), against 24.6% and 27.9% outside.**
+
+That last contrast is the mechanism rather than a correlation. A block on the
+main queue cannot run while the thread is inside a runloop callout, so a long
+callout *is* an undrained queue. The duty-cycle correction that killed the
+poll-cycle hypothesis does not apply here, because this is not a co-occurrence
+claim: it is the same event described from two sides.
+
+The independent form of the claim is the distribution of **uninterrupted
+callout runs** — consecutive samples carrying the same callout marker, which
+splits (never merges) if the thread goes off-CPU, so these are lower bounds:
+
+```
+                                          n     p50    p90    p99    max   >50ms
+w2  runloop observer (SwiftUI flush)     259     2.0  205.0  256.0  295.0    105
+    main-dispatch-queue block           3095     2.0    3.0    6.0   11.0      0
+    source0 (NSEvent / perform)          499     0.0   19.0   30.0   35.0      0
+    source1 (mach port)                  154     0.0   19.0   26.0   34.0      0
+    runloop timer                         31     0.0    0.0    0.0    0.0      0
+
+w3  runloop observer (SwiftUI flush)     529     3.0  179.0  219.0  366.0    118
+    main-dispatch-queue block           4152     2.0    4.0   10.0   89.0      1
+    source0 (NSEvent / perform)         1209     4.0   11.0   21.0   33.0      0
+    source1 (mach port)                  506     3.0   11.0   26.0   61.0      1
+    runloop timer                         49     0.0    0.0    1.0    3.0      0
+```
+
+**No other class of main-thread work in either window exceeds 89 ms, and only
+once.** The observer callout exceeds 50 ms 105 and 118 times — roughly 0.75 per
+second — and reaches 295 ms and 366 ms. It is bimodal: p50 is 2–3 ms, p90 is
+179–205 ms. A flush is either trivial or enormous, with very little between.
+
+The observer is identified by the frames immediately inside the callout:
+`NSRunLoop.flushObservers()` → **`static Update.end()`** — SwiftUI's update
+flush, not CoreAnimation's commit. CoreAnimation's
+`CA::Transaction::flush_as_runloop_observer` appears separately and is small
+(2,878 ms total in w3, 448 ms of it in stalls).
+
+Across the whole trace the flush costs **18.1 s of 151 s (w2) and 19.1 s of
+151 s (w3)** — about 12% of wall clock on one thread.
+
+## Where the time goes inside an expensive flush
+
+Comparing the 105 / 118 flushes ≥ 50 ms against the 139 / 345 flushes < 10 ms as
+a control. Buckets are disjoint; the metadata line is cross-cutting and is
+deliberately *not* additive with them.
+
+Both windows agree within a couple of points:
+
+- **Attribute-graph propagation and comparison, with no body or view-list above
+  it** — 40.7% / 40.3%.
+- **View-list rebuild** (`ForEach`/`ViewList.applyNodes`,
+  `_ViewList_TemporarySublistTransform`, `SubgraphList`) — 33.3% / 31.5%.
+- **`View.body` evaluation** — 21.8% / 23.8%.
+- Display list and layout — under 1%.
+- *(cross-cutting)* Swift **generic-metadata lookup** at the leaf
+  (`MetadataCacheKey::operator==`, `getGenericMetadata`, `getCache`,
+  mangled-name instantiation) — 10.8% / 11.4%.
+
+The TBD entry points reached inside an expensive flush, with their share of
+flush CPU and their enrichment against the cheap-flush control:
+
+- `WorktreeRowView.body` — 6.7% / 7.5% (12.3x, 2.5x)
+- `TabBarItem.body` — 4.1% / 4.6% (present only in fat flushes; 45x in w3)
+- `PanePlaceholder.body` — 2.2% / 2.4% (fat-only; 23.7x in w3)
+- `initializeWithCopy for Worktree` — 2.6% / 2.2%, plus `destroy for Worktree`
+  1.5% / 1.3%: **about 4% of flush CPU is spent copying and releasing
+  `Worktree` values**, in `ForEach`'s ID generation and view-list transforms.
+- `RepoSectionView.body` — 1.1% / 1.2%; `TerminalPanelView.body` — 1.0% / 1.1%;
+  `WorktreeSubtreeView`, `SingleWorktreeView`, `RemoteSessionRowView`,
+  `TerminalPanelRepresentable.updateNSView` each under 1%.
+- Roughly 72% carries no TBDApp frame at all — SwiftUI and AttributeGraph
+  internals between the flush and the next body.
+
+The independent `HangWatchdog` stacks already on disk for this pid corroborate
+the same path from a different instrument: a 1,032 ms hang captured
+`ForEachState` → `ForEach.IDGenerator.makeID` → value-witness work on
+`Worktree` and `PRObservation`, and a 1,246 ms hang captured
+`NSHostingView.layout` → `ViewGraph.updateOutputs` → `EnvironmentObject`
+`StoreBox.update`.
+
+## A second, smaller burst source
+
+`HoverMenuModel.closeNow()`, invoked from a `NotificationCenter` observer
+outside any runloop callout, produced 7 runs of 52–538 ms totalling 2.2 s in
+w2 (`HoverMenuModel.init(openDelay:closeGrace:notificationCenter:)` →
+`closeNow()` → `setOpen(_:)`). It is an order of magnitude smaller than the
+flush and is recorded here so it is not rediscovered as a surprise.
+
+## What this reorders
+
+- **Rendering stays exonerated**, and more firmly. `feed` is 0.11 ms at p50 and
+  a display pass 5–9 ms; neither ever appears as a long uninterrupted run.
+- **The poll cycle stays exonerated.** Nothing here reinstates it. The poll's
+  application of results is one of many writers that can dirty the graph, but
+  the cost is in the flush, and the flush is not the poll.
+- **`@Observable` migration (#667) is now the directly indicated line of work**,
+  not a speculative one: 41% of expensive-flush CPU is attribute-graph
+  propagation with no body above it, which is the shape of invalidating far
+  more of the graph than changed.
+- **Two costs are visible that no migration addresses on its own**: `Worktree`
+  being copied and destroyed by value inside `ForEach` identity and view-list
+  transforms (~4%), and generic-metadata lookup at ~11%, which is a symptom of
+  deeply nested generic view types.
+
+## Still open
+
+- **What dirties the graph before each expensive flush.** The flush is bimodal,
+  so something distinguishes the 2 ms case from the 200 ms case. This record
+  measures the flush, not its trigger.
+- **Whether an off-CPU split understates callout length.** Run grouping breaks
+  when the thread leaves the CPU, so every duration here is a lower bound.
+- **`~/Library/Logs/TBD/hang-stacks/` held 110,512 files** at the time of this
+  investigation. That directory is a durable resource with no named reconciler.
+  Unrelated to this finding; recorded because it was found here.

--- a/docs/specs/2026-08-26-terminal-latency-signposts-design.md
+++ b/docs/specs/2026-08-26-terminal-latency-signposts-design.md
@@ -1,0 +1,151 @@
+# Permanent signposts on the terminal output path
+
+## Why
+
+TBD had no way to see how long terminal output waits before it reaches the
+screen. That gap cost this project several wrong conclusions: main-thread
+*utilisation* was measured repeatedly and found low, and low utilisation was
+read as "the app is not the problem" — but utilisation cannot see queueing
+delay, and a main thread that is idle 80% of the time can still stall terminal
+I/O for a third of a second at a stretch.
+
+Temporary instrumentation closed that gap and immediately produced the answer
+(`docs/perf/2026-08-26-main-thread-burst-attribution.md`): output was waiting up
+to 325 ms behind a single SwiftUI view-graph flush. It also measured the fix —
+after per-property observation tracking (#724), the same instrument shows the
+worst wait falling to 58 ms and the 99th percentile to 5.3 ms.
+
+That instrument is currently a commit marked *do not merge*. Deleting it means
+the next person to investigate this area starts from zero again, which is
+precisely the loop `docs/diagnostics-strategy.md` exists to break:
+
+> Every interesting event in TBD should already be logged. The default log
+> stream should still be quiet enough to read.
+
+This spec makes the two load-bearing intervals permanent.
+
+## What ships
+
+Two `os_signpost` intervals on subsystem `com.tbd.app`, category
+`perf-terminal`, emitted for every chunk of terminal output:
+
+- **`mainThreadHop`** — begins on the pty reader thread immediately before the
+  `DispatchQueue.main.async` in `TerminalPanelRepresentable.Coordinator.dataReceived(slice:)`,
+  ends inside that block. The duration *is* the main-thread queueing delay for
+  terminal output. Carries the chunk's byte count.
+- **`feed`** — the nested `TerminalView.feed(byteArray:)` call, separating parse
+  cost from queueing delay.
+
+Every chunk is instrumented rather than sampled. The tail is the entire point:
+the median hop is 0.05 ms in every window measured, and the finding lives at the
+99th percentile.
+
+`mainThreadHop` is also what defines an analysis *window*. A period during which
+at least one interval is open is a period when terminal bytes were demonstrably
+sitting undelivered — a window definition derived from the symptom rather than
+from a suspect. That property is what let the attribution work rule out the poll
+cycle rather than assume it, and it is the reason this interval in particular is
+worth keeping.
+
+## Rejected: an interval around the display pass
+
+A third interval wrapping one AppKit display pass is deliberately excluded.
+
+`TerminalView.draw(_:)` is `public`, not `open`, so it cannot be overridden from
+this module. The only reachable seam is `viewWillDraw()`, and closing an interval
+opened there requires posting an extra block to the main queue on every display
+pass — roughly nine per second in steady state.
+
+That block lands on **the very queue whose delay `mainThreadHop` exists to
+measure**. A permanent instrument that adds traffic to its own subject is not
+acceptable at any cost, and this one buys little: a display pass is 5–9 ms
+against stalls of hundreds of milliseconds, and display-pass timing has never
+been the quantity in question.
+
+The measurement is also treacherous at the sample sizes available. Display-pass
+duration showed a 3.99x enrichment against stalls on twelve observations — a
+sample size that had already produced one retracted conclusion in the same
+investigation, and which a larger window reduced to noise.
+
+Inter-frame timing remains available from Instruments' own Core Animation
+instruments when it is wanted, without TBD paying for it continuously.
+
+## No feature flag
+
+`docs/diagnostics-strategy.md` settles this. Signposts are silent unless a
+recording tool is attached, which makes them the same class of always-on,
+zero-default-cost diagnostic as a `.debug` log line. `TranscriptSignposts`
+(categories `perf-transcript`, `perf-rpc`) is the existing precedent and carries
+no flag.
+
+CLAUDE.md requires a default-off flag for behaviour that acts autonomously,
+destroys state, or replaces a load-bearing path. Emitting a signpost does none
+of those. Adding a flag would contradict the diagnostics principle directly —
+"never delete a log line to reduce noise" applies with equal force to never
+making one conditional on a toggle nobody will remember to set.
+
+## Placement
+
+`TerminalSignposts` lives in `Sources/TBDApp/Diagnostics/`, beside
+`TranscriptSignposts`, and follows its convention of documenting the region names
+in a doc comment on the enum. The category `perf-terminal` matches the existing
+`perf-transcript` and `perf-rpc`, so the three read as one family and a capture
+predicate can select any of them by prefix.
+
+Region names are load-bearing: the analysis scripts match on them verbatim. They
+are documented in the enum and asserted by a test, so a rename cannot silently
+break the tooling.
+
+## Analysis tooling
+
+`scripts/diag/render-latency-report.py` pairs intervals from `log stream` ndjson
+and prints percentiles. It is the quick check: no Xcode required, useful for
+answering "is output waiting at all right now?".
+
+`scripts/diag/main-thread-attribution.py` is the full instrument, for answering
+"waiting behind *what*?". It records Instruments' hang detector, a 1 ms
+sampling profiler and the signposts into **one** `xctrace` trace, so all three
+share a timeline and correlation is exact rather than clock-matched. They then
+attribute main-thread CPU inside symptom-defined windows by which runloop
+callout it hangs off.
+
+Two traps are documented with them, because both cost real time to rediscover:
+
+- `xctrace export` ref-compresses backtrace frames (`<frame ref="…"/>`).
+  Resolving only the `<backtrace>` element yields a stack with one named frame
+  and *N* unknowns, which reads exactly like a legitimately truncated stack and
+  is not.
+- Raw co-occurrence is not evidence when the suspect occupies a large fraction
+  of the timeline. Compute the suspect's duty cycle and test enrichment against
+  chance. That single check is what refuted the poll-cycle hypothesis, which had
+  looked like a 6x effect on a small sample and turned out to be 1.02x.
+
+## Cost
+
+Two `beginInterval`/`endInterval` pairs per chunk of terminal output. When no
+recording tool is attached, `os_signpost` emission is a predicted-not-taken
+branch on a global flag. No allocation, no dispatch, no lock. Nothing is added
+to the main queue, which is the property that distinguishes this from the
+excluded a display-pass interval.
+
+## Testing
+
+There is no conditional, so the both-branches rule does not apply. One test
+asserts the emitted region names and category are unchanged, since the analysis
+scripts match on them verbatim and a silent rename would break tooling without
+breaking a build.
+
+## What this deliberately does not measure
+
+Both intervals cover terminal output travelling **towards** the screen. Neither
+measures keystroke-to-echo, and neither measures scrolling.
+
+This matters because typing and scrolling have their own suspected mechanisms —
+wheel-event amplification (#719) and the 150 ms post-keystroke window during
+which the frame limiter is disabled — and both are untouched by anything
+measured here. Typing has still never been measured under a validated window.
+
+A future window that intends to cover typing or scrolling must be **checked for
+containing that action**, not assumed to. Four windows earlier in this
+investigation silently captured no scrolling and produced a confident, wrong
+conclusion that reached a committed spec before a validated re-run reversed it.

--- a/scripts/diag/main-thread-attribution.py
+++ b/scripts/diag/main-thread-attribution.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Find what occupies TBD's main thread while terminal output sits undelivered.
+
+This is the instrument that identified SwiftUI's `Update.end` view-graph flush
+as the cause of terminal stalls (docs/perf/2026-08-26-main-thread-burst-attribution.md).
+It does not take a suspect as input: windows are defined by the symptom, and
+attribution is by which run-loop callout the work hangs off.
+
+RECORD (all three instruments in ONE trace, so they share one timeline and
+correlation is exact rather than clock-matched):
+
+    xcrun xctrace record --instrument 'Time Profiler' --instrument 'os_signpost' \
+        --instrument 'Hangs' --attach <pid> --time-limit 150s --no-prompt \
+        --output w.trace
+
+    Verify the recording actually finalised -- it can fail silently, leaving a
+    large unfinalised directory and no "Recording completed" line, after which
+    export reports "Document Missing Template Error":
+
+        grep -c "Output file saved" w.record.log
+
+ANALYSE:
+
+    scripts/diag/main-thread-attribution.py w.trace [more.trace ...]
+
+WHAT EACH INSTRUMENT COUNTS -- state this before believing any number:
+
+  potential-hangs   Instruments' own main-thread unresponsiveness intervals
+                    (100 ms threshold), derived from system responsiveness
+                    events. Knows nothing about TBD's code. Used only as a
+                    cross-check; it is NOT the same notion as "the main dispatch
+                    queue was not drained".
+
+  time-profile      1 ms sampling profiler. Each row is ONE sample of ONE thread
+                    with a full symbolicated backtrace. Every sample is counted
+                    ONCE into ONE bucket, so a parent is never summed with its
+                    own child -- the double-counting that inflated the draw path
+                    ~2x in earlier `sample`-based rounds is impossible here.
+
+  os-signpost-interval
+                    TBD's own `perf-terminal` intervals (see TerminalSignposts).
+
+WINDOW DEFINITION: a stall window is a period during which at least one
+`mainThreadHop` interval was open, i.e. terminal bytes were demonstrably sitting
+on the main queue undelivered. Nothing about any suspect enters that definition.
+
+TWO TRAPS, both of which produced wrong readings during the investigation:
+
+  * `xctrace export` ref-compresses backtrace frames (`<frame ref="11"/>`).
+    Resolving only the <backtrace> element and not each frame yields a stack
+    with one named frame and N unknowns, which reads exactly like a truncated
+    stack and is not. This script resolves frame refs (see Refs.put).
+
+  * Raw co-occurrence is not evidence when the suspect occupies a large fraction
+    of the timeline. Compute duty cycle and test enrichment against chance. That
+    check refuted the poll-cycle hypothesis: it looked like 6x on a small sample
+    and measured 1.02x on a large one. `--enrich NAME` does this for any
+    interval.
+"""
+import argparse, os, subprocess, sys
+from collections import Counter
+import xml.etree.ElementTree as ET
+
+# --- export / parse -------------------------------------------------------
+
+def export(trace, schema, suffix):
+    """Export one table, caching beside the trace. Re-exports an empty cache."""
+    path = f"{trace}.{suffix}.xml"
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        with open(path, "wb") as fh:
+            r = subprocess.run(
+                ["xcrun", "xctrace", "export", "--input", trace, "--xpath",
+                 f'/trace-toc/run[@number="1"]/data/table[@schema="{schema}"]'],
+                stdout=fh, stderr=subprocess.PIPE)
+        if r.returncode != 0:
+            os.unlink(path)
+            sys.exit(f"export of {schema} from {trace} failed: "
+                     f"{r.stderr.decode().strip()}\n"
+                     f"If this says 'Document Missing Template Error', the "
+                     f"recording never finalised and the trace is unusable.")
+    return path
+
+class Refs:
+    """xctrace XML compresses repeated values as id/ref pairs, including nested
+    elements and individual backtrace frames. Register whole subtrees and never
+    clear a parsed row, or later refs dangle."""
+    def __init__(self): self.d = {}
+    def put(self, el):
+        for sub in el.iter():
+            i = sub.get("id")
+            if i and i not in self.d: self.d[i] = sub
+        return el
+    def get(self, el):
+        r = el.get("ref")
+        if r: return self.d[r]
+        self.put(el); return el
+
+def _rows(path):
+    for _, el in ET.iterparse(path, events=("end",)):
+        if el.tag == "row": yield el
+
+def parse_intervals(path, name_index):
+    R, out = Refs(), []
+    for row in _rows(path):
+        k = list(row)
+        s = int(R.get(k[0]).text); d = int(R.get(k[1]).text)
+        out.append((s, s + d, d, R.get(k[name_index]).text))
+    return out
+
+def parse_samples(path):
+    """-> [(time_ns, is_main_thread, [(frame_name, binary_name), ...outer..leaf])]"""
+    R, out = Refs(), []
+    for row in _rows(path):
+        k = list(row)
+        t = int(R.get(k[0]).text)
+        th = R.get(k[1]); is_main = "Main Thread" in (th.get("fmt") or "")
+        frames = []
+        for x in k[2:]:
+            x = R.get(x)
+            if x.tag == "backtrace":
+                for f in x.findall("frame"):
+                    fr = R.get(f)
+                    b = fr.find("binary")
+                    b = R.get(b) if b is not None else None
+                    frames.append((fr.get("name") or "?",
+                                   b.get("name") if b is not None else "?"))
+        out.append((t, is_main, list(reversed(frames))))
+    return out
+
+# --- interval algebra -----------------------------------------------------
+
+def merge(spans):
+    spans, out = sorted(spans), []
+    for s, e in spans:
+        if out and s <= out[-1][1]: out[-1][1] = max(out[-1][1], e)
+        else: out.append([s, e])
+    return [(a, b) for a, b in out]
+
+def in_any(t, spans):
+    lo, hi = 0, len(spans) - 1
+    while lo <= hi:
+        m = (lo + hi) // 2
+        a, b = spans[m]
+        if t < a: hi = m - 1
+        elif t > b: lo = m + 1
+        else: return True
+    return False
+
+# --- attribution ----------------------------------------------------------
+
+CALLOUTS = [
+    ("runloop observer (CA commit / SwiftUI flush)",
+     "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"),
+    ("main-dispatch-queue block", "__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__"),
+    ("runloop timer", "__CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__"),
+    ("source0 (NSEvent / perform)", "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"),
+    ("source1 (mach port)", "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__"),
+    ("block on a runloop", "__CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__"),
+]
+
+def trigger(frames):
+    """Which run-loop callout does this sample hang off? Innermost wins, so a
+    nested run loop is attributed to the inner callout."""
+    names = [n for n, _ in frames]
+    best = None
+    for label, marker in CALLOUTS:
+        for i, n in enumerate(names):
+            if marker in n and (best is None or i > best[0]):
+                best = (i, label)
+    if best: return best[1]
+    if any("_DPSNextEvent" in n or "nextEventMatchingMask" in n for n in names):
+        return "app event pump (idle/blocked)"
+    return "other / outside runloop"
+
+def tbd_entry(frames):
+    """Outermost TBDApp frame -- names OUR code inside the callout."""
+    for n, b in frames:
+        if b == "TBDApp" and not n.startswith(("static TBDAppMain", "TBDApp_main")):
+            return n
+    return "<no TBDApp frame>"
+
+# Specific activities are tested BEFORE the generic AttributeGraph bucket:
+# AG frames appear on virtually every SwiftUI stack because AG is the driver,
+# so testing for them first would swallow every sample.
+INSIDE_RULES = [
+    ("view-list rebuild (ForEach/ViewList applyNodes)",
+     lambda ns: any("applyNodes" in n or "ForEachState" in n or "DynamicViewList" in n
+                    or "_ViewList_" in n or "SubgraphList" in n for n in ns)),
+    ("body evaluation (a View.body getter ran)",
+     lambda ns: any(".body.getter" in n for n in ns)),
+    ("attribute-graph update (AG::Graph)",
+     lambda ns: any(n.startswith("AG::") or "AttributeGraph" in n for n in ns)),
+    ("display-list / layout",
+     lambda ns: any("DisplayList" in n or "layout" in n.lower() for n in ns)),
+]
+
+def inside_bucket(frames):
+    ns = [n for n, _ in frames]
+    for label, pred in INSIDE_RULES:
+        if pred(ns): return label
+    return "other flush machinery"
+
+def runs_of(main_samples, gap_ns=3e6):
+    """Group consecutive samples into uninterrupted callout runs. A run SPLITS
+    (never merges) when the thread leaves the CPU, so every duration is a LOWER
+    bound on the true callout length."""
+    runs, cur = [], None
+    for s in main_samples:
+        t = trigger(s[2])
+        if cur and t == cur[0] and s[0] - cur[2] <= gap_ns:
+            cur[2] = s[0]; cur[3].append(s)
+        else:
+            if cur: runs.append(cur)
+            cur = [t, s[0], s[0], [s]]
+    if cur: runs.append(cur)
+    return runs
+
+def pct(sorted_vals, q):
+    if not sorted_vals: return float("nan")
+    return sorted_vals[min(len(sorted_vals) - 1, int(q / 100 * (len(sorted_vals) - 1)))]
+
+# --- report ---------------------------------------------------------------
+
+def analyse(trace, thresh_ms, enrich_names, verbose):
+    samples = parse_samples(export(trace, "time-profile", "tp"))
+    sps = parse_intervals(export(trace, "os-signpost-interval", "sp"), 3)
+    hops = [(a, b, d) for a, b, d, n in sps if n == "mainThreadHop"]
+    if not hops:
+        sys.exit(f"{trace}: no mainThreadHop intervals — was the app built with "
+                 f"TerminalSignposts, and did any terminal produce output?")
+    spans = [(a, b) for a, b in merge([(a, b) for a, b, _ in hops])
+             if b - a >= thresh_ms * 1e6]
+    span = max(s[0] for s in samples) - min(s[0] for s in samples)
+    stall = sum(b - a for a, b in spans)
+    main_s = sorted([s for s in samples if s[1]], key=lambda s: s[0])
+    inh = [s for s in main_s if in_any(s[0], spans)]
+    out = [s for s in main_s if not in_any(s[0], spans)]
+    ds = sorted(d for _, _, d in hops)
+
+    print(f"\n=== {trace}   {span/1e9:.0f}s")
+    print(f"  mainThreadHop  n={len(ds)}  p50={pct(ds,50)/1e6:.2f}ms  "
+          f"p99={pct(ds,99)/1e6:.1f}ms  max={ds[-1]/1e6:.1f}ms")
+    print(f"  stall windows (bytes undelivered >= {thresh_ms:.0f}ms): {len(spans)}, "
+          f"{stall/1e6:.0f}ms = {stall/span*100:.2f}% of wall")
+    if not inh:
+        print("  no main-thread samples inside stall windows — nothing to attribute")
+        return
+    print(f"  main thread on-CPU: {len(inh)/(stall/1e6)*100:.0f}% inside stalls, "
+          f"{len(out)/((span-stall)/1e6)*100:.0f}% outside")
+
+    def table(title, keyfn, src_in, src_out, n=12):
+        ci = Counter(keyfn(s[2]) for s in src_in)
+        co = Counter(keyfn(s[2]) for s in src_out)
+        print(f"\n  --- {title} ---")
+        print(f"  {'ms':>7s} {'in%':>6s} {'out%':>6s} {'enrich':>8s}  bucket")
+        for k, c in ci.most_common(n):
+            si = c / len(src_in) * 100
+            so = co[k] / len(src_out) * 100 if src_out else 0
+            e = f"{si/so:7.2f}x" if so else "     inf"
+            print(f"  {c:7d} {si:5.1f}% {so:5.1f}% {e}  {k[:88]}")
+
+    table("TRIGGER: which run-loop callout the burst hangs off", trigger, inh, out)
+
+    all_runs = runs_of(main_s)
+    print(f"\n  --- uninterrupted callout runs (ms; lower bounds) ---")
+    print(f"  {'trigger':46s} {'n':>5s} {'p50':>6s} {'p90':>7s} {'max':>7s} {'>50ms':>6s}")
+    by = {}
+    for t, a, b, _ in all_runs: by.setdefault(t, []).append((b - a) / 1e6)
+    for t, dd in sorted(by.items(), key=lambda kv: -sum(kv[1])):
+        dd.sort()
+        print(f"  {t[:46]:46s} {len(dd):5d} {pct(dd,50):6.1f} {pct(dd,90):7.1f} "
+              f"{dd[-1]:7.1f} {sum(1 for d in dd if d > 50):6d}")
+
+    OBS = "runloop observer (CA commit / SwiftUI flush)"
+    fat = [s for r in all_runs if r[0] == OBS and (r[2]-r[1]) >= 50e6 for s in r[3]]
+    thin = [s for r in all_runs if r[0] == OBS and (r[2]-r[1]) < 10e6 for s in r[3]]
+    if fat:
+        print(f"\n  --- inside EXPENSIVE flushes ({len(fat)}ms of CPU) ---")
+        c = Counter(inside_bucket(s[2]) for s in fat)
+        for k, n_ in c.most_common():
+            print(f"  {n_:7d}ms {n_/len(fat)*100:5.1f}%  {k}")
+        if verbose and thin:
+            table("entry point into an expensive flush (control: cheap flushes)",
+                  tbd_entry, fat, thin)
+
+    for name in enrich_names:
+        sp = merge([(a, b) for a, b, _, n in sps if n == name])
+        if not sp:
+            print(f"\n  enrichment: no intervals named {name!r}")
+            continue
+        duty = sum(b - a for a, b in sp) / span
+        hit = sum(1 for a, _ in spans if in_any(a, sp))
+        exp = duty * len(spans)
+        enr = hit / exp if exp else float("nan")
+        print(f"\n  --- enrichment of {name!r} against chance ---")
+        print(f"  duty={duty*100:.1f}%  windows-inside={hit}  expected={exp:.1f}  "
+              f"enrichment={enr:.2f}x   (n={len(spans)} windows)")
+        print(f"  1.0x means co-occurrence is exactly what chance predicts — no evidence.")
+        if len(spans) < 40:
+            print(f"  !! n={len(spans)} is SMALL. This exact measurement read 6.04x on "
+                  f"n=14 and 1.02x on n=363 for the same suspect —")
+            print(f"     the 6x was noise and a hypothesis was retracted because of it. "
+                  f"Do not conclude from a window count this low.")
+        print(f"  Note: windows here are MERGED undelivered-bytes periods, not "
+              f"individual stalled chunks, so n is")
+        print(f"  much smaller than a per-stall count over the same trace. Lower "
+              f"--threshold-ms to raise n.")
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("traces", nargs="+")
+    ap.add_argument("--threshold-ms", type=float, default=50.0,
+                    help="minimum undelivered-bytes window to attribute (default 50)")
+    ap.add_argument("--enrich", action="append", default=[], metavar="NAME",
+                    help="duty-cycle-corrected enrichment for a signpost interval "
+                         "(e.g. --enrich rpc.pollCycle). Repeatable.")
+    ap.add_argument("--verbose", action="store_true",
+                    help="also break expensive flushes down by TBD entry point")
+    a = ap.parse_args()
+    for t in a.traces:
+        analyse(t, a.threshold_ms, a.enrich, a.verbose)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diag/render-latency-report.py
+++ b/scripts/diag/render-latency-report.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Pair render-latency signpost begin/end rows and report the latency distribution.
+
+Feed it the ndjson produced by:
+
+    log stream --style ndjson --signpost \
+        --predicate 'subsystem == "com.tbd.app" AND category == "perf-terminal"' \
+        > /tmp/perf-terminal.ndjson
+
+Usage: render-latency-report.py /tmp/perf-terminal.ndjson
+"""
+import json
+import sys
+from collections import defaultdict
+
+# Apple Silicon mach timebase: 125/3 ns per tick. Verified on this machine via
+# mach_timebase_info(); override if you run this on Intel (numer=denom=1).
+NS_PER_TICK = 125 / 3
+
+
+def main(path: str) -> None:
+    open_intervals: dict[tuple, int] = {}
+    durations: dict[str, list[float]] = defaultdict(list)
+    begins: dict[str, list[int]] = defaultdict(list)
+    unmatched = 0
+
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if row.get("eventType") != "signpostEvent":
+                continue
+            name = row["signpostName"]
+            key = (name, row["signpostID"], row["processID"])
+            kind = row["signpostType"]
+            if kind == "begin":
+                open_intervals[key] = row["machTimestamp"]
+                begins[name].append(row["machTimestamp"])
+            elif kind == "end":
+                start = open_intervals.pop(key, None)
+                if start is None:
+                    unmatched += 1
+                    continue
+                durations[name].append((row["machTimestamp"] - start) * NS_PER_TICK / 1e6)
+
+    for name in sorted(durations):
+        report(f"{name} duration (ms)", sorted(durations[name]))
+
+    # Inter-arrival gaps between chunks of terminal output. Useful for telling
+    # "output stopped arriving" apart from "output arrived and waited", which
+    # the duration percentiles above cannot distinguish on their own.
+    hops = sorted(begins["mainThreadHop"])
+    gaps = sorted((b - a) * NS_PER_TICK / 1e6 for a, b in zip(hops, hops[1:]))
+    if gaps:
+        report("mainThreadHop inter-arrival gap (ms)", gaps)
+
+    if unmatched or open_intervals:
+        print(f"\n(unmatched: {unmatched} end-without-begin, {len(open_intervals)} begin-without-end)")
+
+
+def report(label: str, values: list[float]) -> None:
+    def pct(p: float) -> float:
+        return values[min(len(values) - 1, int(len(values) * p))]
+
+    print(
+        f"{label}: n={len(values)} "
+        f"p50={pct(0.50):.2f} p90={pct(0.90):.2f} p99={pct(0.99):.2f} max={values[-1]:.2f}"
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary

TBD could not see how long terminal output waits before it reaches the screen,
and that blind spot cost this project real time. Main-thread *utilisation* was
measured repeatedly, found low, and read as "the app is not the problem" — but
utilisation cannot see queueing delay. A main thread that is idle 80% of the
time still stalls terminal I/O for a third of a second if it spends that
remaining 20% in long uninterrupted bursts.

This adds two permanent stopwatches on the path terminal output travels from the
pty to the screen, so that question is answerable in one capture instead of a
week of narrowing. It also ships the analysis tool that turns a capture into an
attribution.

There is no user-visible behaviour change. Signposts are silent unless someone is
recording.

## Why this shape

Design: [`docs/specs/2026-08-26-terminal-latency-signposts-design.md`](docs/specs/2026-08-26-terminal-latency-signposts-design.md).
Evidence it was built from: [`docs/perf/2026-08-26-main-thread-burst-attribution.md`](docs/perf/2026-08-26-main-thread-burst-attribution.md).

**`mainThreadHop` is the load-bearing one, and not only for its duration.** A
period during which one is open is a period when terminal bytes were
demonstrably sitting on the main queue undelivered. That makes it a *window
definition derived from the symptom rather than from a suspect* — which is what
let the attribution rule the poll cycle out instead of assuming it in. An earlier
round of this investigation had blamed the poll cycle on a co-occurrence that
turned out to be a duty-cycle artefact (1.02x enrichment against chance).

**No feature flag, deliberately.** `docs/diagnostics-strategy.md` already settles
this: diagnostics live in the code permanently and stay silent by default, and
`TranscriptSignposts` (`perf-transcript`, `perf-rpc`) is the existing precedent
carrying no flag. CLAUDE.md requires a default-off flag for behaviour that acts
autonomously, destroys state, or replaces a load-bearing path; emitting a
signpost does none of those. A flag here would contradict the diagnostics
principle directly — "never delete a log line to reduce noise" applies equally to
never making one conditional on a toggle nobody remembers to set.

**Rejected: an interval around the display pass.** `TerminalView.draw(_:)` is
`public`, not `open`, so the only reachable seam is `viewWillDraw()` — and
closing an interval opened there requires posting an extra block to the main
queue on every display pass, roughly nine per second. That block lands on *the
very queue whose delay `mainThreadHop` exists to measure*. A permanent instrument
must not add traffic to its own subject. The spec records this as rejected
rationale rather than as a changelog entry, because the seam is obvious and the
next person will otherwise reach for it.

## What this PR does

- **`Sources/TBDApp/Diagnostics/TerminalSignposts.swift`** (new) — `mainThreadHop`
  and `feed` on `com.tbd.app` / `perf-terminal`, beside `TranscriptSignposts`.
  Region names are `StaticString` because `OSSignposter` requires it: the name is
  baked into the binary rather than formatted per emission, which is most of why
  a signpost costs nothing when nobody is recording.
- **`Sources/TBDApp/Terminal/TerminalPanelView.swift`** — emits both intervals
  around the existing main-queue hop in `dataReceived(slice:)`. Every chunk is
  instrumented rather than sampled: the median hop is 0.05 ms in every window
  measured, and the finding lives at the 99th percentile.
- **`Tests/TBDAppTests/TerminalSignpostsTests.swift`** (new) — pins the category
  and region names, because `scripts/diag/` matches them verbatim and a rename
  would break the tooling without breaking a build.
- **`scripts/diag/main-thread-attribution.py`** (new) — records Instruments' hang
  detector, a 1 ms sampling profiler and the signposts into **one** `xctrace`, so
  all three share a timeline and correlation is exact rather than clock-matched.
  Attributes main-thread CPU inside symptom-defined windows by which runloop
  callout it hangs off.
- **`scripts/diag/render-latency-report.py`** — the no-Xcode quick check.
- **Docs** — the spec, plus an evidence record covering the finding, the #724
  before/after, and the method.

## Assumptions

- **Region names and category are a published interface.** The analysis scripts
  match them verbatim. If they are renamed without updating `scripts/diag/`, a
  future capture reports "no intervals found", which reads as "the app is not
  emitting" rather than "someone renamed a string". The test exists to make that
  fail loudly instead.
- **`OSSignposter` emission is free when nothing is recording.** Backed by the
  `StaticString` requirement rather than by assertion, but if that stops holding,
  the cost lands on the terminal hot path.
- **Instruments' `Hangs` and `Time Profiler` remain exportable via `xctrace
  export --xpath`.** The attribution tool depends on the table schemas
  `potential-hangs`, `time-profile` and `os-signpost-interval`.

## Evidence & verification

The instrument was used to answer a real open question before being proposed for
merge, which is the evidence that it works.

**The finding**, replicated across two independent 150 s windows: during periods
when terminal output sat undelivered, the main thread was 97–98% on-CPU, 87–92%
of it inside a runloop-observer callout (SwiftUI's `Update.end`), while CPU spent
servicing the main dispatch queue fell from 25–28% to 0.2–5.1%. That contrast is
the mechanism rather than a correlation — a queued block cannot run while the
thread is inside a callout, so it is one event described from both sides. The
observer was the only main-thread callout class ever exceeding ~35 ms
uninterrupted; everything else topped out at 89 ms once, against 105 and 118
observer runs over 50 ms reaching 295 ms and 366 ms.

**The same instrument then measured the fix.** After #724, across five windows at
matched process ages: stall load fell from 1.33–3.71% to 0.26–0.83% of wall
clock, worst observed wait from 228–325 ms to 58–162 ms. Process age was tested
rather than assumed — 6-minute and 59-minute post-fix windows agree almost
exactly, so uptime does not explain the improvement.

**A number in this PR's own evidence record was revised down.** An earlier draft
claimed 325 ms → 58 ms by comparing the worst before-window against the best
after-window; a third after-window contradicted it, and the record now states the
range and notes explicitly that the post-fix side is variable (p99 5.3 ms in one
window, 148.5 ms in another). Flagging it because that number had already been
quoted elsewhere before the correction.

- `scripts/swift-safe build` — clean, run again after rebasing onto current
  `main` since the rebase pulled daemon changes onto the branch.
- `scripts/test.sh --filter TerminalSignposts` — **"Test run with 2 tests in 1
  suite passed"**. Count verified rather than exit code alone, since a
  zero-match filter exits green.
- `swiftlint --strict` — clean.

**What this deliberately does not measure.** Both intervals cover output
travelling *towards* the screen. Keystroke-to-echo has still never been measured
under a validated window, and scrolling was not measured here either. Wheel-event
amplification (#719) and the 150 ms post-keystroke frame-limiter window remain
the better suspects for those, and neither is touched by this PR. A future window
intending to cover typing or scrolling must be checked for containing the action
— four windows earlier in this investigation silently captured no scrolling and
produced a confident, wrong conclusion.

Related: #735 (whose premise this refutes and which needs correcting), #667,
#719, #724.

[main thread bursts](https://cheapsteak.github.io/tbd/open/?worktree=90E977ED-D96C-4BC8-A1D0-238F625E2B46)
