### PR TITLE
fix: CodeRabbit skipped every PR because it thought the default branch was master

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -61,8 +61,13 @@ knowledge_base:
   # Defaults to true, and its default `filePatterns` already include
   # `**/CLAUDE.md`. Stated explicitly because it is now the whole mechanism by
   # which CodeRabbit learns this repository's conventions — worth being loud
-  # about rather than leaving to an unstated default. Do not set `filePatterns`
-  # here without re-listing the defaults; the key replaces them rather than
-  # adding to them.
+  # about rather than leaving to an unstated default.
+  #
+  # `filePatterns` is additive: custom entries are applied on top of the
+  # defaults rather than replacing them, so adding one does not cost us
+  # `**/CLAUDE.md`. Only add an entry for a guideline file the defaults do not
+  # already match, or use the object form (`files` + `applyTo`) when a
+  # guideline needs to govern files outside its own directory subtree. To turn
+  # the feature off, set `enabled: false` — never clear the pattern list.
   code_guidelines:
     enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -114,7 +114,9 @@ reviews:
         host, account, person, or ticket names, no internal URLs, and no
         machine-specific paths. Use `acme` placeholders.
 
-  tools:
-    swiftlint:
-      enabled: true
-      config_file: .swiftlint.yml
+  # No `tools.swiftlint` block on purpose. CodeRabbit skips SwiftLint when a
+  # GitHub workflow already runs it, and `.github/workflows/test.yml` runs
+  # `swiftlint --strict` in the `lint` job — so configuring it here would look
+  # like enforcement while adding no findings. CI owns SwiftLint. (The
+  # `config_file` key would be redundant regardless: CodeRabbit auto-detects
+  # `.swiftlint.yml`, and that key exists for configs named something else.)

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,92 +27,28 @@ reviews:
     - "!rust/comrak-ffi/target/**"
     - "!Package.resolved"
 
-  # Conventions a general-purpose reviewer cannot infer from the code alone.
-  # These mirror the rules in CLAUDE.md; keep the two in step.
-  path_instructions:
-    - path: "Sources/**/*.swift"
-      instructions: |
-        `print()` is banned outside `Sources/TBDCLI` — diagnostics use
-        `os.Logger` with a `com.tbd.*` subsystem and an explicit `privacy:`
-        argument on dynamic interpolations.
-
-        Anything that sleeps, debounces, polls, or times out takes an injected
-        clock as its last initializer parameter, defaulted:
-        `clock: any Clock<Duration> = ContinuousClock()` — existential, not
-        generic. Timestamps that get persisted or compared use a separate date
-        seam instead: `Duration` is behavior, `Date` is data.
-
-        Never infer agent state by parsing rendered terminal output — tmux
-        `capture-pane` text, composer glyphs, placeholder or status strings.
-        Use machine interfaces: hooks, transcript JSONL, tmux control mode,
-        exit codes, or TBD's own DB/RPC state.
-
-        All `ChannelHandlerContext` access must happen on the channel's event
-        loop; wrap in `context.eventLoop.execute { ... }`.
-
-        TBDApp is an unbundled SPM executable, so APIs that require a bundle
-        identifier crash at runtime — guard them with
-        `Bundle.main.bundleIdentifier != nil`.
-
-    - path: "Sources/TBDDaemon/Database/Migrations/**"
-      instructions: |
-        Migrations are `.sql` files named `YYYYMMDDHHMMSS_lower_snake.sql`,
-        whose stem is the GRDB migration identifier — one file per migration, so
-        parallel branches can neither pick the same identifier nor edit the same
-        text. A landed migration is frozen: never modify or delete one, add a
-        new file instead.
-
-        A file may hold several statements; a column add followed by a backfill
-        `UPDATE` is an established pattern. What is constrained is the form of
-        each statement, against the allowlist `scripts/lint-migrations.py`
-        enforces: `CREATE TABLE`, `CREATE [UNIQUE] INDEX`,
-        `ALTER TABLE ... ADD [COLUMN]`, `DROP TABLE`, `DROP INDEX`,
-        `INSERT OR IGNORE`, `INSERT OR REPLACE`, `UPDATE`, `DELETE FROM`.
-        Anything else is rewritten into one of those forms or takes the Swift
-        escape hatch. Do not flag a multi-statement migration on its own.
-
-        Feature-flag columns must omit the SQL `DEFAULT` clause, so NULL stays
-        a distinct "nobody chose" state and the shipped default lives in exactly
-        one place — the `?? Config.<flag>Default` in `ConfigRecord.toModel()`.
-        `ADD COLUMN ... DEFAULT` backfills every existing row, which makes a
-        later default flip a no-op for existing installs.
-
-        A new column needs three changes in the same commit: the migration, the
-        GRDB record type, and the Codable model in `Sources/TBDShared/Models.swift`
-        (new fields optional or defaulted, so existing rows still decode).
-
-    - path: "Tests/**"
-      instructions: |
-        Tests must never touch the developer's real `~/tbd`, `~/.claude`, or
-        `~/.codex`. Prefer injection seams — an explicit environment dict, or an
-        injected directory — over `setenv`. `setenv("TBD_HOME", ...)` is allowed
-        only inside suites nested under `TBDHomeSerialized` in
-        `Tests/TBDDaemonTests`, because all test targets compile into one process
-        and suites run in parallel.
-
-        Teardown must restore `TBD_HOME`, `TBD_CLAUDE_HOST_HOME`, and
-        `TBD_TEST_CODEX_HOME` to their prior values — never `unsetenv` them,
-        which falls back to the developer's real directories process-wide.
-
-        A new branching conditional that gates behavior — a feature flag,
-        toggle, or mode switch — needs a test per branch: that the gated
-        behavior is off when the flag is off, and that ungated behavior still
-        works.
-
-    - path: "docs/**/*.md"
-      instructions: |
-        Documents must stand alone for a first-time reader. No revision history
-        in prose — no "amended <date>" notes, no retracing of earlier drafts.
-        Rewrite superseded passages to state the current design as if it were
-        always so. Keep evidence, drop chronology.
-
-        No prose tables. Use lists with a bolded lead term, an en dash, then
-        prose. Tables are acceptable only when cells are short numeric or
-        scannable values.
-
-        This repository is public and multi-tenant: no real employer, org, repo,
-        host, account, person, or ticket names, no internal URLs, and no
-        machine-specific paths. Use `acme` placeholders.
+  # No `path_instructions` block on purpose, and this is the interesting part
+  # of this file.
+  #
+  # CodeRabbit's Code Guidelines feature already ingests `**/CLAUDE.md` as
+  # review criteria — on by default, no configuration needed — and scopes each
+  # file to its own directory subtree, which is exactly how this repository
+  # already organizes them: the root `CLAUDE.md` applies everywhere,
+  # `Sources/TBDDaemon/Database/CLAUDE.md` governs migrations, `Tests/CLAUDE.md`
+  # governs tests, and so on down eleven files.
+  #
+  # An earlier revision of this file hand-copied a paraphrase of those rules
+  # into `path_instructions`. That was strictly worse in three ways: it summarized
+  # ~1,300 lines of guidance into a few hundred, it would drift the moment a
+  # CLAUDE.md changed, and — the reason this comment is here rather than a
+  # shorter one — two of its lines stated rules the repository does not have.
+  # A wrong line here is not a local defect; it is a reviewer confidently
+  # enforcing a rule nobody wrote, on every future PR.
+  #
+  # So the guidance lives in exactly one place. Edit CLAUDE.md; CodeRabbit and
+  # Claude Code read the same file, and neither can fall out of step with it.
+  # Add a `path_instructions` entry only for something genuinely review-specific
+  # that does not belong in CLAUDE.md at all.
 
   # No `tools.swiftlint` block on purpose. CodeRabbit skips SwiftLint when a
   # GitHub workflow already runs it, and `.github/workflows/test.yml` runs
@@ -120,3 +56,13 @@ reviews:
   # like enforcement while adding no findings. CI owns SwiftLint. (The
   # `config_file` key would be redundant regardless: CodeRabbit auto-detects
   # `.swiftlint.yml`, and that key exists for configs named something else.)
+
+knowledge_base:
+  # Defaults to true, and its default `filePatterns` already include
+  # `**/CLAUDE.md`. Stated explicitly because it is now the whole mechanism by
+  # which CodeRabbit learns this repository's conventions — worth being loud
+  # about rather than leaving to an unstated default. Do not set `filePatterns`
+  # here without re-listing the defaults; the key replaces them rather than
+  # adding to them.
+  code_guidelines:
+    enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,107 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit review configuration.
+#
+# `reviews.auto_review.base_branches` is the load-bearing key here: CodeRabbit
+# skips auto review on any base branch it does not consider the repository
+# default, and it decided this repository's default was `master`. There has
+# never been a `master` branch — GitHub reports `default_branch: main` — so
+# naming `main` explicitly makes the review run regardless of what CodeRabbit
+# believes the default to be.
+language: en-US
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - ^main$
+
+  # Build products, vendored artifacts, and lockfiles carry no review signal.
+  path_filters:
+    - "!.build/**"
+    - "!rust/comrak-ffi/target/**"
+    - "!Package.resolved"
+
+  # Conventions a general-purpose reviewer cannot infer from the code alone.
+  # These mirror the rules in CLAUDE.md; keep the two in step.
+  path_instructions:
+    - path: "Sources/**/*.swift"
+      instructions: |
+        `print()` is banned outside `Sources/TBDCLI` — diagnostics use
+        `os.Logger` with a `com.tbd.*` subsystem and an explicit `privacy:`
+        argument on dynamic interpolations.
+
+        Anything that sleeps, debounces, polls, or times out takes an injected
+        clock as its last initializer parameter, defaulted:
+        `clock: any Clock<Duration> = ContinuousClock()` — existential, not
+        generic. Timestamps that get persisted or compared use a separate date
+        seam instead: `Duration` is behavior, `Date` is data.
+
+        Never infer agent state by parsing rendered terminal output — tmux
+        `capture-pane` text, composer glyphs, placeholder or status strings.
+        Use machine interfaces: hooks, transcript JSONL, tmux control mode,
+        exit codes, or TBD's own DB/RPC state.
+
+        All `ChannelHandlerContext` access must happen on the channel's event
+        loop; wrap in `context.eventLoop.execute { ... }`.
+
+        TBDApp is an unbundled SPM executable, so APIs that require a bundle
+        identifier crash at runtime — guard them with
+        `Bundle.main.bundleIdentifier != nil`.
+
+    - path: "Sources/TBDDaemon/Database/Migrations/**"
+      instructions: |
+        Migrations are `.sql` files named `YYYYMMDDHHMMSS_lower_snake.sql`, one
+        statement kind per file. A landed migration is frozen: never modify or
+        delete one, add a new file instead.
+
+        Feature-flag columns must omit the SQL `DEFAULT` clause, so NULL stays
+        a distinct "nobody chose" state and the shipped default lives in exactly
+        one place — the `?? Config.<flag>Default` in `ConfigRecord.toModel()`.
+        `ADD COLUMN ... DEFAULT` backfills every existing row, which makes a
+        later default flip a no-op for existing installs.
+
+        A new column needs three changes in the same commit: the migration, the
+        GRDB record type, and the Codable model in `Sources/TBDShared/Models.swift`
+        (new fields optional or defaulted, so existing rows still decode).
+
+    - path: "Tests/**"
+      instructions: |
+        Tests must never touch the developer's real `~/tbd`, `~/.claude`, or
+        `~/.codex`. Prefer injection seams — an explicit environment dict, or an
+        injected directory — over `setenv`. `setenv("TBD_HOME", ...)` is allowed
+        only inside suites nested under `TBDHomeSerialized` in
+        `Tests/TBDDaemonTests`, because all test targets compile into one process
+        and suites run in parallel.
+
+        Teardown must restore `TBD_HOME`, `TBD_CLAUDE_HOST_HOME`, and
+        `TBD_TEST_CODEX_HOME` to their prior values — never `unsetenv` them,
+        which falls back to the developer's real directories process-wide.
+
+        A test that asserts a fix must fail against the unfixed code. Flag tests
+        that would pass either way.
+
+    - path: "docs/**/*.md"
+      instructions: |
+        Documents must stand alone for a first-time reader. No revision history
+        in prose — no "amended <date>" notes, no retracing of earlier drafts.
+        Rewrite superseded passages to state the current design as if it were
+        always so. Keep evidence, drop chronology.
+
+        No prose tables. Use lists with a bolded lead term, an en dash, then
+        prose. Tables are acceptable only when cells are short numeric or
+        scannable values.
+
+        This repository is public and multi-tenant: no real employer, org, repo,
+        host, account, person, or ticket names, no internal URLs, and no
+        machine-specific paths. Use `acme` placeholders.
+
+  tools:
+    swiftlint:
+      enabled: true
+      config_file: .swiftlint.yml

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,7 +11,7 @@
 language: en-US
 
 reviews:
-  profile: chill
+  profile: assertive
   high_level_summary: true
   poem: false
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -56,9 +56,20 @@ reviews:
 
     - path: "Sources/TBDDaemon/Database/Migrations/**"
       instructions: |
-        Migrations are `.sql` files named `YYYYMMDDHHMMSS_lower_snake.sql`, one
-        statement kind per file. A landed migration is frozen: never modify or
-        delete one, add a new file instead.
+        Migrations are `.sql` files named `YYYYMMDDHHMMSS_lower_snake.sql`,
+        whose stem is the GRDB migration identifier — one file per migration, so
+        parallel branches can neither pick the same identifier nor edit the same
+        text. A landed migration is frozen: never modify or delete one, add a
+        new file instead.
+
+        A file may hold several statements; a column add followed by a backfill
+        `UPDATE` is an established pattern. What is constrained is the form of
+        each statement, against the allowlist `scripts/lint-migrations.py`
+        enforces: `CREATE TABLE`, `CREATE [UNIQUE] INDEX`,
+        `ALTER TABLE ... ADD [COLUMN]`, `DROP TABLE`, `DROP INDEX`,
+        `INSERT OR IGNORE`, `INSERT OR REPLACE`, `UPDATE`, `DELETE FROM`.
+        Anything else is rewritten into one of those forms or takes the Swift
+        escape hatch. Do not flag a multi-statement migration on its own.
 
         Feature-flag columns must omit the SQL `DEFAULT` clause, so NULL stays
         a distinct "nobody chose" state and the shipped default lives in exactly

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -94,8 +94,10 @@ reviews:
         `TBD_TEST_CODEX_HOME` to their prior values — never `unsetenv` them,
         which falls back to the developer's real directories process-wide.
 
-        A test that asserts a fix must fail against the unfixed code. Flag tests
-        that would pass either way.
+        A new branching conditional that gates behavior — a feature flag,
+        toggle, or mode switch — needs a test per branch: that the gated
+        behavior is off when the flag is off, and that ungated behavior still
+        works.
 
     - path: "docs/**/*.md"
       instructions: |


### PR DESCRIPTION
## What's broken

CodeRabbit is installed on this repository but has never actually reviewed a pull request. On every PR it posts a "Review skipped" comment instead:

> Auto reviews are disabled on base/target branches other than the default branch.

Seen most recently on #742. The stated reason is false: #742's base is `main`, GitHub reports `default_branch: main`, and there has never been a `master` branch on the remote at any point in this repository's history. CodeRabbit is comparing the PR's base against its own cached idea of the default branch, and that cache says something other than `main`.

The effect is that the whole integration is inert — every PR gets a skip comment and no review.

## Why it happens

CodeRabbit gates auto review on the base branch. Its config schema documents `reviews.auto_review.base_branches` as *"Base branches (other than the default branch) to review"* — the default branch is reviewed implicitly, and everything else has to be listed. Whatever CodeRabbit has recorded as this repository's default is not `main`, so `main` falls into the "everything else" bucket, and the implicit allowance never applies.

The skip comment also reports **"Configuration used: defaults"**, confirming there was no `.coderabbit.yaml` in the repository to override that behavior.

## What this PR does

Adds `.coderabbit.yaml`, whose load-bearing key is:

```yaml
reviews:
  auto_review:
    base_branches:
      - ^main$
```

Listing `main` explicitly sidesteps the question entirely: the branch is allowed as a review base whether or not CodeRabbit believes it is the default. This is preferred over chasing the cache — a re-sync in the CodeRabbit UI might clear the stale value, but it is invisible state that can drift again and leaves nothing in the repository explaining why review works. A committed file is the durable form.

The rest of the file is ordinary setup, chosen to be useful rather than exhaustive:

- **Auto review on, drafts off, `assertive` profile** — CodeRabbit reviews every non-draft PR into `main`, alongside the existing `claude-review` gate. Assertive trades a higher nitpick rate for recall, which is the side to err on while we are still deciding whether it earns its noise.
- **`path_filters`** exclude `.build/`, `rust/comrak-ffi/target/`, and `Package.resolved` — build products carry no review signal.
- **No `path_instructions`, deliberately.** CodeRabbit's Code Guidelines feature already ingests `**/CLAUDE.md` as review criteria, on by default, scoping each file to its own directory subtree — exactly how this repo's eleven `CLAUDE.md` files are already organized. Writing path instructions would duplicate a mechanism that is already running, against a worse copy. The guidance keeps one home: edit `CLAUDE.md`, and both readers see the same text. `knowledge_base.code_guidelines.enabled` is stated explicitly since it is now load-bearing.
- **No `tools.swiftlint` block**, also deliberately. CodeRabbit's docs state it skips SwiftLint when a GitHub workflow already runs it, and `test.yml`'s `lint` job runs `swiftlint --strict` — so configuring it here would read as enforcement while contributing nothing. Comments in the file record both omissions, so neither gets re-added.

No spec: this is review-tooling configuration, not a change to the system's own theory, so the brainstorming gate in `CLAUDE.md` does not apply.

## Assumptions

- CodeRabbit resolves `.coderabbit.yaml` from the **head** of the PR branch, so a config change takes effect on the PR that introduces it rather than only after it lands. Confirmed on this PR — see below.
- Assumes `base_branches` entries are matched as regular expressions, per the schema's *"Accepts regex patterns"*. `^main$` is anchored so it cannot accidentally match a future `maintenance-*` branch.
- Assumes CodeRabbit's Code Guidelines feature reads the `CLAUDE.md` files in full and honors their directory scoping, per its documentation. If it truncates them, deep rules — the migration allowlist sits at `CLAUDE.md:121`, and `Sources/TBDDaemon/Database/CLAUDE.md` runs to 255 lines — may not reach the reviewer, and the symptom would be silence rather than an error.

## Evidence & verification

- **The false premise is confirmed, not assumed.** `git ls-remote --heads origin` lists 37 branches and no `master`; `gh api repos/cheapsteak/tbd` returns `default_branch: main`; #742's `baseRefName` is `main`. The three facts together rule out any reading in which CodeRabbit's message is accurate.
- **The config is schema-valid.** Validated with `jsonschema` against CodeRabbit's published `schema.v2.json` — passes, with no unknown keys. This matters because an invalid `.coderabbit.yaml` is itself a silent-skip mode.
- **The two omissions are documented behavior, not guesses.** `**/CLAUDE.md` is a default `code_guidelines.filePatterns` entry and `enabled` defaults to true, per the published schema; `docs.coderabbit.ai/tools/swiftlint` states SwiftLint is skipped when a GitHub workflow already runs it, and `test.yml:103` runs it.
- **The removed path instructions were wrong, which is why they are removed rather than corrected.** Two asserted rules the repo does not have: an invented "one statement kind per file" migration rule, contradicted by `scripts/lint-migrations.py`'s allowlist and two landed multi-statement migrations, and a test rule absent from both `CLAUDE.md` and `Tests/CLAUDE.md`. Deleting the paraphrase removes the class of defect, not just the two instances.
- **This PR is the discriminating test, and it passed.** CodeRabbit reviewed it instead of skipping, and its run configuration reports `Configuration used: Path: .coderabbit.yaml` — the file was read from the head branch and the base-branch gate no longer fires. Compare #742, reviewed minutes earlier under `Configuration used: defaults`, which produced the skip. The fix is therefore already live on this branch and does not wait on merge.

[🐰 CodeRabbit Setup](https://cheapsteak.github.io/tbd/open/?worktree=9A4E3487-E61A-458F-A124-0549F0C3009A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration for eligible pull requests targeting the main branch.
  * Enabled assertive English-language reviews with concise summary reporting.
  * Applied repository-provided coding guidelines to improve review consistency.
  * Excluded generated build artifacts, vendored outputs, and lockfiles from automated reviews.
  * Documented applicable review configuration and project guidance settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->