### PR TITLE
fix: CodeRabbit stops reviewing a branch after five commits, silently

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,6 +21,22 @@ reviews:
     base_branches:
       - ^main$
 
+    # Never stop reviewing a branch part-way through. This defaults to 5,
+    # which pauses automatic review after five reviewed commits and waits for
+    # someone to ask it to resume. That ceiling assumes a human pushing a
+    # handful of commits per PR; work here routinely arrives as long runs of
+    # small agent-authored commits, so the pause would fire mid-branch on
+    # ordinary PRs and the later commits — often the ones carrying review
+    # fixes — would go unreviewed.
+    #
+    # The failure mode is what makes this worth setting rather than living
+    # with: a paused review looks exactly like a clean one. Nothing is posted,
+    # no check fails, and the PR reads as reviewed. This repository has already
+    # been bitten once by CodeRabbit silently declining to review (see the
+    # `base_branches` note above); this is the same shape of trap one setting
+    # over.
+    auto_pause_after_reviewed_commits: 0
+
   # Build products, vendored artifacts, and lockfiles carry no review signal.
   path_filters:
     - "!.build/**"


### PR DESCRIPTION
## What's broken

CodeRabbit stops reviewing a pull request part-way through, and says nothing when it does.

`reviews.auto_review.auto_pause_after_reviewed_commits` defaults to `5`. After five reviewed commits on a branch, automatic review pauses and waits for someone to ask it to resume. Every commit pushed after that point goes unreviewed.

Nobody has hit this yet only because CodeRabbit has been active here for hours, on two short PRs. It will hit routinely: #743 alone carried six commits, and would have gone unreviewed from the sixth onward had the setting been in play across the whole branch rather than a fresh review per push.

## Why it happens

The default encodes an assumption about how commits arrive — a human pushing a handful per PR, where five is a reasonable budget before asking whether the reviewer should keep going. Work in this repository does not arrive that way. It arrives as long runs of small agent-authored commits, and the commits past the fifth are disproportionately the ones that matter for review: they are the fixes written *in response to* review findings on the first five.

What makes it worth changing rather than noting is the failure mode. A paused review is indistinguishable from a clean one — nothing is posted, no check fails, and the PR reads as reviewed. That is the same shape of trap as the bug #743 fixed, one setting over: CodeRabbit silently declining to review while looking like it had.

## What this PR does

Sets `auto_pause_after_reviewed_commits: 0`, the documented value for disabling the pause, with a comment recording why the default does not fit this repository.

No spec: this is review-tooling configuration, not a change to the system's own theory.

## Assumptions

- Assumes the intent is for every commit on a branch to be reviewed, and that the cost of that is acceptable. The setting exists as a spend control, so disabling it means more review runs on long branches. The plan reports included reviews per hour, so the ceiling that actually binds is that quota rather than this counter — if long agent branches start exhausting it, the honest fix is a smaller number here rather than restoring the silent pause.
- Assumes the counter's scope is per-branch, per the documentation's "since the last pause". If it is org-wide, `0` is still correct and the argument for it is stronger.

## Evidence & verification

- **The default and its meaning are from the published schema**, not inferred: `auto_pause_after_reviewed_commits`, default `5`, described as "Pause automatic reviews after this many reviewed commits since the last pause. Set to 0 to disable." `0` is within the schema's stated minimum.
- **The file still validates.** Checked with `jsonschema` against CodeRabbit's `schema.v2.json`, with `base_branches`, `enabled`, and `drafts` confirmed unchanged — an invalid `.coderabbit.yaml` fails silently and would reproduce the exact class of bug this PR is trying to close.
- **This PR does not demonstrate the fix.** It is a single-commit change, so it cannot cross a five-commit threshold. Confirmation is negative and arrives later: a future branch that runs past five commits and still gets reviewed on the sixth.

[🐰 CodeRabbit Setup](https://cheapsteak.github.io/tbd/open/?worktree=9A4E3487-E61A-458F-A124-0549F0C3009A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review settings to review all commits on a branch without pausing after reviewed commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->