### PR TITLE
Perf: Lift the fixed 16.67ms paint floor and move terminal parsing off the main thread

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "05b9d3a267e1b37004a9b00fcb3ceddf883f76c393cae24289146452eda0a363",
+  "originHash" : "6399cb1349f3ec270134d9239262667a01d51cf6d0ece6a4baf1c1507e9d2979",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -139,9 +139,9 @@
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "location" : "https://github.com/cheapsteak/SwiftTerm",
       "state" : {
-        "revision" : "9c2518e21bcc6933a4fc82ce6586f926517d3045"
+        "revision" : "62d0be6d4c9641a4b27f311c55e1489b024271c3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e06da08a9cd41529dba112b2abb2f47e48bc462bd520f5c09a925efc034c3411",
+  "originHash" : "05b9d3a267e1b37004a9b00fcb3ceddf883f76c393cae24289146452eda0a363",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
         "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "h",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rarestype/h",
+      "state" : {
+        "revision" : "aa3626829160917d4378330617971977cbd78f5b",
+        "version" : "1.0.1"
       }
     },
     {
@@ -110,6 +119,15 @@
       }
     },
     {
+      "identity" : "swift-png",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tayloraswift/swift-png",
+      "state" : {
+        "revision" : "8a0bcd4df5e4b307c804937776a56dd6ecdf6396",
+        "version" : "4.5.1"
+      }
+    },
+    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
@@ -123,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm",
       "state" : {
-        "revision" : "16c52867763121b121f3b29a4d439052e7e76034"
+        "revision" : "9c2518e21bcc6933a4fc82ce6586f926517d3045"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,25 +27,37 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.65.0"),
-        // Pinned to a main-branch revision for two reasons. The `fontSmoothing`
-        // public property (PR #531) still hasn't shipped in a tagged release.
-        // And the macOS CoreGraphics draw path needs `context.clear(dirtyRect)`
-        // (upstream d5ee56e / PR #582): SwiftTerm opts into PARTIAL backing-store
-        // updates (`disableFullRedrawOnAnyChanges` + `layer.contentsFormat =
-        // .RGBA8Uint`), so AppKit erases only on a full redraw and the draw path
-        // must erase the dirty region itself. Without that clear, any region the
-        // draw does not touch keeps the previous frame's glyphs — visible as
-        // stale text in default-background cells that a window resize wipes.
-        // Switch back to `from: "1.14.x"` only once a tagged release contains
-        // BOTH #531 and #582.
+        // Pinned to a main-branch revision because no tagged release contains
+        // upstream's display-link frame scheduler. Through v1.20.0, SwiftTerm
+        // repaints via `queuePendingDisplay()`, which coalesces damage behind a
+        // fixed `DispatchQueue.main.asyncAfter(+16.67ms)` — a floor on
+        // key-to-paint latency rather than a rate limit, and one TBD measured
+        // in the field. Upstream `main` deletes that mechanism outright
+        // (`queuePendingDisplay`, `pendingDisplay`, `displayImmediately`,
+        // `scheduleDisplay(immediate:)` are all gone) in favour of a
+        // `FrameDriver` on `CADisplayLink`/`CVDisplayLink`
+        // (`Sources/SwiftTerm/Apple/FrameDriver.swift`), and moves the macOS
+        // Metal layer's rendering off the main thread. TBD runs many streaming
+        // TUI terminals at once — the load upstream issue #658 describes — so
+        // the main-thread cost of the old scheduler is ours to carry.
+        // Switch back to `from: "1.x"` once a tagged release contains the
+        // FrameDriver rewrite.
         //
-        // RE-VERIFIED for 16c5286 (2026-08-18): ChildReaper STAYS, unchanged.
-        // Upstream main still calls `waitpid` from exactly one place — the
-        // `DispatchSourceProcess` handler (`LocalProcess.swift:368`) — and both
-        // `deinit` and `terminate()` are unchanged from dae32cc, so it does NOT
-        // reap its own children on the teardown paths TBD uses. `1c3f353` only
-        // fixes lost exit events for FAST-EXITING children, which is a different
-        // population from the 67 long-lived zombies of #611.
+        // A frame loop that does not run on the main thread may never call
+        // `viewWillDraw()`, which TBD's terminal diagnostics hook. Diagnostics
+        // going quiet is expected on this revision, not a regression.
+        //
+        // RE-VERIFIED for 9c2518e (2026-08-28): ChildReaper STAYS, unchanged.
+        // `LocalProcess` was substantially rewritten on this revision (locked
+        // session state, a `TerminalIOPipeline` read path), but `waitpid` is
+        // still called from exactly one place in the whole package —
+        // `processTerminated()` at `LocalProcess.swift:384`, reachable only
+        // from the `DispatchSourceProcess` `.exit` handler
+        // (`LocalProcess.swift:589`). Neither teardown path TBD uses reaps:
+        // `deinit` (`:356`) and `terminate()` (`:604`) both take the session
+        // resources and cancel the monitor (`:358`, `:620`) with no `waitpid`,
+        // and `terminate()` now cancels *before* it sends `SIGTERM` (`:624`),
+        // so the exit event is even less likely to fire than it was.
         //
         // Re-verify again on the next bump, because the reason ChildReaper
         // exists is a property of the pinned revision: upstream reaps only
@@ -55,7 +67,7 @@ let package = Package(
         // revision reaps its own children, `ChildReaper` becomes a competing
         // waiter on a pid the OS may have recycled, which is worse than the
         // leak it fixes. Its doc comment names the exact lines to re-read.
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", revision: "16c52867763121b121f3b29a4d439052e7e76034"),
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", revision: "9c2518e21bcc6933a4fc82ce6586f926517d3045"),
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -27,21 +27,29 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.65.0"),
-        // Pinned to a main-branch revision because no tagged release contains
-        // upstream's display-link frame scheduler. Through v1.20.0, SwiftTerm
-        // repaints via `queuePendingDisplay()`, which coalesces damage behind a
-        // fixed `DispatchQueue.main.asyncAfter(+16.67ms)` — a floor on
-        // key-to-paint latency rather than a rate limit, and one TBD measured
-        // in the field. Upstream `main` deletes that mechanism outright
+        // Pinned to a TBD fork of an upstream main-branch revision. Main
+        // branch, because no tagged release contains upstream's display-link
+        // frame scheduler: through v1.20.0, SwiftTerm repaints via
+        // `queuePendingDisplay()`, which coalesces damage behind a fixed
+        // `DispatchQueue.main.asyncAfter(+16.67ms)` — a floor on key-to-paint
+        // latency rather than a rate limit, and one TBD measured in the
+        // field. Upstream `main` deletes that mechanism outright
         // (`queuePendingDisplay`, `pendingDisplay`, `displayImmediately`,
         // `scheduleDisplay(immediate:)` are all gone) in favour of a
         // `FrameDriver` on `CADisplayLink`/`CVDisplayLink`
         // (`Sources/SwiftTerm/Apple/FrameDriver.swift`), and moves the macOS
-        // Metal layer's rendering off the main thread. TBD runs many streaming
-        // TUI terminals at once — the load upstream issue #658 describes — so
-        // the main-thread cost of the old scheduler is ours to carry.
-        // Switch back to `from: "1.x"` once a tagged release contains the
-        // FrameDriver rewrite.
+        // Metal layer's rendering off the main thread. TBD runs many
+        // streaming TUI terminals at once — the load upstream issue #658
+        // describes — so the main-thread cost of the old scheduler is ours to
+        // carry. A fork, because SwiftTerm 2.0 removed `getTerminal()` from
+        // the public surface without giving view embedders any public route
+        // to the `Terminal` — `TerminalView.withTerminal(_:caller:)`, the
+        // self-locking accessor TBD needs for OSC state reads and mouse
+        // encoding, is internal upstream. The pinned revision is upstream
+        // `9c2518e` plus one commit (branch `tbd/public-with-terminal`)
+        // making `withTerminal` public. Once upstream merges an equivalent
+        // accessor, re-pin to upstream and delete the fork; once a tagged
+        // release contains both, switch back to `from:`.
         //
         // A frame loop that does not run on the main thread may never call
         // `viewWillDraw()`, which TBD's terminal diagnostics hook. Diagnostics
@@ -67,7 +75,7 @@ let package = Package(
         // revision reaps its own children, `ChildReaper` becomes a competing
         // waiter on a pid the OS may have recycled, which is worse than the
         // leak it fixes. Its doc comment names the exact lines to re-read.
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", revision: "9c2518e21bcc6933a4fc82ce6586f926517d3045"),
+        .package(url: "https://github.com/cheapsteak/SwiftTerm", revision: "62d0be6d4c9641a4b27f311c55e1489b024271c3"),
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),

--- a/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
+++ b/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
@@ -84,6 +84,11 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
         /// headlessly — the reap wiring is otherwise unreachable from a test,
         /// since `start()` needs a live `TerminalView`.
         var localProcess: LocalProcess?
+        /// The IO-thread feed path (`dataReceived` → `feed`) reaches the view
+        /// through this lock-guarded holder rather than the main-confined
+        /// `terminalView` weak var. Written before `startProcess`, cleared by
+        /// `cleanup()` before `terminate()`.
+        private let viewHolder = TerminalViewHolder()
         private var started = false
         private var tornDown = false
         /// Recorded when `LocalProcess`'s own exit monitor fires — by then it
@@ -107,12 +112,21 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
             let args = Array(argv.dropFirst())
             let envPairs = environment.map { "\($0.key)=\($0.value)" }
 
-            let process = LocalProcess(delegate: self)
+            // `dispatchQueue: .main` keeps the exit monitor on main (see the
+            // serialization note in ChildReaper.swift); `directDelivery: true`
+            // delivers `dataReceived` inline on the IO thread, where `feed`
+            // parses off-main — the configuration upstream's own
+            // `MacLocalTerminalView` ships.
+            let process = LocalProcess(delegate: self, dispatchQueue: .main, directDelivery: true)
             self.localProcess = process
+            // Written before startProcess; the IO thread reads it from
+            // `dataReceived`. Cleared by `cleanup()` before `terminate()`.
+            viewHolder.set(terminalView)
             process.startProcess(executable: executable, args: args, environment: envPairs, execName: nil)
 
-            let cols = terminalView.terminal.cols
-            let rows = terminalView.terminal.rows
+            let dims = terminalView.terminalDimensions
+            let cols = dims.cols
+            let rows = dims.rows
             if cols > 0, rows > 0, process.childfd >= 0 {
                 var size = winsize(ws_row: UInt16(rows), ws_col: UInt16(cols), ws_xpixel: 0, ws_ypixel: 0)
                 _ = ioctl(process.childfd, TIOCSWINSZ, &size)
@@ -150,6 +164,11 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
             // a provider `attach`: terminate() only kills the LOCAL viewer
             // process running the verb — the remote session itself is
             // unaffected (docs/remote-provider-contract.md § attach).
+            //
+            // Clear the holder BEFORE terminate(): a late IO batch then reads
+            // nil and drops instead of feeding a view whose session is being
+            // torn down.
+            viewHolder.clear()
             localProcess?.terminate()
             localProcess = nil
             // terminate() cancels `LocalProcess`'s exit monitor (via
@@ -161,8 +180,13 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
         }
 
         // MARK: - LocalProcessDelegate
+        //
+        // `nonisolated`: the Coordinator's `TerminalViewDelegate` conformance
+        // makes the class MainActor-isolated, but `LocalProcess` calls
+        // `dataReceived` inline on the IO thread (`directDelivery: true`) and
+        // the exit monitor's callback contract is queue-, not actor-based.
 
-        func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+        nonisolated func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
             // `LocalProcess.processTerminated()` calls `waitpid` before it
             // calls us, so this child is already reaped and its pid is free to
             // be recycled — a later `cleanup()` must not wait on it, and the
@@ -182,17 +206,23 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
             }
         }
 
-        func dataReceived(slice: ArraySlice<UInt8>) {
-            DispatchQueue.main.async { [weak self] in
-                self?.terminalView?.feed(byteArray: slice)
-            }
+        nonisolated func dataReceived(slice: ArraySlice<UInt8>) {
+            // Feed synchronously on the calling (IO) thread — this is the
+            // off-main parse the 2.0 bump exists for; `feed` is thread-safe
+            // (the parse runs under SwiftTerm's terminal lock) and the view
+            // reference is owned by the holder, so a batch racing teardown
+            // either completes against a live view or reads nil and drops.
+            viewHolder.withView { $0.feed(byteArray: slice) }
         }
 
-        func getWindowSize() -> winsize {
+        nonisolated func getWindowSize() -> winsize {
+            // `assumeIsolated` is sound: the only callers are `LocalProcess`'s
+            // `startProcess` paths, which TBD invokes from main.
             MainActor.assumeIsolated {
-                if let tv = terminalView, tv.terminal.cols > 0, tv.terminal.rows > 0 {
+                let dims = terminalView?.terminalDimensions
+                if let dims, dims.cols > 0, dims.rows > 0 {
                     return winsize(
-                        ws_row: UInt16(tv.terminal.rows), ws_col: UInt16(tv.terminal.cols),
+                        ws_row: UInt16(dims.rows), ws_col: UInt16(dims.cols),
                         ws_xpixel: 0, ws_ypixel: 0)
                 }
                 return winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)

--- a/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
+++ b/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
@@ -94,8 +94,9 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
         /// Recorded when `LocalProcess`'s own exit monitor fires — by then it
         /// has already called `waitpid`, so `cleanup()` must NOT reap this pid
         /// (it is free, and could have been recycled for another child of this
-        /// process). Both sides are main-isolated — the callback by
-        /// `LocalProcess`'s default `dispatchQueue`, `cleanup()` by its
+        /// process). Both sides are main-isolated — the callback by the
+        /// explicit `dispatchQueue: .main` passed at construction (2.0's
+        /// default is a private background queue), `cleanup()` by its
         /// `@MainActor` below — so see `ChildExitObservation` for why the flag
         /// is lock-guarded regardless.
         private let childExitObservation = ChildExitObservation()
@@ -171,8 +172,9 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
             viewHolder.clear()
             localProcess?.terminate()
             localProcess = nil
-            // terminate() cancels `LocalProcess`'s exit monitor (via
-            // childStopped()) before the SIGTERM it just sent can land, so
+            // terminate() cancels `LocalProcess`'s exit monitor directly
+            // (`takeResourcesForShutdown()` → `cancelMonitor()`) before it
+            // even sends SIGTERM, so
             // nothing left will `waitpid` this child — that cancellation is
             // also what makes `ChildReaper` its sole waiter. Without the reap
             // it stays `<defunct>` under TBDApp forever.

--- a/Sources/TBDApp/Terminal/ChildReaper.swift
+++ b/Sources/TBDApp/Terminal/ChildReaper.swift
@@ -53,8 +53,9 @@ final class ChildExitObservation: Sendable {
 ///
 /// - `deinit` cancels the monitor, then closes the master fd; the child only
 ///   notices the resulting `SIGHUP` afterwards.
-/// - `terminate()` closes the fd, sends `SIGTERM`, then cancels the monitor via
-///   `childStopped()`; signal delivery and process teardown are asynchronous.
+/// - `terminate()` cancels the monitor directly (`takeResourcesForShutdown()`
+///   → `cancelMonitor()`), closes the write channel, and only then sends
+///   `SIGTERM` — the monitor is already gone before the signal can land.
 ///
 /// — so on both paths the `.exit` event never fires, `waitpid` is never called,
 /// and the child stays a zombie under TBDApp for the life of the app. Observed

--- a/Sources/TBDApp/Terminal/ChildReaper.swift
+++ b/Sources/TBDApp/Terminal/ChildReaper.swift
@@ -12,9 +12,11 @@ private let reaperLogger = Logger(subsystem: "com.tbd.app", category: "childReap
 /// teardown reap, both on the main queue and again on the reaper thread.
 ///
 /// Serialization note. The *writer* side runs on main for TWO independent
-/// reasons, and both must be kept in mind. First: `LocalProcess.init` defaults
-/// its `dispatchQueue` to `DispatchQueue.main`, neither TBD call site passes
-/// one, and the `DispatchSourceProcess` is created with `queue: dispatchQueue`.
+/// reasons, and both must be kept in mind. First: both TBD call sites pass
+/// `dispatchQueue: .main` explicitly — keep it that way — and the
+/// `DispatchSourceProcess` is created with `queue: dispatchQueue`
+/// (`directDelivery` moves only data delivery onto the IO thread; it does not
+/// affect the exit monitor's queue).
 /// Second, since upstream `1c3f353`: `setEventHandler` is now armed BEFORE
 /// `activate()`, and upstream documents that `activate()` can invoke the
 /// handler SYNCHRONOUSLY for an already-exited child — on that path the handler

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -64,6 +64,10 @@ class TBDTerminalView: TerminalView {
         // Apply current values once so first render uses user settings.
         applyAll()
 
+        // Replace the pre-2.0 `notify` override with the token-scoped OSC
+        // observer (see installNotificationObserver).
+        installNotificationObserver()
+
         // Reapply on any AppearanceSettings change. `objectWillChange` fires
         // *before* the property mutation lands on the published value, so we
         // dispatch async to main — by the time the sink runs, the new value
@@ -196,11 +200,11 @@ class TBDTerminalView: TerminalView {
         self.caretColor = Self.nsColor(from: scheme.cursor)
         self.selectedTextBackgroundColor = Self.nsColor(from: scheme.selection)
 
-        // Force SwiftTerm to repaint every cell. `installColors` updates the
-        // palette but does not invalidate cells already in the buffer; without
-        // this, default-bg cells continue showing the bg color they were drawn
-        // with at first paint (NSColor.textBackgroundColor = system gray).
-        self.getTerminal().updateFullScreen()
+        // No explicit repaint needed: SwiftTerm 2.0's `installColors` runs
+        // `colorsChangedLocked()` under the terminal lock, which itself calls
+        // `terminal.updateFullScreen()` and marks the frame dirty — the
+        // invalidation the old `getTerminal().updateFullScreen()` workaround
+        // existed to force.
         self.needsDisplay = true
     }
 
@@ -215,8 +219,21 @@ class TBDTerminalView: TerminalView {
         )
     }
 
+    // MARK: - Locked terminal access
+    //
+    // SwiftTerm 2.0 parses on the PTY IO thread and renders off-main, so the
+    // `Terminal` is shared mutable state guarded by `terminalLock`. Every
+    // non-snapshot access in TBD goes through `withTerminal { ... }`, which
+    // acquires that lock for the duration of the closure. Discipline, per
+    // docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md:
+    // copy values out of the closure and return them — never store the
+    // `Terminal` reference; never call `TerminalView` APIs from inside the
+    // closure (they may acquire the same lock and deadlock); never re-enter
+    // `withTerminal`. Pure cols/rows reads use the lock-free
+    // `terminalDimensions` snapshot instead.
+
     private func applyCursor() {
-        self.terminal.setCursorStyle(appearanceSettings.cursorStyle)
+        withTerminal { $0.setCursorStyle(appearanceSettings.cursorStyle) }
     }
 
     // MARK: - Cell dimension calculation
@@ -283,13 +300,13 @@ class TBDTerminalView: TerminalView {
     /// Converts a window-coordinate point to terminal grid (col, row).
     func gridPosition(atWindowLocation windowPoint: CGPoint) -> (col: Int, row: Int)? {
         let localPoint = convert(windowPoint, from: nil)
-        let terminal = getTerminal()
+        let dims = terminalDimensions
         let cell = cellDimensions()
 
         let col = Int(localPoint.x / cell.width)
         let row = Int((bounds.height - localPoint.y) / cell.height)
 
-        guard row >= 0 && row < terminal.rows && col >= 0 && col < terminal.cols else {
+        guard row >= 0 && row < dims.rows && col >= 0 && col < dims.cols else {
             return nil
         }
         return (col, row)
@@ -440,24 +457,31 @@ class TBDTerminalView: TerminalView {
         // `allowMouseReporting` is true (e.g. `RemoteAttachTerminalView`),
         // SwiftTerm's native reporting is the sole forwarder and we stand
         // down via the guard above.
-        let term = getTerminal()
-        guard !didDrag && term.mouseMode != .off else { return }
+        guard !didDrag else { return }
 
+        // Cell math stays OUTSIDE the lock (view API — see lock discipline
+        // above); the mouseMode read and the send ride one locked block.
+        // `sendEvent` under the lock matches SwiftTerm's own mouseUp path;
+        // the reply is marshalled to main asynchronously, so no re-entry.
         let cell = cellDimensions()
         let col = Int(point.x / cell.width)
         let row = Int((bounds.height - point.y) / cell.height)
 
-        let pressFlags = term.encodeButton(
-            button: 0, release: false,
-            shift: false, meta: false, control: false
-        )
-        term.sendEvent(buttonFlags: pressFlags, x: col, y: row)
+        withTerminal { term in
+            guard term.mouseMode != .off else { return }
 
-        let releaseFlags = term.encodeButton(
-            button: 0, release: true,
-            shift: false, meta: false, control: false
-        )
-        term.sendEvent(buttonFlags: releaseFlags, x: col, y: row)
+            let pressFlags = term.encodeButton(
+                button: 0, release: false,
+                shift: false, meta: false, control: false
+            )
+            term.sendEvent(buttonFlags: pressFlags, x: col, y: row)
+
+            let releaseFlags = term.encodeButton(
+                button: 0, release: true,
+                shift: false, meta: false, control: false
+            )
+            term.sendEvent(buttonFlags: releaseFlags, x: col, y: row)
+        }
     }
 
     /// True if the cell at the given window point carries an OSC 8 hyperlink
@@ -470,10 +494,11 @@ class TBDTerminalView: TerminalView {
     /// (graphics) don't short-circuit our path-detection path.
     func hasOSC8Payload(atWindowLocation windowPoint: CGPoint) -> Bool {
         guard let pos = gridPosition(atWindowLocation: windowPoint) else { return false }
-        let terminal = getTerminal()
-        guard let line = terminal.getLine(row: pos.row) else { return false }
-        guard pos.col < line.count else { return false }
-        return line[pos.col].getPayload() as? String != nil
+        return withTerminal { terminal in
+            guard let line = terminal.getLine(row: pos.row) else { return false }
+            guard pos.col < line.count else { return false }
+            return line[pos.col].getPayload() as? String != nil
+        }
     }
 
     /// Extracts a file path from the terminal buffer at the given window-coordinate point.
@@ -481,10 +506,12 @@ class TBDTerminalView: TerminalView {
         guard let pos = gridPosition(atWindowLocation: windowPoint) else { return nil }
         let col = pos.col
         let row = pos.row
-        let terminal = getTerminal()
 
-        guard let bufferLine = terminal.getLine(row: row) else { return nil }
-        let lineText = bufferLine.translateToString()
+        // Copy the row text out under the lock; all the path resolution and
+        // filesystem checks below run outside it.
+        guard let lineText = withTerminal({ terminal in
+            terminal.getLine(row: row)?.translateToString()
+        }) else { return nil }
 
         guard col < lineText.count else { return nil }
 
@@ -555,16 +582,20 @@ class TBDTerminalView: TerminalView {
     func extractHyperlinkURL(atWindowLocation windowPoint: CGPoint) -> String? {
         guard let pos = gridPosition(atWindowLocation: windowPoint) else { return nil }
         let row = pos.row
-        let terminal = getTerminal()
 
-        guard let line = terminal.getLine(row: row) else { return nil }
-
-        // Build visible text from line (translateToString may return empty for status bar lines)
-        var visibleText = ""
-        for c in 0..<line.count {
-            let val = line[c].getCharacter().unicodeScalars.first?.value ?? 0
-            visibleText.append(val > 0 ? line[c].getCharacter() : " ")
-        }
+        // Build visible text from the line under the lock, copy it out, and
+        // pattern-match outside (translateToString may return empty for
+        // status bar lines, hence the per-cell walk).
+        guard let visibleText = withTerminal({ terminal -> String? in
+            guard let line = terminal.getLine(row: row) else { return nil }
+            var text = ""
+            for c in 0..<line.count {
+                let character = line[c].getCharacter()
+                let val = character.unicodeScalars.first?.value ?? 0
+                text.append(val > 0 ? character : " ")
+            }
+            return text
+        }) else { return nil }
 
         // Look for "PR #123" pattern anywhere on the line.
         // Wide/emoji chars (e.g. ▶▶) make positional matching unreliable,
@@ -665,13 +696,41 @@ class TBDTerminalView: TerminalView {
         return false
     }
 
-    func notify(source: Terminal, title: String, body: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            // Only notify when this terminal is not focused
-            guard self.window?.isKeyWindow != true else { return }
-            self.onNotification?(title, body)
+    // MARK: - Notifications (OSC 777)
+
+    /// Keeps the OSC event observation alive; the token cancels it on deinit.
+    private var oscObservation: TerminalOscObservation?
+
+    /// Routes OSC 777 `notify;title;body` into `onNotification`, replacing
+    /// the pre-2.0 `notify(source:title:body:)` override (2.0's delegate
+    /// conformance methods are non-open extension members, so a subclass in
+    /// another module cannot override them). `observeOscEvents` observes
+    /// without preempting SwiftTerm's built-in handling — unlike
+    /// `registerOscHandler`, whose user handlers preempt built-ins.
+    private func installNotificationObserver() {
+        oscObservation = withTerminal { terminal in
+            terminal.observeOscEvents { [weak self] event in
+                guard event.code == 777 else { return }
+                guard let (title, body) = Self.parseNotifyPayload(event.payload) else { return }
+                // Delivered on the observer's private serial queue — hop to
+                // main before touching the view.
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    // Only notify when this terminal is not focused
+                    guard self.window?.isKeyWindow != true else { return }
+                    self.onNotification?(title, body)
+                }
+            }
         }
+    }
+
+    /// Mirrors upstream's `Terminal.oscNotification` parse:
+    /// `notify;title;body` where the body may itself contain `;`.
+    nonisolated static func parseNotifyPayload(_ payload: [UInt8]) -> (title: String, body: String)? {
+        guard let text = String(bytes: payload, encoding: .utf8) else { return nil }
+        let parts = text.components(separatedBy: ";")
+        guard parts.count >= 3, parts[0] == "notify" else { return nil }
+        return (parts[1], parts[2...].joined(separator: ";"))
     }
 
 }

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -204,7 +204,9 @@ class TBDTerminalView: TerminalView {
         // `colorsChangedLocked()` under the terminal lock, which itself calls
         // `terminal.updateFullScreen()` and marks the frame dirty — the
         // invalidation the old `getTerminal().updateFullScreen()` workaround
-        // existed to force.
+        // existed to force. Pinned by
+        // TerminalLockedAccessTests.installColorsInvalidatesFullScreen(),
+        // which fails if upstream stops invalidating on palette install.
         self.needsDisplay = true
     }
 

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -229,8 +229,10 @@ class TBDTerminalView: TerminalView {
     // copy values out of the closure and return them — never store the
     // `Terminal` reference; never call `TerminalView` APIs from inside the
     // closure (they may acquire the same lock and deadlock); never re-enter
-    // `withTerminal`. Pure cols/rows reads use the lock-free
-    // `terminalDimensions` snapshot instead.
+    // `withTerminal`. Pure cols/rows reads use the `terminalDimensions`
+    // snapshot instead — no closure to hold, but it briefly takes the same
+    // `terminalLock` internally, so it too must never be called from inside
+    // `withTerminal` (the lock is non-recursive; re-entry traps).
 
     private func applyCursor() {
         withTerminal { $0.setCursorStyle(appearanceSettings.cursorStyle) }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -309,7 +309,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // its last rows (a notice block overwriting the frozen status-bar
             // chrome), padded to the
             // view's REAL column count — onReady fires once layout has given
-            // the terminal its true dimensions, so `tv.terminal.cols` is the
+            // the terminal its true dimensions, so `tv.terminalDimensions.cols` is the
             // same source the resize paths use. A nil snapshot still yields
             // the block alone (a capture-less parked pane used to be pitch
             // black). The live/wake path (`suspendedOnCreate == false`) feeds
@@ -1046,9 +1046,8 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // otherwise stuck at whatever size it had until the user first
                 // drags, so fullscreen Claude would render at the wrong width.
                 // Same debounced path as live resizes.
-                scheduleControlModeResize(
-                    cols: terminalView.terminalDimensions.cols,
-                    rows: terminalView.terminalDimensions.rows)
+                let dims = terminalView.terminalDimensions
+                scheduleControlModeResize(cols: dims.cols, rows: dims.rows)
                 // Intercept ALL pastes at the view level while attached (the
                 // paste ruling v2) and ship them as a `.paste` sidecar frame.
                 // Interception happens BEFORE SwiftTerm brackets the content,

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -317,7 +317,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             let feedText: String?
             if suspendedOnCreate, let parkedMessage {
                 feedText = ParkedSnapshotComposer.compose(
-                    snapshot: snapshot, message: parkedMessage, columns: tv.terminal.cols)
+                    snapshot: snapshot, message: parkedMessage, columns: tv.terminalDimensions.cols)
             } else {
                 feedText = snapshot
             }
@@ -411,6 +411,11 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// headlessly — the reap wiring is otherwise unreachable from a test,
         /// since everything else about this type needs a live `NSView`.
         var localProcess: LocalProcess?
+        /// The IO-thread feed path (`dataReceived` → `feed`) reaches the view
+        /// through this lock-guarded holder rather than the main-confined
+        /// `terminalView` weak var. Written before `startProcess`, cleared by
+        /// `cleanup()` before the `LocalProcess` is released.
+        private let viewHolder = TerminalViewHolder()
         private var groupedViewerProcessRunning = false
         private var groupedViewerProcessGeneration: UInt64 = 0
         private var groupedViewerConfirmationStarted = false
@@ -424,8 +429,11 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// revision; see `ChildExitObservation` for why it is lock-guarded
         /// anyway and for the reaper thread that also reads it.
         private let childExitObservation = ChildExitObservation()
-        private var scrollMonitor: Any?
-        private var clickMonitor: Any?
+        // `nonisolated(unsafe)`: same pattern as `TBDTerminalView.mouseMonitor`
+        // — set and removed on main, but `deinit` is nonisolated and must be
+        // able to remove a monitor the main-actor teardown missed.
+        nonisolated(unsafe) private var scrollMonitor: Any?
+        nonisolated(unsafe) private var clickMonitor: Any?
         private var fedPreparationMessages: Set<String> = []
         /// Set while this panel renders through the control-mode path (Phase 2
         /// FD vending). `cleanup()` uses these to pair the teardown correctly:
@@ -718,8 +726,17 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             let env = TerminalPanelView.makeViewerEnvironment(base: ProcessInfo.processInfo.environment)
             let envPairs = env.map { "\($0.key)=\($0.value)" }
 
-            let process = LocalProcess(delegate: self)
+            // `dispatchQueue: .main` keeps the exit monitor on main (see the
+            // serialization note in ChildReaper.swift); `directDelivery: true`
+            // delivers `dataReceived` inline on the IO thread, where `feed`
+            // parses off-main — the configuration upstream's own
+            // `MacLocalTerminalView` ships.
+            let process = LocalProcess(delegate: self, dispatchQueue: .main, directDelivery: true)
             self.localProcess = process
+            // Written before startProcess; the IO thread reads it from
+            // `dataReceived`. Cleared by `cleanup()` before the process is
+            // released.
+            viewHolder.set(terminalView)
 
             process.startProcess(
                 executable: tmuxPath,
@@ -734,8 +751,9 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // The enclosing function is `@MainActor async`, so we're already
             // main-isolated here — no `assumeIsolated` wrapper needed.
             do {
-                let cols = terminalView.terminal.cols
-                let rows = terminalView.terminal.rows
+                let dims = terminalView.terminalDimensions
+                let cols = dims.cols
+                let rows = dims.rows
                 if cols > 0 && rows > 0 && process.childfd >= 0 {
                     var size = winsize(ws_row: UInt16(rows), ws_col: UInt16(cols), ws_xpixel: 0, ws_ypixel: 0)
                     _ = ioctl(process.childfd, TIOCSWINSZ, &size)
@@ -781,21 +799,27 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                     if self.shouldSuppressEvents() { return false }
                     let point = tv.convert(location, from: nil)
                     guard tv.bounds.contains(point) else { return false }
-                    guard tv.terminal.mouseMode != .off else { return false }
 
-                    // Use actual scroll position so tmux routes to the correct pane
+                    // Use actual scroll position so tmux routes to the correct pane.
+                    // Grid math runs OUTSIDE the lock (view API); the mouseMode
+                    // guard and the sends ride one `withTerminal` block — the
+                    // same calls, under the same lock, as SwiftTerm's own
+                    // native mouse-reporting path.
                     guard let (col, row) = tv.gridPosition(atWindowLocation: location) else { return false }
 
                     let isUp = deltaY > 0
-                    let buttonFlags = tv.terminal.encodeButton(
-                        button: isUp ? 4 : 5,
-                        release: false, shift: false, meta: false, control: false
-                    )
                     let lines = max(1, Int(abs(deltaY)))
-                    for _ in 0..<lines {
-                        tv.terminal.sendEvent(buttonFlags: buttonFlags, x: col, y: row)
+                    return tv.withTerminal { term -> Bool in
+                        guard term.mouseMode != .off else { return false }
+                        let buttonFlags = term.encodeButton(
+                            button: isUp ? 4 : 5,
+                            release: false, shift: false, meta: false, control: false
+                        )
+                        for _ in 0..<lines {
+                            term.sendEvent(buttonFlags: buttonFlags, x: col, y: row)
+                        }
+                        return true
                     }
-                    return true
                 }
                 return consumed ? nil : event
             }
@@ -943,6 +967,11 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             //
             // Control-mode panels have no `LocalProcess` at all, so
             // `ptyChildPid` is 0 for them and `shouldReap` rejects it.
+            //
+            // Clear the holder BEFORE releasing the process: a late IO batch
+            // then reads nil and drops instead of feeding a view whose
+            // session is being torn down.
+            viewHolder.clear()
             localProcess = nil
             ChildReaper.reap(pid: ptyChildPid, unless: childExitObservation)
         }
@@ -1018,7 +1047,8 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // drags, so fullscreen Claude would render at the wrong width.
                 // Same debounced path as live resizes.
                 scheduleControlModeResize(
-                    cols: terminalView.terminal.cols, rows: terminalView.terminal.rows)
+                    cols: terminalView.terminalDimensions.cols,
+                    rows: terminalView.terminalDimensions.rows)
                 // Intercept ALL pastes at the view level while attached (the
                 // paste ruling v2) and ship them as a `.paste` sidecar frame.
                 // Interception happens BEFORE SwiftTerm brackets the content,
@@ -1212,8 +1242,16 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         }
 
         // MARK: - LocalProcessDelegate
+        //
+        // `nonisolated`: the Coordinator's `TerminalViewDelegate` conformance
+        // makes the class MainActor-isolated, but `LocalProcess` calls
+        // `dataReceived` inline on the IO thread (`directDelivery: true`) and
+        // the exit monitor's callback contract is queue-, not actor-based.
 
-        func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+        nonisolated func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+            // Arrives on main already (`dispatchQueue: .main` governs the
+            // exit monitor regardless of `directDelivery`), but the method is
+            // nonisolated, so hop explicitly before touching actor state.
             debugLog("PANEL: process terminated, exitCode=\(exitCode ?? -1)")
             // `LocalProcess.processTerminated()` calls `waitpid` before it
             // calls us, so this child is already reaped and its pid is free to
@@ -1244,22 +1282,31 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             }
         }
 
-        func dataReceived(slice: ArraySlice<UInt8>) {
+        nonisolated func dataReceived(slice: ArraySlice<UInt8>) {
+            // Feed synchronously on the calling (IO) thread — this is the
+            // off-main parse the 2.0 bump exists for; `feed` is thread-safe
+            // (the parse runs under SwiftTerm's terminal lock) and the view
+            // reference is owned by the holder, so a batch racing teardown
+            // either completes against a live view or reads nil and drops.
+            viewHolder.withView { $0.feed(byteArray: slice) }
+            // The viewer-MRU signal keeps its main hop.
             DispatchQueue.main.async { [weak self] in
                 self?.groupedViewerDidReceiveOutput()
-                self?.terminalView?.feed(byteArray: slice)
             }
         }
 
-        func getWindowSize() -> winsize {
+        nonisolated func getWindowSize() -> winsize {
             // Use SwiftTerm's own dimensions — they account for scroller width
-            // and actual cell metrics computed from the font
+            // and actual cell metrics computed from the font.
+            // `assumeIsolated` is sound: the only callers are `LocalProcess`'s
+            // `startProcess` paths, which TBD invokes from main.
             return MainActor.assumeIsolated {
-                if let tv = terminalView, tv.terminal.cols > 0 && tv.terminal.rows > 0 {
-                    let cols = tv.terminal.cols
-                    let rows = tv.terminal.rows
-                    debugLog("PANEL: getWindowSize \(cols)x\(rows)")
-                    return winsize(ws_row: UInt16(rows), ws_col: UInt16(cols), ws_xpixel: 0, ws_ypixel: 0)
+                let dims = terminalView?.terminalDimensions
+                if let dims, dims.cols > 0 && dims.rows > 0 {
+                    debugLog("PANEL: getWindowSize \(dims.cols)x\(dims.rows)")
+                    return winsize(
+                        ws_row: UInt16(dims.rows), ws_col: UInt16(dims.cols),
+                        ws_xpixel: 0, ws_ypixel: 0)
                 }
                 debugLog("PANEL: getWindowSize fallback 80x24")
                 return winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)

--- a/Sources/TBDApp/Terminal/TerminalViewHolder.swift
+++ b/Sources/TBDApp/Terminal/TerminalViewHolder.swift
@@ -1,0 +1,40 @@
+import os
+import SwiftTerm
+
+/// Hands the PTY IO thread a way to reach the terminal view without racing
+/// teardown.
+///
+/// With `LocalProcess(delegate:dispatchQueue:directDelivery: true)`,
+/// `dataReceived` fires on the IO thread and calls `feed` right there —
+/// `feed` itself is thread-safe (the parse runs under SwiftTerm's
+/// `terminalLock`), but the *reference* to the view must be owned separately.
+/// This holder is that ownership: written once on the main actor before
+/// `startProcess`, cleared by `cleanup()` on the main actor BEFORE the
+/// process is terminated or released, so no batch feeds a view whose session
+/// is being torn down.
+final class TerminalViewHolder: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock<TerminalView?>(uncheckedState: nil)
+
+    /// Written once, on the main actor, before `startProcess`.
+    func set(_ view: TerminalView) {
+        lock.withLockUnchecked { $0 = view }
+    }
+
+    /// Cleared by `cleanup()` on the main actor BEFORE `terminate()` (or the
+    /// `LocalProcess` release) so late IO batches read nil and drop.
+    func clear() {
+        lock.withLockUnchecked { $0 = nil }
+    }
+
+    /// Takes a strong local reference under the lock, then runs `body`
+    /// against it outside the lock (`feed` is self-locking and a parse batch
+    /// can run for milliseconds — the unfair lock only guards the pointer
+    /// read). A call racing `clear()` either completes against a live,
+    /// retained view or reads nil and drops; both are safe.
+    @discardableResult
+    func withView<T>(_ body: (TerminalView) -> T) -> T? {
+        let view = lock.withLockUnchecked { $0 }
+        guard let view else { return nil }
+        return body(view)
+    }
+}

--- a/Tests/TBDAppTests/TerminalLockedAccessTests.swift
+++ b/Tests/TBDAppTests/TerminalLockedAccessTests.swift
@@ -1,0 +1,173 @@
+import AppKit
+import Foundation
+import SwiftTerm
+import Testing
+@testable import TBDApp
+
+/// SwiftTerm 2.0 migration round-trips
+/// (docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md).
+///
+/// Everything here goes through the production `feed()` path — no hand-built
+/// terminal state — because the migration moved every buffer read under
+/// `withTerminal { ... }` and re-plumbed notifications from the deleted
+/// `notify` override onto `Terminal.observeOscEvents`. These tests fail if
+/// that wiring is absent: the OSC 8 read returns nothing without the locked
+/// `getLine`/`getPayload` walk, the 777 test's continuation never resumes
+/// without a stored observation token, and the off-main feed exercises the
+/// IO-thread delivery path `directDelivery: true` puts `dataReceived` on.
+@MainActor
+@Suite("SwiftTerm 2.0 locked terminal access")
+struct TerminalLockedAccessTests {
+
+    /// Isolated defaults: AppearanceSettings must never read/write the
+    /// developer's real TBDApp.plist (Tests-must-not-touch-~/tbd rule's
+    /// UserDefaults twin). Same idiom as DragDropPasteRoutingTests.
+    private func withView(_ body: (TBDTerminalView) throws -> Void) rethrows {
+        let suiteName = "TBDAppTests.LockedAccess.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let view = TBDTerminalView(
+            frame: CGRect(x: 0, y: 0, width: 600, height: 300),
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: defaults))
+        try body(view)
+    }
+
+    private func makeView() -> TBDTerminalView {
+        let suiteName = "TBDAppTests.LockedAccess.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        return TBDTerminalView(
+            frame: CGRect(x: 0, y: 0, width: 600, height: 300),
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: defaults))
+    }
+
+    /// Window point at the center of grid cell (col, row) for a view with no
+    /// window (convert(_:from: nil) is then the identity for a frame at the
+    /// origin).
+    private func point(col: Int, row: Int, in view: TBDTerminalView) -> CGPoint {
+        let cell = view.cellDimensions()
+        return CGPoint(
+            x: (CGFloat(col) + 0.5) * cell.width,
+            y: view.bounds.height - (CGFloat(row) + 0.5) * cell.height)
+    }
+
+    // MARK: - OSC 8 round-trip (the #113 dedup guard's locked read)
+
+    @Test("OSC 8 payload fed through feed() is visible to hasOSC8Payload at that cell — and only there")
+    func osc8PayloadRoundTrip() {
+        withView { view in
+            // Anchor text "LINK" carries the payload; " plain" after the
+            // closing OSC 8 does not.
+            let bytes = "\u{1B}]8;;https://example.com/doc\u{07}LINK\u{1B}]8;;\u{07} plain"
+            view.feed(byteArray: [UInt8](bytes.utf8)[...])
+
+            // Cell inside the anchor text.
+            #expect(view.hasOSC8Payload(atWindowLocation: point(col: 1, row: 0, in: view)))
+            // Cell in the plain trailing text: the guard must NOT stand the
+            // monitor down there — this is what makes the test discriminate
+            // payload presence rather than pass on any non-nil answer.
+            #expect(!view.hasOSC8Payload(atWindowLocation: point(col: 8, row: 0, in: view)))
+        }
+    }
+
+    /// `extractHyperlinkURL` is the residual non-OSC-8 recognizer (PR #123
+    /// pattern) — the other buffer read that moved under the lock. Fed
+    /// through the production parse path like everything else.
+    @Test("PR #123 fed through feed() resolves to the repo's pull URL via the locked row read")
+    func prPatternRoundTrip() {
+        withView { view in
+            view.remoteURL = "git@github.com:acme/repo.git"
+            view.feed(byteArray: [UInt8]("See PR #123 for details".utf8)[...])
+
+            let url = view.extractHyperlinkURL(atWindowLocation: point(col: 2, row: 0, in: view))
+            #expect(url == "https://github.com/acme/repo/pull/123")
+        }
+    }
+
+    // MARK: - OSC 777 → onNotification (the notify-override replacement)
+
+    @Test("OSC 777 notify fed through feed() reaches onNotification with title and body",
+          .timeLimit(.minutes(1)))
+    func osc777RoutesToOnNotification() async {
+        let view = makeView()
+        let (title, body): (String, String) = await withCheckedContinuation { continuation in
+            view.onNotification = { title, body in
+                continuation.resume(returning: (title, body))
+            }
+            // The not-key-window guard passes: a test view has no window.
+            // Body deliberately contains a ';' to pin upstream's parse
+            // (body = parts[2...] rejoined).
+            view.feed(byteArray: [UInt8]("\u{1B}]777;notify;Build done;3 warnings; 0 errors\u{07}".utf8)[...])
+        }
+        #expect(title == "Build done")
+        #expect(body == "3 warnings; 0 errors")
+    }
+
+    /// The payload parse alone (mirrors upstream `oscNotification`): non-notify
+    /// 777 payloads must not fire.
+    @Test func notifyPayloadParse() {
+        #expect(TBDTerminalView.parseNotifyPayload([UInt8]("notify;T;B".utf8))! == ("T", "B"))
+        #expect(TBDTerminalView.parseNotifyPayload([UInt8]("notify;T;B;C".utf8))! == ("T", "B;C"))
+        #expect(TBDTerminalView.parseNotifyPayload([UInt8]("other;T;B".utf8)) == nil)
+        #expect(TBDTerminalView.parseNotifyPayload([UInt8]("notify;T".utf8)) == nil)
+    }
+
+    // MARK: - Off-main feed (the IO-thread delivery path)
+
+    @Test("feed() from a background queue parses without loss — the directDelivery dataReceived path",
+          .timeLimit(.minutes(1)))
+    func offMainFeedLandsInBuffer() async {
+        let view = makeView()
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                view.feed(byteArray: [UInt8]("MARKER-7f3a9\r\n".utf8)[...])
+                continuation.resume()
+            }
+        }
+        let text = String(data: view.getBufferAsData(), encoding: .utf8) ?? ""
+        #expect(text.contains("MARKER-7f3a9"))
+    }
+
+    // MARK: - Holder teardown
+
+    @Test("holder: set → withView sees the view; clear → withView returns nil")
+    func holderTeardown() {
+        withView { view in
+            let holder = TerminalViewHolder()
+            #expect(holder.withView { _ in true } == nil)
+            holder.set(view)
+            #expect(holder.withView { $0 === view } == true)
+            holder.clear()
+            #expect(holder.withView { _ in true } == nil)
+        }
+    }
+
+    @Test("holder: concurrent withView racing clear neither crashes nor resurrects the view",
+          .timeLimit(.minutes(1)))
+    func holderConcurrentClearIsSafe() async {
+        let view = makeView()
+        let holder = TerminalViewHolder()
+        holder.set(view)
+        await withCheckedContinuation { continuation in
+            let group = DispatchGroup()
+            for _ in 0..<4 {
+                group.enter()
+                DispatchQueue.global().async {
+                    for _ in 0..<2_000 {
+                        holder.withView { _ in () }
+                    }
+                    group.leave()
+                }
+            }
+            group.enter()
+            DispatchQueue.global().async {
+                holder.clear()
+                group.leave()
+            }
+            group.notify(queue: .main) { continuation.resume() }
+        }
+        #expect(holder.withView { _ in true } == nil)
+    }
+}

--- a/Tests/TBDAppTests/TerminalLockedAccessTests.swift
+++ b/Tests/TBDAppTests/TerminalLockedAccessTests.swift
@@ -130,6 +130,65 @@ struct TerminalLockedAccessTests {
         #expect(text.contains("MARKER-7f3a9"))
     }
 
+    // MARK: - installColors invalidation pin (the deleted updateFullScreen workaround)
+
+    /// Pins the upstream premise the migration deleted a workaround on:
+    /// `applyScheme()` used to call `getTerminal().updateFullScreen()` after
+    /// `installColors(_:)` to force a repaint of already-drawn cells, and the
+    /// migration removed it because SwiftTerm 2.0's `installColors` runs
+    /// `colorsChangedLocked()`, which itself ends in `terminal.updateFullScreen()`
+    /// (Apple/AppleTerminalView.swift). Nothing else in the diff exercised that
+    /// premise, so this test does: quiesce the terminal's pending-update range,
+    /// call the production `installColors(_:)` — the exact call the deleted
+    /// workaround followed; `applyScheme()` itself is private and only reachable
+    /// through an async Combine sink — and assert the full screen is dirty again
+    /// with no manual `updateFullScreen()` anywhere in the test.
+    ///
+    /// Discrimination: the `#require(quiesced == nil)` arm IS the
+    /// no-invalidation baseline — it proves the observable reads nil right up
+    /// until `installColors` runs, so if upstream stops invalidating, the final
+    /// `#require` fails on a nil range rather than passing on residue from the
+    /// feed. (Verified by mutation: with the `installColors` line removed, the
+    /// test fails there.)
+    @Test("installColors alone re-dirties the full screen — no manual updateFullScreen needed")
+    func installColorsInvalidatesFullScreen() throws {
+        try withView { view in
+            // Real content through the production parse path, so the update
+            // range we clear below was genuinely populated first.
+            view.feed(byteArray: [UInt8]("some already-rendered text\r\n".utf8)[...])
+
+            // Quiesce: consume the feed's dirty range the way a UI toolkit
+            // does after drawing. Copy-out only, per the lock discipline.
+            view.withTerminal { $0.clearUpdateRange() }
+            let quiesced = view.withTerminal { $0.getUpdateRange() }
+            try #require(
+                quiesced == nil,
+                "baseline broken: update range non-nil after clearUpdateRange — the final assertion could not attribute dirtiness to installColors")
+
+            view.installColors(Self.pinPalette)
+
+            // Read the range and the row count under one lock acquisition.
+            let observed = view.withTerminal { terminal -> (startY: Int, endY: Int, rows: Int)? in
+                guard let range = terminal.getUpdateRange() else { return nil }
+                return (range.startY, range.endY, terminal.rows)
+            }
+            let range = try #require(
+                observed,
+                "installColors dirtied nothing: upstream no longer invalidates on palette install — applyScheme needs its explicit updateFullScreen back")
+            #expect(range.startY == 0 && range.endY == range.rows,
+                    "installColors dirtied rows \(range.startY)..\(range.endY) of \(range.rows) — a partial range, not the full screen updateFullScreen() sets")
+        }
+    }
+
+    /// 16 entries, as `installPalette` requires — with fewer it silently does
+    /// nothing and the test above would fail on a nil range for the wrong reason.
+    private static let pinPalette: [SwiftTerm.Color] = {
+        (0..<16).map { i in
+            SwiftTerm.Color(
+                red: UInt16(i) * 4369, green: UInt16(15 - i) * 4369, blue: 32768)
+        }
+    }()
+
     // MARK: - Holder teardown
 
     @Test("holder: set → withView sees the view; clear → withView returns nil")

--- a/Tests/TBDAppTests/TerminalStalePixelRepaintTests.swift
+++ b/Tests/TBDAppTests/TerminalStalePixelRepaintTests.swift
@@ -101,7 +101,7 @@ private final class StalePixelHarness {
         view.nativeBackgroundColor = background
         view.nativeForegroundColor = foreground
         view.layer?.backgroundColor = background.cgColor
-        view.getTerminal().updateFullScreen()
+        view.withTerminal { $0.updateFullScreen() }
 
         view.resize(cols: cols, rows: rows)
 
@@ -305,16 +305,25 @@ private final class StalePixelHarness {
     /// the ones still carrying ink. Restricted to cells the scenario knows are
     /// default-background.
     func scanBlankCells(rowRange: Range<Int>, colRange: Range<Int>) -> [CellReading] {
-        let terminal = view.getTerminal()
-        var dirty: [CellReading] = []
-        for row in rowRange {
-            for col in colRange {
-                let ch = terminal.getCharacter(col: col, row: row)
-                guard ch == " " || ch == "\0" else { continue }
-                let reading = readCell(row: row, col: col)
-                if reading.offBackgroundPixels > 0 {
-                    dirty.append(reading)
+        // Copy the blank-cell coordinates out under the lock (SwiftTerm 2.0
+        // locked access); the bitmap reads below run outside it.
+        let blankCells: [(row: Int, col: Int)] = view.withTerminal { terminal in
+            var cells: [(row: Int, col: Int)] = []
+            for row in rowRange {
+                for col in colRange {
+                    let ch = terminal.getCharacter(col: col, row: row)
+                    if ch == " " || ch == "\0" {
+                        cells.append((row, col))
+                    }
                 }
+            }
+            return cells
+        }
+        var dirty: [CellReading] = []
+        for cell in blankCells {
+            let reading = readCell(row: cell.row, col: cell.col)
+            if reading.offBackgroundPixels > 0 {
+                dirty.append(reading)
             }
         }
         return dirty
@@ -323,8 +332,9 @@ private final class StalePixelHarness {
     /// Row as SwiftTerm's grid holds it — used to prove the BUFFER is clean, so
     /// any residue is pixels-only.
     func bufferRow(_ row: Int) -> String {
-        let terminal = view.getTerminal()
-        return (0..<cols).map { String(terminal.getCharacter(col: $0, row: row) ?? " ") }.joined()
+        view.withTerminal { terminal in
+            (0..<cols).map { String(terminal.getCharacter(col: $0, row: row) ?? " ") }.joined()
+        }
     }
 
     func dumpLog() -> String {

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -25,8 +25,9 @@ import Testing
 /// cleanup handler on main; `startChild` passes the same, because any other
 /// queue would test a configuration TBD never uses. That is only sound
 /// because this process genuinely drains the main queue (`Tests/CLAUDE.md`),
-/// so the monitor is live rather than merely idle — the child outlives the coordinator precisely because `cleanup()`
-/// cancels that live monitor, which is the behavior under test.
+/// so the monitor is live rather than merely idle — the child outlives the
+/// coordinator precisely because `cleanup()` cancels that live monitor,
+/// which is the behavior under test.
 ///
 /// **These tests are deliberately NOT `@MainActor`, and each takes exactly one
 /// main-actor hop.** They need main only for the steps that are main-isolated

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -151,7 +151,7 @@ struct TerminalTeardownReapTests {
     /// context, so this matches it; only the waiting below happens off main.
     @MainActor
     private func startChild(
-        delegate: LocalProcessDelegate, lifetime: String, assign: (LocalProcess) -> Void
+        delegate: LocalProcessDelegate, lifetime: String, assign: @MainActor (LocalProcess) -> Void
     ) -> pid_t {
         let process = LocalProcess(delegate: delegate)
         process.startProcess(
@@ -179,9 +179,12 @@ struct TerminalTeardownReapTests {
     /// is the part under test.
     @Test("an exiting PTY child is reaped by TerminalPanelView teardown, not left <defunct>")
     func panelCleanupReapsChild() async throws {
-        let coordinator = TerminalPanelRepresentable.Coordinator()
-        // Every main-isolated step in one hop — see the suite comment.
+        // Every main-isolated step in one hop — see the suite comment. The
+        // coordinator is constructed inside it too: since the SwiftTerm 2.0
+        // migration, `TerminalViewDelegate` is `@MainActor` and the
+        // coordinator class inherits that isolation.
         let pid = await MainActor.run { () -> pid_t in
+            let coordinator = TerminalPanelRepresentable.Coordinator()
             // Outlives cleanup(), then exits on its own — see the doc comment.
             let pid = startChild(delegate: coordinator, lifetime: "0.4") {
                 coordinator.localProcess = $0
@@ -228,16 +231,17 @@ struct TerminalTeardownReapTests {
         throw ChildSurvivedTeardown(pid: pid, state: state)
     }
 
-    /// Drops the coordinator's reference to a probe child's `LocalProcess`
-    /// (whose deinit cancels its exit monitor, making us the sole waiter), then
-    /// kills and reaps it. Probe children are `sleep 120` and nothing in the
-    /// production path under test ends them, so every test that starts one must
-    /// call this — before any assertion that could throw first.
+    /// Kills and reaps a probe child whose `LocalProcess` the test already
+    /// released inside its main hop (that deinit cancels the exit monitor,
+    /// making us the sole waiter — `localProcess` is MainActor state since
+    /// the SwiftTerm 2.0 migration, so the release cannot happen here off
+    /// main). Probe children are `sleep 120` and nothing in the production
+    /// path under test ends them, so every test that starts one must call
+    /// this — before any assertion that could throw first.
     ///
     /// The `pid > 0` guard is load-bearing, not defensive: `kill(0, SIGKILL)`
     /// signals the caller's entire process group, i.e. the whole test process.
-    private func disposeProbe(pid: pid_t, release: () -> Void) {
-        release()
+    private func disposeProbe(pid: pid_t) {
         guard pid > 0 else { return }
         kill(pid, SIGKILL)
         ChildReaper.reapBlocking(pid: pid)
@@ -250,8 +254,11 @@ struct TerminalTeardownReapTests {
     /// only thing standing between this teardown and a permanent zombie.
     @Test("LocalPTYTerminalRepresentable teardown kills AND reaps its child")
     func localPTYCleanupReapsChild() async throws {
-        let coordinator = LocalPTYTerminalRepresentable.Coordinator()
+        // Coordinator constructed inside the single main hop — MainActor
+        // isolation inherited from `TerminalViewDelegate` since the SwiftTerm
+        // 2.0 migration.
         let pid = await MainActor.run { () -> pid_t in
+            let coordinator = LocalPTYTerminalRepresentable.Coordinator()
             let pid = startChild(delegate: coordinator, lifetime: "120") {
                 coordinator.localProcess = $0
             }
@@ -283,8 +290,11 @@ struct TerminalTeardownReapTests {
 
     @Test("a second TerminalPanelView cleanup() tears nothing down")
     func panelCleanupIsOneShot() async throws {
-        let coordinator = TerminalPanelRepresentable.Coordinator()
         let run = await MainActor.run { () -> OneShotRun in
+            // Coordinator constructed in the single main hop — MainActor
+            // isolation inherited from `TerminalViewDelegate` since the
+            // SwiftTerm 2.0 migration.
+            let coordinator = TerminalPanelRepresentable.Coordinator()
             let first = startChild(delegate: coordinator, lifetime: "0.4") {
                 coordinator.localProcess = $0
             }
@@ -294,14 +304,21 @@ struct TerminalTeardownReapTests {
                 coordinator.localProcess = $0
             }
             coordinator.cleanup()
-            return OneShotRun(first: first, probe: probe, stillHeld: coordinator.localProcess != nil)
+            let stillHeld = coordinator.localProcess != nil
+            // Release the probe's `LocalProcess` here, in the same hop —
+            // `localProcess` is MainActor state now, and its deinit does not
+            // end the child (no SIGTERM; the pending read swallows the
+            // SIGHUP — see the suite comment), so `probeAlive` below still
+            // observes only what the second cleanup() did.
+            coordinator.localProcess = nil
+            return OneShotRun(first: first, probe: probe, stillHeld: stillHeld)
         }
         // Observe, then dispose, then assert — in that order, with nothing that
         // can throw in between. See the suite comment: a `defer` registered
         // after a throwing `#require` never runs, and the probe is a `sleep 120`.
         let drain = await drainPendingReaps()
         let probeAlive = processExists(run.probe)
-        disposeProbe(pid: run.probe) { coordinator.localProcess = nil }
+        disposeProbe(pid: run.probe)
         try requireDrained(drain, teardownChild: run.first)
 
         try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
@@ -316,8 +333,10 @@ struct TerminalTeardownReapTests {
 
     @Test("a second LocalPTYTerminalRepresentable cleanup() tears nothing down")
     func localPTYCleanupIsOneShot() async throws {
-        let coordinator = LocalPTYTerminalRepresentable.Coordinator()
         let run = await MainActor.run { () -> OneShotRun in
+            // Constructed and released in the single main hop — see the
+            // sibling test above for both rationales.
+            let coordinator = LocalPTYTerminalRepresentable.Coordinator()
             let first = startChild(delegate: coordinator, lifetime: "120") {
                 coordinator.localProcess = $0
             }
@@ -326,12 +345,14 @@ struct TerminalTeardownReapTests {
                 coordinator.localProcess = $0
             }
             coordinator.cleanup()
-            return OneShotRun(first: first, probe: probe, stillHeld: coordinator.localProcess != nil)
+            let stillHeld = coordinator.localProcess != nil
+            coordinator.localProcess = nil
+            return OneShotRun(first: first, probe: probe, stillHeld: stillHeld)
         }
         // Observe, then dispose, then assert — see the sibling test above.
         let drain = await drainPendingReaps()
         let probeAlive = processExists(run.probe)
-        disposeProbe(pid: run.probe) { coordinator.localProcess = nil }
+        disposeProbe(pid: run.probe)
         try requireDrained(drain, teardownChild: run.first)
 
         try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -18,13 +18,14 @@ import Testing
 /// `localProcess = nil` that makes `LocalProcess.deinit` (and thus the
 /// monitor cancellation and fd close) happen at a known moment.
 ///
-/// **Why the default `dispatchQueue` (main) and not an injected background
-/// queue.** Production passes none, so `LocalProcess` defaults to
-/// `DispatchQueue.main` for both `childMonitor` and the `DispatchIO` cleanup
-/// handler; passing a background queue here would test a configuration TBD
-/// never uses. That is only sound because this process genuinely drains the
-/// main queue (`Tests/CLAUDE.md`), so the monitor is live rather than merely
-/// idle — the child outlives the coordinator precisely because `cleanup()`
+/// **Why `dispatchQueue: .main` and not an injected background queue.**
+/// Production passes `dispatchQueue: .main, directDelivery: true` explicitly
+/// (since the SwiftTerm 2.0 pin, whose default queue is a private background
+/// serial queue, not main), putting `childMonitor` and the `DispatchIO`
+/// cleanup handler on main; `startChild` passes the same, because any other
+/// queue would test a configuration TBD never uses. That is only sound
+/// because this process genuinely drains the main queue (`Tests/CLAUDE.md`),
+/// so the monitor is live rather than merely idle — the child outlives the coordinator precisely because `cleanup()`
 /// cancels that live monitor, which is the behavior under test.
 ///
 /// **These tests are deliberately NOT `@MainActor`, and each takes exactly one
@@ -153,7 +154,9 @@ struct TerminalTeardownReapTests {
     private func startChild(
         delegate: LocalProcessDelegate, lifetime: String, assign: @MainActor (LocalProcess) -> Void
     ) -> pid_t {
-        let process = LocalProcess(delegate: delegate)
+        // Production configuration (see the suite comment): exit monitor on
+        // main, data delivered inline on the IO thread.
+        let process = LocalProcess(delegate: delegate, dispatchQueue: .main, directDelivery: true)
         process.startProcess(
             executable: "/bin/sleep", args: [lifetime], environment: nil, execName: nil)
         assign(process)
@@ -250,7 +253,8 @@ struct TerminalTeardownReapTests {
     /// The remote path *does* end its child — `cleanup()` calls
     /// `LocalProcess.terminate()`, which sends SIGTERM — so a long-lived child
     /// is production-faithful here. `terminate()` cancels the exit monitor
-    /// (via `childStopped()`) before that signal can land, so the reap is the
+    /// directly (`takeResourcesForShutdown()` → `cancelMonitor()`) before it
+    /// even sends that signal, so the reap is the
     /// only thing standing between this teardown and a permanent zombie.
     @Test("LocalPTYTerminalRepresentable teardown kills AND reaps its child")
     func localPTYCleanupReapsChild() async throws {

--- a/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
+++ b/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
@@ -113,12 +113,20 @@ the configuration upstream's own `MacLocalTerminalView` ships.
 
 - **Data path**: `dataReceived` fires on the IO thread and calls `feed`
   right there. `feed` is thread-safe by design (a `Sendable` closure stored
-  in locked state; the parse itself under `terminalLock`). The coordinator
-  reaches the view through a `nonisolated(unsafe)` stash whose safety
-  argument is precisely that documented thread-safety. The panel's
-  viewer-MRU signal keeps its existing `DispatchQueue.main.async` hop. Both
-  coordinators already treated the delegate queue as unspecified and hopped
-  explicitly, so this is a small, local change.
+  in locked state; the parse itself under `terminalLock`), which covers
+  concurrent calls into the view; the *reference* is owned separately. The
+  coordinator reaches the view through a small lock-guarded holder
+  (`OSAllocatedUnfairLock<TerminalView?>`): written once before
+  `startProcess`, cleared by `cleanup()` on the main actor **before**
+  `terminate()` is called. Each `dataReceived` takes a strong local
+  reference under the lock for the duration of its `feed` call, so a batch
+  racing teardown either completes against a live view or reads nil and
+  drops — both safe, and nothing feeds a view whose session is being torn
+  down. The one unfair-lock acquisition per batch is noise at batch
+  granularity. The panel's viewer-MRU signal keeps its existing
+  `DispatchQueue.main.async` hop. Both coordinators already treated the
+  delegate queue as unspecified and hopped explicitly, so this is a small,
+  local change.
 - **Exit path**: `dispatchQueue: .main` still governs the
   `DispatchSourceProcess` exit monitor (`LocalProcess` creates it with
   `queue: dispatchQueue`, unaffected by `directDelivery`), so exit events
@@ -177,10 +185,15 @@ breaks silently on any upstream rename.
   made `installColors` invalidate existing cells itself; if so, delete the
   `updateFullScreen` workaround instead of porting it.
 - **Notifications** — replace the `notify` override with
-  `withTerminal { $0.registerOscHandler(code: 9) { … } }` at view setup,
-  routing into `onNotification` with the same not-focused guard. If OSC 9
-  turns out to bypass the handler table, the fallback is one more `open` in
-  the fork commit.
+  `Terminal.observeOscEvents(_:)`, 2.0's public token-scoped observer,
+  registered at view setup (under `withTerminal`) for **OSC 777** — the code
+  that carries `notify;title;body` and the only path that reached TBD's
+  override — routing into `onNotification` with the same not-focused guard.
+  The observer is documented to deliver copied events without changing
+  built-in or override behavior, which is why it is used rather than
+  `registerOscHandler`: user-registered handlers preempt built-ins in 2.0,
+  so re-registering a code would swallow its default handling. (OSC 9 is
+  ConEmu progress reporting, not notifications.)
 
 Lock discipline, enforced by convention and a comment block at the one place
 TBD touches the lock: bodies copy values out and return — never store the
@@ -190,28 +203,46 @@ TBD touches the lock: bodies copy values out and return — never store the
 
 The repo rule requires a default-off flag when wholesale-replacing a
 load-bearing rendering path. A dependency pin cannot be flagged — two
-SwiftTerm revisions cannot coexist in one build — so this ships unflagged,
-with that stated explicitly in the PR description per the rule's requirement
-to answer the question rather than skip it. Standing in for the soak: the
-existing `useMetalTerminalRenderer` UserDefaults flag still gates the
-Metal-versus-CoreGraphics backend choice at the new revision (verify its
-mapping to upstream's `usesMetalLayerSurface` at implementation); dogfooding
-on the development fleet is the soak; and the before/after performance
-comparison runs on the separately validated key-to-paint harness before the
-merge is judged.
+SwiftTerm revisions cannot coexist in one build — so the bump itself ships
+unflagged, with that stated explicitly in the PR description per the rule's
+requirement to answer the question rather than skip it.
+
+`directDelivery` is different: it is a boolean in TBD's own two
+`LocalProcess` constructions and therefore mechanically flaggable. It ships
+unflagged anyway, deliberately. Its off branch would still run the new
+FrameDriver, lock, and renderer — it only moves parse back to the main
+thread — so it is a partial fallback, not a soak of old-versus-new;
+upstream's `MacLocalTerminalView` ships `directDelivery: true` as its only
+local-process configuration; and the flag rule targets autonomous or
+destructive behavior and wholesale replacement, where the wholesale
+replacement here is the pin, which no TBD flag can gate. A half-switch with
+no meaningful off state is flag sprawl.
+
+Standing in for the soak: the existing `useMetalTerminalRenderer`
+UserDefaults flag still gates the Metal-versus-CoreGraphics backend choice
+at the new revision (verify its mapping to upstream's
+`usesMetalLayerSurface` at implementation) — noting that both branches of
+that flag run the new frame scheduler and lock, so it bounds rendering-
+backend risk only; dogfooding on the development fleet is the soak; and the
+before/after performance comparison runs on the separately validated
+key-to-paint harness before the merge is judged.
 
 ## Testing
 
 - Full suite via `scripts/test.sh`; everything currently green stays green.
 - New: a round-trip test feeding OSC 8 bytes through the production `feed`
   path and asserting `hasOSC8Payload`/`extractHyperlinkURL` see the payload
-  — constructed through the production path, not hand-built state — and a
-  test that `dataReceived` invoked from a non-main queue feeds without crash
-  or data loss.
+  — constructed through the production path, not hand-built state; a
+  matching round-trip test feeding OSC 777 `notify;title;body` bytes and
+  asserting `onNotification` fires (the notification path is a re-plumbing,
+  not a port, so it gets its own production-path test); and a test that
+  `dataReceived` invoked from a non-main queue feeds without crash or data
+  loss.
 - Manual live checklist in the PR (this class of bug is live-only): OSC 8
   cmd-click opens exactly one pane; plain-path click; scroll inside tmux
   mouse mode; theme switch repaints previously drawn cells; cursor style;
-  resize; session exit leaves no `<defunct>` children.
+  resize; a notification arrives from an unfocused terminal and none from a
+  focused one; session exit leaves no `<defunct>` children.
 - Out of scope: performance measurement (separate harness), and
   `viewWillDraw`-based terminal diagnostics going quiet — expected under
   off-main rendering, noted in the `Package.swift` comment block.
@@ -220,6 +251,5 @@ merge is judged.
 
 - `installColors` may now invalidate drawn cells, making the
   `updateFullScreen` workaround deletable — verify at implementation.
-- OSC 9 routing through the handler table — verify; fallback named above.
 - Upstream churn on these internals is high; until the accessor PR merges,
   each pin bump costs one fork rebase.

--- a/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
+++ b/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
@@ -1,0 +1,225 @@
+# SwiftTerm 2.0 migration: locked terminal access and off-main parsing
+
+TBD pins SwiftTerm at a `main`-branch revision containing upstream's
+display-link frame scheduler (`FrameDriver`) and off-main rendering — the fix
+for the fixed 16.67 ms paint-scheduling floor TBD measured in the field, and
+for the main-thread CPU cost of many streaming terminals (upstream issue
+\#658, which matches TBD's symptom). That revision is SwiftTerm 2.0: it moves
+parsing and rendering off the main thread, and in consequence removes every
+API TBD used to reach the `Terminal` object from a view. This spec decides how
+TBD accesses terminal state under the new concurrency model, and where PTY
+parsing runs.
+
+## The 2.0 model
+
+Through v1.20.0, everything about a terminal happens on the main thread: the
+parser mutates the cell grid (`Terminal`), the renderer reads it, and the
+embedding app reads it too, via `TerminalView.getTerminal()`. One thread, no
+locking.
+
+In 2.0 the parser runs on the PTY IO thread and the renderer on a Metal
+thread, so `Terminal` becomes shared mutable state guarded by a public
+`TerminalLock` — a FIFO-fair ticket lock with documented re-entry rules
+(`TerminalLock.swift`). Because a raw reference is only safe under that lock,
+upstream removed `getTerminal()` and made the view's `terminal` property
+internal, offering `Sendable` snapshots for common reads:
+`terminalDimensions` (cols/rows) and `terminalStateSnapshot()` (cursor,
+viewport, visible row text). Direct access is still sanctioned — upstream's
+Kitty graphics integration docs instruct callers to hold
+`terminal.terminalLock.withLock { … }` — but only for callers that already
+hold a `Terminal` reference.
+
+For a view embedder there is no public way to obtain that reference. The
+migration guide claims `TerminalViewDelegate` callbacks pass the `Terminal`;
+they pass the `TerminalView`. The view's own `withTerminal` helper and its
+`terminal` property are internal, and the view's `TerminalDelegate`
+conformance methods (which do receive `source: Terminal`) are public non-open
+extension members, so a subclass in another module cannot override them. This
+is an upstream oversight — docs and API disagree — not a policy.
+
+## What TBD accesses, and how often
+
+Every TBD access is gesture-frequency — a click, a scroll tick, a theme
+change, a spawn — never inside a render or parse loop.
+
+- **Dimensions (cols/rows)** — seven sites across `TerminalPanelView`,
+  `LocalPTYTerminalView`, and `TBDTerminalView.gridPosition`. Covered exactly
+  by the `terminalDimensions` snapshot.
+- **Per-cell buffer reads on click** — `hasOSC8Payload`, `extractFilePath`,
+  `extractHyperlinkURL` in `TBDTerminalView`. Read `getLine(row:)`, per-cell
+  `getPayload()`/`getCharacter()`. No snapshot carries payloads.
+- **Mouse forwarding** — click passthrough to tmux and scroll-wheel
+  forwarding: read `mouseMode`, call `encodeButton` and `sendEvent`.
+- **Mutations** — `updateFullScreen()` on theme change, `setCursorStyle`.
+- **Notification interception** — an override of the view's
+  `notify(source:title:body:)`, which 2.0 makes non-overridable.
+
+`hasOSC8Payload` deserves its history: it is a deduplication guard, not the
+link-opening feature (PR #113). SwiftTerm opens OSC 8 links itself
+(`mouseUp` → `requestOpenLink`); TBD's mouseDown monitor also matches visible
+text. When both fired, one click opened two viewer panes. The guard reads the
+clicked cell's payload and stands the monitor down so the authoritative
+handler owns the click — which means the read must agree with what SwiftTerm's
+own mouseUp will see moments later.
+
+## Decisions
+
+### One access mechanism: everything under the lock
+
+All non-snapshot access — per-cell reads, mouse calls, mutations — goes
+through the view's `withTerminal { … }` under `terminalLock`. No second
+mechanism.
+
+The lock's cost supports this. Uncontended acquisition is a lock/unlock pair
+on `NSCondition` — sub-microsecond. Contended, upstream's own doc comment on
+the lock bounds the wait: parse batches cost a couple of milliseconds, and
+FIFO fairness bounds any waiter at one batch (fairness is called out there as
+a correctness requirement, not a nicety). Worst case for a click during
+full-blast streaming output is a few milliseconds, once — noise against a
+~100 ms gesture budget. The hottest TBD site, scroll-wheel forwarding in tmux
+mouse mode, performs the same calls under the same lock as SwiftTerm's own
+native mouse-reporting path, so TBD sits on the cost curve upstream designed
+for. If the lock is ever suspected in practice, SwiftTerm's built-in
+`SWIFTTERM_PROFILE=1` records `.lockWait`/`.lockHold` intervals per owner.
+
+**Rejected: snapshots plus a sink-side open throttle.** Cell reads could use
+`terminalStateSnapshot().visibleRows` text, with duplicate opens suppressed by
+a canonical-target throttle at the viewer sink. Two defects. First, priority
+inversion: the monitor fires on mouseDown, SwiftTerm on mouseUp, so a throttle
+keeps whichever open comes first — the text guess — and discards the
+authoritative payload open as a duplicate. A link whose payload is a web URL
+but whose visible text looks path-like would open the wrong thing. Second, the
+dedup only works if the monitor's extracted relative path and the payload's
+absolute URL normalize to the same key, an invariant that must hold across
+every case forever — the same fragility PR #113 removed. And since mutations
+and mouse sends need the locked reference regardless, the hybrid saves no
+machinery; it splits access across two mechanisms and adds an invariant.
+
+**Rejected: degrading to text-only detection.** Reintroduces the #113
+double-open for links whose visible text is a real path — the case Claude
+Code emits constantly.
+
+### Parsing runs on the IO thread
+
+`TerminalView.feed(byteArray:)` parses synchronously on the calling thread,
+under `terminalLock` (`TerminalRenderOwner.feed(bytes:)`); there is no
+internal worker handoff. So the thread TBD feeds from decides whether parse
+cost leaves the main thread — the bulk of the main-thread CPU this bump
+exists to shed.
+
+Both coordinators construct
+`LocalProcess(delegate: self, dispatchQueue: .main, directDelivery: true)` —
+the configuration upstream's own `MacLocalTerminalView` ships.
+
+- **Data path**: `dataReceived` fires on the IO thread and calls `feed`
+  right there. `feed` is thread-safe by design (a `Sendable` closure stored
+  in locked state; the parse itself under `terminalLock`). The coordinator
+  reaches the view through a `nonisolated(unsafe)` stash whose safety
+  argument is precisely that documented thread-safety. The panel's
+  viewer-MRU signal keeps its existing `DispatchQueue.main.async` hop. Both
+  coordinators already treated the delegate queue as unspecified and hopped
+  explicitly, so this is a small, local change.
+- **Exit path**: `dispatchQueue: .main` still governs the
+  `DispatchSourceProcess` exit monitor (`LocalProcess` creates it with
+  `queue: dispatchQueue`, unaffected by `directDelivery`), so exit events
+  arrive on main exactly as before. `ChildReaper` and
+  `ChildExitObservation` code are untouched; the serialization note in
+  `ChildReaper.swift` changes its first reason from "`LocalProcess.init`
+  defaults its queue to main" to "both call sites pass `.main` explicitly —
+  keep it that way".
+- **Conformance**: the `LocalProcessDelegate` methods become `nonisolated`.
+  `processTerminated` hops to main internally (it already arrives there).
+  `getWindowSize` keeps `MainActor.assumeIsolated`: its only callers are
+  `startProcess` paths, which TBD invokes from main; its `terminal.cols`
+  reads become `terminalDimensions`.
+
+**Rejected: keeping delivery and parse on main.** Smallest possible diff, and
+`FrameDriver` still removes the 16.67 ms floor — but every streaming
+terminal's parse cost stays on the main thread, forfeiting the larger half of
+the win.
+
+### The reference comes from a one-commit fork, offered upstream
+
+A fork of `migueldeicaza/SwiftTerm`, branched from the pinned `main` revision,
+carries one commit: make the view's `withTerminal<T>((Terminal) throws -> T)`
+helper public. The helper already takes `terminalLock` itself, so TBD adds no
+lock code; if inspection shows it expects the lock already held, the commit
+adds a public locking equivalent instead. The same commit goes upstream as a
+PR, together with the migration-doc correction (the guide names an access
+route for view embedders that does not exist). `Package.swift` pins the fork
+by revision; the comment block states the patch, the reason, and the exit
+criterion — upstream merges an equivalent accessor, TBD re-pins to upstream,
+the fork is deleted. Until then every bump costs one rebase of one commit.
+
+**Rejected: waiting for upstream.** No fork to carry, but blocks the perf
+bump on an unbounded review cycle while the performance work is active.
+
+**Rejected: reflection (`Mirror`) on the view's internals.** Works today,
+breaks silently on any upstream rename.
+
+## Site map
+
+- **Dimensions → `terminalDimensions`, no lock** — `TerminalPanelView`
+  parked-snapshot compose, initial `TIOCSWINSZ`, control-mode resize,
+  `getWindowSize`; `LocalPTYTerminalView` spawn-time size and
+  `getWindowSize`; `TBDTerminalView.gridPosition`.
+- **Per-cell reads → `withTerminal` copy-out** — `hasOSC8Payload`,
+  `extractFilePath`, `extractHyperlinkURL`. Byte-identical behavior; the
+  #113 guard reads the same cells under the same lock as SwiftTerm's click
+  path.
+- **Mouse → `withTerminal`** — click passthrough (`mouseMode`,
+  `encodeButton`, `sendEvent`) and scroll-wheel forwarding. `sendEvent`
+  under the lock matches upstream's own mouseUp; the reply path is
+  marshalled to main asynchronously (`TerminalInputMainActorDelivery`), so
+  no synchronous re-entry.
+- **Mutations → `withTerminal`** — theme repaint (`updateFullScreen`) and
+  `setCursorStyle`. First verify whether 2.0's rewritten render pipeline
+  made `installColors` invalidate existing cells itself; if so, delete the
+  `updateFullScreen` workaround instead of porting it.
+- **Notifications** — replace the `notify` override with
+  `withTerminal { $0.registerOscHandler(code: 9) { … } }` at view setup,
+  routing into `onNotification` with the same not-focused guard. If OSC 9
+  turns out to bypass the handler table, the fallback is one more `open` in
+  the fork commit.
+
+Lock discipline, enforced by convention and a comment block at the one place
+TBD touches the lock: bodies copy values out and return — never store the
+`Terminal`, never call view APIs from inside, never re-enter.
+
+## Gating
+
+The repo rule requires a default-off flag when wholesale-replacing a
+load-bearing rendering path. A dependency pin cannot be flagged — two
+SwiftTerm revisions cannot coexist in one build — so this ships unflagged,
+with that stated explicitly in the PR description per the rule's requirement
+to answer the question rather than skip it. Standing in for the soak: the
+existing `useMetalTerminalRenderer` UserDefaults flag still gates the
+Metal-versus-CoreGraphics backend choice at the new revision (verify its
+mapping to upstream's `usesMetalLayerSurface` at implementation); dogfooding
+on the development fleet is the soak; and the before/after performance
+comparison runs on the separately validated key-to-paint harness before the
+merge is judged.
+
+## Testing
+
+- Full suite via `scripts/test.sh`; everything currently green stays green.
+- New: a round-trip test feeding OSC 8 bytes through the production `feed`
+  path and asserting `hasOSC8Payload`/`extractHyperlinkURL` see the payload
+  — constructed through the production path, not hand-built state — and a
+  test that `dataReceived` invoked from a non-main queue feeds without crash
+  or data loss.
+- Manual live checklist in the PR (this class of bug is live-only): OSC 8
+  cmd-click opens exactly one pane; plain-path click; scroll inside tmux
+  mouse mode; theme switch repaints previously drawn cells; cursor style;
+  resize; session exit leaves no `<defunct>` children.
+- Out of scope: performance measurement (separate harness), and
+  `viewWillDraw`-based terminal diagnostics going quiet — expected under
+  off-main rendering, noted in the `Package.swift` comment block.
+
+## Risks and open verifications
+
+- `installColors` may now invalidate drawn cells, making the
+  `updateFullScreen` workaround deletable — verify at implementation.
+- OSC 9 routing through the handler table — verify; fallback named above.
+- Upstream churn on these internals is high; until the accessor PR merges,
+  each pin bump costs one fork rebase.

--- a/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
+++ b/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
@@ -221,14 +221,16 @@ destructive behavior and wholesale replacement, where the wholesale
 replacement here is the pin, which no TBD flag can gate. A half-switch with
 no meaningful off state is flag sprawl.
 
-Standing in for the soak: the existing `useMetalTerminalRenderer`
-UserDefaults flag still gates the Metal-versus-CoreGraphics backend choice
-at the new revision (verify its mapping to upstream's
-`usesMetalLayerSurface` at implementation) — noting that both branches of
-that flag run the new frame scheduler and lock, so it bounds rendering-
-backend risk only; dogfooding on the development fleet is the soak; and the
-before/after performance comparison runs on the separately validated
-key-to-paint harness before the merge is judged.
+Standing in for the soak: dogfooding on the development fleet, and the
+before/after performance comparison on the separately validated
+key-to-paint harness before the merge is judged. (The
+`useMetalTerminalRenderer` UserDefaults flag lives on the unmerged
+`tbd/metal-terminal-renderer` branch, not this tree; when that branch
+rebases, its `setUseMetal(_:)` call survives unchanged at the new revision,
+and upstream's `usesMetalLayerSurface` is a separate additional
+surface-selection toggle, not a rename. Either way both branches of any
+rendering-backend flag run the new frame scheduler and lock, so such a flag
+bounds rendering-backend risk only.)
 
 ## Testing
 

--- a/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
+++ b/docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md
@@ -167,10 +167,13 @@ breaks silently on any upstream rename.
 
 ## Site map
 
-- **Dimensions → `terminalDimensions`, no lock** — `TerminalPanelView`
-  parked-snapshot compose, initial `TIOCSWINSZ`, control-mode resize,
-  `getWindowSize`; `LocalPTYTerminalView` spawn-time size and
-  `getWindowSize`; `TBDTerminalView.gridPosition`.
+- **Dimensions → `terminalDimensions`, no locked closure** — the snapshot
+  is not lock-free (it takes `terminalLock` briefly inside, and the lock is
+  non-recursive, so it must never be called from within `withTerminal`) but
+  needs no closure at the call site — `TerminalPanelView` parked-snapshot
+  compose, initial `TIOCSWINSZ`, control-mode resize, `getWindowSize`;
+  `LocalPTYTerminalView` spawn-time size and `getWindowSize`;
+  `TBDTerminalView.gridPosition`.
 - **Per-cell reads → `withTerminal` copy-out** — `hasOSC8Payload`,
   `extractFilePath`, `extractHyperlinkURL`. Byte-identical behavior; the
   #113 guard reads the same cells under the same lock as SwiftTerm's click


### PR DESCRIPTION
## Summary

Every TBD terminal repaints through SwiftTerm's legacy scheduler: damage coalesces behind a fixed `DispatchQueue.main.asyncAfter(+16.67ms)` — a floor on key-to-paint latency, not a rate limit — and parsing plus rendering both run on the main thread, so a handful of streaming TUI sessions peg main (upstream issue migueldeicaza/SwiftTerm#658, which matches TBD's measured symptom). Upstream has rebuilt this outright on `main`: a `FrameDriver` on `CADisplayLink`/`CVDisplayLink` replaces the fixed delay, Metal-layer rendering moves off the main thread, and the `Terminal` grid becomes lock-guarded shared state. This PR adopts that revision and migrates TBD's terminal-access code to the new concurrency model, additionally moving PTY parsing onto the IO thread so streaming output stops costing main-thread parse CPU. (The upstream Metal-off-main rendering is present but not yet engaged: Metal stays gated behind setUseMetal, which TBD wires up only on the separate metal-renderer branch — at this revision drawing remains on the Core Graphics path, scheduled by the FrameDriver. Verified in the field by sampling the running app: FrameDriver ticks + swiftterm-io threads present, no Metal/render-loop threads.)

No tagged release contains any of this — `v1.19.0` and `v1.20.0` still carry the fixed-delay scheduler — so this continues the repo's existing practice of pinning an unreleased revision, now via a fork (below).

## Why this shape

Spec: `docs/specs/2026-08-28-swiftterm-2-locked-terminal-access-design.md` (brainstormed + design-reviewed). The three decisions, telegraphically:

- **All non-snapshot terminal access goes through `withTerminal` under upstream's public `TerminalLock`** (per-cell click reads, mouse forwarding, mutations); pure cols/rows reads use the `terminalDimensions` snapshot. Every access is gesture-frequency; FIFO fairness bounds a contended wait at one ~2ms parse batch. Rejected in the spec: snapshot-plus-throttle (priority inversion at the OSC 8 dedup guard from #113, plus a fragile normalization invariant) and text-only degradation (reintroduces the #113 double-open).
- **Parsing moves to the IO thread**: `LocalProcess(delegate:, dispatchQueue: .main, directDelivery: true)` — upstream's own shipped configuration. `feed()` parses on the calling thread, so the delivery thread decides where parse cost lands.
- **The pin is a one-commit fork.** SwiftTerm 2.0 removed every public route from a view to its `Terminal` (`getTerminal()` deleted, `terminal` internal, delegate callbacks pass the view, and its migration guide's claimed route does not exist). The fork `cheapsteak/SwiftTerm`, branch `tbd/public-with-terminal`, revision `62d0be6` = upstream `9c2518e` (main, 2026-08-27) + one commit making the existing self-locking `withTerminal` helper public (plus the migration-doc correction). Exit criterion, recorded in `Package.swift`: upstream merges an equivalent accessor → re-pin to upstream, delete the fork. The upstream PR is prepared but deliberately not yet opened.

Pin provenance: old `16c5286` (upstream main) → new `62d0be6` (fork, = upstream `9c2518e` + accessor commit).

## What this PR does

- `Package.swift`: pin moved to the fork revision; comment block rewritten (pin rationale, fork exit criterion, ChildReaper re-verification for `9c2518e`).
- `TBDTerminalView`: per-cell click reads (`hasOSC8Payload`, `extractFilePath`, `extractHyperlinkURL`), click passthrough, and `setCursorStyle` migrate to `withTerminal` copy-out blocks; `gridPosition` to `terminalDimensions`; the theme-repaint `updateFullScreen()` workaround is **deleted** — 2.0's `installColors` performs the invalidation itself (`colorsChangedLocked()` ends in `updateFullScreen()` + `frameDriver.markDirty()`); the `notify` override is replaced by `observeOscEvents` filtering OSC 777 (observer token stored; user-registered OSC *handlers* would preempt built-ins, the observer does not).
- `TerminalPanelView` / `LocalPTYTerminalView` coordinators: `directDelivery` init; `dataReceived` feeds synchronously on the IO thread through a new lock-guarded `TerminalViewHolder` (set before `startProcess`, cleared during cleanup before terminate/release, so a batch racing teardown reads nil and drops); `getWindowSize` reads `terminalDimensions`; scroll forwarding under `withTerminal`.
- `ChildReaper`: **doc comment only.** Re-verified at the new revision: `waitpid` is still called from exactly one place in the whole package (`LocalProcess.swift:384`, reachable only from the `DispatchSourceProcess` `.exit` handler at `:589`), and neither teardown path TBD uses reaps — `deinit` (`:356`) and `terminate()` (`:604`) both cancel the monitor without waiting (`terminate()` now cancels *before* sending `SIGTERM`, `:624`). So TBD must keep reaping, and ChildReaper stays. The exit monitor arms on `dispatchQueue`, which both call sites now pass as `.main` explicitly, keeping the serialization analysis intact.
- Tests: new production-path round-trips (OSC 8 payload at the exact cell, OSC 777 → `onNotification`, off-main `feed`, holder teardown + race); two pre-existing suites that used removed APIs migrated.

## Flag & rollout

Ships unflagged; the spec's Gating section carries the full argument. Short form: the pin itself cannot be flagged (two SwiftTerm revisions cannot coexist in one build), and `directDelivery` — the one mechanically flaggable piece — has no meaningful off state (its off branch still runs the new FrameDriver, lock, and renderer; it only moves parse back onto main). Soak = dogfooding on the development fleet; the separately validated key-to-paint harness provides the before/after judgment before merge.

## Assumptions

- `withTerminal` bodies copy values out and never re-enter — enforced by convention and a comment block, per the spec.
- Terminal-diagnostics code that hooks `viewWillDraw()` may go quiet at this revision (a frame loop off the main thread may never call it). Expected, noted in `Package.swift`; not a regression.
- The fork is temporary; each future bump costs one rebase of one commit until upstream merges the accessor.

## Evidence & verification

- Build green (`scripts/swift-safe build`, exit 0); SwiftLint `--strict` clean on touched files.
- Full suite: 8378 tests / 813 suites; the only unexpected reds were 60s-timeout waits during a run on a machine ~80× over its load baseline, and a targeted rerun of every affected suite passed 19/19 in 0.37s — the waits starved, no value assertion failed in any run.
- Discriminating tests: OSC 8 asserts payload at the anchor cell AND absence one cell past it; OSC 777 resumes only through the full registration → token → parse → main-hop chain; off-main `feed` asserts the bytes landed via `getBufferAsData`.
- **Performance before/after has NOT yet been measured** — that comparison runs on the separately validated key-to-paint harness and is explicitly out of scope here.
- **Live verification (in progress)**: the fleet daemon+app are running this branch. Verified so far, with log evidence: OSC 777 notification interception end-to-end in BOTH directions — delivered to `onNotification` while the terminal's window is not key (`OSC-DIAG event code=777 → parsed → delivering → sink log line`, via a tmux-passthrough-wrapped sequence into an attached viewer), and suppressed at the key-window guard while focused. Zombie scan: 0 `<defunct>` children under the new app. Still pending eyes-on: OSC 8 cmd-click single-open, plain-path click, theme-switch repaint, scroll inside tmux mouse mode. (Note for future readers: the production sink for terminal OSC 777 is a debug log line, not a UI banner — same as before this PR; tmux only forwards OSC 777 to an attached client when wrapped in the `ESC Ptmux;` passthrough, and TBD attaches viewers lazily, so a probe needs the tab visible.)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=C1A2C601-5B14-4BF5-A7B3-7428FBEFD49F)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal stability during background input, resizing, scrolling, and process shutdown.
  - Fixed terminal notifications so OSC 777 title and message alerts are reliably parsed and delivered.
  - Improved hyperlink detection and terminal content handling.
  - Reduced stale display artifacts during terminal repainting.
  - Improved cleanup and child-process handling to prevent hangs and stale terminal activity.
- **Tests**
  - Added coverage for locked terminal access, notifications, hyperlinks, concurrent access, and process cleanup.
- **Documentation**
  - Added design documentation for the updated terminal integration and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

