### PR TITLE
Fix: A terminal tab bricks forever when tmux cannot be resolved, and panels leak their tmux view sessions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -215,6 +215,9 @@ let package = Package(
                 "TBDDaemonLib",
                 "TBDShared",
                 "TestSupport",
+                // TmuxBridge (app side) drives a real tmux server in
+                // TmuxBridgeViewSessionLiveTests, which makes it tier 3.
+                "TBDApp",
                 .product(name: "Clocks", package: "swift-clocks"),
             ]
         ),

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -180,6 +180,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var cachedIcon: NSImage = generateAppIcon(worktreeName: detectWorktreeName())
     private var relaunchSource: (any DispatchSourceRead)?
     private var heartbeatTimer: Timer?
+    /// The app's tmux bridge, handed over when the main scene first appears so
+    /// `applicationWillTerminate` can reclaim the view sessions it is tracking.
+    /// `AppState` owns it for the life of the process; this is a plain
+    /// reference because the delegate is torn down with the app anyway.
+    var tmuxBridge: TmuxBridge?
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         lifecycleLogger.info("willFinishLaunching")
@@ -359,7 +364,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        lifecycleLogger.info("willTerminate")
+        // Reclaim this app's tmux view sessions before the process goes. Each
+        // one holds a worktree window linked into it, and tmux destroys a
+        // window only when its last session reference drops — so a view
+        // session that outlives the app keeps that window, its pane process
+        // and the whole tmux server alive. The call blocks (see
+        // `cleanupAllSessionsBlocking`): work handed to a detached task here
+        // would never run.
+        let reclaimed = tmuxBridge?.cleanupAllSessionsBlocking() ?? 0
+        lifecycleLogger.info("willTerminate reclaimedViewSessions=\(reclaimed, privacy: .public)")
     }
 
     // MARK: - Self-relaunch
@@ -483,6 +496,10 @@ struct TBDAppMain: App {
                 .onAppear {
                     lifecycleLogger.info("scene main onAppear")
                     JumpMenuController.shared.configure(appState: appState)
+                    // So `applicationWillTerminate` can reclaim the tmux view
+                    // sessions the bridge is tracking (the delegate has no
+                    // other route to `AppState`).
+                    appDelegate.tmuxBridge = appState.tmuxBridge
                     // Hand AppState a reference to the appearance settings so
                     // `mainAreaTerminalSize()` can compute pre-spawn tmux pane
                     // dimensions using the user's current font. Done in

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -948,8 +948,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 clickMonitor = nil
             }
             if let generation = tmuxSessionGeneration {
-                tmuxBridge?.cleanupSession(
-                    panelID: panelID, server: tmuxServer, generation: generation)
+                tmuxBridge?.cleanupSession(panelID: panelID, generation: generation)
             }
             resizeDebounceTask?.cancel()
             resizeDebounceTask = nil
@@ -1297,8 +1296,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // this coordinator's own generation makes that a no-op instead of
             // killing the fresh session.
             if let generation = tmuxSessionGeneration {
-                tmuxBridge?.cleanupSession(
-                    panelID: panelID, server: tmuxServer, generation: generation)
+                tmuxBridge?.cleanupSession(panelID: panelID, generation: generation)
             }
         }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -7,7 +7,7 @@ import os
 private let logger = Logger(subsystem: "com.tbd.app", category: "TerminalPanel")
 
 enum TerminalPreparationAction: Equatable, Sendable {
-    case startViewer(TmuxPreparedSession)
+    case startViewer(TmuxSessionPreparation)
     case showMessage(String)
     case requestAutomaticRecovery(failedStage: TmuxPreparationStage)
 }
@@ -407,6 +407,16 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         var tmuxBridge: TmuxBridge?
         var tmuxServer: String = ""
         var panelID: UUID = UUID()
+        /// Generation of this coordinator's own `prepareSession`, `nil` until
+        /// one succeeds (and forever for a control-mode panel, which has no
+        /// tmux view session). Both teardown paths pass it back so a stale
+        /// teardown cannot kill a session a *newer* coordinator prepared for
+        /// the same `panelID`: `panelID` is the terminal's id and survives the
+        /// SwiftUI view rebuild that waking a parked terminal triggers, which
+        /// mints a fresh `Coordinator` for it. Written from the `@MainActor`
+        /// preparation path and read from the non-isolated `deinit`, exactly
+        /// like `tmuxBridge`/`panelID`/`tmuxServer` beside it.
+        var tmuxSessionGeneration: UInt64?
         var tabCloseContext: TabCloseContext?
         var onMissingWindow: (@MainActor () async -> AutomaticTerminalRecreationOutcome)?
         var onRecoveryGuidance: (@MainActor (String) -> Void)?
@@ -479,7 +489,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         }
 
         nonisolated static func preparationAction(
-            for result: Result<TmuxPreparedSession, TmuxPreparationFailure>
+            for result: Result<TmuxSessionPreparation, TmuxPreparationFailure>
         ) -> TerminalPreparationAction {
             switch result {
             case .success(let prepared):
@@ -690,7 +700,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // `prepareSession` is non-isolated and awaits tmux subprocesses
             // off the main actor — Swift releases main while we suspend here,
             // so SwiftUI's render loop is no longer blocked while tmux runs.
-            let result: Result<TmuxPreparedSession, TmuxPreparationFailure> = await bridge.prepareSession(
+            let result: Result<TmuxSessionPreparation, TmuxPreparationFailure> = await bridge.prepareSession(
                 panelID: panelID,
                 server: server,
                 windowID: windowID
@@ -726,7 +736,11 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 }
                 return
             case .startViewer(let value):
-                prepared = value
+                prepared = value.session
+                // Scope this coordinator's teardown to the preparation it just
+                // made, so `cleanup()`/`deinit` can only reclaim the view
+                // session this coordinator owns — see `cleanupSession`.
+                tmuxSessionGeneration = value.generation
             }
 
             let tmuxPath = prepared.executablePath
@@ -933,7 +947,10 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 clickMonitor = nil
             }
-            tmuxBridge?.cleanupSession(panelID: panelID, server: tmuxServer)
+            if let generation = tmuxSessionGeneration {
+                tmuxBridge?.cleanupSession(
+                    panelID: panelID, server: tmuxServer, generation: generation)
+            }
             resizeDebounceTask?.cancel()
             resizeDebounceTask = nil
             (terminalView as? TBDTerminalView)?.onControlModePaste = nil
@@ -1272,7 +1289,17 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // this call returns without issuing a second `kill-session`. That
             // idempotence is what is relied on — NOT `isTornDown`, which is
             // `@MainActor`-confined and must not be read from here.
-            tmuxBridge?.cleanupSession(panelID: panelID, server: tmuxServer)
+            //
+            // Generation-scoped, like `cleanup()`'s call: `deinit` fires
+            // strictly later and less predictably than `dismantleNSView`, so a
+            // superseded coordinator's release can land well after a rebuild
+            // has prepared a new session under the same `panelID`. Passing
+            // this coordinator's own generation makes that a no-op instead of
+            // killing the fresh session.
+            if let generation = tmuxSessionGeneration {
+                tmuxBridge?.cleanupSession(
+                    panelID: panelID, server: tmuxServer, generation: generation)
+            }
         }
 
         // MARK: - LocalProcessDelegate

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -407,16 +407,19 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         var tmuxBridge: TmuxBridge?
         var tmuxServer: String = ""
         var panelID: UUID = UUID()
-        /// Generation of this coordinator's own `prepareSession`, `nil` until
-        /// one succeeds (and forever for a control-mode panel, which has no
-        /// tmux view session). Both teardown paths pass it back so a stale
-        /// teardown cannot kill a session a *newer* coordinator prepared for
-        /// the same `panelID`: `panelID` is the terminal's id and survives the
-        /// SwiftUI view rebuild that waking a parked terminal triggers, which
-        /// mints a fresh `Coordinator` for it. Written from the `@MainActor`
-        /// preparation path and read from the non-isolated `deinit`, exactly
-        /// like `tmuxBridge`/`panelID`/`tmuxServer` beside it.
-        var tmuxSessionGeneration: UInt64?
+        /// This coordinator's own successful `prepareSession` — the bridge that
+        /// tracks the view session and the generation naming that preparation
+        /// — empty until one succeeds (and forever for a control-mode panel,
+        /// which has no tmux view session). Both teardown paths reclaim
+        /// through it, so a stale teardown cannot kill a session a *newer*
+        /// coordinator prepared for the same `panelID`: `panelID` is the
+        /// terminal's id and survives the SwiftUI view rebuild that waking a
+        /// parked terminal triggers, which mints a fresh `Coordinator` for it.
+        ///
+        /// A lock-guarded holder rather than plain properties because the
+        /// write is `@MainActor` and `deinit`'s read is not isolated at all —
+        /// see `ViewSessionReclaim`.
+        let viewSessionReclaim = ViewSessionReclaim()
         var tabCloseContext: TabCloseContext?
         var onMissingWindow: (@MainActor () async -> AutomaticTerminalRecreationOutcome)?
         var onRecoveryGuidance: (@MainActor (String) -> Void)?
@@ -755,7 +758,9 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // Scope this coordinator's teardown to the preparation it just
                 // made, so `cleanup()`/`deinit` can only reclaim the view
                 // session this coordinator owns — see `cleanupSession`.
-                tmuxSessionGeneration = value.generation
+                // Published under a lock because `deinit` reads it off the
+                // main actor — see `ViewSessionReclaim`.
+                viewSessionReclaim.publish(bridge: bridge, generation: value.generation)
             }
 
             let tmuxPath = prepared.executablePath
@@ -962,8 +967,9 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 clickMonitor = nil
             }
-            if let generation = tmuxSessionGeneration {
-                tmuxBridge?.cleanupSession(panelID: panelID, generation: generation)
+            if let preparation = viewSessionReclaim.published {
+                preparation.bridge.cleanupSession(
+                    panelID: panelID, generation: preparation.generation)
             }
             resizeDebounceTask?.cancel()
             resizeDebounceTask = nil
@@ -1304,14 +1310,22 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // idempotence is what is relied on — NOT `isTornDown`, which is
             // `@MainActor`-confined and must not be read from here.
             //
+            // The same reasoning covers the facts this reclamation needs. They
+            // are written from the `@MainActor` preparation path and read here
+            // on whatever thread drops the last strong reference, so they are
+            // published through `viewSessionReclaim`, which guards them with a
+            // lock. Nothing here relies on SwiftUI releasing coordinators on
+            // the main thread; a stale read would silently skip the kill.
+            //
             // Generation-scoped, like `cleanup()`'s call: `deinit` fires
             // strictly later and less predictably than `dismantleNSView`, so a
             // superseded coordinator's release can land well after a rebuild
             // has prepared a new session under the same `panelID`. Passing
             // this coordinator's own generation makes that a no-op instead of
             // killing the fresh session.
-            if let generation = tmuxSessionGeneration {
-                tmuxBridge?.cleanupSession(panelID: panelID, generation: generation)
+            if let preparation = viewSessionReclaim.published {
+                preparation.bridge.cleanupSession(
+                    panelID: panelID, generation: preparation.generation)
             }
         }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -1250,6 +1250,29 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             if let monitor = clickMonitor {
                 NSEvent.removeMonitor(monitor)
             }
+            // Reclaim the tmux view session this panel owns. `cleanup()` is
+            // the only other caller and it runs solely from
+            // `dismantleNSView`, which SwiftUI does not guarantee to run: the
+            // bridge log recorded 15 `PANEL: deinit` lines in 35 seconds with
+            // no matching `PANEL: cleanup`, each one a view session left
+            // behind. That leak is not cosmetic — a view session holding a
+            // linked window keeps that window, its pane process and the whole
+            // tmux server alive after the owning `main` session is killed,
+            // because tmux destroys a window only when its last session
+            // reference drops.
+            //
+            // Only the tmux session is reclaimed here. The pid capture, the
+            // PTY reap and the control-mode detach stay in `cleanup()`, which
+            // documents why they must happen exactly once.
+            //
+            // Safe from a non-isolated `deinit`, and idempotent, by
+            // construction: `cleanupSession` takes the bridge's own lock,
+            // removes this panel from `activeSessions` and kills from a
+            // detached task, so after a `cleanup()` there is no entry left and
+            // this call returns without issuing a second `kill-session`. That
+            // idempotence is what is relied on — NOT `isTornDown`, which is
+            // `@MainActor`-confined and must not be read from here.
+            tmuxBridge?.cleanupSession(panelID: panelID, server: tmuxServer)
         }
 
         // MARK: - LocalProcessDelegate

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -17,6 +17,14 @@ struct TerminalRecoveryDiagnosticContext: Equatable, Sendable {
     let worktreeID: UUID?
 }
 
+/// User-facing copy for a terminal that could not be prepared.
+enum TerminalPreparationPresentation {
+    static let commandFailedMessage =
+        "TBD couldn't attach to this terminal. The terminal was left unchanged. Check diagnostics for details or close the tab."
+    static let tmuxExecutableUnavailableMessage =
+        "TBD couldn't find tmux — it is not in PATH and no fallback path is saved. Locate the tmux executable in Settings → Terminal, then reopen this terminal."
+}
+
 enum TerminalRecoveryPresentation {
     static let failedMessage =
         "Automatic terminal recovery failed. Retry manually or close the tab."
@@ -477,11 +485,11 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             case .success(let prepared):
                 return .startViewer(prepared)
             case .failure(.commandFailed):
-                return .showMessage(
-                    "TBD couldn't attach to this terminal. The terminal was left unchanged. Check diagnostics for details or close the tab."
-                )
+                return .showMessage(TerminalPreparationPresentation.commandFailedMessage)
             case .failure(.windowMissing(let failedStage)):
                 return .requestAutomaticRecovery(failedStage: failedStage)
+            case .failure(.tmuxExecutableUnavailable):
+                return .showMessage(TerminalPreparationPresentation.tmuxExecutableUnavailableMessage)
             }
         }
 
@@ -617,6 +625,10 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             case .windowMissing(let failedStage):
                 logger.error(
                     "terminal preparation failed terminal=\(self.panelID, privacy: .public) worktree=\(worktreeID, privacy: .public) stage=\(failedStage.rawValue, privacy: .public) category=windowMissing"
+                )
+            case .tmuxExecutableUnavailable:
+                logger.error(
+                    "terminal preparation failed terminal=\(self.panelID, privacy: .public) worktree=\(worktreeID, privacy: .public) stage=\(TmuxPreparationStage.createViewSession.rawValue, privacy: .public) category=tmuxExecutableUnavailable"
                 )
             case .commandFailed(let stage, let output):
                 logger.error(

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -708,7 +708,22 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
 
             // Teardown may land while preparation is in flight. Do not render,
             // recover, or start a viewer for a coordinator that is no longer live.
-            guard ControlModeAttachAbort.shouldStartFallback(tornDown: isTornDown) else { return }
+            //
+            // A preparation that succeeded anyway must be reclaimed here, and
+            // this is the only place that can do it: `prepareSession` has
+            // already registered the session in the bridge, but
+            // `tmuxSessionGeneration` — the token both `cleanup()` and
+            // `deinit` reclaim by — is assigned further down, in the
+            // `.startViewer` branch we are about to skip. `cleanup()` has
+            // already run and `deinit` would find nil, so nothing else would
+            // ever kill it: a fast tab close would leak the view session and,
+            // with it, the linked worktree window and its pane process.
+            guard ControlModeAttachAbort.shouldStartFallback(tornDown: isTornDown) else {
+                if case .success(let preparation) = result {
+                    bridge.cleanupSession(panelID: panelID, generation: preparation.generation)
+                }
+                return
+            }
 
             let prepared: TmuxPreparedSession
             switch Self.preparationAction(for: result) {

--- a/Sources/TBDApp/Terminal/TmuxBridge.swift
+++ b/Sources/TBDApp/Terminal/TmuxBridge.swift
@@ -87,6 +87,10 @@ final class TmuxBridge: @unchecked Sendable {
     private struct ActiveSession: Sendable {
         let name: String
         let tmuxExecutablePath: String
+        /// The tmux server socket this view session lives on. Recorded so a
+        /// teardown that holds no per-panel context — app termination — can
+        /// kill every tracked session on the server that actually owns it.
+        let server: String
     }
 
     private let lock = NSLock()
@@ -96,9 +100,11 @@ final class TmuxBridge: @unchecked Sendable {
     private var activeSessions: [UUID: ActiveSession] = [:]
 
     /// Serial background queue retained for any future synchronous teardown
-    /// needs. Today cleanup is fire-and-forget via `Task { ... }` invoking
+    /// needs. Per-panel cleanup is fire-and-forget via `Task { ... }` invoking
     /// the async `runTmux`, which uses `Process.terminationHandler` (no
-    /// `waitUntilExit`) so it doesn't pump the main runloop.
+    /// `waitUntilExit`) so it doesn't pump the main runloop; the one teardown
+    /// that must not return early — `cleanupAllSessionsBlocking`, on app
+    /// termination — waits on its own semaphore rather than through here.
     private let cleanupQueue = DispatchQueue(label: "com.tbd.app.tmux-cleanup", qos: .utility)
 
     /// Runs each tmux command. Defaults to the real subprocess runner.
@@ -348,7 +354,8 @@ final class TmuxBridge: @unchecked Sendable {
         lock.withLock {
             activeSessions[panelID] = ActiveSession(
                 name: sessionName,
-                tmuxExecutablePath: tmuxExecutablePath
+                tmuxExecutablePath: tmuxExecutablePath,
+                server: server
             )
         }
 
@@ -380,22 +387,72 @@ final class TmuxBridge: @unchecked Sendable {
         }
     }
 
-    /// Clean up all grouped sessions for a server.
+    /// Clean up every view session on one server.
+    ///
+    /// Fire-and-forget like `cleanupSession`. Sessions belonging to other
+    /// servers are left alone: `activeSessions` spans every server the app
+    /// currently shows a panel on.
     func cleanupAllSessions(server: String) {
-        lock.lock()
-        let sessions = activeSessions
-        activeSessions.removeAll()
-        lock.unlock()
+        let sessions = takeSessions { $0.server == server }
+        guard !sessions.isEmpty else { return }
 
         Task.detached { [self] in
-            for (_, session) in sessions {
-                let _ = await runTmux(
-                    tmuxExecutablePath: session.tmuxExecutablePath,
-                    server: server,
-                    args: Self.killSessionArgs(sessionName: session.name)
-                )
-            }
-            debugLog("CLEANUP ALL: server=\(server)")
+            await killSessions(sessions)
+            debugLog("CLEANUP ALL: server=\(server) sessions=\(sessions.count)")
+        }
+    }
+
+    /// Reclaim every tracked view session, each on the server that owns it,
+    /// blocking the caller until the kills have run.
+    ///
+    /// This is the app-termination path, and blocking is the whole point:
+    /// `cleanupAllSessions(server:)` hands its kills to a detached task, and
+    /// nothing scheduled that way outlives the process — on
+    /// `applicationWillTerminate` the task would be enqueued and then die with
+    /// the app, having killed nothing. A view session that outlives the app
+    /// keeps its linked worktree window alive (tmux destroys a window only
+    /// when the last session referencing it goes away), and with it that
+    /// window's pane process and the whole tmux server.
+    ///
+    /// Bounded rather than open-ended: a wedged tmux may delay quitting by
+    /// `timeout` at most, and one leaked session is the lesser harm.
+    ///
+    /// - Returns: the number of sessions this call took ownership of.
+    @discardableResult
+    func cleanupAllSessionsBlocking(timeout: TimeInterval = 2.0) -> Int {
+        let sessions = takeSessions { _ in true }
+        guard !sessions.isEmpty else { return 0 }
+
+        let finished = DispatchSemaphore(value: 0)
+        Task.detached { [self] in
+            await killSessions(sessions)
+            finished.signal()
+        }
+        let outcome = finished.wait(timeout: .now() + timeout)
+        debugLog("CLEANUP ALL (blocking): sessions=\(sessions.count) timedOut=\(outcome == .timedOut)")
+        return sessions.count
+    }
+
+    /// Removes the matching sessions from the tracking table and returns them,
+    /// so a caller owns exactly what it is about to kill and no second caller
+    /// can kill the same session twice.
+    private func takeSessions(matching predicate: (ActiveSession) -> Bool) -> [ActiveSession] {
+        lock.lock()
+        defer { lock.unlock() }
+        let taken = activeSessions.filter { predicate($0.value) }
+        for panelID in taken.keys {
+            activeSessions.removeValue(forKey: panelID)
+        }
+        return Array(taken.values)
+    }
+
+    private func killSessions(_ sessions: [ActiveSession]) async {
+        for session in sessions {
+            let _ = await runTmux(
+                tmuxExecutablePath: session.tmuxExecutablePath,
+                server: session.server,
+                args: Self.killSessionArgs(sessionName: session.name)
+            )
         }
     }
 

--- a/Sources/TBDApp/Terminal/TmuxBridge.swift
+++ b/Sources/TBDApp/Terminal/TmuxBridge.swift
@@ -22,6 +22,11 @@ enum TmuxPreparationStage: String, Equatable, Sendable {
 enum TmuxPreparationFailure: LocalizedError, Equatable, Sendable {
     case windowMissing(failedStage: TmuxPreparationStage)
     case commandFailed(stage: TmuxPreparationStage, output: String)
+    /// No tmux executable could be resolved, so nothing ran. This is not a
+    /// tmux failure and retrying cannot help: the remedy is to locate the
+    /// binary (Settings -> Terminal), which is why it is a case of its own
+    /// rather than a `commandFailed` carrying a synthetic output string.
+    case tmuxExecutableUnavailable
 
     var errorDescription: String? {
         switch self {
@@ -29,9 +34,24 @@ enum TmuxPreparationFailure: LocalizedError, Equatable, Sendable {
             return "tmux window is missing (failed at stage: \(stage.rawValue))"
         case .commandFailed(let stage, let output):
             return "tmux command failed at stage \(stage.rawValue): \(output)"
+        case .tmuxExecutableUnavailable:
+            return "tmux executable unavailable: not found in PATH and no saved fallback is set"
         }
     }
 }
+
+/// Outcome of one tmux subprocess invocation.
+struct TmuxCommandOutcome: Equatable, Sendable {
+    let success: Bool
+    let output: String
+}
+
+/// Runs one tmux command: executable path, server socket name, arguments.
+///
+/// Injectable so tests can drive command sequences a live tmux server cannot
+/// be made to produce on demand — notably a `new-session` that fails once
+/// with `duplicate session:` and succeeds on the retry.
+typealias TmuxCommandRunner = @Sendable (String, String, [String]) async -> TmuxCommandOutcome
 
 /// File-based debug log for diagnostics
 func debugLog(_ msg: String) {
@@ -81,8 +101,21 @@ final class TmuxBridge: @unchecked Sendable {
     /// `waitUntilExit`) so it doesn't pump the main runloop.
     private let cleanupQueue = DispatchQueue(label: "com.tbd.app.tmux-cleanup", qos: .utility)
 
-    init(tmuxExecutableResolver: TmuxExecutableResolver = TmuxExecutableResolver()) {
+    /// Runs each tmux command. Defaults to the real subprocess runner.
+    private let commandRunner: TmuxCommandRunner
+
+    init(
+        tmuxExecutableResolver: TmuxExecutableResolver = TmuxExecutableResolver(),
+        commandRunner: TmuxCommandRunner? = nil
+    ) {
         self.tmuxExecutableResolver = tmuxExecutableResolver
+        self.commandRunner = commandRunner ?? { executablePath, server, args in
+            await TmuxBridge.runTmuxProcess(
+                tmuxExecutablePath: executablePath,
+                server: server,
+                args: args
+            )
+        }
     }
 
     static func sessionName(for panelID: UUID) -> String {
@@ -129,10 +162,14 @@ final class TmuxBridge: @unchecked Sendable {
         ["kill-session", "-t", sessionName]
     }
 
+    static func hasSessionArgs(sessionName: String) -> [String] {
+        ["has-session", "-t", sessionName]
+    }
+
     /// Complete command used for a tmux preparation subprocess.
     func tmuxCommand(server: String, args: [String]) -> [String]? {
         guard let tmuxExecutablePath = tmuxExecutableResolver.resolve()?.path else { return nil }
-        return tmuxCommand(tmuxExecutablePath: tmuxExecutablePath, server: server, args: args)
+        return Self.tmuxCommand(tmuxExecutablePath: tmuxExecutablePath, server: server, args: args)
     }
 
     /// Command used by the SwiftTerm PTY to attach its viewer client.
@@ -150,7 +187,7 @@ final class TmuxBridge: @unchecked Sendable {
         )
     }
 
-    private func tmuxCommand(
+    private static func tmuxCommand(
         tmuxExecutablePath: String,
         server: String,
         args: [String]
@@ -188,10 +225,11 @@ final class TmuxBridge: @unchecked Sendable {
     ) async -> Result<TmuxPreparedSession, TmuxPreparationFailure> {
         let sessionName = Self.sessionName(for: panelID)
         guard let tmuxExecutablePath = tmuxExecutableResolver.resolve()?.path else {
-            return .failure(.commandFailed(
-                stage: .createViewSession,
-                output: "tmux executable unavailable"
-            ))
+            bridgeLogger.error(
+                "Preparation failed: tmux executable unavailable (not in PATH, no saved fallback) session=\(sessionName, privacy: .public) server=\(server, privacy: .public)"
+            )
+            debugLog("PREPARE: tmux executable unavailable (not in PATH, no saved fallback) session=\(sessionName) server=\(server)")
+            return .failure(.tmuxExecutableUnavailable)
         }
         let preparedSession = preparedSession(
             tmuxExecutablePath: tmuxExecutablePath,
@@ -205,10 +243,10 @@ final class TmuxBridge: @unchecked Sendable {
             args: Self.killSessionArgs(sessionName: sessionName)
         )
 
-        let createResult = await runTmux(
+        let createResult = await createViewSession(
             tmuxExecutablePath: tmuxExecutablePath,
             server: server,
-            args: Self.newIsolatedSessionArgs(sessionName: sessionName)
+            sessionName: sessionName
         )
         guard createResult.success else {
             debugLog("PREPARE: failed to create view session \(sessionName) on server \(server): \(createResult.output)")
@@ -363,9 +401,60 @@ final class TmuxBridge: @unchecked Sendable {
 
     // MARK: - Helpers
 
-    private struct TmuxResult {
-        let success: Bool
-        let output: String
+    /// Create the isolated view session, replacing any same-named leftover.
+    ///
+    /// `prepareSession` kills a same-named session before creating one, but
+    /// that kill's result is advisory: it can fail transiently (a momentarily
+    /// unavailable or wedged server). `new-session` then fails with
+    /// `duplicate session:` and the panel is bricked for good, because the
+    /// session name is derived from the panel UUID and never changes. So when
+    /// the create fails, probe for the session — and only when the probe
+    /// affirms it exists, kill it and retry the create exactly once. A failed
+    /// probe is ambiguous (same reason `classifyPreparationFailure` refuses to
+    /// act on one) and does not justify a retry.
+    ///
+    /// Replacement, never adoption: `prepareSession` unconditionally runs
+    /// `kill-window -t <session>:0` after linking, and tmux's `kill-window`
+    /// destroys the window globally rather than unlinking it from one session,
+    /// so adopting a leftover session whose index 0 holds a real linked window
+    /// would destroy a live agent window.
+    private func createViewSession(
+        tmuxExecutablePath: String,
+        server: String,
+        sessionName: String
+    ) async -> TmuxCommandOutcome {
+        let createArgs = Self.newIsolatedSessionArgs(sessionName: sessionName)
+        let firstAttempt = await runTmux(
+            tmuxExecutablePath: tmuxExecutablePath,
+            server: server,
+            args: createArgs
+        )
+        guard !firstAttempt.success else { return firstAttempt }
+
+        debugLog("PREPARE: create failed for \(sessionName) on server \(server): \(firstAttempt.output)")
+        let probe = await runTmux(
+            tmuxExecutablePath: tmuxExecutablePath,
+            server: server,
+            args: Self.hasSessionArgs(sessionName: sessionName)
+        )
+        guard probe.success else {
+            debugLog("PREPARE: no leftover session \(sessionName) on server \(server); not retrying create")
+            return firstAttempt
+        }
+
+        debugLog("PREPARE: leftover session \(sessionName) still present on server \(server); killing it and retrying create")
+        let _ = await runTmux(
+            tmuxExecutablePath: tmuxExecutablePath,
+            server: server,
+            args: Self.killSessionArgs(sessionName: sessionName)
+        )
+        let retry = await runTmux(
+            tmuxExecutablePath: tmuxExecutablePath,
+            server: server,
+            args: createArgs
+        )
+        debugLog("PREPARE: create retry for \(sessionName) on server \(server) succeeded=\(retry.success) output=\(retry.output)")
+        return retry
     }
 
     func preparedSession(server: String, sessionName: String) -> TmuxPreparedSession? {
@@ -473,6 +562,15 @@ final class TmuxBridge: @unchecked Sendable {
         return .failure(failure)
     }
 
+    /// Run one tmux command through the injected runner.
+    private func runTmux(
+        tmuxExecutablePath: String,
+        server: String,
+        args: [String]
+    ) async -> TmuxCommandOutcome {
+        await commandRunner(tmuxExecutablePath, server, args)
+    }
+
     /// Run a tmux subprocess without blocking the calling thread.
     ///
     /// Uses `Process.terminationHandler` + `withCheckedContinuation` instead of
@@ -480,11 +578,11 @@ final class TmuxBridge: @unchecked Sendable {
     /// `makeNSView` for tens to hundreds of ms per panel (tmux fork+exec +
     /// new-session/select-window), starving SwiftUI's render loop so newly
     /// inserted terminal panels never displayed content.
-    private func runTmux(
+    private static func runTmuxProcess(
         tmuxExecutablePath: String,
         server: String,
         args: [String]
-    ) async -> TmuxResult {
+    ) async -> TmuxCommandOutcome {
         let command = tmuxCommand(
             tmuxExecutablePath: tmuxExecutablePath,
             server: server,
@@ -505,7 +603,7 @@ final class TmuxBridge: @unchecked Sendable {
                 let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
                 let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
                 let output = String(data: outData + errData, encoding: .utf8) ?? ""
-                continuation.resume(returning: TmuxResult(
+                continuation.resume(returning: TmuxCommandOutcome(
                     success: process.terminationStatus == 0,
                     output: output.trimmingCharacters(in: .whitespacesAndNewlines)
                 ))
@@ -514,7 +612,7 @@ final class TmuxBridge: @unchecked Sendable {
             do {
                 try process.run()
             } catch {
-                continuation.resume(returning: TmuxResult(
+                continuation.resume(returning: TmuxCommandOutcome(
                     success: false,
                     output: error.localizedDescription
                 ))

--- a/Sources/TBDApp/Terminal/TmuxBridge.swift
+++ b/Sources/TBDApp/Terminal/TmuxBridge.swift
@@ -10,6 +10,23 @@ struct TmuxPreparedSession: Equatable, Sendable {
     let arguments: [String]
 }
 
+/// One successful `TmuxBridge.prepareSession`: how the viewer attaches, plus
+/// the generation that scopes the reclaim of the view session it created.
+///
+/// The generation exists because `panelID` alone does not identify a
+/// preparation. It is the *terminal's* id and survives SwiftUI view rebuilds,
+/// so the same panel can be prepared again — waking a parked terminal flips
+/// `isParked`, re-keying the view and minting a fresh `Coordinator` — while
+/// the previous coordinator is still alive and yet to be torn down. Handing
+/// the generation back lets each coordinator reclaim only the view session its
+/// own preparation created, so a stale teardown cannot kill a fresher session.
+/// Same shape, and same reason, as the control-mode attach generation in
+/// `TerminalPanelView`.
+struct TmuxSessionPreparation: Equatable, Sendable {
+    let session: TmuxPreparedSession
+    let generation: UInt64
+}
+
 enum TmuxPreparationStage: String, Equatable, Sendable {
     case createViewSession
     case linkWindow
@@ -91,6 +108,11 @@ final class TmuxBridge: @unchecked Sendable {
         /// teardown that holds no per-panel context — app termination — can
         /// kill every tracked session on the server that actually owns it.
         let server: String
+        /// The preparation that created this session. `cleanupSession` kills
+        /// only a session whose generation matches the one its caller was
+        /// handed, so a superseded coordinator cannot kill the entry a newer
+        /// preparation put here under the same `panelID`.
+        let generation: UInt64
     }
 
     private let lock = NSLock()
@@ -98,6 +120,11 @@ final class TmuxBridge: @unchecked Sendable {
 
     /// Tracks each grouped session with the executable snapshotted for its lifecycle.
     private var activeSessions: [UUID: ActiveSession] = [:]
+
+    /// Next generation to mint. Monotonic across the whole bridge — the values
+    /// only ever need to be compared for equality — and guarded by `lock`.
+    /// Starts at 1 so no valid generation is zero.
+    private var nextGeneration: UInt64 = 1
 
     /// Serial background queue retained for any future synchronous teardown
     /// needs. Per-panel cleanup is fire-and-forget via `Task { ... }` invoking
@@ -223,12 +250,13 @@ final class TmuxBridge: @unchecked Sendable {
     ///   - panelID: Unique ID for this terminal panel (used as session name suffix)
     ///   - server: tmux server socket name (e.g. "tbd-a1b2c3d4")
     ///   - windowID: tmux window ID to display (e.g. "@3")
-    /// - Returns: A prepared viewer attachment or a classified failure.
+    /// - Returns: A prepared viewer attachment — carrying the generation its
+    ///   caller must pass back to `cleanupSession` — or a classified failure.
     func prepareSession(
         panelID: UUID,
         server: String,
         windowID: String
-    ) async -> Result<TmuxPreparedSession, TmuxPreparationFailure> {
+    ) async -> Result<TmuxSessionPreparation, TmuxPreparationFailure> {
         let sessionName = Self.sessionName(for: panelID)
         guard let tmuxExecutablePath = tmuxExecutableResolver.resolve()?.path else {
             bridgeLogger.error(
@@ -351,30 +379,47 @@ final class TmuxBridge: @unchecked Sendable {
             )
         }
 
-        lock.withLock {
+        let generation: UInt64 = lock.withLock {
+            let generation = nextGeneration
+            nextGeneration &+= 1
             activeSessions[panelID] = ActiveSession(
                 name: sessionName,
                 tmuxExecutablePath: tmuxExecutablePath,
-                server: server
+                server: server,
+                generation: generation
             )
+            return generation
         }
 
-        debugLog("PREPARE: panelID=\(panelID.uuidString.prefix(8)) server=\(server) window=\(windowID) session=\(sessionName)")
+        debugLog("PREPARE: panelID=\(panelID.uuidString.prefix(8)) server=\(server) window=\(windowID) session=\(sessionName) generation=\(generation)")
 
-        return .success(preparedSession)
+        return .success(TmuxSessionPreparation(session: preparedSession, generation: generation))
     }
 
     /// Clean up a view session when a panel is hidden.
     ///
     /// Fire-and-forget: the kill-session call runs on a background queue so
     /// callers can return immediately. Safe to call from the main thread
-    /// during SwiftUI dismantle.
-    func cleanupSession(panelID: UUID, server: String) {
+    /// during SwiftUI dismantle, and from a non-isolated `deinit`.
+    ///
+    /// Scoped to `generation`, which the caller was handed by the
+    /// `prepareSession` whose session it is reclaiming. A teardown whose
+    /// generation no longer matches the tracked entry is a **no-op**: it
+    /// neither forgets the entry nor issues `kill-session`. That is what stops
+    /// a superseded coordinator — SwiftUI rebuilds the terminal view when a
+    /// parked terminal wakes, so a second `prepareSession` for the same
+    /// `panelID` runs while the first coordinator is still awaiting teardown —
+    /// from killing the freshly woken terminal's session.
+    ///
+    /// Still idempotent: the matching call removes the entry, so a second
+    /// teardown for the same generation finds nothing and returns.
+    func cleanupSession(panelID: UUID, server: String, generation: UInt64) {
         lock.lock()
-        guard let session = activeSessions.removeValue(forKey: panelID) else {
+        guard let session = activeSessions[panelID], session.generation == generation else {
             lock.unlock()
             return
         }
+        activeSessions.removeValue(forKey: panelID)
         lock.unlock()
 
         Task.detached { [self] in
@@ -392,6 +437,11 @@ final class TmuxBridge: @unchecked Sendable {
     /// Fire-and-forget like `cleanupSession`. Sessions belonging to other
     /// servers are left alone: `activeSessions` spans every server the app
     /// currently shows a panel on.
+    ///
+    /// Deliberately not generation-scoped. This reclaims *everything* tracked
+    /// on the server rather than one panel's preparation, so there is no
+    /// stale-teardown race to guard against — filtering by generation here
+    /// could only leave a session behind.
     func cleanupAllSessions(server: String) {
         let sessions = takeSessions { $0.server == server }
         guard !sessions.isEmpty else { return }
@@ -594,7 +644,7 @@ final class TmuxBridge: @unchecked Sendable {
         server: String,
         windowID: String,
         sessionName: String
-    ) async -> Result<TmuxPreparedSession, TmuxPreparationFailure> {
+    ) async -> Result<TmuxSessionPreparation, TmuxPreparationFailure> {
         let probeResult = await runTmux(
             tmuxExecutablePath: tmuxExecutablePath,
             server: server,

--- a/Sources/TBDApp/Terminal/TmuxBridge.swift
+++ b/Sources/TBDApp/Terminal/TmuxBridge.swift
@@ -126,14 +126,6 @@ final class TmuxBridge: @unchecked Sendable {
     /// Starts at 1 so no valid generation is zero.
     private var nextGeneration: UInt64 = 1
 
-    /// Serial background queue retained for any future synchronous teardown
-    /// needs. Per-panel cleanup is fire-and-forget via `Task { ... }` invoking
-    /// the async `runTmux`, which uses `Process.terminationHandler` (no
-    /// `waitUntilExit`) so it doesn't pump the main runloop; the one teardown
-    /// that must not return early — `cleanupAllSessionsBlocking`, on app
-    /// termination — waits on its own semaphore rather than through here.
-    private let cleanupQueue = DispatchQueue(label: "com.tbd.app.tmux-cleanup", qos: .utility)
-
     /// Runs each tmux command. Defaults to the real subprocess runner.
     private let commandRunner: TmuxCommandRunner
 

--- a/Sources/TBDApp/Terminal/TmuxBridge.swift
+++ b/Sources/TBDApp/Terminal/TmuxBridge.swift
@@ -413,7 +413,14 @@ final class TmuxBridge: @unchecked Sendable {
     ///
     /// Still idempotent: the matching call removes the entry, so a second
     /// teardown for the same generation finds nothing and returns.
-    func cleanupSession(panelID: UUID, server: String, generation: UInt64) {
+    ///
+    /// Takes no server: the tracked `ActiveSession` is the authority on which
+    /// socket its session lives on. A caller-supplied server could disagree
+    /// with the entry it just removed — a panel whose coordinator recorded one
+    /// server while the preparation ran against another — and the kill would
+    /// then go to a socket that has no such session, leaking the tracked one
+    /// with no path left to reclaim it.
+    func cleanupSession(panelID: UUID, generation: UInt64) {
         lock.lock()
         guard let session = activeSessions[panelID], session.generation == generation else {
             lock.unlock()
@@ -425,7 +432,7 @@ final class TmuxBridge: @unchecked Sendable {
         Task.detached { [self] in
             let _ = await runTmux(
                 tmuxExecutablePath: session.tmuxExecutablePath,
-                server: server,
+                server: session.server,
                 args: Self.killSessionArgs(sessionName: session.name)
             )
             debugLog("CLEANUP: panelID=\(panelID.uuidString.prefix(8)) session=\(session.name)")

--- a/Sources/TBDApp/Terminal/ViewSessionReclaim.swift
+++ b/Sources/TBDApp/Terminal/ViewSessionReclaim.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// The facts a terminal coordinator's `deinit` needs in order to reclaim the
+/// tmux view session its own preparation created: the bridge that tracks the
+/// session, and the generation that names *this* coordinator's preparation of
+/// it.
+///
+/// They exist as a separate lock-guarded holder because of where they are
+/// written and where they are read. The write happens on the main actor, when
+/// a preparation succeeds; the read happens in a non-isolated `deinit`, which
+/// runs on whatever thread drops the last strong reference to the coordinator.
+/// As plain stored properties on a non-`@MainActor` class that is an
+/// unsynchronized cross-thread read, and its failure is silent in the worst
+/// way: `deinit` sees `nil`, skips `cleanupSession`, and the view session —
+/// with the worktree window linked into it and that window's pane process —
+/// leaks with no diagnostic anywhere.
+///
+/// In practice the ordering holds today: `SwiftTerm.LocalProcess.delegate` is
+/// `weak`, so the last strong reference is SwiftUI's, and SwiftUI releases
+/// coordinators on the main thread. That is an assumption about two other
+/// components, not an invariant this file enforces — the lock is what turns it
+/// into one, at the cost of two `NSLock` acquisitions per panel lifetime.
+///
+/// Deliberately narrow. The coordinator stays a plain class and its other
+/// properties stay unguarded; only the facts a `deinit` reads cross a thread
+/// boundary, so only they are published here.
+final class ViewSessionReclaim: @unchecked Sendable {
+    /// A preparation that succeeded, and everything needed to reclaim it.
+    struct Preparation: Sendable {
+        let bridge: TmuxBridge
+        let generation: UInt64
+    }
+
+    private let lock = NSLock()
+    private var preparation: Preparation?
+
+    /// Publish the preparation this coordinator owns. Called from the main
+    /// actor when `prepareSession` succeeds; a later preparation for the same
+    /// coordinator replaces the earlier one.
+    func publish(bridge: TmuxBridge, generation: UInt64) {
+        lock.withLock { preparation = Preparation(bridge: bridge, generation: generation) }
+    }
+
+    /// The published preparation, or `nil` when none has succeeded. Safe to
+    /// read from any thread, including a non-isolated `deinit`.
+    var published: Preparation? {
+        lock.withLock { preparation }
+    }
+}

--- a/Tests/TBDAppTests/LocalizedErrorPayloadTests.swift
+++ b/Tests/TBDAppTests/LocalizedErrorPayloadTests.swift
@@ -119,6 +119,10 @@ struct LocalizedErrorPayloadTests {
                 TmuxPreparationFailure.commandFailed(stage: .verifySelection, output: "can't find window @91")
             ),
             (
+                "TmuxPreparationFailure.tmuxExecutableUnavailable",
+                TmuxPreparationFailure.tmuxExecutableUnavailable
+            ),
+            (
                 "UserTerminalTheme.ValidationError.wrongAnsiCount",
                 UserTerminalTheme.ValidationError.wrongAnsiCount(9)
             ),

--- a/Tests/TBDAppTests/TerminalPanelViewTests.swift
+++ b/Tests/TBDAppTests/TerminalPanelViewTests.swift
@@ -16,6 +16,20 @@ struct TerminalPanelViewTests {
         ))
     }
 
+    @Test("unresolvable tmux executable names the remedy instead of diagnostics")
+    func tmuxExecutableUnavailableRendersLocateGuidance() {
+        let action = TerminalPanelRepresentable.Coordinator.preparationAction(
+            for: .failure(.tmuxExecutableUnavailable)
+        )
+
+        #expect(action == .showMessage(
+            "TBD couldn't find tmux — it is not in PATH and no fallback path is saved. Locate the tmux executable in Settings → Terminal, then reopen this terminal."
+        ))
+        #expect(action != .showMessage(
+            TerminalPreparationPresentation.commandFailedMessage
+        ))
+    }
+
     @Test("confirmed missing window requests automatic recovery")
     func confirmedMissingWindowRequestsRecovery() {
         let action = TerminalPanelRepresentable.Coordinator.preparationAction(

--- a/Tests/TBDAppTests/TerminalPanelViewTests.swift
+++ b/Tests/TBDAppTests/TerminalPanelViewTests.swift
@@ -46,8 +46,10 @@ struct TerminalPanelViewTests {
             arguments: ["-u", "attach"]
         )
 
-        #expect(TerminalPanelRepresentable.Coordinator.preparationAction(for: .success(prepared)) ==
-            .startViewer(prepared))
+        let preparation = TmuxSessionPreparation(session: prepared, generation: 7)
+
+        #expect(TerminalPanelRepresentable.Coordinator.preparationAction(
+            for: .success(preparation)) == .startViewer(preparation))
     }
 
     @MainActor

--- a/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
+++ b/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
@@ -83,7 +83,7 @@ struct TerminalViewSessionReclamationTests {
             coordinator?.tmuxBridge = bridge
             coordinator?.tmuxServer = "tbd-repo"
             coordinator?.panelID = Self.panelID
-            coordinator?.tmuxSessionGeneration = generations[0]
+            coordinator?.viewSessionReclaim.publish(bridge: bridge, generation: generations[0])
             // No `cleanup()`, no `dismantleNSView` — only ARC.
             coordinator = nil
         }
@@ -122,7 +122,7 @@ struct TerminalViewSessionReclamationTests {
         coordinator?.tmuxBridge = bridge
         coordinator?.tmuxServer = "tbd-repo"
         coordinator?.panelID = Self.panelID
-        coordinator?.tmuxSessionGeneration = generations[0]
+        coordinator?.viewSessionReclaim.publish(bridge: bridge, generation: generations[0])
         await MainActor.run { [coordinator] in
             coordinator?.cleanup()
         }
@@ -214,7 +214,7 @@ struct TerminalViewSessionReclamationTests {
             superseded?.tmuxBridge = bridge
             superseded?.tmuxServer = "tbd-repo"
             superseded?.panelID = Self.panelID
-            superseded?.tmuxSessionGeneration = generations[0]
+            superseded?.viewSessionReclaim.publish(bridge: bridge, generation: generations[0])
             superseded = nil
         }
 
@@ -298,7 +298,7 @@ struct TerminalViewSessionReclamationTests {
             // Disagrees with the server the session was prepared on.
             coordinator?.tmuxServer = "tbd-repo-stale"
             coordinator?.panelID = Self.panelID
-            coordinator?.tmuxSessionGeneration = generations[0]
+            coordinator?.viewSessionReclaim.publish(bridge: bridge, generation: generations[0])
             coordinator = nil
         }
 
@@ -318,7 +318,7 @@ struct TerminalViewSessionReclamationTests {
     /// run while `prepareSession` is suspended: the panel's `Task` starts the
     /// preparation, tmux takes a while, and the user closes the tab. The
     /// post-await torn-down guard then returns *before* the `.startViewer`
-    /// branch that records `tmuxSessionGeneration` — but `prepareSession` has
+    /// branch that publishes the generation — but `prepareSession` has
     /// already registered the session with the bridge. Neither `cleanup()`
     /// (already run, generation still nil) nor `deinit` (nil forever) can
     /// name it, so nothing reclaims the view session, the linked worktree
@@ -393,6 +393,36 @@ struct TerminalViewSessionReclamationTests {
                 args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
             ),
         ])
+    }
+
+    /// The holder exists so that what the `@MainActor` preparation publishes is
+    /// visible to a `deinit` running on whatever thread drops the last strong
+    /// reference. Publish from the main actor, read from a plain dispatch
+    /// queue — never from a cooperative-pool thread, which this must not park
+    /// (`Tests/CLAUDE.md`, "Thread-blocking gates run off the cooperative
+    /// pool").
+    ///
+    /// A stale read here is the silent failure the lock rules out: `deinit`
+    /// would see `nil`, skip `cleanupSession`, and leak the view session with
+    /// no diagnostic anywhere.
+    @Test("a preparation published on the main actor is readable from another thread")
+    func publishedPreparationIsReadableOffTheMainThread() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let bridge = TmuxBridge(
+            tmuxExecutableResolver: try fixture.resolvingResolver(),
+            commandRunner: { _, _, _ in TmuxCommandOutcome(success: true, output: "") }
+        )
+        let reclaim = ViewSessionReclaim()
+
+        await MainActor.run { reclaim.publish(bridge: bridge, generation: 7) }
+
+        let observed: UInt64? = await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: reclaim.published?.generation)
+            }
+        }
+        #expect(observed == 7)
     }
 }
 

--- a/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
+++ b/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
@@ -133,8 +133,8 @@ struct TerminalViewSessionReclamationTests {
 
     /// The terminate path, end to end through the delegate method the app
     /// actually implements — and across two servers, because `activeSessions`
-    /// spans every server the app has a panel on while `cleanupSession` learns
-    /// the server from its caller.
+    /// spans every server the app has a panel on while each kill has to reach
+    /// the socket its own session lives on.
     ///
     /// `applicationWillTerminate` blocks while the kills run, and it is
     /// `@MainActor`-isolated, so this test blocks the main thread exactly as
@@ -225,8 +225,7 @@ struct TerminalViewSessionReclamationTests {
         // And the fresh preparation is still tracked: its own teardown still
         // finds an entry to reclaim. (Before the fix the superseded release had
         // already removed it, so this kill never happened.)
-        bridge.cleanupSession(
-            panelID: Self.panelID, server: "tbd-repo", generation: generations[1])
+        bridge.cleanupSession(panelID: Self.panelID, generation: generations[1])
         let kills = try await runner.awaitKillSessions(
             atLeast: 1,
             describedAs: "the rebuilt panel's view session on its own teardown"
@@ -251,8 +250,7 @@ struct TerminalViewSessionReclamationTests {
             panels: [(Self.panelID, "tbd-repo", "@147")]
         )
 
-        bridge.cleanupSession(
-            panelID: Self.panelID, server: "tbd-repo", generation: generations[0])
+        bridge.cleanupSession(panelID: Self.panelID, generation: generations[0])
 
         let kills = try await runner.awaitKillSessions(
             atLeast: 1,
@@ -261,6 +259,51 @@ struct TerminalViewSessionReclamationTests {
         #expect(kills == [
             RecordingTmuxRunner.Invocation(
                 server: "tbd-repo",
+                args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
+            ),
+        ])
+    }
+
+    /// **The test that pins the wrong-socket bug.** A tmux session exists on
+    /// exactly one server socket, and the bridge already records which one when
+    /// it prepares the session. A teardown that carried its caller's idea of
+    /// the server instead would remove the tracked entry — the only handle
+    /// anything has on that session — and then send `kill-session` to a socket
+    /// that has no such session: the view session survives with nothing left
+    /// able to reclaim it, holding its linked worktree window, that window's
+    /// pane process and the whole tmux server alive.
+    ///
+    /// A coordinator whose `tmuxServer` disagrees with the preparation is the
+    /// reachable shape: the field is assigned when SwiftUI makes the view,
+    /// while the server the preparation actually ran against is the one the
+    /// bridge recorded.
+    @Test("a teardown kills on the session's own server, not the one its caller holds")
+    func teardownKillsOnThePreparationsServerNotTheCallers() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let (bridge, runner, generations) = try await makePreparedBridge(
+            fixture: fixture,
+            panels: [(Self.panelID, "tbd-repo-actual", "@147")]
+        )
+
+        autoreleasepool {
+            var coordinator: TerminalPanelRepresentable.Coordinator? =
+                TerminalPanelRepresentable.Coordinator()
+            coordinator?.tmuxBridge = bridge
+            // Disagrees with the server the session was prepared on.
+            coordinator?.tmuxServer = "tbd-repo-stale"
+            coordinator?.panelID = Self.panelID
+            coordinator?.tmuxSessionGeneration = generations[0]
+            coordinator = nil
+        }
+
+        let kills = try await runner.awaitKillSessions(
+            atLeast: 1,
+            describedAs: "the view session of a coordinator holding a stale server name"
+        )
+        #expect(kills == [
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo-actual",
                 args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
             ),
         ])

--- a/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
+++ b/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
@@ -23,33 +23,41 @@ import Testing
 ///   `cleanupSession`'s idempotence so a normal dismantle still kills once.
 /// - **App termination.** `applicationWillTerminate` has to *block* on the
 ///   kills; a detached task does not outlive the process.
+///
+/// Both per-panel paths are scoped to the generation their own
+/// `prepareSession` minted, because `panelID` alone does not identify a
+/// preparation — see `supersededCoordinatorReleaseSparesTheRebuiltViewSession`.
+/// The termination path deliberately is not: it reclaims everything tracked.
 @Suite("tmux view sessions are reclaimed on every teardown path")
 struct TerminalViewSessionReclamationTests {
     private static let panelID = UUID(uuidString: "4C4F1A61-F385-46AB-861D-42A425DB427B")!
     private static let sessionName = "tbd-view-4c4f1a61"
 
-    /// A prepared bridge plus the runner recording what it asked tmux to do.
+    /// A prepared bridge plus the runner recording what it asked tmux to do,
+    /// and the generation each preparation minted — the token its teardown has
+    /// to carry back.
     /// `prepareSession` issues a pre-emptive `kill-session` of its own, so the
     /// runner's log is cleared once preparation has finished: everything left
     /// in it afterwards was issued by a teardown.
     private func makePreparedBridge(
         fixture: TmuxBridgeFixture,
         panels: [(panelID: UUID, server: String, windowID: String)]
-    ) async throws -> (bridge: TmuxBridge, runner: RecordingTmuxRunner) {
+    ) async throws -> (bridge: TmuxBridge, runner: RecordingTmuxRunner, generations: [UInt64]) {
         let runner = RecordingTmuxRunner()
         let bridge = TmuxBridge(
             tmuxExecutableResolver: try fixture.resolvingResolver(),
             commandRunner: { _, server, args in await runner.run(server: server, args: args) }
         )
+        var generations: [UInt64] = []
         for panel in panels {
-            _ = try await bridge.prepareSession(
+            generations.append(try await bridge.prepareSession(
                 panelID: panel.panelID,
                 server: panel.server,
                 windowID: panel.windowID
-            ).get()
+            ).get().generation)
         }
         await runner.forgetInvocations()
-        return (bridge, runner)
+        return (bridge, runner, generations)
     }
 
     /// **The test that pins the bug.** Releasing the coordinator without ever
@@ -59,7 +67,7 @@ struct TerminalViewSessionReclamationTests {
     func coordinatorReleaseWithoutDismantleKillsViewSession() async throws {
         let fixture = try TmuxBridgeFixture()
         defer { fixture.remove() }
-        let (bridge, runner) = try await makePreparedBridge(
+        let (bridge, runner, generations) = try await makePreparedBridge(
             fixture: fixture,
             panels: [(Self.panelID, "tbd-repo", "@147")]
         )
@@ -70,6 +78,7 @@ struct TerminalViewSessionReclamationTests {
             coordinator?.tmuxBridge = bridge
             coordinator?.tmuxServer = "tbd-repo"
             coordinator?.panelID = Self.panelID
+            coordinator?.tmuxSessionGeneration = generations[0]
             // No `cleanup()`, no `dismantleNSView` — only ARC.
             coordinator = nil
         }
@@ -98,7 +107,7 @@ struct TerminalViewSessionReclamationTests {
     func cleanedUpCoordinatorReleaseDoesNotKillTwice() async throws {
         let fixture = try TmuxBridgeFixture()
         defer { fixture.remove() }
-        let (bridge, runner) = try await makePreparedBridge(
+        let (bridge, runner, generations) = try await makePreparedBridge(
             fixture: fixture,
             panels: [(Self.panelID, "tbd-repo", "@147")]
         )
@@ -108,6 +117,7 @@ struct TerminalViewSessionReclamationTests {
         coordinator?.tmuxBridge = bridge
         coordinator?.tmuxServer = "tbd-repo"
         coordinator?.panelID = Self.panelID
+        coordinator?.tmuxSessionGeneration = generations[0]
         await MainActor.run { [coordinator] in
             coordinator?.cleanup()
         }
@@ -138,7 +148,7 @@ struct TerminalViewSessionReclamationTests {
         let fixture = try TmuxBridgeFixture()
         defer { fixture.remove() }
         let secondPanelID = UUID(uuidString: "9B2E77C0-1111-4222-8333-444455556666")!
-        let (bridge, runner) = try await makePreparedBridge(
+        let (bridge, runner, _) = try await makePreparedBridge(
             fixture: fixture,
             panels: [
                 (Self.panelID, "tbd-repo-one", "@147"),
@@ -166,6 +176,92 @@ struct TerminalViewSessionReclamationTests {
                 server: "tbd-repo-two",
                 args: TmuxBridge.killSessionArgs(
                     sessionName: TmuxBridge.sessionName(for: secondPanelID))
+            ),
+        ])
+    }
+
+    /// **The test that pins the generation bug.** `panelID` is the *terminal's*
+    /// id and is stable across SwiftUI view rebuilds, so it does not identify a
+    /// preparation: `PanePlaceholder` keys the terminal view on
+    /// `"\(terminal.id)-\(terminal.tmuxWindowID)-\(terminal.isParked)"`, and
+    /// waking a parked terminal flips `isParked`, mints a fresh `Coordinator`
+    /// and prepares the panel again. The superseded coordinator is released
+    /// afterwards — from `deinit`, which fires later and less predictably than
+    /// `dismantleNSView` — and before the fix its teardown removed and killed
+    /// whatever `activeSessions` held for that `panelID`, which by then was the
+    /// *new* coordinator's session. Symptom: the freshly woken terminal is dead.
+    @Test("a superseded coordinator's release does not kill the rebuilt panel's view session")
+    func supersededCoordinatorReleaseSparesTheRebuiltViewSession() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        // The same panel prepared twice — exactly what the rebuild does.
+        let (bridge, runner, generations) = try await makePreparedBridge(
+            fixture: fixture,
+            panels: [
+                (Self.panelID, "tbd-repo", "@147"),
+                (Self.panelID, "tbd-repo", "@147"),
+            ]
+        )
+
+        autoreleasepool {
+            var superseded: TerminalPanelRepresentable.Coordinator? =
+                TerminalPanelRepresentable.Coordinator()
+            superseded?.tmuxBridge = bridge
+            superseded?.tmuxServer = "tbd-repo"
+            superseded?.panelID = Self.panelID
+            superseded?.tmuxSessionGeneration = generations[0]
+            superseded = nil
+        }
+
+        // One-sided negative, and sound because `cleanupSession` decides
+        // whether to kill synchronously under the bridge's lock before it
+        // returns: a teardown that wrongly matched has already spawned its kill
+        // task by now, and the settle window only has to cover that task being
+        // scheduled. A stray landing after the window still fails the exact-set
+        // assertion below, which re-reads every kill recorded.
+        let strayKills = await runner.killSessionsAfterSettling(for: .milliseconds(250))
+        #expect(strayKills == [])
+
+        // And the fresh preparation is still tracked: its own teardown still
+        // finds an entry to reclaim. (Before the fix the superseded release had
+        // already removed it, so this kill never happened.)
+        bridge.cleanupSession(
+            panelID: Self.panelID, server: "tbd-repo", generation: generations[1])
+        let kills = try await runner.awaitKillSessions(
+            atLeast: 1,
+            describedAs: "the rebuilt panel's view session on its own teardown"
+        )
+        #expect(kills == [
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo",
+                args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
+            ),
+        ])
+    }
+
+    /// The ordinary path, unchanged by generation scoping: a teardown carrying
+    /// the generation of the preparation it belongs to reclaims that session,
+    /// exactly once.
+    @Test("a teardown carrying its own preparation's generation kills that view session once")
+    func matchingGenerationTeardownKillsTheViewSession() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let (bridge, runner, generations) = try await makePreparedBridge(
+            fixture: fixture,
+            panels: [(Self.panelID, "tbd-repo", "@147")]
+        )
+
+        bridge.cleanupSession(
+            panelID: Self.panelID, server: "tbd-repo", generation: generations[0])
+
+        let kills = try await runner.awaitKillSessions(
+            atLeast: 1,
+            describedAs: "the view session torn down by its own preparation's generation"
+        )
+        #expect(kills == [
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo",
+                args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
             ),
         ])
     }
@@ -205,6 +301,15 @@ private actor RecordingTmuxRunner {
 
     func forgetInvocations() {
         invocations.removeAll()
+    }
+
+    /// Every `kill-session` recorded once the process has been left to run for
+    /// `window` — the negative counterpart of `awaitKillSessions`, for
+    /// asserting that a teardown killed *nothing*. One-sided by construction;
+    /// pair it with a positive assertion that re-reads the full list.
+    func killSessionsAfterSettling(for window: Duration) async -> [Invocation] {
+        try? await Task.sleep(for: window)
+        return killSessions
     }
 
     /// Bounded wait for kills that teardown issues off the caller's thread

--- a/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
+++ b/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftTerm
 import Testing
 @testable import TBDApp
 
@@ -23,6 +24,10 @@ import Testing
 ///   `cleanupSession`'s idempotence so a normal dismantle still kills once.
 /// - **App termination.** `applicationWillTerminate` has to *block* on the
 ///   kills; a detached task does not outlive the process.
+/// - **A preparation that lands after teardown.** `prepareSession` registers
+///   the session with the bridge before its caller records the generation, so
+///   a teardown that lands inside that window leaves an entry neither
+///   `cleanup()` nor `deinit` can name. The preparation reclaims it itself.
 ///
 /// Both per-panel paths are scoped to the generation their own
 /// `prepareSession` minted, because `panelID` alone does not identify a
@@ -308,6 +313,87 @@ struct TerminalViewSessionReclamationTests {
             ),
         ])
     }
+
+    /// **The test that pins the in-flight-preparation leak.** `cleanup()` can
+    /// run while `prepareSession` is suspended: the panel's `Task` starts the
+    /// preparation, tmux takes a while, and the user closes the tab. The
+    /// post-await torn-down guard then returns *before* the `.startViewer`
+    /// branch that records `tmuxSessionGeneration` — but `prepareSession` has
+    /// already registered the session with the bridge. Neither `cleanup()`
+    /// (already run, generation still nil) nor `deinit` (nil forever) can
+    /// name it, so nothing reclaims the view session, the linked worktree
+    /// window, or that window's pane process.
+    ///
+    /// The interleave is real rather than simulated: the injected runner holds
+    /// the preparation's last tmux command until the test has torn the
+    /// coordinator down, so the suspension the bug needs is the one under test.
+    /// It awaits rather than blocking a thread, so no cooperative-pool thread
+    /// is parked (`Tests/CLAUDE.md`, "Thread-blocking gates run off the
+    /// cooperative pool"), and every wait carries a deadline.
+    ///
+    /// Two kills are expected, not one: `prepareSession` opens with a
+    /// pre-emptive `kill-session` of any leftover session under the same name,
+    /// and that is indistinguishable from a teardown's kill by arguments
+    /// alone. Before the fix only the pre-emptive one is ever recorded.
+    @MainActor
+    @Test("a preparation that completes after teardown reclaims its own view session")
+    func preparationCompletingAfterTeardownReclaimsItsSession() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let runner = RecordingTmuxRunner()
+        // The verification query is preparation's last command, so holding it
+        // parks the preparation with everything else already done.
+        await runner.hold(command: "display-message")
+        let bridge = TmuxBridge(
+            tmuxExecutableResolver: try fixture.resolvingResolver(),
+            commandRunner: { _, server, args in await runner.run(server: server, args: args) }
+        )
+
+        let terminalView = TBDTerminalView(
+            frame: CGRect(x: 0, y: 0, width: 640, height: 480),
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(
+                defaults: UserDefaults(
+                    suiteName: "TerminalViewSessionReclamationTests.inFlightPreparation")!)
+        )
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.tmuxBridge = bridge
+        coordinator.tmuxServer = "tbd-repo"
+        coordinator.panelID = Self.panelID
+
+        let preparing = Task { @MainActor in
+            await coordinator.startTmuxClient(
+                terminalView: terminalView,
+                bridge: bridge,
+                server: "tbd-repo",
+                windowID: "@147",
+                panelID: Self.panelID
+            )
+        }
+
+        // Awaiting here hands the main actor back, which is what lets the
+        // preparation above run far enough to reach the held command.
+        try await runner.awaitHold(
+            describedAs: "the in-flight preparation this teardown has to race")
+        coordinator.cleanup()
+        await runner.release()
+        await preparing.value
+
+        let kills = try await runner.awaitKillSessions(
+            atLeast: 2,
+            describedAs: "the view session of a preparation that completed after teardown"
+        )
+        #expect(kills == [
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo",
+                args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
+            ),
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo",
+                args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
+            ),
+        ])
+    }
 }
 
 /// Records every tmux invocation with the server it targeted, and answers
@@ -322,9 +408,46 @@ private actor RecordingTmuxRunner {
     /// Window linked into each view session, learned from `link-window`, so
     /// preparation's verification query can be answered truthfully.
     private var linkedWindows: [String: String] = [:]
+    /// tmux subcommand to park on, so a test can interleave work with a
+    /// preparation that is genuinely mid-flight.
+    private var heldCommand: String?
+    private var holdWasReached = false
+    private var holdWasReleased = false
 
-    func run(server: String, args: [String]) -> TmuxCommandOutcome {
+    /// Park the next invocation of `command` until `release()`. The hold
+    /// *awaits* — actors are reentrant across suspension, so `release()` and
+    /// `awaitHold()` still run while an invocation sits here, and no thread is
+    /// blocked.
+    func hold(command: String) {
+        heldCommand = command
+    }
+
+    func release() {
+        holdWasReleased = true
+    }
+
+    /// Bounded wait for the held command to be reached. Throws a described
+    /// error rather than recording an `#expect` failure, so the diagnostic
+    /// reaches the CI summary's primary failure line.
+    func awaitHold(
+        describedAs subject: String,
+        within deadline: Duration = .seconds(10)
+    ) async throws {
+        for _ in 0..<attempts(for: deadline) {
+            if holdWasReached { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        throw HoldNeverReached(subject: subject, command: heldCommand, after: deadline)
+    }
+
+    func run(server: String, args: [String]) async -> TmuxCommandOutcome {
         invocations.append(Invocation(server: server, args: args))
+        if let heldCommand, args.first == heldCommand, !holdWasReleased {
+            holdWasReached = true
+            for _ in 0..<attempts(for: .seconds(10)) where !holdWasReleased {
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+        }
         switch args.first {
         case "link-window":
             // ["link-window", "-s", <windowID>, "-t", "<session>:"]
@@ -388,6 +511,25 @@ private actor RecordingTmuxRunner {
 
     private var killSessions: [Invocation] {
         invocations.filter { $0.args.first == "kill-session" }
+    }
+
+    private func attempts(for deadline: Duration) -> Int {
+        let seconds = Double(deadline.components.seconds)
+            + Double(deadline.components.attoseconds) / 1e18
+        return max(1, Int(seconds / 0.01))
+    }
+}
+
+/// Reports which command the runner was told to park on, so a hold that never
+/// fired is distinguishable from one whose command never ran.
+private struct HoldNeverReached: Error, CustomStringConvertible {
+    let subject: String
+    let command: String?
+    let after: Duration
+
+    var description: String {
+        "tmux never reached the held `\(command ?? "<none>")` command for \(subject) "
+            + "after polling up to \(after), so the teardown had nothing to interleave with"
     }
 }
 

--- a/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
+++ b/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
@@ -33,6 +33,24 @@ import Testing
 /// `prepareSession` minted, because `panelID` alone does not identify a
 /// preparation — see `supersededCoordinatorReleaseSparesTheRebuiltViewSession`.
 /// The termination path deliberately is not: it reclaims everything tracked.
+///
+/// **Every test that touches a `Coordinator` is `@MainActor`.** `Coordinator`
+/// conforms to SwiftTerm's `TerminalViewDelegate`, which is `@MainActor` on
+/// the pinned fork, so the class inherits that isolation — its `init`,
+/// `tmuxBridge`, `tmuxServer`, `panelID` and `viewSessionReclaim` are all
+/// main-isolated and cannot be reached from a non-isolated test body. The
+/// releases those tests drive therefore run on the main thread, which is where
+/// SwiftUI drops coordinators in production anyway; `deinit` stays
+/// non-isolated and still reads its facts through `ViewSessionReclaim`, which
+/// is the property `publishedPreparationIsReadableOffTheMainThread` pins —
+/// that test constructs no `Coordinator`, so it stays off the main actor and
+/// does its read from a global queue.
+///
+/// The annotation costs one main-actor hop per `await`, not one per poll:
+/// every bounded wait here is a method on the `RecordingTmuxRunner` actor, so
+/// the polling loop runs on that actor's executor and the test body resumes
+/// exactly once. (`TerminalTeardownReapTests` batches its hops by hand for the
+/// opposite reason — its waits resume on the caller.)
 @Suite("tmux view sessions are reclaimed on every teardown path")
 struct TerminalViewSessionReclamationTests {
     private static let panelID = UUID(uuidString: "4C4F1A61-F385-46AB-861D-42A425DB427B")!
@@ -68,6 +86,7 @@ struct TerminalViewSessionReclamationTests {
     /// **The test that pins the bug.** Releasing the coordinator without ever
     /// calling `cleanup()` is exactly what SwiftUI does when it skips
     /// `dismantleNSView`, and before the fix nothing killed the session.
+    @MainActor
     @Test("releasing a panel coordinator without dismantle still kills its view session")
     func coordinatorReleaseWithoutDismantleKillsViewSession() async throws {
         let fixture = try TmuxBridgeFixture()
@@ -108,6 +127,7 @@ struct TerminalViewSessionReclamationTests {
     /// deciding whether to spawn a kill *before* the wait below starts, so no
     /// later invocation can appear — a second kill would already be recorded
     /// or already be impossible.
+    @MainActor
     @Test("a cleaned-up coordinator that is then released kills its session exactly once")
     func cleanedUpCoordinatorReleaseDoesNotKillTwice() async throws {
         let fixture = try TmuxBridgeFixture()
@@ -195,6 +215,7 @@ struct TerminalViewSessionReclamationTests {
     /// `dismantleNSView` — and before the fix its teardown removed and killed
     /// whatever `activeSessions` held for that `panelID`, which by then was the
     /// *new* coordinator's session. Symptom: the freshly woken terminal is dead.
+    @MainActor
     @Test("a superseded coordinator's release does not kill the rebuilt panel's view session")
     func supersededCoordinatorReleaseSparesTheRebuiltViewSession() async throws {
         let fixture = try TmuxBridgeFixture()
@@ -282,6 +303,7 @@ struct TerminalViewSessionReclamationTests {
     /// reachable shape: the field is assigned when SwiftUI makes the view,
     /// while the server the preparation actually ran against is the one the
     /// bridge recorded.
+    @MainActor
     @Test("a teardown kills on the session's own server, not the one its caller holds")
     func teardownKillsOnThePreparationsServerNotTheCallers() async throws {
         let fixture = try TmuxBridgeFixture()

--- a/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
+++ b/Tests/TBDAppTests/TerminalViewSessionReclamationTests.swift
@@ -1,0 +1,266 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tier 2: the two teardown paths that must reclaim a tmux **view session**,
+/// driven against a recording command runner instead of a tmux server.
+///
+/// Every viewed panel gets its own `tbd-view-<panel prefix>` session with the
+/// worktree's window linked into it, and tmux destroys a window only when the
+/// last session referencing it goes away — so a view session nobody kills
+/// keeps that window, its pane process and the whole tmux server alive after
+/// the owning `main` session is gone. `TmuxBridge` also kills the view
+/// session's own initial window, so a leaked one holds nothing *but* linked
+/// worktree windows.
+///
+/// The two paths, and why each has a test:
+///
+/// - **Coordinator release.** `cleanup()` runs only from `dismantleNSView`,
+///   which SwiftUI does not guarantee to run; the bridge log recorded 15
+///   `PANEL: deinit` lines in 35 seconds with no matching `PANEL: cleanup`.
+///   `deinit` therefore reclaims the session itself, relying on
+///   `cleanupSession`'s idempotence so a normal dismantle still kills once.
+/// - **App termination.** `applicationWillTerminate` has to *block* on the
+///   kills; a detached task does not outlive the process.
+@Suite("tmux view sessions are reclaimed on every teardown path")
+struct TerminalViewSessionReclamationTests {
+    private static let panelID = UUID(uuidString: "4C4F1A61-F385-46AB-861D-42A425DB427B")!
+    private static let sessionName = "tbd-view-4c4f1a61"
+
+    /// A prepared bridge plus the runner recording what it asked tmux to do.
+    /// `prepareSession` issues a pre-emptive `kill-session` of its own, so the
+    /// runner's log is cleared once preparation has finished: everything left
+    /// in it afterwards was issued by a teardown.
+    private func makePreparedBridge(
+        fixture: TmuxBridgeFixture,
+        panels: [(panelID: UUID, server: String, windowID: String)]
+    ) async throws -> (bridge: TmuxBridge, runner: RecordingTmuxRunner) {
+        let runner = RecordingTmuxRunner()
+        let bridge = TmuxBridge(
+            tmuxExecutableResolver: try fixture.resolvingResolver(),
+            commandRunner: { _, server, args in await runner.run(server: server, args: args) }
+        )
+        for panel in panels {
+            _ = try await bridge.prepareSession(
+                panelID: panel.panelID,
+                server: panel.server,
+                windowID: panel.windowID
+            ).get()
+        }
+        await runner.forgetInvocations()
+        return (bridge, runner)
+    }
+
+    /// **The test that pins the bug.** Releasing the coordinator without ever
+    /// calling `cleanup()` is exactly what SwiftUI does when it skips
+    /// `dismantleNSView`, and before the fix nothing killed the session.
+    @Test("releasing a panel coordinator without dismantle still kills its view session")
+    func coordinatorReleaseWithoutDismantleKillsViewSession() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let (bridge, runner) = try await makePreparedBridge(
+            fixture: fixture,
+            panels: [(Self.panelID, "tbd-repo", "@147")]
+        )
+
+        autoreleasepool {
+            var coordinator: TerminalPanelRepresentable.Coordinator? =
+                TerminalPanelRepresentable.Coordinator()
+            coordinator?.tmuxBridge = bridge
+            coordinator?.tmuxServer = "tbd-repo"
+            coordinator?.panelID = Self.panelID
+            // No `cleanup()`, no `dismantleNSView` — only ARC.
+            coordinator = nil
+        }
+
+        let kills = try await runner.awaitKillSessions(
+            atLeast: 1,
+            describedAs: "the view session for a coordinator released without dismantle"
+        )
+        #expect(kills == [
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo",
+                args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
+            ),
+        ])
+    }
+
+    /// The idempotence half. `deinit` does not consult `cleanup()`'s
+    /// `isTornDown` flag (it is `@MainActor`-confined); it relies on the
+    /// bridge having already removed the panel from `activeSessions`.
+    ///
+    /// One observation settles this: both teardown steps run to the point of
+    /// deciding whether to spawn a kill *before* the wait below starts, so no
+    /// later invocation can appear — a second kill would already be recorded
+    /// or already be impossible.
+    @Test("a cleaned-up coordinator that is then released kills its session exactly once")
+    func cleanedUpCoordinatorReleaseDoesNotKillTwice() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let (bridge, runner) = try await makePreparedBridge(
+            fixture: fixture,
+            panels: [(Self.panelID, "tbd-repo", "@147")]
+        )
+
+        var coordinator: TerminalPanelRepresentable.Coordinator? =
+            TerminalPanelRepresentable.Coordinator()
+        coordinator?.tmuxBridge = bridge
+        coordinator?.tmuxServer = "tbd-repo"
+        coordinator?.panelID = Self.panelID
+        await MainActor.run { [coordinator] in
+            coordinator?.cleanup()
+        }
+        coordinator = nil
+
+        let kills = try await runner.awaitKillSessions(
+            atLeast: 1,
+            describedAs: "the view session of a coordinator torn down and then released"
+        )
+        #expect(kills.count == 1)
+        #expect(kills.first?.args == TmuxBridge.killSessionArgs(sessionName: Self.sessionName))
+    }
+
+    /// The terminate path, end to end through the delegate method the app
+    /// actually implements — and across two servers, because `activeSessions`
+    /// spans every server the app has a panel on while `cleanupSession` learns
+    /// the server from its caller.
+    ///
+    /// `applicationWillTerminate` blocks while the kills run, and it is
+    /// `@MainActor`-isolated, so this test blocks the main thread exactly as
+    /// production does. That is safe here and cannot wedge the pool
+    /// (`Tests/CLAUDE.md`, "Thread-blocking gates run off the cooperative
+    /// pool"): the main thread is not a cooperative-pool thread, so the kill
+    /// task that releases the wait always has somewhere to run — and the wait
+    /// is bounded by `cleanupAllSessionsBlocking`'s own timeout regardless.
+    @Test("applicationWillTerminate reclaims tracked view sessions on every server")
+    func terminateReclaimsSessionsAcrossServers() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let secondPanelID = UUID(uuidString: "9B2E77C0-1111-4222-8333-444455556666")!
+        let (bridge, runner) = try await makePreparedBridge(
+            fixture: fixture,
+            panels: [
+                (Self.panelID, "tbd-repo-one", "@147"),
+                (secondPanelID, "tbd-repo-two", "@201"),
+            ]
+        )
+
+        await MainActor.run {
+            let delegate = AppDelegate()
+            delegate.tmuxBridge = bridge
+            delegate.applicationWillTerminate(
+                Notification(name: NSApplication.willTerminateNotification))
+        }
+
+        let kills = try await runner.awaitKillSessions(
+            atLeast: 2,
+            describedAs: "both tracked view sessions on the terminate path"
+        )
+        #expect(Set(kills) == [
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo-one",
+                args: TmuxBridge.killSessionArgs(sessionName: Self.sessionName)
+            ),
+            RecordingTmuxRunner.Invocation(
+                server: "tbd-repo-two",
+                args: TmuxBridge.killSessionArgs(
+                    sessionName: TmuxBridge.sessionName(for: secondPanelID))
+            ),
+        ])
+    }
+}
+
+/// Records every tmux invocation with the server it targeted, and answers
+/// preparation's one query so `prepareSession` can succeed without a tmux.
+private actor RecordingTmuxRunner {
+    struct Invocation: Sendable, Equatable, Hashable {
+        let server: String
+        let args: [String]
+    }
+
+    private var invocations: [Invocation] = []
+    /// Window linked into each view session, learned from `link-window`, so
+    /// preparation's verification query can be answered truthfully.
+    private var linkedWindows: [String: String] = [:]
+
+    func run(server: String, args: [String]) -> TmuxCommandOutcome {
+        invocations.append(Invocation(server: server, args: args))
+        switch args.first {
+        case "link-window":
+            // ["link-window", "-s", <windowID>, "-t", "<session>:"]
+            if args.count >= 5 {
+                linkedWindows[String(args[4].dropLast())] = args[2]
+            }
+            return TmuxCommandOutcome(success: true, output: "")
+        case "display-message":
+            // ["display-message", "-p", "-t", <session>, "#{window_id}"] —
+            // preparation requires the answer to match the linked window.
+            let sessionName = args.count >= 4 ? args[3] : ""
+            return TmuxCommandOutcome(success: true, output: linkedWindows[sessionName] ?? "")
+        default:
+            return TmuxCommandOutcome(success: true, output: "")
+        }
+    }
+
+    func forgetInvocations() {
+        invocations.removeAll()
+    }
+
+    /// Bounded wait for kills that teardown issues off the caller's thread
+    /// (`cleanupSession` kills from a detached task).
+    ///
+    /// Returns every `kill-session` recorded, so a caller can assert an exact
+    /// set rather than only a lower bound. Throws a described error rather
+    /// than recording an `#expect` failure: a bounded-wait diagnostic is the
+    /// whole finding, and only a thrown error reaches the CI summary's primary
+    /// failure line (`Tests/CLAUDE.md`, "Assertion hygiene").
+    func awaitKillSessions(
+        atLeast count: Int,
+        describedAs subject: String,
+        within deadline: Duration = .seconds(10)
+    ) async throws -> [Invocation] {
+        let pollInterval = Duration.milliseconds(10)
+        let deadlineSeconds = Double(deadline.components.seconds)
+            + Double(deadline.components.attoseconds) / 1e18
+        let attempts = max(1, Int(deadlineSeconds / 0.01))
+        for _ in 0..<attempts {
+            let kills = killSessions
+            if kills.count >= count { return kills }
+            try? await Task.sleep(for: pollInterval)
+        }
+        throw MissingKillSessions(
+            subject: subject,
+            expected: count,
+            observed: killSessions,
+            allInvocations: invocations,
+            after: deadline
+        )
+    }
+
+    private var killSessions: [Invocation] {
+        invocations.filter { $0.args.first == "kill-session" }
+    }
+}
+
+/// Reports what the runner actually saw, not what it wanted — including every
+/// invocation, since "no kill at all" and "a kill on the wrong server" are
+/// different bugs.
+private struct MissingKillSessions: Error, CustomStringConvertible {
+    let subject: String
+    let expected: Int
+    let observed: [RecordingTmuxRunner.Invocation]
+    let allInvocations: [RecordingTmuxRunner.Invocation]
+    let after: Duration
+
+    var description: String {
+        let rendered = allInvocations
+            .map { "\($0.server): \($0.args.joined(separator: " "))" }
+            .joined(separator: "; ")
+        return """
+            tmux never killed \(subject): expected at least \(expected) kill-session \
+            invocation(s), observed \(observed.count) after polling up to \(after). \
+            Invocations since preparation finished: [\(rendered.isEmpty ? "none" : rendered)]
+            """
+    }
+}

--- a/Tests/TBDAppTests/TmuxBridgeTests.swift
+++ b/Tests/TBDAppTests/TmuxBridgeTests.swift
@@ -44,6 +44,9 @@ struct TmuxBridgeTests {
         #expect(TmuxBridge.killSessionArgs(sessionName: sessionName) == [
             "kill-session", "-t", sessionName,
         ])
+        #expect(TmuxBridge.hasSessionArgs(sessionName: sessionName) == [
+            "has-session", "-t", sessionName,
+        ])
     }
 
     @Test func commandsObserveSavedFallbackAfterInitializationAndPathStillWins() throws {
@@ -230,6 +233,137 @@ struct TmuxBridgeTests {
         #expect(bridge.tmuxCommand(server: "tbd-repo", args: ["list-windows"])?.first
             == secondExecutable.path)
     }
+
+    @Test func unresolvableTmuxExecutableIsItsOwnFailure() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let resolver = TmuxExecutableResolver(
+            environment: ["PATH": ""],
+            configurationURL: fixture.root.appendingPathComponent("no-such-saved-path")
+        )
+        let bridge = TmuxBridge(tmuxExecutableResolver: resolver)
+
+        let result = await bridge.prepareSession(
+            panelID: UUID(),
+            server: "tbd-repo",
+            windowID: "@147"
+        )
+
+        guard case .failure(let failure) = result else {
+            Issue.record("preparation should fail when no tmux executable resolves")
+            return
+        }
+        #expect(failure == .tmuxExecutableUnavailable)
+    }
+
+    @Test func duplicateSessionCreateFailureIsRetriedAfterKillingTheLeftover() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let resolver = try fixture.resolvingResolver()
+        let runner = ScriptedTmuxRunner(
+            newSessionFailures: 1,
+            failureOutput: "duplicate session: tbd-view-4c4f1a61",
+            leftoverSessionExists: true
+        )
+        let bridge = TmuxBridge(
+            tmuxExecutableResolver: resolver,
+            commandRunner: { _, _, args in await runner.run(args) }
+        )
+        let panelID = UUID(uuidString: "4C4F1A61-F385-46AB-861D-42A425DB427B")!
+
+        let prepared = try await bridge.prepareSession(
+            panelID: panelID,
+            server: "tbd-repo",
+            windowID: "@147"
+        ).get()
+
+        #expect(prepared.arguments == [
+            "-u", "-L", "tbd-repo", "attach", "-t", "tbd-view-4c4f1a61",
+        ])
+        #expect(await runner.verbs == [
+            "kill-session",
+            "new-session",
+            "has-session",
+            "kill-session",
+            "new-session",
+            "link-window",
+            "kill-window",
+            "select-window",
+            "set-option",
+            "set-option",
+            "display-message",
+        ])
+    }
+
+    @Test func createFailureWithoutALeftoverSessionIsNotRetried() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let resolver = try fixture.resolvingResolver()
+        let runner = ScriptedTmuxRunner(
+            newSessionFailures: 1,
+            failureOutput: "no space left on device",
+            leftoverSessionExists: false
+        )
+        let bridge = TmuxBridge(
+            tmuxExecutableResolver: resolver,
+            commandRunner: { _, _, args in await runner.run(args) }
+        )
+
+        let result = await bridge.prepareSession(
+            panelID: UUID(uuidString: "4C4F1A61-F385-46AB-861D-42A425DB427B")!,
+            server: "tbd-repo",
+            windowID: "@147"
+        )
+
+        guard case .failure(let failure) = result else {
+            Issue.record("preparation should fail when the view session cannot be created")
+            return
+        }
+        #expect(failure == .commandFailed(
+            stage: .createViewSession,
+            output: "no space left on device"
+        ))
+        #expect(await runner.verbs == ["kill-session", "new-session", "has-session"])
+    }
+}
+
+/// Replies to tmux invocations from a script, so a test can drive a sequence a
+/// live server cannot be made to produce on demand — a `new-session` that
+/// fails once with `duplicate session:` and succeeds on the retry.
+private actor ScriptedTmuxRunner {
+    private var invocations: [[String]] = []
+    private var remainingNewSessionFailures: Int
+    private let failureOutput: String
+    private let leftoverSessionExists: Bool
+
+    init(newSessionFailures: Int, failureOutput: String, leftoverSessionExists: Bool) {
+        self.remainingNewSessionFailures = newSessionFailures
+        self.failureOutput = failureOutput
+        self.leftoverSessionExists = leftoverSessionExists
+    }
+
+    var verbs: [String] { invocations.compactMap(\.first) }
+
+    func run(_ args: [String]) -> TmuxCommandOutcome {
+        invocations.append(args)
+        switch args.first {
+        case "new-session":
+            guard remainingNewSessionFailures > 0 else {
+                return TmuxCommandOutcome(success: true, output: "")
+            }
+            remainingNewSessionFailures -= 1
+            return TmuxCommandOutcome(success: false, output: failureOutput)
+        case "has-session":
+            return TmuxCommandOutcome(
+                success: leftoverSessionExists,
+                output: leftoverSessionExists ? "" : "can't find session"
+            )
+        case "display-message":
+            return TmuxCommandOutcome(success: true, output: "@147")
+        default:
+            return TmuxCommandOutcome(success: true, output: "")
+        }
+    }
 }
 
 private struct TmuxBridgeFixture {
@@ -292,6 +426,17 @@ private struct TmuxBridgeFixture {
             ofItemAtPath: executable.path
         )
         return executable
+    }
+
+    /// A resolver that resolves to a stub executable the test never runs
+    /// (every command goes through an injected runner instead).
+    func resolvingResolver() throws -> TmuxExecutableResolver {
+        let resolver = TmuxExecutableResolver(
+            environment: ["PATH": ""],
+            configurationURL: configurationURL
+        )
+        try resolver.save(executable(named: "stub-tmux", in: root).path)
+        return resolver
     }
 
     func lineCount(at url: URL) -> Int {

--- a/Tests/TBDAppTests/TmuxBridgeTests.swift
+++ b/Tests/TBDAppTests/TmuxBridgeTests.swift
@@ -225,8 +225,7 @@ struct TmuxBridgeTests {
         #expect(afterConfirmationInvocationCount == firstInvocationCount + 1)
         #expect(fixture.lineCount(at: secondLog) == 0)
 
-        bridge.cleanupSession(
-            panelID: panelID, server: "tbd-repo", generation: preparation.generation)
+        bridge.cleanupSession(panelID: panelID, generation: preparation.generation)
         try await fixture.waitForLineCount(afterConfirmationInvocationCount + 1, at: firstLog)
 
         #expect(fixture.lineCount(at: firstLog) == afterConfirmationInvocationCount + 1)

--- a/Tests/TBDAppTests/TmuxBridgeTests.swift
+++ b/Tests/TBDAppTests/TmuxBridgeTests.swift
@@ -366,7 +366,9 @@ private actor ScriptedTmuxRunner {
     }
 }
 
-private struct TmuxBridgeFixture {
+/// Internal rather than file-private so the view-session reclamation suite
+/// (`TerminalViewSessionReclamationTests`) can build its bridges the same way.
+struct TmuxBridgeFixture {
     let root: URL
     let configurationURL: URL
 

--- a/Tests/TBDAppTests/TmuxBridgeTests.swift
+++ b/Tests/TBDAppTests/TmuxBridgeTests.swift
@@ -209,11 +209,11 @@ struct TmuxBridgeTests {
             server: "tbd-repo",
             windowID: "@147"
         )
-        let prepared = try result.get()
+        let preparation = try result.get()
 
         #expect(resolver.savedPath == secondExecutable.path)
-        #expect(prepared.executablePath == firstExecutable.path)
-        #expect(prepared.arguments == [
+        #expect(preparation.session.executablePath == firstExecutable.path)
+        #expect(preparation.session.arguments == [
             "-u", "-L", "tbd-repo", "attach", "-t", TmuxBridge.sessionName(for: panelID),
         ])
         let firstInvocationCount = fixture.lineCount(at: firstLog)
@@ -225,7 +225,8 @@ struct TmuxBridgeTests {
         #expect(afterConfirmationInvocationCount == firstInvocationCount + 1)
         #expect(fixture.lineCount(at: secondLog) == 0)
 
-        bridge.cleanupSession(panelID: panelID, server: "tbd-repo")
+        bridge.cleanupSession(
+            panelID: panelID, server: "tbd-repo", generation: preparation.generation)
         try await fixture.waitForLineCount(afterConfirmationInvocationCount + 1, at: firstLog)
 
         #expect(fixture.lineCount(at: firstLog) == afterConfirmationInvocationCount + 1)
@@ -275,7 +276,7 @@ struct TmuxBridgeTests {
             panelID: panelID,
             server: "tbd-repo",
             windowID: "@147"
-        ).get()
+        ).get().session
 
         #expect(prepared.arguments == [
             "-u", "-L", "tbd-repo", "attach", "-t", "tbd-view-4c4f1a61",

--- a/Tests/TBDDaemonLiveTests/TmuxBridgeViewSessionLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/TmuxBridgeViewSessionLiveTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// Tier 3: `TmuxBridge.prepareSession` against a real tmux server on a
+/// throwaway socket. Lives here, not in `TBDAppTests`, because its runtime
+/// depends on an external process it does not fully control.
+@Suite("TmuxBridge view session (live tmux)")
+struct TmuxBridgeViewSessionLiveTests {
+    @Test(.timeLimit(.minutes(1)))
+    func staleUnattachedViewSessionIsReplaced() async throws {
+        guard let tmuxExecutablePath = TmuxExecutableResolver().resolve()?.path else { return }
+        let server = "tbd-view-live-\(UUID().uuidString.prefix(8).lowercased())"
+        defer { _ = runTmuxCLI(tmuxExecutablePath, ["-L", server, "kill-server"]) }
+        let panelID = UUID()
+        let sessionName = TmuxBridge.sessionName(for: panelID)
+
+        try #require(runTmuxCLI(tmuxExecutablePath, [
+            "-L", server, "new-session", "-d", "-s", "main", "-x", "80", "-y", "24",
+        ]).status == 0)
+        let windowID = runTmuxCLI(tmuxExecutablePath, [
+            "-L", server, "display-message", "-p", "-t", "main", "#{window_id}",
+        ]).output
+        try #require(windowID.hasPrefix("@"))
+        // Exactly what a pre-kill that failed leaves behind: a same-named,
+        // unattached leftover session. The name is derived from the panel
+        // UUID, so it can never be sidestepped by picking a fresh one.
+        try #require(runTmuxCLI(tmuxExecutablePath, [
+            "-L", server, "new-session", "-d", "-s", sessionName, "-c", "/tmp",
+        ]).status == 0)
+
+        let prepared = try await TmuxBridge().prepareSession(
+            panelID: panelID,
+            server: server,
+            windowID: windowID
+        ).get()
+
+        #expect(prepared.arguments == ["-u", "-L", server, "attach", "-t", sessionName])
+        let activeWindow = runTmuxCLI(tmuxExecutablePath, [
+            "-L", server, "display-message", "-p", "-t", sessionName, "#{window_id}",
+        ])
+        #expect(activeWindow.status == 0)
+        #expect(activeWindow.output == windowID)
+        // Replacement must not cost the agent its window: `kill-window`
+        // destroys a window globally rather than unlinking it from one
+        // session, which is why the leftover is replaced and never adopted.
+        let inventory = runTmuxCLI(tmuxExecutablePath, [
+            "-L", server, "list-windows", "-a", "-F", "#{window_id}",
+        ])
+        #expect(inventory.output.split(whereSeparator: { $0.isNewline }).contains(windowID[...]))
+    }
+
+    /// Runs one tmux command with a hard deadline, so a wedged server fails
+    /// the test instead of hanging it.
+    private func runTmuxCLI(
+        _ executablePath: String,
+        _ args: [String],
+        timeout: TimeInterval = 10
+    ) -> (status: Int32, output: String) {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = args
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+        } catch {
+            return (-1, error.localizedDescription)
+        }
+        let watchdog = DispatchWorkItem {
+            if process.isRunning { process.terminate() }
+        }
+        DispatchQueue.global(qos: .userInitiated)
+            .asyncAfter(deadline: .now() + timeout, execute: watchdog)
+        process.waitUntilExit()
+        watchdog.cancel()
+        let output = String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        return (
+            process.terminationStatus,
+            output.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+}

--- a/Tests/TBDDaemonLiveTests/TmuxBridgeViewSessionLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/TmuxBridgeViewSessionLiveTests.swift
@@ -34,7 +34,7 @@ struct TmuxBridgeViewSessionLiveTests {
             panelID: panelID,
             server: server,
             windowID: windowID
-        ).get()
+        ).get().session
 
         #expect(prepared.arguments == ["-u", "-L", server, "attach", "-t", sessionName])
         let activeWindow = runTmuxCLI(tmuxExecutablePath, [


### PR DESCRIPTION
## What's broken

Two failures, both in how the app attaches a terminal panel to tmux.

**A tab that can never attach.** Clicking a terminal tab shows "TBD couldn't attach to
this terminal. The terminal was left unchanged. Check diagnostics for details or close
the tab." It does not recover on its own and it survives restarts. Every panel on the
machine fails the same way at the same moment, and the only remedy is to relaunch the
app from somewhere that happens to have a different `PATH`.

**Leaked tmux view sessions.** Each viewed panel gets its own tmux session named
`tbd-view-<8 hex of the panel UUID>`. Closing a panel is supposed to destroy it. Often
it didn't: the bridge log recorded 15 panel teardowns in 35 seconds that destroyed
nothing, leaving stale sessions behind on the server.

## Why it happens

**The unattachable tab** is a missing tmux executable, reported as though tmux had
failed. `TmuxBridge.prepareSession` resolves the tmux binary from the `PATH` the app
was launched with, falling back to a saved path the user can set in Settings. When
neither yields anything, it returned `commandFailed(stage: .createViewSession)` — the
same shape a genuinely failed tmux command produces — and, uniquely among the failure
paths, wrote nothing to the bridge log. So the one diagnostic the message tells you to
consult is silent precisely when this fires, and the banner points at diagnostics
rather than at Settings, where the fix actually is. Nothing about it is transient:
resolution depends only on the launch environment, so every panel fails identically
until the app is relaunched.

**The leak** is a teardown that SwiftUI is not obliged to run. `cleanupSession` was
reachable only from `Coordinator.cleanup()`, which runs only from `dismantleNSView`.
When SwiftUI drops a coordinator without dismantling it, `deinit` runs and the tmux
session survives.

There is a third, latent failure the same code invites. `prepareSession` kills a
same-named session before creating one but discards that kill's result; if the kill
fails transiently, `new-session` fails with `duplicate session:` and the panel is
bricked permanently, because the session name derives from the panel UUID and never
changes.

## What this PR does

- Gives the unresolvable-tmux case its own failure value, `.tmuxExecutableUnavailable`,
  with its own log category, a bridge-log breadcrumb, and a banner naming the remedy
  ("Locate the tmux executable in Settings → Terminal") instead of pointing at
  diagnostics. It is deliberately not routed into automatic terminal recreation —
  retrying cannot help.
- Makes the create tolerant of a same-named leftover: on failure it probes
  `has-session` and, only when that probe affirmatively succeeds, kills and retries
  once. A failed probe stays ambiguous and does not justify a retry, matching how
  `classifyPreparationFailure` already treats an unanswerable probe.
- Reclaims the view session from `Coordinator.deinit` and from
  `applicationWillTerminate`, which previously only logged.
- Scopes each reclaim to the preparation that created it with a generation, so a
  superseded coordinator's late teardown cannot kill a rebuilt panel's session — the
  shape the control-mode attach path already uses for the same race.

**Replacement, never adoption.** `prepareSession` runs `kill-window -t <session>:0`
after linking, and tmux's `kill-window` destroys a window globally rather than
unlinking it from one session. Adopting a leftover session whose index 0 held a real
linked window would therefore destroy a live agent window. Replacing is the only
variant that cannot.

**Why no spec.** These are bug fixes: they restore the system to its existing theory
rather than revising it. A tab that can never attach, and a teardown that doesn't tear
down, are both broken behavior.

## Who reclaims the orphans

A tmux session is a durable external resource, so the doctrine asks who reclaims one
that outlives its owner. The answer here is that three existing paths already bound the
population, and no new reconciler is warranted:

- The daemon's window disposal (archive, forget, and the orphan sweep) calls tmux
  `kill-window`, which destroys a window **globally**. Killing a worktree window
  therefore removes it from any view session holding it, and a view session left with
  no windows is destroyed by tmux.
- `reconcileTmuxResources` kills a whole server once no live worktree row names it,
  which takes every view session on it.
- `prepareSession` kills a same-named leftover before creating its own, so re-viewing a
  panel reclaims that panel's own stray.

Measured on a scratch server: with a worktree window linked into both `main` and a view
session, a single `kill-window` on that window emptied both sessions and exited the
server — no session, no window, no server left behind.

The residue those three do not cover is cosmetic: a dead `tbd-view-*` entry on a server
whose worktrees are still live, for a panel nobody re-views. It pins no window, no
process, and no server.

## Assumptions

- Assumes the app's launch environment can resolve tmux, or that the user has saved a
  fallback path. If neither holds the terminals cannot work at all — this PR makes that
  state legible and actionable rather than fixing it.
- Assumes tmux keeps `kill-window`'s global semantics. If a future tmux made
  `kill-window` unlink from one session instead of destroying the window, the
  reclamation reasoning above would need revisiting, and adoption would become viable.
- Assumes panel UUIDs do not collide in their first 8 hex characters. At TBD's panel
  counts the probability is negligible, but the truncation means two distinct panels
  could in principle share a session name, in which case one panel's pre-kill would
  tear down the other's session.

## Evidence & verification

**The repro.** The unattachable tab was pinned to the second from the unified log —
two `stage=createViewSession category=commandFailed` errors — cross-referenced against
`/tmp/tbd-bridge.log`, which had no corresponding entry at that timestamp. Since the
create-failure path logs and the resolver-guard path does not, the silence identifies
the guard as the failing path. The leak was read directly from the same log: 15
`PANEL: deinit` lines with no matching `PANEL: cleanup` or `CLEANUP:` line.

**Discriminating tests.** Each fix has a test that fails without it, verified by
mutation rather than assumed:

- `duplicateSessionCreateFailureIsRetriedAfterKillingTheLeftover` asserts the exact tmux
  verb sequence through an injected command runner, so it fails without the retry.
- `createFailureWithoutALeftoverSessionIsNotRetried` pins the negative case.
- `unresolvableTmuxExecutableIsItsOwnFailure` and
  `tmuxExecutableUnavailableRendersLocateGuidance` cover the new failure value and its
  banner copy.
- `coordinatorReleaseWithoutDismantleKillsViewSession` fails with the `deinit` call
  removed; `terminateReclaimsSessionsAcrossServers` fails with the terminate call
  stubbed out.
- `supersededCoordinatorReleaseSparesTheRebuiltViewSession` fails with the generation
  comparison removed, observed as a stray `kill-session` for
  `tbd-view-4c4f1a61`; the other four tests in that suite pass under the same mutation,
  so it is the discriminating one.
- A tier-3 live test drives `prepareSession` against a real tmux server on a throwaway
  socket with bounded per-command deadlines, standing up a stale unattached session
  first. It is a regression guard rather than a discriminating test — the pre-kill
  already handled that case.

**Suite.** `scripts/test.sh` reports the pre-existing known-issue baseline; the residual
non-known failures are starvation-class flakes in unrelated targets (`AppearanceDebounceTests`
and `ArchivedWorktreeSearchTests` on the `EventDrivenTestClock` arming handshake,
plus `PasteExecutorIntegrationTests`, `CodexUsageFetcherLifecycleTests` and
`MarkdownStylesheetTests`), none of which touch tmux or terminal panels. `swiftlint
--strict` reports 0 violations.

**Live verification.** Exercised against the running app, with a one-second sampler
recording process liveness and attached/unattached view-session counts across a real
Cmd-Q and relaunch:

- `applicationWillTerminate` fires and reclaims on a genuine quit, and its bounded wait
  completes rather than hitting its ceiling: `CLEANUP ALL (blocking): sessions=1
  timedOut=false`.
- A bulk teardown of ten panels (a worktree switch) produced ten `CLEANUP` lines for ten
  panels — no panel torn down without its session reclaimed.
- Across 240 one-second samples spanning the quit, the unattached count held at 3 (three
  pre-existing strays) in 239 of them. The single sample reading 4 is the one-second gap
  between the relaunched app creating a session and its viewer attaching. Had the
  terminate path failed, that count would have jumped by the number of open panels.
- The generation counter is live and monotonic in the bridge log.

Two paths remain unverified live. The `deinit`-without-dismantle case never occurred
during the session — every teardown logged went through `dismantleNSView` — so it rests
on the mutation-verified test plus the directly observed log evidence that motivated it.
The `tmuxExecutableUnavailable` banner is unit-tested only; rendering it live would mean
running a second app instance with a stripped `PATH`, which would contend with the
running app over tmux and the database.

**A caveat on reach, learned from the exercise.** `scripts/restart.sh` stops the app with
SIGTERM, and AppKit runs no delegate and Swift runs no `deinit` on SIGTERM — so a
restart, a `kill`, or a crash still strands that app's view sessions regardless of this
change. What this PR fixes is panel teardown during app life and a user's graceful quit.
Those strays are harmless for the reasons given under "Who reclaims the orphans", which
is why no further work is proposed here.

[20260827-yodelling-coral](https://cheapsteak.github.io/tbd/open/?worktree=D00B7A31-8FF8-43F1-B63B-35EB31A01E22)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved terminal session recovery when stale sessions are detected.
  - Added clearer guidance when tmux is unavailable or commands fail.
  - Automatically reclaims tracked terminal sessions when the app exits.

- **Bug Fixes**
  - Prevented outdated terminal views from cleaning up newer sessions.
  - Added retry handling for leftover tmux sessions while preserving existing windows.

- **Tests**
  - Expanded coverage for session cleanup, recovery, executable resolution, and live tmux integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->