### PR TITLE
fix: the tmux teardown suite was timing the CI runner, not the supervisor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -390,10 +390,21 @@ jobs:
       # takes the complement of steps 1+3, the quiet pass takes
       # TBDDaemonLiveTests: no gap, no overlap, nothing to maintain.
       #
-      # Floors: `swift test --list-tests` today reports TBDDaemonTests 2194,
-      # TBDAppTests 1725, TBDSharedTests 502, TBDCLITests 127,
-      # TBDDaemonLiveTests 57 (4605 total). What actually EXECUTES is slightly
-      # lower for step 2 — 2342, not 1725+502+127=2354 — because a handful of
+      # Floors: `swift test --list-tests` on 2026-08-28 reports TBDDaemonTests
+      # 4354, TBDAppTests 2790, TBDSharedTests 858, TBDCLITests 306,
+      # TBDDaemonLiveTests 85 (8393 total). Those numbers are worth reading
+      # next to the ones this comment carried when the split landed —
+      # TBDDaemonTests 2194, 4605 total — because step 1 alone now runs more
+      # tests than the whole package did then, and step 1 is where the tail
+      # lives. Halving the in-flight population is what the split bought, and
+      # growth has since spent it: measured on the 2026-08-28 run of `main`,
+      # step 1's median test reported an 85.8 s span (p90 112.1 s, max
+      # 132.8 s) and 47% of its tests spanned longer than the 90 s
+      # `ciSafeDeadline` they are bounded by. Re-splitting step 1 is the
+      # remedy that follows from "population is the scheduler"
+      # (`Tests/CLAUDE.md`); raising the deadlines instead re-derives four
+      # coupled constants and wants a spec first. What actually EXECUTES is
+      # slightly lower for step 2 — 3876 on that run — because a handful of
       # tests are conditionally skipped at runtime. The floors are set against
       # the executed counts (the summary line these steps grep), which is the
       # only number the check can see; don't "correct" them to the listed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -394,17 +394,18 @@ jobs:
       # 4354, TBDAppTests 2790, TBDSharedTests 858, TBDCLITests 306,
       # TBDDaemonLiveTests 85 (8393 total). Those numbers are worth reading
       # next to the ones this comment carried when the split landed —
-      # TBDDaemonTests 2194, 4605 total — because step 1 alone now runs more
-      # tests than the whole package did then, and step 1 is where the tail
-      # lives. Halving the in-flight population is what the split bought, and
-      # growth has since spent it: measured on the 2026-08-28 run of `main`,
-      # step 1's median test reported an 85.8 s span (p90 112.1 s, max
-      # 132.8 s) and 47% of its tests spanned longer than the 90 s
-      # `ciSafeDeadline` they are bounded by. Re-splitting step 1 is the
+      # TBDDaemonTests 2194, 4605 total — because step 1 alone now runs 95% of
+      # what the whole package ran then, and step 1 is where the tail lives.
+      # Halving the in-flight population is what the split bought, and growth
+      # has since spent it: measured on the 2026-08-28 run of `main`, step 1's
+      # median test reported an 85.8 s span (p90 112.1 s, max 132.8 s) and 47%
+      # of its tests spanned longer than the whole 90 s `ciSafeDeadline` that
+      # bounds the handshake waits among them. Re-splitting step 1 is the
       # remedy that follows from "population is the scheduler"
       # (`Tests/CLAUDE.md`); raising the deadlines instead re-derives four
       # coupled constants and wants a spec first. What actually EXECUTES is
-      # slightly lower for step 2 — 3876 on that run — because a handful of
+      # slightly lower for step 2 — 3876 on the 2026-08-27 green run, the
+      # most recent one to reach step 2 at all — because a handful of
       # tests are conditionally skipped at runtime. The floors are set against
       # the executed counts (the summary line these steps grep), which is the
       # only number the check can see; don't "correct" them to the listed

--- a/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
+++ b/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
 
@@ -38,8 +39,10 @@ struct ProviderEventsSupervisorTests {
     /// per-test duration is ~1/3 of total wall time). 90s matches the
     /// `ciSafeDeadline` re-derivation for this same contention class; that
     /// constant lives in `Tests/TBDDaemonTests` and is not importable from this
-    /// target, hence the local literal rather than a shared symbol.
-    private static let saturatedWaitDeadline: TimeInterval = 90
+    /// target, so both take the same value from `TestSupport` rather than
+    /// repeating the literal.
+    private static let saturatedWaitDeadline: TimeInterval =
+        TestDeadlines.saturatedPassSeconds
 
     /// Hang guard for the "no leaked children" waits, which are cheaper than
     /// the ones above but not free: SIGKILL delivery is kernel-immediate, yet

--- a/Tests/TBDDaemonLiveTests/TmuxControlSupervisorTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/TmuxControlSupervisorTeardownTests.swift
@@ -32,9 +32,9 @@ import Testing
 ///   `stop()` returned → the parked `ensureConnection` resumed → a successor
 ///   was created — passed, along with every assertion after it. The work was in
 ///   flight, not absent.
-/// - The waiter overran its own 90 s deadline by ~33 s: the issue landed at
-///   122.77 s of test time, because the poll loop could not be scheduled to
-///   observe its own expiry any sooner.
+/// - The waiter could not be scheduled to observe its own expiry: the issue
+///   landed at 122.77 s of test time, well past when a 90 s deadline armed at
+///   the top of the test could have fired.
 /// - In that pass the median test's own reported span was 85.8 s (p90 112.1,
 ///   max 132.8) and 47% of its 4359 tests spanned longer than the whole
 ///   deadline — the same figures on the green run either side of it, so the
@@ -43,7 +43,19 @@ import Testing
 /// Here the pass is `--no-parallel` on an otherwise idle machine, the
 /// handshakes settle in milliseconds, and the bound below goes back to being
 /// what it is meant to be: a hang-catcher that asserts nothing.
-@Suite("TmuxControlSupervisor teardown isolation")
+/// ## Why an explicit `.timeLimit`
+///
+/// Tier-3 suites pin their own rather than inheriting `.clockDriven`, whose
+/// value is sized for the fast parallel pass (`Tests/CLAUDE.md`). Not every
+/// wait here is bounded: the bare `await`s on the supervisor actor — the
+/// `command(server:)` probes taken while stops are held, and each closing
+/// `stopAll()` — are calls on the very actor whose wedging is the regression
+/// under test, so a real regression hangs the quiet-pass step to its
+/// 15-minute `timeout-minutes` with no test named. 4 minutes affords one full
+/// `teardownWaitDeadline` plus one full `TestGate.deadline` after it — the
+/// invariant `Tests/CLAUDE.md` derives for the other limits — and still
+/// clears the 1.97 s this suite actually takes by two orders of magnitude.
+@Suite("TmuxControlSupervisor teardown isolation", .timeLimit(.minutes(4)))
 struct TmuxControlSupervisorTeardownTests {
 
     /// Write an executable stub "tmux" that ignores its args and sleeps, so a

--- a/Tests/TBDDaemonLiveTests/TmuxControlSupervisorTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/TmuxControlSupervisorTeardownTests.swift
@@ -43,7 +43,7 @@ import Testing
 /// Here the pass is `--no-parallel` on an otherwise idle machine, the
 /// handshakes settle in milliseconds, and the bound below goes back to being
 /// what it is meant to be: a hang-catcher that asserts nothing.
-/// ## Why an explicit `.timeLimit`
+/// ## Why an explicit `.timeLimit`, and why 7 minutes
 ///
 /// Tier-3 suites pin their own rather than inheriting `.clockDriven`, whose
 /// value is sized for the fast parallel pass (`Tests/CLAUDE.md`). Not every
@@ -51,11 +51,21 @@ import Testing
 /// `command(server:)` probes taken while stops are held, and each closing
 /// `stopAll()` — are calls on the very actor whose wedging is the regression
 /// under test, so a real regression hangs the quiet-pass step to its
-/// 15-minute `timeout-minutes` with no test named. 4 minutes affords one full
-/// `teardownWaitDeadline` plus one full `TestGate.deadline` after it — the
-/// invariant `Tests/CLAUDE.md` derives for the other limits — and still
+/// 15-minute `timeout-minutes` with no test named.
+///
+/// The number is sized above this suite's worst-case chain, the way
+/// `ProviderEventsSupervisorTests` sizes its own. `stopAllDoesNotBlockActor`
+/// chains FOUR `teardownWaitDeadline` waits — 360 s — and the gate holds run
+/// concurrently on GCD threads rather than adding to that. A 4-minute limit
+/// would sit under the chain, and the failure that produced would be the worst
+/// kind: a generic time-limit expiry with no named diagnostic, reached on
+/// waits that were merely slow rather than wrong. 7 minutes clears 360 s with
+/// margin, stays well inside the quiet pass's 15-minute step budget, and still
 /// clears the 1.97 s this suite actually takes by two orders of magnitude.
-@Suite("TmuxControlSupervisor teardown isolation", .timeLimit(.minutes(4)))
+///
+/// If that chain ever needs to grow, shorten it rather than raising this
+/// again — the standing remedy in `Tests/CLAUDE.md`.
+@Suite("TmuxControlSupervisor teardown isolation", .timeLimit(.minutes(7)))
 struct TmuxControlSupervisorTeardownTests {
 
     /// Write an executable stub "tmux" that ignores its args and sleeps, so a
@@ -348,20 +358,35 @@ struct TmuxControlSupervisorTeardownTests {
 /// Every wait is positive and breaks on its first satisfying probe, so the
 /// value costs a passing run nothing and only a genuinely wedged one pays it.
 /// `ciSafeDeadline` itself lives in `Tests/TBDDaemonTests` and is not
-/// importable from this target, hence the local literal rather than a shared
-/// symbol — the same accommodation `ProviderEventsSupervisorTests` makes.
-private let teardownWaitDeadline: Duration = .seconds(90)
+/// importable from this target, so the value comes from `TestSupport` — one
+/// literal for all three consumers, with the derivation still recorded at
+/// `ciSafeDeadline`.
+private let teardownWaitDeadline: Duration = TestDeadlines.saturatedPass
 
 /// Poll `condition` until it holds or `timeout` elapses. Returns its final
 /// value. File-local twin of `Tests/TBDDaemonTests`' `waitUntil`, which this
 /// target cannot import.
+///
+/// **Cancellation ends the wait; it does not shorten the sleep.** `Task.sleep`
+/// throws `CancellationError` the instant the task is cancelled — which the
+/// suite's own `.timeLimit` does — so swallowing it with `try?` would leave
+/// the loop spinning with nothing to suspend on, burning its whole remaining
+/// budget on a cooperative thread and then blaming the call site. That exact
+/// shape cost this repo a diagnosis once already (33.7M iterations in 30 s)
+/// and `Tests/CLAUDE.md` lists it as an anti-pattern to check for in any flake
+/// fix. Returning the condition's current value keeps the verdict honest: a
+/// cancelled wait reports what it last saw rather than a stale `false`.
 private func waitUntil(
     _ condition: @Sendable () -> Bool, timeout: Duration
 ) async -> Bool {
     let deadline = ContinuousClock.now + timeout
     while ContinuousClock.now < deadline {
         if condition() { return true }
-        try? await Task.sleep(for: .milliseconds(10))
+        do {
+            try await Task.sleep(for: .milliseconds(10))
+        } catch {
+            return condition()
+        }
     }
     return condition()
 }

--- a/Tests/TBDDaemonLiveTests/TmuxControlSupervisorTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/TmuxControlSupervisorTeardownTests.swift
@@ -8,6 +8,41 @@ import Testing
 /// R5-M1: a fatal-error teardown's blocking `stop()` (up to ~2 s of SIGTERM →
 /// SIGKILL escalation) must run OFF the supervisor actor — otherwise every
 /// supervisor call for every worktree stalls behind one wedged connection.
+///
+/// ## Why this is tier 3
+///
+/// Every test here spawns a real child over a real pty — a stub standing in
+/// for `tmux -CC` — and then races a wall-clock deadline for a handshake that
+/// crosses three executors (the correlator's `onFatalError` → a fresh
+/// unstructured `Task` → the supervisor actor → `DispatchQueue.global`). That
+/// is the target's own admission criterion verbatim: "a spawned child racing a
+/// deadline" (`Package.swift`), the same one `ClaudeCloudSpawnerTimeoutTests`
+/// cites, and the sibling `TmuxControlConnectionTeardownTests` already sits
+/// here on it.
+///
+/// It was in the fast parallel pass instead, and that is where it went red. In
+/// the week to 2026-08-28 it took 4–5 of its 5 tests down in 3 of the 5 red
+/// runs on `main`, always on the FIRST handshake wait and never on anything
+/// downstream of it. The measurements say the deadline was reading contention,
+/// not the supervisor:
+///
+/// - Every failing test recorded exactly ONE issue. In
+///   `ensureConnectionWaitsForInFlightStop` the first 90 s wait timed out while
+///   the *later* 90 s wait — for a strictly longer chain: gate released →
+///   `stop()` returned → the parked `ensureConnection` resumed → a successor
+///   was created — passed, along with every assertion after it. The work was in
+///   flight, not absent.
+/// - The waiter overran its own 90 s deadline by ~33 s: the issue landed at
+///   122.77 s of test time, because the poll loop could not be scheduled to
+///   observe its own expiry any sooner.
+/// - In that pass the median test's own reported span was 85.8 s (p90 112.1,
+///   max 132.8) and 47% of its 4359 tests spanned longer than the whole
+///   deadline — the same figures on the green run either side of it, so the
+///   colour of a run was luck.
+///
+/// Here the pass is `--no-parallel` on an otherwise idle machine, the
+/// handshakes settle in milliseconds, and the bound below goes back to being
+/// what it is meant to be: a hang-catcher that asserts nothing.
 @Suite("TmuxControlSupervisor teardown isolation")
 struct TmuxControlSupervisorTeardownTests {
 
@@ -60,7 +95,7 @@ struct TmuxControlSupervisorTeardownTests {
         // teardown. (Reachable in production from any untolerated %error too.)
         await client.handle(.commandSucceeded(number: 1, fromClient: true, lines: []))
         #expect(await waitUntil(
-            { stopStarted.count == 1 }, timeout: ciSafeDeadline), "teardown never reached stop()")
+            { stopStarted.count == 1 }, timeout: teardownWaitDeadline), "teardown never reached stop()")
 
         // While the stop is STILL blocked, unrelated supervisor calls must
         // complete. Bounded by a generous CI-safe deadline: pre-fix, the
@@ -72,7 +107,7 @@ struct TmuxControlSupervisorTeardownTests {
             _ = await supervisor.command(server: "srv-unrelated")
             unrelatedDone.increment()
         }
-        let unrelatedCompleted = await waitUntil({ unrelatedDone.count == 1 }, timeout: ciSafeDeadline)
+        let unrelatedCompleted = await waitUntil({ unrelatedDone.count == 1 }, timeout: teardownWaitDeadline)
         #expect(unrelatedCompleted, "supervisor actor is blocked by a mid-stop teardown")
         // Pre-fix the actor stays wedged until the gate opens — unwedge so the
         // remaining assertions (and cleanup) can run instead of hanging.
@@ -127,7 +162,7 @@ struct TmuxControlSupervisorTeardownTests {
         // Fatal correlator violation → teardown; eviction runs, stop is held.
         await client.handle(.commandSucceeded(number: 1, fromClient: true, lines: []))
         #expect(await waitUntil(
-            { stopStarted.count == 1 }, timeout: ciSafeDeadline), "teardown never reached stop()")
+            { stopStarted.count == 1 }, timeout: teardownWaitDeadline), "teardown never reached stop()")
 
         // A re-attach's ensureConnection lands while the old tmux client
         // process is still dying. It must SUSPEND: `PaneFanout.route` keys by
@@ -148,7 +183,7 @@ struct TmuxControlSupervisorTeardownTests {
         // The held stop completes → the parked ensureConnection resumes and
         // creates exactly one successor.
         stopGate.signal()
-        #expect(await waitUntil({ ensured.count == 1 }, timeout: ciSafeDeadline),
+        #expect(await waitUntil({ ensured.count == 1 }, timeout: teardownWaitDeadline),
                 "ensureConnection must resume once the stop completed")
         #expect(stopFinished.count == 1)
         #expect(created.count == 2, "exactly one successor after the teardown finished")
@@ -186,7 +221,7 @@ struct TmuxControlSupervisorTeardownTests {
         // stopAll must route through the injectable stop seam (pre-fix it
         // called connection.stop() directly ON the actor).
         #expect(await waitUntil(
-            { stopStarted.count == 2 }, timeout: ciSafeDeadline), "stopAll never reached the stop seam")
+            { stopStarted.count == 2 }, timeout: teardownWaitDeadline), "stopAll never reached the stop seam")
 
         // While BOTH stops are still held open, an unrelated actor call must
         // complete promptly — pre-fix the actor is wedged inside the stops.
@@ -196,7 +231,7 @@ struct TmuxControlSupervisorTeardownTests {
             _ = await supervisor.command(server: "srv-third")
             unrelatedDone.increment()
         }
-        #expect(await waitUntil({ unrelatedDone.count == 1 }, timeout: ciSafeDeadline),
+        #expect(await waitUntil({ unrelatedDone.count == 1 }, timeout: teardownWaitDeadline),
                 "supervisor actor is blocked by a mid-stop stopAll")
 
         // Bookkeeping ran BEFORE the stops: both clients already evicted.
@@ -217,12 +252,12 @@ struct TmuxControlSupervisorTeardownTests {
 
         stopGate.signal()
         stopGate.signal()
-        #expect(await waitUntil({ stopAllDone.count == 1 }, timeout: ciSafeDeadline),
+        #expect(await waitUntil({ stopAllDone.count == 1 }, timeout: teardownWaitDeadline),
                 "stopAll must return once its stops complete")
         // The parked ensureConnection resumes and creates a fresh connection:
         // the supervisor stays usable after stopAll (the reconnect-after-
         // stopAll contract in TmuxControlCommandClientIntegrationTests).
-        #expect(await waitUntil({ ensured.count == 1 }, timeout: ciSafeDeadline),
+        #expect(await waitUntil({ ensured.count == 1 }, timeout: teardownWaitDeadline),
                 "parked ensureConnection must resume after stopAll finishes")
         #expect(await supervisor.command(server: "srv-a") != nil)
 
@@ -254,7 +289,7 @@ struct TmuxControlSupervisorTeardownTests {
         let client = try #require(await supervisor.command(server: "srv-pool"))
         await client.handle(.commandSucceeded(number: 1, fromClient: true, lines: []))
 
-        #expect(await waitUntil({ stopSeen.count >= 1 }, timeout: ciSafeDeadline),
+        #expect(await waitUntil({ stopSeen.count >= 1 }, timeout: teardownWaitDeadline),
                 "fatal teardown never reached stop()")
         let label = labelBox.get() ?? ""
         #expect(!label.contains("cooperative"),
@@ -285,11 +320,38 @@ struct TmuxControlSupervisorTeardownTests {
             })
 
         await supervisor.ensureConnection(serverName: "srv-natural")
-        #expect(await waitUntil({ stopSeen.count == 1 }, timeout: ciSafeDeadline),
+        #expect(await waitUntil({ stopSeen.count == 1 }, timeout: teardownWaitDeadline),
                 "natural stream end must stop() the connection to release its pty fd")
         // The map entry is gone too (drain owned it at stream end).
         #expect(await supervisor.command(server: "srv-natural") == nil)
     }
+}
+
+/// Hang guard for this suite's bounded waits on teardown progress.
+///
+/// Deliberately unchanged at the 90 s the suite carried in the fast pass. The
+/// point of the move is that the number is no longer load-bearing — in the
+/// serial quiet pass a healthy handshake returns in milliseconds — so keeping
+/// it makes this a pure re-tiering with no deadline re-derivation smuggled in.
+/// Every wait is positive and breaks on its first satisfying probe, so the
+/// value costs a passing run nothing and only a genuinely wedged one pays it.
+/// `ciSafeDeadline` itself lives in `Tests/TBDDaemonTests` and is not
+/// importable from this target, hence the local literal rather than a shared
+/// symbol — the same accommodation `ProviderEventsSupervisorTests` makes.
+private let teardownWaitDeadline: Duration = .seconds(90)
+
+/// Poll `condition` until it holds or `timeout` elapses. Returns its final
+/// value. File-local twin of `Tests/TBDDaemonTests`' `waitUntil`, which this
+/// target cannot import.
+private func waitUntil(
+    _ condition: @Sendable () -> Bool, timeout: Duration
+) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if condition() { return true }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    return condition()
 }
 
 /// Lock-boxed single string for cross-thread capture in seams.

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -104,6 +104,16 @@ import Testing
 /// `.serialized` before a longer timeout; that advice is about a suite starving
 /// *itself* (its own tests megaYielding against each other) and does not cover
 /// this case.
+///
+/// ## Two copies live outside this target
+///
+/// `Tests/TBDDaemonLiveTests` cannot import this symbol, so
+/// `ProviderEventsSupervisorTests.saturatedWaitDeadline` and
+/// `TmuxControlSupervisorTeardownTests.teardownWaitDeadline` each carry the
+/// same 90 s as a local literal. Nothing detects divergence between the three,
+/// so re-derive them together — and note that the two copies sit in the quiet
+/// pass, which never sees the saturation this value is sized against, so they
+/// have room this one does not.
 let ciSafeDeadline: Duration = .seconds(90)
 
 /// Thread-safe, synchronous recorder of fake-client stream writes in call

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 
 @testable import TBDDaemonLib
@@ -105,16 +106,16 @@ import Testing
 /// *itself* (its own tests megaYielding against each other) and does not cover
 /// this case.
 ///
-/// ## Two copies live outside this target
+/// ## The value is shared; this is where its derivation lives
 ///
-/// `Tests/TBDDaemonLiveTests` cannot import this symbol, so
-/// `ProviderEventsSupervisorTests.saturatedWaitDeadline` and
-/// `TmuxControlSupervisorTeardownTests.teardownWaitDeadline` each carry the
-/// same 90 s as a local literal. Nothing detects divergence between the three,
-/// so re-derive them together — and note that the two copies sit in the quiet
-/// pass, which never sees the saturation this value is sized against, so they
-/// have room this one does not.
-let ciSafeDeadline: Duration = .seconds(90)
+/// The number itself is `TestDeadlines.saturatedPass`
+/// (`Tests/TestSupport/BoundedGateSupport.swift`), because
+/// `Tests/TBDDaemonLiveTests` cannot import this symbol and two waits there
+/// need the same budget. Keeping one literal is what stops the three from
+/// drifting apart unnoticed; the reasoning above is what re-derives it, and it
+/// stays here. Re-derive it together with `TestGate.deadline`, which must
+/// dominate it, and with `waitForSuspension` / `.clockDriven`.
+let ciSafeDeadline: Duration = TestDeadlines.saturatedPass
 
 /// Thread-safe, synchronous recorder of fake-client stream writes in call
 /// order.

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -151,7 +151,15 @@ private actor GitLabFake {
     /// Wait for the mergeability recheck to arrive, up to `timeout`. It is
     /// issued from a detached task, so a test that asserts on it must wait for
     /// it rather than assume the refresh already ran it.
-    func waitForRecheck(within timeout: Duration = .seconds(10)) async -> Bool {
+    ///
+    /// Bounded by `ciSafeDeadline`, not by a snappier number of its own: this
+    /// asserts nothing about how *fast* the recheck lands, only that it does,
+    /// so the bound is a hang-catcher and a passing run never pays it. Its
+    /// previous 10 s went red on `main` at `ea27710d` while asserting nothing —
+    /// in that pass the median test's own reported span was 85.8 s, so a 10 s
+    /// wall-clock budget was an order of magnitude under the noise floor. See
+    /// `ciSafeDeadline`'s own derivation in `ControlModeTestSupport.swift`.
+    func waitForRecheck(within timeout: Duration = ciSafeDeadline) async -> Bool {
         let deadline = ContinuousClock.now.advanced(by: timeout)
         while !sawRecheck && ContinuousClock.now < deadline {
             try? await Task.sleep(for: .milliseconds(5))

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -155,9 +155,9 @@ private actor GitLabFake {
     /// Bounded by `ciSafeDeadline`, not by a snappier number of its own: this
     /// asserts nothing about how *fast* the recheck lands, only that it does,
     /// so the bound is a hang-catcher and a passing run never pays it. Its
-    /// previous 10 s went red on `main` at `ea27710d` while asserting nothing —
-    /// in that pass the median test's own reported span was 85.8 s, so a 10 s
-    /// wall-clock budget was an order of magnitude under the noise floor. See
+    /// previous 10 s went red on `main` while asserting nothing: in that pass
+    /// the median test's own reported span was 85.8 s, so a 10 s wall-clock
+    /// budget sat an order of magnitude under the noise floor. See
     /// `ciSafeDeadline`'s own derivation in `ControlModeTestSupport.swift`.
     func waitForRecheck(within timeout: Duration = ciSafeDeadline) async -> Bool {
         let deadline = ContinuousClock.now.advanced(by: timeout)

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -159,10 +159,19 @@ private actor GitLabFake {
     /// the median test's own reported span was 85.8 s, so a 10 s wall-clock
     /// budget sat an order of magnitude under the noise floor. See
     /// `ciSafeDeadline`'s own derivation in `ControlModeTestSupport.swift`.
+    ///
+    /// Cancellation ends the wait rather than being swallowed: `Task.sleep`
+    /// throws immediately once the task is cancelled, so a `try?` here would
+    /// leave the loop spinning with nothing to suspend on for the rest of its
+    /// budget — the anti-pattern `Tests/CLAUDE.md` names.
     func waitForRecheck(within timeout: Duration = ciSafeDeadline) async -> Bool {
         let deadline = ContinuousClock.now.advanced(by: timeout)
         while !sawRecheck && ContinuousClock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(5))
+            do {
+                try await Task.sleep(for: .milliseconds(5))
+            } catch {
+                return sawRecheck
+            }
         }
         return sawRecheck
     }

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -106,7 +106,8 @@ public func gateHoldingTask<Success: Sendable>(
 /// is held for as long as the test's own observation takes, and the outer
 /// observations are themselves hang-catchers sized against a loaded runner:
 /// the `TmuxControlSupervisor` teardown gates are held across a `waitUntil`
-/// bounded by `ciSafeDeadline` (90 s). A gate deadline below that would go red
+/// bounded by that suite's own `teardownWaitDeadline` (90 s, the value
+/// `ciSafeDeadline` carries). A gate deadline below that would go red
 /// on a merely slow machine, and a spuriously red CI is worse than the bug
 /// this bound exists to report. 120 s clears 90 s with margin while staying a
 /// small fraction of the 30-minute step budget, so a wedge reports in minutes

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -100,6 +100,30 @@ public func gateHoldingTask<Success: Sendable>(
     Task(executorPreference: GateExecutor.shared) { await operation() }
 }
 
+/// The handshake budget a bounded wait gets in a saturated pass.
+///
+/// One literal, two typed accessors, because the value is consumed as a
+/// `Duration` by the poll-loop helpers and as a `TimeInterval` by the
+/// `Date`-arithmetic ones. It lives here, next to ``TestGate/deadline``, for
+/// two reasons: it is the value that deadline must dominate — so a change to
+/// either that is not checked against the other is a bug, and adjacency is
+/// what makes that checkable — and it is reachable from both
+/// `Tests/TBDDaemonTests` and `Tests/TBDDaemonLiveTests`, which is what keeps
+/// `ciSafeDeadline`, `TmuxControlSupervisorTeardownTests.teardownWaitDeadline`
+/// and `ProviderEventsSupervisorTests.saturatedWaitDeadline` one constant
+/// rather than three that can drift apart unnoticed.
+///
+/// The derivation itself — why 90 s, and what re-derives it — stays with
+/// `ciSafeDeadline` in `Tests/TBDDaemonTests/ControlModeTestSupport.swift`,
+/// which is where the reasoning about population and contention lives.
+public enum TestDeadlines {
+    /// 90 s, as a `TimeInterval` for `Date`-based waits.
+    public static let saturatedPassSeconds: TimeInterval = 90
+
+    /// The same 90 s, as a `Duration` for poll-loop waits.
+    public static let saturatedPass: Duration = .seconds(saturatedPassSeconds)
+}
+
 /// How long a bounded gate wait tolerates before it reports itself.
 ///
 /// **Sized to dominate the longest legitimate hold, not to be snappy.** A gate


### PR DESCRIPTION
## What's broken

The `test` job on `main` has been red 5 runs out of 8. Branch protection is
therefore telling us nothing: a contributor cannot tell a real regression from
the weather, and neither can the merge gate.

The dominant contributor is one suite. `TmuxControlSupervisorTeardownTests`
took 4-5 of its 5 tests down in 3 of those 5 red runs, always the same way — a
`waitUntil(...)` handshake expectation reporting "teardown never reached
stop()". Nothing about the tmux control-mode teardown is actually broken; the
suite passes locally in under two seconds and has done throughout.

## Why it happens

The suite is in the fast parallel pass, where Swift Testing starts every test
in the process at once with no concurrency cap. Its tests are the ones that
suffer most from that: each spawns a real child over a real pty and then waits
on a handshake that crosses three executors — the correlator's `onFatalError`,
a fresh unstructured `Task`, the supervisor actor, and a
`DispatchQueue.global(qos: .utility)` hop — before the observable it polls for
can be set. Under saturation that chain is slow, and the 90 s wall-clock bound
around it stops being a hang-catcher and becomes a measurement of the runner.

Three things in the failing runs distinguish that from a wedge, which is the
distinction that decides the fix:

- **Every failing test recorded exactly ONE issue, on its first wait.** In the
  R6-M4 test the first 90 s wait timed out while the *later* 90 s wait — for a
  strictly longer chain: gate released, `stop()` returned, the parked
  `ensureConnection` resumed, a successor was created — passed, as did every
  assertion after it. The work was in flight, not absent.
- **The waiter could not be scheduled to notice its own expiry.** The issue
  landed at 122.77 s of test time, well past when a 90 s deadline armed at the
  top of the test could have fired.
- **The deadline is under the pass's noise floor.** In that pass the median
  test's own reported span was 85.8 s (p90 112.1, max 132.8) and 47% of its
  4359 tests spanned longer than the whole 90 s bound. The green run either
  side of it is statistically identical — p50 87.1, p90 113.7, 47.5% over 90 s
  — so which colour a run comes out is luck, not code.

The background condition is population. `test.yml`'s own floors comment
recorded `TBDDaemonTests 2194` of `4605 total`; listing the tests today reports
`4354` of `8393`. Step 1 alone now runs 95% of what the whole package ran when
the two-step split was introduced to halve exactly this tail.

## What this PR does

Moves the suite to the tier-3 target, `Tests/TBDDaemonLiveTests/`, which runs
`--no-parallel` on an otherwise idle machine. That is where it belonged: the
target's own `Package.swift` comment admits "suites whose runtime depends on an
external process they do not fully control — a real tmux server, **a spawned
child racing a deadline**, the replay firehose", `ClaudeCloudSpawnerTimeoutTests`
is already there citing that same clause, and the sibling
`TmuxControlConnectionTeardownTests` is already there too.

**No deadline value changes.** The suite keeps the same 90 s bound, reached
through `teardownWaitDeadline` (see below for where that value lives). Keeping
the number is the point: it makes this a re-tiering with no re-derivation
smuggled in, and in the quiet pass the same 90 s is now ~450x the handshake it
bounds. The `waitUntil` poll helper is duplicated file-locally, because
`Tests/TBDDaemonTests`' copy is not importable from the live target and moving
it would put a second `waitUntil` in scope for every caller of the original.

The suite also picks up `.timeLimit(.minutes(7))`, the tier-3 convention it
joined. Not every wait in it is bounded — the bare `await`s on the supervisor
actor are calls on the very actor whose wedging is the regression under test —
so without one, a real regression would hang the quiet pass to its 15-minute
step budget naming no test. 7 minutes sits above this suite's worst-case chain
(`stopAllDoesNotBlockActor` chains four 90 s waits = 360 s; the gate holds run
concurrently on GCD threads rather than adding to it), the way
`ProviderEventsSupervisorTests` sizes its own limit.

`PRStatusManagerBindingTests.waitForRecheck` — the sixth failure in the same
run — is the same class with a worse number: a pure hang-catcher on a detached
task, bounded at 10 s inside a pass whose median test spans 85.8 s. It takes
`ciSafeDeadline` instead.

The 90 s itself now lives in exactly one place, `TestDeadlines.saturatedPass`
in `Tests/TestSupport`, next to `TestGate.deadline` — the value that must
dominate it, so adjacency is what makes divergence checkable. `ciSafeDeadline`,
the suite's `teardownWaitDeadline` and
`ProviderEventsSupervisorTests.saturatedWaitDeadline` all derive from it, and
the derivation prose stays with `ciSafeDeadline`. The `test.yml` floors comment
is corrected to today's counts.

Both polling helpers touched here end their wait on cancellation rather than
swallowing it with `try?`. `Task.sleep` throws the moment its task is
cancelled — which the new `.timeLimit` does — so a swallowed cancellation
leaves the loop spinning with nothing to suspend on for the rest of its budget,
then blames the call site. `Tests/CLAUDE.md` names that anti-pattern and the
repo has measured it once at 33.7M iterations in 30 s.

## Why no spec

This restores the system to its existing theory rather than revising it: the
tier definition, the deadline invariants and "population is the scheduler" are
all already committed, and this applies them to a suite that was filed in the
wrong tier. The change that *would* revise the theory — re-deriving
`ciSafeDeadline` / `TestGate.deadline` / `waitForSuspension` / `.clockDriven`
together, or re-splitting step 1 — is deliberately **not** here. It needs
`/tbd-brainstorming` with a human answering, and the measurements above are
recorded in `test.yml` so whoever picks it up starts from data.

## Assumptions

Assumes the quiet pass stays serial and stays scheduled after the parallel
passes on an idle machine; if it is ever parallelised or moved alongside them,
this suite's 90 s bound returns to measuring contention and these five tests
are the first that will say so.

## Evidence & verification

The discriminating observation is the same suite, same code, same 90 s bound,
in the two passes:

- fast parallel pass, 4359 concurrent tests: 121-123 s per test, 5 of 5 timed
  out on the first wait
- quiet serial pass, this branch: 0.048-0.691 s per test, suite total 1.975 s

CI on this branch is green: the `test` job passed in 12m32s at `dd25370a`,
against 5 red runs in 8 on `main`.

Full local runs on this branch, all through `scripts/test.sh` (at `dd25370a`;
the review-feedback commit after it is verified by CI rather than locally — this
box was at load 150+ with the machine-global build slot held by a sibling):

- quiet pass (`--filter '^TBDDaemonLiveTests\.' --no-parallel`) → **85 tests in
  24 suites passed** in 50.07 s (was 80; the 5 moved tests are the difference)
- fast pass 1 (`--parallel --filter '^TBDDaemonTests\.'`) → **4354 tests**
  executed, exactly 4359 minus the 5 moved
- `PRStatusManagerBindingTests` → **52 tests in 2 suites passed** in 0.606 s

Both per-step floors still clear with margin (4354 >= 1800, 85 >= 35).

One thing a reviewer should expect: **this does not by itself make step 1
green.** The local fast-pass run also failed
`WorktreeDeletionQueueTests.drainQueuesTheUnlinkBehindTheSerialDrainQueue`,
which blew the 120 s `TestGate.deadline` under load and then passed in 0.385 s
on its own — a different suite, untouched by this diff, same contention class.
That is the population problem this PR names and does not fix.

[ci-red-tmux-teardown](https://cheapsteak.github.io/tbd/open/?worktree=6E45A9D7-4434-4F27-A293-55E0741B51BD)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability by extending bounded waits for GitLab status checks.
  * Added more reliable teardown handling for live daemon tests, including cancellation-aware polling and clearer timeout behavior.
  * Standardized supervisor and teardown timing across related test suites.

* **Documentation**
  * Updated test-count, scheduling, timeout, and teardown guidance to reflect current behavior.
  * Documented shared deadline and synchronization requirements.

* **Tests**
  * Classified live teardown tests as tier 3 and applied a seven-minute execution limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->