### PR TITLE
fix: the review gate's Stop hook ran out of blocks long before its deadline

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,6 +49,16 @@ jobs:
       # and the validate step passes it as --expected-specialists. Two literals
       # would let the hook and the validator drift apart silently.
       REVIEW_SPECIALISTS: correctness,conventions
+      # The harness overrides a Stop hook that blocks 8 times CONSECUTIVELY —
+      # it ends the turn and reports the session as normally completed, which
+      # is how run 33010660928 finished with both findings files on disk, no
+      # review-result.json, and a gate that failed closed 2 seconds after the
+      # second specialist landed. Eight blocks is the whole hold, so the
+      # default caps it far below the 25-minute deadline the hook is built
+      # around (hooks/stop-hook.sh). Raised past the hook's own worst case —
+      # 20 holds plus 5 nudges — so those bounds, not this one, decide when a
+      # waiting session is finally released.
+      CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: 100
 
     permissions:
       contents: read

--- a/.github/workflows/claude-review-v2/hooks/settings.json
+++ b/.github/workflows/claude-review-v2/hooks/settings.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.github/workflows/claude-review-v2/hooks/stop-hook.sh\"",
-            "timeout": 60
+            "timeout": 120
           }
         ]
       }

--- a/.github/workflows/claude-review-v2/hooks/stop-hook.sh
+++ b/.github/workflows/claude-review-v2/hooks/stop-hook.sh
@@ -12,12 +12,16 @@
 #
 # It distinguishes two reasons the file is absent, because the right response
 # differs. While an expected findings-<name>.json is missing, the specialists
-# are still running and the hook sleeps, then holds WITHOUT consuming its nudge
-# budget — bounded by a 25-minute wall clock. Once every findings file is
-# present and only the merge is missing, the model has what it needs and the
-# bounded nudge applies. Conflating the two is what let a session exit 3 minutes
-# into a 14-minute review
-# (docs/specs/2026-08-10-review-orchestrator-liveness-design.md).
+# are still running and the hook waits — watching for the files, up to 90
+# seconds a turn — then holds WITHOUT consuming its nudge budget, bounded by a
+# 25-minute wall clock. Once every findings file is present and only the merge
+# is missing, the model has what it needs and the bounded nudge applies.
+# Conflating the two is what let a session exit 3 minutes into a 14-minute
+# review (docs/specs/2026-08-10-review-orchestrator-liveness-design.md).
+#
+# The wait is long, and watchful, because BLOCKS are what the hold is short of:
+# the harness overrides a Stop hook after 8 consecutive blocks and ends the
+# turn anyway. See the arithmetic at the hold itself.
 #
 # Contract (Claude Code Stop hook):
 #   - stdin: JSON with at least { "stop_hook_active": bool }
@@ -90,12 +94,20 @@ case "$specialists" in
      specialists="${REVIEW_SPECIALISTS:-correctness,conventions}" ;;
 esac
 
-findings_pending=0
-for name in $(printf '%s' "$specialists" | tr ',' ' '); do
-  [ -n "$name" ] || continue
-  findings_file="$workdir/findings-$name.json"
-  json_ready "$findings_file" || findings_pending=1
-done
+# Re-runnable, because the hold below re-scans while it waits: a hold that
+# reported the state it saw BEFORE its wait would tell the orchestrator its
+# specialists are still running when they had in fact just finished, spending
+# a whole further hold — and one of the harness's eight — on stale news.
+scan_findings() {
+  findings_pending=0
+  for name in $(printf '%s' "$specialists" | tr ',' ' '); do
+    [ -n "$name" ] || continue
+    findings_file="$workdir/findings-$name.json"
+    json_ready "$findings_file" || findings_pending=1
+  done
+}
+
+scan_findings
 
 if [ "$findings_pending" -eq 1 ]; then
   # THE SPECIALISTS ARE STILL RUNNING. Blocking here is what keeps the process
@@ -109,33 +121,46 @@ if [ "$findings_pending" -eq 1 ]; then
   # is a defensive backstop so a broken clock cannot make the session
   # unstoppable. Past either, we give up and validate.py fails closed.
   hold_deadline_seconds=1500   # 25 minutes (spec §2)
-  max_holds=60
+  max_holds=20
 
-  # WHY THE HOLD SLEEPS, AND THE ARITHMETIC THAT MAKES THE BOUNDS AGREE.
+  # WHY THE HOLD WAITS, AND THE ARITHMETIC THAT MAKES THE BOUNDS AGREE.
   #
-  # Every hold is a block, and every block costs one turn of the session's
-  # --max-turns 100 budget. Turns, not seconds, are what the session runs out
-  # of: PR #604 burned 35 turns in 184 s (~5 s per turn), leaving ~65. Held at
-  # that rate those 65 turns cover about 5 minutes of wall clock — less than
-  # the ~10 minutes the specialists need — so the session would die of turn
-  # exhaustion with the 25-minute deadline never reached, in exactly the case
-  # the deadline exists for. Sleeping converts a turn into wall clock at zero
-  # token cost, which is the currency that is short. At 30 s per hold, ~65
-  # remaining turns cover ~32 minutes, so the wall clock binds first.
+  # A hold is a block, and blocks are rationed twice over. The session's
+  # --max-turns 100 budget charges one turn per block; and the HARNESS caps
+  # CONSECUTIVE Stop-hook blocks — default 8 — after which it overrides the
+  # hook, ends the turn and reports the session as normally completed. That
+  # harness cap is the tighter of the two by a wide margin, and it is the one
+  # this hook has to be built around: at 8 blocks the entire hold is only ever
+  # 8 windows long, however many turns or minutes remain.
   #
-  # The two bounds are consistent by the same arithmetic: 60 holds x 30 s =
-  # 1800 s of sleep against a 1500 s deadline, so the deadline is always
-  # reached first and the hold cap is only a backstop for a broken clock. 60
-  # holds also sits under the ~65 turns the budget leaves, so neither bound
-  # asks for turns the session does not have.
+  # So the hold buys wall clock per block rather than blocks per minute. At
+  # 90 s a window, the harness's 8 give ~12 minutes — past the ~10 minutes the
+  # specialists need — and the job also raises the cap (CLAUDE_CODE_STOP_HOOK_
+  # BLOCK_CAP in .github/workflows/claude-code-review.yml) so the deadline
+  # below is what really binds. Both legs are deliberate: the raised cap is a
+  # floating-tag harness knob this repository does not control, and the window
+  # holds the review up on its own if a release ever drops it.
   #
-  # The Stop hook's command timeout in hooks/settings.json (60 s) must stay
-  # strictly greater than this sleep: a hook killed mid-sleep emits no block,
+  # The two local bounds stay consistent as they always were: 20 holds x 90 s =
+  # 1800 s of waiting against a 1500 s deadline, so the deadline is always
+  # reached first and the hold cap is only a backstop for a broken clock. 20
+  # blocks also sits far under the turn budget, so neither bound asks for turns
+  # the session does not have.
+  #
+  # The Stop hook's command timeout in hooks/settings.json (120 s) must stay
+  # strictly greater than this window: a hook killed mid-wait emits no block,
   # and the session ends. The env override exists so the unit tests need not
-  # spend 30 s per invocation; the job sets it nowhere, so production is 30 s
+  # spend 90 s per invocation; the job sets it nowhere, so production is 90 s
   # with no configuration.
-  hold_sleep_seconds="${REVIEW_HOLD_SLEEP_SECONDS:-30}"
-  case "$hold_sleep_seconds" in ''|*[!0-9]*) hold_sleep_seconds=30 ;; esac
+  hold_sleep_seconds="${REVIEW_HOLD_SLEEP_SECONDS:-90}"
+  case "$hold_sleep_seconds" in ''|*[!0-9]*) hold_sleep_seconds=90 ;; esac
+
+  # The window is spent in short steps so the hold ends the moment the last
+  # findings file lands rather than up to 90 s later. Waiting out the full
+  # window regardless would hand the orchestrator a stale "still running" when
+  # it could already be merging — and each such wasted block is one of the
+  # eight the harness allows.
+  hold_poll_seconds=5
 
   now="$(date +%s 2>/dev/null || echo 0)"
   started="$(cat "$start_file" 2>/dev/null || echo '')"
@@ -155,7 +180,7 @@ if [ "$findings_pending" -eq 1 ]; then
   holds="$(cat "$hold_file" 2>/dev/null || echo 0)"
   case "$holds" in ''|*[!0-9]*) holds=0 ;; esac
 
-  # Both bounds are tested BEFORE the sleep. Sleeping and then releasing would
+  # Both bounds are tested BEFORE the wait. Waiting and then releasing would
   # buy nothing and spend runner minutes doing it.
   if [ "$((now - started))" -ge "$hold_deadline_seconds" ] \
      || [ "$holds" -ge "$max_holds" ]; then
@@ -163,16 +188,25 @@ if [ "$findings_pending" -eq 1 ]; then
   fi
   printf '%s' "$((holds + 1))" > "$hold_file" 2>/dev/null || exit 0
 
-  # Hold the turn open in wall clock rather than in turns. The specialists run
-  # in the same process, so this sleep is time they get to finish in.
-  [ "$hold_sleep_seconds" -eq 0 ] || sleep "$hold_sleep_seconds"
+  # Hold the turn open in wall clock rather than in blocks. The specialists run
+  # in the same process, so this wait is time they get to finish in.
+  waited=0
+  while [ "$waited" -lt "$hold_sleep_seconds" ] && [ "$findings_pending" -eq 1 ]; do
+    step="$hold_poll_seconds"
+    [ "$((waited + step))" -le "$hold_sleep_seconds" ] \
+      || step="$((hold_sleep_seconds - waited))"
+    sleep "$step"
+    waited="$((waited + step))"
+    scan_findings
+  done
+fi
 
-  # The reason asks for a bare acknowledgment and NO tool calls, because the
-  # sleep arithmetic above prices a hold at one turn. Every tool call the model
+if [ "$findings_pending" -eq 1 ]; then
+  # The reason asks for a bare acknowledgment and NO tool calls, because a
+  # block is rationed (see the arithmetic above). Every tool call the model
   # makes while waiting is another turn, so inviting it to poll for the files
-  # halves the wall clock the turn budget buys — and buys nothing, since this
-  # hook just checked those files and will check them again on the next stop
-  # attempt.
+  # buys nothing — this hook just watched those files for a whole window and
+  # will watch them again on the next stop attempt.
   hold_reason="Your specialist subagents are still running — at least one findings-<name>.json is not yet on disk. Do NOT end your turn. This session is headless: ending the turn ends the whole session and kills the specialists with it, so no findings are ever written and the review gate fails with no verdict. Do NOT call any tools while waiting: this hook is already checking the files for you and will keep holding until they land, and every tool call spends turn budget the wait needs. Reply with one short sentence acknowledging that you are waiting. When every findings file is on disk you will be allowed to stop, so merge them into review-result.json then. Expected specialists: ${specialists}."
 
   jq -n --arg reason "$hold_reason" '{decision: "block", reason: $reason}' 2>/dev/null \

--- a/.github/workflows/claude-review-v2/hooks/stop-hook.sh
+++ b/.github/workflows/claude-review-v2/hooks/stop-hook.sh
@@ -134,12 +134,16 @@ if [ "$findings_pending" -eq 1 ]; then
   # 8 windows long, however many turns or minutes remain.
   #
   # So the hold buys wall clock per block rather than blocks per minute. At
-  # 90 s a window, the harness's 8 give ~12 minutes — past the ~10 minutes the
-  # specialists need — and the job also raises the cap (CLAUDE_CODE_STOP_HOOK_
-  # BLOCK_CAP in .github/workflows/claude-code-review.yml) so the deadline
-  # below is what really binds. Both legs are deliberate: the raised cap is a
-  # floating-tag harness knob this repository does not control, and the window
-  # holds the review up on its own if a release ever drops it.
+  # 90 s a window the harness's 8 cover ~12 minutes, and the LAST of them is
+  # spent on the merge rather than on waiting: the block whose window the
+  # findings land in carries the merge instruction, and the orchestrator may
+  # yet end a turn between reading those files and writing the result, so a
+  # spare block has to be there for it. That leaves ~10.5 minutes of specialist
+  # time against the ~10 a review takes. The job also raises the cap
+  # (CLAUDE_CODE_STOP_HOOK_BLOCK_CAP in .github/workflows/claude-code-review.yml)
+  # so the deadline below is what really binds. Both legs are deliberate: the
+  # raised cap is a floating-tag harness knob this repository does not control,
+  # and the window holds the review up on its own if a release ever drops it.
   #
   # The two local bounds stay consistent as they always were: 20 holds x 90 s =
   # 1800 s of waiting against a 1500 s deadline, so the deadline is always
@@ -199,6 +203,14 @@ if [ "$findings_pending" -eq 1 ]; then
     waited="$((waited + step))"
     scan_findings
   done
+
+  # The result file is checked at the top of this script, up to a whole window
+  # ago. Everything the hook says from here rests on it still being absent, so
+  # re-check it for the same reason the findings are re-scanned: nudging the
+  # model to write a file that landed during the wait would spend one of the
+  # rationed blocks on stale news, and this is the branch that ends the session
+  # rather than blocking it.
+  json_ready "$result_file" && exit 0
 fi
 
 if [ "$findings_pending" -eq 1 ]; then

--- a/.github/workflows/claude-review-v2/hooks/stop-hook.sh
+++ b/.github/workflows/claude-review-v2/hooks/stop-hook.sh
@@ -185,7 +185,8 @@ if [ "$findings_pending" -eq 1 ]; then
   case "$holds" in ''|*[!0-9]*) holds=0 ;; esac
 
   # Both bounds are tested BEFORE the wait. Waiting and then releasing would
-  # buy nothing and spend runner minutes doing it.
+  # buy nothing and spend runner minutes doing it. The deadline is tested a
+  # second time AFTER the wait as well — see there.
   if [ "$((now - started))" -ge "$hold_deadline_seconds" ] \
      || [ "$holds" -ge "$max_holds" ]; then
     exit 0   # deadline reached; validate.py fails closed with a stall report
@@ -211,6 +212,17 @@ if [ "$findings_pending" -eq 1 ]; then
   # rationed blocks on stale news, and this is the branch that ends the session
   # rather than blocking it.
   json_ready "$result_file" && exit 0
+
+  # The deadline was tested against a clock reading taken before the wait, so
+  # on its own it admits one more hold that then runs a whole window past it.
+  # Re-test it against a fresh reading, so the bound this hook, the workflow
+  # docs and the spec all state — 25 minutes — is the bound that holds, rather
+  # than 25 minutes plus one window.
+  now="$(date +%s 2>/dev/null || echo 0)"
+  if [ "$findings_pending" -eq 1 ] \
+     && [ "$((now - started))" -ge "$hold_deadline_seconds" ]; then
+    exit 0   # deadline crossed during the wait; validate.py fails closed
+  fi
 fi
 
 if [ "$findings_pending" -eq 1 ]; then

--- a/.github/workflows/claude-review-v2/tests/hook_bounds.py
+++ b/.github/workflows/claude-review-v2/tests/hook_bounds.py
@@ -1,0 +1,50 @@
+"""The Stop hook's numeric bounds, read out of the hook itself.
+
+The hold is held together by arithmetic between numbers that live in four
+different files: the hook's own hold cap, nudge cap, wall-clock deadline and
+wait window; the command timeout in `hooks/settings.json`; and the harness
+block cap in the workflow. Every relation between them is silent when it
+breaks — a window raised past the command timeout means every hold is killed
+mid-wait and emits no block, and the session ends at the first stop attempt
+with CI green.
+
+So the tests that assert those relations read the numbers here rather than
+restating them. A restated copy is exactly the drift they exist to catch: the
+test keeps comparing its own stale literal to itself and stays green while the
+hook it guards no longer holds.
+
+Not a test module — pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# .../.github/workflows/claude-review-v2/tests/ -> .../.github/workflows/
+_WORKFLOWS_DIR = Path(__file__).resolve().parents[2]
+HOOK_PATH = _WORKFLOWS_DIR / "claude-review-v2" / "hooks" / "stop-hook.sh"
+SETTINGS_PATH = _WORKFLOWS_DIR / "claude-review-v2" / "hooks" / "settings.json"
+
+_HOOK_NUMBER_RES = {
+    "max_holds": re.compile(r"^\s*max_holds=(\d+)\s*$", re.MULTILINE),
+    "max_blocks": re.compile(r"^\s*max_blocks=(\d+)\s*$", re.MULTILINE),
+    "deadline": re.compile(r"^\s*hold_deadline_seconds=(\d+)", re.MULTILINE),
+    # Both spellings of the wait window: the parameter expansion's default and
+    # the fallback the non-numeric guard assigns. They are two literals of one
+    # number, so both are collected and hook_number() requires them to agree.
+    "window": re.compile(
+        r"(?:REVIEW_HOLD_SLEEP_SECONDS:-|hold_sleep_seconds=)(\d+)"
+    ),
+}
+
+
+def hook_number(name: str) -> int:
+    """One of the hold's bounds, read out of the hook itself."""
+    matches = _HOOK_NUMBER_RES[name].findall(HOOK_PATH.read_text(encoding="utf-8"))
+    assert matches, (
+        f"{HOOK_PATH.name} no longer sets `{name}` where this test looks for "
+        "it; retarget the pattern rather than deleting the check"
+    )
+    assert len(set(matches)) == 1, f"{name} is spelled more than one way: {matches}"
+    return int(matches[0])

--- a/.github/workflows/claude-review-v2/tests/test_stop_hook.py
+++ b/.github/workflows/claude-review-v2/tests/test_stop_hook.py
@@ -11,11 +11,13 @@ Every case also re-asserts the hook's fail-safe contract: exit code 0. A
 hook that exits non-zero wedges the session, and allowing a stop is never a
 gate bypass because validate.py fails closed downstream.
 
-The hold path sleeps in production, because a hold costs a turn and the
-session's turn budget is scarcer than its wall clock. Cases here drive the
-sleep to 0 via REVIEW_HOLD_SLEEP_SECONDS so the suite stays fast; the cases
-that are ABOUT the sleep set it explicitly, and one asserts the production
-default is still 30 seconds with no configuration.
+The hold path waits in production, because BLOCKS are what the hold is short
+of: the harness overrides a Stop hook after 8 consecutive blocks and ends the
+turn regardless, so the hold has to buy wall clock per block rather than
+blocks per minute. Cases here drive the wait to 0 via
+REVIEW_HOLD_SLEEP_SECONDS so the suite stays fast; the cases that are ABOUT
+the wait set it explicitly, and one asserts the production default is still
+90 seconds with no configuration.
 """
 
 from __future__ import annotations
@@ -68,6 +70,15 @@ def _run(
     )
 
 
+def _slept(sleep_log: Path) -> int:
+    """Total seconds the hook asked `sleep` for across the whole window.
+
+    The window is spent in short polling steps so the hold can end early, so
+    no single `sleep` call carries the window length — the sum does.
+    """
+    return sum(int(arg) for arg in sleep_log.read_text().split())
+
+
 def _path_without_jq(tmp_path: Path) -> str:
     """A PATH carrying everything the hook shells out to EXCEPT jq.
 
@@ -89,10 +100,12 @@ def _path_without_jq(tmp_path: Path) -> str:
 def _path_with_sleep_stub(tmp_path: Path) -> tuple[str, Path]:
     """A PATH whose `sleep` records its argument and returns at once.
 
-    The hook's sleep is the one behavior a test cannot observe by waiting for
-    it: the shipped default is 30 seconds, so asserting on the real wait would
-    cost the suite 30 seconds per case. Recording the argument asserts the same
-    thing — which number reached `sleep` — in no time at all.
+    The hook's wait is the one behavior a test cannot observe by waiting for
+    it: the shipped default is 90 seconds, so asserting on the real wait would
+    cost the suite 90 seconds per case. Recording the arguments asserts the
+    same thing — how much wall clock the hook asked for — in no time at all.
+    The hook spends the window in short polling steps, so the invariant is the
+    SUM of what reached `sleep`, not any single call.
     """
     bindir = tmp_path / "sleepstub-bin"
     bindir.mkdir(exist_ok=True)
@@ -279,13 +292,15 @@ def test_the_pending_hold_sleeps_before_emitting_its_block(
 
 
 def test_the_production_sleep_default_needs_no_configuration() -> None:
-    """30 s is the shipped default: the workflow sets no override, so the
-    arithmetic in the hook's comment holds for the real job."""
-    assert 'REVIEW_HOLD_SLEEP_SECONDS:-30}' in HOOK.read_text()
+    """90 s is the shipped default: the workflow sets no override, so the
+    arithmetic in the hook's comment holds for the real job. It is the number
+    that makes the harness's 8-block cap survivable — 8 x 90 s is ~12 minutes,
+    past the ~10 the specialists need."""
+    assert 'REVIEW_HOLD_SLEEP_SECONDS:-90}' in HOOK.read_text()
 
 
 def test_the_stop_hook_command_outlives_its_own_sleep() -> None:
-    """A hook killed at its default timeout mid-sleep would emit no block and
+    """A hook killed at its declared timeout mid-wait would emit no block and
     the session would end — the exact failure the hold exists to prevent."""
     settings = json.loads(SETTINGS.read_text())
     entries = [
@@ -295,8 +310,8 @@ def test_the_stop_hook_command_outlives_its_own_sleep() -> None:
     ]
     assert entries, "no Stop hook command declared"
     for cmd in entries:
-        assert cmd["timeout"] == 60
-        assert cmd["timeout"] > 30  # strictly longer than the sleep
+        assert cmd["timeout"] == 120
+        assert cmd["timeout"] > 90  # strictly longer than the hold window
 
 
 def test_the_deadline_is_checked_before_the_hook_sleeps(
@@ -317,7 +332,7 @@ def test_the_hold_cap_is_checked_before_the_hook_sleeps(
     dirs: tuple[Path, Path],
 ) -> None:
     project, state = dirs
-    (state / HOLD_FILE).write_text("60")
+    (state / HOLD_FILE).write_text("20")
     started = time.monotonic()
     proc = _run(project, state, sleep_seconds="30")
     elapsed = time.monotonic() - started
@@ -461,6 +476,78 @@ def test_an_unwritable_hold_counter_alone_releases(
     assert (state / START_FILE).exists()
 
 
+# --- the wait watches, so the hold ends when the work does -----------------
+
+
+def _path_with_findings_dropping_sleep(
+    tmp_path: Path, project_dir: Path
+) -> str:
+    """A `sleep` stub that lands both findings files on its FIRST call.
+
+    Models what the hold exists for: the specialists finish partway through a
+    wait the hook has already committed to. A stub is the only way to place
+    that event inside the window deterministically.
+    """
+    bindir = tmp_path / "landing-bin"
+    bindir.mkdir(exist_ok=True)
+    for tool in ("bash", "cat", "date", "tr", "jq"):
+        found = shutil.which(tool)
+        assert found, f"test prerequisite missing: {tool}"
+        link = bindir / tool
+        if not link.exists():
+            link.symlink_to(found)
+    payload = json.dumps({"specialist": "x", "findings": []})
+    stub = bindir / "sleep"
+    stub.write_text(
+        "#!/bin/sh\n"
+        f"for n in correctness conventions; do\n"
+        f"  [ -f '{project_dir}'/findings-$n.json ] "
+        f"|| printf '%s' '{payload}' > '{project_dir}'/findings-$n.json\n"
+        "done\n"
+    )
+    stub.chmod(0o755)
+    return str(bindir)
+
+
+def test_findings_landing_mid_wait_end_the_wait_and_change_the_message(
+    dirs: tuple[Path, Path], tmp_path: Path
+) -> None:
+    """The block that follows a wait must report the state AFTER it.
+
+    A hold is one of only 8 consecutive blocks the harness allows, so a hold
+    that reported its pre-wait snapshot would spend a whole further block
+    telling the orchestrator to keep waiting for files already on disk. The
+    discriminating assertion is on WHICH reason came back: a hook that waits
+    blindly still blocks, so "did it block" passes against the bug.
+    """
+    project, state = dirs
+    path = _path_with_findings_dropping_sleep(tmp_path, project)
+    proc = _run(project, state, sleep_seconds="90", path=path)
+    assert proc.returncode == 0
+    reason = _decision(proc)["reason"]
+    assert "review-result.json" in reason
+    assert "specialist subagents are still running" not in reason
+    # And it is charged to the nudge budget, which is the budget for a model
+    # that now HAS everything it needs.
+    assert _count(state) == 1
+
+
+def test_the_wait_stops_polling_once_the_findings_land(
+    dirs: tuple[Path, Path], tmp_path: Path
+) -> None:
+    """Early exit is the point: the remaining window is not spent."""
+    project, state = dirs
+    path = _path_with_findings_dropping_sleep(tmp_path, project)
+    log = tmp_path / "landing-sleep.log"
+    stub = Path(path) / "sleep"
+    stub.write_text(
+        stub.read_text() + f'printf "%s\\n" "$@" >> "{log}"\n'
+    )
+    log.touch()
+    _run(project, state, sleep_seconds="90", path=path)
+    assert _slept(log) == 5  # one poll step, not the whole 90 s window
+
+
 def test_a_non_numeric_sleep_override_falls_back_to_the_default(
     dirs: tuple[Path, Path], tmp_path: Path
 ) -> None:
@@ -470,7 +557,7 @@ def test_a_non_numeric_sleep_override_falls_back_to_the_default(
     wait entirely — the hold stops costing wall clock and starts costing only
     turns, which is the trade the sleep exists to reverse. Asserting on the
     argument the hook actually passes to `sleep` (recorded by a stub, so the
-    green path does not spend 30 real seconds) is what makes the clamp
+    green path does not spend 90 real seconds) is what makes the clamp
     observable at all.
     """
     project, state = dirs
@@ -479,7 +566,7 @@ def test_a_non_numeric_sleep_override_falls_back_to_the_default(
     assert proc.returncode == 0
     assert _decision(proc)["decision"] == "block"
     assert proc.stderr == ""
-    assert sleep_log.read_text().split() == ["30"]
+    assert _slept(sleep_log) == 90
 
 
 def test_a_numeric_sleep_override_is_passed_through(
@@ -491,7 +578,7 @@ def test_a_numeric_sleep_override_is_passed_through(
     path, sleep_log = _path_with_sleep_stub(tmp_path)
     proc = _run(project, state, sleep_seconds="7", path=path)
     assert _decision(proc)["decision"] == "block"
-    assert sleep_log.read_text().split() == ["7"]
+    assert _slept(sleep_log) == 7
 
 
 # --- jq absent: the fallback must not invent a pending review --------------

--- a/.github/workflows/claude-review-v2/tests/test_stop_hook.py
+++ b/.github/workflows/claude-review-v2/tests/test_stop_hook.py
@@ -532,6 +532,38 @@ def test_findings_landing_mid_wait_end_the_wait_and_change_the_message(
     assert _count(state) == 1
 
 
+def test_a_result_file_landing_mid_wait_releases_the_session(
+    dirs: tuple[Path, Path], tmp_path: Path
+) -> None:
+    """The result check at the top of the hook is up to a window stale.
+
+    Everything the hold says after its wait rests on that file still being
+    absent, so it is re-checked for the same reason the findings are. Blocking
+    here would nudge the model to write a file already on disk, spending one of
+    the rationed blocks — and this branch ENDS the session rather than holding
+    it, so a test that only watched the findings would never see the gap.
+    """
+    project, state = dirs
+    bindir = tmp_path / "result-bin"
+    bindir.mkdir()
+    for tool in ("bash", "cat", "date", "tr", "jq"):
+        found = shutil.which(tool)
+        assert found, f"test prerequisite missing: {tool}"
+        (bindir / tool).symlink_to(found)
+    payload = json.dumps({"findings": [], "disposition": [], "comment_body": "x"})
+    stub = bindir / "sleep"
+    stub.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s' '{payload}' > '{project}'/review-result.json\n"
+    )
+    stub.chmod(0o755)
+    proc = _run(project, state, sleep_seconds="90", path=str(bindir))
+    assert proc.returncode == 0
+    assert _decision(proc) is None
+    # Not the nudge budget either: nothing was nudged.
+    assert _count(state) == 0
+
+
 def test_the_wait_stops_polling_once_the_findings_land(
     dirs: tuple[Path, Path], tmp_path: Path
 ) -> None:

--- a/.github/workflows/claude-review-v2/tests/test_stop_hook.py
+++ b/.github/workflows/claude-review-v2/tests/test_stop_hook.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import pytest
 
+from hook_bounds import hook_number
+
 HOOK = (
     Path(__file__).resolve().parent.parent / "hooks" / "stop-hook.sh"
 )
@@ -295,13 +297,22 @@ def test_the_production_sleep_default_needs_no_configuration() -> None:
     """90 s is the shipped default: the workflow sets no override, so the
     arithmetic in the hook's comment holds for the real job. It is the number
     that makes the harness's 8-block cap survivable — 8 x 90 s is ~12 minutes,
-    past the ~10 the specialists need."""
-    assert 'REVIEW_HOLD_SLEEP_SECONDS:-90}' in HOOK.read_text()
+    past the ~10 the specialists need.
+
+    This is the ONE place the window is restated. Every other check reads it
+    off the hook, so raising it is a one-line edit here and nowhere else."""
+    assert hook_number("window") == 90
 
 
 def test_the_stop_hook_command_outlives_its_own_sleep() -> None:
     """A hook killed at its declared timeout mid-wait would emit no block and
-    the session would end — the exact failure the hold exists to prevent."""
+    the session would end — the exact failure the hold exists to prevent.
+
+    The window is READ from the hook rather than restated, because a restated
+    copy makes this guard vacuous exactly when it is needed: raise the window
+    past the timeout and the tests that pin the window fail loudly and get
+    updated, while a hardcoded `120 > 90` here still compares two literals to
+    each other and stays green — shipping the very regression it guards."""
     settings = json.loads(SETTINGS.read_text())
     entries = [
         cmd
@@ -310,8 +321,7 @@ def test_the_stop_hook_command_outlives_its_own_sleep() -> None:
     ]
     assert entries, "no Stop hook command declared"
     for cmd in entries:
-        assert cmd["timeout"] == 120
-        assert cmd["timeout"] > 90  # strictly longer than the hold window
+        assert cmd["timeout"] > hook_number("window")
 
 
 def test_the_deadline_is_checked_before_the_hook_sleeps(
@@ -326,6 +336,73 @@ def test_the_deadline_is_checked_before_the_hook_sleeps(
     elapsed = time.monotonic() - started
     assert _decision(proc) is None
     assert elapsed < 5
+
+
+def _path_with_time_jumping_sleep(tmp_path: Path, jump: int) -> str:
+    """A PATH whose `sleep` returns at once but advances what `date` reports.
+
+    The post-wait deadline test is about a clock that moved WHILE the hook
+    waited, and the hook reads that clock through `date`. Waiting for real
+    would cost the suite the deadline itself, so the wait is instant and the
+    clock jumps instead: the stub `sleep` drops a marker, and the stub `date`
+    adds the jump once that marker exists.
+    """
+    bindir = tmp_path / "timejump-bin"
+    bindir.mkdir(exist_ok=True)
+    real_date = shutil.which("date")
+    assert real_date, "test prerequisite missing: date"
+    for tool in ("bash", "cat", "tr", "jq"):
+        found = shutil.which(tool)
+        assert found, f"test prerequisite missing: {tool}"
+        link = bindir / tool
+        if not link.exists():
+            link.symlink_to(found)
+    marker = tmp_path / "waited.marker"
+    (bindir / "sleep").write_text(f'#!/bin/sh\n: > "{marker}"\n')
+    (bindir / "sleep").chmod(0o755)
+    (bindir / "date").write_text(
+        "#!/bin/sh\n"
+        f'[ -f "{marker}" ] || exec {real_date} "$@"\n'
+        f'echo $(( $({real_date} +%s) + {jump} ))\n'
+    )
+    (bindir / "date").chmod(0o755)
+    return str(bindir)
+
+
+def test_a_deadline_crossed_during_the_wait_releases_the_session(
+    dirs: tuple[Path, Path], tmp_path: Path
+) -> None:
+    """The deadline is re-tested against a clock read AFTER the wait.
+
+    Tested only before, it admits one last hold that then runs a whole window
+    past it — so the real ceiling would be the deadline plus 90 seconds while
+    the hook's comment, docs/pr-review-gate.md and the spec all state a flat
+    25 minutes. The overshoot is harmless to the job (timeout-minutes absorbs
+    it) and corrosive to the document: a stated bound that is not the bound is
+    how the next person's arithmetic goes wrong.
+    """
+    project, state = dirs
+    (state / START_FILE).write_text(str(int(time.time()) - 1400))
+    path = _path_with_time_jumping_sleep(tmp_path, jump=200)
+    proc = _run(project, state, sleep_seconds="90", path=path)
+    assert proc.returncode == 0
+    assert _decision(proc) is None
+    # Released for the deadline, not for the nudge budget — nothing was nudged.
+    assert _count(state) == 0
+
+
+def test_a_wait_that_stays_inside_the_deadline_still_holds(
+    dirs: tuple[Path, Path], tmp_path: Path
+) -> None:
+    """The post-wait re-test must not release a hold that has time left, which
+    is the whole point of holding — a re-test that fired unconditionally would
+    turn every hold into a release and pass the test above."""
+    project, state = dirs
+    (state / START_FILE).write_text(str(int(time.time()) - 1400))
+    path = _path_with_time_jumping_sleep(tmp_path, jump=50)
+    proc = _run(project, state, sleep_seconds="90", path=path)
+    assert proc.returncode == 0
+    assert _decision(proc)["decision"] == "block"
 
 
 def test_the_hold_cap_is_checked_before_the_hook_sleeps(

--- a/.github/workflows/claude-review-v2/tests/test_validate.py
+++ b/.github/workflows/claude-review-v2/tests/test_validate.py
@@ -954,6 +954,82 @@ def test_main_mixed_causes_are_reported_separately(
     assert _WAS_REJECTED in err and "conventions" in err
 
 
+# --- unmerged-review class --------------------------------------------------
+
+from validate import UNMERGED_REPORT, is_unmerged_review  # noqa: E402
+
+
+def test_a_complete_lens_set_with_no_result_file_is_unmerged() -> None:
+    assert is_unmerged_review(["correctness", "conventions"],
+                              ["correctness", "conventions"], False)
+
+
+def test_a_result_file_on_disk_is_never_unmerged() -> None:
+    """PRESENCE, not validity — a rejected result file is a schema problem and
+    its own error names the defect."""
+    assert not is_unmerged_review(["correctness"], ["correctness"], True)
+
+
+def test_a_missing_lens_is_a_partial_fan_out_not_an_unmerged_review() -> None:
+    """The per-lens diagnostic owns this shape: the review itself is
+    incomplete, so pointing the operator at the Stop hook would be a false
+    lead."""
+    assert not is_unmerged_review(
+        ["correctness", "conventions"], ["correctness"], False
+    )
+
+
+def test_no_expected_set_means_no_unmerged_claim() -> None:
+    assert not is_unmerged_review([], [], False)
+
+
+def test_unmerged_report_names_infrastructure_not_verdict() -> None:
+    assert "INFRASTRUCTURE" in UNMERGED_REPORT
+    assert "not a review verdict" in UNMERGED_REPORT
+
+
+def test_main_on_an_unmerged_review_replaces_the_bare_missing_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The discriminating assertion is on WHICH last error line came out.
+
+    The workflow lifts the last `error:` line into the step annotation, and an
+    operator reading a red check sees that and nothing else. "No such file or
+    directory" is true and useless here: the review ran, both lenses reported,
+    and a session was cut off before merging them.
+    """
+    for name in ("correctness", "conventions"):
+        payload = _valid_findings()
+        payload["specialist"] = name
+        for index, finding in enumerate(payload["findings"], start=1):
+            finding["id"] = f"{name}-{index}"
+        _write(tmp_path / f"findings-{name}.json", payload)
+    exit_code = _run_main(monkeypatch, tmp_path, "correctness,conventions")
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    last_error = [
+        line for line in err.splitlines() if line.startswith("error: ")
+    ][-1]
+    assert "never written" in last_error
+    assert "No such file or directory" not in last_error
+
+
+def test_main_keeps_the_bare_missing_file_when_a_lens_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A partial fan-out is not an unmerged review, and must not be dressed as
+    one — the missing lens is the finding, not the missing merge."""
+    _write(tmp_path / "findings-correctness.json", _valid_findings())
+    assert _run_main(monkeypatch, tmp_path, "correctness,conventions") == 1
+    err = capsys.readouterr().err
+    assert "never written" not in err
+    assert "review-result.json" in err
+
+
 # --- session-stall class ----------------------------------------------------
 
 from validate import STALL_REPORT, is_session_stall  # noqa: E402

--- a/.github/workflows/claude-review-v2/tests/test_validate.py
+++ b/.github/workflows/claude-review-v2/tests/test_validate.py
@@ -960,14 +960,20 @@ from validate import UNMERGED_REPORT, is_unmerged_review  # noqa: E402
 
 
 def test_a_complete_lens_set_with_no_result_file_is_unmerged() -> None:
-    assert is_unmerged_review(["correctness", "conventions"],
-                              ["correctness", "conventions"], False)
+    assert is_unmerged_review(
+        ["correctness", "conventions"],
+        ["correctness", "conventions"],
+        result_present=False,
+        other_failures=False,
+    )
 
 
 def test_a_result_file_on_disk_is_never_unmerged() -> None:
     """PRESENCE, not validity — a rejected result file is a schema problem and
     its own error names the defect."""
-    assert not is_unmerged_review(["correctness"], ["correctness"], True)
+    assert not is_unmerged_review(
+        ["correctness"], ["correctness"], result_present=True, other_failures=False
+    )
 
 
 def test_a_missing_lens_is_a_partial_fan_out_not_an_unmerged_review() -> None:
@@ -975,12 +981,26 @@ def test_a_missing_lens_is_a_partial_fan_out_not_an_unmerged_review() -> None:
     incomplete, so pointing the operator at the Stop hook would be a false
     lead."""
     assert not is_unmerged_review(
-        ["correctness", "conventions"], ["correctness"], False
+        ["correctness", "conventions"],
+        ["correctness"],
+        result_present=False,
+        other_failures=False,
     )
 
 
 def test_no_expected_set_means_no_unmerged_claim() -> None:
-    assert not is_unmerged_review([], [], False)
+    assert not is_unmerged_review(
+        [], [], result_present=False, other_failures=False
+    )
+
+
+def test_another_failure_alongside_it_is_not_an_unmerged_review() -> None:
+    """This branch prints last, so it becomes the step annotation. Claiming it
+    while something else already failed hides the defect that actually needs
+    acting on behind a line that says re-running may clear it."""
+    assert not is_unmerged_review(
+        ["correctness"], ["correctness"], result_present=False, other_failures=True
+    )
 
 
 def test_unmerged_report_names_infrastructure_not_verdict() -> None:
@@ -1014,6 +1034,34 @@ def test_main_on_an_unmerged_review_replaces_the_bare_missing_file(
     ][-1]
     assert "never written" in last_error
     assert "No such file or directory" not in last_error
+
+
+def test_main_keeps_the_schema_error_visible_alongside_a_missing_merge(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A rejected EXTRA lens does not make the missing merge the diagnosis.
+
+    Both expected lenses reported valid findings, so the shape looks like an
+    unmerged review — but a third file failed the schema, and that is what an
+    operator has to act on. The annotation is the last error line, so the
+    discriminating assertion is on which one that is: a re-run clears a cut-off
+    session and does nothing at all for a schema rejection.
+    """
+    for name in ("correctness", "conventions"):
+        payload = _valid_findings()
+        payload["specialist"] = name
+        for index, finding in enumerate(payload["findings"], start=1):
+            finding["id"] = f"{name}-{index}"
+        _write(tmp_path / f"findings-{name}.json", payload)
+    (tmp_path / "findings-security.json").write_text("{not json", encoding="utf-8")
+    assert _run_main(monkeypatch, tmp_path, "correctness,conventions") == 1
+    err = capsys.readouterr().err
+    last_error = [
+        line for line in err.splitlines() if line.startswith("error: ")
+    ][-1]
+    assert "never written" not in last_error
 
 
 def test_main_keeps_the_bare_missing_file_when_a_lens_is_absent(

--- a/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
+++ b/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import yaml
 
+from hook_bounds import HOOK_PATH, hook_number
 from validate import STALL_REPORT
 from workflow_steps import (
     _WORKFLOWS_DIR,
@@ -413,8 +414,6 @@ def test_validate_reads_the_specialist_set_from_that_declaration() -> None:
     assert "'correctness,conventions'" not in body
 
 
-HOOK_PATH = _WORKFLOWS_DIR / "claude-review-v2" / "hooks" / "stop-hook.sh"
-
 _HOOK_FALLBACK_RE = re.compile(
     r'^\s*specialists="\$\{REVIEW_SPECIALISTS:-(?P<fallback>[^}]*)\}"\s*$',
     re.MULTILINE,
@@ -444,34 +443,6 @@ def _hook_specialist_fallback() -> str:
     return fallbacks[0]
 
 
-_HOOK_NUMBER_RES = {
-    "max_holds": re.compile(r"^\s*max_holds=(?P<value>\d+)\s*$", re.MULTILINE),
-    "max_blocks": re.compile(r"^\s*max_blocks=(?P<value>\d+)\s*$", re.MULTILINE),
-    "deadline": re.compile(
-        r"^\s*hold_deadline_seconds=(?P<value>\d+)", re.MULTILINE
-    ),
-    "window": re.compile(
-        r'REVIEW_HOLD_SLEEP_SECONDS:-(?P<value>\d+)\}"\s*$', re.MULTILINE
-    ),
-}
-
-
-def _hook_number(name: str) -> int:
-    """One of the hold's bounds, read out of the hook itself.
-
-    The bounds are compared against each other and against the workflow below,
-    so they have to be read rather than restated — a restated copy is the drift
-    these checks exist to catch.
-    """
-    matches = _HOOK_NUMBER_RES[name].findall(HOOK_PATH.read_text(encoding="utf-8"))
-    assert matches, (
-        f"{HOOK_PATH.name} no longer sets `{name}` where this test looks for "
-        "it; retarget the pattern rather than deleting the check"
-    )
-    assert len(set(matches)) == 1, f"{name} is spelled more than one way: {matches}"
-    return int(matches[0])
-
-
 def test_the_job_raises_the_harness_consecutive_block_cap() -> None:
     """The harness overrides a Stop hook after N consecutive blocks.
 
@@ -484,7 +455,7 @@ def test_the_job_raises_the_harness_consecutive_block_cap() -> None:
     a waiting session is released.
     """
     cap = int(_review_job()["env"]["CLAUDE_CODE_STOP_HOOK_BLOCK_CAP"])
-    assert cap > _hook_number("max_holds") + _hook_number("max_blocks")
+    assert cap > hook_number("max_holds") + hook_number("max_blocks")
 
 
 def test_the_hold_window_survives_the_harness_default_cap_alone() -> None:
@@ -505,7 +476,7 @@ def test_the_hold_window_survives_the_harness_default_cap_alone() -> None:
     HARNESS_DEFAULT_BLOCK_CAP = 8
     SPECIALIST_SECONDS = 600  # ~10 min, measured on the PR #604 good run
     holds = HARNESS_DEFAULT_BLOCK_CAP - 1  # one reserved for the merge itself
-    assert _hook_number("window") * holds > SPECIALIST_SECONDS
+    assert hook_number("window") * holds > SPECIALIST_SECONDS
 
 
 def test_the_deadline_stays_the_binding_bound_locally() -> None:
@@ -513,8 +484,8 @@ def test_the_deadline_stays_the_binding_bound_locally() -> None:
     deadline: spending every hold must take longer than the deadline, so the
     deadline is always what releases a genuinely stalled session."""
     assert (
-        _hook_number("max_holds") * _hook_number("window")
-        > _hook_number("deadline")
+        hook_number("max_holds") * hook_number("window")
+        > hook_number("deadline")
     )
 
 

--- a/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
+++ b/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
@@ -444,6 +444,73 @@ def _hook_specialist_fallback() -> str:
     return fallbacks[0]
 
 
+_HOOK_NUMBER_RES = {
+    "max_holds": re.compile(r"^\s*max_holds=(?P<value>\d+)\s*$", re.MULTILINE),
+    "max_blocks": re.compile(r"^\s*max_blocks=(?P<value>\d+)\s*$", re.MULTILINE),
+    "deadline": re.compile(
+        r"^\s*hold_deadline_seconds=(?P<value>\d+)", re.MULTILINE
+    ),
+    "window": re.compile(
+        r'REVIEW_HOLD_SLEEP_SECONDS:-(?P<value>\d+)\}"\s*$', re.MULTILINE
+    ),
+}
+
+
+def _hook_number(name: str) -> int:
+    """One of the hold's bounds, read out of the hook itself.
+
+    The bounds are compared against each other and against the workflow below,
+    so they have to be read rather than restated — a restated copy is the drift
+    these checks exist to catch.
+    """
+    matches = _HOOK_NUMBER_RES[name].findall(HOOK_PATH.read_text(encoding="utf-8"))
+    assert matches, (
+        f"{HOOK_PATH.name} no longer sets `{name}` where this test looks for "
+        "it; retarget the pattern rather than deleting the check"
+    )
+    assert len(set(matches)) == 1, f"{name} is spelled more than one way: {matches}"
+    return int(matches[0])
+
+
+def test_the_job_raises_the_harness_consecutive_block_cap() -> None:
+    """The harness overrides a Stop hook after N consecutive blocks.
+
+    Its default is 8, and it does not fail the run when it fires: it ends the
+    turn and reports the session as normally completed, so the whole hold is 8
+    blocks long however many turns or minutes remain. Run 33010660928 died
+    that way — both findings files on disk, no review-result.json, gate failed
+    closed 2 seconds after the second specialist landed. The cap must clear the
+    hook's OWN worst case so the hook's bounds, not the harness's, decide when
+    a waiting session is released.
+    """
+    cap = int(_review_job()["env"]["CLAUDE_CODE_STOP_HOOK_BLOCK_CAP"])
+    assert cap > _hook_number("max_holds") + _hook_number("max_blocks")
+
+
+def test_the_hold_window_survives_the_harness_default_cap_alone() -> None:
+    """The raised cap is a harness knob this repository does not control.
+
+    `anthropics/claude-code-action@v1` is a floating tag, so a release could
+    drop or rename the variable with no change of ours. The window is the leg
+    that does not depend on it: at the harness's own default of 8 blocks the
+    hold must still cover the ~10 minutes the specialists need, or the failure
+    comes straight back the day the knob stops working.
+    """
+    HARNESS_DEFAULT_BLOCK_CAP = 8
+    SPECIALIST_SECONDS = 600  # ~10 min, measured on the PR #604 good run
+    assert _hook_number("window") * HARNESS_DEFAULT_BLOCK_CAP > SPECIALIST_SECONDS
+
+
+def test_the_deadline_stays_the_binding_bound_locally() -> None:
+    """The hold count is a backstop against a broken clock, not a second
+    deadline: spending every hold must take longer than the deadline, so the
+    deadline is always what releases a genuinely stalled session."""
+    assert (
+        _hook_number("max_holds") * _hook_number("window")
+        > _hook_number("deadline")
+    )
+
+
 _PROMPT_FINDINGS_RE = re.compile(r"findings-(?P<name>[a-z][a-z0-9_-]*)\.json")
 
 

--- a/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
+++ b/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
@@ -495,10 +495,17 @@ def test_the_hold_window_survives_the_harness_default_cap_alone() -> None:
     that does not depend on it: at the harness's own default of 8 blocks the
     hold must still cover the ~10 minutes the specialists need, or the failure
     comes straight back the day the knob stops working.
+
+    One block is subtracted rather than counted as hold time. The block whose
+    window the findings land in carries the merge instruction, and the
+    orchestrator can still end a turn between reading those files and writing
+    the result — so the last of the eight has to be available for the merge,
+    not spent waiting for it.
     """
     HARNESS_DEFAULT_BLOCK_CAP = 8
     SPECIALIST_SECONDS = 600  # ~10 min, measured on the PR #604 good run
-    assert _hook_number("window") * HARNESS_DEFAULT_BLOCK_CAP > SPECIALIST_SECONDS
+    holds = HARNESS_DEFAULT_BLOCK_CAP - 1  # one reserved for the merge itself
+    assert _hook_number("window") * holds > SPECIALIST_SECONDS
 
 
 def test_the_deadline_stays_the_binding_bound_locally() -> None:

--- a/.github/workflows/claude-review-v2/validate.py
+++ b/.github/workflows/claude-review-v2/validate.py
@@ -184,6 +184,51 @@ STALL_REPORT = (
 )
 
 
+UNMERGED_REPORT = (
+    "every expected specialist reported VALID findings and review-result.json "
+    "was never written. This is an INFRASTRUCTURE failure — the review ran and "
+    "the session ended before merging it — and is not a review verdict: the "
+    "findings reported above were never dispositioned, so no verdict can be "
+    "computed from them. The Stop hook exists to hold the session open until "
+    "that file lands, so the cause is normally something that overrode it: the "
+    "harness releases a hook that blocks too many times CONSECUTIVELY (see "
+    "CLAUDE_CODE_STOP_HOOK_BLOCK_CAP in the workflow), and the hold has a "
+    "25-minute deadline of its own. Re-running the check may clear it. If it "
+    "recurs, see docs/specs/2026-08-10-review-orchestrator-liveness-design.md; "
+    "failing closed"
+)
+
+
+def is_unmerged_review(
+    expected: list[str],
+    seen: list[str],
+    result_present: bool,
+) -> bool:
+    """True when every expected lens reported and only the merge is missing.
+
+    The complement of a stall: there, nothing reached disk and no code was
+    reviewed; here the whole review is on disk and the one artifact the verdict
+    is computed from is not. Both fail closed, and the distinction is entirely
+    in where it sends an operator — a stall is a session that never started, an
+    unmerged review is a finished review whose session was cut off, which is
+    the Stop hook's business and nobody else's.
+
+    Without it the operator's only annotation is the result file's own
+    "no such file or directory", which is true, is the last error line, and
+    says nothing about a review that in fact completed.
+
+    `result_present` is PRESENCE, never validity, for the same reason it is in
+    `is_session_stall`: a present-but-invalid result file is a schema problem,
+    and its error names the actual defect.
+
+    Requires a declared expected set — without one there is no claim to make
+    about which lenses should have reported.
+    """
+    if result_present or not expected:
+        return False
+    return not missing_specialists(expected, seen)
+
+
 def is_session_stall(
     expected: list[str],
     seen: list[str],
@@ -681,7 +726,20 @@ def main() -> int:
                 )
                 failed = True
         if result_error is not None:
-            print(_sanitize_log_text(f"error: {result_error}"), file=sys.stderr)
+            # One decisive line instead of a bare "no such file". A complete,
+            # valid specialist set with no result file is not a missing file
+            # the operator can go look for — it is a review that finished and
+            # a session that ended before merging it. The suppressed
+            # `result_error` is only ever "no such file" here, because this
+            # class requires the result file to be ABSENT, so a schema
+            # rejection can never be swallowed. Printed last so it is the line
+            # the workflow lifts into the step annotation.
+            if is_unmerged_review(expected, seen_specialists, result_present):
+                print(f"error: {UNMERGED_REPORT}", file=sys.stderr)
+            else:
+                print(
+                    _sanitize_log_text(f"error: {result_error}"), file=sys.stderr
+                )
             failed = True
 
     if expected:

--- a/.github/workflows/claude-review-v2/validate.py
+++ b/.github/workflows/claude-review-v2/validate.py
@@ -203,6 +203,7 @@ def is_unmerged_review(
     expected: list[str],
     seen: list[str],
     result_present: bool,
+    other_failures: bool,
 ) -> bool:
     """True when every expected lens reported and only the merge is missing.
 
@@ -221,10 +222,20 @@ def is_unmerged_review(
     `is_session_stall`: a present-but-invalid result file is a schema problem,
     and its error names the actual defect.
 
+    `other_failures` is what keeps the class from swallowing a defect it does
+    not describe. This branch prints LAST, so the workflow lifts it into the
+    step annotation and it becomes the only line an operator sees. A schema
+    rejection anywhere — an unexpected lens's file, or a `findings-.json` that
+    matches the glob but names no lens — would otherwise be annotated as
+    "every expected specialist reported VALID findings, re-running may clear
+    it", sending the operator to the Stop hook and to a re-run for a defect
+    that will not clear on one. The claim is only true when the missing merge
+    is the SOLE thing wrong.
+
     Requires a declared expected set — without one there is no claim to make
     about which lenses should have reported.
     """
-    if result_present or not expected:
+    if result_present or other_failures or not expected:
         return False
     return not missing_specialists(expected, seen)
 
@@ -734,7 +745,9 @@ def main() -> int:
             # class requires the result file to be ABSENT, so a schema
             # rejection can never be swallowed. Printed last so it is the line
             # the workflow lifts into the step annotation.
-            if is_unmerged_review(expected, seen_specialists, result_present):
+            if is_unmerged_review(
+                expected, seen_specialists, result_present, other_failures=failed
+            ):
                 print(f"error: {UNMERGED_REPORT}", file=sys.stderr)
             else:
                 print(

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -101,9 +101,12 @@ split that difference; the thresholds and the reasoning behind them are in
   hook after **8 consecutive blocks**, ending the turn and reporting the session as
   normally completed, so at the default the whole hold is only eight windows long
   however many turns or minutes remain. The hold therefore buys wall clock per
-  block — eight 90-second windows is about twelve minutes, past the ten the
-  specialists need — and it spends each window in five-second polling steps so it
-  ends the moment the last findings file lands rather than a window later. The job
+  block — eight 90-second windows is about twelve minutes, of which the last is
+  reserved for the merge rather than the wait, leaving ~10.5 minutes against the
+  ten a review takes — and it spends each window in five-second polling steps so
+  it ends the moment the last findings file lands rather than a window later. The
+  block that follows a wait reports what the poll last saw, `review-result.json`
+  included, so a hold never nudges for a file that arrived while it waited. The job
   also sets `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: 100`, clearing the hook's own worst
   case (20 holds plus five nudges) so the hook's bounds decide when a waiting
   session is released; the window is the leg that still works if a

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -96,13 +96,22 @@ split that difference; the thresholds and the reasoning behind them are in
   session refusing to. The hold is bounded by a 25-minute wall clock, past which
   the hook stands aside — measured from the session's first stop attempt, not from
   the start of the job.
-- **Each hold sleeps 30 seconds before it blocks.** A block costs a turn, and the
-  session's `--max-turns` budget runs out well before 25 minutes of holding would;
-  sleeping spends wall clock instead, which is what makes the deadline the real
-  bound. Two numbers follow from it and must move together: the hook's command
-  timeout in `hooks/settings.json` is 60 seconds, strictly greater than the sleep,
-  because a hook killed mid-sleep emits no block at all; and the defensive cap of
-  60 holds is 30 minutes of sleeping, so the 25-minute deadline still binds first.
+- **Each hold waits up to 90 seconds, watching for the files, before it blocks.**
+  Blocks are what the hold is short of, not seconds: the harness overrides a Stop
+  hook after **8 consecutive blocks**, ending the turn and reporting the session as
+  normally completed, so at the default the whole hold is only eight windows long
+  however many turns or minutes remain. The hold therefore buys wall clock per
+  block — eight 90-second windows is about twelve minutes, past the ten the
+  specialists need — and it spends each window in five-second polling steps so it
+  ends the moment the last findings file lands rather than a window later. The job
+  also sets `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: 100`, clearing the hook's own worst
+  case (20 holds plus five nudges) so the hook's bounds decide when a waiting
+  session is released; the window is the leg that still works if a
+  `claude-code-action@v1` release ever drops that knob. Two local numbers move with
+  the window: the hook's command timeout in `hooks/settings.json` is 120 seconds,
+  strictly greater than it, because a hook killed mid-wait emits no block at all;
+  and the defensive cap of 20 holds is 30 minutes of waiting, so the 25-minute
+  deadline still binds first.
 - **The hook nudges, boundedly, once only the merge is missing.** When every
   expected findings file is present and parses but `review-result.json` is not
   there, the model has all its inputs and is simply not writing the merge. The hook
@@ -131,6 +140,13 @@ distinguishing error line in the job log is what an operator reads:
   rather than a verdict, and read nothing into it about the diff. Re-running the
   check may clear it, because the underlying failure is a race; a stall that
   recurs is a pipeline defect to fix, not a check to re-run.
+- **An unmerged review** — `every expected specialist reported VALID findings and
+  review-result.json was never written`. The opposite shape to a stall: the whole
+  review is on disk and only the artifact the verdict is computed from is missing,
+  so the session was cut off after reviewing and before merging. That is the Stop
+  hook's business — usually something overriding it, such as the harness's cap on
+  consecutive blocks — and not a statement about the diff. Re-running may clear it;
+  a recurrence is a pipeline defect.
 - **A partial fan-out** — one lens named as having produced no findings file while
   another reported. The session ran and the review is incomplete.
 - **A findings file the schema rejected** — a lens named as having produced a file
@@ -162,7 +178,7 @@ distinguishing error line in the job log is what an operator reads:
   `gh pr diff`, which computes the same merge-base diff server-side; the
   specialists run no `gh` and have no such fallback.)
 
-All five fail closed, and none of them posts a review comment: the post step runs
+All six fail closed, and none of them posts a review comment: the post step runs
 only behind a trustworthy verdict. A stall is therefore something you read in the
 run — `validate.py` writes the diagnosis to the job log — never on the PR. Whatever
 a step annotation or check summary shows alongside it is the workflow's and GitHub's

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -95,7 +95,8 @@ split that difference; the thresholds and the reasoning behind them are in
   none of its nudge budget** doing so: a session that cannot comply yet is not a
   session refusing to. The hold is bounded by a 25-minute wall clock, past which
   the hook stands aside — measured from the session's first stop attempt, not from
-  the start of the job.
+  the start of the job, and tested on both sides of the wait below so the stated
+  bound is the real one rather than the bound plus one window.
 - **Each hold waits up to 90 seconds, watching for the files, before it blocks.**
   Blocks are what the hold is short of, not seconds: the harness overrides a Stop
   hook after **8 consecutive blocks**, ending the turn and reporting the session as

--- a/docs/specs/2026-08-10-review-orchestrator-liveness-design.md
+++ b/docs/specs/2026-08-10-review-orchestrator-liveness-design.md
@@ -145,13 +145,19 @@ is the tighter of the two by a wide margin, and it does not care how many turns 
 remain — at the default, the entire hold is eight blocks long.
 
 Both budgets are counted in blocks, so the hold buys wall clock per block rather than blocks
-per minute. At 90 seconds a window, the harness's eight cover about twelve minutes, past the
-ten the specialists need; the turn budget is nowhere near binding. Waiting converts a block
-into wall clock at zero token cost, which is precisely the currency the hold is short of.
+per minute. At 90 seconds a window the harness's eight cover about twelve minutes, and the
+last of them is spent on the merge rather than on waiting: the block whose window the
+findings land in carries the merge instruction, and the orchestrator can still end a turn
+between reading those files and writing the result, so a spare block has to be there for it.
+That leaves about ten and a half minutes of specialist time against the ten a review takes;
+the turn budget is nowhere near binding. Waiting converts a block into wall clock at zero
+token cost, which is precisely the currency the hold is short of.
 
 The window is spent in five-second polling steps, and the block reports what the poll last
-saw. Waiting out the whole window regardless would hand the orchestrator a stale "still
-running" for files already on disk — and each such block is one of only eight.
+saw — `review-result.json` as well as the findings, since the top-of-script check on it is
+by then a whole window old. Waiting out the window regardless would hand the orchestrator a
+stale "still running", or nudge it to write a file that landed while the hook waited — and
+each such block is one of only eight.
 
 The job raises the harness cap directly, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: 100`, clearing
 the hook's own worst case of 20 holds plus five nudges so that the hook's bounds, not the

--- a/docs/specs/2026-08-10-review-orchestrator-liveness-design.md
+++ b/docs/specs/2026-08-10-review-orchestrator-liveness-design.md
@@ -37,7 +37,7 @@ is lost the moment the orchestrator ends its turn early, and holding that turn o
 the findings files exist is what removes the failure. A design that encoded one mechanism
 would be wrong half the time; this one is indifferent to which is right.
 
-Two independent defects produce this, and either alone is survivable.
+Three independent defects produce this, and any one alone is survivable.
 
 **The prompt teaches turn-end as the waiting mechanism.** The fan-out step asserts that
 Task results return immediately with launch acknowledgments and that each specialist's
@@ -54,6 +54,16 @@ that will not comply still terminates. It cannot distinguish that model from one
 turns rather than elapsed time, and each nudge costs one short round trip, a hook meant
 to prevent a premature end instead imposed a roughly three-minute deadline on a
 fourteen-minute job. The bound released a session that was obeying its instructions.
+
+**The harness overrides a Stop hook that blocks too many times in a row.** Past eight
+consecutive blocks — its default — it ends the turn regardless of what the hook returned,
+and reports the session as `stop_reason: end_turn`, `subtype: success`. The override is
+silent from the workflow's side: the step goes green, and only the empty workspace says
+anything happened. So a hook bounded in minutes is really bounded in blocks, and a hold
+that does not buy wall clock per block cannot reach its own deadline no matter what that
+deadline says. Measured on run 33010660928: eight holds released the session two seconds
+after the second specialist's findings landed, leaving both findings files on disk, no
+`review-result.json`, and a gate that failed closed on a review that had in fact finished.
 
 Two properties make this worse than an ordinary intermittent failure. A stall is
 indistinguishable from a rejected review at the check level — both are a red
@@ -82,8 +92,8 @@ of ours. A fix that encodes the current scheduling behavior would inherit that e
   run for the hook, with a generous outer bound on the job. The threshold errs toward
   paying for a slow review rather than killing a working one, because killing a working
   review reproduces the failure this design exists to remove. A wall-clock deadline is
-  only reachable if holding costs wall clock, so each hold sleeps 30 seconds before it
-  blocks; §3.2 gives the turn-budget arithmetic that fixes that number.
+  only reachable if holding costs wall clock, so each hold waits up to 90 seconds before
+  it blocks; §3.2 gives the block-budget arithmetic that fixes that number.
 
 ## 3. Design
 
@@ -111,11 +121,13 @@ changes, from "a notification arrived" to "both files are on disk".
 wall-clock deadline. On its first invocation it stamps a start time beside its counter
 file.
 
-- **A findings file is missing, and the run is inside 25 minutes** — sleep 30 seconds,
-  then block **without consuming the nudge budget**, with a reason that tells the
-  orchestrator its specialists are still running and its turn must continue. This is the
-  repair: an uncounted hold keeps the process alive, and the in-flight specialists with
-  it.
+- **A findings file is missing, and the run is inside 25 minutes** — wait up to 90
+  seconds, watching for the files and returning as soon as they land, then block
+  **without consuming the nudge budget**, with a reason that tells the orchestrator its
+  specialists are still running and its turn must continue. This is the repair: an
+  uncounted hold keeps the process alive, and the in-flight specialists with it. The
+  block reports the state *after* the wait, not before it, so findings that land inside
+  a window are merged in the next turn rather than a whole window later.
 - **Every findings file is present and `review-result.json` is missing** — block and
   consume the budget, exactly as today, with today's reason. The model has everything it
   needs and is not writing the result. This is the state the five-nudge ceiling was
@@ -123,26 +135,40 @@ file.
 - **Past 25 minutes** — exit 0 and let the session end. `validate.py` then fails closed.
   The deadline is what keeps an uncounted hold from becoming an unbounded one.
 
-**The hold sleeps, because a hold costs a turn.** Every hold is a block, and every block
-costs one turn of the session's `--max-turns 100` budget — so the scarce resource is turns,
-not seconds. PR #604 burned 35 turns in 184 seconds, about five seconds a turn, leaving
-roughly 65. Holding at that rate spends those 65 turns in about five minutes of wall clock,
-against specialists that need ten: the session would die of turn exhaustion long before a
-25-minute deadline could be reached, in exactly the case the deadline exists for, and a
-60-hold cap would never be approached either. Sleeping converts a turn into wall clock at
-zero token cost, which is precisely the currency the hold is short of. At 30 seconds a
-hold, the remaining turns cover a little over thirty minutes, so the 25-minute wall clock
-becomes the binding bound as designed.
+**The hold waits, because blocks are rationed twice over.** Every hold is a block, and a
+block is spent against two separate budgets. The session's `--max-turns 100` charges one
+turn per block; PR #604 burned 35 turns in 184 seconds, about five seconds a turn, leaving
+roughly 65 — enough for five minutes of unwaiting holds against specialists that need ten.
+And the harness caps **consecutive** Stop-hook blocks: past its default of eight it
+overrides the hook, ends the turn, and reports the session as normally completed. That cap
+is the tighter of the two by a wide margin, and it does not care how many turns or minutes
+remain — at the default, the entire hold is eight blocks long.
 
-The same arithmetic keeps the two bounds consistent: 60 holds of 30 seconds is 30 minutes
-of sleep against a 25-minute deadline, so the deadline is always reached first and the hold
-cap remains what it is meant to be — a backstop against a broken clock, not a second
-deadline. The cap also sits below the turns the budget leaves, so neither bound asks for
-turns the session does not have.
+Both budgets are counted in blocks, so the hold buys wall clock per block rather than blocks
+per minute. At 90 seconds a window, the harness's eight cover about twelve minutes, past the
+ten the specialists need; the turn budget is nowhere near binding. Waiting converts a block
+into wall clock at zero token cost, which is precisely the currency the hold is short of.
 
-The sleep makes the hook's command timeout load-bearing, so `hooks/settings.json` declares
-one explicitly at 60 seconds rather than relying on a default that a harness release could
-move. It must stay strictly greater than the sleep: a hook killed mid-sleep emits no block,
+The window is spent in five-second polling steps, and the block reports what the poll last
+saw. Waiting out the whole window regardless would hand the orchestrator a stale "still
+running" for files already on disk — and each such block is one of only eight.
+
+The job raises the harness cap directly, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: 100`, clearing
+the hook's own worst case of 20 holds plus five nudges so that the hook's bounds, not the
+harness's, decide when a waiting session is released. Both legs are deliberate rather than
+redundant. The cap is a knob inside a floating action tag this repository does not control —
+§1's exposure exactly — so the window has to hold the review up on its own if a release ever
+drops it; and the window alone would leave a genuinely slow review at twelve minutes rather
+than the twenty-five §2 chose.
+
+The two local bounds stay consistent by the same arithmetic as before: 20 holds of 90
+seconds is 30 minutes of waiting against a 25-minute deadline, so the deadline is always
+reached first and the hold cap remains what it is meant to be — a backstop against a broken
+clock, not a second deadline.
+
+The wait makes the hook's command timeout load-bearing, so `hooks/settings.json` declares
+one explicitly at 120 seconds rather than relying on a default that a harness release could
+move. It must stay strictly greater than the window: a hook killed mid-wait emits no block,
 and the session ends — the failure the hold exists to prevent.
 
 The hook learns which files to expect from `REVIEW_SPECIALISTS`, a job-level environment
@@ -184,7 +210,14 @@ an infrastructure failure rather than a review — and the existing per-lens wor
 misdiagnoses it, since its "orchestrator may have merged before all specialists completed"
 parenthetical describes a merge that never happened.
 
-All three classes still fail closed and write no verdict. Only the sentence differs, which
+It gains a fourth for the mirror-image signature, which the harness's block cap produces:
+**every** expected specialist reported **valid** findings and `review-result.json` is
+absent. There the review is entirely on disk and only the merge is missing, so the session
+was cut off between reviewing and merging — the Stop hook's business. Without the class the
+operator's only annotation is the result file's own "no such file or directory", which is
+true, is the last error line, and says nothing about a review that in fact completed.
+
+All four classes still fail closed and write no verdict. Only the sentence differs, which
 is the point: `validate.py` writes the diagnosis into the job log, so an operator looking
 into a red check reads a line that names a stalled session as an infrastructure failure
 rather than inferring it from an empty workspace. Whether any of that reaches a surface
@@ -237,13 +270,25 @@ The unit tests live beside the code they cover, in
   no result file blocks and increments the counter; a run past the deadline exits 0. The
   counter assertion is the discriminating one — a test that only checks "it blocked" passes
   against a hook that conflates the two states.
-- **The sleep and the bounds it interacts with.** A pending hold takes at least its
-  configured sleep before emitting the block; a run past the deadline, and one at the hold
-  cap, each return promptly and release, proving both bounds are tested before the sleep
+- **The wait and the bounds it interacts with.** A pending hold takes at least its
+  configured window before emitting the block; a run past the deadline, and one at the hold
+  cap, each return promptly and release, proving both bounds are tested before the wait
   rather than after it. The unit tests drive the duration to zero through an environment
   variable so the suite stays fast, so two further assertions pin what the tests cannot
-  exercise: that the shipped default is 30 seconds with no configuration, and that
+  exercise: that the shipped default is 90 seconds with no configuration, and that
   `settings.json` declares a hook timeout strictly greater than it.
+- **That the wait watches.** Findings dropped onto disk partway through a window must end
+  that window and change the message the block carries, from "your specialists are still
+  running" to the merge instruction, charged to the nudge budget. This is the discriminating
+  case for the polling: a hook that waits blindly still blocks, so "did it block" passes
+  against it.
+- **That the window survives the harness cap on its own.** `test_workflow_structure.py`
+  multiplies the hook's window by the harness's *default* of eight blocks and requires the
+  product to exceed the ten minutes a review takes, so the hold does not silently come to
+  rest on `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` — a knob inside a floating action tag. A
+  companion check requires that variable to clear the hook's own worst case, and a third
+  requires hold cap × window to exceed the deadline, so the deadline stays the binding
+  bound.
 - **The fail-safe contract**, in a form that can fail. Exit code 0 alone is not an
   assertion here — every path of the script exits 0, so a test that checks only that passes
   against a hook that holds forever. Empty stdin and an absent `REVIEW_SPECIALISTS` are
@@ -294,13 +339,24 @@ repeating the trust, checkout, and restore sequence per job.
   waiting between turns, not something the orchestrator can invoke — so the poll degrades
   to a tight loop of `Read` calls that burns the turn budget, and each iteration remains a
   turn that can end. It re-creates the failure with more steps.
-- **Raising `--max-turns` instead of sleeping** — buy the hold its wall clock by giving the
+- **Raising `--max-turns` instead of waiting** — buy the hold its wall clock by giving the
   session more turns rather than by spending fewer. Every hold is a real model round trip,
   so the cost scales with the budget, and the number that would have to be guessed is the
   product of two unknowns: how long a review takes and how fast the harness turns holds
-  over. The sleep fixes the seconds-per-hold directly, which is why 60 holds and 25 minutes
-  can be stated as a single arithmetic rather than as a hope about pacing. The budget stays
-  where the fan-out spec set it, sized for review work rather than for waiting.
+  over. Worse, it buys nothing against the bound that actually binds: the harness's
+  consecutive-block cap is counted in blocks, and more turns produce more blocks, not
+  fewer. The wait fixes the seconds-per-block directly, which is why 20 holds and 25
+  minutes can be stated as a single arithmetic rather than as a hope about pacing. The
+  budget stays where the fan-out spec set it, sized for review work rather than for
+  waiting.
+- **Raising the harness block cap alone** — set `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` and leave
+  the 30-second window as it was. It removes the observed failure in one line, and the
+  workflow does set it. It is rejected as the *whole* fix because it makes the gate's
+  liveness depend on an undeclared knob inside `anthropics/claude-code-action@v1`, a
+  floating tag — the exposure §1 names — and the failure it prevents is silent, so a
+  release that dropped or renamed the variable would look exactly like the intermittent
+  red this design already exists to remove. The window is sized so the review survives that
+  release; the cap is what lets a slow review use the full 25 minutes.
 - **Automatic retry of the review step** — recovers the observed case without a human, at
   double the worst-case cost and latency. Rejected mainly because it makes a systematic
   regression present as an intermittent one, which is how a required check quietly stops

--- a/docs/specs/2026-08-10-review-orchestrator-liveness-design.md
+++ b/docs/specs/2026-08-10-review-orchestrator-liveness-design.md
@@ -133,7 +133,11 @@ file.
   needs and is not writing the result. This is the state the five-nudge ceiling was
   designed for, and it keeps that ceiling.
 - **Past 25 minutes** — exit 0 and let the session end. `validate.py` then fails closed.
-  The deadline is what keeps an uncounted hold from becoming an unbounded one.
+  The deadline is what keeps an uncounted hold from becoming an unbounded one. It is
+  tested on both sides of the wait: before, because waiting and then releasing buys
+  nothing; and again after, because a deadline tested only against a clock read a window
+  ago admits one last hold that runs a whole window past it, and a stated bound that is
+  not the bound is how the next reader's arithmetic goes wrong.
 
 **The hold waits, because blocks are rationed twice over.** Every hold is a block, and a
 block is spent against two separate budgets. The session's `--max-turns 100` charges one
@@ -278,11 +282,15 @@ The unit tests live beside the code they cover, in
   against a hook that conflates the two states.
 - **The wait and the bounds it interacts with.** A pending hold takes at least its
   configured window before emitting the block; a run past the deadline, and one at the hold
-  cap, each return promptly and release, proving both bounds are tested before the wait
-  rather than after it. The unit tests drive the duration to zero through an environment
-  variable so the suite stays fast, so two further assertions pin what the tests cannot
-  exercise: that the shipped default is 90 seconds with no configuration, and that
-  `settings.json` declares a hook timeout strictly greater than it.
+  cap, each return promptly and release, proving both bounds are tested before the wait.
+  A stub whose `sleep` advances what `date` reports covers the other side: a deadline
+  crossed *during* a wait releases, while one still inside it after the wait holds. The
+  unit tests drive the duration to zero through an environment variable so the suite stays
+  fast, so two further assertions pin what the tests cannot exercise: that the shipped
+  default is 90 seconds with no configuration, and that `settings.json` declares a hook
+  timeout strictly greater than it. The second reads the window out of the hook rather
+  than restating it — a restated copy compares two literals to each other and stays green
+  exactly when the window outgrows the timeout, which is the one case it exists to catch.
 - **That the wait watches.** Findings dropped onto disk partway through a window must end
   that window and change the message the block carries, from "your specialists are still
   running" to the merge instruction, charged to the nudge budget. This is the discriminating


### PR DESCRIPTION
## What's broken

The `claude-review` merge gate — a required check on `main` — fails a PR with no
verdict even though the review itself completed. The step output looks like this:

```
ok: findings-conventions.json (1 finding(s))
ok: findings-correctness.json (4 finding(s))
validation FAILED — no verdict written (gate fails closed)
error: review-result.json: not readable as JSON: [Errno 2] No such file or directory
```

Both specialists ran, both wrote valid findings, and the orchestrator never
merged them. The review session's own step is reported **green** — the failure
surfaces one step later, in validation. The author sees a red required check on a
PR whose review actually succeeded, and the only remedy is a re-run that may hit
the same wall. It hits any review whose specialists take longer than a few
minutes, which is most non-trivial PRs.

## Why it happens

The review session runs headless, so when its turn ends, the session ends and any
in-flight subagents die with it. A Stop hook holds the session open: while an
expected `findings-<name>.json` is still missing it refuses the stop, and each
refusal is a "block".

**Blocks are rationed by the harness, and the hook was not built around that.**
The CLI caps *consecutive* Stop-hook blocks — `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`,
default 8. Past the cap it overrides the hook, ends the turn, and reports the
session as **normally completed**. Not an error, not a failure: a success. That is
why the session step went green with no result file.

The hook's own bounds were counted in currencies the harness does not ration — a
25-minute wall clock and a 60-hold cap — while each hold bought only 30 seconds.
Eight blocks × 30 seconds is **four minutes** of real ceiling against the ~10
minutes a two-specialist review takes. The 25-minute deadline was unreachable by
construction.

Run 33010660928 shows it exactly. Nine blocks, ~31.5 s apart: 20:31:48 … 20:36:01.
`findings-correctness.json` landed at **20:35:59.435**. The ninth block was
emitted at **20:36:01.704**, the harness overrode it, and the session ended
**6 ms later**. The review missed by two seconds.

## When it broke

Not a regression — the hook has been shaped this way since the fan-out pipeline
landed. It went unnoticed because the failure mode is invisible from inside the
session: the harness's override is indistinguishable from a normal completion
(`stop_reason: end_turn`, `subtype: success`, empty result), so nothing in the job
reports that a hold was cut short.

## What this PR does

Rebuilds the hold around the budget that actually binds — blocks, not seconds.

- **Each hold buys wall clock per block instead of blocks per minute.** The window
  goes 30 s → 90 s, so the harness's own default of 8 covers ~12 minutes.
- **The window is spent in 5-second polling steps**, ending the moment the last
  findings file lands. A hold that waited blindly would report what it saw *before*
  the wait — telling the orchestrator its specialists are still running when they
  had just finished, and spending one of eight rationed blocks on stale news.
  `review-result.json` is re-checked after the wait for the same reason.
- **The last of the eight is reserved for the merge, not spent waiting.** The block
  whose window the findings land in carries the merge instruction, and the
  orchestrator can still end a turn between reading those files and writing the
  result. That leaves ~10.5 minutes of specialist time against the ~10 a review
  takes.
- **The job raises the cap** (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: 100`) so the hook's
  own bounds decide when a waiting session is released. Both legs are deliberate:
  the cap is a knob inside a floating `claude-code-action@v1` tag that this
  repository does not control, and the 90-second window holds the review up on its
  own if a release ever drops it.
- **The hook's command timeout goes 60 s → 120 s**, strictly greater than the
  window. A hook killed mid-wait emits no block at all.
- **The deadline is tested on both sides of the wait.** Tested only before, it
  admitted one last hold that then ran a full window past it — 1590 s against the
  flat 1500 s the hook and both documents state.
- **`validate.py` gains a diagnostic class for this exact shape:** every expected
  specialist reported valid findings and no result file was written. It reads as an
  *infrastructure* failure and names the cap, rather than the bare "no such file"
  that sent this investigation looking in the wrong place.

Rejected: raising the harness cap alone. It is one variable inside a floating tag,
it fixes nothing if a release renames or drops it, and it leaves the hook's stated
bounds still unreachable.

Spec updated: [`docs/specs/2026-08-10-review-orchestrator-liveness-design.md`](docs/specs/2026-08-10-review-orchestrator-liveness-design.md)
(§1 now names three defects, §3.2's arithmetic is rewritten around blocks), plus
the operator-facing [`docs/pr-review-gate.md`](docs/pr-review-gate.md).

## Assumptions

- **The harness's default consecutive-block cap is 8.** Read out of the shipping
  CLI (`2.1.246`). If a release raises it, the hold only gets roomier; if one
  *lowers* it, the 90-second window's margin shrinks and the reserved merge block
  is the first thing that stops fitting.
- **A two-specialist review takes ~10 minutes.** Measured on the PR #604 good run.
  A third lens, or a much larger diff, moves that number and the window should move
  with it — `test_the_hold_window_survives_the_harness_default_cap_alone` encodes
  the relation and will redden.
- **`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` is honored as a job-level `env:`.** Proven in
  the same job by `REVIEW_SPECIALISTS`, which already reaches the hook that way.

## Evidence & verification

**The repro.** Run 33010660928's own log lines, above: nine blocks 31.5 s apart,
the last one overridden 6 ms after it was emitted, two seconds after the findings
landed. The mechanism was then confirmed against the shipping CLI binary, whose
override path caps consecutive blocks at `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP ?? 8`
and returns `{reason: "completed"}`.

**Replay of the failing timeline.** A simulation driving the real hook with
specialists landing at T+360 s reaches the merge nudge at **block 5** with the new
90-second window, against **still holding at block 12** with the old 30-second one
— i.e. past the harness's 8 and dead.

**The 120-second hook timeout is honored,** verified live: a `claude -p` session
with a Stop hook that sleeps 75 seconds is held, not killed.

**405 tests pass**, and every new test was mutation-checked against the behavior it
guards:

- delete the post-wait deadline re-check → the deadline-crossed test fails
- make that re-check unconditional → the still-inside-the-deadline test fails
- raise the window past the command timeout → the timeout guard fails
- let the hook's two window literals disagree → `hook_number` asserts

That third one is itself a fix from review: the guard used to assert `120 == 120`
and `120 > 90`, so raising the window would have reddened the tests that *pin* the
window while the guard kept comparing its own stale copy to itself and stayed
green — shipping the exact regression it exists to catch. The bounds now come from
a shared `tests/hook_bounds.py` that reads them out of the hook.

[20260826-enormous-rat](https://cheapsteak.github.io/tbd/open/?worktree=E250B37D-50A8-4B2A-B37A-B43A478E4E9B)
