### PR TITLE
Feat: The Claude Cloud provider gets a create entry of its own, by name

### DIFF
--- a/Sources/TBDApp/Sidebar/CloudCreateEntryPresentation.swift
+++ b/Sources/TBDApp/Sidebar/CloudCreateEntryPresentation.swift
@@ -1,56 +1,73 @@
 import Foundation
 import TBDShared
 
-/// Which providers a repository's create surfaces offer.
+/// Which create entries a repository's surfaces offer, and on what terms.
 ///
-/// The daemon registers the compiled cloud provider only when it BOOTED with
-/// `claude_cloud_enabled` on, so a provider that is absent is already absent
-/// from `remoteProviders` and needs no filtering. What this gate covers is the
-/// other direction: a daemon that booted with the flag on and a user who has
-/// since turned it off, where the provider is still registered but every one
-/// of its verbs is refused by the daemon's inner gate. Offering an entry that
-/// can only fail is exactly what the repository's omit-don't-disable
-/// convention exists to prevent.
+/// TBD can start an agent session somewhere other than this machine, and the
+/// two kinds of "somewhere" are not the same kind of thing. The **compiled
+/// cloud provider** ships with TBD; a user who turned `claude_cloud_enabled`
+/// on did so by name, and comes to the `+` menu looking for the thing they
+/// enabled. A **registry provider** is one the user wrote into
+/// `~/tbd/agent-providers.json` themselves, and TBD enumerating those is the
+/// whole service the generic entry provides. So the cloud provider gets an
+/// entry of its own on every surface that has a generic one, and is filtered
+/// **out** of the generic enumeration rather than surfaced twice — a shortcut
+/// that duplicates one member of a list teaches that the list is incomplete
+/// somewhere else too.
+///
+/// Three functions, and no surface derives a gate inline. The flag check lives
+/// in two of them and nowhere else, and its subject is narrow enough to state:
+/// the daemon registers the compiled provider only when it BOOTED with
+/// `claude_cloud_enabled` on, so a provider that was never registered is
+/// already absent from `remoteProviders` and needs no filtering. What the flag
+/// covers is the other direction — a daemon that booted with the flag on and a
+/// user who has since turned it off, where the provider is still registered
+/// but every one of its verbs is refused by the daemon's inner gate. Offering
+/// an entry that can only fail is exactly what the repository's
+/// omit-don't-disable convention exists to prevent.
+///
+/// Staleness is the opposite case and gets the opposite treatment: it is a
+/// transient state of a capability this install *does* have, so a stale
+/// provider keeps its entry everywhere and each surface renders it disabled,
+/// naming its own reason. See `cloudEntry(_:claudeCloudEnabled:)`.
 enum CloudCreateEntryPresentation {
-    /// The providers the "New Remote Session…" enumeration should list.
-    static func createProviders(
-        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
-    ) -> [RemoteProviderStatus] {
-        guard !claudeCloudEnabled else { return providers }
-        return providers.filter { $0.config.name != ClaudeCloudProvider.name }
-    }
-
-    /// The providers the `+` picker's remote-lane row may offer.
+    /// Every provider except the compiled cloud one — what the generic
+    /// "New Remote Session" enumeration lists on every surface that has one.
     ///
-    /// The picker enumerates every registered provider, so the cloud entry
-    /// needs no row of its own — but it does keep its own gate, which is
-    /// strictly narrower than `createProviders`: `cloudProvider` also
-    /// withdraws it on a stale inventory, where the context menu and the
-    /// Remote header instead render a disabled control. Expressing that as a
-    /// filter over the full list keeps one gate for the cloud provider and
-    /// leaves every other provider to the row's own staleness handling.
-    static func pickerProviders(
-        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
-    ) -> [RemoteProviderStatus] {
-        let cloud = cloudProvider(providers, claudeCloudEnabled: claudeCloudEnabled)
-        return createProviders(providers, claudeCloudEnabled: claudeCloudEnabled)
-            .filter { $0.config.name != ClaudeCloudProvider.name || cloud != nil }
+    /// It takes no flag, because the flag has nothing to say here: cloud is
+    /// never a member of this list at any flag value. Every registry provider
+    /// passes through untouched, staleness included — a stale row renders
+    /// disabled, which is a decision the row makes and not this filter's.
+    static func registryProviders(_ providers: [RemoteProviderStatus]) -> [RemoteProviderStatus] {
+        providers.filter { $0.config.name != ClaudeCloudProvider.name }
     }
 
-    /// The compiled cloud provider, when there is one to offer. Nil when the
-    /// flag is off, when the daemon never registered it, or when its
-    /// inventory is stale. `pickerProviders` — the `+` picker's gate, and
-    /// this function's only caller — withdraws the cloud entry outright on a
-    /// stale snapshot, unlike the context menu and the Remote section header,
-    /// which both disable their own `+` on `hasStaleSnapshot`. A create the
-    /// daemon would refuse with "inventory is stale" is worth no row at all.
-    static func cloudProvider(
+    /// The compiled cloud provider's own entry, or nil when there is none to
+    /// offer: the flag is off, or the daemon never registered it.
+    ///
+    /// A stale snapshot does **not** withdraw the entry. The row is not only a
+    /// button — it is also the menu's statement about what exists, and to a
+    /// user hunting for a provider they know is configured, absence reads as
+    /// "TBD dropped support for this", an error that is both wrong and
+    /// unrecoverable from inside the menu. Every surface renders the entry it
+    /// gets back disabled and subtitled with its reason, exactly as it already
+    /// does for a stale registry provider.
+    static func cloudEntry(
         _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
     ) -> RemoteProviderStatus? {
         guard claudeCloudEnabled else { return nil }
-        guard let provider = providers.first(where: { $0.config.name == ClaudeCloudProvider.name }) else {
-            return nil
-        }
-        return provider.hasStaleSnapshot ? nil : provider
+        return providers.first { $0.config.name == ClaudeCloudProvider.name }
+    }
+
+    /// Whether one already-registered provider may be created against — the
+    /// per-provider verdict the Remote section's provider header row needs for
+    /// its own `+`, where the surface is handed a single provider rather than
+    /// a list to enumerate. True for every provider except the compiled cloud
+    /// one with the flag off. Staleness stays a separate axis: the header
+    /// still renders its `+` for a stale provider and disables the button.
+    static func offersCreate(
+        provider: RemoteProviderStatus, claudeCloudEnabled: Bool
+    ) -> Bool {
+        provider.config.name != ClaudeCloudProvider.name || claudeCloudEnabled
     }
 }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -197,17 +197,18 @@ struct RemoteProviderHeaderRow: View {
     }
 
     /// Whether this header's `+` and its `RemoteCreateSheet` may be offered
-    /// at all — the third create surface routed through
-    /// `CloudCreateEntryPresentation`, alongside `RepoSectionView`'s context
-    /// menu (`remoteSessionMenuProviders`) and `+` picker
-    /// (`cloudSessionProvider`). True for every non-cloud provider regardless
-    /// of the flag; false for the compiled cloud provider once
-    /// `claude_cloud_enabled` has been turned off, even though the daemon
+    /// at all — the fifth create entry routed through
+    /// `CloudCreateEntryPresentation`, alongside the two `+` pickers' cloud
+    /// rows (`WorktreeProfilePickerView.cloudLaneEntry`) and the two
+    /// context-menu items (`RepoSectionView.cloudSessionMenuEntry`,
+    /// `WorktreeRowView.cloudSessionMenuEntry`). True for every non-cloud
+    /// provider regardless of the flag; false for the compiled cloud provider
+    /// once `claude_cloud_enabled` has been turned off, even though the daemon
     /// booted with it on and still keeps the provider registered here — the
     /// state `remote.create` refuses with "claude cloud sessions disabled".
-    /// Omitted (not merely disabled) to match the same convention the
-    /// context menu and `+` picker already follow for this gate; staleness
-    /// stays a separate, disabled-not-omitted axis on the button below.
+    /// Omitted (not merely disabled) to match the same convention every other
+    /// entry follows for this gate; staleness stays a separate,
+    /// disabled-not-omitted axis on the button below.
     private var canCreate: Bool {
         RemoteProviderHeaderRow.canCreate(
             provider: provider,
@@ -217,14 +218,18 @@ struct RemoteProviderHeaderRow: View {
     /// Pure form of `canCreate`, over a single provider — split out so a test
     /// can call the exact decision this row renders from without an
     /// `AppState`/view hierarchy, and so a parity test can check it against
-    /// `RepoSectionView`'s two create surfaces directly (see
+    /// the four other create entries directly (see
     /// `CloudCreateEntryPresentationTests`'s cross-surface parity suite).
+    ///
+    /// This is the one surface handed a single provider rather than a list to
+    /// enumerate — `RemoteSectionView` renders one header per registered
+    /// provider — which is why it reads the per-provider verdict instead of
+    /// filtering.
     nonisolated static func canCreate(
         provider: RemoteProviderStatus, claudeCloudEnabled: Bool
     ) -> Bool {
-        !CloudCreateEntryPresentation.createProviders(
-            [provider], claudeCloudEnabled: claudeCloudEnabled
-        ).isEmpty
+        CloudCreateEntryPresentation.offersCreate(
+            provider: provider, claudeCloudEnabled: claudeCloudEnabled)
     }
 
     var body: some View {

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -550,23 +550,34 @@ struct RepoSectionView: View {
         }
     }
 
-    // MARK: - The cloud gate — pure, view-free forms of what the two owned
-    // create surfaces render, so a test can call the exact decision each
-    // surface makes rather than re-deriving it. See
-    // `CloudCreateEntryPresentationTests`'s cross-surface parity suite,
-    // which checks this against `CloudCreateEntryPresentation.pickerProviders`
-    // (the `+` picker's gate) and `RemoteProviderHeaderRow.canCreate`
-    // (`RemoteSectionView.swift`) — the other two owned surfaces — for
-    // agreement.
+    // MARK: - The create gates — pure, view-free forms of what this section's
+    // two context-menu items render, so a test can call the exact decision
+    // each one makes rather than re-deriving it. See
+    // `CloudCreateEntryPresentationTests`'s cross-surface parity suite, which
+    // checks `cloudSessionMenuEntry` against the `+` picker's cloud row
+    // (`WorktreeProfilePickerView.cloudLaneEntry`), the worktree row's item
+    // (`WorktreeRowView.cloudSessionMenuEntry`) and the Remote section header
+    // (`RemoteProviderHeaderRow.canCreate`) for agreement.
 
-    /// The providers `newRemoteSessionMenuItem`'s context menu lists. A thin,
-    /// named forward to `CloudCreateEntryPresentation.createProviders` so the
-    /// view has no inline gate logic of its own to drift from what this
-    /// function (and its test coverage) pins.
+    /// The providers `newRemoteSessionMenuItem`'s context menu lists — the
+    /// ones the user configured themselves. A thin, named forward to
+    /// `CloudCreateEntryPresentation.registryProviders` so the view has no
+    /// inline gate logic of its own to drift from what that function (and its
+    /// test coverage) pins. The compiled cloud provider is never a member: it
+    /// gets `newCloudSessionMenuItem` instead.
     nonisolated static func remoteSessionMenuProviders(
-        providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+        providers: [RemoteProviderStatus]
     ) -> [RemoteProviderStatus] {
-        CloudCreateEntryPresentation.createProviders(providers, claudeCloudEnabled: claudeCloudEnabled)
+        CloudCreateEntryPresentation.registryProviders(providers)
+    }
+
+    /// The compiled cloud provider `newCloudSessionMenuItem` offers, or nil
+    /// when there is none. The same thin, named forward, for the same reason.
+    nonisolated static func cloudSessionMenuEntry(
+        providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+    ) -> RemoteProviderStatus? {
+        CloudCreateEntryPresentation.cloudEntry(
+            providers, claudeCloudEnabled: claudeCloudEnabled)
     }
 
 
@@ -588,6 +599,7 @@ struct RepoSectionView: View {
         Button(repo.hidden ? "Unhide" : "Hide") {
             Task { await appState.setRepoHidden(id: repo.id, hidden: !repo.hidden) }
         }
+        newCloudSessionMenuItem
         newRemoteSessionMenuItem
         Divider()
         Button("Remove from List...", role: .destructive) {
@@ -595,22 +607,47 @@ struct RepoSectionView: View {
         }
     }
 
+    /// The compiled cloud provider's own repo-scoped entry into the create
+    /// sheet, sitting beside its generic sibling rather than inside it. A user
+    /// who turned `claude_cloud_enabled` on scans this menu for the word they
+    /// enabled, in the position a title occupies — inferring it from a
+    /// submenu they have no reason to expect it behind spends their attention
+    /// to save a row.
+    ///
+    /// Omitted (not disabled) when the flag is off or the daemon never
+    /// registered the provider, mirroring how `RemoteSessionActionMenu` omits
+    /// capability-gated items. A stale snapshot instead keeps the item and
+    /// disables it, exactly as the generic item does for a stale registry
+    /// provider. Like its sibling it always opens the form — the `+` menu's
+    /// rows are the one-click path.
+    @ViewBuilder
+    private var newCloudSessionMenuItem: some View {
+        if let entry = RepoSectionView.cloudSessionMenuEntry(
+            providers: appState.remoteProviders,
+            claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false) {
+            Button("New Cloud Session…") { openRemoteCreateSheet(for: entry) }
+                .disabled(entry.hasStaleSnapshot)
+        }
+    }
+
     /// A repo-scoped entry point into the create sheet, prefilled with this
-    /// repo — omitted (not disabled) when no remote provider is offerable at
+    /// repo — omitted (not disabled) when no registry provider is offerable at
     /// all, mirroring how `RemoteSessionActionMenu` omits capability-gated
     /// items rather than graying them out. A single provider skips straight
     /// to the sheet; more than one asks which provider first.
     ///
-    /// The compiled cloud provider joins this list for free once the daemon
-    /// registers it; `CloudCreateEntryPresentation` is what takes it back out
-    /// when the flag has been turned off since boot, and the fast-path count
-    /// is decided AFTER that filter so a hidden entry cannot leave a
-    /// two-entry submenu with a dead row in it.
+    /// It enumerates the providers the user wrote into
+    /// `~/tbd/agent-providers.json`, which is what earns it a generic title:
+    /// their own config file is the authority on what they are called, and
+    /// enumerating them is the whole service this item provides. The compiled
+    /// cloud provider is not one of them and has `newCloudSessionMenuItem`
+    /// above instead — surfacing it in both places would make "how many
+    /// providers are there" ambiguous at exactly the moment the count decides
+    /// whether this item is a button or a submenu.
     @ViewBuilder
     private var newRemoteSessionMenuItem: some View {
         let providers = RepoSectionView.remoteSessionMenuProviders(
-            providers: appState.remoteProviders,
-            claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false)
+            providers: appState.remoteProviders)
         if !providers.isEmpty {
             if providers.count == 1, let only = providers.first {
                 Button("New Remote Session…") { openRemoteCreateSheet(for: only) }

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -20,11 +20,15 @@ enum RemoteLaneOffer {
 ///
 /// Three in-place pages (NOT nested popovers — those are fragile on macOS):
 ///  - `.profiles` (default): a fixed "Choose a branch…" drill-in row at the
-///    top, an optional "New remote session" row beneath it (see
-///    `remoteLaneOffer`; it carries a trailing ellipsis only when selecting it
-///    will itself open the create form — never when it drills into the
-///    provider list, where the chevron says so), then one row per configured
-///    model profile. Selecting a profile row one-click-creates a worktree
+///    top, then up to two "start something other than a plain local worktree"
+///    rows beneath it — an optional "New cloud session" row for the compiled
+///    cloud provider (see `cloudLaneEntry`) and an optional "New remote
+///    session" row for the providers the user configured themselves (see
+///    `remoteLaneOffer`) — then one row per configured model profile.
+///    Each of those two rows carries a trailing ellipsis only when selecting
+///    it will itself open the create form — never when it drills into the
+///    provider list, where the chevron says so.
+///    Selecting a profile row one-click-creates a worktree
 ///    pinned to that profile. (A plain click on the `+` — without opening this
 ///    menu — already creates a default worktree via repo → scratch → global
 ///    default precedence, so there is no separate "resolve automatically" row
@@ -63,9 +67,12 @@ struct WorktreeProfilePickerView: View {
     /// a `FloatingPanel` that is about to be torn down. Both call sites wire
     /// it; the default exists only so a preview or a future host can omit it.
     ///
-    /// The compiled cloud provider reaches the sheet through this same hook:
-    /// it is one registered provider among the others, so it needs no row of
-    /// its own — only the gate `offerableProviders` applies to it.
+    /// The compiled cloud provider reaches the sheet through this same hook.
+    /// It has a row of its own rather than a place in the generic
+    /// enumeration — a user who enabled a feature called Claude Cloud is
+    /// looking for that name in the position a title occupies — but the row it
+    /// gets is an ordinary provider row, so what it hands back here is the
+    /// same `RemoteProviderStatus` any other row would.
     var onStartRemoteSession: (RemoteProviderStatus) -> Void = { _ in }
     @Environment(AppState.self) var appState
     @Environment(\.dismiss) private var dismiss
@@ -130,9 +137,11 @@ struct WorktreeProfilePickerView: View {
             }
             .padding(.top, 2)
 
-            // Sits with "Choose a branch…" in the top group of "start
+            // Sit with "Choose a branch…" in the top group of "start
             // something other than a plain local worktree" rows, above the
-            // profile list.
+            // profile list. Cloud first: it is the one entry a user came
+            // looking for by name.
+            cloudLaneRow
             remoteLaneRow
 
             Divider()
@@ -207,7 +216,8 @@ struct WorktreeProfilePickerView: View {
     @ViewBuilder
     private var profilesPageHeader: some View {
         HStack {
-            Text(Self.profilesPageTitle(offer: remoteLaneOffer))
+            Text(Self.profilesPageTitle(
+                offer: remoteLaneOffer, hasCloudEntry: cloudEntry != nil))
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
             Spacer()
@@ -216,17 +226,42 @@ struct WorktreeProfilePickerView: View {
         .padding(.vertical, 8)
     }
 
-    /// The registered providers this menu may offer, after the cloud
-    /// provider's own gate. Every other provider passes through untouched.
+    /// The providers the generic "New remote session" row enumerates — the
+    /// ones the user configured themselves. The compiled cloud provider has a
+    /// row of its own (`cloudLaneRow`) and is never a member of this list.
     private var offerableProviders: [RemoteProviderStatus] {
-        CloudCreateEntryPresentation.pickerProviders(
-            appState.remoteProviders,
-            claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false)
+        Self.registryLaneProviders(appState.remoteProviders)
+    }
+
+    /// The compiled cloud provider's row, or nil when there is none to offer.
+    private var cloudEntry: RemoteProviderStatus? {
+        Self.cloudLaneEntry(
+            providers: appState.remoteProviders,
+            claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false,
+            parentWorktreeID: parentWorktreeID)
     }
 
     /// What this menu offers as a remote-lane entry point right now.
     private var remoteLaneOffer: RemoteLaneOffer {
         Self.remoteLaneOffer(providers: offerableProviders, parentWorktreeID: parentWorktreeID)
+    }
+
+    /// The optional "New cloud session…" row — the compiled provider's own
+    /// entry, named so a user who enabled Claude Cloud finds the word they
+    /// enabled where a title goes rather than inferring it from a subtitle.
+    /// Omitted entirely when the flag is off or the daemon never registered
+    /// it; a stale provider keeps its row, disabled, with the reason in its
+    /// subtitle (`remoteProviderRow` handles both).
+    @ViewBuilder
+    private var cloudLaneRow: some View {
+        if let entry = cloudEntry {
+            remoteProviderRow(
+                entry,
+                title: Self.cloudLaneRowTitle(opensForm: !willCreateImmediately(entry)),
+                subtitle: Self.providerRowSubtitle(entry)
+                    ?? "Runs on Anthropic's infrastructure",
+                systemImage: Self.cloudLaneSymbol)
+        }
     }
 
     /// The optional "New remote session…" row. Omitted entirely (never shown
@@ -266,12 +301,13 @@ struct WorktreeProfilePickerView: View {
     private func remoteProviderRow(
         _ provider: RemoteProviderStatus,
         title: String,
-        subtitle: String?
+        subtitle: String?,
+        systemImage: String = WorktreeProfilePickerView.remoteLaneSymbol
     ) -> some View {
         ProfilePickerRow(
             title: title,
             subtitle: subtitle,
-            systemImage: Self.remoteLaneSymbol
+            systemImage: systemImage
         ) {
             startRemoteSession(provider)
         }
@@ -352,6 +388,13 @@ struct WorktreeProfilePickerView: View {
         opensForm ? "New remote session…" : "New remote session"
     }
 
+    /// The cloud row's copy. Special in placement, not in behavior: it makes
+    /// the same ellipsis promise on the same terms as every other row that
+    /// acts, decided from the same inputs the click uses.
+    nonisolated static func cloudLaneRowTitle(opensForm: Bool) -> String {
+        opensForm ? "New cloud session…" : "New cloud session"
+    }
+
     /// The remote-lane row's title for the offer it is rendering — the form
     /// the view calls, and the one place the ellipsis rule lives.
     ///
@@ -402,6 +445,38 @@ struct WorktreeProfilePickerView: View {
     /// not this one".
     static let remoteLaneSymbol = "server.rack"
 
+    /// Leading glyph for the cloud row, which names one specific elsewhere
+    /// rather than "not this machine" in general.
+    static let cloudLaneSymbol = "cloud"
+
+    /// The providers `remoteLaneRow` enumerates — a thin, named forward to
+    /// `CloudCreateEntryPresentation.registryProviders` so this view has no
+    /// inline gate of its own to drift from what that function pins, and so
+    /// the cross-surface parity suite can call the exact list this page shows.
+    nonisolated static func registryLaneProviders(
+        _ providers: [RemoteProviderStatus]
+    ) -> [RemoteProviderStatus] {
+        CloudCreateEntryPresentation.registryProviders(providers)
+    }
+
+    /// The compiled cloud provider's row, or nil when there is none to offer —
+    /// the pure, view-free form of `cloudLaneRow`'s gate, so the cross-surface
+    /// parity suite can call the decision this page renders rather than
+    /// re-deriving it.
+    ///
+    /// `parentWorktreeID` is **not** a gate, and the parameter is kept to say
+    /// so where a test can pin it, for the same reason `remoteLaneOffer` keeps
+    /// it: nesting is TBD-side filing, and the remote side neither knows nor
+    /// needs to know about it.
+    nonisolated static func cloudLaneEntry(
+        providers: [RemoteProviderStatus],
+        claudeCloudEnabled: Bool,
+        parentWorktreeID: UUID?
+    ) -> RemoteProviderStatus? {
+        CloudCreateEntryPresentation.cloudEntry(
+            providers, claudeCloudEnabled: claudeCloudEnabled)
+    }
+
     /// What the `+` menu offers as its remote-lane entry point.
     ///
     /// One gate: **no provider registered → nothing at all.** Omitting rather
@@ -444,8 +519,14 @@ struct WorktreeProfilePickerView: View {
 
     /// The page's own header copy. "New worktree with…" stops being true once
     /// the page can also start a remote lane, which is a provider session and
-    /// not a worktree — so the title widens exactly when the row is offered.
-    nonisolated static func profilesPageTitle(offer: RemoteLaneOffer) -> String {
+    /// not a worktree — so the title widens exactly when either row is
+    /// offered. `hasCloudEntry` is passed rather than inferred because the
+    /// cloud row is not a member of `offer`: the two rows are siblings, and
+    /// either one alone is enough to make the narrow title false.
+    nonisolated static func profilesPageTitle(
+        offer: RemoteLaneOffer, hasCloudEntry: Bool
+    ) -> String {
+        if hasCloudEntry { return "New worktree or remote session…" }
         switch offer {
         case .hidden: return "New worktree with…"
         case .single, .chooseProvider: return "New worktree or remote session…"

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -36,8 +36,10 @@ enum RemoteLaneOffer {
 ///  - `.branches`: the reused searchable branch list (`BranchListView`) behind
 ///    a back affordance. Selecting a branch creates a worktree on that existing
 ///    branch using the DEFAULT model (accepted tradeoff).
-///  - `.remoteProviders`: one row per registered remote provider, reached only
-///    when more than one is registered. A third page rather than a nested
+///  - `.remoteProviders`: one row per provider the user configured, reached
+///    only when more than one of those is registered — the compiled cloud
+///    provider is never a member and never lands here, because it has its own
+///    row on the page above. A third page rather than a nested
 ///    `Menu`/popover for the same reason `.branches` is one. Each row carries
 ///    its own trailing ellipsis when selecting that provider will open the
 ///    create form, since these are the rows that act.

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -232,66 +232,101 @@ struct WorktreeRowView: View {
         }
     }
 
-    // MARK: - Context menu: "New Remote Session…"
+    // MARK: - Context menu: "New Cloud Session…" / "New Remote Session…"
 
-    /// The providers this row's context-menu item lists — the pure, view-free
-    /// form of the decision `newRemoteSessionMenuItem` renders, so a test can
-    /// call it rather than re-deriving it. A thin, named forward to
-    /// `CloudCreateEntryPresentation.createProviders` (the same gate
-    /// `RepoSectionView.remoteSessionMenuProviders` forwards to, and the same
-    /// one `CloudCreateEntryPresentationTests`'s cross-surface parity suite
-    /// pins), plus this row's own `isMain` gate.
+    /// The providers this row's generic context-menu item lists — the pure,
+    /// view-free form of the decision `newRemoteSessionMenuItem` renders, so a
+    /// test can call it rather than re-deriving it. A thin, named forward to
+    /// `CloudCreateEntryPresentation.registryProviders` (the same enumeration
+    /// `RepoSectionView.remoteSessionMenuProviders` forwards to), plus this
+    /// row's own `isMain` gate.
     ///
     /// `isMain` is a gate here and not on the repo header because the main
     /// worktree is the repo's checkout, not a parent to nest under: the nested
     /// `+` is withheld from that row for the same reason, and this item is that
     /// button's always-opens-the-form twin. The two gates are independent —
-    /// the cloud filter answers "which providers", `isMain` answers "does this
-    /// row offer nesting at all".
+    /// the registry filter answers "which providers", `isMain` answers "does
+    /// this row offer nesting at all".
     nonisolated static func remoteSessionMenuProviders(
-        providers: [RemoteProviderStatus], claudeCloudEnabled: Bool, isMain: Bool
+        providers: [RemoteProviderStatus], isMain: Bool
     ) -> [RemoteProviderStatus] {
         guard !isMain else { return [] }
-        return CloudCreateEntryPresentation.createProviders(providers, claudeCloudEnabled: claudeCloudEnabled)
+        return CloudCreateEntryPresentation.registryProviders(providers)
     }
 
-    /// A worktree-scoped entry point into the create sheet, nested under this
-    /// row — the always-opens-the-form twin of the nested `+`'s remote-lane
-    /// row, and the exact counterpart of
-    /// `RepoSectionView.newRemoteSessionMenuItem` on the repo header.
+    /// The compiled cloud provider this row's own context-menu item offers, or
+    /// nil when there is none — the same pure, view-free treatment its generic
+    /// sibling gets, so `CloudCreateEntryPresentationTests`'s cross-surface
+    /// parity suite can call the decision this row renders. `isMain` gates it
+    /// exactly as it gates the sibling: the main row offers neither.
+    nonisolated static func cloudSessionMenuEntry(
+        providers: [RemoteProviderStatus], claudeCloudEnabled: Bool, isMain: Bool
+    ) -> RemoteProviderStatus? {
+        guard !isMain else { return nil }
+        return CloudCreateEntryPresentation.cloudEntry(
+            providers, claudeCloudEnabled: claudeCloudEnabled)
+    }
+
+    /// The pair of worktree-scoped entry points into the create sheet, nested
+    /// under this row — the always-opens-the-form twins of the nested `+`'s
+    /// two lane rows, and the exact counterparts of `RepoSectionView`'s pair
+    /// on the repo header. Cloud first, matching that pair's order.
     ///
-    /// It sets `remoteCreateSheetProvider` DIRECTLY rather than going through
+    /// Both set `remoteCreateSheetProvider` DIRECTLY rather than going through
     /// `startRemoteSession(with:)`: opening the form unconditionally is the
-    /// whole point of this item. Routing it through the launch decision would
-    /// make it one-click-create exactly when every answer is already knowable,
-    /// which is precisely the case where there is no other way to type a
-    /// prompt or choose a branch for a NESTED lane.
+    /// whole point of these items. Routing them through the launch decision
+    /// would make them one-click-create exactly when every answer is already
+    /// knowable, which is precisely the case where there is no other way to
+    /// type a prompt or choose a branch for a NESTED lane.
     ///
-    /// Same shape as the repo header's item: omitted (not disabled) when no
-    /// provider is offerable, a single provider skips the submenu, and the
-    /// fast-path count is decided AFTER the cloud filter so a hidden entry
-    /// cannot leave a two-entry submenu with a dead row in it.
+    /// The leading separator belongs to the pair rather than to either item,
+    /// so a row that offers neither leaves no dangling separator on its action
+    /// list and a row that offers both gets one separator, not two.
     @ViewBuilder
-    private var newRemoteSessionMenuItem: some View {
-        let providers = WorktreeRowView.remoteSessionMenuProviders(
+    private var remoteCreateMenuItems: some View {
+        let claudeCloudEnabled = appState.daemonCapabilities?.claudeCloudEnabled ?? false
+        let cloud = WorktreeRowView.cloudSessionMenuEntry(
             providers: appState.remoteProviders,
-            claudeCloudEnabled: appState.daemonCapabilities?.claudeCloudEnabled ?? false,
-            isMain: isMain)
-        if !providers.isEmpty {
-            // Inside the conditional so an omitted item leaves no dangling
-            // trailing separator on the row's action list.
+            claudeCloudEnabled: claudeCloudEnabled, isMain: isMain)
+        let providers = WorktreeRowView.remoteSessionMenuProviders(
+            providers: appState.remoteProviders, isMain: isMain)
+        if cloud != nil || !providers.isEmpty {
             Divider()
-            if providers.count == 1, let only = providers.first {
-                Button("New Remote Session…") { remoteCreateSheetProvider = only }
-                    .disabled(only.hasStaleSnapshot)
-            } else {
-                Menu("New Remote Session…") {
-                    ForEach(providers, id: \.config.name) { provider in
-                        Button(provider.describe?.name ?? provider.config.name) {
-                            remoteCreateSheetProvider = provider
-                        }
-                        .disabled(provider.hasStaleSnapshot)
+            newCloudSessionMenuItem(cloud)
+            newRemoteSessionMenuItem(providers)
+        }
+    }
+
+    /// The compiled cloud provider's own item, named so a user who enabled
+    /// Claude Cloud finds the word they enabled where a title goes. Omitted
+    /// when the flag is off or the daemon never registered it; a stale
+    /// snapshot keeps the item and disables it, as its sibling does for a
+    /// stale registry provider.
+    @ViewBuilder
+    private func newCloudSessionMenuItem(_ entry: RemoteProviderStatus?) -> some View {
+        if let entry {
+            Button("New Cloud Session…") { remoteCreateSheetProvider = entry }
+                .disabled(entry.hasStaleSnapshot)
+        }
+    }
+
+    /// The generic item over the providers the user configured themselves.
+    /// Same shape as the repo header's: omitted when none is offerable, and a
+    /// single provider skips the submenu. The compiled cloud provider is not a
+    /// member of this enumeration, so the one-versus-many count is a count of
+    /// registry providers only.
+    @ViewBuilder
+    private func newRemoteSessionMenuItem(_ providers: [RemoteProviderStatus]) -> some View {
+        if providers.count == 1, let only = providers.first {
+            Button("New Remote Session…") { remoteCreateSheetProvider = only }
+                .disabled(only.hasStaleSnapshot)
+        } else if !providers.isEmpty {
+            Menu("New Remote Session…") {
+                ForEach(providers, id: \.config.name) { provider in
+                    Button(provider.describe?.name ?? provider.config.name) {
+                        remoteCreateSheetProvider = provider
                     }
+                    .disabled(provider.hasStaleSnapshot)
                 }
             }
         }
@@ -658,10 +693,10 @@ struct WorktreeRowView: View {
         .contextMenu {
             SidebarContextMenu(worktree: worktree, onRename: startRename)
             // Added here rather than inside `SidebarContextMenu` because the
-            // sheet it opens is this row's state (`remoteCreateSheetProvider`,
-            // `remoteCreateSheetContent(for:)`); pushing the item down would
+            // sheet they open is this row's state (`remoteCreateSheetProvider`,
+            // `remoteCreateSheetContent(for:)`); pushing the items down would
             // mean handing that state back up through a closure for no gain.
-            newRemoteSessionMenuItem
+            remoteCreateMenuItems
         }
         .onChange(of: appState.editingWorktreeID) { _, newID in
             if newID == worktree.id {

--- a/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
+++ b/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
@@ -174,22 +174,24 @@ struct CloudCreateEntryPresentationParityTests {
     }
 
     /// Whether each of the four entry-yielding surfaces offers a cloud entry,
-    /// in a fixed order so a failing `#expect` names which one diverged.
+    /// each labelled so a failing `#expect` names which one diverged. An
+    /// ordered array rather than a dictionary, so a run that fails on more
+    /// than one surface reports them in the same order every time.
     private func entriesShown(
         _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
-    ) -> [String: Bool] {
+    ) -> [(surface: String, shown: Bool)] {
         [
-            "repo + picker": WorktreeProfilePickerView.cloudLaneEntry(
+            ("repo + picker", WorktreeProfilePickerView.cloudLaneEntry(
                 providers: providers, claudeCloudEnabled: claudeCloudEnabled,
-                parentWorktreeID: nil) != nil,
-            "nested + picker": WorktreeProfilePickerView.cloudLaneEntry(
+                parentWorktreeID: nil) != nil),
+            ("nested + picker", WorktreeProfilePickerView.cloudLaneEntry(
                 providers: providers, claudeCloudEnabled: claudeCloudEnabled,
-                parentWorktreeID: UUID()) != nil,
-            "repo context menu": RepoSectionView.cloudSessionMenuEntry(
-                providers: providers, claudeCloudEnabled: claudeCloudEnabled) != nil,
-            "worktree row context menu": WorktreeRowView.cloudSessionMenuEntry(
+                parentWorktreeID: UUID()) != nil),
+            ("repo context menu", RepoSectionView.cloudSessionMenuEntry(
+                providers: providers, claudeCloudEnabled: claudeCloudEnabled) != nil),
+            ("worktree row context menu", WorktreeRowView.cloudSessionMenuEntry(
                 providers: providers, claudeCloudEnabled: claudeCloudEnabled,
-                isMain: false) != nil,
+                isMain: false) != nil),
         ]
     }
 

--- a/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
+++ b/Tests/TBDAppTests/CloudCreateEntryPresentationTests.swift
@@ -13,92 +13,6 @@ struct CloudCreateEntryPresentationTests {
             health: .ok, errorMessage: nil, remediationLabel: nil, remediationCommand: nil)
     }
 
-    private var both: [RemoteProviderStatus] {
-        [status("acme"), status(ClaudeCloudProvider.name)]
-    }
-
-    /// OMITTED, not disabled — matching how capability-gated remote items are
-    /// already omitted rather than grayed out.
-    @Test func theCloudProviderIsOmittedWhenTheFlagIsOff() {
-        let shown = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: false)
-        #expect(shown.map { $0.config.name } == ["acme"])
-        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: false) == nil)
-    }
-
-    /// The discriminating half: with the flag on it is shown, so the filter
-    /// did not simply delete the entry.
-    @Test func theCloudProviderIsShownWhenTheFlagIsOn() {
-        let shown = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: true)
-        #expect(shown.map { $0.config.name } == ["acme", ClaudeCloudProvider.name])
-        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: true)?
-            .config.name == ClaudeCloudProvider.name)
-    }
-
-    /// A registered provider is never touched by this gate, whichever way the
-    /// cloud flag points.
-    @Test func aRegisteredProviderIsUnaffectedByTheCloudFlag() {
-        let only = [status("acme")]
-        #expect(CloudCreateEntryPresentation.createProviders(only, claudeCloudEnabled: false)
-            .map { $0.config.name } == ["acme"])
-        #expect(CloudCreateEntryPresentation.createProviders(only, claudeCloudEnabled: true)
-            .map { $0.config.name } == ["acme"])
-        #expect(CloudCreateEntryPresentation.cloudProvider(only, claudeCloudEnabled: true) == nil)
-    }
-
-    /// The daemon registers the cloud provider only when it booted with the
-    /// flag on, so "flag on but provider absent" is the flipped-after-boot
-    /// state and must show nothing rather than a row that cannot work.
-    @Test func aFlagOnWithNoRegisteredCloudProviderShowsNoCloudEntry() {
-        let only = [status("acme")]
-        #expect(CloudCreateEntryPresentation.cloudProvider(only, claudeCloudEnabled: true) == nil)
-    }
-
-    @Test func anEmptyProviderListStaysEmpty() {
-        #expect(CloudCreateEntryPresentation.createProviders([], claudeCloudEnabled: true).isEmpty)
-        #expect(CloudCreateEntryPresentation.cloudProvider([], claudeCloudEnabled: true) == nil)
-    }
-
-    // MARK: - The menu's own shape
-
-    /// The single-provider fast path must be computed from the FILTERED list,
-    /// not the raw one: with the flag off and cloud plus one registry
-    /// provider on file, the menu must be the one-provider shape, not a
-    /// two-entry submenu with a dead row.
-    @Test func theSingleProviderFastPathIsDecidedAfterFiltering() {
-        let filtered = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: false)
-        #expect(filtered.count == 1)
-        #expect(filtered.first?.config.name == "acme")
-
-        let unfiltered = CloudCreateEntryPresentation.createProviders(both, claudeCloudEnabled: true)
-        #expect(unfiltered.count == 2)
-    }
-
-    /// With cloud the only provider and the flag off, the menu item is
-    /// omitted whole — an empty filtered list is what `newRemoteSessionMenuItem`
-    /// already reads as "show nothing".
-    @Test func cloudAloneWithTheFlagOffLeavesNothingToOffer() {
-        let cloudOnly = [status(ClaudeCloudProvider.name)]
-        #expect(CloudCreateEntryPresentation.createProviders(
-            cloudOnly, claudeCloudEnabled: false).isEmpty)
-        #expect(CloudCreateEntryPresentation.createProviders(
-            cloudOnly, claudeCloudEnabled: true).count == 1)
-    }
-
-    // MARK: - The `+` button's row
-
-    /// The `+` button's row is present exactly when there is a cloud provider
-    /// to open the sheet for — omitted, never disabled.
-    @Test func thePlusButtonRowFollowsTheSameGateAsTheMenu() {
-        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: true) != nil)
-        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: false) == nil)
-        // And a daemon that never registered it shows nothing even with the
-        // flag on — the flipped-on-without-restart state.
-        #expect(CloudCreateEntryPresentation.cloudProvider(
-            [status("acme")], claudeCloudEnabled: true) == nil)
-    }
-
-    // MARK: - The `+` button's row honors staleness (final review item 2)
-
     private func staleStatus(_ name: String) -> RemoteProviderStatus {
         RemoteProviderStatus(
             config: RemoteProviderConfig(name: name, exec: "/x"),
@@ -107,54 +21,123 @@ struct CloudCreateEntryPresentationTests {
             freshnessUnreadable: true)
     }
 
-    /// The picker withdraws a stale cloud entry outright — unlike the
-    /// context menu and the Remote section header, which both disable their
-    /// own `+` on `hasStaleSnapshot` — so a stale cloud provider must be
-    /// OMITTED the same way an absent or flag-off provider is, or the sheet
-    /// opens onto a create call the daemon refuses as stale.
-    @Test func cloudProviderIsOmittedWhenTheCloudProvidersInventoryIsStale() {
+    private var both: [RemoteProviderStatus] {
+        [status("acme"), status(ClaudeCloudProvider.name)]
+    }
+
+    // MARK: - registryProviders: the generic enumeration
+
+    /// The generic "New Remote Session" enumeration is the user's own
+    /// `agent-providers.json`, and the compiled provider is never a member of
+    /// it — it has an entry of its own on every surface that has a generic
+    /// one. No flag can put it back.
+    @Test func theCloudProviderIsNeverAMemberOfTheGenericEnumeration() {
+        #expect(CloudCreateEntryPresentation.registryProviders(both)
+            .map { $0.config.name } == ["acme"])
+        #expect(CloudCreateEntryPresentation.registryProviders([status(ClaudeCloudProvider.name)])
+            .isEmpty)
+    }
+
+    /// The discriminating half: registry providers pass through untouched, in
+    /// order, so the filter did not simply empty the list.
+    @Test func everyRegistryProviderPassesThroughInOrder() {
+        let many = [status("acme"), status(ClaudeCloudProvider.name), status("widgets")]
+        #expect(CloudCreateEntryPresentation.registryProviders(many)
+            .map { $0.config.name } == ["acme", "widgets"])
+    }
+
+    /// A stale registry provider still reaches the enumeration — staleness is
+    /// the row's business (it renders disabled), never this filter's.
+    @Test func aStaleRegistryProviderStillReachesTheEnumeration() {
+        let mixed = [staleStatus("acme"), status("widgets")]
+        #expect(CloudCreateEntryPresentation.registryProviders(mixed)
+            .map { $0.config.name } == ["acme", "widgets"])
+    }
+
+    @Test func anEmptyProviderListStaysEmpty() {
+        #expect(CloudCreateEntryPresentation.registryProviders([]).isEmpty)
+        #expect(CloudCreateEntryPresentation.cloudEntry([], claudeCloudEnabled: true) == nil)
+    }
+
+    // MARK: - cloudEntry: the compiled provider's own entry
+
+    /// OMITTED, not disabled — the flag being off means this install does not
+    /// have the capability, and a row for it would advertise something untrue.
+    @Test func theCloudEntryIsOmittedWhenTheFlagIsOff() {
+        #expect(CloudCreateEntryPresentation.cloudEntry(both, claudeCloudEnabled: false) == nil)
+    }
+
+    /// The discriminating half: with the flag on it is offered, so the gate
+    /// did not simply delete the entry.
+    @Test func theCloudEntryIsOfferedWhenTheFlagIsOn() {
+        #expect(CloudCreateEntryPresentation.cloudEntry(both, claudeCloudEnabled: true)?
+            .config.name == ClaudeCloudProvider.name)
+    }
+
+    /// The daemon registers the cloud provider only when it booted with the
+    /// flag on, so "flag on but provider absent" is the flipped-after-boot
+    /// state and must show nothing rather than a row that cannot work.
+    @Test func aFlagOnWithNoRegisteredCloudProviderShowsNoCloudEntry() {
+        #expect(CloudCreateEntryPresentation.cloudEntry(
+            [status("acme")], claudeCloudEnabled: true) == nil)
+    }
+
+    /// Staleness DISABLES, it does not withdraw: a stale snapshot is a
+    /// transient state of a capability this install does have, and the row is
+    /// the menu's statement that the capability exists. Each surface renders
+    /// the entry it gets back disabled, subtitled with its reason.
+    @Test func aStaleCloudProviderStillYieldsAnEntry() {
         let stale = [status("acme"), staleStatus(ClaudeCloudProvider.name)]
-        #expect(CloudCreateEntryPresentation.cloudProvider(stale, claudeCloudEnabled: true) == nil)
+        #expect(staleStatus(ClaudeCloudProvider.name).hasStaleSnapshot)
+        #expect(CloudCreateEntryPresentation.cloudEntry(stale, claudeCloudEnabled: true)?
+            .config.name == ClaudeCloudProvider.name)
     }
 
-    /// The discriminating half: a non-stale cloud provider is unaffected —
-    /// confirms the staleness check doesn't simply always return nil.
-    @Test func cloudProviderIsShownWhenNotStale() {
-        #expect(CloudCreateEntryPresentation.cloudProvider(both, claudeCloudEnabled: true) != nil)
-    }
-
-    /// Staleness on a DIFFERENT, unrelated provider must never suppress the
-    /// cloud row — the check is scoped to the cloud provider's own status.
-    @Test func aStaleUnrelatedProviderDoesNotSuppressTheCloudRow() {
+    /// Staleness on a DIFFERENT, unrelated provider says nothing about the
+    /// cloud entry — the lookup is scoped to the cloud provider's own status.
+    @Test func aStaleUnrelatedProviderDoesNotDisturbTheCloudEntry() {
         let mixed = [staleStatus("acme"), status(ClaudeCloudProvider.name)]
-        #expect(CloudCreateEntryPresentation.cloudProvider(mixed, claudeCloudEnabled: true) != nil)
+        #expect(CloudCreateEntryPresentation.cloudEntry(mixed, claudeCloudEnabled: true) != nil)
     }
 
-    /// The cloud gate is scoped to the cloud provider. Every other registered
-    /// provider reaches the picker whatever the flag says and whatever its own
-    /// inventory looks like — the row renders it disabled when stale, which is
-    /// a decision the row makes, not this filter.
-    @Test func pickerProvidersLeaveEveryNonCloudProviderAlone() {
-        let mixed = [staleStatus("acme"), status("widgets"), status(ClaudeCloudProvider.name)]
+    // MARK: - offersCreate: the per-provider verdict
+
+    /// A registry provider's own `+` is never the cloud flag's business.
+    @Test func aRegistryProviderOffersCreateWhicheverWayTheFlagPoints() {
         for flag in [true, false] {
-            let offered = CloudCreateEntryPresentation.pickerProviders(mixed, claudeCloudEnabled: flag)
-            #expect(offered.contains { $0.config.name == "acme" })
-            #expect(offered.contains { $0.config.name == "widgets" })
+            #expect(CloudCreateEntryPresentation.offersCreate(
+                provider: status("acme"), claudeCloudEnabled: flag))
         }
+    }
+
+    @Test func theCloudProviderOffersCreateOnlyWhenTheFlagIsOn() {
+        #expect(CloudCreateEntryPresentation.offersCreate(
+            provider: status(ClaudeCloudProvider.name), claudeCloudEnabled: true))
+        #expect(!CloudCreateEntryPresentation.offersCreate(
+            provider: status(ClaudeCloudProvider.name), claudeCloudEnabled: false))
+    }
+
+    /// Staleness is a separate axis from this verdict: the header still
+    /// renders its `+` for a stale provider and disables the button instead.
+    @Test func aStaleProviderStillOffersCreate() {
+        #expect(CloudCreateEntryPresentation.offersCreate(
+            provider: staleStatus(ClaudeCloudProvider.name), claudeCloudEnabled: true))
+        #expect(CloudCreateEntryPresentation.offersCreate(
+            provider: staleStatus("acme"), claudeCloudEnabled: false))
     }
 }
 
-// MARK: - Cross-surface parity (final review item 4)
+// MARK: - Cross-surface parity
 //
-// The four owned create surfaces — `RepoSectionView`'s context menu
-// (`remoteSessionMenuProviders`), `WorktreeRowView`'s context menu (its own
-// `remoteSessionMenuProviders`), the `+` picker
-// (`CloudCreateEntryPresentation.pickerProviders`), and `RemoteSectionView`'s
-// header `+` (`RemoteProviderHeaderRow.canCreate`) — must reach the same "can
-// this surface offer cloud?" verdict for a given (providers,
-// claudeCloudEnabled) pair, with one documented exception: the picker
-// additionally omits a STALE cloud provider, which the others instead
-// render and disable (see the staleness tests above).
+// Five owned create entries carry the compiled cloud provider — the repo
+// header `+` picker's cloud row and the nested `+` picker's cloud row
+// (`WorktreeProfilePickerView.cloudLaneEntry`), `RepoSectionView`'s
+// context-menu item (`cloudSessionMenuEntry`), `WorktreeRowView`'s
+// context-menu item (its own `cloudSessionMenuEntry`), and
+// `RemoteSectionView`'s provider header `+` (`RemoteProviderHeaderRow
+// .canCreate`) — and all five must reach the same "is the cloud entry shown?"
+// verdict for a given (providers, claudeCloudEnabled, staleness) input. There
+// is no documented divergence: staleness shows the entry disabled everywhere.
 //
 // `WorktreeRowView`'s item carries one extra gate of its own — the main row
 // offers nothing, because the main worktree is not a parent to nest under —
@@ -162,14 +145,14 @@ struct CloudCreateEntryPresentationTests {
 // `WorktreeRowRemoteSessionMenuTests` rather than here. Every call below
 // passes `isMain: false` so this suite reads only the cloud verdict.
 //
-// Each test below calls the actual `nonisolated static` functions the four
-// view bodies call — not a re-implementation of their logic — so a future
-// edit that re-derives the gate inline in one surface, drops a filter, or
-// stops routing through `CloudCreateEntryPresentation` reddens this suite
-// even without a rendered view. That is the gap the pure
+// Each test below calls the actual `nonisolated static` functions the view
+// bodies call — not a re-implementation of their logic — so a future edit
+// that re-derives the gate inline in one surface, drops a filter, or stops
+// routing through `CloudCreateEntryPresentation` reddens this suite even
+// without a rendered view. That is the gap the pure
 // `CloudCreateEntryPresentation` tests above cannot close on their own: they
-// only ever called the shared function directly, so a surface that silently
-// stopped calling it left the whole suite green.
+// only ever call the shared function directly, so a surface that silently
+// stopped calling it would leave the whole suite green.
 @Suite("CloudCreateEntryPresentation — cross-surface parity")
 struct CloudCreateEntryPresentationParityTests {
     private func status(
@@ -186,79 +169,106 @@ struct CloudCreateEntryPresentationParityTests {
         [status("acme"), status(ClaudeCloudProvider.name)]
     }
 
-    private func cloudEntry(in providers: [RemoteProviderStatus]) -> RemoteProviderStatus {
+    private func cloudStatus(in providers: [RemoteProviderStatus]) -> RemoteProviderStatus {
         providers.first { $0.config.name == ClaudeCloudProvider.name }!
     }
 
-    /// Flag off: all four surfaces must agree the cloud row is hidden.
-    @Test func allFourSurfacesAgreeTheCloudRowIsHiddenWhenTheFlagIsOff() {
-        let menu = RepoSectionView.remoteSessionMenuProviders(providers: both, claudeCloudEnabled: false)
-        let rowMenu = WorktreeRowView.remoteSessionMenuProviders(
-            providers: both, claudeCloudEnabled: false, isMain: false)
-        let picker = CloudCreateEntryPresentation.pickerProviders(both, claudeCloudEnabled: false)
-        let header = RemoteProviderHeaderRow.canCreate(provider: cloudEntry(in: both), claudeCloudEnabled: false)
-
-        #expect(!menu.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(!rowMenu.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(!picker.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(!header)
+    /// Whether each of the four entry-yielding surfaces offers a cloud entry,
+    /// in a fixed order so a failing `#expect` names which one diverged.
+    private func entriesShown(
+        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+    ) -> [String: Bool] {
+        [
+            "repo + picker": WorktreeProfilePickerView.cloudLaneEntry(
+                providers: providers, claudeCloudEnabled: claudeCloudEnabled,
+                parentWorktreeID: nil) != nil,
+            "nested + picker": WorktreeProfilePickerView.cloudLaneEntry(
+                providers: providers, claudeCloudEnabled: claudeCloudEnabled,
+                parentWorktreeID: UUID()) != nil,
+            "repo context menu": RepoSectionView.cloudSessionMenuEntry(
+                providers: providers, claudeCloudEnabled: claudeCloudEnabled) != nil,
+            "worktree row context menu": WorktreeRowView.cloudSessionMenuEntry(
+                providers: providers, claudeCloudEnabled: claudeCloudEnabled,
+                isMain: false) != nil,
+        ]
     }
 
-    /// Flag on, healthy provider: all four surfaces must agree it is shown.
-    @Test func allFourSurfacesAgreeTheCloudRowIsShownWhenTheFlagIsOnAndHealthy() {
-        let menu = RepoSectionView.remoteSessionMenuProviders(providers: both, claudeCloudEnabled: true)
-        let rowMenu = WorktreeRowView.remoteSessionMenuProviders(
-            providers: both, claudeCloudEnabled: true, isMain: false)
-        let picker = CloudCreateEntryPresentation.pickerProviders(both, claudeCloudEnabled: true)
-        let header = RemoteProviderHeaderRow.canCreate(provider: cloudEntry(in: both), claudeCloudEnabled: true)
+    /// Flag off: all five entries must agree the cloud entry is hidden.
+    @Test func allFiveEntriesAgreeTheCloudRowIsHiddenWhenTheFlagIsOff() {
+        for (surface, shown) in entriesShown(both, claudeCloudEnabled: false) {
+            #expect(!shown, "\(surface) still offers the cloud entry with the flag off")
+        }
+        #expect(!RemoteProviderHeaderRow.canCreate(
+            provider: cloudStatus(in: both), claudeCloudEnabled: false))
+    }
 
-        #expect(menu.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(rowMenu.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(picker.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(header)
+    /// Flag on, healthy provider: all five entries must agree it is shown.
+    @Test func allFiveEntriesAgreeTheCloudRowIsShownWhenTheFlagIsOnAndHealthy() {
+        for (surface, shown) in entriesShown(both, claudeCloudEnabled: true) {
+            #expect(shown, "\(surface) hides the cloud entry with the flag on and healthy")
+        }
+        #expect(RemoteProviderHeaderRow.canCreate(
+            provider: cloudStatus(in: both), claudeCloudEnabled: true))
     }
 
     /// Flipped-on-without-restart: the daemon never registered the provider,
-    /// so it is simply absent from `providers` — both surfaces that can be
+    /// so it is simply absent from `providers` — every surface that can be
     /// checked against an empty registration must show nothing rather than
-    /// inventing a row.
-    @Test func menuAndPickerShowNothingWhenTheProviderWasNeverRegistered() {
+    /// inventing a row, with no flag dependence.
+    @Test func everyEntryShowsNothingWhenTheProviderWasNeverRegistered() {
         let onlyAcme = [status("acme")]
-        let menu = RepoSectionView.remoteSessionMenuProviders(providers: onlyAcme, claudeCloudEnabled: true)
-        let rowMenu = WorktreeRowView.remoteSessionMenuProviders(
-            providers: onlyAcme, claudeCloudEnabled: true, isMain: false)
-        let picker = CloudCreateEntryPresentation.pickerProviders(onlyAcme, claudeCloudEnabled: true)
-
-        #expect(!menu.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(!rowMenu.contains { $0.config.name == ClaudeCloudProvider.name })
-        #expect(!picker.contains { $0.config.name == ClaudeCloudProvider.name })
+        for flag in [true, false] {
+            for (surface, shown) in entriesShown(onlyAcme, claudeCloudEnabled: flag) {
+                #expect(!shown, "\(surface) invented a cloud entry for an unregistered provider")
+            }
+        }
         // No header assertion here: `RemoteSectionView` only ever renders a
         // header for a provider present in `appState.remoteProviders`
         // (`ForEach(appState.remoteProviders, ...)`), so there is no
         // `RemoteProviderStatus` to call `canCreate` with in this state.
     }
 
-    /// The one documented divergence: a STALE cloud provider is disabled
-    /// (not omitted) by the two context menus and the header's `+`, but
-    /// OMITTED by the picker. The picker's remote-lane row does render other stale providers
-    /// disabled; the cloud entry keeps the narrower gate because a create it
-    /// cannot serve is worth no row at all. Pinning this as a deliberate
-    /// divergence — rather than asserting the three must always agree —
-    /// catches a future change that makes them agree the wrong way.
-    @Test func staleInventoryDivergesByDesignBetweenThePickerAndTheOthers() {
-        let stale = [status("acme"), status(ClaudeCloudProvider.name, health: .stale, freshnessUnreadable: true)]
-        let menu = RepoSectionView.remoteSessionMenuProviders(providers: stale, claudeCloudEnabled: true)
-        let rowMenu = WorktreeRowView.remoteSessionMenuProviders(
-            providers: stale, claudeCloudEnabled: true, isMain: false)
-        let picker = CloudCreateEntryPresentation.pickerProviders(stale, claudeCloudEnabled: true)
-        let header = RemoteProviderHeaderRow.canCreate(provider: cloudEntry(in: stale), claudeCloudEnabled: true)
+    /// Staleness converges: every surface SHOWS the entry and renders it
+    /// disabled, because the row is not only a button — it is also the menu's
+    /// statement about what exists, and a transient outage is no reason to
+    /// retract a true statement.
+    @Test func everyEntryShowsAStaleCloudProviderSoEachSurfaceCanDisableIt() {
+        let stale = [status("acme"),
+                     status(ClaudeCloudProvider.name, health: .stale, freshnessUnreadable: true)]
+        #expect(cloudStatus(in: stale).hasStaleSnapshot)
+        for (surface, shown) in entriesShown(stale, claudeCloudEnabled: true) {
+            let why = "\(surface) withdrew the cloud entry on a stale snapshot, "
+                + "instead of showing it disabled"
+            #expect(shown, "\(why)")
+        }
+        #expect(RemoteProviderHeaderRow.canCreate(
+            provider: cloudStatus(in: stale), claudeCloudEnabled: true),
+                "the header's + still renders for a stale provider — it disables the button instead")
+    }
 
-        #expect(menu.contains { $0.config.name == ClaudeCloudProvider.name },
-                "the menu still lists a stale provider — it disables the row instead of omitting it")
-        #expect(rowMenu.contains { $0.config.name == ClaudeCloudProvider.name },
-                "the worktree row's menu disables a stale provider too, rather than omitting it")
-        #expect(header, "the header's + still renders for a stale provider — it disables the button instead")
-        #expect(!picker.contains { $0.config.name == ClaudeCloudProvider.name },
-                "a stale cloud provider is omitted from the picker, not offered and disabled")
+    /// A registry provider is unaffected by the flag in every state.
+    @Test func aRegistryProviderIsUnaffectedByTheCloudFlag() {
+        for flag in [true, false] {
+            #expect(RepoSectionView.remoteSessionMenuProviders(providers: both)
+                .map(\.config.name) == ["acme"])
+            #expect(WorktreeRowView.remoteSessionMenuProviders(providers: both, isMain: false)
+                .map(\.config.name) == ["acme"])
+            #expect(RemoteProviderHeaderRow.canCreate(
+                provider: status("acme"), claudeCloudEnabled: flag))
+        }
+    }
+
+    /// The cloud provider never appears in any surface's generic enumeration,
+    /// at either flag value — a shortcut that duplicated one entry of a list
+    /// would teach that the list is incomplete somewhere else too.
+    @Test func theCloudProviderNeverAppearsInAGenericEnumeration() {
+        #expect(!WorktreeProfilePickerView.registryLaneProviders(both)
+            .contains { $0.config.name == ClaudeCloudProvider.name })
+        #expect(!RepoSectionView.remoteSessionMenuProviders(providers: both)
+            .contains { $0.config.name == ClaudeCloudProvider.name })
+        #expect(!WorktreeRowView.remoteSessionMenuProviders(providers: both, isMain: false)
+            .contains { $0.config.name == ClaudeCloudProvider.name })
+        #expect(!CloudCreateEntryPresentation.registryProviders(both)
+            .contains { $0.config.name == ClaudeCloudProvider.name })
     }
 }

--- a/Tests/TBDAppTests/RepoSectionRemoteSessionsTests.swift
+++ b/Tests/TBDAppTests/RepoSectionRemoteSessionsTests.swift
@@ -200,3 +200,95 @@ struct RepoSectionRemoteSessionsTests {
         #expect(result.map(\.payload.id) == ["whole", "fractional"])
     }
 }
+
+/// Covers the two gates behind the repo context menu's create items —
+/// `RepoSectionView.remoteSessionMenuProviders(providers:)` for the generic
+/// "New Remote Session…" item, and
+/// `cloudSessionMenuEntry(providers:claudeCloudEnabled:)` for the compiled
+/// provider's "New Cloud Session…" item beside it. Both are pure, view-free
+/// forms of what the menu renders, so every branch is decided somewhere a
+/// test can reach without an `AppState` or a view hierarchy.
+@Suite("RepoSectionView — remote create menu items")
+struct RepoSectionRemoteCreateMenuTests {
+
+    private func provider(
+        _ name: String, health: ProviderHealth = .ok, freshnessUnreadable: Bool = false
+    ) -> RemoteProviderStatus {
+        RemoteProviderStatus(
+            config: RemoteProviderConfig(name: name, exec: "/usr/bin/true"),
+            describe: ProviderDescribe(contractVersions: [2], name: name, capabilities: ["send"]),
+            health: health, errorMessage: nil, remediationLabel: nil, remediationCommand: nil,
+            freshnessUnreadable: freshnessUnreadable)
+    }
+
+    private var both: [RemoteProviderStatus] {
+        [provider("acme"), provider(ClaudeCloudProvider.name)]
+    }
+
+    private func names(_ providers: [RemoteProviderStatus]) -> [String] {
+        RepoSectionView.remoteSessionMenuProviders(providers: providers).map(\.config.name)
+    }
+
+    private func cloudName(
+        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool
+    ) -> String? {
+        RepoSectionView.cloudSessionMenuEntry(
+            providers: providers, claudeCloudEnabled: claudeCloudEnabled)?.config.name
+    }
+
+    // MARK: - the generic item enumerates registry providers only
+
+    /// No provider registered → the item is omitted whole, not shown disabled.
+    @Test func noRegisteredProviderLeavesNothingToOffer() {
+        #expect(names([]).isEmpty)
+    }
+
+    @Test func registryProvidersFillTheItemInOrder() {
+        #expect(names([provider("acme"), provider("widgets")]) == ["acme", "widgets"])
+    }
+
+    /// The compiled provider has an item of its own, so it is never a member
+    /// of this enumeration — which is also what keeps the one-versus-many
+    /// count (button versus submenu) a count of registry providers.
+    @Test func theCloudProviderIsNeverListedInTheGenericItem() {
+        #expect(names(both) == ["acme"])
+        #expect(names([provider(ClaudeCloudProvider.name)]).isEmpty)
+    }
+
+    /// A stale registry provider keeps its row — the view disables it.
+    @Test func aStaleRegistryProviderIsStillListed() {
+        let stale = provider("acme", health: .stale, freshnessUnreadable: true)
+        #expect(stale.hasStaleSnapshot)
+        #expect(names([stale]) == ["acme"])
+    }
+
+    // MARK: - the cloud item's own gate
+
+    @Test func theCloudItemIsOmittedWhenTheFlagIsOff() {
+        #expect(cloudName(both, claudeCloudEnabled: false) == nil)
+    }
+
+    /// The discriminating half: with the flag on the item is offered, so the
+    /// gate did not simply delete it.
+    @Test func theCloudItemIsOfferedWhenTheFlagIsOn() {
+        #expect(cloudName(both, claudeCloudEnabled: true) == ClaudeCloudProvider.name)
+    }
+
+    /// The flipped-on-without-restart state: the daemon never registered the
+    /// provider, so there is nothing to offer whichever way the flag points.
+    @Test func theCloudItemIsOmittedWhenTheProviderWasNeverRegistered() {
+        for flag in [true, false] {
+            #expect(cloudName([provider("acme")], claudeCloudEnabled: flag) == nil)
+        }
+    }
+
+    /// Staleness disables rather than withdraws: the item stays so the menu
+    /// can name its own reason, exactly as the generic item does for a stale
+    /// registry provider.
+    @Test func aStaleCloudProviderStillOffersItsItem() {
+        let stale = provider(ClaudeCloudProvider.name, health: .stale, freshnessUnreadable: true)
+        #expect(stale.hasStaleSnapshot)
+        #expect(cloudName([provider("acme"), stale], claudeCloudEnabled: true)
+            == ClaudeCloudProvider.name)
+    }
+}

--- a/Tests/TBDAppTests/WorktreeProfilePickerRemoteLaneTests.swift
+++ b/Tests/TBDAppTests/WorktreeProfilePickerRemoteLaneTests.swift
@@ -3,13 +3,16 @@ import Foundation
 @testable import TBDApp
 import TBDShared
 
-/// Covers the `+` menu's remote-lane entry point —
-/// `WorktreeProfilePickerView.remoteLaneOffer(providers:parentWorktreeID:)`
-/// and the copy helpers that hang off its result. Every gating branch the row
-/// has (no provider / one / several, stale provider) is decided here, so it is
-/// decided in a place a test can reach without an `AppState` or a view
-/// hierarchy — including the fact that the nested `+` is no longer a gate.
-@Suite("WorktreeProfilePickerView — remote lane row")
+/// Covers the `+` menu's two create entry points — the generic remote-lane
+/// row (`WorktreeProfilePickerView.remoteLaneOffer(providers:parentWorktreeID:)`
+/// over `registryLaneProviders`) and the compiled cloud provider's own row
+/// (`cloudLaneEntry(providers:claudeCloudEnabled:parentWorktreeID:)`) — plus
+/// the copy helpers that hang off their results. Every gating branch the two
+/// rows have (no provider / one / several, the cloud flag, stale provider) is
+/// decided here, so it is decided in a place a test can reach without an
+/// `AppState` or a view hierarchy — including the fact that the nested `+` is
+/// not a gate on either.
+@Suite("WorktreeProfilePickerView — remote lane rows")
 struct WorktreeProfilePickerRemoteLaneTests {
 
     private func provider(
@@ -158,20 +161,38 @@ struct WorktreeProfilePickerRemoteLaneTests {
     // MARK: - header copy follows the row
 
     /// "New worktree with…" stops being true once the page can also start a
-    /// provider session, so the title widens exactly when the row is offered —
-    /// and stays narrow (the nested `+`, or no provider) when it is not.
-    @Test func headerNamesOnlyWorktreesWhenNoRemoteRowIsOffered() {
-        #expect(WorktreeProfilePickerView.profilesPageTitle(offer: .hidden) == "New worktree with…")
+    /// provider session, so the title widens exactly when EITHER row is
+    /// offered — and stays narrow only when neither is.
+    @Test func headerNamesOnlyWorktreesWhenNeitherRowIsOffered() {
+        #expect(WorktreeProfilePickerView.profilesPageTitle(offer: .hidden, hasCloudEntry: false)
+            == "New worktree with…")
     }
 
     @Test func headerNamesRemoteSessionsForASingleProvider() {
-        #expect(WorktreeProfilePickerView.profilesPageTitle(offer: .single(provider(name: "acme")))
+        #expect(WorktreeProfilePickerView.profilesPageTitle(
+            offer: .single(provider(name: "acme")), hasCloudEntry: false)
             == "New worktree or remote session…")
     }
 
     @Test func headerNamesRemoteSessionsForSeveralProviders() {
         #expect(WorktreeProfilePickerView.profilesPageTitle(
-            offer: .chooseProvider([provider(name: "acme"), provider(name: "acme-prod")]))
+            offer: .chooseProvider([provider(name: "acme"), provider(name: "acme-prod")]),
+            hasCloudEntry: false)
+            == "New worktree or remote session…")
+    }
+
+    /// The cloud row is not a member of the offer, so it has to widen the
+    /// title on its own — a page whose only non-worktree row is the cloud one
+    /// would otherwise be headed "New worktree with…" while offering a
+    /// provider session.
+    @Test func headerNamesRemoteSessionsForTheCloudRowAlone() {
+        #expect(WorktreeProfilePickerView.profilesPageTitle(offer: .hidden, hasCloudEntry: true)
+            == "New worktree or remote session…")
+    }
+
+    @Test func headerNamesRemoteSessionsWhenBothRowsAreOffered() {
+        #expect(WorktreeProfilePickerView.profilesPageTitle(
+            offer: .single(provider(name: "acme")), hasCloudEntry: true)
             == "New worktree or remote session…")
     }
 
@@ -242,5 +263,79 @@ struct WorktreeProfilePickerRemoteLaneTests {
             == "acme…")
         #expect(WorktreeProfilePickerView.providerRowTitle(provider(name: "acme"), opensForm: false)
             == "acme")
+    }
+
+    // MARK: - the cloud row is a sibling, never a member
+
+    /// The generic row enumerates the providers the user configured
+    /// themselves; the compiled provider has a row of its own and is never a
+    /// member of that list.
+    @Test func theCloudProviderIsNeverInTheGenericEnumeration() {
+        let mixed = [provider(name: "acme"), provider(name: ClaudeCloudProvider.name)]
+        #expect(WorktreeProfilePickerView.registryLaneProviders(mixed).map(\.config.name)
+            == ["acme"])
+    }
+
+    /// And so the one-versus-many decision counts registry providers only:
+    /// cloud plus one configured provider is still the single-provider shape.
+    @Test func theOfferCountsRegistryProvidersOnly() {
+        let mixed = [provider(name: "acme"), provider(name: ClaudeCloudProvider.name)]
+        #expect(describeOffer(WorktreeProfilePickerView.remoteLaneOffer(
+            providers: WorktreeProfilePickerView.registryLaneProviders(mixed),
+            parentWorktreeID: nil)) == ("single", ["acme"]))
+    }
+
+    @Test func theCloudRowIsOmittedWhenTheFlagIsOff() {
+        let mixed = [provider(name: "acme"), provider(name: ClaudeCloudProvider.name)]
+        #expect(WorktreeProfilePickerView.cloudLaneEntry(
+            providers: mixed, claudeCloudEnabled: false, parentWorktreeID: nil) == nil)
+    }
+
+    /// The discriminating half: with the flag on the row is offered.
+    @Test func theCloudRowIsOfferedWhenTheFlagIsOn() {
+        let mixed = [provider(name: "acme"), provider(name: ClaudeCloudProvider.name)]
+        #expect(WorktreeProfilePickerView.cloudLaneEntry(
+            providers: mixed, claudeCloudEnabled: true, parentWorktreeID: nil)?
+            .config.name == ClaudeCloudProvider.name)
+    }
+
+    /// Nesting is TBD-side filing, which the remote side neither knows nor
+    /// needs to know about — so the nested `+` offers the cloud row on exactly
+    /// the same terms as the repo header does.
+    @Test func theNestedPlusOffersTheCloudRowToo() {
+        let mixed = [provider(name: "acme"), provider(name: ClaudeCloudProvider.name)]
+        #expect(WorktreeProfilePickerView.cloudLaneEntry(
+            providers: mixed, claudeCloudEnabled: true, parentWorktreeID: UUID())?
+            .config.name == ClaudeCloudProvider.name)
+    }
+
+    /// A stale cloud provider keeps its row, which `remoteProviderRow` then
+    /// renders disabled and subtitled with its reason — the row is the menu's
+    /// statement that the capability exists, and a transient outage is no
+    /// reason to retract it.
+    @Test func aStaleCloudProviderKeepsItsRow() {
+        let stale = provider(name: ClaudeCloudProvider.name, health: .needsAuth,
+                             lastSuccessfulSnapshotAt: Date())
+        #expect(stale.hasStaleSnapshot)
+        #expect(WorktreeProfilePickerView.cloudLaneEntry(
+            providers: [provider(name: "acme"), stale],
+            claudeCloudEnabled: true, parentWorktreeID: nil)?
+            .config.name == ClaudeCloudProvider.name)
+        #expect(WorktreeProfilePickerView.providerRowSubtitle(stale)
+            == "Unavailable — inventory is stale")
+    }
+
+    // MARK: - the cloud row's ellipsis is the same promise
+
+    /// Special in placement, not in behavior: the cloud row makes the ellipsis
+    /// promise on exactly the terms every other acting row does.
+    @Test func theCloudRowKeepsItsEllipsisWhenSelectingItOpensTheForm() {
+        #expect(WorktreeProfilePickerView.cloudLaneRowTitle(opensForm: true)
+            == "New cloud session…")
+    }
+
+    @Test func theCloudRowDropsItsEllipsisWhenSelectingItCreatesOutright() {
+        #expect(WorktreeProfilePickerView.cloudLaneRowTitle(opensForm: false)
+            == "New cloud session")
     }
 }

--- a/Tests/TBDAppTests/WorktreeRowRemoteSessionMenuTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowRemoteSessionMenuTests.swift
@@ -3,15 +3,17 @@ import Foundation
 @testable import TBDApp
 import TBDShared
 
-/// Covers `WorktreeRowView.remoteSessionMenuProviders(providers:claudeCloudEnabled:isMain:)`
-/// — the gate behind the worktree row's "New Remote Session…" context-menu
-/// item, which is the always-opens-the-form twin of the nested `+`'s
-/// remote-lane row. Every branch the item has (no provider / one / several,
-/// the cloud filter, the main-row gate, staleness) is decided here, so it is
-/// decided somewhere a test can reach without an `AppState` or a view
-/// hierarchy — the same treatment `RepoSectionView.remoteSessionMenuProviders`
-/// gets for the repo header's copy of the item.
-@Suite("WorktreeRowView — New Remote Session menu item")
+/// Covers the two gates behind the worktree row's create context-menu items —
+/// `WorktreeRowView.remoteSessionMenuProviders(providers:isMain:)` for the
+/// generic "New Remote Session…" item and
+/// `cloudSessionMenuEntry(providers:claudeCloudEnabled:isMain:)` for the
+/// compiled provider's "New Cloud Session…" item beside it. The two are the
+/// always-opens-the-form twins of the nested `+`'s two lane rows. Every branch
+/// they have (no provider / one / several, the cloud flag, the main-row gate,
+/// staleness) is decided here, so it is decided somewhere a test can reach
+/// without an `AppState` or a view hierarchy — the same treatment
+/// `RepoSectionView`'s copies of the two items get.
+@Suite("WorktreeRowView — remote create menu items")
 struct WorktreeRowRemoteSessionMenuTests {
 
     private func provider(
@@ -33,11 +35,18 @@ struct WorktreeRowRemoteSessionMenuTests {
     }
 
     private func names(
-        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool = true, isMain: Bool = false
+        _ providers: [RemoteProviderStatus], isMain: Bool = false
     ) -> [String] {
-        WorktreeRowView.remoteSessionMenuProviders(
-            providers: providers, claudeCloudEnabled: claudeCloudEnabled, isMain: isMain)
+        WorktreeRowView.remoteSessionMenuProviders(providers: providers, isMain: isMain)
             .map(\.config.name)
+    }
+
+    private func cloudName(
+        _ providers: [RemoteProviderStatus], claudeCloudEnabled: Bool = true, isMain: Bool = false
+    ) -> String? {
+        WorktreeRowView.cloudSessionMenuEntry(
+            providers: providers, claudeCloudEnabled: claudeCloudEnabled, isMain: isMain)?
+            .config.name
     }
 
     // MARK: - the provider-registered gate
@@ -60,48 +69,77 @@ struct WorktreeRowRemoteSessionMenuTests {
         #expect(names([provider("acme"), provider("widgets")]) == ["acme", "widgets"])
     }
 
-    /// The fast-path count must be read off the FILTERED list: with the flag
-    /// off and cloud plus one registry provider on file, the item must be the
-    /// one-provider shape, not a two-entry submenu with a dead row.
-    @Test func theFastPathIsDecidedAfterTheCloudFilter() {
-        #expect(names(both, claudeCloudEnabled: false) == ["acme"])
-        #expect(names(both, claudeCloudEnabled: true).count == 2)
+    /// The one-versus-many count is a count of REGISTRY providers: with cloud
+    /// plus one configured provider on file, the generic item must be the
+    /// one-provider shape, because cloud is not one of its members.
+    @Test func theFastPathCountsRegistryProvidersOnly() {
+        #expect(names(both) == ["acme"])
+        #expect(names([provider("acme"), provider("widgets"),
+                       provider(ClaudeCloudProvider.name)]).count == 2)
     }
 
-    // MARK: - the cloud gate
+    // MARK: - the cloud item is a sibling, never a member
 
-    @Test func theCloudProviderIsOmittedWhenTheFlagIsOff() {
-        #expect(!names(both, claudeCloudEnabled: false).contains(ClaudeCloudProvider.name))
+    /// The compiled provider has an item of its own, so it never appears in
+    /// the generic enumeration — surfacing it in both would make the count
+    /// above ambiguous at exactly the moment it decides button versus submenu.
+    @Test func theCloudProviderIsNeverListedInTheGenericItem() {
+        #expect(!names(both).contains(ClaudeCloudProvider.name))
     }
 
-    /// The discriminating half: the filter does not simply always drop it.
-    @Test func theCloudProviderIsListedWhenTheFlagIsOn() {
-        #expect(names(both, claudeCloudEnabled: true).contains(ClaudeCloudProvider.name))
+    @Test func theCloudItemIsOmittedWhenTheFlagIsOff() {
+        #expect(cloudName(both, claudeCloudEnabled: false) == nil)
+    }
+
+    /// The discriminating half: the gate does not simply always drop it.
+    @Test func theCloudItemIsOfferedWhenTheFlagIsOn() {
+        #expect(cloudName(both, claudeCloudEnabled: true) == ClaudeCloudProvider.name)
+    }
+
+    @Test func theCloudItemIsOmittedWhenTheProviderWasNeverRegistered() {
+        #expect(cloudName([provider("acme")], claudeCloudEnabled: true) == nil)
+    }
+
+    /// The cloud flag is not the generic item's business in either direction.
+    @Test func theGenericItemIsUnaffectedByTheCloudFlag() {
+        #expect(names(both) == ["acme"])
+        #expect(names([provider("acme")]) == ["acme"])
     }
 
     // MARK: - the main-row gate
 
     /// The main worktree is the repo's checkout, not a parent to nest under —
-    /// the nested `+` is withheld from that row, and so is this item.
-    @Test func theMainRowOffersNoRemoteSessionItem() {
+    /// the nested `+` is withheld from that row, and so are BOTH items.
+    @Test func theMainRowOffersNeitherCreateItem() {
         #expect(names(both, isMain: true).isEmpty)
         #expect(names([provider("acme")], isMain: true).isEmpty)
+        #expect(cloudName(both, isMain: true) == nil)
     }
 
     /// The discriminating half: the same providers on an ordinary row DO
-    /// produce the item, so `isMain` gates rather than disables everything.
-    @Test func anOrdinaryRowOffersTheItemForTheSameProviders() {
-        #expect(names(both, isMain: false).count == 2)
+    /// produce both items, so `isMain` gates rather than disables everything.
+    @Test func anOrdinaryRowOffersBothItemsForTheSameProviders() {
+        #expect(names(both, isMain: false) == ["acme"])
+        #expect(cloudName(both, isMain: false) == ClaudeCloudProvider.name)
     }
 
     // MARK: - staleness disables, it does not omit
 
-    /// A stale provider keeps its row (the view disables it) rather than
-    /// vanishing — the same divergence from the `+` picker that the repo
-    /// header's item has.
+    /// A stale provider keeps its item (the view disables it) rather than
+    /// vanishing — the menu's statement that the provider exists is worth
+    /// keeping through a transient outage.
     @Test func aStaleProviderIsStillListedSoTheRowCanExplainItself() {
         let stale = provider("acme", health: .stale, freshnessUnreadable: true)
         #expect(stale.hasStaleSnapshot)
         #expect(names([stale]) == ["acme"])
+    }
+
+    /// And the cloud item converges on that: staleness disables it, exactly
+    /// as it disables a stale registry provider's row, rather than
+    /// withdrawing the entry.
+    @Test func aStaleCloudProviderStillOffersItsItem() {
+        let stale = provider(ClaudeCloudProvider.name, health: .stale, freshnessUnreadable: true)
+        #expect(stale.hasStaleSnapshot)
+        #expect(cloudName([provider("acme"), stale]) == ClaudeCloudProvider.name)
     }
 }

--- a/docs/specs/2026-08-27-remote-create-menu-entries-design.md
+++ b/docs/specs/2026-08-27-remote-create-menu-entries-design.md
@@ -1,0 +1,180 @@
+# Remote create menu entries: a named place, and a list you configured
+
+TBD can start an agent session somewhere other than this machine. Two kinds of
+"somewhere" exist, and they are not the same kind of thing:
+
+- **The compiled Claude Cloud provider.** TBD ships it. A user who has turned
+  `claude_cloud_enabled` on did so by name, and comes to the `+` menu looking
+  for the thing they enabled.
+- **A registry provider.** The user wrote it into `~/tbd/agent-providers.json`
+  themselves. They already know its name, because they chose it.
+
+This document fixes how the create surfaces present those two. The short form:
+**the cloud provider gets an entry of its own, and is not a member of the
+generic enumeration.** Everything else about the two entries — when they act
+outright, when they ask first, what they do when the provider is unhealthy,
+whether they may nest — is identical.
+
+Scope is presentation. No flag, no migration, and no config column: this is how
+existing create paths are offered, over the existing default-off
+`claude_cloud_enabled`.
+
+## Why cloud is not just another row
+
+A single generic row can name the cloud provider — with one provider
+registered, the row's subtitle carries the negotiated `describe` name, so
+"Run on Claude Cloud" does appear. That is enough to identify the row once you
+are reading it closely, and not enough for the job the row has.
+
+The menu is scanned, not read. A user who enabled a feature called Claude Cloud
+is looking for the word they enabled, in the position a title occupies. Making
+them infer it from a subtitle under a generic title spends their attention to
+save a row. Worse, the inference fails exactly when the fleet grows: add one
+registry provider and the subtitle stops naming any provider at all — it
+becomes "Choose a provider", and the only path to cloud is a drill-in page the
+user has no reason to expect it behind.
+
+The generic row earns its generic title for the opposite reason. Its members
+are user-authored; the user's own config file is the authority on what they are
+called, and TBD enumerating them is the whole service it provides.
+
+So the two entries are siblings, never nested inside one another. Cloud is
+filtered **out** of the generic list rather than surfaced twice: a shortcut that
+duplicates one entry of a list teaches that the list is incomplete somewhere
+else too, and it makes "how many providers are there" ambiguous at exactly the
+moment the count decides whether the generic row drills in.
+
+## The gates
+
+Three named functions in `CloudCreateEntryPresentation`, and no surface derives
+a gate inline:
+
+- **`registryProviders(_:)`** — every provider except the compiled cloud one.
+  This is what the generic row and both context-menu submenus enumerate. It
+  does not consult `claudeCloudEnabled`: cloud is never in this list, so the
+  flag has nothing to say about it.
+- **`cloudEntry(_:claudeCloudEnabled:)`** — the compiled provider when the flag
+  is on and the daemon registered it; nil otherwise. A stale snapshot does
+  **not** withdraw it (see "Staleness disables" below).
+- **`offersCreate(provider:claudeCloudEnabled:)`** — the per-provider verdict
+  the Remote section's provider header row needs for its own `+`: true for
+  every provider except the cloud one with the flag off.
+
+The flag check lives in the last two and nowhere else. Its subject is narrow
+and worth stating: a provider that was never registered is already absent from
+`remoteProviders` and needs no filtering. What the flag covers is a daemon that
+**booted** with `claude_cloud_enabled` on and a user who has since turned it
+off — the provider is still registered, and every one of its verbs is refused
+by the daemon's inner gate. An entry that can only fail is what
+omit-don't-disable exists to prevent.
+
+## Five entries, four surfaces
+
+- **Repo-header `+` picker** — cloud row, then generic row, both in the top
+  group above the profile list.
+- **Nested worktree-row `+` picker** — the same pair. Cloud nests; see
+  "Nesting" below.
+- **Repo context menu** — a "New Cloud Session…" item beside the existing "New
+  Remote Session…" item (which becomes a submenu at two or more registry
+  providers).
+- **Worktree-row context menu** — the same pair, behind that row's existing
+  `isMain` gate. The main worktree is the repo's checkout, not a parent to nest
+  under, so it offers neither.
+- **Remote section provider header row** — its own `+`, gated per provider by
+  `offersCreate`.
+
+The pairing is what makes the split safe: because a cloud entry accompanies the
+generic one on every surface that had a generic one, removing cloud from the
+enumeration takes nothing away.
+
+## Both entries behave alike
+
+**The ellipsis is a promise, kept exactly when it is made.** A row that will
+open the create form carries a trailing "…"; a row that will create outright
+carries none. The decision comes from `RemoteCreateFormLogic
+.willCreateImmediately`, asked with the same inputs the click itself uses, so
+the label and the action cannot disagree. The cloud row obeys this like any
+other — it is special in placement, not in behavior.
+
+A row that drills into the provider list never spends the ellipsis on that
+fact: its trailing chevron already says so, and the provider chosen on the next
+page may create outright. Each row on that page then makes the promise for
+itself.
+
+**One provider acts directly.** The generic row with exactly one registry
+provider *is* that provider — its name in the subtitle, selecting it starts the
+session. A page containing a single row asks the user to confirm a choice they
+had no alternative to. The drill-in exists to disambiguate, so it appears when
+there is something to disambiguate.
+
+**The `+` menu's rows are the one-click path; the context-menu items always
+open the form.** That asymmetry is deliberate: a
+nested lane created one-click has no other surface on which to type a prompt or
+pick a branch, so the context menu keeps an always-asks entry point next to the
+sometimes-acts one.
+
+## Staleness disables, never withdraws
+
+A provider whose inventory snapshot is stale keeps its row on every surface,
+rendered disabled and subtitled "Unavailable — inventory is stale". This holds
+for the cloud entry and for registry providers alike.
+
+Omit-don't-disable is the convention for capabilities **this install does not
+have**, where a row would advertise something untrue. Staleness is a transient
+state of a capability the install *does* have. To a user hunting for a provider
+they know is configured, absence reads as "TBD dropped support for this" — an
+error that is both wrong and unrecoverable from inside the menu, because there
+is nothing left to click and no text explaining anything. A dimmed row naming
+its own reason costs one line and answers the question.
+
+**Rejected: withdrawing the cloud entry on staleness** on the grounds that the
+daemon would refuse the create with "inventory is stale", so a row leading to a
+guaranteed error is worth no row. The premise is true and the conclusion does
+not follow: the row is not only a button, it is also the menu's statement about
+what exists. Suppressing it suppresses a true statement to avoid an error the
+row can simply decline to commit.
+
+**Rejected: withdrawing every stale provider,** harmonising the other
+direction. Same objection, applied more widely, and it can empty the menu of
+remote entries entirely during a transient outage.
+
+## Nesting
+
+`parentWorktreeID` is not a gate on either entry. The nested `+` promises the
+new lane nests under that worktree, and the create path keeps that promise:
+`RemoteCreateParams.parentWorktreeID` carries the click through to adoption.
+
+**Rejected: cloud sessions on the repo header only,** on the theory that a
+cloud session is created against a repository and not beneath a lane. That
+describes a limitation of one implementation of one provider, not a property of
+remote sessions. Nesting is TBD-side filing — where the row appears in the
+user's tree — and the remote side neither knows nor needs to know about it. A
+provider that genuinely could not be filed under a parent would be saying
+something about TBD's tree, which is not a thing a provider gets to say.
+
+## Testing
+
+The cross-surface parity suite is the load-bearing test, and it exists because
+these gates are duplicated across surfaces that are easy to edit one at a time.
+It covers five entries rather than four, and asserts the same verdict from each
+for a given (providers, flag, staleness) input:
+
+- Flag off, cloud registered: every surface hides the cloud entry.
+- Flag on, healthy: every surface shows it.
+- Never registered: every surface shows nothing for it, with no flag
+  dependence.
+- Stale: every surface **shows it, disabled** — one verdict, no divergence.
+- A registry provider is unaffected by the flag in every state.
+- Cloud never appears in `registryProviders`, at any flag value.
+
+Both flag branches stay covered, per the repository's rule that a gating
+conditional gets a test per branch.
+
+## Non-goals
+
+Repo-declared remotes and their trust gate, the resolution ladder above tier 1,
+and any change to the create form itself are out of scope. So is the shape of
+the precedence chain that decides whether a click can create outright, which is
+fixed by
+[`2026-08-20-remote-lane-creation-design.md`](2026-08-20-remote-lane-creation-design.md)
+and only consumed here.


### PR DESCRIPTION
## Summary

TBD can start an agent session somewhere other than this machine, and there are
two kinds of "somewhere". The compiled Claude Cloud provider ships with TBD: a
user who turns it on does so by name, and comes to the `+` menu looking for the
thing they enabled. A registry provider is one the user wrote into
`~/tbd/agent-providers.json` themselves — TBD enumerating those is the whole
service the generic entry provides.

Until now the cloud provider was one anonymous member of that generic
enumeration. With it as the only provider you got "New remote session…" with
"Run on Claude Cloud" underneath, which identifies the row once you are reading
it closely. Register one more provider and even that goes: the subtitle becomes
"Choose a provider", and cloud sits behind a drill-in page a user has no reason
to expect it behind.

After this PR the cloud provider has an entry of its own, by name, on every
surface that has a generic one — and it is filtered out of the generic
enumeration rather than duplicated into it.

## Why this shape

Spec: [`docs/specs/2026-08-27-remote-create-menu-entries-design.md`](docs/specs/2026-08-27-remote-create-menu-entries-design.md).

Two rows rather than one, because the menu is scanned rather than read, and
making a user infer the provider they enabled from a subtitle spends their
attention to save a row — in the configuration where it matters most, it does
not even work.

Sibling rows rather than a shortcut into the list. A fast path that duplicates
one member of a list teaches that the list is incomplete somewhere else too,
and it makes "how many providers are there" ambiguous at exactly the moment
that count decides whether the generic row drills in.

**Staleness now disables, never withdraws.** A stale cloud provider used to be
removed from the `+` picker outright, on the reasoning that the daemon would
refuse its create with "inventory is stale", so a row leading to a guaranteed
error was worth no row. The premise is true and the conclusion does not follow:
the row is not only a button, it is also the menu's statement about what
exists. To a user hunting for a provider they know is configured, absence reads
as "TBD dropped support for this" — wrong, and unrecoverable from inside a menu
with nothing left to click. Omit-don't-disable is the convention for
capabilities an install does not have; staleness is a transient state of one it
does. Every provider now keeps its entry, dimmed, naming its own reason.

**Nesting is TBD-side filing, and no provider gets a say in it.** The claim that
a cloud session is "created against a repository, not beneath a lane" described
a limitation of one implementation, not a property of remote sessions.
`RemoteCreateParams.parentWorktreeID` carries the click through to adoption, so
the nested `+` offers the cloud entry on the same terms as everything else.

Also rejected, and recorded in the spec: naming the provider in the generic
row's title instead of giving it a row; always drilling into the provider list
even when there is one provider; making the cloud row always open the create
form; and harmonising staleness the other way by withdrawing every stale
provider.

## What this PR does

- `CloudCreateEntryPresentation` trades three gates for three clearer ones —
  `registryProviders(_:)` (no flag parameter; cloud is never a member),
  `cloudEntry(_:claudeCloudEnabled:)` (staleness no longer withdraws it), and
  `offersCreate(provider:claudeCloudEnabled:)` for the per-provider header row.
  The old names are deleted outright, with no aliases.
- Both `+` pickers — repo header and nested worktree row — gain a cloud row
  above the generic one, with the cloud glyph and its own title.
- Both context menus gain a "New Cloud Session…" item beside the existing "New
  Remote Session…" one. On the worktree row the existing `isMain` gate covers
  both, and the pair now shares one leading divider instead of growing a second.
- `RemoteProviderHeaderRow.canCreate` forwards to `offersCreate` —
  boolean-identical across all four inputs, so the old gates could be removed.
- Behavior is uniform across both entries: the trailing ellipsis promises a
  form and is kept exactly when made, one registry provider still acts directly
  rather than drilling into a single-row page, and a stale provider renders
  disabled with its reason.

Presentation only — no flag, no migration, no config column, no daemon or
shared-model change.

## Evidence & verification

The cross-surface parity suite is the load-bearing test here, because these
gates are duplicated across surfaces that are easy to edit one at a time. It
grows from four surfaces to five entries and calls the `nonisolated static`
function each view body actually calls, rather than re-deriving the decision.
Its staleness case **inverts**: where it previously asserted the picker
diverged from the other surfaces by design, every surface must now agree the
entry is shown and disabled.

Both inverted tests fail against the pre-change code, which returned nil there
— they discriminate rather than merely pass. Both branches of the
`claudeCloudEnabled` conditional stay covered on every surface, along with
never-registered and stale inputs.

`scripts/swift-safe build --build-tests` exits 0; `swiftlint --strict` reports
0 violations across 834 files. All five of the branch's own suites pass. The
full `scripts/test.sh` run exits 1 on 13 issues confined to four suites that
`Tests/CLAUDE.md` names as load-sensitive — the FileWatcher arming flake, a
tier-3 PTY-reaping test with a 60s limit, and two debounce suites reporting
`EventDrivenTestClock: zero registered sleepers`. None reference a symbol this
branch touches; the box was running ~20 concurrent `swift-frontend` processes
throughout, and the branch's own pure-value suites reported passing "after
116.8 seconds", which is the scheduling-latency signature that document
describes.

**Not live-verified.** The machine owner was taking timing measurements while
this was built, so the app was deliberately never restarted and nobody has seen
the new rows on screen. The ellipsis behavior and the stale-disabled state are
the two things a compile cannot confirm read correctly, and both deserve an
eyeball before merge.

[20260827-blind-hedgehog](https://cheapsteak.github.io/tbd/open/?worktree=AA60763B-C905-49F1-BBE4-4A6CA5B02591)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Cloud Session option across worktree menus, repository menus, provider pickers, and provider headers.
  * Generic remote providers are now listed separately from the cloud provider.
  * Unavailable or outdated providers remain visible with disabled states and explanatory labeling.
  * Cloud session creation supports direct creation and nested provider selection where applicable.

* **Documentation**
  * Added a design specification covering cloud and remote-session creation behavior.

* **Tests**
  * Expanded coverage for provider visibility, availability rules, stale providers, and consistency across creation surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->