### PR TITLE
Fix: A raised hand never comes back down after a permission prompt is answered

### DIFF
--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -854,6 +854,69 @@ public struct TerminalStore: Sendable {
         }
     }
 
+    /// Retract a standing prompt whose transcript no longer matches the
+    /// fingerprint taken when it was recorded, WITHOUT asserting an activity
+    /// state — the same entitlement `clearAwaitingInputReasonIfNotNewer` has,
+    /// for the same reason: this caller knows the prompt is gone, not what the
+    /// session is doing instead.
+    ///
+    /// `expected` is re-checked inside this transaction. The stat that decided
+    /// to call happened outside the database and
+    /// `handleTerminalNotificationEvent` writes on its own connection, so a
+    /// prompt raised in that window carries a fresh fingerprint — and clearing
+    /// it would drop a prompt nobody has answered.
+    ///
+    /// A terminal that vanished between the caller's read and this write
+    /// reports `false` rather than throwing: the callers are read paths.
+    public func clearAwaitingInputReasonIfFingerprintMatches(
+        id: UUID,
+        expected: TranscriptFingerprint
+    ) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString),
+                  let standing = FactColumnJSON.decode(
+                      AwaitingInputReason.self, from: record.awaitingInputReason),
+                  standing.transcriptFingerprint == expected else {
+                return false
+            }
+            record.awaitingInputReason = nil
+            record.awaitingInputObservedAt = nil
+            try record.update(db)
+            return true
+        }
+    }
+
+    /// Attach a fingerprint to a standing prompt that has none — a reason
+    /// recorded before fingerprints existed.
+    ///
+    /// Adoption rather than retraction, because an absent fingerprint says
+    /// nothing about whether the prompt was answered. Adopting makes the row
+    /// answerable to the transcript's next write without inventing a comparison
+    /// against a clock, and it leaves a genuinely pending prompt raised.
+    public func adoptTranscriptFingerprint(
+        id: UUID,
+        fingerprint: TranscriptFingerprint
+    ) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString),
+                  let standing = FactColumnJSON.decode(
+                      AwaitingInputReason.self, from: record.awaitingInputReason),
+                  standing.classification == .promptOnScreen,
+                  standing.transcriptFingerprint == nil else {
+                return false
+            }
+            record.awaitingInputReason = FactColumnJSON.encode(
+                AwaitingInputReason(
+                    message: standing.message,
+                    hookEventName: standing.hookEventName,
+                    raw: standing.raw,
+                    notificationType: standing.notificationType,
+                    transcriptFingerprint: fingerprint))
+            try record.update(db)
+            return true
+        }
+    }
+
     /// Retract a standing wait reason WITHOUT asserting an activity state.
     ///
     /// The mirror of `recordAwaitingInputReason`, and it exists for the same

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -917,6 +917,47 @@ public struct TerminalStore: Sendable {
         }
     }
 
+    /// Move a standing prompt's fingerprint forward to a transcript state that
+    /// only a nested agent wrote.
+    ///
+    /// Deliberately not `adoptTranscriptFingerprint`, which refuses a reason
+    /// that already carries one — a test pins that, because adoption is for a
+    /// row that has never been measured. This is the other case: a measured row
+    /// whose file grew with sidechain records alone, where the prompt still
+    /// stands and the baseline should advance so the next pass costs one stat
+    /// instead of re-reading records already attributed.
+    ///
+    /// Conditional on `expected` for the reason
+    /// `clearAwaitingInputReasonIfFingerprintMatches` is: the stat and the read
+    /// happened outside the database, and `handleTerminalNotificationEvent`
+    /// runs concurrently on its own connection, so a reason recorded in between
+    /// must not have its fingerprint overwritten by a comparison against the
+    /// row this replaced.
+    public func refreshTranscriptFingerprint(
+        id: UUID,
+        expected: TranscriptFingerprint,
+        fingerprint: TranscriptFingerprint
+    ) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString),
+                  let standing = FactColumnJSON.decode(
+                      AwaitingInputReason.self, from: record.awaitingInputReason),
+                  standing.classification == .promptOnScreen,
+                  standing.transcriptFingerprint == expected else {
+                return false
+            }
+            record.awaitingInputReason = FactColumnJSON.encode(
+                AwaitingInputReason(
+                    message: standing.message,
+                    hookEventName: standing.hookEventName,
+                    raw: standing.raw,
+                    notificationType: standing.notificationType,
+                    transcriptFingerprint: fingerprint))
+            try record.update(db)
+            return true
+        }
+    }
+
     /// Retract a standing wait reason WITHOUT asserting an activity state.
     ///
     /// The mirror of `recordAwaitingInputReason`, and it exists for the same

--- a/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
@@ -129,6 +129,7 @@ extension RPCRouter {
             sessionCounters: sessionCounters,
             branchTips: lifecycle.branchTipTracker,
             actuationRecord: ActuationRecordReader(activePath: actuationLog.path),
+            transcriptFingerprinter: transcriptFingerprinter,
             now: now)
         return try RPCResponse(result: await builder.build(facts: facts))
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SupervisionHandlers.swift
@@ -130,6 +130,7 @@ extension RPCRouter {
             branchTips: lifecycle.branchTipTracker,
             actuationRecord: ActuationRecordReader(activePath: actuationLog.path),
             transcriptFingerprinter: transcriptFingerprinter,
+            transcriptDeltaInspector: transcriptDeltaInspector,
             now: now)
         return try RPCResponse(result: await builder.build(facts: facts))
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -555,6 +555,21 @@ extension RPCRouter {
     func handleTerminalList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalListParams.self, from: paramsData)
         var terminals = try await db.terminals.list(worktreeID: params.worktreeID)
+        // Transcript supersession, on the pass that is about to report these
+        // rows. A prompt reason describes a stopped session; a transcript that
+        // changed since the prompt was raised is proof it is not, and no hook
+        // will ever say so — Claude Code fires none when a human answers.
+        // Corrected in the response as well as in the database, so this pass
+        // does not report a prompt it just retracted.
+        // See docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md.
+        let supersession = AwaitingInputSupersession(
+            db: db, fingerprint: transcriptFingerprinter)
+        for index in terminals.indices {
+            guard await supersession.reconcile(terminal: terminals[index]) else { continue }
+            terminals[index].awaitingInputReason = nil
+            terminals[index].awaitingInputObservedAt = nil
+            broadcastAwaitingInputRetraction(terminal: terminals[index])
+        }
         var codexTargets: [CodexTranscriptActivityTracker.Target] = []
         let observedIdentities = Dictionary(uniqueKeysWithValues: terminals
             .filter(\.isCodexTerminal)
@@ -3279,11 +3294,21 @@ extension RPCRouter {
 
         // The classification is a label on the record, computed once here from
         // the verbatim type. An unrecognized or absent type stays unrecognized.
+        let classification = AwaitingInputClass(notificationType: params.notificationType)
+        // A prompt-on-screen reason carries the transcript as it stood when the
+        // prompt was raised, so a later reader can tell "still waiting" from
+        // "answered, and the session moved on" without a hook to tell it —
+        // Claude Code fires none when a human decides. Only that class gets
+        // one: no other class raises a hand there would be anything to lower.
+        let fingerprint: TranscriptFingerprint? = classification == .promptOnScreen
+            ? terminal.transcriptPath.flatMap { $0.isEmpty ? nil : transcriptFingerprinter($0) }
+            : nil
         let reason = AwaitingInputReason(
             message: params.message,
             hookEventName: "Notification",
             raw: params.rawPayload,
-            notificationType: params.notificationType)
+            notificationType: params.notificationType,
+            transcriptFingerprint: fingerprint)
 
         // Deliberately NOT `setActivityState`: this hook reports that a prompt
         // was raised, not that the session is still sitting on one, and

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -556,14 +556,14 @@ extension RPCRouter {
         let params = try decoder.decode(TerminalListParams.self, from: paramsData)
         var terminals = try await db.terminals.list(worktreeID: params.worktreeID)
         // Transcript supersession, on the pass that is about to report these
-        // rows. A prompt reason describes a stopped session; a transcript that
-        // changed since the prompt was raised is proof it is not, and no hook
-        // will ever say so — Claude Code fires none when a human answers.
-        // Corrected in the response as well as in the database, so this pass
-        // does not report a prompt it just retracted.
+        // rows. A prompt reason describes a stopped session; a transcript the
+        // session itself wrote to since the prompt was raised is proof it is
+        // not, and no hook will ever say so — Claude Code fires none when a
+        // human answers. Corrected in the response as well as in the database,
+        // so this pass does not report a prompt it just retracted.
         // See docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md.
         let supersession = AwaitingInputSupersession(
-            db: db, fingerprint: transcriptFingerprinter)
+            db: db, fingerprint: transcriptFingerprinter, delta: transcriptDeltaInspector)
         for index in terminals.indices {
             guard await supersession.reconcile(terminal: terminals[index]) else { continue }
             terminals[index].awaitingInputReason = nil

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -233,6 +233,10 @@ public final class RPCRouter: Sendable {
     /// it. A seam, not a clock: a file's modification time is data, so it
     /// follows the same rule as `now` rather than the `Clock` rule.
     let transcriptFingerprinter: TranscriptFingerprinter
+    /// How the records a transcript gained since a stored fingerprint are read
+    /// and attributed. Paired with the fingerprinter: the stat says the file
+    /// moved, this says whether the session itself did.
+    let transcriptDeltaInspector: TranscriptDeltaInspector
 
     public init(
         db: TBDDatabase,
@@ -257,11 +261,14 @@ public final class RPCRouter: Sendable {
         now: @escaping @Sendable () -> Date = { Date() },
         tmuxSocketPathResolver: TmuxSocketPathResolver = TmuxSocketPathResolver(),
         transcriptFingerprinter: @escaping TranscriptFingerprinter = TranscriptFingerprinting.live,
+        transcriptDeltaInspector: @escaping TranscriptDeltaInspector
+            = TranscriptDeltaInspection.live,
         actuationLog: ActuationLog
     ) {
         self.now = now
         self.tmuxSocketPathResolver = tmuxSocketPathResolver
         self.transcriptFingerprinter = transcriptFingerprinter
+        self.transcriptDeltaInspector = transcriptDeltaInspector
         self.actuationLog = actuationLog
         self.db = db
         self.lifecycle = lifecycle

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -229,6 +229,10 @@ public final class RPCRouter: Sendable {
     /// the daemon's own environment, which is the environment the servers it
     /// spawned were created under.
     let tmuxSocketPathResolver: TmuxSocketPathResolver
+    /// How a session transcript is measured when a prompt is recorded against
+    /// it. A seam, not a clock: a file's modification time is data, so it
+    /// follows the same rule as `now` rather than the `Clock` rule.
+    let transcriptFingerprinter: TranscriptFingerprinter
 
     public init(
         db: TBDDatabase,
@@ -252,10 +256,12 @@ public final class RPCRouter: Sendable {
         prBindingRepoResolver: (@Sendable (UUID) async -> (owner: String, name: String, host: String)?)? = nil,
         now: @escaping @Sendable () -> Date = { Date() },
         tmuxSocketPathResolver: TmuxSocketPathResolver = TmuxSocketPathResolver(),
+        transcriptFingerprinter: @escaping TranscriptFingerprinter = TranscriptFingerprinting.live,
         actuationLog: ActuationLog
     ) {
         self.now = now
         self.tmuxSocketPathResolver = tmuxSocketPathResolver
+        self.transcriptFingerprinter = transcriptFingerprinter
         self.actuationLog = actuationLog
         self.db = db
         self.lifecycle = lifecycle

--- a/Sources/TBDDaemon/Supervision/AwaitingInputSupersession.swift
+++ b/Sources/TBDDaemon/Supervision/AwaitingInputSupersession.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "supervision.supersession")
 
 /// How a transcript is measured. Injected so tests drive fingerprints without
 /// a filesystem, and so the daemon's one real measurement lives in one place.
@@ -19,13 +22,136 @@ public enum TranscriptFingerprinting {
     }
 }
 
+/// What was appended to a transcript after a given byte offset.
+///
+/// A transcript that merely GREW does not say the session moved. A parallel
+/// `Task` subagent writes its whole conversation into the parent's JSONL as
+/// `isSidechain` records, and it keeps writing while the parent sits on a
+/// permission prompt — so growth alone drops the hand on a human who is still
+/// blocked. `SessionStateResolver` documents that exact failure and refuses the
+/// inference for the same reason. Only the parent's own writing is evidence.
+public enum TranscriptDelta: Sendable, Equatable {
+    /// At least one non-sidechain record — the parent session itself wrote.
+    case containsParentContent
+    /// The file grew, but only with a nested agent's sidechain records. Also
+    /// the answer when the delta holds no complete record at all: nothing the
+    /// parent wrote has appeared.
+    case sidechainOnly
+}
+
+/// Reads what a transcript gained after a byte offset. Injected beside
+/// `TranscriptFingerprinter` so tests drive the judgment without a filesystem.
+///
+/// nil means the delta could not be read. Inability to look is never evidence.
+public typealias TranscriptDeltaInspector = @Sendable (String, Int64) -> TranscriptDelta?
+
+public enum TranscriptDeltaInspection {
+    /// How much of a delta to read. The same order as
+    /// `ClaudeDelegationTracker.tailByteLimit`, which reads the JSONL's tail on
+    /// a far hotter path; a prompt's delta is normally a handful of records.
+    /// A delta larger than this is read from its END — the newest records are
+    /// the ones that describe what the session is doing now — and a window that
+    /// shows only sidechain records leaves the hand up, which is the direction
+    /// every edge on this rail fails toward.
+    static let deltaByteLimit = 64 * 1024
+
+    /// How far back to look for the record boundary at or before the offset.
+    /// Transcript records are assistant messages and tool results, so this
+    /// covers them with room to spare; past it the inspector declines to answer
+    /// rather than parse a fragment.
+    static let boundaryScanLimit = 1024 * 1024
+
+    /// Read size for the backward scan. One of these usually settles it: the
+    /// byte before a stat-captured size is a newline whenever the writer was
+    /// between records.
+    private static let boundaryChunkSize = 8 * 1024
+
+    public static let live: TranscriptDeltaInspector = { path, offset in
+        inspect(path: path, offset: offset)
+    }
+
+    static func inspect(path: String, offset: Int64) -> TranscriptDelta? {
+        guard !path.isEmpty, offset >= 0,
+              let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        do {
+            let end = try handle.seekToEnd()
+            // The caller compares sizes before asking, so a file shorter than
+            // the offset is a race rather than a state to interpret.
+            guard UInt64(offset) <= end else { return nil }
+            guard let boundary = try recordBoundary(handle: handle, at: UInt64(offset))
+            else { return nil }
+            let capped = end - boundary > UInt64(deltaByteLimit)
+            let start = capped ? end - UInt64(deltaByteLimit) : boundary
+            try handle.seek(toOffset: start)
+            let window = try handle.read(upToCount: Int(end - start)) ?? Data()
+            return classify(window: window, startsMidRecord: capped)
+        } catch {
+            logger.debug(
+                "transcript delta read failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    /// The start of the record that `offset` falls inside.
+    ///
+    /// `offset` is a file SIZE captured by a stat, so it lands mid-record
+    /// whenever the fingerprint was taken while a line was being written. The
+    /// bytes of that fragment were already present, but its record was not
+    /// complete — starting the window at the raw offset would hand the parser a
+    /// tail fragment and silently lose the one real append. nil when no
+    /// boundary sits within `boundaryScanLimit`: no answer beats a guessed one.
+    private static func recordBoundary(handle: FileHandle, at offset: UInt64) throws -> UInt64? {
+        guard offset > 0 else { return 0 }
+        let floor = offset > UInt64(boundaryScanLimit) ? offset - UInt64(boundaryScanLimit) : 0
+        var high = offset
+        while high > floor {
+            let chunk = min(high - floor, UInt64(boundaryChunkSize))
+            let low = high - chunk
+            try handle.seek(toOffset: low)
+            let data = try handle.read(upToCount: Int(chunk)) ?? Data()
+            if let index = data.lastIndex(of: 0x0A) {
+                return low + UInt64(data.distance(from: data.startIndex, to: index)) + 1
+            }
+            high = low
+        }
+        return floor == 0 ? 0 : nil
+    }
+
+    /// A record the parent wrote is one that parses and does not carry
+    /// `isSidechain: true` — the same partition `TranscriptParser` already makes
+    /// when it drops a nested agent's conversation from the parent's transcript.
+    /// A line this build cannot read as a record at all is not a parent record
+    /// until it is read as one, so it decides nothing and is passed over.
+    private static func classify(window: Data, startsMidRecord: Bool) -> TranscriptDelta {
+        var lines = window.split(separator: 0x0A, omittingEmptySubsequences: false)
+        // Whatever follows the final newline is a record still being written.
+        // Incomplete is not yet evidence of anything.
+        if !lines.isEmpty { lines.removeLast() }
+        // The byte cap moved the window's start into a record whose beginning
+        // was left behind; that fragment is not parseable as one.
+        if startsMidRecord, !lines.isEmpty { lines.removeFirst() }
+        for line in lines {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line)),
+                  let record = object as? [String: Any] else { continue }
+            if record["isSidechain"] as? Bool != true { return .containsParentContent }
+        }
+        return .sidechainOnly
+    }
+}
+
 /// The second superseder of an awaiting-input reason.
 ///
 /// The activity rail retracts a reason when a hook reports the session moved.
-/// This one retracts it when the session's TRANSCRIPT moved, which is the only
-/// evidence available when no hook arrives — and none does: Claude Code fires
-/// nothing when a human answers a permission prompt, and a session whose hook
-/// rail has gone quiet produces no activity observation at all.
+/// This one retracts it when the session's TRANSCRIPT shows the session itself
+/// moved, which is the only evidence available when no hook arrives — and none
+/// does: Claude Code fires nothing when a human answers a permission prompt,
+/// and a session whose hook rail has gone quiet produces no activity
+/// observation at all.
+///
+/// A transcript that grew is not on its own that evidence. A nested agent's
+/// sidechain records land in the parent's file while the parent is blocked, so
+/// the delta is read and attributed before a hand comes down.
 ///
 /// Every branch fails toward leaving the prompt raised. A lingering hand is the
 /// defect this exists to fix; a hand dropped while a human is still being asked
@@ -35,6 +161,7 @@ public enum TranscriptFingerprinting {
 struct AwaitingInputSupersession: Sendable {
     let db: TBDDatabase
     let fingerprint: TranscriptFingerprinter
+    let delta: TranscriptDeltaInspector
 
     /// Reconcile one terminal against its transcript. Returns whether a
     /// standing prompt was retracted, so a caller entitled to announce the
@@ -50,7 +177,31 @@ struct AwaitingInputSupersession: Sendable {
                 id: terminal.id, fingerprint: observed)
             return false
         }
+        // The steady state: a session sitting on a prompt writes nothing, so an
+        // unchanged file is the pending case and costs exactly one stat — no
+        // open, no read, no parse.
         guard stored != observed else { return false }
+
+        // A retargeted session (`/clear`, compaction, resume) or a truncated
+        // file leaves the stored offset describing a file that no longer
+        // exists in that shape. Neither can be read as a delta.
+        if stored.path == observed.path, observed.size >= stored.size {
+            switch delta(path, stored.size) {
+            case .sidechainOnly:
+                // A nested agent wrote; the parent did not. The hand stays up,
+                // and the baseline moves forward so the next pass is a stat
+                // again rather than a re-read of the same records.
+                _ = try? await db.terminals.refreshTranscriptFingerprint(
+                    id: terminal.id, expected: stored, fingerprint: observed)
+                return false
+            case nil:
+                // Unreadable: change nothing, not even the baseline. Refreshing
+                // here would move the offset past bytes nobody ever read.
+                return false
+            case .containsParentContent:
+                break
+            }
+        }
         return (try? await db.terminals.clearAwaitingInputReasonIfFingerprintMatches(
             id: terminal.id, expected: stored)) ?? false
     }

--- a/Sources/TBDDaemon/Supervision/AwaitingInputSupersession.swift
+++ b/Sources/TBDDaemon/Supervision/AwaitingInputSupersession.swift
@@ -1,0 +1,57 @@
+import Foundation
+import TBDShared
+
+/// How a transcript is measured. Injected so tests drive fingerprints without
+/// a filesystem, and so the daemon's one real measurement lives in one place.
+public typealias TranscriptFingerprinter = @Sendable (String) -> TranscriptFingerprint?
+
+public enum TranscriptFingerprinting {
+    /// One `stat`: no open, no read, no parse. Cheap enough to run on every
+    /// pass that reports a terminal, and it runs only for the rows holding a
+    /// standing prompt.
+    public static let live: TranscriptFingerprinter = { path in
+        guard !path.isEmpty,
+              let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modifiedAt = attrs[.modificationDate] as? Date,
+              let size = (attrs[.size] as? NSNumber)?.int64Value
+        else { return nil }
+        return TranscriptFingerprint(path: path, modifiedAt: modifiedAt, size: size)
+    }
+}
+
+/// The second superseder of an awaiting-input reason.
+///
+/// The activity rail retracts a reason when a hook reports the session moved.
+/// This one retracts it when the session's TRANSCRIPT moved, which is the only
+/// evidence available when no hook arrives — and none does: Claude Code fires
+/// nothing when a human answers a permission prompt, and a session whose hook
+/// rail has gone quiet produces no activity observation at all.
+///
+/// Every branch fails toward leaving the prompt raised. A lingering hand is the
+/// defect this exists to fix; a hand dropped while a human is still being asked
+/// hides the one row that needs attention.
+///
+/// See `docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md`.
+struct AwaitingInputSupersession: Sendable {
+    let db: TBDDatabase
+    let fingerprint: TranscriptFingerprinter
+
+    /// Reconcile one terminal against its transcript. Returns whether a
+    /// standing prompt was retracted, so a caller entitled to announce the
+    /// retraction can do so from what the write actually did.
+    func reconcile(terminal: Terminal) async -> Bool {
+        guard let reason = terminal.awaitingInputReason,
+              reason.classification == .promptOnScreen else { return false }
+        guard let path = terminal.transcriptPath, !path.isEmpty else { return false }
+        // Inability to look is never evidence that a prompt was answered.
+        guard let observed = fingerprint(path) else { return false }
+        guard let stored = reason.transcriptFingerprint else {
+            _ = try? await db.terminals.adoptTranscriptFingerprint(
+                id: terminal.id, fingerprint: observed)
+            return false
+        }
+        guard stored != observed else { return false }
+        return (try? await db.terminals.clearAwaitingInputReasonIfFingerprintMatches(
+            id: terminal.id, expected: stored)) ?? false
+    }
+}

--- a/Sources/TBDDaemon/Supervision/SupervisionReadoutBuilder.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionReadoutBuilder.swift
@@ -43,6 +43,10 @@ struct SupervisionReadoutBuilder: Sendable {
     /// How a session transcript is measured when a standing prompt is checked
     /// against it. A seam, not a clock: a file's modification time is data.
     let transcriptFingerprinter: TranscriptFingerprinter
+    /// How the records a transcript gained since a stored fingerprint are read
+    /// and attributed. A nested agent's sidechain writes are not the parent
+    /// session moving, so growth alone may not take a raised hand down.
+    let transcriptDeltaInspector: TranscriptDeltaInspector
     let now: @Sendable () -> Date
 
     init(
@@ -52,6 +56,8 @@ struct SupervisionReadoutBuilder: Sendable {
         branchTips: BranchTipTracker,
         actuationRecord: ActuationRecordReader,
         transcriptFingerprinter: @escaping TranscriptFingerprinter = TranscriptFingerprinting.live,
+        transcriptDeltaInspector: @escaping TranscriptDeltaInspector
+            = TranscriptDeltaInspection.live,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.db = db
@@ -60,6 +66,7 @@ struct SupervisionReadoutBuilder: Sendable {
         self.branchTips = branchTips
         self.actuationRecord = actuationRecord
         self.transcriptFingerprinter = transcriptFingerprinter
+        self.transcriptDeltaInspector = transcriptDeltaInspector
         self.now = now
     }
 
@@ -91,7 +98,7 @@ struct SupervisionReadoutBuilder: Sendable {
         // one. No delta is broadcast from here: a readout is a pull, not a UI
         // event, and the app's own poll re-reads the row within its interval.
         let supersession = AwaitingInputSupersession(
-            db: db, fingerprint: transcriptFingerprinter)
+            db: db, fingerprint: transcriptFingerprinter, delta: transcriptDeltaInspector)
 
         for agent in agents {
             guard var terminal = try await db.terminals.get(id: agent.terminal) else { continue }

--- a/Sources/TBDDaemon/Supervision/SupervisionReadoutBuilder.swift
+++ b/Sources/TBDDaemon/Supervision/SupervisionReadoutBuilder.swift
@@ -40,6 +40,9 @@ struct SupervisionReadoutBuilder: Sendable {
     let sessionCounters: SessionCountersTracker
     let branchTips: BranchTipTracker
     let actuationRecord: ActuationRecordReader
+    /// How a session transcript is measured when a standing prompt is checked
+    /// against it. A seam, not a clock: a file's modification time is data.
+    let transcriptFingerprinter: TranscriptFingerprinter
     let now: @Sendable () -> Date
 
     init(
@@ -48,6 +51,7 @@ struct SupervisionReadoutBuilder: Sendable {
         sessionCounters: SessionCountersTracker,
         branchTips: BranchTipTracker,
         actuationRecord: ActuationRecordReader,
+        transcriptFingerprinter: @escaping TranscriptFingerprinter = TranscriptFingerprinting.live,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.db = db
@@ -55,6 +59,7 @@ struct SupervisionReadoutBuilder: Sendable {
         self.sessionCounters = sessionCounters
         self.branchTips = branchTips
         self.actuationRecord = actuationRecord
+        self.transcriptFingerprinter = transcriptFingerprinter
         self.now = now
     }
 
@@ -81,8 +86,19 @@ struct SupervisionReadoutBuilder: Sendable {
         var entries: [SupervisionReadoutAgent] = []
         entries.reserveCapacity(agents.count)
 
+        // The readout may be the only reader on a daemon with no app attached,
+        // so it supersedes a stale prompt on its own pass rather than reporting
+        // one. No delta is broadcast from here: a readout is a pull, not a UI
+        // event, and the app's own poll re-reads the row within its interval.
+        let supersession = AwaitingInputSupersession(
+            db: db, fingerprint: transcriptFingerprinter)
+
         for agent in agents {
-            guard let terminal = try await db.terminals.get(id: agent.terminal) else { continue }
+            guard var terminal = try await db.terminals.get(id: agent.terminal) else { continue }
+            if await supersession.reconcile(terminal: terminal) {
+                terminal.awaitingInputReason = nil
+                terminal.awaitingInputObservedAt = nil
+            }
             let worktree: Worktree
             if let cached = worktreeRows[agent.worktree] {
                 worktree = cached

--- a/Sources/TBDShared/SessionStateModel.swift
+++ b/Sources/TBDShared/SessionStateModel.swift
@@ -246,15 +246,20 @@ public enum AwaitingInputClass: String, Sendable, Equatable, Codable {
     /// File a `notification_type` under its class. Absent or unknown →
     /// `.unrecognized`.
     ///
-    /// The three groups are Claude Code's documented types, listed exhaustively
-    /// so that adding one is a visible edit rather than a silent reclassification.
+    /// The three groups are the types Claude Code emits — a wider set than its
+    /// published documentation lists — enumerated exhaustively so that adding
+    /// one is a visible edit rather than a silent reclassification.
     public init(notificationType: String?) {
         switch notificationType {
-        case "permission_prompt", "elicitation_dialog", "agent_needs_input":
+        case "permission_prompt", "elicitation_dialog", "agent_needs_input",
+             "worker_permission_prompt", "elicitation_url_dialog":
             self = .promptOnScreen
         case "idle_prompt":
             self = .doneWaiting
-        case "auth_success", "elicitation_complete", "elicitation_response", "agent_completed":
+        case "auth_success", "elicitation_complete", "elicitation_response",
+             "agent_completed", "computer_use_enter", "computer_use_exit",
+             "push_notification", "quota_auto_resume_fired",
+             "quota_auto_resume_stale", "quota_auto_resume_disabled":
             self = .informational
         default:
             // Absent, or a type this build has never heard of. It stops here:
@@ -283,6 +288,29 @@ public enum AwaitingInputClass: String, Sendable, Equatable, Codable {
     }
 }
 
+/// A session transcript as it stood when a prompt was recorded against it.
+///
+/// Identity is the file, its size, and its modification time. Comparing a
+/// stored fingerprint against a fresh one asks whether the file CHANGED since
+/// the prompt was raised — a different and more durable question than whether
+/// the file is newer than some timestamp. It depends on no ordering between
+/// Claude Code's debounced notification timer and its own transcript flush,
+/// and on no clock agreeing with another clock.
+public struct TranscriptFingerprint: Codable, Sendable, Equatable {
+    /// The transcript this was taken from. A terminal whose `transcriptPath`
+    /// no longer matches has been retargeted — a `/clear`, a compaction, a
+    /// resume — and a fingerprint cannot describe a file it was not taken from.
+    public let path: String
+    public let modifiedAt: Date
+    public let size: Int64
+
+    public init(path: String, modifiedAt: Date, size: Int64) {
+        self.path = path
+        self.modifiedAt = modifiedAt
+        self.size = size
+    }
+}
+
 /// The structured reason an agent is waiting, carried verbatim from Claude
 /// Code's `Notification` hook.
 ///
@@ -307,6 +335,11 @@ public struct AwaitingInputReason: Codable, Sendable, Equatable {
     /// carried none (an older Claude Code). Stored unmodified even when this
     /// build does not recognize it.
     public let notificationType: String?
+    /// The transcript as it stood when this reason was recorded, for a
+    /// `.promptOnScreen` class only. Absent on every other class — there is no
+    /// raised hand to take down — and absent on rows written before this
+    /// existed, which `AwaitingInputSupersession` adopts rather than acts on.
+    public let transcriptFingerprint: TranscriptFingerprint?
     /// Which class `notificationType` falls under.
     ///
     /// Derived from `notificationType` at construction and **re-derived on
@@ -322,12 +355,14 @@ public struct AwaitingInputReason: Codable, Sendable, Equatable {
         message: String,
         hookEventName: String? = nil,
         raw: String? = nil,
-        notificationType: String? = nil
+        notificationType: String? = nil,
+        transcriptFingerprint: TranscriptFingerprint? = nil
     ) {
         self.message = message
         self.hookEventName = hookEventName
         self.raw = raw
         self.notificationType = notificationType
+        self.transcriptFingerprint = transcriptFingerprint
         self.classification = AwaitingInputClass(notificationType: notificationType)
     }
 
@@ -336,6 +371,7 @@ public struct AwaitingInputReason: Codable, Sendable, Equatable {
         case hookEventName
         case raw
         case notificationType
+        case transcriptFingerprint
         case classification
     }
 
@@ -348,7 +384,9 @@ public struct AwaitingInputReason: Codable, Sendable, Equatable {
             message: try c.decode(String.self, forKey: .message),
             hookEventName: try c.decodeIfPresent(String.self, forKey: .hookEventName),
             raw: try c.decodeIfPresent(String.self, forKey: .raw),
-            notificationType: try c.decodeIfPresent(String.self, forKey: .notificationType)
+            notificationType: try c.decodeIfPresent(String.self, forKey: .notificationType),
+            transcriptFingerprint: try c.decodeIfPresent(
+                TranscriptFingerprint.self, forKey: .transcriptFingerprint)
         )
     }
 }

--- a/Tests/TBDDaemonTests/AwaitingInputFingerprintStoreTests.swift
+++ b/Tests/TBDDaemonTests/AwaitingInputFingerprintStoreTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The two writers that let a read path correct a standing awaiting-input
+/// prompt from the transcript rather than from a hook.
+///
+/// Both re-read the standing reason inside their own transaction, so the
+/// interesting assertions are the refusals: a prompt raised between a caller's
+/// stat and its write must survive, and a reason that already carries a
+/// fingerprint must not have it overwritten.
+@Suite struct AwaitingInputFingerprintStoreTests {
+    let db: TBDDatabase
+    let terminalID: UUID
+
+    static let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+    static let modifiedAt = Date(timeIntervalSince1970: 1_779_900_000)
+    static let transcriptPath = "/tmp/awaiting-input-fingerprint.jsonl"
+
+    init() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        let repo = try await db.repos.create(
+            path: "/tmp/fp-repo-\(UUID().uuidString)", displayName: "F", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/fp-wt-\(UUID().uuidString)", tmuxServer: "tbd-fp")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "s-1", kind: .claude)
+        terminalID = terminal.id
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "s-1", transcriptPath: Self.transcriptPath)
+    }
+
+    private static func fingerprint(size: Int64) -> TranscriptFingerprint {
+        TranscriptFingerprint(path: transcriptPath, modifiedAt: modifiedAt, size: size)
+    }
+
+    /// Install a standing reason exactly as the notification hook would.
+    private func record(
+        type: String?,
+        message: String = "Claude needs your permission to use Bash",
+        fingerprint: TranscriptFingerprint?
+    ) async throws {
+        _ = try await db.terminals.recordAwaitingInputReason(
+            id: terminalID,
+            reason: AwaitingInputReason(
+                message: message,
+                hookEventName: "Notification",
+                raw: "{}",
+                notificationType: type,
+                transcriptFingerprint: fingerprint),
+            observedAt: Self.observedAt)
+    }
+
+    private func terminal() async throws -> Terminal {
+        try #require(try await db.terminals.get(id: terminalID))
+    }
+
+    // MARK: - Conditional clear
+
+    @Test func clearsWhenTheStoredFingerprintStillMatches() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+
+        let cleared = try await db.terminals.clearAwaitingInputReasonIfFingerprintMatches(
+            id: terminalID, expected: Self.fingerprint(size: 10))
+
+        #expect(cleared)
+        let after = try await terminal()
+        #expect(after.awaitingInputReason == nil)
+        #expect(after.awaitingInputObservedAt == nil)
+    }
+
+    /// A fresh prompt raised between the caller's stat and this write carries a
+    /// fingerprint of its own. Clearing on the stale comparison would drop a
+    /// prompt nobody has answered.
+    @Test func refusesWhenTheStandingFingerprintChangedUnderneath() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        try await record(
+            type: "permission_prompt", message: "A newer prompt",
+            fingerprint: Self.fingerprint(size: 20))
+
+        let cleared = try await db.terminals.clearAwaitingInputReasonIfFingerprintMatches(
+            id: terminalID, expected: Self.fingerprint(size: 10))
+
+        #expect(cleared == false)
+        let after = try await terminal()
+        let standing = try #require(after.awaitingInputReason)
+        #expect(standing.message == "A newer prompt")
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 20))
+        #expect(after.awaitingInputObservedAt == Self.observedAt)
+    }
+
+    /// The callers are read paths, so a row that vanished under them reports
+    /// `false` rather than throwing.
+    @Test func refusesOnAMissingTerminal() async throws {
+        let cleared = try await db.terminals.clearAwaitingInputReasonIfFingerprintMatches(
+            id: UUID(), expected: Self.fingerprint(size: 10))
+        #expect(cleared == false)
+    }
+
+    // MARK: - Adoption
+
+    @Test func adoptsAFingerprintOntoAReasonThatHasNone() async throws {
+        try await record(type: "permission_prompt", fingerprint: nil)
+
+        let adopted = try await db.terminals.adoptTranscriptFingerprint(
+            id: terminalID, fingerprint: Self.fingerprint(size: 10))
+
+        #expect(adopted)
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
+        // Adoption attaches; it must not rewrite what the hook reported.
+        #expect(standing.message == "Claude needs your permission to use Bash")
+        #expect(standing.hookEventName == "Notification")
+        #expect(standing.raw == "{}")
+        #expect(standing.notificationType == "permission_prompt")
+        #expect(standing.classification == .promptOnScreen)
+    }
+
+    @Test func adoptionLeavesAReasonThatAlreadyHasOneAlone() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+
+        let adopted = try await db.terminals.adoptTranscriptFingerprint(
+            id: terminalID, fingerprint: Self.fingerprint(size: 20))
+
+        #expect(adopted == false)
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
+    }
+
+    /// Only a raised hand is worth making answerable to the transcript. No
+    /// other class has anything to take down.
+    @Test func adoptionIgnoresAReasonThatIsNotPromptOnScreen() async throws {
+        try await record(type: "idle_prompt", fingerprint: nil)
+
+        let adopted = try await db.terminals.adoptTranscriptFingerprint(
+            id: terminalID, fingerprint: Self.fingerprint(size: 10))
+
+        #expect(adopted == false)
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.classification == .doneWaiting)
+        #expect(standing.transcriptFingerprint == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/AwaitingInputFingerprintStoreTests.swift
+++ b/Tests/TBDDaemonTests/AwaitingInputFingerprintStoreTests.swift
@@ -144,4 +144,52 @@ import Testing
         #expect(standing.classification == .doneWaiting)
         #expect(standing.transcriptFingerprint == nil)
     }
+
+    // MARK: - Refresh after a sidechain-only append
+
+    /// The sibling of adoption, and deliberately not adoption itself: this one
+    /// REPLACES a baseline the caller has just read past, so the next pass is a
+    /// stat rather than a re-read of records already attributed to a subagent.
+    @Test func refreshesTheBaselineOnTheFingerprintItWasComparedAgainst() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+
+        let refreshed = try await db.terminals.refreshTranscriptFingerprint(
+            id: terminalID, expected: Self.fingerprint(size: 10),
+            fingerprint: Self.fingerprint(size: 20))
+
+        #expect(refreshed)
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 20))
+        // The hand is still up, and the hook's own words are untouched.
+        #expect(standing.classification == .promptOnScreen)
+        #expect(standing.message == "Claude needs your permission to use Bash")
+        #expect(standing.notificationType == "permission_prompt")
+        #expect(try await terminal().awaitingInputObservedAt == Self.observedAt)
+    }
+
+    /// The same guard the conditional clear carries, for the same reason: a
+    /// prompt raised while the delta was being read must not have its
+    /// fingerprint overwritten by a measurement of the file as it stood before.
+    @Test func refreshRefusesWhenTheStandingFingerprintChangedUnderneath() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        try await record(
+            type: "permission_prompt", message: "A newer prompt",
+            fingerprint: Self.fingerprint(size: 30))
+
+        let refreshed = try await db.terminals.refreshTranscriptFingerprint(
+            id: terminalID, expected: Self.fingerprint(size: 10),
+            fingerprint: Self.fingerprint(size: 20))
+
+        #expect(refreshed == false)
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.message == "A newer prompt")
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 30))
+    }
+
+    @Test func refreshRefusesOnAMissingTerminal() async throws {
+        let refreshed = try await db.terminals.refreshTranscriptFingerprint(
+            id: UUID(), expected: Self.fingerprint(size: 10),
+            fingerprint: Self.fingerprint(size: 20))
+        #expect(refreshed == false)
+    }
 }

--- a/Tests/TBDDaemonTests/AwaitingInputSupersessionTests.swift
+++ b/Tests/TBDDaemonTests/AwaitingInputSupersessionTests.swift
@@ -23,9 +23,46 @@ private final class FingerprintSpy: @unchecked Sendable {
     }
 }
 
-/// The transcript superseder: it retracts a standing prompt when the session's
-/// JSONL moved since the prompt was raised, and fails toward leaving the hand
-/// up in every other case.
+/// Records every (path, offset) it was asked to read, so a test can assert the
+/// delta was never opened — the steady state costs one stat and nothing more.
+private final class DeltaSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [String] = []
+    /// Each call rendered as `path@offset`, which is all any assertion here
+    /// needs and keeps the expectations readable.
+    var calls: [String] { lock.lock(); defer { lock.unlock() }; return _calls }
+    let result: TranscriptDelta?
+
+    init(result: TranscriptDelta?) { self.result = result }
+
+    var inspector: TranscriptDeltaInspector {
+        { [self] path, offset in
+            lock.lock()
+            _calls.append("\(path)@\(offset)")
+            lock.unlock()
+            return result
+        }
+    }
+}
+
+/// A temp directory that cleans itself up when the suite instance for one test
+/// is released.
+private final class TempDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-delta-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    deinit { try? FileManager.default.removeItem(at: url) }
+}
+
+/// The transcript superseder: it retracts a standing prompt when the SESSION
+/// wrote to its own JSONL since the prompt was raised, and fails toward leaving
+/// the hand up in every other case — a nested agent's sidechain writes
+/// included.
 @Suite struct AwaitingInputSupersessionTests {
     let db: TBDDatabase
     let terminalID: UUID
@@ -78,24 +115,92 @@ private final class FingerprintSpy: @unchecked Sendable {
         try #require(try await db.terminals.get(id: terminalID))
     }
 
-    private func reconcile(_ spy: FingerprintSpy) async throws -> Bool {
-        let supersession = AwaitingInputSupersession(db: db, fingerprint: spy.fingerprinter)
+    private func reconcile(_ spy: FingerprintSpy, _ delta: DeltaSpy) async throws -> Bool {
+        let supersession = AwaitingInputSupersession(
+            db: db, fingerprint: spy.fingerprinter, delta: delta.inspector)
         return await supersession.reconcile(terminal: try await terminal())
     }
 
-    /// The file moved since the prompt was raised, so the session is not
+    /// The session itself wrote since the prompt was raised, so it is not
     /// stopped on it. That is the whole mechanism.
-    @Test func retractsWhenTheTranscriptChanged() async throws {
+    @Test func retractsWhenTheParentSessionWrote() async throws {
         try await setTranscriptPath(Self.pathA)
         try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
         let spy = FingerprintSpy(result: Self.fingerprint(size: 20))
+        let delta = DeltaSpy(result: .containsParentContent)
 
-        #expect(try await reconcile(spy))
+        #expect(try await reconcile(spy, delta))
 
         let after = try await terminal()
         #expect(after.awaitingInputReason == nil)
         #expect(after.awaitingInputObservedAt == nil)
         #expect(spy.calls == [Self.pathA])
+        // Read from the stored size, which is where the prompt was raised.
+        #expect(delta.calls == ["\(Self.pathA)@10"])
+    }
+
+    /// The failure this exists to fix. A parallel `Task` subagent appends
+    /// sidechain records to the parent's JSONL while the permission prompt is
+    /// still on screen; growth alone would drop the hand on a blocked human.
+    @Test func leavesTheHandUpWhenOnlyASubagentWrote() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = FingerprintSpy(result: Self.fingerprint(size: 20))
+        let delta = DeltaSpy(result: .sidechainOnly)
+
+        #expect(try await reconcile(spy, delta) == false)
+
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.classification == .promptOnScreen)
+        // The baseline moved forward, so the next pass is a stat again rather
+        // than a re-read of records already attributed to the subagent.
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 20))
+        #expect(delta.calls == ["\(Self.pathA)@10"])
+    }
+
+    /// A refreshed baseline is not a retraction in disguise: the very next pass
+    /// against the same file still leaves the hand up, and reads nothing.
+    @Test func aRefreshedBaselineMakesTheNextPassAStatAgain() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        _ = try await reconcile(
+            FingerprintSpy(result: Self.fingerprint(size: 20)),
+            DeltaSpy(result: .sidechainOnly))
+
+        let second = DeltaSpy(result: .containsParentContent)
+        #expect(try await reconcile(FingerprintSpy(result: Self.fingerprint(size: 20)), second)
+                == false)
+
+        #expect(try await terminal().awaitingInputReason != nil)
+        #expect(second.calls.isEmpty)
+    }
+
+    /// Inability to read the delta is never evidence — and the baseline stays
+    /// where it was, so nothing advances past bytes nobody ever read.
+    @Test func changesNothingWhenTheDeltaCannotBeRead() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let delta = DeltaSpy(result: nil)
+
+        #expect(try await reconcile(FingerprintSpy(result: Self.fingerprint(size: 20)), delta)
+                == false)
+
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
+        #expect(delta.calls == ["\(Self.pathA)@10"])
+    }
+
+    /// A file that shrank was rotated or rewritten. The stored offset describes
+    /// nothing in the file that is there now, so there is no delta to attribute.
+    @Test func retractsWhenTheTranscriptWasTruncated() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 100))
+        let delta = DeltaSpy(result: .sidechainOnly)
+
+        #expect(try await reconcile(FingerprintSpy(result: Self.fingerprint(size: 20)), delta))
+
+        #expect(try await terminal().awaitingInputReason == nil)
+        #expect(delta.calls.isEmpty, "a truncated file is not a delta to read")
     }
 
     /// A `/clear`, a compaction or a resume retargeted the session. A
@@ -106,24 +211,30 @@ private final class FingerprintSpy: @unchecked Sendable {
             type: "permission_prompt",
             fingerprint: Self.fingerprint(path: Self.pathA, size: 10))
         let spy = FingerprintSpy(result: Self.fingerprint(path: Self.pathB, size: 10))
+        let delta = DeltaSpy(result: .sidechainOnly)
 
-        #expect(try await reconcile(spy))
+        #expect(try await reconcile(spy, delta))
 
         #expect(try await terminal().awaitingInputReason == nil)
         #expect(spy.calls == [Self.pathB])
+        #expect(delta.calls.isEmpty, "an offset into the old file describes nothing in the new one")
     }
 
     /// A session sitting on a permission prompt writes nothing, so an unchanged
-    /// file is the pending case.
-    @Test func leavesAPendingPromptAlone() async throws {
+    /// file is the pending case — and it costs exactly one stat. The zero-call
+    /// assertion is what pins that: no open, no read, no parse.
+    @Test func leavesAPendingPromptAloneWithoutReadingTheFile() async throws {
         try await setTranscriptPath(Self.pathA)
         try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
         let spy = FingerprintSpy(result: Self.fingerprint(size: 10))
+        let delta = DeltaSpy(result: .containsParentContent)
 
-        #expect(try await reconcile(spy) == false)
+        #expect(try await reconcile(spy, delta) == false)
 
         let standing = try #require(try await terminal().awaitingInputReason)
         #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
+        #expect(spy.calls == [Self.pathA])
+        #expect(delta.calls.isEmpty)
     }
 
     /// Inability to look is never evidence that a prompt was answered.
@@ -131,23 +242,27 @@ private final class FingerprintSpy: @unchecked Sendable {
         try await setTranscriptPath(Self.pathA)
         try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
         let spy = FingerprintSpy(result: nil)
+        let delta = DeltaSpy(result: .containsParentContent)
 
-        #expect(try await reconcile(spy) == false)
+        #expect(try await reconcile(spy, delta) == false)
 
         let standing = try #require(try await terminal().awaitingInputReason)
         #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
         #expect(spy.calls == [Self.pathA])
+        #expect(delta.calls.isEmpty)
     }
 
     @Test func leavesThePromptAloneWhenThereIsNoTranscriptPath() async throws {
         try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
         let spy = FingerprintSpy(result: Self.fingerprint(size: 20))
+        let delta = DeltaSpy(result: .containsParentContent)
 
         #expect(try await terminal().transcriptPath == nil)
-        #expect(try await reconcile(spy) == false)
+        #expect(try await reconcile(spy, delta) == false)
 
         #expect(try await terminal().awaitingInputReason != nil)
         #expect(spy.calls.isEmpty)
+        #expect(delta.calls.isEmpty)
     }
 
     /// A row that predates fingerprints says nothing about whether its prompt
@@ -157,24 +272,167 @@ private final class FingerprintSpy: @unchecked Sendable {
         try await setTranscriptPath(Self.pathA)
         try await record(type: "permission_prompt", fingerprint: nil)
         let spy = FingerprintSpy(result: Self.fingerprint(size: 10))
+        let delta = DeltaSpy(result: .containsParentContent)
 
-        #expect(try await reconcile(spy) == false)
+        #expect(try await reconcile(spy, delta) == false)
 
         let standing = try #require(try await terminal().awaitingInputReason)
         #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
         #expect(standing.classification == .promptOnScreen)
+        #expect(delta.calls.isEmpty, "there is no baseline to read a delta from")
     }
 
     @Test func ignoresAReasonThatIsNotPromptOnScreen() async throws {
         try await setTranscriptPath(Self.pathA)
         try await record(type: "idle_prompt", fingerprint: nil)
         let spy = FingerprintSpy(result: Self.fingerprint(size: 10))
+        let delta = DeltaSpy(result: .containsParentContent)
 
-        #expect(try await reconcile(spy) == false)
+        #expect(try await reconcile(spy, delta) == false)
 
         let standing = try #require(try await terminal().awaitingInputReason)
         #expect(standing.classification == .doneWaiting)
         #expect(standing.transcriptFingerprint == nil)
         #expect(spy.calls.isEmpty)
+        #expect(delta.calls.isEmpty)
+    }
+}
+
+/// The live delta inspector, against real files. What the superseder believes
+/// about a transcript is only as good as this reader, so these exercise the
+/// bytes rather than a stub.
+@Suite struct TranscriptDeltaInspectionTests {
+    private let temp: TempDirectory
+
+    init() throws { temp = try TempDirectory() }
+
+    private static let sidechain =
+        #"{"type":"assistant","isSidechain":true,"message":{"role":"assistant"}}"#
+    private static let parent =
+        #"{"type":"user","isSidechain":false,"message":{"role":"user"}}"#
+
+    /// Writes `contents` and answers with the path and the byte length.
+    @discardableResult
+    private func write(_ contents: String, name: String = "session.jsonl") throws
+        -> (path: String, size: Int64) {
+        let url = temp.url.appendingPathComponent(name)
+        let data = Data(contents.utf8)
+        try data.write(to: url)
+        return (url.path, Int64(data.count))
+    }
+
+    /// A subagent's records are the parent's file growing without the parent
+    /// writing. That distinction is the whole point of this reader.
+    @Test func attributesSidechainRecordsToTheNestedAgent() async throws {
+        let base = try write(Self.parent + "\n")
+        let full = try write(Self.parent + "\n" + Self.sidechain + "\n" + Self.sidechain + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, base.size) == .sidechainOnly)
+    }
+
+    @Test func seesARecordTheParentWrote() async throws {
+        let base = try write(Self.sidechain + "\n")
+        let full = try write(Self.sidechain + "\n" + Self.parent + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, base.size) == .containsParentContent)
+    }
+
+    /// One parent record among a subagent's is still the parent writing.
+    @Test func aMixedDeltaIsParentContent() async throws {
+        let base = try write(Self.parent + "\n")
+        let full = try write(
+            Self.parent + "\n" + Self.sidechain + "\n" + Self.parent + "\n"
+                + Self.sidechain + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, base.size) == .containsParentContent)
+    }
+
+    /// A record with no `isSidechain` at all is the parent's — that is how
+    /// Claude Code writes the parent conversation's own lines.
+    @Test func aRecordWithoutTheFlagIsParentContent() async throws {
+        let base = try write(Self.sidechain + "\n")
+        let full = try write(Self.sidechain + "\n" + #"{"type":"user"}"# + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, base.size) == .containsParentContent)
+    }
+
+    /// The offset is a stat-captured SIZE, so it lands mid-record whenever the
+    /// fingerprint was taken while a line was being written. The record whose
+    /// middle it points into must still be read whole, and both plausible ways
+    /// of getting that wrong lose it: skipping forward to the next newline
+    /// drops the record outright, and starting at the raw offset hands the
+    /// parser a fragment that reads as no record at all. Either leaves a raised
+    /// hand standing over a session that has moved on.
+    @Test func aMidRecordOffsetStillSeesTheParentRecord() async throws {
+        let full = try write(Self.sidechain + "\n" + Self.parent + "\n")
+        let midRecord = Int64((Self.sidechain + "\n").utf8.count + 5)
+
+        #expect(TranscriptDeltaInspection.live(full.path, midRecord) == .containsParentContent)
+    }
+
+    /// A line this build cannot read as a record decides nothing. It is not a
+    /// parent record until it is read as one, so it may not take a hand down.
+    @Test func anUnparseableRecordIsNotEvidence() async throws {
+        let base = try write(Self.sidechain + "\n")
+        let full = try write(Self.sidechain + "\n" + "}not json{" + "\n" + Self.sidechain + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, base.size) == .sidechainOnly)
+    }
+
+    /// Passing over an unreadable line does not blind the reader to the records
+    /// around it.
+    @Test func aParentRecordBesideAnUnparseableOneStillRetracts() async throws {
+        let base = try write(Self.sidechain + "\n")
+        let full = try write(Self.sidechain + "\n" + "}not json{" + "\n" + Self.parent + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, base.size) == .containsParentContent)
+    }
+
+    /// A delta larger than the cap is read from its END, and a window showing
+    /// only sidechain records leaves the hand up. The parent record here sits
+    /// far outside the window on purpose: failing toward a standing hand is the
+    /// direction this rail chooses.
+    @Test func aDeltaOverTheCapIsReadFromItsEnd() async throws {
+        let padding = String(repeating: "x", count: 900)
+        let padded = #"{"type":"assistant","isSidechain":true,"pad":"\#(padding)"}"#
+        var contents = Self.parent + "\n"
+        for _ in 0..<120 { contents += padded + "\n" }
+        let full = try write(contents)
+        #expect(full.size > Int64(TranscriptDeltaInspection.deltaByteLimit))
+
+        #expect(TranscriptDeltaInspection.live(full.path, 0) == .sidechainOnly)
+    }
+
+    /// A record still being written is not yet evidence of anything.
+    @Test func anIncompleteFinalRecordIsNotEvidence() async throws {
+        let base = try write(Self.sidechain + "\n")
+        let full = try write(Self.sidechain + "\n" + #"{"type":"user","mes"#)
+
+        #expect(TranscriptDeltaInspection.live(full.path, base.size) == .sidechainOnly)
+    }
+
+    /// Same size, different modification time: the file was touched but gained
+    /// no record, so the parent has not written.
+    @Test func anEmptyDeltaIsNotParentContent() async throws {
+        let full = try write(Self.parent + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, full.size) == .sidechainOnly)
+    }
+
+    @Test func returnsNilWhenTheFileCannotBeOpened() async throws {
+        let missing = temp.url.appendingPathComponent("absent.jsonl").path
+
+        #expect(TranscriptDeltaInspection.live(missing, 0) == nil)
+    }
+
+    /// An offset past the end is a race, not a state to interpret.
+    @Test func returnsNilWhenTheOffsetIsBeyondTheEnd() async throws {
+        let full = try write(Self.parent + "\n")
+
+        #expect(TranscriptDeltaInspection.live(full.path, full.size + 500) == nil)
+    }
+
+    @Test func returnsNilForAnEmptyPath() async throws {
+        #expect(TranscriptDeltaInspection.live("", 0) == nil)
     }
 }

--- a/Tests/TBDDaemonTests/AwaitingInputSupersessionTests.swift
+++ b/Tests/TBDDaemonTests/AwaitingInputSupersessionTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Records every path it was asked to measure, so a test can assert the stat
+/// never happened at all — the cheap-path claim this helper rests on.
+private final class FingerprintSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [String] = []
+    var calls: [String] { lock.lock(); defer { lock.unlock() }; return _calls }
+    let result: TranscriptFingerprint?
+
+    init(result: TranscriptFingerprint?) { self.result = result }
+
+    var fingerprinter: TranscriptFingerprinter {
+        { [self] path in
+            lock.lock()
+            _calls.append(path)
+            lock.unlock()
+            return result
+        }
+    }
+}
+
+/// The transcript superseder: it retracts a standing prompt when the session's
+/// JSONL moved since the prompt was raised, and fails toward leaving the hand
+/// up in every other case.
+@Suite struct AwaitingInputSupersessionTests {
+    let db: TBDDatabase
+    let terminalID: UUID
+
+    static let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+    static let modifiedAt = Date(timeIntervalSince1970: 1_779_900_000)
+    static let pathA = "/tmp/supersession-a.jsonl"
+    static let pathB = "/tmp/supersession-b.jsonl"
+
+    init() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        let repo = try await db.repos.create(
+            path: "/tmp/sup-repo-\(UUID().uuidString)", displayName: "S", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/sup-wt-\(UUID().uuidString)", tmuxServer: "tbd-sup")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "s-1", kind: .claude)
+        terminalID = terminal.id
+    }
+
+    private static func fingerprint(
+        path: String = pathA, size: Int64
+    ) -> TranscriptFingerprint {
+        TranscriptFingerprint(path: path, modifiedAt: modifiedAt, size: size)
+    }
+
+    private func setTranscriptPath(_ path: String) async throws {
+        try await db.terminals.updateSession(
+            id: terminalID, sessionID: "s-1", transcriptPath: path)
+    }
+
+    private func record(
+        type: String?, fingerprint: TranscriptFingerprint?
+    ) async throws {
+        _ = try await db.terminals.recordAwaitingInputReason(
+            id: terminalID,
+            reason: AwaitingInputReason(
+                message: "Claude needs your permission to use Bash",
+                hookEventName: "Notification",
+                raw: "{}",
+                notificationType: type,
+                transcriptFingerprint: fingerprint),
+            observedAt: Self.observedAt)
+    }
+
+    private func terminal() async throws -> Terminal {
+        try #require(try await db.terminals.get(id: terminalID))
+    }
+
+    private func reconcile(_ spy: FingerprintSpy) async throws -> Bool {
+        let supersession = AwaitingInputSupersession(db: db, fingerprint: spy.fingerprinter)
+        return await supersession.reconcile(terminal: try await terminal())
+    }
+
+    /// The file moved since the prompt was raised, so the session is not
+    /// stopped on it. That is the whole mechanism.
+    @Test func retractsWhenTheTranscriptChanged() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = FingerprintSpy(result: Self.fingerprint(size: 20))
+
+        #expect(try await reconcile(spy))
+
+        let after = try await terminal()
+        #expect(after.awaitingInputReason == nil)
+        #expect(after.awaitingInputObservedAt == nil)
+        #expect(spy.calls == [Self.pathA])
+    }
+
+    /// A `/clear`, a compaction or a resume retargeted the session. A
+    /// fingerprint cannot describe a file it was not taken from.
+    @Test func retractsWhenTheTranscriptWasRetargeted() async throws {
+        try await setTranscriptPath(Self.pathB)
+        try await record(
+            type: "permission_prompt",
+            fingerprint: Self.fingerprint(path: Self.pathA, size: 10))
+        let spy = FingerprintSpy(result: Self.fingerprint(path: Self.pathB, size: 10))
+
+        #expect(try await reconcile(spy))
+
+        #expect(try await terminal().awaitingInputReason == nil)
+        #expect(spy.calls == [Self.pathB])
+    }
+
+    /// A session sitting on a permission prompt writes nothing, so an unchanged
+    /// file is the pending case.
+    @Test func leavesAPendingPromptAlone() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = FingerprintSpy(result: Self.fingerprint(size: 10))
+
+        #expect(try await reconcile(spy) == false)
+
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
+    }
+
+    /// Inability to look is never evidence that a prompt was answered.
+    @Test func leavesThePromptAloneWhenTheFileCannotBeRead() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = FingerprintSpy(result: nil)
+
+        #expect(try await reconcile(spy) == false)
+
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
+        #expect(spy.calls == [Self.pathA])
+    }
+
+    @Test func leavesThePromptAloneWhenThereIsNoTranscriptPath() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = FingerprintSpy(result: Self.fingerprint(size: 20))
+
+        #expect(try await terminal().transcriptPath == nil)
+        #expect(try await reconcile(spy) == false)
+
+        #expect(try await terminal().awaitingInputReason != nil)
+        #expect(spy.calls.isEmpty)
+    }
+
+    /// A row that predates fingerprints says nothing about whether its prompt
+    /// was answered, so it is adopted rather than acted on — and self-heals on
+    /// the transcript's next write.
+    @Test func adoptsAFingerprintWhenTheReasonHasNone() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "permission_prompt", fingerprint: nil)
+        let spy = FingerprintSpy(result: Self.fingerprint(size: 10))
+
+        #expect(try await reconcile(spy) == false)
+
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(size: 10))
+        #expect(standing.classification == .promptOnScreen)
+    }
+
+    @Test func ignoresAReasonThatIsNotPromptOnScreen() async throws {
+        try await setTranscriptPath(Self.pathA)
+        try await record(type: "idle_prompt", fingerprint: nil)
+        let spy = FingerprintSpy(result: Self.fingerprint(size: 10))
+
+        #expect(try await reconcile(spy) == false)
+
+        let standing = try #require(try await terminal().awaitingInputReason)
+        #expect(standing.classification == .doneWaiting)
+        #expect(standing.transcriptFingerprint == nil)
+        #expect(spy.calls.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -28,10 +28,21 @@ import TestSupport
     /// Shared with `activityRouter` so the retraction broadcast the activity
     /// rail emits lands in the same collector as the notification's.
     private let subscriptions: StateSubscriptionManager
+    /// Every transcript path the handler measured, so "this class pays no stat"
+    /// is asserted rather than inferred from an absent field.
+    fileprivate let fingerprints: NotificationFingerprintSpy
 
     /// Pinned through the router's date seam, so the stored observed-at is an
     /// exact assertion rather than a freshness window.
     static let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+
+    /// The transcript this suite's terminal points at once a test gives it one,
+    /// and the fingerprint the stubbed stat reports for it.
+    static let transcriptPath = "/tmp/notif-transcript.jsonl"
+    static let stubFingerprint = TranscriptFingerprint(
+        path: transcriptPath,
+        modifiedAt: Date(timeIntervalSince1970: 1_779_500_000),
+        size: 7)
 
     init() async throws {
         let db = try TBDDatabase(inMemory: true)
@@ -46,6 +57,8 @@ import TestSupport
             }
             return true
         }
+        let fingerprints = NotificationFingerprintSpy(result: Self.stubFingerprint)
+        self.fingerprints = fingerprints
         self.router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
@@ -55,6 +68,7 @@ import TestSupport
             startTime: Date(),
             subscriptions: subscriptions,
             now: { Self.observedAt },
+            transcriptFingerprinter: fingerprints.fingerprinter,
             actuationLog: makeTestActuationLog())
         let repo = try await db.repos.create(
             path: "/tmp/notif-repo-\(UUID().uuidString)", displayName: "N", defaultBranch: "main")
@@ -629,6 +643,41 @@ import TestSupport
         #expect(retraction.terminalID == terminalID)
     }
 
+    // MARK: - The transcript fingerprint
+
+    /// A prompt-on-screen reason carries the transcript as it stood when the
+    /// prompt was raised — the only thing a later reader can use to tell "still
+    /// waiting" from "answered, and the session moved on", since Claude Code
+    /// fires no hook when a human decides.
+    @Test func aPromptOnScreenReasonRecordsTheTranscriptFingerprint() async throws {
+        try await db.terminals.updateSession(
+            id: terminalID, sessionID: "s-1", transcriptPath: Self.transcriptPath)
+
+        #expect(await notify(type: "permission_prompt").success)
+
+        let reason = try #require(try await terminal().awaitingInputReason)
+        #expect(reason.classification == .promptOnScreen)
+        #expect(reason.transcriptFingerprint == Self.stubFingerprint)
+        #expect(reason.transcriptFingerprint?.size == 7)
+        #expect(fingerprints.calls == [Self.transcriptPath])
+    }
+
+    /// No other class raises a hand there would be anything to lower, so none of
+    /// them stats the transcript. The spy makes that the assertion rather than
+    /// leaving it inferred from a nil field a bug could also produce.
+    @Test(arguments: ["idle_prompt", "agent_completed"])
+    func otherClassesRecordNoFingerprint(type: String) async throws {
+        try await db.terminals.updateSession(
+            id: terminalID, sessionID: "s-1", transcriptPath: Self.transcriptPath)
+
+        #expect(await notify(type: type).success)
+
+        let reason = try #require(try await terminal().awaitingInputReason)
+        #expect(reason.classification != .promptOnScreen)
+        #expect(reason.transcriptFingerprint == nil)
+        #expect(fingerprints.calls.isEmpty)
+    }
+
     /// The router's date seam reaches BOTH stamps the resolver's rung-4 decision
     /// compares. `setActivityState` defaults `observedAt` to a bare `Date()` at
     /// the store, so a handler that omitted it would leave one end of that
@@ -642,6 +691,27 @@ import TestSupport
         let after = try await terminal()
         #expect(after.activityStateObservedAt == Self.observedAt)
         #expect(after.observedActivity?.observedAt == Self.observedAt)
+    }
+}
+
+/// Records every path the router asked it to measure, and answers with one
+/// fixed fingerprint. The call log is what lets a test assert the stat never
+/// happened at all.
+private final class NotificationFingerprintSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [String] = []
+    var calls: [String] { lock.lock(); defer { lock.unlock() }; return _calls }
+    let result: TranscriptFingerprint?
+
+    init(result: TranscriptFingerprint?) { self.result = result }
+
+    var fingerprinter: TranscriptFingerprinter {
+        { [self] path in
+            lock.lock()
+            _calls.append(path)
+            lock.unlock()
+            return result
+        }
     }
 }
 

--- a/Tests/TBDDaemonTests/SupervisionReadoutTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionReadoutTests.swift
@@ -25,7 +25,10 @@ struct SupervisionReadoutTests {
 
         var record: ActuationRecordReader { ActuationRecordReader(activePath: actuationPath) }
 
-        func builder() -> SupervisionReadoutBuilder {
+        func builder(
+            transcriptFingerprinter: @escaping TranscriptFingerprinter
+                = TranscriptFingerprinting.live
+        ) -> SupervisionReadoutBuilder {
             let stamp = now
             return SupervisionReadoutBuilder(
                 db: db,
@@ -33,6 +36,7 @@ struct SupervisionReadoutTests {
                 sessionCounters: counters,
                 branchTips: branchTips,
                 actuationRecord: record,
+                transcriptFingerprinter: transcriptFingerprinter,
                 now: { stamp })
         }
 
@@ -315,6 +319,82 @@ struct SupervisionReadoutTests {
             terminalID: beta.terminal.id, worktreeID: beta.worktree.id,
             transcriptPath: transcript, commitsUnchangedSince: nil, at: fixture.now))
         #expect(sampled.turnsInWindow == 3, "beta's baseline survived alpha's readout")
+    }
+
+    // MARK: - Transcript supersession
+
+    /// The readout can be the only reader on a daemon with no app attached, so
+    /// it supersedes a stale prompt on its own pass rather than reporting one.
+
+    private static let transcriptModifiedAt = Date(timeIntervalSince1970: 1_785_900_000)
+
+    private static func fingerprint(path: String, size: Int64) -> TranscriptFingerprint {
+        TranscriptFingerprint(path: path, modifiedAt: transcriptModifiedAt, size: size)
+    }
+
+    private func recordPrompt(
+        _ fixture: Fixture, terminal: UUID, fingerprint: TranscriptFingerprint
+    ) async throws {
+        _ = try await fixture.db.terminals.recordAwaitingInputReason(
+            id: terminal,
+            reason: AwaitingInputReason(
+                message: "Claude needs your permission to use Bash",
+                hookEventName: "Notification",
+                raw: "{}",
+                notificationType: "permission_prompt",
+                transcriptFingerprint: fingerprint),
+            observedAt: fixture.now)
+    }
+
+    private func isAwaitingInput(_ state: SessionState) -> Bool {
+        if case .awaitingInput = state.value { return true }
+        return false
+    }
+
+    @Test("The readout supersedes a prompt whose transcript moved")
+    func theReadoutSupersedesAPromptWhoseTranscriptMoved() async throws {
+        let fixture = try makeFixture()
+        let transcript = fixture.directory.appendingPathComponent("moved.jsonl").path
+        let seeded = try await seed(fixture, project: "acme-super", transcript: transcript)
+        try fixture.writeRecord([])
+        try await recordPrompt(
+            fixture, terminal: seeded.terminal.id,
+            fingerprint: Self.fingerprint(path: transcript, size: 10))
+
+        let facts = try await fixture.store.projectFacts(project: "acme-super", brake: .released)
+        let readout = try await fixture.builder(
+            transcriptFingerprinter: { _ in Self.fingerprint(path: transcript, size: 20) }
+        ).build(facts: facts)
+
+        let agent = try #require(readout.agents.first)
+        #expect(isAwaitingInput(agent.state) == false,
+                "the readout reported a prompt its own pass retracted")
+        let row = try #require(try await fixture.db.terminals.get(id: seeded.terminal.id))
+        #expect(row.awaitingInputReason == nil)
+        #expect(row.awaitingInputObservedAt == nil)
+    }
+
+    @Test("The readout leaves a pending prompt raised")
+    func theReadoutLeavesAPendingPromptRaised() async throws {
+        let fixture = try makeFixture()
+        let transcript = fixture.directory.appendingPathComponent("pending.jsonl").path
+        let seeded = try await seed(fixture, project: "acme-pending", transcript: transcript)
+        try fixture.writeRecord([])
+        try await recordPrompt(
+            fixture, terminal: seeded.terminal.id,
+            fingerprint: Self.fingerprint(path: transcript, size: 10))
+
+        let facts = try await fixture.store.projectFacts(project: "acme-pending", brake: .released)
+        let readout = try await fixture.builder(
+            transcriptFingerprinter: { _ in Self.fingerprint(path: transcript, size: 10) }
+        ).build(facts: facts)
+
+        let agent = try #require(readout.agents.first)
+        #expect(isAwaitingInput(agent.state))
+        let standing = try #require(
+            try await fixture.db.terminals.get(id: seeded.terminal.id)?.awaitingInputReason)
+        #expect(standing.classification == .promptOnScreen)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(path: transcript, size: 10))
     }
 
     // MARK: - The bounded record walk

--- a/Tests/TBDDaemonTests/SupervisionReadoutTests.swift
+++ b/Tests/TBDDaemonTests/SupervisionReadoutTests.swift
@@ -27,7 +27,9 @@ struct SupervisionReadoutTests {
 
         func builder(
             transcriptFingerprinter: @escaping TranscriptFingerprinter
-                = TranscriptFingerprinting.live
+                = TranscriptFingerprinting.live,
+            transcriptDeltaInspector: @escaping TranscriptDeltaInspector
+                = { _, _ in .containsParentContent }
         ) -> SupervisionReadoutBuilder {
             let stamp = now
             return SupervisionReadoutBuilder(
@@ -37,6 +39,7 @@ struct SupervisionReadoutTests {
                 branchTips: branchTips,
                 actuationRecord: record,
                 transcriptFingerprinter: transcriptFingerprinter,
+                transcriptDeltaInspector: transcriptDeltaInspector,
                 now: { stamp })
         }
 
@@ -372,6 +375,30 @@ struct SupervisionReadoutTests {
         let row = try #require(try await fixture.db.terminals.get(id: seeded.terminal.id))
         #expect(row.awaitingInputReason == nil)
         #expect(row.awaitingInputObservedAt == nil)
+    }
+
+    @Test("The readout leaves the hand up when only a subagent wrote")
+    func theReadoutLeavesTheHandUpWhenOnlyASubagentWrote() async throws {
+        let fixture = try makeFixture()
+        let transcript = fixture.directory.appendingPathComponent("sidechain.jsonl").path
+        let seeded = try await seed(fixture, project: "acme-sidechain", transcript: transcript)
+        try fixture.writeRecord([])
+        try await recordPrompt(
+            fixture, terminal: seeded.terminal.id,
+            fingerprint: Self.fingerprint(path: transcript, size: 10))
+
+        let facts = try await fixture.store.projectFacts(project: "acme-sidechain", brake: .released)
+        let readout = try await fixture.builder(
+            transcriptFingerprinter: { _ in Self.fingerprint(path: transcript, size: 20) },
+            transcriptDeltaInspector: { _, _ in .sidechainOnly }
+        ).build(facts: facts)
+
+        let agent = try #require(readout.agents.first)
+        #expect(isAwaitingInput(agent.state),
+                "a nested agent's writes are not the parent answering a prompt")
+        let standing = try #require(
+            try await fixture.db.terminals.get(id: seeded.terminal.id)?.awaitingInputReason)
+        #expect(standing.transcriptFingerprint == Self.fingerprint(path: transcript, size: 20))
     }
 
     @Test("The readout leaves a pending prompt raised")

--- a/Tests/TBDDaemonTests/TerminalListSupersessionTests.swift
+++ b/Tests/TBDDaemonTests/TerminalListSupersessionTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// Records every path the list pass measured, and answers with one fixed
+/// fingerprint. The call log is what lets a test assert the stat never happened.
+private final class ListFingerprintSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [String] = []
+    var calls: [String] { lock.lock(); defer { lock.unlock() }; return _calls }
+    let result: TranscriptFingerprint?
+
+    init(result: TranscriptFingerprint?) { self.result = result }
+
+    var fingerprinter: TranscriptFingerprinter {
+        { [self] path in
+            lock.lock()
+            _calls.append(path)
+            lock.unlock()
+            return result
+        }
+    }
+}
+
+/// Thread-safe collector for broadcast StateDeltas.
+private final class ListBroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}
+
+/// Tier 1. `terminal.list` supersedes a standing prompt on the pass that is
+/// about to report it.
+///
+/// Three things have to agree, and each is asserted separately because a
+/// partial fix can satisfy any one of them alone: the row in the RESPONSE, the
+/// row in the DATABASE, and the `.terminalAwaitingInputChanged` delta the app
+/// mirrors its own copy from. A response corrected without a write reports a
+/// prompt the next poll raises again; a write without a broadcast leaves the
+/// indicator standing until that poll.
+@Suite struct TerminalListSupersessionTests {
+    let db: TBDDatabase
+    let worktreeID: UUID
+    let terminalID: UUID
+    private let subscriptions: StateSubscriptionManager
+    private let broadcasts: ListBroadcastDeltas
+
+    static let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+    static let modifiedAt = Date(timeIntervalSince1970: 1_779_900_000)
+    static let transcriptPath = "/tmp/terminal-list-supersession.jsonl"
+
+    init() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        let broadcasts = ListBroadcastDeltas()
+        self.broadcasts = broadcasts
+        let subscriptions = StateSubscriptionManager()
+        self.subscriptions = subscriptions
+        subscriptions.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                broadcasts.append(delta)
+            }
+            return true
+        }
+        let repo = try await db.repos.create(
+            path: "/tmp/tls-repo-\(UUID().uuidString)", displayName: "T", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/tls-wt-\(UUID().uuidString)", tmuxServer: "tbd-tls")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "s-1", kind: .claude)
+        terminalID = terminal.id
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "s-1", transcriptPath: Self.transcriptPath)
+    }
+
+    private static func fingerprint(size: Int64) -> TranscriptFingerprint {
+        TranscriptFingerprint(path: transcriptPath, modifiedAt: modifiedAt, size: size)
+    }
+
+    private func record(type: String, fingerprint: TranscriptFingerprint?) async throws {
+        _ = try await db.terminals.recordAwaitingInputReason(
+            id: terminalID,
+            reason: AwaitingInputReason(
+                message: "Claude needs your permission to use Bash",
+                hookEventName: "Notification",
+                raw: "{}",
+                notificationType: type,
+                transcriptFingerprint: fingerprint),
+            observedAt: Self.observedAt)
+    }
+
+    private func router(_ spy: ListFingerprintSpy) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subscriptions,
+            now: { Self.observedAt },
+            transcriptFingerprinter: spy.fingerprinter,
+            actuationLog: makeTestActuationLog())
+    }
+
+    /// The response rows, through the real RPC surface the app calls.
+    private func list(_ spy: ListFingerprintSpy) async throws -> [Terminal] {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: worktreeID))
+        let response = await router(spy).handle(request)
+        #expect(response.success)
+        return try response.decodeResult([Terminal].self)
+    }
+
+    private func awaitingInputDeltas() -> [TerminalAwaitingInputDelta] {
+        broadcasts.snapshot().compactMap { delta in
+            if case .terminalAwaitingInputChanged(let d) = delta { return d }
+            return nil
+        }
+    }
+
+    @Test func terminalListRetractsAPromptWhoseTranscriptMoved() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = ListFingerprintSpy(result: Self.fingerprint(size: 20))
+
+        let reported = try await list(spy)
+        let row = try #require(reported.first { $0.id == terminalID })
+        #expect(row.awaitingInputReason == nil, "this pass must not report a prompt it retracted")
+        #expect(row.awaitingInputObservedAt == nil)
+        #expect(row.hasPromptOnScreen == false)
+
+        let stored = try #require(try await db.terminals.get(id: terminalID))
+        #expect(stored.awaitingInputReason == nil)
+        #expect(stored.awaitingInputObservedAt == nil)
+
+        let deltas = awaitingInputDeltas()
+        #expect(deltas.count == 1)
+        #expect(deltas.first?.terminalID == terminalID)
+        #expect(deltas.first?.worktreeID == worktreeID)
+        #expect(deltas.first?.reason == nil)
+        #expect(deltas.first?.observedAt == nil)
+        #expect(spy.calls == [Self.transcriptPath])
+    }
+
+    /// A session sitting on a permission prompt writes nothing, so an unchanged
+    /// file is the pending case — and the app must hear nothing about it.
+    @Test func terminalListLeavesAPendingPromptRaised() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = ListFingerprintSpy(result: Self.fingerprint(size: 10))
+
+        let reported = try await list(spy)
+        let row = try #require(reported.first { $0.id == terminalID })
+        let reason = try #require(row.awaitingInputReason)
+        #expect(reason.classification == .promptOnScreen)
+        #expect(reason.transcriptFingerprint == Self.fingerprint(size: 10))
+        #expect(row.hasPromptOnScreen)
+        #expect(row.awaitingInputObservedAt == Self.observedAt)
+
+        #expect(try await db.terminals.get(id: terminalID)?.awaitingInputReason != nil)
+        #expect(awaitingInputDeltas().isEmpty)
+        #expect(spy.calls == [Self.transcriptPath])
+    }
+
+    /// Only a raised hand can be lowered. A `doneWaiting` reason is not one, so
+    /// the pass neither stats nor announces anything for it.
+    @Test func terminalListDoesNotBroadcastForANonPromptReason() async throws {
+        try await record(type: "idle_prompt", fingerprint: nil)
+        let spy = ListFingerprintSpy(result: Self.fingerprint(size: 20))
+
+        let reported = try await list(spy)
+        let row = try #require(reported.first { $0.id == terminalID })
+        let reason = try #require(row.awaitingInputReason)
+        #expect(reason.classification == .doneWaiting)
+
+        #expect(try await db.terminals.get(id: terminalID)?.awaitingInputReason != nil)
+        #expect(awaitingInputDeltas().isEmpty)
+        #expect(spy.calls.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalListSupersessionTests.swift
+++ b/Tests/TBDDaemonTests/TerminalListSupersessionTests.swift
@@ -103,7 +103,13 @@ private final class ListBroadcastDeltas: @unchecked Sendable {
             observedAt: Self.observedAt)
     }
 
-    private func router(_ spy: ListFingerprintSpy) -> RPCRouter {
+    /// The delta these tests default to: the parent session wrote, which is
+    /// the shape that retracts. Tests about a subagent's writes pass their own.
+    private static let parentWrote: TranscriptDeltaInspector = { _, _ in .containsParentContent }
+
+    private func router(
+        _ spy: ListFingerprintSpy, delta: @escaping TranscriptDeltaInspector
+    ) -> RPCRouter {
         RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
@@ -114,15 +120,19 @@ private final class ListBroadcastDeltas: @unchecked Sendable {
             subscriptions: subscriptions,
             now: { Self.observedAt },
             transcriptFingerprinter: spy.fingerprinter,
+            transcriptDeltaInspector: delta,
             actuationLog: makeTestActuationLog())
     }
 
     /// The response rows, through the real RPC surface the app calls.
-    private func list(_ spy: ListFingerprintSpy) async throws -> [Terminal] {
+    private func list(
+        _ spy: ListFingerprintSpy,
+        delta: @escaping TranscriptDeltaInspector = TerminalListSupersessionTests.parentWrote
+    ) async throws -> [Terminal] {
         let request = try RPCRequest(
             method: RPCMethod.terminalList,
             params: TerminalListParams(worktreeID: worktreeID))
-        let response = await router(spy).handle(request)
+        let response = await router(spy, delta: delta).handle(request)
         #expect(response.success)
         return try response.decodeResult([Terminal].self)
     }
@@ -132,6 +142,25 @@ private final class ListBroadcastDeltas: @unchecked Sendable {
             if case .terminalAwaitingInputChanged(let d) = delta { return d }
             return nil
         }
+    }
+
+    /// A parallel `Task` subagent appends to the parent's JSONL while the
+    /// permission prompt is still on screen. The file moved; the session did
+    /// not. The app must hear nothing, and the row must still raise its hand.
+    @Test func terminalListLeavesTheHandUpWhenOnlyASubagentWrote() async throws {
+        try await record(type: "permission_prompt", fingerprint: Self.fingerprint(size: 10))
+        let spy = ListFingerprintSpy(result: Self.fingerprint(size: 20))
+
+        let reported = try await list(spy, delta: { _, _ in .sidechainOnly })
+        let row = try #require(reported.first { $0.id == terminalID })
+        #expect(row.hasPromptOnScreen)
+        #expect(row.awaitingInputObservedAt == Self.observedAt)
+
+        let stored = try #require(try await db.terminals.get(id: terminalID)?.awaitingInputReason)
+        #expect(stored.classification == .promptOnScreen)
+        #expect(stored.transcriptFingerprint == Self.fingerprint(size: 20),
+                "the baseline advances so the next poll is a stat again")
+        #expect(awaitingInputDeltas().isEmpty)
     }
 
     @Test func terminalListRetractsAPromptWhoseTranscriptMoved() async throws {

--- a/Tests/TBDSharedTests/SessionStateModelTests.swift
+++ b/Tests/TBDSharedTests/SessionStateModelTests.swift
@@ -107,6 +107,30 @@ import Testing
         #expect(decoded.classification == branch.expected)
     }
 
+    /// Claude Code emits more notification types than its published documentation
+    /// lists. Two of them raise a prompt a human must answer, and both fell to
+    /// `.unrecognized`, so they raised no hand at all.
+    @Test func undocumentedPromptTypesRaiseAHand() {
+        #expect(AwaitingInputClass(notificationType: "worker_permission_prompt") == .promptOnScreen)
+        #expect(AwaitingInputClass(notificationType: "elicitation_url_dialog") == .promptOnScreen)
+    }
+
+    @Test func theRemainingUndocumentedTypesAreInformational() {
+        for type in ["computer_use_enter", "computer_use_exit", "push_notification",
+                     "quota_auto_resume_fired", "quota_auto_resume_stale",
+                     "quota_auto_resume_disabled"] {
+            #expect(AwaitingInputClass(notificationType: type) == .informational,
+                    "\(type) should be informational")
+        }
+    }
+
+    /// The default stays a refusal to guess: no prefix match, no case folding.
+    @Test func anUnknownTypeIsStillUnrecognized() {
+        #expect(AwaitingInputClass(notificationType: "permission_prompt_v2") == .unrecognized)
+        #expect(AwaitingInputClass(notificationType: "PERMISSION_PROMPT") == .unrecognized)
+        #expect(AwaitingInputClass(notificationType: nil) == .unrecognized)
+    }
+
     /// The stored class is a convenience for outside readers, never an input:
     /// a record claiming `prompt_on_screen` for a type this build does not
     /// know is re-derived to `unrecognized` on the way in. Without that, a
@@ -188,6 +212,46 @@ import Testing
         // where it came from" check while saying nothing.
         let blank = AwaitingInputReason(message: "m", hookEventName: "")
         #expect(terminal(reason: blank, observedAt: epoch).observedAwaitingInput == nil)
+    }
+
+    // MARK: - Transcript fingerprint
+
+    @Test func awaitingInputReasonCarriesATranscriptFingerprint() throws {
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let reason = AwaitingInputReason(
+            message: "Claude needs your permission",
+            hookEventName: "Notification",
+            raw: "{}",
+            notificationType: "permission_prompt",
+            transcriptFingerprint: TranscriptFingerprint(
+                path: "/tmp/a.jsonl", modifiedAt: stamp, size: 42))
+        let round = try JSONDecoder().decode(
+            AwaitingInputReason.self, from: JSONEncoder().encode(reason))
+        #expect(round.transcriptFingerprint?.path == "/tmp/a.jsonl")
+        #expect(round.transcriptFingerprint?.modifiedAt == stamp)
+        #expect(round.transcriptFingerprint?.size == 42)
+        #expect(round.classification == .promptOnScreen)
+    }
+
+    /// A row written before fingerprints existed must still decode. This is what
+    /// makes the field migration-free: the column is JSON and the key is absent.
+    @Test func aReasonWithoutAFingerprintDecodesAsAbsent() throws {
+        let legacy = #"{"message":"m","notificationType":"permission_prompt","classification":"prompt_on_screen"}"#
+        let reason = try JSONDecoder().decode(
+            AwaitingInputReason.self, from: Data(legacy.utf8))
+        #expect(reason.transcriptFingerprint == nil)
+        #expect(reason.classification == .promptOnScreen)
+        #expect(reason.message == "m")
+    }
+
+    @Test func fingerprintsDifferOnPathMtimeOrSize() {
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let base = TranscriptFingerprint(path: "/tmp/a.jsonl", modifiedAt: stamp, size: 10)
+        #expect(base == TranscriptFingerprint(path: "/tmp/a.jsonl", modifiedAt: stamp, size: 10))
+        #expect(base != TranscriptFingerprint(path: "/tmp/b.jsonl", modifiedAt: stamp, size: 10))
+        #expect(base != TranscriptFingerprint(
+            path: "/tmp/a.jsonl", modifiedAt: stamp.addingTimeInterval(1), size: 10))
+        #expect(base != TranscriptFingerprint(path: "/tmp/a.jsonl", modifiedAt: stamp, size: 11))
     }
 
     // MARK: - FactSource

--- a/docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md
+++ b/docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md
@@ -125,7 +125,7 @@ does when it supersedes a reason.
 state — in a 153-terminal fleet, two rows held a standing prompt. When a file is
 growing, a bounded read of only the region appended since the previous pass, and
 the refresh means that region is what arrived in one interval rather than the
-whole file. The delta read is capped at the same order of tail window the
+whole file. The delta read is capped at 64 KiB, the same order of tail window the
 daemon's other transcript readers use; when the appended region exceeds the cap,
 only its tail is examined, which can miss a parent record buried in the
 unexamined part and therefore fails toward leaving the hand raised.

--- a/docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md
+++ b/docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md
@@ -52,28 +52,41 @@ progress, with no activity observation reaching the daemon in that window.
 
 ## The signal TBD already has
 
-A session sitting on a permission prompt writes nothing. The assistant message
-carrying the tool call is flushed before the prompt is raised; from then until a
-human answers, the session JSONL does not move. A second terminal in the same
-fleet made the positive case: a `permission_prompt` reason recorded at 14:51
-against a transcript whose last write was 14:45, six minutes of a pending prompt
-with a frozen file. That terminal was later answered, its activity rail fired,
-and the reason retracted normally.
+**A session sitting on a permission prompt stops writing to its own transcript.**
+The assistant message carrying the tool call is flushed before the prompt is
+raised; from then until a human answers, the parent session's turn contributes
+nothing further to the JSONL. A terminal in the live fleet made the positive
+case: a `permission_prompt` reason recorded at 14:51 against a transcript whose
+last write was 14:45, six minutes of a pending prompt with a frozen file. That
+terminal was later answered, its activity rail fired, and the reason retracted
+normally.
 
-So the transcript discriminates the two cases that the hook rail cannot tell
-apart: a prompt still standing, and a prompt already answered.
+**But the file is not the session's alone, and this is the whole difficulty.**
+A parallel `Task` subagent appends **sidechain** records to the same JSONL while
+the prompt is still on screen — as does a backgrounded task's completion record,
+and a queued user message. So the file growing is not proof the prompt was
+answered. Claude issues a `Task` and a `Bash` in one turn, the `Bash` raises a
+permission prompt, the subagent appends two seconds later: a mechanism that read
+growth as an answer would drop the hand at the exact moment a human is being
+waited on, and the row would show a working session indefinitely. That is the
+failure that costs a night, and it is the reason `SessionStateResolver` refuses
+the growth-as-answer inference outright.
+
+What discriminates the two cases is not *whether* the file grew but *who* wrote.
+The parent session's records are the ones the prompt gates; a nested agent's are
+not. A record appended since the prompt that does not carry `isSidechain` is the
+parent writing again, and the parent cannot write while blocked. That is the
+signal, and it is a machine field on a machine record — the same field
+`TranscriptParser` and `ClaudeDelegationSample` already partition on, never a
+reading of prose.
 
 ## The rule
 
 When `handleTerminalNotificationEvent` records a reason whose class is
-`.promptOnScreen`, it stats the session JSONL and stores the file's modification
-time and size inside the `AwaitingInputReason` value.
+`.promptOnScreen`, it stats the session JSONL and stores the file's path,
+modification time and size inside the `AwaitingInputReason` value.
 
-When a reader later loads that terminal, it stats the file again. **If the
-fingerprint differs from the stored one, the prompt is gone**: clear the reason
-columns and broadcast `.terminalAwaitingInputChanged` with a nil reason, exactly
-as the activity rail does when it supersedes a reason.
-
+When a reader later loads that terminal, it stats the file again and compares.
 The comparison asks whether the file changed since the prompt was raised, not
 whether the file is newer than some timestamp. That distinction is the point.
 Claude Code raises the `permission_prompt` notification from a debounced,
@@ -82,27 +95,89 @@ observed-at stamp is set by someone else's internals and can change without
 notice. A fingerprint captured at raise time depends on none of it, and is
 immune to clock skew between the writer of the file and the writer of the row.
 
+What a difference means:
+
+- **Nothing changed** — the hand stays up. This is the steady state, and it
+  costs one `stat`: no open, no read, no parse.
+- **The path changed** — the session was retargeted by a `/clear`, a compaction
+  or a resume. Retract: a fingerprint cannot describe a file it was not taken
+  from, and the reason it described belongs to a session that no longer exists.
+  The activity rail reaches the same conclusion by its own route when
+  `SessionStart` lands.
+- **The size shrank** — the file was truncated or rotated. The stored offset no
+  longer names a position in this file, so nothing can be compared against it.
+  Retract.
+- **The file grew** — and only here does the check cost more than a `stat`. The
+  region appended since the stored size is read and its records examined. A
+  single non-sidechain record means the parent session itself wrote, so the
+  prompt was answered: retract. Sidechain-only means a nested agent wrote while
+  the human is still blocked: **the hand stays up**, and the stored fingerprint
+  is refreshed to what was just observed, so the next pass is a `stat` again and
+  the same bytes are never re-read.
+- **The file cannot be read** — nothing changes, and it is retried on the next
+  pass. Inability to look is never evidence.
+
+Retraction clears the reason columns and broadcasts
+`.terminalAwaitingInputChanged` with a nil reason, exactly as the activity rail
+does when it supersedes a reason.
+
+**The cost, stated honestly.** One `stat` per raised hand per pass in the steady
+state — in a 153-terminal fleet, two rows held a standing prompt. When a file is
+growing, a bounded read of only the region appended since the previous pass, and
+the refresh means that region is what arrived in one interval rather than the
+whole file. The delta read is capped at the same order of tail window the
+daemon's other transcript readers use; when the appended region exceeds the cap,
+only its tail is examined, which can miss a parent record buried in the
+unexamined part and therefore fails toward leaving the hand raised.
+
 `AwaitingInputReason` is stored as JSON in a text column and decodes through
-`decodeIfPresent`, so the new field needs no migration and rows written before
-it shipped decode it as absent.
+`decodeIfPresent`, so the fingerprint field needs no migration and rows written
+before it shipped decode it as absent.
 
 ## Where the check runs
 
-Two readers consult the reason, and they reach terminal rows by different
-routes: the app's `terminal.list` poll, which runs every two seconds while the
-app is connected, and `SupervisionReadoutBuilder`, which loads rows one at a
-time for a readout and can run with no app attached. One shared helper is called
-from both.
+Three readers consult `awaitingInputReason`, and they reach terminal rows by
+different routes. **Two of them reconcile**, through one shared helper:
 
-There is no sweep and no timer. The check costs a `stat` — one syscall, no open,
-no read, no parse — and it runs only for terminals holding a standing
-`.promptOnScreen` reason, which in a 153-terminal fleet was two rows. Both call
-sites already perform far heavier transcript I/O on the same pass:
-`CodexTranscriptActivityTracker` reads Codex transcripts on every `terminal.list`,
-`ClaudeDelegationTracker` opens and reads a byte-limited tail of the JSONL for
-every terminal that just ended a turn, and the readout builder samples session
-counters from the transcript per agent. A background sweep would perform the
-same two stats on a worse schedule and add a timer to own, name, and test.
+- **`terminal.list`** — the app's poll, every two seconds while the app is
+  connected. This is the path that heals a row for the sidebar.
+- **`SupervisionReadoutBuilder`** — loads rows one at a time for a readout, and
+  can run with no app attached, which is exactly the case `terminal.list` cannot
+  cover.
+
+**The third reader does not reconcile.** `handleSessionStates`, backing the
+`session.states` RPC, reads the same column through `SessionStateFactGatherer`
+and resolves it with `SessionStateResolver`. It performs no supersession, and
+this is sound rather than an oversight:
+
+- It never wrote the row, and it is not the rail that owns retraction. A
+  read-only reporter that also mutated the record it reports would give the same
+  column two writers on two schedules.
+- A stale row it reads is transient. `terminal.list` heals it on its own polling
+  cadence, so `session.states` sees the corrected value on a later cycle without
+  doing anything itself.
+- Most importantly, the resolver does not report a stale prompt confidently. It
+  independently compares the transcript's append stamp against the reason's
+  observed-at, and when the transcript has moved it degrades the answer to
+  `.unknown(why:)` naming both possibilities, rather than asserting
+  `.awaitingInput`. Its refusal is coarser than the supersession's — it does not
+  distinguish a sidechain writer from the parent — and it is deliberately
+  coarser, because a resolver that guessed wrong would report `.working` for a
+  session blocked on a human. The two mechanisms agree on direction and differ
+  only in how much they are willing to conclude.
+
+So the precision the supersession buys is available on the paths that write, and
+the path that only reads stays honest about what it does not know.
+
+There is no sweep and no timer. The check runs only for terminals holding a
+standing `.promptOnScreen` reason, and both reconciling call sites already
+perform far heavier transcript I/O on the same pass:
+`CodexTranscriptActivityTracker` reads Codex transcripts on every
+`terminal.list`, `ClaudeDelegationTracker` opens and reads a byte-limited tail of
+the JSONL for every terminal that just ended a turn, and the readout builder
+samples session counters from the transcript per agent. A background sweep would
+perform the same stats on a worse schedule and add a timer to own, name, and
+test.
 
 ## Edges
 
@@ -110,36 +185,43 @@ Every edge fails toward leaving the hand up. A hand that lingers is the bug this
 document fixes; a hand that drops while a human is still being asked for
 something is worse, because it hides the one row that needs attention.
 
-- **The file cannot be read** — no retraction. TBD's delegation rail already
-  states the principle this borrows: inability to look is never evidence. Here
-  it is never evidence that a prompt was answered.
-- **The terminal's `transcriptPath` differs from the one fingerprinted** — a
-  `/clear`, a compaction, or a resume retargeted the session. Retract: a
-  fingerprint cannot describe a file it was not taken from. The activity rail
-  reaches the same conclusion by its own route when `SessionStart` lands.
+- **The file cannot be read, or has no path** — no retraction. TBD's delegation
+  rail already states the principle this borrows: inability to look is never
+  evidence. Here it is never evidence that a prompt was answered.
+- **The appended region cannot be parsed** — a partial line at the tail, a
+  record shape this build does not model. It is not a non-sidechain parent
+  record until it is read as one, so it does not retract.
 - **No fingerprint stored** — the row predates this mechanism. Adopt the current
   stat and store it, so the row self-heals on the transcript's next write. This
   needs no clock comparison and no horizon constant, and it leaves a genuinely
   pending prompt raised.
-- **Concurrency** — the stat happens outside the database, so the clear
-  re-reads the stored fingerprint inside the write transaction and clears only
-  if it still matches what was compared. This mirrors
+- **Concurrency** — the stat and the delta read happen outside the database, so
+  the clear re-reads the stored fingerprint inside the write transaction and
+  clears only if it still matches what was compared. This mirrors
   `clearAwaitingInputReasonIfNotNewer`, whose comment explains why: the row a
   handler read before an unbounded stretch of async work may already be stale,
   and `handleTerminalNotificationEvent` runs concurrently on its own connection.
+  The fingerprint refresh on a sidechain-only append takes the same conditional
+  form, so a reason recorded while the delta was being read is not overwritten
+  by a measurement of the file as it stood before it.
 
 ## Seams and testing
 
 The stat is reached through an injected closure so tests drive fingerprints
-without a filesystem. No clock seam is required: nothing here sleeps, debounces,
-or polls, and a file's modification time is data rather than behavior — the
-distinction `CLAUDE.md` draws between the `Duration` and `Date` seams.
+without a filesystem, and the delta read is driven from written temp files whose
+contents the test controls. No clock seam is required: nothing here sleeps,
+debounces, or polls, and a file's modification time is data rather than behavior
+— the distinction `CLAUDE.md` draws between the `Duration` and `Date` seams.
 
 Tests cover: the fingerprint is captured when a `.promptOnScreen` reason is
-recorded and not for other classes; a changed modification time retracts; a
-changed size retracts; a changed `transcriptPath` retracts; an unchanged file
-does not; an unreadable file does not; an absent fingerprint is adopted rather
-than acted on; and the broadcast carries a nil reason.
+recorded and not for other classes; an unchanged file does not retract; a
+changed `transcriptPath` retracts; a shrunken file retracts; an appended region
+carrying a non-sidechain record retracts; an appended region carrying only
+sidechain records does **not** retract and refreshes the stored fingerprint; a
+second pass after such a refresh reads no bytes; an unreadable file does not
+retract; an absent fingerprint is adopted rather than acted on; a stale expected
+fingerprint makes the conditional clear a no-op; and the broadcast carries a nil
+reason.
 
 ## The classifier's vocabulary
 
@@ -164,16 +246,40 @@ sounds like a prompt.
 
 ## No feature flag
 
-`CLAUDE.md` requires a default-off flag for behavior that acts without a user
-gesture, destroys state, or wholesale-replaces a load-bearing path. This is none
-of those. It adds no timer and no autonomous action, kills nothing, deletes no
-persisted state, and replaces no path — it corrects one column on a read path
-that an existing rail already corrects by another route, and the correction's
-failure direction is the status quo. A flag here would mean a config column and
-a migration to gate a bug fix.
+`CLAUDE.md` requires a default-off flag for behavior that acts autonomously or
+can destroy state, and exempts bug fixes. This is a bug fix — a raised hand that
+never comes down is the system failing its own existing theory, not a revision
+of it — and the four properties that make the exemption apply here are worth
+naming, because the feature does write to a persisted column and "it deletes no
+state" would be the wrong reason to reach the right conclusion:
+
+- **The write is narrow.** One column pair on one row, to nil, and only for rows
+  already holding a `.promptOnScreen` reason. Nothing else in the record is
+  touched, and no row without a standing prompt is read past its reason field.
+- **The write is idempotent and conditional.** It clears only when the stored
+  fingerprint still matches what was compared, so a repeated pass over an
+  already-cleared row does nothing, and a concurrent raise is not clobbered.
+- **Every failure direction is the status quo.** An unreadable file, an
+  unparseable append, an over-cap region, a mismatched expectation: each leaves
+  the hand raised, which is the behavior shipping today.
+- **It rides an existing read path.** No timer, no sweep, no background actor,
+  no new schedule to reason about — the work happens on passes that already load
+  these rows and already read these transcripts.
+
+A flag here would mean a config column and a migration to gate a correction, and
+would leave the defect standing for everyone who never found the toggle.
 
 ## Rejected alternatives
 
+- **Retracting on any transcript change.** The simplest rule — the file moved,
+  therefore the prompt is gone — and it is wrong in the direction that matters.
+  A parallel `Task` subagent appends sidechain records to the same JSONL while
+  the prompt is still on screen, as do a backgrounded task's completion record
+  and a queued user message. The hand would drop seconds after a permission
+  prompt in any turn that also delegated, and the row would then show a working
+  session for as long as the human took to notice by other means. Reading who
+  wrote the appended records costs a bounded read only while the file is
+  growing, and buys the one distinction the raw growth signal cannot make.
 - **A `PostToolUse` hook as the take-down signal.** A tool that ran is proof its
   permission prompt was answered, and the hook fires within milliseconds. It was
   rejected on coverage rather than cost: it says nothing about a refusal, which
@@ -202,8 +308,9 @@ a migration to gate a bug fix.
   stat a daemon-side path on behalf of a remote lane.
 - **A background sweep.** The doctrine that every durable external resource
   needs a named reconciler covers resources that outlive the request that made
-  them. A stale column read by two pull-based readers is not one: both readers
-  can correct it on the pass that consults it, for the cost of a stat.
+  them. A stale column read by pull-based readers is not one: the readers that
+  own the retraction can correct it on the pass that consults it, for the cost
+  of a stat.
 
 ## Out of scope
 

--- a/docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md
+++ b/docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md
@@ -1,0 +1,224 @@
+# Taking the raised hand down: transcript supersession for awaiting-input
+
+A Claude session that stops on a permission prompt shows a raised hand in the
+sidebar. Nothing reliably takes that hand down. This document records why the
+existing mechanism cannot, and adds a second superseder that TBD evaluates for
+itself rather than waiting to be told.
+
+## The rail as it stands
+
+A terminal's `awaitingInputReason` column carries a structured reason — the
+verbatim `notification_type`, the message, and the class TBD files it under.
+`Terminal.hasPromptOnScreen` is true when that class is `.promptOnScreen`, and
+that is what puts the amber `hand.raised.fill` in the sidebar's suffix slot and
+bolds the row's name.
+
+Exactly one thing writes the reason: Claude Code's `Notification` hook, bridged
+through `tbd hooks notification` into `handleTerminalNotificationEvent`. Exactly
+one thing retracts it: **a later activity observation.** `setActivityState` nils
+the reason columns unconditionally — it is the superseding rail — and the
+same-value path calls `clearAwaitingInputReasonIfNotNewer` so a repeated state
+still supersedes a not-newer wait. Activity observations arrive from a small set
+of hooks the TBD overlay registers: `UserPromptSubmit` reports working, `Stop`
+and `StopFailure` report idle, `SessionStart` re-establishes identity, and the
+`AskUserQuestion` pre/post pair brackets a question.
+
+That design is sound and stays. It is also incomplete in a way no tuning fixes.
+
+## Why the hand stays up
+
+**Claude Code has no permission-decision hook.** The event vocabulary carries
+`PermissionRequest`, which fires on the ask path *before* the human decides, and
+`PermissionDenied`, whose own help text reads "After auto mode classifier denies
+a tool call" — auto-mode denials, not human ones. A user's approval or refusal
+fires nothing. The `Notification` hook is raise-only by construction: it reports
+that a prompt was raised, never that it went away.
+
+So after a human approves a permission, the next activity observation is the
+`Stop` at the end of the turn, which can be many minutes away. The row shows a
+raised hand at a session that is working.
+
+A refusal is no better. Rejecting a tool call is not an error; it resolves to a
+tool result telling the model the user does not want to proceed, so neither
+`PostToolUse` nor `PostToolUseFailure` fires. The hand waits for `Stop` there
+too, though in practice a refusal is usually followed closely by one.
+
+And when a session's hook rail stops reaching the daemon at all, nothing
+retracts the reason ever. This is not hypothetical. A terminal observed in the
+live fleet held a `permission_prompt` reason recorded at 15:05 on one day while
+its session transcript was still being written at 15:59 on the next — a raised
+hand standing for twenty-five hours over a session that was demonstrably making
+progress, with no activity observation reaching the daemon in that window.
+
+## The signal TBD already has
+
+A session sitting on a permission prompt writes nothing. The assistant message
+carrying the tool call is flushed before the prompt is raised; from then until a
+human answers, the session JSONL does not move. A second terminal in the same
+fleet made the positive case: a `permission_prompt` reason recorded at 14:51
+against a transcript whose last write was 14:45, six minutes of a pending prompt
+with a frozen file. That terminal was later answered, its activity rail fired,
+and the reason retracted normally.
+
+So the transcript discriminates the two cases that the hook rail cannot tell
+apart: a prompt still standing, and a prompt already answered.
+
+## The rule
+
+When `handleTerminalNotificationEvent` records a reason whose class is
+`.promptOnScreen`, it stats the session JSONL and stores the file's modification
+time and size inside the `AwaitingInputReason` value.
+
+When a reader later loads that terminal, it stats the file again. **If the
+fingerprint differs from the stored one, the prompt is gone**: clear the reason
+columns and broadcast `.terminalAwaitingInputChanged` with a nil reason, exactly
+as the activity rail does when it supersedes a reason.
+
+The comparison asks whether the file changed since the prompt was raised, not
+whether the file is newer than some timestamp. That distinction is the point.
+Claude Code raises the `permission_prompt` notification from a debounced,
+cancellable timer, so the delay between the transcript write and the reason's
+observed-at stamp is set by someone else's internals and can change without
+notice. A fingerprint captured at raise time depends on none of it, and is
+immune to clock skew between the writer of the file and the writer of the row.
+
+`AwaitingInputReason` is stored as JSON in a text column and decodes through
+`decodeIfPresent`, so the new field needs no migration and rows written before
+it shipped decode it as absent.
+
+## Where the check runs
+
+Two readers consult the reason, and they reach terminal rows by different
+routes: the app's `terminal.list` poll, which runs every two seconds while the
+app is connected, and `SupervisionReadoutBuilder`, which loads rows one at a
+time for a readout and can run with no app attached. One shared helper is called
+from both.
+
+There is no sweep and no timer. The check costs a `stat` — one syscall, no open,
+no read, no parse — and it runs only for terminals holding a standing
+`.promptOnScreen` reason, which in a 153-terminal fleet was two rows. Both call
+sites already perform far heavier transcript I/O on the same pass:
+`CodexTranscriptActivityTracker` reads Codex transcripts on every `terminal.list`,
+`ClaudeDelegationTracker` opens and reads a byte-limited tail of the JSONL for
+every terminal that just ended a turn, and the readout builder samples session
+counters from the transcript per agent. A background sweep would perform the
+same two stats on a worse schedule and add a timer to own, name, and test.
+
+## Edges
+
+Every edge fails toward leaving the hand up. A hand that lingers is the bug this
+document fixes; a hand that drops while a human is still being asked for
+something is worse, because it hides the one row that needs attention.
+
+- **The file cannot be read** — no retraction. TBD's delegation rail already
+  states the principle this borrows: inability to look is never evidence. Here
+  it is never evidence that a prompt was answered.
+- **The terminal's `transcriptPath` differs from the one fingerprinted** — a
+  `/clear`, a compaction, or a resume retargeted the session. Retract: a
+  fingerprint cannot describe a file it was not taken from. The activity rail
+  reaches the same conclusion by its own route when `SessionStart` lands.
+- **No fingerprint stored** — the row predates this mechanism. Adopt the current
+  stat and store it, so the row self-heals on the transcript's next write. This
+  needs no clock comparison and no horizon constant, and it leaves a genuinely
+  pending prompt raised.
+- **Concurrency** — the stat happens outside the database, so the clear
+  re-reads the stored fingerprint inside the write transaction and clears only
+  if it still matches what was compared. This mirrors
+  `clearAwaitingInputReasonIfNotNewer`, whose comment explains why: the row a
+  handler read before an unbounded stretch of async work may already be stale,
+  and `handleTerminalNotificationEvent` runs concurrently on its own connection.
+
+## Seams and testing
+
+The stat is reached through an injected closure so tests drive fingerprints
+without a filesystem. No clock seam is required: nothing here sleeps, debounces,
+or polls, and a file's modification time is data rather than behavior — the
+distinction `CLAUDE.md` draws between the `Duration` and `Date` seams.
+
+Tests cover: the fingerprint is captured when a `.promptOnScreen` reason is
+recorded and not for other classes; a changed modification time retracts; a
+changed size retracts; a changed `transcriptPath` retracts; an unchanged file
+does not; an unreadable file does not; an absent fingerprint is adopted rather
+than acted on; and the broadcast carries a nil reason.
+
+## The classifier's vocabulary
+
+`AwaitingInputClass` files a verbatim `notification_type` under a class, and
+states that it lists Claude Code's types exhaustively so that adding one is a
+visible edit rather than a silent reclassification. That claim has drifted:
+Claude Code emits more types than the published documentation lists, and two of
+them raise a prompt a human must answer.
+
+- **`worker_permission_prompt`** and **`elicitation_url_dialog`** join
+  `.promptOnScreen`. Today they fall through to `.unrecognized` and raise no
+  hand at all.
+- **`computer_use_enter`**, **`computer_use_exit`**, **`push_notification`**,
+  **`quota_auto_resume_fired`**, **`quota_auto_resume_stale`** and
+  **`quota_auto_resume_disabled`** join `.informational`, restoring the
+  exhaustiveness the type claims. None of these changes behavior; they make the
+  next drift a visible edit again.
+
+The default case stays as it is. A type this build has never heard of remains
+`.unrecognized`: no prefix matching, no case folding, no guessing that something
+sounds like a prompt.
+
+## No feature flag
+
+`CLAUDE.md` requires a default-off flag for behavior that acts without a user
+gesture, destroys state, or wholesale-replaces a load-bearing path. This is none
+of those. It adds no timer and no autonomous action, kills nothing, deletes no
+persisted state, and replaces no path — it corrects one column on a read path
+that an existing rail already corrects by another route, and the correction's
+failure direction is the status quo. A flag here would mean a config column and
+a migration to gate a bug fix.
+
+## Rejected alternatives
+
+- **A `PostToolUse` hook as the take-down signal.** A tool that ran is proof its
+  permission prompt was answered, and the hook fires within milliseconds. It was
+  rejected on coverage rather than cost: it says nothing about a refusal, which
+  fires no tool-completion hook at all, and it cannot help a session whose hook
+  rail has stopped reaching the daemon — the twenty-five-hour case above. Adding
+  it alongside the transcript check would buy roughly two seconds of latency in
+  exchange for a second rail that can disagree with the first, a hook-overlay
+  entry, and a `tbd` process spawn per tool call across the whole fleet.
+- **Scoping a hook to the permission prompt itself.** There is nothing to scope
+  to. A permission prompt is a gate on another tool's call, not a tool; for
+  `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest` and
+  `PermissionDenied` the matcher key is the tool name, and no synthetic name
+  represents the prompt. `AskUserQuestion` is the misleading precedent: it is a
+  real tool with a real name, which is why the overlay can matcher-scope it.
+- **Comparing the transcript's modification time against the reason's
+  observed-at stamp.** Simpler, and it would repair existing rows the moment it
+  shipped. It depends on Claude Code flushing the assistant message before its
+  debounce timer fires — true in every sample taken, but an assumption about
+  another program's internals whose failure mode is dropping every hand
+  instantly. Adding a margin in seconds does not remove the dependency; it
+  encodes a guess about it, and costs that latency on every prompt.
+- **Deriving the state at read time without writing.** Leaving the column stale
+  and having `hasPromptOnScreen` disbelieve it would avoid writes and
+  broadcasts, but it leaves a value in the record that nothing believes — the
+  outcome the existing supersession comments argue against — and the app cannot
+  stat a daemon-side path on behalf of a remote lane.
+- **A background sweep.** The doctrine that every durable external resource
+  needs a named reconciler covers resources that outlive the request that made
+  them. A stale column read by two pull-based readers is not one: both readers
+  can correct it on the pass that consults it, for the cost of a stat.
+
+## Out of scope
+
+Two findings surfaced alongside this work and are deliberately not addressed
+here.
+
+The first is why a session's hook rail goes silent while its transcript keeps
+advancing. This design makes such a row render correctly; it does not explain
+it, and the explanation likely lies in hook routing or CLI staleness rather than
+in the awaiting-input rail.
+
+The second is the raise signal. `PermissionRequest` fires immediately on the ask
+path, carries the `tool_name` being gated, and cannot be switched off, while the
+`Notification` hook TBD reads today is debounced, carries no tool name, and is
+disabled outright by the `CLAUDE_CODE_DISABLE_PERMISSION_PROMPT_NOTIFY_HOOKS`
+environment variable. Moving the raise onto `PermissionRequest` is a clear
+improvement and an independent one: it changes when and how well the hand goes
+up, and nothing in this document depends on which hook raised it.


### PR DESCRIPTION
## What's broken

When a Claude session raises a permission prompt, TBD puts a raised hand next to it in the sidebar. Nothing reliably puts that hand back down. You answer the prompt, the session carries on working for hours, and the hand stays up — so the one indicator that means "a human is needed here" degrades into noise, and a fleet of sessions accumulates hands that no longer mean anything.

Probing the running daemon on a development machine found it live: of 153 terminals, one had been showing a raised hand for roughly 25 hours while writing to its transcript all day. A second showed the healthy case for contrast — a prompt genuinely pending, its transcript frozen for six minutes, the hand coming down on its own once answered.

Separately, two of Claude Code's prompt notification types raised no hand at all.

## Why it happens

The hand goes up on Claude Code's `Notification` hook and comes down only when some *later* observation of the session's activity reaches the daemon and retracts it. That retraction is the only take-down path, and it depends on a hook firing again. When the hook rail goes quiet — and it does — nothing else ever revisits the standing reason. The row sits there indefinitely, because no read path asks whether it is still true.

There is no hook to lean on instead. Claude Code has no permission-*decision* event: `PermissionRequest` fires before the decision, `PermissionDenied` is auto-mode-classifier only, and a user rejection produces a tool_result string rather than an error, so neither `PostToolUse` nor `PostToolUseFailure` fires either. Scoping a `PostToolUse` matcher to "the permission prompt" is not possible — the matcher key is `tool_name`, and a permission prompt is not a tool.

The second bug is narrower: `AwaitingInputClass` enumerated the notification types Claude Code's *documentation* lists, but the binary emits a wider set. `worker_permission_prompt` and `elicitation_url_dialog` fell through to `.unrecognized` and raised nothing.

## What this PR does

Uses the signal TBD already has. While a prompt is on screen the session is blocked, so its transcript file does not move; once the prompt is answered the transcript starts growing again. That makes a transcript change a sound retraction signal, and it needs no hook to fire.

- When a `.promptOnScreen` reason is recorded, capture a fingerprint of the transcript as it stood: path, size, mtime. Other classes store nothing and pay no `stat`.
- On each read path, compare a fresh fingerprint against the stored one. Different — the file moved — and the hand comes down.
- Fingerprints are compared, not ordered against a clock. This asks "did the file change since the prompt was raised", which depends on no ordering between Claude Code's debounced notification timer and its own transcript flush, and on no two clocks agreeing.
- Rows written before this existed carry no fingerprint. Those get one *adopted* on first sight rather than being retracted on a guess, so nothing standing is taken down speculatively.
- The classifier now enumerates the types the binary actually emits, so the two missing prompt types raise a hand and six quota/computer-use types are filed as informational.

A transcript change is not by itself an answer, and this is the part worth reading closely. A parallel `Task` subagent appends **sidechain** records to the same JSONL while the prompt is still on screen, so raw file growth would drop the hand on a session that is still blocked — the exact inference `SessionStateResolver` already refuses, for the same documented reason. So the check is two-tier: an unchanged fingerprint costs one `stat` and the hand stays up; only a *changed* one pays to look, and then only at the region appended since the stored size. A non-sidechain record there means the parent session itself wrote, so the prompt was answered and the hand comes down. Sidechain-only means a nested agent wrote while the human is still blocked — the hand stays up, and the stored fingerprint is refreshed so the next pass is cheap again. The delta read is capped at 64 KiB; over the cap only the tail is examined, which fails toward leaving the hand raised.

`terminal.list` and the supervision readout reconcile. A third reader, the `session.states` RPC, deliberately does not: it never wrote the row, `terminal.list` heals it on its own cadence, and `SessionStateResolver` independently degrades a stale prompt to `unknown` rather than asserting it confidently. Net cost is one `stat` per raised hand per pass, with no timer, no sweep, and no new background work. Design rationale and rejected alternatives: [`docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md`](docs/specs/2026-08-27-awaiting-input-transcript-supersession-design.md).

No feature flag. This is a bug fix — an exempted category — and the write it makes is narrow, conditional and idempotent: it nils or rewrites one reason row on a read path rather than adding a timer or a sweep. Every failure direction is the status quo (a hand that stays up), not a new one.

## Assumptions

- **A blocked session's *parent* does not write to its transcript.** Nested agents do, which is why the appended region is examined rather than the file's size alone. If Claude Code ever wrote a non-sidechain record while a prompt was pending, the hand would come down early.
- **`transcriptPath` identifies the file the prompt was raised against.** A terminal retargeted by a `/clear`, a compaction, or a resume gets a fingerprint whose `path` no longer matches, which reads as changed — the hand comes down. That is the intended reading: a retargeted session is not sitting on the old prompt.
- **Fingerprints are not persisted across a schema change.** The field rides inside the existing JSON reason blob, which is why this needs no migration; a reason written by an older build simply has the key absent.

## Evidence & verification

- **The repro** is the live daemon probe described above: a standing `prompt_on_screen` reason whose transcript mtime was a day newer than the observation that raised it, with no activity observation in between.
- **Discriminating tests.** Each new behavior has a test that fails without the fix. The classifier change was run red first and produced exactly the two intended failures before the implementation landed. The supersession helper's tests assert both directions — a moved transcript retracts, an unmoved one leaves the hand raised — and two of them assert the fingerprinter was *never called* for non-prompt classes, so the "pays no stat" claim is enforced rather than described.
- **Full suite:** 8285 tests in 806 suites. Two failures remain, both pre-existing load flakes unrelated to this change — a child-process PID-marker timeout, and a live-tmux replay test whose own failure message reads "harness/load, not production". Repo-wide `swiftlint --strict`: 0 violations across 835 files.
- **Not live-verified in the running app.** Confirming the hand visibly drops requires restarting the daemon, and this machine is running a live fleet of sessions. The behavior is covered by tests at both read paths, but a reviewer should know the pixels have not been watched.

## Review history

Two findings from the review gate are addressed here rather than argued with. The `session.states` completeness gap was real — the description did claim two readers where there are three — and is corrected above and in the spec. The no-flag justification did argue from a false premise (that the feature deletes no persisted state); the conclusion stands but the reasoning is rebuilt on the applicable carve-out.

Checking the first of those turned up something neither review raised: `SessionStateResolver` carries a committed argument against reading transcript growth as an answer, naming the sidechain case. That was the load-bearing assumption of the original implementation, and it was wrong. The two-tier check above is the fix.

## Note for commit-by-commit review

The commits were produced by parallel agents and landed interleaved: `b405e655` and `c0e590d5` reference `AwaitingInputReason.transcriptFingerprint` but sit *before* `21eba5be`, which introduces it. The branch tip builds; those two intermediate commits do not build in isolation. Review the diff as a whole, and note it if you bisect.

[20260827-quiet-ferret](https://cheapsteak.github.io/tbd/open/?worktree=D66E687D-3E8C-4E24-8E78-027028EC2D07)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Awaiting-input prompts now clear automatically when parent conversation transcripts change.
  * Prompts remain visible for unchanged, unavailable, unreadable, or sidechain-only transcript updates.
  * Expanded recognition of Claude Code permission, URL, computer-use, quota, and related notification events.
  * Prompt notifications now retain transcript information for more accurate status updates.

* **Documentation**
  * Added design documentation covering transcript-based prompt reconciliation and notification handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->