### PR TITLE
diag: benchmark the render path with a real Claude Code TUI against a scripted endpoint

### DIFF
--- a/docs/perf/2026-08-26-claude-code-render-benchmark.md
+++ b/docs/perf/2026-08-26-claude-code-render-benchmark.md
@@ -1,0 +1,159 @@
+# Benchmarking TBD's terminal render path with a real agent as the producer
+
+**Audit record.** Measured 2026-08-26 against `/Applications/TBD.app` built at
+14:09 from the temporary signpost branch described below, on a 12-core Apple
+Silicon machine carrying ~40 concurrent agent sessions (load average 30–92
+across the runs; no Swift builds active). Numbers are that machine on that day;
+the method is what generalizes.
+
+## What problem this solves
+
+TBD's embedded terminals feel laggy under heavy output. Measuring that honestly
+needs a producer that is both *realistic* (a real agent TUI, not a synthetic
+byte stream) and *deterministic* (the same bytes every run, so an A/B compares
+renderers rather than two different workloads).
+
+Driving a live agent against the real API gives realism and no determinism: the
+token stream differs every run, costs money, and carries network jitter. A
+synthetic `printf` loop gives determinism and no realism: it emits byte patterns
+no TUI produces, and its own overhead can silently become the bottleneck.
+
+Pointing Claude Code at a local fake Anthropic endpoint gives both. The real TUI
+does the rendering; a scripted SSE stream decides exactly what it renders, at a
+rate we choose, for free and offline.
+
+## How it works
+
+Claude Code honours `ANTHROPIC_BASE_URL`, so it can be aimed at a local server.
+`ANTHROPIC_AUTH_TOKEN` set to any dummy string bypasses the OAuth flow, and
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` silences background chatter that
+would otherwise hit the fake server. Verified against Claude Code 2.1.246, which
+ships as a Bun-compiled native binary rather than a `cli.js`.
+
+The pieces:
+
+- **`scripts/diag/fake-anthropic-server.py`** — a stdlib HTTP server answering
+  `POST /v1/messages` with a scripted SSE stream. `FA_DELTAS`, `FA_RATE`,
+  `FA_TEXT` and `FA_NEWLINE` control length, pace, delta size, and how often a
+  newline is emitted (which decides whether the TUI scrolls).
+- **`scripts/diag/bench-cc-render.sh`** — spawns a TBD terminal running Claude
+  Code against that server, optionally switches renderer, foregrounds the tab,
+  submits a prompt, captures signposts, and reports.
+- **`scripts/diag/signpost-report.py`** — summarizes a capture.
+
+Injection must go through `tbd terminal create --cmd`. TBD's `envOverrides` is
+repo-wide, so using it would silently point *real* sessions at the fake endpoint.
+
+```
+scripts/diag/bench-cc-render.sh --worktree <worktree-id> --label cc-fs --mode fullscreen
+scripts/diag/bench-cc-render.sh --worktree <worktree-id> --label cc-def --mode default
+```
+
+### Prerequisite: the signpost build
+
+The scripts read three `os_signpost` intervals that exist only on a temporary
+instrumentation branch (`diag: signpost the terminal render path`), which is
+deliberately unmerged. Confirm the running app carries it before trusting a run:
+
+```
+strings /Applications/TBD.app/Contents/MacOS/TBDApp | grep -c RenderLatencySignposts   # must be 1
+```
+
+Rebuilding from a branch without the instrumentation destroys the instrument.
+
+## Reading the three intervals
+
+Each measures something different, and conflating them produces wrong
+conclusions:
+
+- **`mainThreadHop`** — the main-thread *queueing delay* for a pty chunk, from
+  just before `DispatchQueue.main.async` to the block running. It is waiting,
+  not work. A large value means the main thread was busy with something else.
+- **`feed`** — the nested `TerminalView.feed()` call: parse plus damage
+  tracking. Synchronous and nested, so this is the **trustworthy cost signal**.
+- **`displayPass`** — an **upper bound** on one AppKit display pass. It begins in
+  `viewWillDraw()` and ends on the next main-queue turn, so a backed-up main
+  queue inflates it. A large `displayPass` does not mean drawing was slow.
+
+The derived figure that matters most is **`feed` work per wall-second**: total
+`feed` time divided by the span. Above ~1.0 the main thread is saturated by
+parsing alone, before any drawing happens.
+
+## Results
+
+Two producers, same machine, same instrument. `chunks/s` is `mainThreadHop`
+count over the window span.
+
+    producer                            renderer      chunks/s  feed p50  feed work/s  passes/s
+    Claude Code, 40 deltas/s            fullscreen        38.9   0.12 ms       0.01        5.4
+    Claude Code, 40 deltas/s (repeat)   fullscreen        37.7   0.12 ms       0.01        5.0
+    Claude Code, 40 deltas/s            default           36.5   0.12 ms       0.01        6.2
+    Claude Code, 400 deltas/s           default           30.0   0.10 ms       0.00        7.1
+    synthetic, 2637 lines/s             alt-screen       354.8   0.38 ms       0.13       22.7
+    synthetic, 2637 lines/s (repeat)    alt-screen       364.1   0.38 ms       0.14       21.2
+    synthetic, 2637 lines/s             scrolling        274.3   6.15 ms       0.96        1.1
+    synthetic, 2637 lines/s (repeat)    scrolling        226.8   6.30 ms       0.96        1.0
+
+Three findings:
+
+**An agent cannot saturate TBD.** Claude Code emits ~30–40 screen updates per
+second regardless of renderer, and raising the token rate tenfold (40 → 400
+deltas/s) *lowered* the chunk rate to 30/s — it coalesces repaints internally.
+Feed work stays at 0.01 s/s, leaving the main thread ~99% idle. The renderer
+choice makes no material difference either.
+
+**Full-viewport repaint is cheap; scrolling line-append is expensive.** At
+matched volume (2,637 lines/s, ~320 KB/s), alt-screen repaint costs 0.38 ms per
+chunk while scrolling append costs 6.2 ms — about 10x per byte. The scrolling
+case consumes 0.96 s of parse work per wall-second and the view drops to ~1
+display pass per second. This is the opposite of the intuition that redrawing
+every visible row must cost more than appending one line.
+
+**The cost is upstream of drawing.** It lands in `feed` — parse and damage
+tracking — not in `drawTerminalContents`. Optimizing the per-row
+`NSAttributedString` rebuild would target a path that is not the bottleneck.
+
+Together these point away from agent output as the lag source and toward
+high-rate scrolling output in ordinary tabs: build logs, test runs, `cat` of a
+large file.
+
+## Pitfalls that have produced wrong answers here
+
+Every one of these produced a confident, wrong number during this work.
+
+- **A capture with no `displayPass` intervals is void.** Those only occur if the
+  view actually draws, which requires the tab to be on screen. A hidden terminal
+  feeds and parses happily and yields a plausible table that means nothing. The
+  bench script now aborts loudly below 20 passes.
+- **A fixed `sleep` after spawning loses keystrokes.** Under load, Claude Code
+  took longer than 10 s to boot; the mode command and the prompt both went
+  nowhere, producing a capture containing no load at all. Wait on machine
+  signals instead: `HEAD /api/hello` in the server log proves the TUI booted, and
+  `POST /v1/messages` proves the prompt submitted.
+- **Verify the renderer actually switched.** `/tui default` applies reliably when
+  sent programmatically; `/tui fullscreen` often does not. Check tmux's
+  `alternate_on` (1 = alternate screen, 0 = normal screen) rather than assuming.
+  Note that `default` is the *name* of the inline/scrolling renderer, so "already
+  using the default renderer" is a statement about mode, not about your config.
+- **The producer can be the bottleneck.** A naive Python loop building strings
+  per line capped at ~345 lines/s and was misread as pty backpressure. A `cat` of
+  1.92 MB completes in 0.095 s (~20 MB/s), which settles it: the pipe is not the
+  constraint. Precompute the frame buffers and report achieved throughput.
+- **Rates must divide by the span actually covered by data.** `log stream` starts
+  mid-flight, so intervals whose `begin` predates the first captured
+  `mainThreadHop` must be excluded, and a load period that ends early must not be
+  divided by the nominal window width. Getting both wrong once inflated a figure
+  from 0.75 to 0.97 s/s by coincidence.
+- **Take more than one window, and note the load.** A single window produced a
+  wrong committed conclusion earlier in this investigation. Run the A/B
+  back-to-back so both halves share machine state, and record the load average.
+- **`pgrep -f` matches your own command line**, which once produced a phantom
+  "the app restarted eight times" reading.
+
+## Limits
+
+The fake stream removes network jitter by construction, so this measures render
+cost, not end-to-end perceived latency. It also drives text deltas; a real
+session additionally renders tool-use blocks and their results, and Claude Code
+buffers bulk tool output rather than painting it — which is why pointing the
+harness at an agent's *tool* output does not reproduce heavy load either.

--- a/scripts/diag/bench-cc-render.sh
+++ b/scripts/diag/bench-cc-render.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Benchmark TBD's terminal render path with the REAL Claude Code TUI as the byte
+# producer, fed a deterministic scripted stream by a local fake Anthropic endpoint.
+# No tokens are spent and no network is involved.
+#
+#   scripts/diag/bench-cc-render.sh --worktree <id> --label <name> [--mode default|fullscreen]
+#
+# Requires the temporary RenderLatencySignposts instrumentation to be running --
+# see docs/perf/2026-08-26-claude-code-render-benchmark.md. Verify with:
+#   strings /Applications/TBD.app/Contents/MacOS/TBDApp | grep -c RenderLatencySignposts
+#
+# --mode issues `/tui <mode>` before the run. Claude Code's two renderers are
+# `fullscreen` (alternate screen, repaints the viewport in place) and `default`
+# (normal screen, appends lines and scrolls). Confirm which one is live via the
+# alternate_on line this script prints: 1 = fullscreen, 0 = default.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKTREE=""; LABEL="bench"; MODE=""
+DELTAS=2400; RATE=40; NEWLINE=6; CAPTURE=25; PORT=8787
+OUT="${TMPDIR:-/tmp}/tbd-ccbench"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --worktree) WORKTREE="$2"; shift 2;;
+    --label)    LABEL="$2"; shift 2;;
+    --mode)     MODE="$2"; shift 2;;
+    --deltas)   DELTAS="$2"; shift 2;;
+    --rate)     RATE="$2"; shift 2;;
+    --capture)  CAPTURE="$2"; shift 2;;
+    --port)     PORT="$2"; shift 2;;
+    --out)      OUT="$2"; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+[ -n "$WORKTREE" ] || { echo "--worktree is required" >&2; exit 2; }
+mkdir -p "$OUT"
+
+# tmux socket TBD uses, for the alternate-screen check (a machine interface, not
+# screen scraping). Derived from $TMUX when this script runs inside a TBD terminal.
+SOCK=""
+[ -n "${TMUX:-}" ] && SOCK="$(basename "${TMUX%%,*}")"
+
+TERMID=""; SRVPID=""
+cleanup() {
+  [ -n "$TERMID" ] && tbd terminal close --terminal "$TERMID" >/dev/null 2>&1 || true
+  [ -n "$SRVPID" ] && kill "$SRVPID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> starting fake Anthropic endpoint on 127.0.0.1:$PORT (deltas=$DELTAS rate=$RATE/s)"
+FA_PORT=$PORT FA_DELTAS=$DELTAS FA_RATE=$RATE FA_NEWLINE=$NEWLINE \
+  python3 "$DIR/fake-anthropic-server.py" > "$OUT/$LABEL.server.log" 2>&1 &
+SRVPID=$!
+sleep 1
+
+echo "==> spawning Claude Code pointed at it"
+TERMID="$(tbd terminal create "$WORKTREE" --type shell --json \
+  --cmd "env ANTHROPIC_BASE_URL=http://127.0.0.1:$PORT ANTHROPIC_AUTH_TOKEN=fake-local-bench CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 claude --model claude-opus-5" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+PANE="$(tbd terminal list "$WORKTREE" | awk -v id="$TERMID" '$1==id {print $3}')"
+echo "    terminal=$TERMID pane=$PANE"
+
+# Wait on a machine signal, not a fixed sleep: Claude Code probes HEAD /api/hello
+# at startup, so its arrival in the server log proves the TUI booted. A fixed sleep
+# silently loses every subsequent keystroke on a loaded machine, which yields a
+# capture that looks real but contains no load at all.
+wait_for() {  # wait_for <pattern> <seconds> <file>
+  local i=0
+  while [ "$i" -lt "$2" ]; do
+    grep -q "$1" "$3" 2>/dev/null && return 0
+    sleep 1; i=$((i+1))
+  done
+  return 1
+}
+if wait_for "HEAD /api/hello" 90 "$OUT/$LABEL.server.log"; then
+  echo "    Claude Code booted (reached the fake endpoint)"
+else
+  echo "!!! Claude Code never contacted the endpoint -- aborting" >&2; exit 1
+fi
+sleep 2
+
+if [ -n "$MODE" ]; then
+  echo "==> switching renderer: /tui $MODE"
+  tbd terminal send --terminal "$TERMID" --text "/tui $MODE" >/dev/null
+  tbd terminal send --terminal "$TERMID" --keys "Enter" >/dev/null
+  sleep 4
+fi
+
+# Verify the renderer actually changed. `/tui default` applies reliably when sent
+# programmatically; `/tui fullscreen` often does not (the completion menu appears to
+# swallow it), so a run can silently measure the wrong renderer. tmux's alternate_on
+# is a machine interface, not screen text, and it settles the question.
+if [ -n "$SOCK" ] && [ -n "$PANE" ]; then
+  ALT="$(tmux -L "$SOCK" display -p -t "$PANE" '#{alternate_on}' 2>/dev/null || echo '?')"
+  echo "    alternate_on=$ALT  (1 = alternate screen, 0 = normal screen + scrollback)"
+  if [ -n "$MODE" ]; then
+    case "$MODE" in
+      fullscreen) WANT=1;;
+      default)    WANT=0;;
+      *)          WANT="$ALT";;
+    esac
+    if [ "$ALT" != "$WANT" ]; then
+      echo "!!! renderer did not switch: asked for '$MODE' (alternate_on=$WANT) but pane reports $ALT." >&2
+      echo "!!! This run would be mislabelled. Aborting." >&2
+      exit 1
+    fi
+  fi
+fi
+
+# The tab MUST be on screen: displayPass intervals only occur if the view draws.
+echo "==> foregrounding the tab (this interrupts the user)"
+tbd terminal focus --terminal "$TERMID" --activate >/dev/null
+sleep 2
+
+echo "==> prompting"
+tbd terminal send --terminal "$TERMID" --text "go" >/dev/null
+tbd terminal send --terminal "$TERMID" --keys "Enter" >/dev/null
+# Proof the prompt actually submitted: the stream request reaches the fake server.
+if wait_for "POST /v1/messages" 30 "$OUT/$LABEL.server.log"; then
+  echo "    stream started"
+else
+  echo "!!! prompt never submitted -- capture would be void, aborting" >&2; exit 1
+fi
+echo "==> capturing $CAPTURE s of signposts"
+sleep 3
+echo "    load average at capture start: $(sysctl -n vm.loadavg)"
+/usr/bin/log stream --style ndjson --signpost --predicate 'subsystem == "com.tbd.app"' \
+  > "$OUT/$LABEL.ndjson" 2>"$OUT/$LABEL.err" &
+LOGPID=$!
+sleep "$CAPTURE"
+kill "$LOGPID" 2>/dev/null || true
+wait "$LOGPID" 2>/dev/null || true
+
+echo
+python3 "$DIR/signpost-report.py" "$OUT/$LABEL.ndjson" "$LABEL"
+
+# A window with no display passes means the tab was not on screen: the terminal fed
+# and parsed but never drew, so every render number in it is meaningless. Say so
+# loudly rather than letting a plausible-looking table be believed.
+PASSES="$(python3 - "$OUT/$LABEL.ndjson" <<'PY'
+import sys, json, re
+n = 0
+for line in open(sys.argv[1], errors="replace"):
+    line = line.strip().rstrip(",")
+    if line.startswith("{") and '"displayPass"' in line and '"begin"' in line:
+        n += 1
+print(n)
+PY
+)"
+echo
+if [ "${PASSES:-0}" -lt 20 ]; then
+  echo "*** VOID: only ${PASSES} displayPass begins -- the tab was not drawing."
+  echo "*** Re-run with the subject tab on screen; do not report these numbers."
+fi
+echo
+echo "capture: $OUT/$LABEL.ndjson"

--- a/scripts/diag/bench-cc-render.sh
+++ b/scripts/diag/bench-cc-render.sh
@@ -41,10 +41,13 @@ mkdir -p "$OUT"
 SOCK=""
 [ -n "${TMUX:-}" ] && SOCK="$(basename "${TMUX%%,*}")"
 
-TERMID=""; SRVPID=""
+TERMID=""; SRVPID=""; LOGPID=""
 cleanup() {
   [ -n "$TERMID" ] && tbd terminal close --terminal "$TERMID" >/dev/null 2>&1 || true
   [ -n "$SRVPID" ] && kill "$SRVPID" >/dev/null 2>&1 || true
+  # `log stream` never terminates on its own, so an interrupt during the capture
+  # sleep would leave it running and writing to disk for the rest of the session.
+  [ -n "$LOGPID" ] && kill "$LOGPID" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -131,6 +134,7 @@ LOGPID=$!
 sleep "$CAPTURE"
 kill "$LOGPID" 2>/dev/null || true
 wait "$LOGPID" 2>/dev/null || true
+LOGPID=""
 
 echo
 python3 "$DIR/signpost-report.py" "$OUT/$LABEL.ndjson" "$LABEL"
@@ -149,9 +153,14 @@ print(n)
 PY
 )"
 echo
+VOID=0
 if [ "${PASSES:-0}" -lt 20 ]; then
-  echo "*** VOID: only ${PASSES} displayPass begins -- the tab was not drawing."
-  echo "*** Re-run with the subject tab on screen; do not report these numbers."
+  echo "*** VOID: only ${PASSES} displayPass begins -- the tab was not drawing." >&2
+  echo "*** Re-run with the subject tab on screen; do not report these numbers." >&2
+  VOID=1
 fi
 echo
 echo "capture: $OUT/$LABEL.ndjson"
+# Fail the run, not just the reader: a caller that only checks the exit code must
+# not treat a void capture as a successful measurement.
+[ "$VOID" -eq 0 ] || exit 1

--- a/scripts/diag/fake-anthropic-server.py
+++ b/scripts/diag/fake-anthropic-server.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Deterministic fake Anthropic /v1/messages SSE server for TBD render benchmarking.
+
+Emits a scripted assistant stream at a controlled rate so Claude Code's real TUI
+becomes the byte producer. Knobs (env):
+  FA_PORT      listen port                       (default 8787)
+  FA_DELTAS    number of text_delta events       (default 400)
+  FA_RATE      deltas per second                 (default 50)
+  FA_TEXT      characters per delta              (default 24)
+  FA_NEWLINE   insert '\n' every N deltas, 0=off (default 8)
+"""
+import json, os, sys, time, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT   = int(os.environ.get("FA_PORT", "8787"))
+DELTAS = int(os.environ.get("FA_DELTAS", "400"))
+RATE   = float(os.environ.get("FA_RATE", "50"))
+TEXTN  = int(os.environ.get("FA_TEXT", "24"))
+NLEVERY= int(os.environ.get("FA_NEWLINE", "8"))
+
+def sse(w, ev, obj):
+    w.write(f"event: {ev}\ndata: {json.dumps(obj)}\n\n".encode())
+    w.flush()
+
+class H(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    def log_message(self, fmt, *a):
+        sys.stderr.write("[fake] %s %s\n" % (self.command, self.path))
+
+    def _read_body(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        return self.rfile.read(n) if n else b""
+
+    def do_POST(self):
+        body = self._read_body()
+        if self.path.startswith("/v1/messages/count_tokens"):
+            return self._json({"input_tokens": 42})
+        if self.path.startswith("/v1/messages"):
+            try: req = json.loads(body or b"{}")
+            except Exception: req = {}
+            if req.get("stream"): return self._stream(req)
+            return self._json({"id":"msg_fake","type":"message","role":"assistant",
+                "model":req.get("model","claude-opus-5"),
+                "content":[{"type":"text","text":"ok"}],
+                "stop_reason":"end_turn","stop_sequence":None,
+                "usage":{"input_tokens":10,"output_tokens":5}})
+        return self._json({"ok": True})
+
+    def do_GET(self):
+        return self._json({"ok": True, "fake": True})
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length","0")
+        self.end_headers()
+
+    def _json(self, obj, code=200):
+        b = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length",str(len(b)))
+        self.end_headers(); self.wfile.write(b); self.wfile.flush()
+
+    def _stream(self, req):
+        model = req.get("model","claude-opus-5")
+        self.send_response(200)
+        self.send_header("Content-Type","text/event-stream")
+        self.send_header("Cache-Control","no-cache")
+        self.send_header("Connection","close")
+        self.end_headers()
+        self.close_connection = True
+        w = self.wfile
+        mid = "msg_fake_%d" % int(time.time()*1000)
+        sse(w,"message_start",{"type":"message_start","message":{"id":mid,"type":"message",
+            "role":"assistant","model":model,"content":[],"stop_reason":None,
+            "stop_sequence":None,"usage":{"input_tokens":10,"output_tokens":1}}})
+        sse(w,"content_block_start",{"type":"content_block_start","index":0,
+            "content_block":{"type":"text","text":""}})
+        per = 1.0/RATE if RATE>0 else 0
+        t0 = time.time()
+        for i in range(DELTAS):
+            txt = ("w%04d " % i) + "abcdefghijklmnopqrstuvwxyz"[:max(0,TEXTN-6)]
+            if NLEVERY and i % NLEVERY == NLEVERY-1: txt += "\n"
+            sse(w,"content_block_delta",{"type":"content_block_delta","index":0,
+                "delta":{"type":"text_delta","text":txt}})
+            if per:
+                d = t0 + (i+1)*per - time.time()
+                if d>0: time.sleep(d)
+        sse(w,"content_block_stop",{"type":"content_block_stop","index":0})
+        sse(w,"message_delta",{"type":"message_delta",
+            "delta":{"stop_reason":"end_turn","stop_sequence":None},
+            "usage":{"output_tokens":DELTAS}})
+        sse(w,"message_stop",{"type":"message_stop"})
+
+if __name__ == "__main__":
+    srv = ThreadingHTTPServer(("127.0.0.1", PORT), H)
+    sys.stderr.write("[fake] listening on 127.0.0.1:%d deltas=%d rate=%.0f/s\n"%(PORT,DELTAS,RATE))
+    srv.serve_forever()

--- a/scripts/diag/signpost-report.py
+++ b/scripts/diag/signpost-report.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Summarize com.tbd.app render-latency signposts from an `log stream --signpost` ndjson capture.
+
+Usage: signpost-report.py <capture.ndjson> <label> [--window START END]
+
+Reads the three intervals emitted by the temporary RenderLatencySignposts
+instrumentation (see the accompanying research doc for how to build it):
+
+  mainThreadHop  main-thread QUEUEING DELAY for a pty chunk -- not work done.
+  feed           the nested TerminalView.feed() call: parse + damage tracking.
+                 Synchronous and nested, so this is the trustworthy cost signal.
+  displayPass    UPPER BOUND on one AppKit display pass. It ends on the next
+                 main-queue turn, so a backed-up main queue inflates it. Do not
+                 read a large displayPass as "drawing was slow".
+
+Also reports `feed work per wall-second`: total feed time divided by window span.
+Above ~1.0 the main thread is saturated by parsing alone, before any drawing.
+
+By default the densest contiguous 25s sub-window is chosen, so idle head/tail
+around the load period does not dilute the rates. Pass --window to override.
+"""
+import json, re, sys
+from collections import defaultdict
+
+
+def load(path):
+    """Match begin/end signpost pairs by (signpostID, name). Returns {name: [(start, end)]}."""
+    open_intervals, intervals = {}, defaultdict(list)
+    for line in open(path, errors="replace"):
+        line = line.strip().rstrip(",")
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        sid = event.get("signpostID")
+        name = event.get("signpostName") or event.get("eventMessage", "").split(":")[0]
+        stamp = re.search(r"(\d{2}):(\d{2}):(\d{2})\.(\d+)", event.get("timestamp", ""))
+        if not stamp or sid is None:
+            continue
+        frac = (stamp.group(4) + "000000000")[:9]
+        t = (int(stamp.group(1)) * 3600 + int(stamp.group(2)) * 60
+             + int(stamp.group(3)) + int(frac) / 1e9)
+        key = (sid, name)
+        kind = event.get("signpostType", "")
+        if kind == "begin":
+            open_intervals[key] = t
+        elif kind == "end" and key in open_intervals:
+            intervals[name].append((open_intervals.pop(key), t))
+    return intervals
+
+
+def pct(values, q):
+    if not values:
+        return float("nan")
+    values = sorted(values)
+    return values[min(len(values) - 1, int(len(values) * q))]
+
+
+def densest_window(hops, t0, span):
+    per_second = defaultdict(int)
+    for start, _ in hops:
+        per_second[int(start - t0)] += 1
+    last = max(per_second) if per_second else 0
+    best = (0, -1)
+    for begin in range(0, max(1, last - span + 1)):
+        count = sum(per_second.get(s, 0) for s in range(begin, begin + span))
+        if count > best[1]:
+            best = (begin, count)
+    return best[0], per_second, last
+
+
+def main():
+    args = sys.argv[1:]
+    window = None
+    if "--window" in args:
+        i = args.index("--window")
+        window = (float(args[i + 1]), float(args[i + 2]))
+        del args[i:i + 3]
+    path, label = args[0], args[1]
+
+    intervals = load(path)
+    hops = sorted(intervals.get("mainThreadHop", []))
+    if not hops:
+        print(f"{label}: no mainThreadHop intervals -- capture is void")
+        return 1
+    t0 = min(h[0] for h in hops)
+
+    if window:
+        start, end = window
+        per_second, last = None, None
+    else:
+        span = 25
+        start, per_second, last = densest_window(hops, t0, span)
+        end = start + span
+        print("per-second mainThreadHop counts:")
+        print("  " + " ".join(str(per_second.get(s, 0)) for s in range(last + 1)))
+
+    lo, hi = t0 + start, t0 + end
+    # Effective span: `log stream` starts mid-flight and the load may end before the
+    # nominal window does, so rates must divide by the span actually covered by data,
+    # not by the nominal window width. Intervals whose begin predates t0 (their
+    # matching begin was never captured) are excluded by the `lo <= s` bound below.
+    covered = [(s_, e_) for v in intervals.values() for s_, e_ in v if lo <= s_ < hi]
+    width = (max(e_ for _, e_ in covered) - min(s_ for s_, _ in covered)) if covered else (end - start)
+    if width <= 0:
+        width = end - start
+    print(f"\n=== {label} | window t=[{start:.0f},{end:.0f}) covered span={width:.1f}s ===")
+    for name in ("mainThreadHop", "feed", "displayPass", "rpc.pollCycle"):
+        durations = [(e - s) * 1000 for s, e in intervals.get(name, []) if lo <= s < hi]
+        if not durations:
+            print(f"  {name:14s} none")
+            continue
+        print(f"  {name:14s} n={len(durations):5d} rate={len(durations)/width:6.1f}/s  "
+              f"p50={pct(durations,.5):7.2f}  p90={pct(durations,.9):7.2f}  "
+              f"p99={pct(durations,.99):8.2f}  max={max(durations):8.2f} ms")
+
+    passes = sorted(p for p in intervals.get("displayPass", []) if lo <= p[0] < hi)
+    if len(passes) > 1:
+        gaps = [(passes[i + 1][0] - passes[i][1]) * 1000 for i in range(len(passes) - 1)]
+        print(f"  gaps between passes  p50={pct(gaps,.5):7.1f}  p90={pct(gaps,.9):7.1f}  "
+              f"max={max(gaps):8.1f} ms   ({sum(1 for g in gaps if g > 100)} over 100ms)")
+
+    feed_work = sum(e - s for s, e in intervals.get("feed", []) if lo <= s < hi) / width
+    pass_work = sum(e - s for s, e in intervals.get("displayPass", []) if lo <= s < hi) / width
+    print(f"\n  feed work per wall-second        = {feed_work:.2f} s/s"
+          f"   ({'SATURATED' if feed_work > 0.9 else 'headroom'})")
+    print(f"  displayPass(upper bound) per s   = {pass_work:.2f} s/s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Measuring TBD's terminal render path needs a producer that is both realistic and deterministic, and the obvious options are each missing one half. A live agent renders through the real TUI but emits a different token stream every run. A synthetic `printf` loop is repeatable but produces byte patterns no TUI actually emits, and its own overhead quietly becomes the thing you measure.

This points Claude Code at a local fake Anthropic endpoint. The real TUI does the rendering, while a scripted SSE stream fixes exactly what it renders and how fast — offline, deterministic, and free.

## Why this shape

The harness exists because the investigation kept producing numbers that turned out to measure something other than the claim. A benchmark you can re-run identically is how a future change gets a before-and-after instead of an anecdote.

Design decisions worth naming:

- **Drive the real TUI, not a stand-in.** Renderer behaviour — alternate screen, full-viewport repaints, damage tracking — is exactly what is under test, so substituting a simpler producer would measure the wrong renderer.
- **Fix the token rate in the server.** Making delta rate a parameter is what allowed the finding that a tenfold token-rate increase *lowers* TBD's chunk rate, which is not something a live agent could have shown.
- **Gate and abort rather than report.** `bench-cc-render.sh` checks machine signals before running and aborts on a void capture or an unapplied renderer switch, because in this investigation a mistimed or mislabelled window has repeatedly been more expensive than no window at all.

## What this PR does

- `scripts/diag/fake-anthropic-server.py` — scripted SSE endpoint; Claude Code is aimed at it with `ANTHROPIC_BASE_URL` so the real TUI renders deterministic content
- `scripts/diag/bench-cc-render.sh` — orchestration, machine-signal gating, abort conditions
- `scripts/diag/signpost-report.py` — capture summarizer
- `docs/perf/2026-08-26-claude-code-render-benchmark.md` — method, results, how to read the signposts, and the pitfalls that produced wrong numbers along the way

Diagnostic tooling only. No production code paths, no flags, no migrations.

## Assumptions

The harness reads `os_signpost` intervals that currently exist only on a temporary instrumentation branch, so it is useful today against a build carrying them and useful permanently once the signposts land (spec on `tbd/735-poll-cycle-main-thread`). It verifies their presence and aborts rather than silently reporting an empty capture.

`ANTHROPIC_AUTH_TOKEN=fake-local-bench` in the orchestration script is a deliberate placeholder pointing at the local server; no real credential is involved and no traffic leaves the machine.

## Evidence & verification

The harness produced the measurements in the accompanying document, including two findings that contradicted prior expectations and one metric discarded as unsound:

- **An agent cannot saturate TBD.** Claude Code emits ~30-40 screen updates/s regardless of renderer, and raising the token rate tenfold *lowered* the chunk rate.
- **Streaming does not degrade typing — it slightly improves it.** Key-to-paint latency was lower while streaming (p50 40.8-41.6 ms) than typing alone (45.7-53.8 ms), despite higher machine load, because more output means more frequently scheduled draws.
- **A discarded metric is recorded rather than deleted** — "time from chunk to next display pass" gave plausible-looking figures but is inflated and partly circular, since a shell emits ~8.75 chunks per typed character while only ~1 draw occurs.

Both caveats are stated in the document rather than buried: the input leg is excluded because macOS blocked synthetic keystrokes without Accessibility, making the latency figures a **lower bound**; and machine load was 63-119 throughout, so within-pair comparisons are sound while cross-comparison to differently-loaded baselines is not.

[🌙 Diagnose Early Hibernate](https://cheapsteak.github.io/tbd/open/?worktree=09FAE901-FB70-4991-A8D9-E7C3AE6AEB1B)
