### PR TITLE
Fix activity recovery across process replacement

### DIFF
--- a/Sources/TBDCLI/Commands/SessionEndCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEndCommand.swift
@@ -17,8 +17,13 @@ struct SessionEndCommand: AsyncParsableCommand {
         shouldDisplay: false
     )
 
+    static func sessionIncarnationID(environment: [String: String]) -> UUID? {
+        environment["TBD_TERMINAL_INCARNATION_ID"].flatMap(UUID.init(uuidString:))
+    }
+
     mutating func run() async throws {
-        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+        let environment = ProcessInfo.processInfo.environment
+        guard let terminalIDString = environment["TBD_TERMINAL_ID"],
               let terminalID = UUID(uuidString: terminalIDString) else {
             sessionEndLogger.debug("suppressed reason=noTerminalID")
             return
@@ -33,7 +38,9 @@ struct SessionEndCommand: AsyncParsableCommand {
         do {
             try client.callVoid(
                 method: RPCMethod.terminalSessionEnded,
-                params: TerminalSessionEndedParams(terminalID: terminalID)
+                params: TerminalSessionEndedParams(
+                    terminalID: terminalID,
+                    sessionIncarnationID: Self.sessionIncarnationID(environment: environment))
             )
         } catch {
             sessionEndLogger.debug(

--- a/Sources/TBDCLI/Commands/SessionEventCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEventCommand.swift
@@ -30,6 +30,10 @@ struct SessionEventCommand: AsyncParsableCommand {
         let cwd: String?
     }
 
+    static func sessionIncarnationID(environment: [String: String]) -> UUID? {
+        environment["TBD_TERMINAL_INCARNATION_ID"].flatMap(UUID.init(uuidString:))
+    }
+
     mutating func run() async throws {
         // 1. Resolve terminal ID from env. Without this, we can't route the
         //    event — silent exit (the hook is also configured globally and
@@ -59,6 +63,7 @@ struct SessionEventCommand: AsyncParsableCommand {
 
         // 4. Fire the RPC. Ignore the response — hook is best-effort.
         do {
+            let environment = ProcessInfo.processInfo.environment
             try client.callVoid(
                 method: RPCMethod.terminalSessionEvent,
                 params: TerminalSessionEventParams(
@@ -66,7 +71,8 @@ struct SessionEventCommand: AsyncParsableCommand {
                     sessionID: sessionID,
                     transcriptPath: payload.transcript_path,
                     source: payload.source,
-                    cwd: payload.cwd
+                    cwd: payload.cwd,
+                    sessionIncarnationID: Self.sessionIncarnationID(environment: environment)
                 )
             )
         } catch {

--- a/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
+++ b/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
@@ -67,8 +67,13 @@ struct TerminalActivityEventCommand: AsyncParsableCommand {
         return sessionID
     }
 
+    static func sessionIncarnationID(environment: [String: String]) -> UUID? {
+        environment["TBD_TERMINAL_INCARNATION_ID"].flatMap(UUID.init(uuidString:))
+    }
+
     mutating func run() async throws {
-        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+        let environment = ProcessInfo.processInfo.environment
+        guard let terminalIDString = environment["TBD_TERMINAL_ID"],
               let terminalID = UUID(uuidString: terminalIDString) else {
             activityLogger.debug("suppressed reason=noTerminalID")
             return
@@ -90,7 +95,8 @@ struct TerminalActivityEventCommand: AsyncParsableCommand {
                 params: TerminalActivityEventParams(
                     terminalID: terminalID,
                     activityState: state.activityState,
-                    sessionID: sessionID
+                    sessionID: sessionID,
+                    sessionIncarnationID: Self.sessionIncarnationID(environment: environment)
                 )
             )
         } catch {

--- a/Sources/TBDDaemon/Claude/ClaudeDelegationTracker.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeDelegationTracker.swift
@@ -7,6 +7,17 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-deleg
 struct ClaudeDelegationTarget: Sendable, Equatable {
     let terminalID: UUID
     let transcriptPath: String?
+    let sessionIncarnationID: UUID?
+
+    init(
+        terminalID: UUID,
+        transcriptPath: String?,
+        sessionIncarnationID: UUID? = nil
+    ) {
+        self.terminalID = terminalID
+        self.transcriptPath = transcriptPath
+        self.sessionIncarnationID = sessionIncarnationID
+    }
 }
 
 /// Owns which Claude terminals owe a delegation sample and what the last
@@ -29,25 +40,48 @@ actor ClaudeDelegationTracker {
     /// rail already reports working and this rail is not needed.
     private static let tailByteLimit = 64 * 1024
 
+    private struct Incarnation: Hashable {
+        let id: UUID?
+    }
+
     private struct Claim {
         let transcriptPath: String
+        let incarnation: Incarnation
         let count: Int
     }
 
-    private var marked: Set<UUID> = []
+    private var marked: [UUID: Set<Incarnation>] = [:]
     private var claims: [UUID: Claim] = [:]
 
-    func mark(terminalID: UUID) {
-        marked.insert(terminalID)
+    func mark(terminalID: UUID, sessionIncarnationID: UUID? = nil) {
+        marked[terminalID, default: []].insert(Incarnation(id: sessionIncarnationID))
     }
 
     /// Whether a terminal currently owes a sample. Exists so a test can pin
     /// the mark independently of any filesystem evidence.
-    func isMarked(terminalID: UUID) -> Bool { marked.contains(terminalID) }
+    func isMarked(terminalID: UUID) -> Bool { marked[terminalID]?.isEmpty == false }
 
+    /// User actions target the selected terminal rather than one process, so
+    /// their clear deliberately removes every incarnation's transient state.
     func clear(terminalID: UUID) {
-        marked.remove(terminalID)
+        marked.removeValue(forKey: terminalID)
         claims.removeValue(forKey: terminalID)
+    }
+
+    /// Process-derived clears affect only state produced by that process.
+    func clear(terminalID: UUID, sessionIncarnationID: UUID?) {
+        let incarnation = Incarnation(id: sessionIncarnationID)
+        if var marks = marked[terminalID] {
+            marks.remove(incarnation)
+            if marks.isEmpty {
+                marked.removeValue(forKey: terminalID)
+            } else {
+                marked[terminalID] = marks
+            }
+        }
+        if claims[terminalID]?.incarnation == incarnation {
+            claims.removeValue(forKey: terminalID)
+        }
     }
 
     /// Re-reads every marked target, keeps standing claims for the rest, and
@@ -56,17 +90,25 @@ actor ClaudeDelegationTracker {
         var result: [UUID: Int] = [:]
         for target in targets {
             let id = target.terminalID
+            let incarnation = Incarnation(id: target.sessionIncarnationID)
             // A retargeted terminal's old count cannot describe its new
-            // transcript, so drop it whether or not a fresh mark arrived.
-            if let claim = claims[id], claim.transcriptPath != target.transcriptPath {
+            // transcript or process, so drop it whether or not a fresh mark
+            // arrived.
+            if let claim = claims[id],
+               claim.transcriptPath != target.transcriptPath
+                   || claim.incarnation != incarnation {
                 claims.removeValue(forKey: id)
             }
-            if marked.remove(id) != nil {
+            let marks = marked.removeValue(forKey: id)
+            if marks?.contains(incarnation) == true {
                 claims.removeValue(forKey: id)
                 if let path = target.transcriptPath, !path.isEmpty,
                    let tail = Self.readTail(path: path),
                    let count = ClaudeDelegationSample.pendingCount(inTail: tail) {
-                    claims[id] = Claim(transcriptPath: path, count: count)
+                    claims[id] = Claim(
+                        transcriptPath: path,
+                        incarnation: incarnation,
+                        count: count)
                 }
             }
             if let claim = claims[id] { result[id] = claim.count }
@@ -76,7 +118,7 @@ actor ClaudeDelegationTracker {
 
     /// Drops state for terminals that no longer exist.
     func retain(terminalIDs: Set<UUID>) {
-        marked.formIntersection(terminalIDs)
+        marked = marked.filter { terminalIDs.contains($0.key) }
         claims = claims.filter { terminalIDs.contains($0.key) }
     }
 

--- a/Sources/TBDDaemon/Claude/SessionRecaptureScheduler.swift
+++ b/Sources/TBDDaemon/Claude/SessionRecaptureScheduler.swift
@@ -32,12 +32,13 @@ struct SessionRecaptureScheduler: Sendable {
         self.captureSessionID = captureSessionID
     }
 
+    @discardableResult
     func schedule(
         terminalID: UUID,
         paneID: String,
         server: String,
         expectedIncarnationID: UUID?
-    ) {
+    ) -> Task<Void, Never> {
         Task {
             guard (try? await clock.sleep(for: .seconds(5))) != nil else { return }
             if let sessionID = await captureSessionID(server, paneID) {

--- a/Sources/TBDDaemon/Claude/SessionRecaptureScheduler.swift
+++ b/Sources/TBDDaemon/Claude/SessionRecaptureScheduler.swift
@@ -32,11 +32,19 @@ struct SessionRecaptureScheduler: Sendable {
         self.captureSessionID = captureSessionID
     }
 
-    func schedule(terminalID: UUID, paneID: String, server: String) {
+    func schedule(
+        terminalID: UUID,
+        paneID: String,
+        server: String,
+        expectedIncarnationID: UUID?
+    ) {
         Task {
             guard (try? await clock.sleep(for: .seconds(5))) != nil else { return }
             if let sessionID = await captureSessionID(server, paneID) {
-                try? await db.terminals.updateSessionID(id: terminalID, sessionID: sessionID)
+                _ = try? await db.terminals.updateSessionIDIfIncarnationMatches(
+                    id: terminalID,
+                    expectedIncarnationID: expectedIncarnationID,
+                    sessionID: sessionID)
             }
         }
     }

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -56,7 +56,7 @@ enum CodexHookOverlay {
     static let relativePath = "hooks/hooks.json"
 
     static let sessionStartCommand =
-        #"PAYLOAD=$(cat); printf '%s' "$PAYLOAD" | tbd session-event 2>/dev/null || true; printf '%s' "$PAYLOAD" | tbd terminal-activity idle --read-hook-payload 2>/dev/null || true"#
+        #"TBD_BIN="${TBD_CLI_PATH-tbd}"; PAYLOAD=$(cat); printf '%s' "$PAYLOAD" | "$TBD_BIN" session-event 2>/dev/null || true; printf '%s' "$PAYLOAD" | "$TBD_BIN" terminal-activity idle --read-hook-payload 2>/dev/null || true"#
 
     // Only an active goal can cross a Stop hook into autonomous continuation.
     // Paused and limited goals have stopped the current run, so they publish idle.

--- a/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
+++ b/Sources/TBDDaemon/Codex/CodexTranscriptActivityTracker.swift
@@ -1,7 +1,12 @@
 import Foundation
 import TBDShared
 
-struct CodexTurnLifecycleReducer: Sendable {
+struct CodexTurnLifecycleEvent: Sendable {
+    enum Kind: Sendable {
+        case started
+        case closed
+    }
+
     private struct EventEnvelope: Decodable {
         let type: String
         let payload: Payload
@@ -19,6 +24,36 @@ struct CodexTurnLifecycleReducer: Sendable {
         }
     }
 
+    let kind: Kind
+    let turnID: String?
+    let startedAt: Double?
+
+    static func decode(line: Data) -> Self? {
+        guard let envelope = try? JSONDecoder().decode(EventEnvelope.self, from: line),
+              envelope.type == "event_msg" else { return nil }
+
+        let kind: Kind
+        switch envelope.payload.type {
+        case "task_started":
+            kind = .started
+        case "task_complete", "turn_aborted":
+            kind = .closed
+        default:
+            return nil
+        }
+        return Self(
+            kind: kind,
+            turnID: envelope.payload.turnID,
+            startedAt: envelope.payload.startedAt)
+    }
+}
+
+struct CodexTurnLifecycleReducer: Sendable {
+    enum RecoverySeed: Sendable {
+        case noEvidence
+        case idle
+    }
+
     private struct Turn: Sendable {
         let id: String
         let startedAt: Double?
@@ -27,64 +62,115 @@ struct CodexTurnLifecycleReducer: Sendable {
     private var currentTurn: Turn?
     private var hasLifecycleEvidence = false
 
+    init() {}
+
+    init(recoverySeed: RecoverySeed) {
+        switch recoverySeed {
+        case .noEvidence:
+            break
+        case .idle:
+            hasLifecycleEvidence = true
+        }
+    }
+
     var activityState: TerminalActivityState? {
         guard hasLifecycleEvidence else { return nil }
         return currentTurn == nil ? .idle : .working
     }
 
     mutating func consume(line: Data) {
-        guard let envelope = try? JSONDecoder().decode(EventEnvelope.self, from: line),
-              envelope.type == "event_msg" else { return }
+        guard let event = CodexTurnLifecycleEvent.decode(line: line) else { return }
+        consume(event: event)
+    }
 
-        switch envelope.payload.type {
-        case "task_started":
-            guard let turnID = envelope.payload.turnID else { return }
+    mutating func consume(event: CodexTurnLifecycleEvent) {
+        switch event.kind {
+        case .started:
+            guard let turnID = event.turnID else { return }
             hasLifecycleEvidence = true
-            currentTurn = Turn(id: turnID, startedAt: envelope.payload.startedAt)
-        case "task_complete", "turn_aborted":
+            currentTurn = Turn(id: turnID, startedAt: event.startedAt)
+        case .closed:
             hasLifecycleEvidence = true
             // Some rollout writers omit or rewrite the close ID. With no
             // trustworthy identity key, prefer false idle to a permanent
             // false-working indicator. When both records carry identity, a
             // present timestamp still protects a newer turn from a late close.
             if let currentTurn,
-               envelope.payload.turnID == nil
-                || currentTurn.id == envelope.payload.turnID
+               event.turnID == nil
+                || currentTurn.id == event.turnID
                 || currentTurn.startedAt != nil
-                && currentTurn.startedAt == envelope.payload.startedAt
-                || envelope.payload.startedAt == nil {
+                && currentTurn.startedAt == event.startedAt
+                || event.startedAt == nil {
                 self.currentTurn = nil
             }
-        default:
-            break
         }
     }
 }
 
+private struct CodexReverseLifecycleSearch: Sendable {
+    enum Outcome: Sendable {
+        case idle
+        case replayFrom(UInt64)
+    }
+
+    private var sawClose = false
+
+    mutating func consume(
+        event: CodexTurnLifecycleEvent,
+        recordStartOffset: UInt64
+    ) -> Outcome? {
+        switch event.kind {
+        case .closed:
+            sawClose = true
+            guard event.turnID != nil,
+                  event.startedAt != nil else { return .idle }
+            return nil
+        case .started:
+            guard event.turnID != nil else { return nil }
+            return .replayFrom(recordStartOffset)
+        }
+    }
+
+    var boundarySeed: CodexTurnLifecycleReducer.RecoverySeed {
+        sawClose ? .idle : .noEvidence
+    }
+}
+
 /// Reconstructs a Codex session's turn activity from its append-only JSONL
-/// transcript. Each path is bootstrapped from a bounded tail once, then only
-/// from the last successfully-read offset on later observations. An observation
-/// advances by a bounded amount and reports no state until it reaches the EOF
-/// captured at its start, so partially-reduced lifecycle history is never shown.
+/// transcript. A persisted session boundary is recovered by scanning backward
+/// from a fixed EOF to the newest valid start or an unconditional close. A
+/// start anchors a bounded forward replay through that same EOF so reliable
+/// closes are correlated exactly. An observation advances by a bounded amount
+/// and reports no state until both phases finish. Targets without a known
+/// durable boundary fence at current EOF rather than inferring state from an
+/// arbitrary historical window.
 /// SessionStart operations are ordered by their persisted observation generation
 /// so a delayed actor hop cannot reverse initial-attachment and boundary policy.
 actor CodexTranscriptActivityTracker {
+    enum ColdRecoveryPhase: Equatable, Sendable {
+        case reverseSearch
+        case forwardReplay
+    }
+
     struct Target: Sendable {
         let transcriptPath: String
         let worktreeID: UUID
         let terminalID: UUID?
         let sessionGeneration: Date?
+        let transcriptBoundaryOffset: Int64?
 
         init(
             transcriptPath: String,
             worktreeID: UUID,
             terminalID: UUID? = nil,
-            sessionGeneration: Date? = nil
+            sessionGeneration: Date? = nil,
+            transcriptBoundaryOffset: Int64? = nil
         ) {
             self.transcriptPath = transcriptPath
             self.worktreeID = worktreeID
             self.terminalID = terminalID
             self.sessionGeneration = sessionGeneration
+            self.transcriptBoundaryOffset = transcriptBoundaryOffset
         }
     }
 
@@ -94,11 +180,42 @@ actor CodexTranscriptActivityTracker {
     }
 
     private struct Baseline {
+        enum Policy {
+            case knownBoundary(UInt64)
+            case unknownBoundary
+        }
+
         var worktreeID: UUID
         var offset: UInt64
         var pendingFragment: Data
         var discardingCurrentLine: Bool
         var reducer: CodexTurnLifecycleReducer
+        var policy: Policy
+        var recovery: Recovery?
+    }
+
+    private enum Recovery {
+        case reverse(ReverseRecovery)
+        case forward(targetEOF: UInt64)
+
+        var targetEOF: UInt64 {
+            switch self {
+            case let .reverse(recovery): recovery.targetEOF
+            case let .forward(targetEOF): targetEOF
+            }
+        }
+    }
+
+    private struct ReverseRecovery {
+        let boundary: UInt64
+        var cursor: UInt64
+        var targetEOF: UInt64
+        var awaitingCapturedLineNewline: Bool
+        var recordSuffix: Data
+        var hasTerminatingNewline: Bool
+        var discardingRecord: Bool
+        let boundaryStartsRecord: Bool
+        var search: CodexReverseLifecycleSearch
     }
 
     private struct SessionGeneration {
@@ -112,6 +229,7 @@ actor CodexTranscriptActivityTracker {
         let observedAt: Date
         let attachment: Attachment
         let boundaryEstablished: Bool
+        let boundaryOffset: Int64?
     }
 
     private struct StepResult {
@@ -130,16 +248,16 @@ actor CodexTranscriptActivityTracker {
     // gets one bounded step before another path can consume the shared budget.
     private static let readChunkSize = 64 * 1024
     // terminal.list is a two-second polling hot path. One MiB bounds all
-    // transcript work per request while still covering ordinary rollout tails.
-    static let initialTailByteLimit: UInt64 = 1024 * 1024
-    static let incrementalReadByteLimit = initialTailByteLimit
+    // transcript work per request without imposing a historical horizon.
+    static let transcriptReadByteLimit: UInt64 = 1024 * 1024
+    static let incrementalReadByteLimit = transcriptReadByteLimit
     static let requestReadByteLimit = incrementalReadByteLimit
     // Sixteen 64 KiB steps cap zero-byte metadata work as well as byte reads,
     // so missing or truncated files cannot expand one request without bound.
     static let requestStepLimit = Int(requestReadByteLimit) / readChunkSize
     // Observed lifecycle records are tens of KiB or less; one MiB leaves broad
     // margin while preventing a malformed unterminated record from growing.
-    static let maxBufferedRecordByteCount = Int(initialTailByteLimit)
+    static let maxBufferedRecordByteCount = Int(transcriptReadByteLimit)
     private var baselines: [String: Baseline] = [:]
     private var sessionGenerations: [UUID: SessionGeneration] = [:]
     private var nextBatchPathOrder: [String] = []
@@ -147,7 +265,9 @@ actor CodexTranscriptActivityTracker {
 
     var baselineCount: Int { baselines.count }
 
-    /// Returns nil when the transcript cannot be read for this observation.
+    /// A cold, generationless observation fences at current EOF and returns nil;
+    /// later calls reduce only bytes appended after that fence. Also returns nil
+    /// when the transcript cannot be read for this observation.
     /// In particular, a cached positive state is never served as evidence that
     /// an inaccessible transcript is still active.
     func observe(transcriptPath: String, worktreeID: UUID) -> TerminalActivityState? {
@@ -168,17 +288,18 @@ actor CodexTranscriptActivityTracker {
     ) -> [String: TerminalActivityState] {
         guard totalByteLimit > 0 else { return [:] }
 
+        establishSessionBoundariesIfAbsent(transcripts: transcripts)
+
         var seenPaths: Set<String> = []
         let uniqueTargets = transcripts.filter {
             seenPaths.insert($0.transcriptPath).inserted
         }
-        let observableTargets = uniqueTargets.filter { !hasPendingBoundary(for: $0) }
-        guard !observableTargets.isEmpty else { return [:] }
+        guard !uniqueTargets.isEmpty else { return [:] }
 
         let targetsByPath = Dictionary(
-            uniqueKeysWithValues: observableTargets.map { ($0.transcriptPath, $0) })
+            uniqueKeysWithValues: uniqueTargets.map { ($0.transcriptPath, $0) })
         var knownPaths = Set(nextBatchPathOrder)
-        for target in observableTargets {
+        for target in uniqueTargets {
             batchPathWorktreeIDs[target.transcriptPath] = target.worktreeID
             if knownPaths.insert(target.transcriptPath).inserted {
                 nextBatchPathOrder.append(target.transcriptPath)
@@ -196,6 +317,16 @@ actor CodexTranscriptActivityTracker {
             if active[cursor] {
                 let target = targets[cursor]
                 remainingStepCount -= 1
+                if hasPendingBoundary(for: target) {
+                    let established = capturePendingBoundary(for: target)
+                    advanceBatchPath(target.transcriptPath)
+                    if !established {
+                        active[cursor] = false
+                        activeCount -= 1
+                    }
+                    cursor = (cursor + 1) % targets.count
+                    continue
+                }
                 let result = observeStep(
                     transcriptPath: target.transcriptPath,
                     worktreeID: target.worktreeID,
@@ -234,7 +365,7 @@ actor CodexTranscriptActivityTracker {
               let current = sessionGenerations[terminalID] else { return false }
         return current.observedAt == generation
             && current.transcriptPath == target.transcriptPath
-            && current.attachment == .boundary
+            && current.boundaryOffset == target.transcriptBoundaryOffset
             && !current.boundaryEstablished
     }
 
@@ -247,10 +378,6 @@ actor CodexTranscriptActivityTracker {
         totalByteLimit: UInt64 = requestReadByteLimit,
         now: @Sendable () -> Date
     ) -> StampedObservation {
-        // Boundary preparation and observation must share one actor turn. If a
-        // missing persisted rollout appears between separate calls, ordinary
-        // bootstrap could otherwise replay its pre-boundary lifecycle records.
-        establishSessionBoundariesIfAbsent(transcripts: transcripts)
         return StampedObservation(
             states: observe(transcripts: transcripts, totalByteLimit: totalByteLimit),
             observedAt: now()
@@ -259,63 +386,70 @@ actor CodexTranscriptActivityTracker {
 
     /// Attach the first accepted session without fencing lifecycle records the
     /// rollout wrote before its SessionStart hook reached TBD. Reuse the
-    /// ordinary bounded observation path so an existing baseline survives and
-    /// an absent baseline gets the same tail bootstrap as terminal.list.
+    /// durable boundary path so recovery can continue across bounded polls.
     func adoptInitialSession(
         transcriptPath: String,
         worktreeID: UUID,
         terminalID: UUID,
-        generation: Date
+        generation: Date,
+        boundaryOffset: Int64 = 0
     ) {
+        guard boundaryOffset == 0 else { return }
         if let current = sessionGenerations[terminalID] {
             guard current.observedAt <= generation else { return }
             if current.observedAt == generation {
                 guard current.attachment == .boundary else {
-                    _ = observe(transcriptPath: transcriptPath, worktreeID: worktreeID)
                     return
                 }
-                // A list raced the handler after persistence and reconstructed
-                // this same generation as a restart boundary. Initial-session
-                // knowledge is more specific, so discard that EOF baseline and
-                // perform the ordinary bounded bootstrap below.
+                if current.boundaryOffset == 0 {
+                    sessionGenerations[terminalID] = SessionGeneration(
+                        worktreeID: worktreeID,
+                        transcriptPath: transcriptPath,
+                        observedAt: generation,
+                        attachment: .initial,
+                        boundaryEstablished: current.boundaryEstablished,
+                        boundaryOffset: 0)
+                    return
+                }
                 baselines.removeValue(forKey: current.transcriptPath)
             } else {
                 baselines.removeValue(forKey: current.transcriptPath)
             }
         }
+        let established = captureSessionBoundary(
+            transcriptPath: transcriptPath,
+            worktreeID: worktreeID,
+            boundaryOffset: 0)
         sessionGenerations[terminalID] = SessionGeneration(
             worktreeID: worktreeID,
             transcriptPath: transcriptPath,
             observedAt: generation,
             attachment: .initial,
-            boundaryEstablished: false)
-        _ = observe(transcriptPath: transcriptPath, worktreeID: worktreeID)
+            boundaryEstablished: established,
+            boundaryOffset: 0)
     }
 
-    /// Establish a lifecycle boundary for an accepted SessionStart without
-    /// re-reading history before that event. This matters when Codex reuses the
-    /// same transcript path after an interrupted turn: an unmatched historical
-    /// `task_started` must not become current-session working evidence again.
-    /// Bytes appended after the captured EOF are reduced normally, so the next
-    /// genuine turn supersedes the boundary. A missing file leaves a pending
-    /// boundary that terminal.list retries without replaying history.
+    /// Attach the exact durable offset returned by the SessionStart writer.
+    /// A persisted nil remains unknown and cold-fences current EOF until a
+    /// later accepted generation supplies an exact offset.
     func establishSessionBoundary(
         transcriptPath: String,
         worktreeID: UUID,
         terminalID: UUID,
-        generation: Date
+        generation: Date,
+        boundaryOffset: Int64?
     ) {
         applySessionBoundary(
             transcriptPath: transcriptPath,
             worktreeID: worktreeID,
             terminalID: terminalID,
-            generation: generation)
+            generation: generation,
+            boundaryOffset: boundaryOffset)
     }
 
-    /// Reconstruct the boundary from a persisted SessionStart generation after
-    /// daemon restart. An established boundary or live initial attachment wins
-    /// at the same generation; an unavailable pending boundary is retried until
-    /// it can capture EOF. Later generations always replace older actor state.
+    /// Reconstruct the exact persisted SessionStart target after daemon restart.
+    /// An unavailable boundary is retried until its path can be fenced. Later
+    /// generations always replace older actor state.
     func establishSessionBoundariesIfAbsent(transcripts: [Target]) {
         for transcript in transcripts {
             guard let terminalID = transcript.terminalID,
@@ -324,7 +458,9 @@ actor CodexTranscriptActivityTracker {
                 transcriptPath: transcript.transcriptPath,
                 worktreeID: transcript.worktreeID,
                 terminalID: terminalID,
-                generation: generation)
+                generation: generation,
+                boundaryOffset: transcript.transcriptBoundaryOffset,
+                captureImmediately: false)
         }
     }
 
@@ -332,50 +468,114 @@ actor CodexTranscriptActivityTracker {
         transcriptPath: String,
         worktreeID: UUID,
         terminalID: UUID,
-        generation: Date
+        generation: Date,
+        boundaryOffset: Int64?,
+        captureImmediately: Bool = true
     ) {
         if let current = sessionGenerations[terminalID] {
             guard current.observedAt <= generation else { return }
             if current.observedAt == generation {
-                guard current.attachment == .boundary,
-                      !current.boundaryEstablished else { return }
+                if current.boundaryOffset == boundaryOffset {
+                    if current.boundaryEstablished || !captureImmediately {
+                        return
+                    }
+                }
+                // A terminal-list reconstruction is provisional. The
+                // SessionStart writer's exact offset is authoritative even if
+                // the provisional nil-boundary fence reached current EOF.
+                baselines.removeValue(forKey: current.transcriptPath)
             } else {
                 baselines.removeValue(forKey: current.transcriptPath)
             }
         }
+        guard captureImmediately else {
+            baselines.removeValue(forKey: transcriptPath)
+            sessionGenerations[terminalID] = SessionGeneration(
+                worktreeID: worktreeID,
+                transcriptPath: transcriptPath,
+                observedAt: generation,
+                attachment: .boundary,
+                boundaryEstablished: false,
+                boundaryOffset: boundaryOffset)
+            return
+        }
         let established = captureSessionBoundary(
             transcriptPath: transcriptPath,
-            worktreeID: worktreeID)
+            worktreeID: worktreeID,
+            boundaryOffset: boundaryOffset)
         sessionGenerations[terminalID] = SessionGeneration(
             worktreeID: worktreeID,
             transcriptPath: transcriptPath,
             observedAt: generation,
             attachment: .boundary,
-            boundaryEstablished: established)
+            boundaryEstablished: established,
+            boundaryOffset: boundaryOffset)
+    }
+
+    private func capturePendingBoundary(for target: Target) -> Bool {
+        guard let terminalID = target.terminalID,
+              let generation = target.sessionGeneration,
+              let current = sessionGenerations[terminalID],
+              current.observedAt == generation,
+              current.transcriptPath == target.transcriptPath,
+              current.boundaryOffset == target.transcriptBoundaryOffset,
+              !current.boundaryEstablished else { return true }
+        let established = captureSessionBoundary(
+            transcriptPath: target.transcriptPath,
+            worktreeID: target.worktreeID,
+            boundaryOffset: current.boundaryOffset)
+        sessionGenerations[terminalID] = SessionGeneration(
+            worktreeID: target.worktreeID,
+            transcriptPath: target.transcriptPath,
+            observedAt: generation,
+            attachment: current.attachment,
+            boundaryEstablished: established,
+            boundaryOffset: current.boundaryOffset)
+        return established
     }
 
     @discardableResult
     private func captureSessionBoundary(
         transcriptPath: String,
-        worktreeID: UUID
+        worktreeID: UUID,
+        boundaryOffset: Int64?
     ) -> Bool {
         batchPathWorktreeIDs[transcriptPath] = worktreeID
         do {
             let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: transcriptPath))
             defer { try? handle.close() }
             let fileSize = try handle.seekToEnd()
-            var discardingCurrentLine = false
-            if fileSize > 0 {
-                try handle.seek(toOffset: fileSize - 1)
-                let lastByte = try handle.read(upToCount: 1)?.first
-                discardingCurrentLine = lastByte != 0x0A
+            switch boundaryOffset {
+            case nil:
+                baselines[transcriptPath] = try makeFenceBaseline(
+                    handle: handle,
+                    offset: fileSize,
+                    worktreeID: worktreeID,
+                    policy: .unknownBoundary)
+            case let boundaryOffset?:
+                guard boundaryOffset >= 0 else {
+                    baselines[transcriptPath] = try makeFenceBaseline(
+                        handle: handle,
+                        offset: fileSize,
+                        worktreeID: worktreeID,
+                        policy: .unknownBoundary)
+                    return true
+                }
+                let boundary = UInt64(boundaryOffset)
+                if boundary <= fileSize {
+                    baselines[transcriptPath] = try makeRecoveryBaseline(
+                        handle: handle,
+                        boundary: boundary,
+                        recoveryTargetEOF: fileSize,
+                        worktreeID: worktreeID)
+                } else {
+                    baselines[transcriptPath] = try makeFenceBaseline(
+                        handle: handle,
+                        offset: fileSize,
+                        worktreeID: worktreeID,
+                        policy: .knownBoundary(boundary))
+                }
             }
-            baselines[transcriptPath] = Baseline(
-                worktreeID: worktreeID,
-                offset: fileSize,
-                pendingFragment: Data(),
-                discardingCurrentLine: discardingCurrentLine,
-                reducer: CodexTurnLifecycleReducer())
             return true
         } catch {
             // Never retain positive evidence across a session boundary when
@@ -409,32 +609,67 @@ actor CodexTranscriptActivityTracker {
 
             let fileSize = try handle.seekToEnd()
             var baseline: Baseline
-            if let previous, fileSize >= previous.offset {
+            if let previous,
+               fileSize >= previous.offset,
+               previous.recovery.map({ fileSize >= $0.targetEOF }) ?? true {
                 baseline = previous
                 baseline.worktreeID = worktreeID
+            } else if let previous {
+                baseline = try resetBaselineAfterShrink(
+                    previous, handle: handle, fileSize: fileSize, worktreeID: worktreeID)
             } else {
-                let prepared = try makeTailBaseline(
+                baseline = try makeFenceBaseline(
                     handle: handle,
-                    fileSize: fileSize,
-                    worktreeID: worktreeID)
-                baseline = prepared.baseline
-                bytesRead = prepared.bytesRead
+                    offset: fileSize,
+                    worktreeID: worktreeID,
+                    policy: .unknownBoundary)
+            }
+
+            let wasRecovering = baseline.recovery != nil
+            while let recovery = baseline.recovery, bytesRead < byteLimit {
+                let bytesReadBeforePhase = bytesRead
+                switch recovery {
+                case .reverse:
+                    try readReverseRecoveryBytes(
+                        handle: handle,
+                        fileSize: fileSize,
+                        byteLimit: byteLimit - bytesRead,
+                        baseline: &baseline,
+                        bytesRead: &bytesRead)
+                case .forward:
+                    try readForwardRecoveryBytes(
+                        handle: handle,
+                        byteLimit: byteLimit - bytesRead,
+                        baseline: &baseline,
+                        bytesRead: &bytesRead)
+                }
+
+                if bytesRead == bytesReadBeforePhase,
+                   baseline.recovery != nil {
+                    break
+                }
+            }
+
+            if baseline.recovery != nil {
+                baselines[transcriptPath] = baseline
+                return StepResult(state: nil, bytesRead: bytesRead, status: .behind)
+            }
+
+            if wasRecovering {
+                baselines[transcriptPath] = baseline
+                return StepResult(
+                    state: baseline.reducer.activityState,
+                    bytesRead: bytesRead,
+                    status: .caughtUp)
             }
 
             let unreadByteCount = fileSize - baseline.offset
             let readByteCount = min(unreadByteCount, byteLimit - bytesRead)
-            let observationEndOffset = baseline.offset + readByteCount
-            try handle.seek(toOffset: baseline.offset)
-            while baseline.offset < observationEndOffset {
-                let remaining = observationEndOffset - baseline.offset
-                let count = Int(min(UInt64(Self.readChunkSize), remaining))
-                guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else {
-                    return StepResult(state: nil, bytesRead: bytesRead, status: .unavailable)
-                }
-                baseline.offset += UInt64(chunk.count)
-                bytesRead += UInt64(chunk.count)
-                consumeCompleteLines(from: chunk, into: &baseline)
-            }
+            try readBytes(
+                handle: handle,
+                count: readByteCount,
+                baseline: &baseline,
+                bytesRead: &bytesRead)
 
             baselines[transcriptPath] = baseline
             guard baseline.offset == fileSize else {
@@ -493,32 +728,345 @@ actor CodexTranscriptActivityTracker {
         return (baseline.pendingFragment.count, baseline.discardingCurrentLine)
     }
 
-    private func makeTailBaseline(
+    func coldRecoveryPhase(transcriptPath: String) -> ColdRecoveryPhase? {
+        guard let recovery = baselines[transcriptPath]?.recovery else { return nil }
+        switch recovery {
+        case .reverse: return .reverseSearch
+        case .forward: return .forwardReplay
+        }
+    }
+
+    private func makeRecoveryBaseline(
+        handle: FileHandle,
+        boundary: UInt64,
+        recoveryTargetEOF: UInt64,
+        worktreeID: UUID
+    ) throws -> Baseline {
+        var baseline = try makeFenceBaseline(
+            handle: handle,
+            offset: boundary,
+            worktreeID: worktreeID,
+            policy: .knownBoundary(boundary))
+        let targetNeedsNewline: Bool
+        if recoveryTargetEOF == 0 {
+            targetNeedsNewline = false
+        } else {
+            try handle.seek(toOffset: recoveryTargetEOF - 1)
+            guard let byte = try handle.read(upToCount: 1)?.first else {
+                throw CocoaError(.fileReadUnknown)
+            }
+            targetNeedsNewline = byte != 0x0A
+        }
+        if boundary != recoveryTargetEOF || targetNeedsNewline {
+            let boundaryStartsRecord: Bool
+            if boundary == 0 {
+                boundaryStartsRecord = true
+            } else {
+                try handle.seek(toOffset: boundary - 1)
+                guard let byte = try handle.read(upToCount: 1)?.first else {
+                    throw CocoaError(.fileReadUnknown)
+                }
+                boundaryStartsRecord = byte == 0x0A
+            }
+            baseline.offset = recoveryTargetEOF
+            baseline.pendingFragment.removeAll(keepingCapacity: false)
+            baseline.recovery = .reverse(ReverseRecovery(
+                boundary: boundary,
+                cursor: recoveryTargetEOF,
+                targetEOF: recoveryTargetEOF,
+                awaitingCapturedLineNewline: targetNeedsNewline,
+                recordSuffix: Data(),
+                hasTerminatingNewline: false,
+                discardingRecord: false,
+                boundaryStartsRecord: boundaryStartsRecord,
+                search: CodexReverseLifecycleSearch()))
+            baseline.discardingCurrentLine = false
+        }
+        return baseline
+    }
+
+    private func makeFenceBaseline(
+        handle: FileHandle,
+        offset: UInt64,
+        worktreeID: UUID,
+        policy: Baseline.Policy
+    ) throws -> Baseline {
+        var discardingCurrentLine = false
+        if offset > 0 {
+            try handle.seek(toOffset: offset - 1)
+            guard let lastByte = try handle.read(upToCount: 1)?.first else {
+                throw CocoaError(.fileReadUnknown)
+            }
+            discardingCurrentLine = lastByte != 0x0A
+        }
+        return Baseline(
+            worktreeID: worktreeID,
+            offset: offset,
+            pendingFragment: Data(),
+            discardingCurrentLine: discardingCurrentLine,
+            reducer: CodexTurnLifecycleReducer(),
+            policy: policy,
+            recovery: nil)
+    }
+
+    private func resetBaselineAfterShrink(
+        _ previous: Baseline,
         handle: FileHandle,
         fileSize: UInt64,
         worktreeID: UUID
-    ) throws -> (baseline: Baseline, bytesRead: UInt64) {
-        let startOffset = fileSize > Self.initialTailByteLimit
-            ? fileSize - Self.initialTailByteLimit
-            : 0
-        var discardingCurrentLine = false
-        var bytesRead: UInt64 = 0
+    ) throws -> Baseline {
+        switch previous.policy {
+        case .knownBoundary(0):
+            return try makeRecoveryBaseline(
+                handle: handle,
+                boundary: 0,
+                recoveryTargetEOF: fileSize,
+                worktreeID: worktreeID)
+        case let .knownBoundary(boundary):
+            guard fileSize >= boundary else {
+                return try makeFenceBaseline(
+                    handle: handle,
+                    offset: fileSize,
+                    worktreeID: worktreeID,
+                    policy: .knownBoundary(boundary))
+            }
+            return try makeRecoveryBaseline(
+                handle: handle,
+                boundary: boundary,
+                recoveryTargetEOF: fileSize,
+                worktreeID: worktreeID)
+        case .unknownBoundary:
+            return try makeFenceBaseline(
+                handle: handle,
+                offset: fileSize,
+                worktreeID: worktreeID,
+                policy: .unknownBoundary)
+        }
+    }
 
-        if startOffset > 0 {
-            try handle.seek(toOffset: startOffset - 1)
-            let precedingByte = try handle.read(upToCount: 1)?.first
-            bytesRead = precedingByte == nil ? 0 : 1
-            discardingCurrentLine = precedingByte != 0x0A
+    private func readReverseRecoveryBytes(
+        handle: FileHandle,
+        fileSize: UInt64,
+        byteLimit: UInt64,
+        baseline: inout Baseline,
+        bytesRead: inout UInt64
+    ) throws {
+        var remainingBudget = byteLimit
+        guard case var .reverse(recovery) = baseline.recovery else { return }
+
+        if recovery.awaitingCapturedLineNewline, remainingBudget > 0 {
+            try handle.seek(toOffset: baseline.offset)
+            let available = min(fileSize - baseline.offset, remainingBudget)
+            let count = Int(min(UInt64(Self.readChunkSize), available))
+            guard count > 0 else {
+                baseline.recovery = .reverse(recovery)
+                return
+            }
+            guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else {
+                throw CocoaError(.fileReadUnknown)
+            }
+            let consumedCount: Int
+            if let newline = chunk.firstIndex(of: 0x0A) {
+                consumedCount = chunk.distance(from: chunk.startIndex, to: newline) + 1
+                recovery.awaitingCapturedLineNewline = false
+            } else {
+                consumedCount = chunk.count
+            }
+            baseline.offset += UInt64(consumedCount)
+            recovery.targetEOF = baseline.offset
+            recovery.cursor = baseline.offset
+            bytesRead += UInt64(chunk.count)
+            remainingBudget -= UInt64(chunk.count)
         }
 
-        return (
-            Baseline(
-                worktreeID: worktreeID,
-                offset: startOffset,
-                pendingFragment: Data(),
-                discardingCurrentLine: discardingCurrentLine,
-                reducer: CodexTurnLifecycleReducer()),
-            bytesRead)
+        guard !recovery.awaitingCapturedLineNewline else {
+            baseline.recovery = .reverse(recovery)
+            return
+        }
+
+        while recovery.cursor > recovery.boundary, remainingBudget > 0 {
+            let count = min(
+                recovery.cursor - recovery.boundary,
+                min(UInt64(Self.readChunkSize), remainingBudget))
+            let start = recovery.cursor - count
+            try handle.seek(toOffset: start)
+            guard let chunk = try handle.read(upToCount: Int(count)),
+                  chunk.count == Int(count) else {
+                throw CocoaError(.fileReadUnknown)
+            }
+            recovery.cursor = start
+            bytesRead += count
+            remainingBudget -= count
+
+            if let outcome = consumeBackward(
+                chunk: chunk, chunkStartOffset: start, recovery: &recovery
+            ) {
+                applyReverseSearchOutcome(
+                    outcome, recovery: recovery, baseline: &baseline)
+                return
+            }
+        }
+
+        if recovery.cursor == recovery.boundary {
+            if recovery.boundaryStartsRecord,
+               let outcome = finishBoundaryRecord(recovery: &recovery) {
+                applyReverseSearchOutcome(
+                    outcome, recovery: recovery, baseline: &baseline)
+                return
+            }
+            finishReverseRecovery(
+                seed: recovery.search.boundarySeed,
+                recovery: recovery,
+                baseline: &baseline)
+            return
+        }
+
+        baseline.recovery = .reverse(recovery)
+    }
+
+    private func consumeBackward(
+        chunk: Data,
+        chunkStartOffset: UInt64,
+        recovery: inout ReverseRecovery
+    ) -> CodexReverseLifecycleSearch.Outcome? {
+        var scanEnd = chunk.endIndex
+
+        while scanEnd > chunk.startIndex,
+              let newline = chunk[chunk.startIndex..<scanEnd].lastIndex(of: 0x0A) {
+            let segmentStart = chunk.index(after: newline)
+            if recovery.hasTerminatingNewline {
+                prependBackwardSegment(
+                    chunk[segmentStart..<scanEnd], recovery: &recovery)
+                let recordStartOffset = chunkStartOffset
+                    + UInt64(chunk.distance(from: chunk.startIndex, to: segmentStart))
+                if let outcome = finishBackwardRecord(
+                    recordStartOffset: recordStartOffset,
+                    recovery: &recovery
+                ) {
+                    return outcome
+                }
+            } else {
+                recovery.hasTerminatingNewline = true
+            }
+            scanEnd = newline
+        }
+
+        if scanEnd > chunk.startIndex, recovery.hasTerminatingNewline {
+            prependBackwardSegment(chunk[chunk.startIndex..<scanEnd], recovery: &recovery)
+        }
+        return nil
+    }
+
+    private func prependBackwardSegment(
+        _ segment: Data.SubSequence,
+        recovery: inout ReverseRecovery
+    ) {
+        guard !recovery.discardingRecord else { return }
+        guard segment.count
+                <= Self.maxBufferedRecordByteCount - recovery.recordSuffix.count else {
+            recovery.recordSuffix.removeAll(keepingCapacity: false)
+            recovery.discardingRecord = true
+            return
+        }
+        guard !segment.isEmpty else { return }
+        var record = Data(capacity: segment.count + recovery.recordSuffix.count)
+        record.append(contentsOf: segment)
+        record.append(recovery.recordSuffix)
+        recovery.recordSuffix = record
+    }
+
+    private func finishBackwardRecord(
+        recordStartOffset: UInt64,
+        recovery: inout ReverseRecovery
+    ) -> CodexReverseLifecycleSearch.Outcome? {
+        defer {
+            recovery.recordSuffix.removeAll(keepingCapacity: false)
+            recovery.discardingRecord = false
+        }
+        guard !recovery.discardingRecord,
+              let event = CodexTurnLifecycleEvent.decode(line: recovery.recordSuffix) else {
+            return nil
+        }
+        return recovery.search.consume(
+            event: event,
+            recordStartOffset: recordStartOffset)
+    }
+
+    private func finishBoundaryRecord(
+        recovery: inout ReverseRecovery
+    ) -> CodexReverseLifecycleSearch.Outcome? {
+        guard recovery.hasTerminatingNewline else { return nil }
+        return finishBackwardRecord(
+            recordStartOffset: recovery.boundary,
+            recovery: &recovery)
+    }
+
+    private func applyReverseSearchOutcome(
+        _ outcome: CodexReverseLifecycleSearch.Outcome,
+        recovery: ReverseRecovery,
+        baseline: inout Baseline
+    ) {
+        switch outcome {
+        case .idle:
+            finishReverseRecovery(seed: .idle, recovery: recovery, baseline: &baseline)
+        case let .replayFrom(offset):
+            baseline.offset = offset
+            baseline.pendingFragment.removeAll(keepingCapacity: false)
+            baseline.discardingCurrentLine = false
+            baseline.reducer = CodexTurnLifecycleReducer()
+            baseline.recovery = .forward(targetEOF: recovery.targetEOF)
+        }
+    }
+
+    private func finishReverseRecovery(
+        seed: CodexTurnLifecycleReducer.RecoverySeed,
+        recovery: ReverseRecovery,
+        baseline: inout Baseline
+    ) {
+        baseline.offset = recovery.targetEOF
+        baseline.pendingFragment.removeAll(keepingCapacity: false)
+        baseline.discardingCurrentLine = false
+        baseline.reducer = CodexTurnLifecycleReducer(recoverySeed: seed)
+        baseline.recovery = nil
+    }
+
+    private func readForwardRecoveryBytes(
+        handle: FileHandle,
+        byteLimit: UInt64,
+        baseline: inout Baseline,
+        bytesRead: inout UInt64
+    ) throws {
+        guard case let .forward(targetEOF) = baseline.recovery else { return }
+        let count = min(targetEOF - baseline.offset, byteLimit)
+        try readBytes(
+            handle: handle,
+            count: count,
+            baseline: &baseline,
+            bytesRead: &bytesRead)
+        guard baseline.offset == targetEOF,
+              baseline.pendingFragment.isEmpty,
+              !baseline.discardingCurrentLine else { return }
+        baseline.recovery = nil
+    }
+
+    private func readBytes(
+        handle: FileHandle,
+        count: UInt64,
+        baseline: inout Baseline,
+        bytesRead: inout UInt64
+    ) throws {
+        let observationEndOffset = baseline.offset + count
+        try handle.seek(toOffset: baseline.offset)
+        while baseline.offset < observationEndOffset {
+            let remaining = observationEndOffset - baseline.offset
+            let readCount = Int(min(UInt64(Self.readChunkSize), remaining))
+            guard let chunk = try handle.read(upToCount: readCount), !chunk.isEmpty else {
+                throw CocoaError(.fileReadUnknown)
+            }
+            baseline.offset += UInt64(chunk.count)
+            bytesRead += UInt64(chunk.count)
+            consumeCompleteLines(from: chunk, into: &baseline)
+        }
     }
 
     private func consumeCompleteLines(from chunk: Data, into baseline: inout Baseline) {

--- a/Sources/TBDDaemon/Database/Migrations/20260825024814_codex_transcript_boundary.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260825024814_codex_transcript_boundary.sql
@@ -1,0 +1,1 @@
+ALTER TABLE terminal ADD COLUMN codexTranscriptBoundaryOffset INTEGER;

--- a/Sources/TBDDaemon/Database/Migrations/20260825060216_terminal_session_incarnation.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260825060216_terminal_session_incarnation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE terminal ADD COLUMN sessionIncarnationID TEXT;

--- a/Sources/TBDDaemon/Database/Migrations/20260829210843_pending_terminal_incarnation.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260829210843_pending_terminal_incarnation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE terminal ADD COLUMN pendingSessionIncarnationID TEXT;

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -34,6 +34,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var profile_id: String?
     var transcriptPath: String?
     var sessionOrderObservedAt: Date?
+    var codexTranscriptBoundaryOffset: Int64?
+    var sessionIncarnationID: String?
     var kind: String?
     var activityState: String?
     var hibernatedAt: Date?
@@ -66,6 +68,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.profile_id = terminal.profileID?.uuidString
         self.transcriptPath = terminal.transcriptPath
         self.sessionOrderObservedAt = terminal.sessionOrderObservedAt
+        self.codexTranscriptBoundaryOffset = terminal.codexTranscriptBoundaryOffset
+        self.sessionIncarnationID = terminal.sessionIncarnationID?.uuidString
         self.kind = terminal.kind?.rawValue
         self.activityState = terminal.activityState.rawValue
         self.hibernatedAt = terminal.hibernatedAt
@@ -106,6 +110,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             profileID: profile_id.flatMap(UUID.init(uuidString:)),
             transcriptPath: transcriptPath,
             sessionOrderObservedAt: sessionOrderObservedAt,
+            codexTranscriptBoundaryOffset: codexTranscriptBoundaryOffset,
+            sessionIncarnationID: sessionIncarnationID.flatMap(UUID.init(uuidString:)),
             kind: kind.flatMap(TerminalKind.init(rawValue:)),
             activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown,
             hibernatedAt: hibernatedAt,
@@ -182,6 +188,7 @@ struct AppliedTerminalSessionStart: Sendable {
     let sessionID: String
     let transcriptPath: String?
     let orderObservedAt: Date?
+    let transcriptBoundaryOffset: Int64?
     let isInitialAttachment: Bool
     let activityObservation: AppliedTerminalActivityObservation?
     /// True when applying this SessionStart retracted a standing awaiting-input
@@ -189,6 +196,189 @@ struct AppliedTerminalSessionStart: Sendable {
     /// Claude/shell branch retracts one while returning no activity observation
     /// at all — a retraction read off that field alone would be missed there.
     let clearedAwaitingInput: Bool
+}
+
+struct ObservedTranscriptBoundary: Sendable {
+    let path: String
+    let eof: Int64
+}
+
+/// The durable process incarnation and launch-owned coordinates observed
+/// before a SessionStart handler suspends. The nonce is authoritative across
+/// tmux ABA reuse; coordinates and label remain additional rejection rails.
+struct TerminalSessionIncarnation: Sendable {
+    let tmuxWindowID: String
+    let tmuxPaneID: String
+    let label: String?
+    let sessionIncarnationID: UUID?
+
+    init(terminal: Terminal) {
+        self.tmuxWindowID = terminal.tmuxWindowID
+        self.tmuxPaneID = terminal.tmuxPaneID
+        self.label = terminal.label
+        self.sessionIncarnationID = terminal.sessionIncarnationID
+    }
+
+    fileprivate init(record: TerminalRecord) {
+        self.tmuxWindowID = record.tmuxWindowID
+        self.tmuxPaneID = record.tmuxPaneID
+        self.label = record.label
+        self.sessionIncarnationID = record.sessionIncarnationID.flatMap(UUID.init(uuidString:))
+    }
+
+    fileprivate func matches(_ record: TerminalRecord) -> Bool {
+        record.tmuxWindowID == tmuxWindowID
+            && record.tmuxPaneID == tmuxPaneID
+            && record.label == label
+            && record.sessionIncarnationID == sessionIncarnationID?.uuidString
+    }
+
+    func matches(_ terminal: Terminal) -> Bool {
+        terminal.tmuxWindowID == tmuxWindowID
+            && terminal.tmuxPaneID == tmuxPaneID
+            && terminal.label == label
+            && terminal.sessionIncarnationID == sessionIncarnationID
+    }
+}
+
+/// The launch-relevant terminal state observed before an operation suspends.
+/// Process replacement callers compare this inside the writer transaction so
+/// a command prepared for one session/profile/park state cannot commit against
+/// another. Activity facts are deliberately excluded: hooks from the same
+/// process may advance them without changing which process a replacement owns.
+struct TerminalReplacementSnapshot: Sendable {
+    let incarnation: TerminalSessionIncarnation
+    let worktreeID: UUID
+    let kind: TerminalKind?
+    let claudeSessionID: String?
+    let transcriptPath: String?
+    let profileID: UUID?
+    let suspendedAt: Date?
+    let hibernatedAt: Date?
+
+    init(terminal: Terminal) {
+        incarnation = TerminalSessionIncarnation(terminal: terminal)
+        worktreeID = terminal.worktreeID
+        kind = terminal.kind
+        claudeSessionID = terminal.claudeSessionID
+        transcriptPath = terminal.transcriptPath
+        profileID = terminal.profileID
+        suspendedAt = terminal.suspendedAt
+        hibernatedAt = terminal.hibernatedAt
+    }
+
+    fileprivate func matches(_ record: TerminalRecord) -> Bool {
+        incarnation.matches(record)
+            && record.worktreeID == worktreeID.uuidString
+            && record.kind == kind?.rawValue
+            && record.claudeSessionID == claudeSessionID
+            && record.transcriptPath == transcriptPath
+            && record.profile_id == profileID?.uuidString
+            && record.suspendedAt == suspendedAt
+            && record.hibernatedAt == hibernatedAt
+    }
+
+    func matches(_ terminal: Terminal) -> Bool {
+        incarnation.matches(terminal)
+            && terminal.worktreeID == worktreeID
+            && terminal.kind == kind
+            && terminal.claudeSessionID == claudeSessionID
+            && terminal.transcriptPath == transcriptPath
+            && terminal.profileID == profileID
+            && terminal.suspendedAt == suspendedAt
+            && terminal.hibernatedAt == hibernatedAt
+    }
+}
+
+/// The complete safety state that authorizes hibernating a live process.
+/// Unlike general replacement snapshots, this includes the activity and
+/// keep-warm rails so a hook or preference change between the final read and
+/// the park transaction rejects without writing.
+struct TerminalHibernationSnapshot: Sendable {
+    let replacement: TerminalReplacementSnapshot
+    let keepWarm: Bool
+    let activityState: TerminalActivityState
+    let activityStateSource: FactSource?
+    let activityStateObservedAt: Date?
+    let activityStateOrderObservedAt: Date?
+    let awaitingInputReason: AwaitingInputReason?
+    let awaitingInputObservedAt: Date?
+
+    init(terminal: Terminal) {
+        replacement = TerminalReplacementSnapshot(terminal: terminal)
+        keepWarm = terminal.keepWarm
+        activityState = terminal.activityState
+        activityStateSource = terminal.activityStateSource
+        activityStateObservedAt = terminal.activityStateObservedAt
+        activityStateOrderObservedAt = terminal.activityStateOrderObservedAt
+        awaitingInputReason = terminal.awaitingInputReason
+        awaitingInputObservedAt = terminal.awaitingInputObservedAt
+    }
+
+    fileprivate func matches(_ record: TerminalRecord) -> Bool {
+        replacement.matches(record)
+            && (record.keepWarm ?? false) == keepWarm
+            && record.activityState == activityState.rawValue
+            && record.activityStateSource == FactColumnJSON.encode(activityStateSource)
+            && record.activityStateObservedAt == activityStateObservedAt
+            && record.activityStateOrderObservedAt == activityStateOrderObservedAt
+            && record.awaitingInputReason == FactColumnJSON.encode(awaitingInputReason)
+            && record.awaitingInputObservedAt == awaitingInputObservedAt
+    }
+
+    func matchesActivity(_ terminal: Terminal) -> Bool {
+        terminal.activityState == activityState
+            && terminal.activityStateSource == activityStateSource
+            && terminal.activityStateObservedAt == activityStateObservedAt
+            && terminal.activityStateOrderObservedAt == activityStateOrderObservedAt
+            && terminal.awaitingInputReason == awaitingInputReason
+            && terminal.awaitingInputObservedAt == awaitingInputObservedAt
+    }
+}
+
+private enum HibernatedTranscriptPathUpdate {
+    case preserve
+    case replace(String?)
+}
+
+@discardableResult
+private func resetAgentProcessLifecycle(
+    record: inout TerminalRecord,
+    sessionID: String?,
+    transcriptPath: String?,
+    at date: Date
+) -> UUID {
+    let incarnationID = UUID()
+    record.claudeSessionID = sessionID
+    record.transcriptPath = transcriptPath
+    record.sessionOrderObservedAt = nil
+    record.codexTranscriptBoundaryOffset = nil
+    record.sessionIncarnationID = incarnationID.uuidString
+    record.activityState = TerminalActivityState.unknown.rawValue
+    record.activityStateSource = FactColumnJSON.encode(FactSource.derived)
+    record.activityStateObservedAt = date
+    record.activityStateOrderObservedAt = date
+    record.awaitingInputReason = nil
+    record.awaitingInputObservedAt = nil
+    return incarnationID
+}
+
+private func resetRecreatedShellLifecycle(
+    record: inout TerminalRecord,
+    at date: Date
+) -> UUID {
+    let incarnationID = resetAgentProcessLifecycle(
+        record: &record,
+        sessionID: nil,
+        transcriptPath: nil,
+        at: date)
+    record.suspendedAt = nil
+    record.suspendedSnapshot = nil
+    record.hibernatedAt = nil
+    record.hibernateReason = nil
+    record.label = TerminalLabel.shell
+    record.kind = TerminalKind.shell.rawValue
+    return incarnationID
 }
 
 private func preservesStoredActivityAtEqualOrder(
@@ -417,27 +607,58 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Update the Claude session ID for a terminal.
+    /// Replace a terminal session identity without an ordered SessionStart.
+    /// Any Codex boundary belongs to the replaced process and is cleared in the
+    /// same write; Claude terminals have no boundary, so their behavior is
+    /// unchanged.
     public func updateSessionID(id: UUID, sessionID: String) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
+            record.codexTranscriptBoundaryOffset = nil
             try record.update(db)
         }
     }
 
-    /// Update the Claude session ID and the absolute JSONL transcript path for
-    /// a terminal in one write. Direct lifecycle callers use this when they do
-    /// not have a SessionStart observation to order; the hook bridge uses
-    /// `applySessionStart` below.
+    /// Persist a same-process session recapture only while the process token
+    /// observed before capture still names the current terminal incarnation.
+    /// A replacement that lands during the detector await wins atomically.
+    @discardableResult
+    func updateSessionIDIfIncarnationMatches(
+        id: UUID,
+        expectedIncarnationID: UUID?,
+        sessionID: String
+    ) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard record.sessionIncarnationID == expectedIncarnationID?.uuidString else {
+                return false
+            }
+            record.claudeSessionID = sessionID
+            record.codexTranscriptBoundaryOffset = nil
+            try record.update(db)
+            return true
+        }
+    }
+
+    /// Update the session ID and absolute JSONL transcript path in one write.
+    /// Direct lifecycle callers use this when they do not have a SessionStart
+    /// observation to order, so the same write clears any Codex boundary. The
+    /// hook bridge uses `applySessionStart` below to establish one instead.
     public func updateSession(id: UUID, sessionID: String, transcriptPath: String?) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
+            // This writer has no ordered SessionStart observation with which
+            // to choose a safe lifecycle fence. A replacement identity must
+            // not inherit the prior Codex process's durable boundary.
+            record.codexTranscriptBoundaryOffset = nil
             // Only overwrite when the caller supplied a path. A SessionStart
             // payload that omits `transcript_path` (theoretical — Claude
             // currently always sends it) shouldn't clobber a previously
@@ -464,16 +685,30 @@ public struct TerminalStore: Sendable {
     /// idempotent no-op and therefore cannot move a transcript boundary. The
     /// same transaction classifies an initial attachment from the complete
     /// prior session history so callers never decide from a stale row snapshot.
+    /// A handler's durable incarnation snapshot must still match, preventing
+    /// a delayed hook from attaching to a recreated terminal even when tmux
+    /// reuses the same launch coordinates.
     func applySessionStart(
         id: UUID,
+        expectedIncarnation: TerminalSessionIncarnation,
+        reportedIncarnationID: UUID? = nil,
         sessionID: String,
         transcriptPath: String?,
+        observedTranscriptBoundary: ObservedTranscriptBoundary? = nil,
         observedAt: Date
     ) async throws -> AppliedTerminalSessionStart? {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
+            // Legacy terminals have never had a managed replacement and carry
+            // no process token on either side. Once TBD rotates a row to a
+            // durable token, every replacement-process SessionStart must echo
+            // that exact value; nil and mismatches are stale by construction.
+            guard record.sessionIncarnationID == reportedIncarnationID?.uuidString else {
+                return nil
+            }
+            guard expectedIncarnation.matches(record) else { return nil }
             let isCodex = record.kind == TerminalKind.codex.rawValue
                 || record.label == TerminalLabel.codex
             guard isCodex else {
@@ -495,6 +730,7 @@ public struct TerminalStore: Sendable {
                     sessionID: sessionID,
                     transcriptPath: record.transcriptPath,
                     orderObservedAt: nil,
+                    transcriptBoundaryOffset: record.codexTranscriptBoundaryOffset,
                     isInitialAttachment: false,
                     activityObservation: nil,
                     clearedAwaitingInput: hadReason)
@@ -502,6 +738,7 @@ public struct TerminalStore: Sendable {
             let isInitialAttachment = record.claudeSessionID == nil
                 && record.transcriptPath == nil
                 && record.sessionOrderObservedAt == nil
+                && record.codexTranscriptBoundaryOffset == nil
             if let storedSessionOrder = record.sessionOrderObservedAt,
                storedSessionOrder >= observedAt {
                 return nil
@@ -516,9 +753,24 @@ public struct TerminalStore: Sendable {
                 replaceSameValue: true
             )
 
+            let effectiveTranscriptPath = transcriptPath ?? record.transcriptPath
             record.claudeSessionID = sessionID
             if let transcriptPath {
                 record.transcriptPath = transcriptPath
+            }
+            // The initial Codex process owns the rollout from byte zero, even
+            // when its hook arrives after the file starts growing. Every later
+            // accepted process is fenced at the caller-observed EOF only while
+            // that observation still names the transaction's effective path;
+            // nil means no safe matching offset was available when accepted.
+            if isInitialAttachment {
+                record.codexTranscriptBoundaryOffset = 0
+            } else if let observedTranscriptBoundary,
+                      observedTranscriptBoundary.path == effectiveTranscriptPath,
+                      observedTranscriptBoundary.eof >= 0 {
+                record.codexTranscriptBoundaryOffset = observedTranscriptBoundary.eof
+            } else {
+                record.codexTranscriptBoundaryOffset = nil
             }
             // The activity helper performs this when it accepts Codex's idle
             // fact. Keep the independent call so a rejected stale activity
@@ -536,6 +788,7 @@ public struct TerminalStore: Sendable {
                 // The tracker must use the exact durable generation a later
                 // terminal-list read will reload.
                 orderObservedAt: persistedRecord.sessionOrderObservedAt,
+                transcriptBoundaryOffset: persistedRecord.codexTranscriptBoundaryOffset,
                 isInitialAttachment: isInitialAttachment,
                 activityObservation: activityObservation,
                 clearedAwaitingInput: clearedHere
@@ -554,22 +807,31 @@ public struct TerminalStore: Sendable {
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
-            record.claudeSessionID = nil
-            record.transcriptPath = nil
-            record.sessionOrderObservedAt = nil
-            record.suspendedAt = nil
-            record.suspendedSnapshot = nil
-            record.hibernatedAt = nil
-            record.hibernateReason = nil
-            record.label = TerminalLabel.shell
-            record.kind = TerminalKind.shell.rawValue
-            record.activityState = TerminalActivityState.unknown.rawValue
-            record.activityStateSource = FactColumnJSON.encode(FactSource.derived)
-            record.activityStateObservedAt = date
-            record.activityStateOrderObservedAt = date
-            record.awaitingInputReason = nil
-            record.awaitingInputObservedAt = nil
+            _ = resetRecreatedShellLifecycle(record: &record, at: date)
             try record.update(db)
+        }
+    }
+
+    /// Bind a newly staged shell window to its terminal row before launching
+    /// the interactive shell. The returned token must be injected into that
+    /// shell so a manually launched agent can identify this incarnation.
+    func replaceRecreatedShellWindow(
+        id: UUID,
+        expectedIncarnation: TerminalSessionIncarnation,
+        windowID: String,
+        paneID: String,
+        at date: Date
+    ) async throws -> UUID? {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard expectedIncarnation.matches(record) else { return nil }
+            record.tmuxWindowID = windowID
+            record.tmuxPaneID = paneID
+            let incarnationID = resetRecreatedShellLifecycle(record: &record, at: date)
+            try record.update(db)
+            return incarnationID
         }
     }
 
@@ -579,19 +841,24 @@ public struct TerminalStore: Sendable {
     /// look like a resume of the dead process.
     func replaceRecreatedCodexWindow(
         id: UUID,
+        expectedIncarnation: TerminalSessionIncarnation,
         windowID: String,
         paneID: String,
         at date: Date
-    ) async throws {
+    ) async throws -> UUID? {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
+            guard expectedIncarnation.matches(record) else { return nil }
             record.tmuxWindowID = windowID
             record.tmuxPaneID = paneID
+            let incarnationID = UUID()
+            record.sessionIncarnationID = incarnationID.uuidString
             record.claudeSessionID = nil
             record.transcriptPath = nil
             record.sessionOrderObservedAt = nil
+            record.codexTranscriptBoundaryOffset = nil
             record.suspendedAt = nil
             record.suspendedSnapshot = nil
             record.hibernatedAt = nil
@@ -603,6 +870,34 @@ public struct TerminalStore: Sendable {
             record.awaitingInputReason = nil
             record.awaitingInputObservedAt = nil
             try record.update(db)
+            return incarnationID
+        }
+    }
+
+    /// Commit the complete intended state for an in-place profile replacement
+    /// before tmux starts the new Claude process. The returned token is the
+    /// exact value the caller must inject into that process environment.
+    func prepareProfileAgentRespawn(
+        id: UUID,
+        expectedState: TerminalReplacementSnapshot,
+        sessionID: String,
+        transcriptPath: String?,
+        profileID: UUID?,
+        at date: Date
+    ) async throws -> UUID? {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard expectedState.matches(record) else { return nil }
+            record.profile_id = profileID?.uuidString
+            let incarnationID = resetAgentProcessLifecycle(
+                record: &record,
+                sessionID: sessionID,
+                transcriptPath: transcriptPath,
+                at: date)
+            try record.update(db)
+            return incarnationID
         }
     }
 
@@ -616,6 +911,29 @@ public struct TerminalStore: Sendable {
         }
     }
 
+    /// Re-home a parked session only while the complete launch state observed
+    /// by the caller is still current. A wake or replacement that wins first
+    /// rejects this write atomically instead of leaving the row's profile out
+    /// of sync with the process that was launched.
+    func setParkedProfileID(
+        id: UUID,
+        expectedState: TerminalReplacementSnapshot,
+        profileID: UUID?
+    ) async throws -> Terminal? {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard expectedState.matches(record),
+                  record.hibernatedAt != nil || record.suspendedAt != nil else {
+                return nil
+            }
+            record.profile_id = profileID?.uuidString
+            try record.update(db)
+            return record.toModel()
+        }
+    }
+
     /// Update the tmux window and pane IDs for a terminal.
     public func updateTmuxIDs(id: UUID, windowID: String, paneID: String) async throws {
         try await writer.write { db in
@@ -624,6 +942,7 @@ public struct TerminalStore: Sendable {
             }
             record.tmuxWindowID = windowID
             record.tmuxPaneID = paneID
+            record.sessionIncarnationID = UUID().uuidString
             try record.update(db)
         }
     }
@@ -1009,20 +1328,104 @@ public struct TerminalStore: Sendable {
     /// unconditionally (a re-park overwrites any stale reason); `nil` keeps
     /// legacy semantics (the row is still eligible for wake-on-focus).
     ///
-    /// This is the choke point EVERY park site flows through
-    /// (`HibernationCoordinator.performHibernate`, the reconcile recovery park,
-    /// and `handleTerminalRecreateWindow`'s dead-window park), so it also
-    /// cancels any scheduled auto-resume in the same write transaction: a
-    /// parked session's Claude process is dead — a resume firing later would
-    /// type "continue" into a bare shell — and `pendingResumeAt` must not
-    /// keep advertising a resume that will never happen. Wake
-    /// (`clearHibernated`) deliberately does NOT resurrect the cancelled row.
+    /// Park sites whose process is already replaced use this complete
+    /// transition. `HibernationCoordinator.performHibernate` instead uses the
+    /// staged begin/finalize pair below so a failed first tmux replacement can
+    /// retain a still-running agent's token. Both paths cancel any scheduled
+    /// auto-resume atomically with their park intent: while a row is parked, a
+    /// resume must not type into either the outgoing agent or its replacement
+    /// shell. Wake (`clearHibernated`) deliberately does not resurrect the
+    /// cancelled row.
     public func setHibernated(id: UUID, sessionID: String, snapshot: String? = nil, reason: HibernateReason? = nil, at date: Date = Date()) async throws {
+        _ = try await persistHibernatedState(
+            id: id,
+            sessionID: sessionID,
+            transcriptPathUpdate: .preserve,
+            snapshot: snapshot,
+            reason: reason,
+            at: date)
+    }
+
+    /// Record the hibernation intent before replacing the live agent. The
+    /// current process token and ordering fences remain intact until tmux has
+    /// replaced that process with an inert pane, so startup reconciliation can
+    /// safely unpark a still-running agent after a crash or failed respawn. A
+    /// process-incarnation mismatch rejects without writing and returns nil.
+    func beginHibernatedShellRespawn(
+        id: UUID,
+        expectedState: TerminalHibernationSnapshot,
+        snapshot: String? = nil,
+        reason: HibernateReason? = nil,
+        at date: Date = Date()
+    ) async throws -> TerminalSessionIncarnation? {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard expectedState.matches(record) else { return nil }
+            record.hibernatedAt = date
+            record.hibernateReason = reason?.rawValue
+            if let snapshot {
+                record.suspendedSnapshot = snapshot
+            }
+            try record.update(db)
+            try ScheduledResumeStore.cancelPendingInTransaction(db, terminalID: id.uuidString)
+            return TerminalSessionIncarnation(record: record)
+        }
+    }
+
+    /// Fence the process that tmux has already replaced with an inert pane.
+    /// The returned token belongs to the hibernated shell launched next; all
+    /// ordering and activity evidence from the former agent clears atomically.
+    /// A process-incarnation mismatch rejects without writing and returns nil.
+    func finalizeHibernatedShellRespawn(
+        id: UUID,
+        expectedIncarnation: TerminalSessionIncarnation,
+        at date: Date = Date()
+    ) async throws -> UUID? {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard expectedIncarnation.matches(record) else { return nil }
+            guard record.hibernatedAt != nil || record.suspendedAt != nil else {
+                throw DatabaseError(message: "Terminal is not parked")
+            }
+            record.sessionOrderObservedAt = nil
+            record.codexTranscriptBoundaryOffset = nil
+            let incarnationID = UUID()
+            record.sessionIncarnationID = incarnationID.uuidString
+            record.activityState = TerminalActivityState.idle.rawValue
+            record.activityStateSource = FactColumnJSON.encode(FactSource.database)
+            record.activityStateObservedAt = date
+            record.activityStateOrderObservedAt = date
+            record.awaitingInputReason = nil
+            record.awaitingInputObservedAt = nil
+            try record.update(db)
+            return incarnationID
+        }
+    }
+
+    private func persistHibernatedState(
+        id: UUID,
+        sessionID: String,
+        transcriptPathUpdate: HibernatedTranscriptPathUpdate,
+        snapshot: String?,
+        reason: HibernateReason?,
+        at date: Date
+    ) async throws -> UUID {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
+            if case .replace(let transcriptPath) = transcriptPathUpdate {
+                record.transcriptPath = transcriptPath
+            }
+            record.sessionOrderObservedAt = nil
+            record.codexTranscriptBoundaryOffset = nil
+            let incarnationID = UUID()
+            record.sessionIncarnationID = incarnationID.uuidString
             record.hibernatedAt = date
             record.hibernateReason = reason?.rawValue
             if let snapshot {
@@ -1043,16 +1446,16 @@ public struct TerminalStore: Sendable {
             // SQL, and an update of the (stale-fetched) record afterward
             // would write the old value back.
             try ScheduledResumeStore.cancelPendingInTransaction(db, terminalID: id.uuidString)
+            return incarnationID
         }
     }
 
-    /// Clear a terminal's parked state (on wake). Nils BOTH the authoritative
-    /// `hibernatedAt` AND the legacy `suspendedAt` so a row parked by either the
-    /// unified path or the pre-merge Suspend feature fully un-parks. Leaves
-    /// `claudeSessionID` intact — the wake respawn re-captures a fresh id
-    /// afterward — and keeps `suspendedSnapshot` so the app can feed it into the
-    /// terminal view as initial content while the live tmux client reconnects
-    /// (matches the old Suspend behavior; overwritten on the next park).
+    /// Clear a stale parked marker when startup reconciliation proves the
+    /// recorded process is still alive, or after a replacement agent launches.
+    /// Nils both the authoritative `hibernatedAt` and
+    /// legacy `suspendedAt`, while preserving the live process's identity and
+    /// incarnation. A real wake first uses
+    /// `prepareHibernatedAgentRespawn` below before launching the process.
     public func clearHibernated(id: UUID) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
@@ -1062,6 +1465,42 @@ public struct TerminalStore: Sendable {
             record.suspendedAt = nil
             record.hibernateReason = nil
             try record.update(db)
+        }
+    }
+
+    /// Prepare a parked shell for a fresh agent before launch. Preserve the
+    /// captured session identity and transcript needed for a failed launch to
+    /// retry, while clearing process-local ordering/activity and rotating the
+    /// durable incarnation atomically. The parked marker remains until tmux
+    /// confirms launch; `clearHibernated` then removes only that marker.
+    func prepareHibernatedAgentRespawn(
+        id: UUID,
+        expectedState: TerminalReplacementSnapshot,
+        windowID: String? = nil,
+        paneID: String? = nil,
+        at date: Date = Date()
+    ) async throws -> UUID? {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            guard expectedState.matches(record),
+                  record.hibernatedAt != nil || record.suspendedAt != nil else {
+                return nil
+            }
+            if let windowID, let paneID {
+                record.tmuxWindowID = windowID
+                record.tmuxPaneID = paneID
+            }
+            let resumeSessionID = record.claudeSessionID
+            let resumeTranscriptPath = record.transcriptPath
+            let incarnationID = resetAgentProcessLifecycle(
+                record: &record,
+                sessionID: resumeSessionID,
+                transcriptPath: resumeTranscriptPath,
+                at: date)
+            try record.update(db)
+            return incarnationID
         }
     }
 

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -36,6 +36,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var sessionOrderObservedAt: Date?
     var codexTranscriptBoundaryOffset: Int64?
     var sessionIncarnationID: String?
+    var pendingSessionIncarnationID: String?
     var kind: String?
     var activityState: String?
     var hibernatedAt: Date?
@@ -70,6 +71,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.sessionOrderObservedAt = terminal.sessionOrderObservedAt
         self.codexTranscriptBoundaryOffset = terminal.codexTranscriptBoundaryOffset
         self.sessionIncarnationID = terminal.sessionIncarnationID?.uuidString
+        self.pendingSessionIncarnationID = terminal.pendingSessionIncarnationID?.uuidString
         self.kind = terminal.kind?.rawValue
         self.activityState = terminal.activityState.rawValue
         self.hibernatedAt = terminal.hibernatedAt
@@ -112,6 +114,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             sessionOrderObservedAt: sessionOrderObservedAt,
             codexTranscriptBoundaryOffset: codexTranscriptBoundaryOffset,
             sessionIncarnationID: sessionIncarnationID.flatMap(UUID.init(uuidString:)),
+            pendingSessionIncarnationID: pendingSessionIncarnationID.flatMap(UUID.init(uuidString:)),
             kind: kind.flatMap(TerminalKind.init(rawValue:)),
             activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown,
             hibernatedAt: hibernatedAt,
@@ -165,6 +168,10 @@ public struct AppliedTerminalActivityObservation: Sendable {
     public let source: FactSource
     public let observedAt: Date
     public let orderObservedAt: Date
+    /// Whether the durable activity value changed. Legacy non-Codex hooks
+    /// still return an accepted observation when only an awaiting-input reason
+    /// was cleared or the value was already current.
+    public let activityStateChanged: Bool
     /// True when applying this observation retracted a standing awaiting-input
     /// reason, so the caller knows there is a retraction worth broadcasting.
     public let clearedAwaitingInput: Bool
@@ -174,12 +181,14 @@ public struct AppliedTerminalActivityObservation: Sendable {
         source: FactSource,
         observedAt: Date,
         orderObservedAt: Date,
+        activityStateChanged: Bool = true,
         clearedAwaitingInput: Bool = false
     ) {
         self.activityState = activityState
         self.source = source
         self.observedAt = observedAt
         self.orderObservedAt = orderObservedAt
+        self.activityStateChanged = activityStateChanged
         self.clearedAwaitingInput = clearedAwaitingInput
     }
 }
@@ -211,12 +220,14 @@ struct TerminalSessionIncarnation: Sendable {
     let tmuxPaneID: String
     let label: String?
     let sessionIncarnationID: UUID?
+    let pendingSessionIncarnationID: UUID?
 
     init(terminal: Terminal) {
         self.tmuxWindowID = terminal.tmuxWindowID
         self.tmuxPaneID = terminal.tmuxPaneID
         self.label = terminal.label
         self.sessionIncarnationID = terminal.sessionIncarnationID
+        self.pendingSessionIncarnationID = terminal.pendingSessionIncarnationID
     }
 
     fileprivate init(record: TerminalRecord) {
@@ -224,6 +235,8 @@ struct TerminalSessionIncarnation: Sendable {
         self.tmuxPaneID = record.tmuxPaneID
         self.label = record.label
         self.sessionIncarnationID = record.sessionIncarnationID.flatMap(UUID.init(uuidString:))
+        self.pendingSessionIncarnationID = record.pendingSessionIncarnationID.flatMap(
+            UUID.init(uuidString:))
     }
 
     fileprivate func matches(_ record: TerminalRecord) -> Bool {
@@ -231,6 +244,7 @@ struct TerminalSessionIncarnation: Sendable {
             && record.tmuxPaneID == tmuxPaneID
             && record.label == label
             && record.sessionIncarnationID == sessionIncarnationID?.uuidString
+            && record.pendingSessionIncarnationID == pendingSessionIncarnationID?.uuidString
     }
 
     func matches(_ terminal: Terminal) -> Bool {
@@ -238,6 +252,7 @@ struct TerminalSessionIncarnation: Sendable {
             && terminal.tmuxPaneID == tmuxPaneID
             && terminal.label == label
             && terminal.sessionIncarnationID == sessionIncarnationID
+            && terminal.pendingSessionIncarnationID == pendingSessionIncarnationID
     }
 }
 
@@ -354,6 +369,7 @@ private func resetAgentProcessLifecycle(
     record.sessionOrderObservedAt = nil
     record.codexTranscriptBoundaryOffset = nil
     record.sessionIncarnationID = incarnationID.uuidString
+    record.pendingSessionIncarnationID = nil
     record.activityState = TerminalActivityState.unknown.rawValue
     record.activityStateSource = FactColumnJSON.encode(FactSource.derived)
     record.activityStateObservedAt = date
@@ -706,6 +722,7 @@ public struct TerminalStore: Sendable {
             // no process token on either side. Once TBD rotates a row to a
             // durable token, every replacement-process SessionStart must echo
             // that exact value; nil and mismatches are stale by construction.
+            guard record.pendingSessionIncarnationID == nil else { return nil }
             guard record.sessionIncarnationID == reportedIncarnationID?.uuidString else {
                 return nil
             }
@@ -856,6 +873,7 @@ public struct TerminalStore: Sendable {
             record.tmuxPaneID = paneID
             let incarnationID = UUID()
             record.sessionIncarnationID = incarnationID.uuidString
+            record.pendingSessionIncarnationID = nil
             record.claudeSessionID = nil
             record.transcriptPath = nil
             record.sessionOrderObservedAt = nil
@@ -944,6 +962,7 @@ public struct TerminalStore: Sendable {
             record.tmuxWindowID = windowID
             record.tmuxPaneID = paneID
             record.sessionIncarnationID = UUID().uuidString
+            record.pendingSessionIncarnationID = nil
             try record.update(db)
         }
     }
@@ -1000,8 +1019,9 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Apply a Codex or explicit-interrupt activity fact only when it is not
-    /// older than the ordering watermark already stored for the terminal.
+    /// Apply an activity fact after validating process identity in the same
+    /// writer transaction. Codex and explicit-interrupt facts additionally
+    /// obey the durable ordering watermark.
     ///
     /// The ordering comparison and write share one database-writer
     /// transaction. Callers may therefore do
@@ -1019,7 +1039,8 @@ public struct TerminalStore: Sendable {
     /// waits are preserved, while ambiguous working/non-working ties resolve
     /// toward non-working; the next strictly newer hook advances order. Other
     /// agent hooks retain their established changed-value replacement and
-    /// same-value no-op behavior.
+    /// same-value no-op behavior. `processBound` is false only for app actions
+    /// such as the explicit user interrupt; hook callers must leave it true.
     public func applyActivityObservation(
         id: UUID,
         activityState: TerminalActivityState,
@@ -1027,6 +1048,7 @@ public struct TerminalStore: Sendable {
         observedAt: Date,
         sessionID: String? = nil,
         sessionIncarnationID: UUID? = nil,
+        processBound: Bool = true,
         replaceSameValue: Bool = false
     ) async throws -> AppliedTerminalActivityObservation? {
         try await writer.write { db in
@@ -1036,12 +1058,37 @@ public struct TerminalStore: Sendable {
             let usesOrderedCodexActivity = record.kind == TerminalKind.codex.rawValue
                 || record.label == TerminalLabel.codex
                 || source == .terminalInterrupt
+            // Hook observations name a running process. During the staged
+            // hibernation replacement there intentionally is no process
+            // entitled to mutate the row: the outgoing token remains current
+            // only for rollback, and the staged token has not launched yet.
+            // Non-process-bound app actions remain valid throughout.
+            if processBound {
+                guard record.pendingSessionIncarnationID == nil,
+                      record.sessionIncarnationID == sessionIncarnationID?.uuidString else {
+                    return nil
+                }
+                if let sessionID, sessionID != record.claudeSessionID {
+                    return nil
+                }
+            }
             guard usesOrderedCodexActivity else {
                 // This API is public to the daemon module, so keep the scope
                 // boundary here as well as at the RPC router. An accidental
                 // non-Codex caller must retain the pre-existing changed-value
                 // replacement and same-value no-op behavior.
-                guard record.activityState != activityState.rawValue else { return nil }
+                guard record.activityState != activityState.rawValue else {
+                    let cleared = clearAwaitingInputIfNotNewer(
+                        record: &record, than: observedAt)
+                    if cleared { try record.update(db) }
+                    return AppliedTerminalActivityObservation(
+                        activityState: activityState,
+                        source: source,
+                        observedAt: observedAt,
+                        orderObservedAt: observedAt,
+                        activityStateChanged: false,
+                        clearedAwaitingInput: cleared)
+                }
                 let hadReason = record.awaitingInputReason != nil
                     || record.awaitingInputObservedAt != nil
                 record.activityState = activityState.rawValue
@@ -1057,20 +1104,6 @@ public struct TerminalStore: Sendable {
                     observedAt: observedAt,
                     orderObservedAt: observedAt,
                     clearedAwaitingInput: hadReason)
-            }
-            // Validate hook identity in this transaction, rather than against
-            // the terminal loaded by the router, so a delayed old-process
-            // event cannot race an accepted SessionStart. Legacy nil tokens
-            // match only rows that have never entered managed replacement;
-            // explicit app interrupts are user actions, not process-bound hook
-            // observations, and remain accepted without hook identity.
-            if source != .terminalInterrupt {
-                guard record.sessionIncarnationID == sessionIncarnationID?.uuidString else {
-                    return nil
-                }
-                if let sessionID, sessionID != record.claudeSessionID {
-                    return nil
-                }
             }
             guard let application = applyActivityObservationToRecord(
                 to: &record,
@@ -1354,10 +1387,12 @@ public struct TerminalStore: Sendable {
     }
 
     /// Record the hibernation intent before replacing the live agent. The
-    /// current process token and ordering fences remain intact until tmux has
-    /// replaced that process with an inert pane, so startup reconciliation can
-    /// safely unpark a still-running agent after a crash or failed respawn. A
-    /// process-incarnation mismatch rejects without writing and returns nil.
+    /// current process token remains intact until tmux has replaced that
+    /// process with an inert pane, so startup reconciliation can safely unpark
+    /// a still-running agent after a crash or failed respawn. A pending token
+    /// makes process-bound hook writes inert during this interval; finalize
+    /// promotes it once replacement is confirmed. A process-incarnation
+    /// mismatch rejects without writing and returns nil.
     func beginHibernatedShellRespawn(
         id: UUID,
         expectedState: TerminalHibernationSnapshot,
@@ -1370,11 +1405,18 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             guard expectedState.matches(record) else { return nil }
+            record.pendingSessionIncarnationID = UUID().uuidString
             record.hibernatedAt = date
             record.hibernateReason = reason?.rawValue
             if let snapshot {
                 record.suspendedSnapshot = snapshot
             }
+            record.activityState = TerminalActivityState.idle.rawValue
+            record.activityStateSource = FactColumnJSON.encode(FactSource.database)
+            record.activityStateObservedAt = date
+            record.activityStateOrderObservedAt = date
+            record.awaitingInputReason = nil
+            record.awaitingInputObservedAt = nil
             try record.update(db)
             try ScheduledResumeStore.cancelPendingInTransaction(db, terminalID: id.uuidString)
             return TerminalSessionIncarnation(record: record)
@@ -1398,10 +1440,14 @@ public struct TerminalStore: Sendable {
             guard record.hibernatedAt != nil || record.suspendedAt != nil else {
                 throw DatabaseError(message: "Terminal is not parked")
             }
+            guard let pendingIncarnationID = record.pendingSessionIncarnationID,
+                  let incarnationID = UUID(uuidString: pendingIncarnationID) else {
+                return nil
+            }
             record.sessionOrderObservedAt = nil
             record.codexTranscriptBoundaryOffset = nil
-            let incarnationID = UUID()
-            record.sessionIncarnationID = incarnationID.uuidString
+            record.sessionIncarnationID = pendingIncarnationID
+            record.pendingSessionIncarnationID = nil
             record.activityState = TerminalActivityState.idle.rawValue
             record.activityStateSource = FactColumnJSON.encode(FactSource.database)
             record.activityStateObservedAt = date
@@ -1433,6 +1479,7 @@ public struct TerminalStore: Sendable {
             record.codexTranscriptBoundaryOffset = nil
             let incarnationID = UUID()
             record.sessionIncarnationID = incarnationID.uuidString
+            record.pendingSessionIncarnationID = nil
             record.hibernatedAt = date
             record.hibernateReason = reason?.rawValue
             if let snapshot {
@@ -1461,7 +1508,8 @@ public struct TerminalStore: Sendable {
     /// recorded process is still alive, or after a replacement agent launches.
     /// Nils both the authoritative `hibernatedAt` and
     /// legacy `suspendedAt`, while preserving the live process's identity and
-    /// incarnation. A real wake first uses
+    /// current incarnation. Any abandoned pending replacement is rolled back.
+    /// A real wake first uses
     /// `prepareHibernatedAgentRespawn` below before launching the process.
     public func clearHibernated(id: UUID) async throws {
         try await writer.write { db in
@@ -1471,6 +1519,7 @@ public struct TerminalStore: Sendable {
             record.hibernatedAt = nil
             record.suspendedAt = nil
             record.hibernateReason = nil
+            record.pendingSessionIncarnationID = nil
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -1026,6 +1026,7 @@ public struct TerminalStore: Sendable {
         source: FactSource,
         observedAt: Date,
         sessionID: String? = nil,
+        sessionIncarnationID: UUID? = nil,
         replaceSameValue: Bool = false
     ) async throws -> AppliedTerminalActivityObservation? {
         try await writer.write { db in
@@ -1057,14 +1058,19 @@ public struct TerminalStore: Sendable {
                     orderObservedAt: observedAt,
                     clearedAwaitingInput: hadReason)
             }
-            // Codex writes session identity into every supported hook payload.
-            // Check it in this transaction, rather than against the terminal
-            // loaded by the router, so a delayed old-session event cannot race
-            // an accepted SessionStart. Identity-free callers retain legacy
-            // behavior for already-running sessions with an older hook overlay
-            // and for the app's explicit interrupt.
-            if let sessionID, sessionID != record.claudeSessionID {
-                return nil
+            // Validate hook identity in this transaction, rather than against
+            // the terminal loaded by the router, so a delayed old-process
+            // event cannot race an accepted SessionStart. Legacy nil tokens
+            // match only rows that have never entered managed replacement;
+            // explicit app interrupts are user actions, not process-bound hook
+            // observations, and remain accepted without hook identity.
+            if source != .terminalInterrupt {
+                guard record.sessionIncarnationID == sessionIncarnationID?.uuidString else {
+                    return nil
+                }
+                if let sessionID, sessionID != record.claudeSessionID {
+                    return nil
+                }
             }
             guard let application = applyActivityObservationToRecord(
                 to: &record,

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -150,6 +150,15 @@ enum FactColumnJSON {
         guard let json, let data = json.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(type, from: data)
     }
+
+    /// Compare a decoded fact with its persisted JSON representation. JSON
+    /// object key order is not identity, while a malformed non-NULL value must
+    /// not collapse into the same state as an absent fact.
+    static func matches<T: Decodable & Equatable>(_ expected: T?, encoded json: String?) -> Bool {
+        guard let json else { return expected == nil }
+        guard let expected else { return false }
+        return decode(T.self, from: json) == expected
+    }
 }
 
 /// What a `recordAwaitingInputReason` call did to the record.
@@ -339,10 +348,12 @@ struct TerminalHibernationSnapshot: Sendable {
         replacement.matches(record)
             && (record.keepWarm ?? false) == keepWarm
             && record.activityState == activityState.rawValue
-            && record.activityStateSource == FactColumnJSON.encode(activityStateSource)
+            && FactColumnJSON.matches(
+                activityStateSource, encoded: record.activityStateSource)
             && record.activityStateObservedAt == activityStateObservedAt
             && record.activityStateOrderObservedAt == activityStateOrderObservedAt
-            && record.awaitingInputReason == FactColumnJSON.encode(awaitingInputReason)
+            && FactColumnJSON.matches(
+                awaitingInputReason, encoded: record.awaitingInputReason)
             && record.awaitingInputObservedAt == awaitingInputObservedAt
     }
 

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -588,6 +588,7 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
+            record.codexTranscriptBoundaryOffset = nil
             record.suspendedAt = date
             record.suspendedSnapshot = snapshot
             try record.update(db)

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -172,6 +172,9 @@ public struct AppliedTerminalActivityObservation: Sendable {
     /// still return an accepted observation when only an awaiting-input reason
     /// was cleared or the value was already current.
     public let activityStateChanged: Bool
+    /// Whether this accepted working observation atomically cancelled a
+    /// scheduled resume for the same terminal incarnation.
+    public let cancelledPendingResume: Bool
     /// True when applying this observation retracted a standing awaiting-input
     /// reason, so the caller knows there is a retraction worth broadcasting.
     public let clearedAwaitingInput: Bool
@@ -182,6 +185,7 @@ public struct AppliedTerminalActivityObservation: Sendable {
         observedAt: Date,
         orderObservedAt: Date,
         activityStateChanged: Bool = true,
+        cancelledPendingResume: Bool = false,
         clearedAwaitingInput: Bool = false
     ) {
         self.activityState = activityState
@@ -189,6 +193,7 @@ public struct AppliedTerminalActivityObservation: Sendable {
         self.observedAt = observedAt
         self.orderObservedAt = orderObservedAt
         self.activityStateChanged = activityStateChanged
+        self.cancelledPendingResume = cancelledPendingResume
         self.clearedAwaitingInput = clearedAwaitingInput
     }
 }
@@ -482,6 +487,27 @@ private func applyActivityObservationToRecord(
     )
 }
 
+private func finishActivityObservation(
+    _ application: AppliedTerminalActivityObservation,
+    activityState: TerminalActivityState,
+    terminalID: String,
+    in db: Database
+) throws -> AppliedTerminalActivityObservation {
+    guard activityState == .working,
+          try ScheduledResumeStore.cancelPendingInTransaction(
+              db, terminalID: terminalID) else {
+        return application
+    }
+    return AppliedTerminalActivityObservation(
+        activityState: application.activityState,
+        source: application.source,
+        observedAt: application.observedAt,
+        orderObservedAt: application.orderObservedAt,
+        activityStateChanged: application.activityStateChanged,
+        cancelledPendingResume: true,
+        clearedAwaitingInput: application.clearedAwaitingInput)
+}
+
 /// Provides CRUD operations for terminals.
 public struct TerminalStore: Sendable {
     let writer: any DatabaseWriter
@@ -640,8 +666,9 @@ public struct TerminalStore: Sendable {
     }
 
     /// Persist a same-process session recapture only while the process token
-    /// observed before capture still names the current terminal incarnation.
-    /// A replacement that lands during the detector await wins atomically.
+    /// observed before capture still names the current terminal incarnation
+    /// and no replacement is being staged. A replacement that lands during
+    /// the detector await wins atomically.
     @discardableResult
     func updateSessionIDIfIncarnationMatches(
         id: UUID,
@@ -652,7 +679,8 @@ public struct TerminalStore: Sendable {
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
-            guard record.sessionIncarnationID == expectedIncarnationID?.uuidString else {
+            guard record.pendingSessionIncarnationID == nil,
+                  record.sessionIncarnationID == expectedIncarnationID?.uuidString else {
                 return false
             }
             record.claudeSessionID = sessionID
@@ -1081,13 +1109,18 @@ public struct TerminalStore: Sendable {
                     let cleared = clearAwaitingInputIfNotNewer(
                         record: &record, than: observedAt)
                     if cleared { try record.update(db) }
-                    return AppliedTerminalActivityObservation(
+                    let application = AppliedTerminalActivityObservation(
                         activityState: activityState,
                         source: source,
                         observedAt: observedAt,
                         orderObservedAt: observedAt,
                         activityStateChanged: false,
                         clearedAwaitingInput: cleared)
+                    return try finishActivityObservation(
+                        application,
+                        activityState: activityState,
+                        terminalID: id.uuidString,
+                        in: db)
                 }
                 let hadReason = record.awaitingInputReason != nil
                     || record.awaitingInputObservedAt != nil
@@ -1098,12 +1131,17 @@ public struct TerminalStore: Sendable {
                 record.awaitingInputReason = nil
                 record.awaitingInputObservedAt = nil
                 try record.update(db)
-                return AppliedTerminalActivityObservation(
+                let application = AppliedTerminalActivityObservation(
                     activityState: activityState,
                     source: source,
                     observedAt: observedAt,
                     orderObservedAt: observedAt,
                     clearedAwaitingInput: hadReason)
+                return try finishActivityObservation(
+                    application,
+                    activityState: activityState,
+                    terminalID: id.uuidString,
+                    in: db)
             }
             guard let application = applyActivityObservationToRecord(
                 to: &record,
@@ -1113,7 +1151,11 @@ public struct TerminalStore: Sendable {
                 replaceSameValue: replaceSameValue
             ) else { return nil }
             try record.update(db)
-            return application
+            return try finishActivityObservation(
+                application,
+                activityState: activityState,
+                terminalID: id.uuidString,
+                in: db)
         }
     }
 

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -65,7 +65,7 @@ public enum ClaudeHookOverlay {
     /// command tolerates `tbd` not being on PATH — silent failure is fine.
     /// Also initializes terminal activity to idle.
     static let sessionStartCommand =
-        #"tbd session-event 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
+        #"TBD_BIN="${TBD_CLI_PATH-tbd}"; "$TBD_BIN" session-event 2>/dev/null || true; "$TBD_BIN" terminal-activity idle 2>/dev/null || true"#
 
     /// The shell command for the Stop hook. Mirrors the legacy
     /// `setup-hooks --global` command so TBD can replace it without

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -4,10 +4,6 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation")
 
-private struct StaleTerminalWakeError: LocalizedError {
-    let errorDescription: String? = "Terminal changed while wake was preparing"
-}
-
 public enum HibernateResult: Equatable, Sendable {
     case ok
     case alreadyHibernated
@@ -1196,21 +1192,15 @@ public actor HibernationCoordinator {
                 if let bootstrapWindowID, !bootstrapWindowID.isEmpty {
                     try? await tmux.killWindow(server: server, windowID: bootstrapWindowID)
                 }
-                let incarnationID: UUID
-                let replacementEnv: [String: String]
+                let preparedIncarnationID: UUID?
                 do {
-                    guard let preparedIncarnationID = try await db.terminals
+                    preparedIncarnationID = try await db.terminals
                         .prepareHibernatedAgentRespawn(
                         id: terminal.id,
                         expectedState: TerminalReplacementSnapshot(terminal: terminal),
                         windowID: window.windowID,
                         paneID: window.paneID,
-                        at: now()) else {
-                        throw StaleTerminalWakeError()
-                    }
-                    incarnationID = preparedIncarnationID
-                    replacementEnv = AgentProcessEnvironment.replacement(
-                        base: env, incarnationID: incarnationID)
+                        at: now())
                 } catch {
                     // Don't leave an orphaned claude the DB doesn't know
                     // about: best-effort kill of the just-created window,
@@ -1220,6 +1210,14 @@ public actor HibernationCoordinator {
                     logger.warning("wake: created window \(window.windowID, privacy: .public) but failed to persist tmux ids for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
                     return .failed(.respawnFailed(reason: "recreated tmux window \(window.windowID), but persisting the new tmux ids failed: \(error.localizedDescription)"))
                 }
+                guard let incarnationID = preparedIncarnationID else {
+                    try? await tmux.killWindow(
+                        server: server, windowID: window.windowID)
+                    return .failed(.respawnFailed(
+                        reason: "terminal changed before wake could launch; retry"))
+                }
+                let replacementEnv = AgentProcessEnvironment.replacement(
+                    base: env, incarnationID: incarnationID)
                 do {
                     try await tmux.respawnWindow(
                         server: server,

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -4,11 +4,25 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation")
 
+private struct StaleTerminalWakeError: LocalizedError {
+    let errorDescription: String? = "Terminal changed while wake was preparing"
+}
+
 public enum HibernateResult: Equatable, Sendable {
     case ok
     case alreadyHibernated
     case notEligible(reason: String)
     case notFound
+}
+
+private enum HibernateEligibilityPolicy: Sendable {
+    case manual
+    case merge(inputVetoEnabled: Bool)
+    case automatic(
+        enabled: Bool,
+        inputVetoEnabled: Bool,
+        idleTimeout: TimeInterval,
+        idleSince: Date?)
 }
 
 /// How an unparked terminal's pane disagreed with the row that claims it is
@@ -92,7 +106,6 @@ public enum WakeResult: Equatable, Sendable {
 public actor HibernationCoordinator {
     private let db: TBDDatabase
     private let tmux: TmuxManager
-    private let detector: ClaudeStateDetector
     private let modelProfileResolver: ModelProfileResolver?
     private let subscriptions: StateSubscriptionManager?
     /// Routes ambient claude-projects-root resolution for the wake transcript
@@ -183,7 +196,6 @@ public actor HibernationCoordinator {
     ) {
         self.db = db
         self.tmux = tmux
-        self.detector = ClaudeStateDetector(tmux: tmux)
         self.modelProfileResolver = modelProfileResolver
         self.subscriptions = subscriptions
         self.configDirManager = configDirManager
@@ -253,7 +265,10 @@ public actor HibernationCoordinator {
         guard terminal.isManuallyHibernatable else {
             return .notEligible(reason: manualBlockReason(terminal))
         }
-        return await performHibernate(terminal: terminal, reason: .manual)
+        return await performHibernate(
+            terminal: terminal,
+            reason: .manual,
+            policy: .manual)
     }
 
     /// The reason a manual hibernate was refused, for the RPC error string.
@@ -312,7 +327,10 @@ public actor HibernationCoordinator {
             return .notEligible(reason: "\(error)")
         }
 
-        let result = await performHibernate(terminal: terminal, reason: .merged)
+        let result = await performHibernate(
+            terminal: terminal,
+            reason: .merged,
+            policy: .merge(inputVetoEnabled: inputVetoEnabled))
         await actuationLog.appendOutcome(
             confirms: actuationID,
             result: ActuationOutcome.classify(result),
@@ -349,14 +367,18 @@ public actor HibernationCoordinator {
     /// `reason` records WHO parked the session (`.manual` from the explicit
     /// "Hibernate now" entry points, `.auto` from the idle sweep) — persisted
     /// so the app's wake-on-focus can skip manual parks.
-    private func performHibernate(terminal: Terminal, reason: HibernateReason) async -> HibernateResult {
+    private func performHibernate(
+        terminal: Terminal,
+        reason: HibernateReason,
+        policy: HibernateEligibilityPolicy
+    ) async -> HibernateResult {
         guard !hibernatesInFlight.contains(terminal.id) else {
             return .alreadyHibernated
         }
         hibernatesInFlight.insert(terminal.id)
         defer { hibernatesInFlight.remove(terminal.id) }
 
-        guard let sessionID = terminal.claudeSessionID else {
+        guard terminal.claudeSessionID != nil else {
             return .notEligible(reason: "No session id to resume later")
         }
         guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
@@ -364,14 +386,11 @@ public actor HibernationCoordinator {
         }
         let server = worktree.tmuxServer
         let paneID = terminal.tmuxPaneID
-        let windowID = terminal.tmuxWindowID
 
-        // Capture the ANSI pane snapshot FIRST (ported from the old Suspend
-        // feature), before any interrupt disturbs the pane. Doubles as the
-        // input for the typed-but-unsent rail below, so we capture once. If
-        // capture fails we proceed with no snapshot (the DB rails already
-        // cleared it as idle-at-rest); parked-view falls back to a blank pane.
-        let capturedSnapshot: String?
+        // Fast pre-lock rail: refuse obvious typed input before queueing for a
+        // server replacement. The authoritative capture and the snapshot that
+        // is persisted happen after the lock is acquired, because this pane
+        // can change while the operation waits.
         if let capture = try? await tmux.capturePaneWithAnsi(server: server, paneID: paneID) {
             // Rail: typed-but-unsent input. Chrome's single biggest tab-discard
             // backlash was lost typed text — never park a pane with a
@@ -380,9 +399,6 @@ public actor HibernationCoordinator {
                 logger.debug("hibernate: skipping \(terminal.id, privacy: .public) — pending typed input in prompt")
                 return .notEligible(reason: "Terminal has unsent typed input")
             }
-            capturedSnapshot = capture.isEmpty ? nil : capture
-        } else {
-            capturedSnapshot = nil
         }
 
         // Rail: transcript-tail validity. Killing mid-write can leave an
@@ -396,26 +412,193 @@ public actor HibernationCoordinator {
             return .notEligible(reason: "Transcript is mid-write; try again shortly")
         }
 
+        do {
+            return try await tmux.withWorktreeServerLock(
+                db: db,
+                worktreeID: worktree.id,
+                allowedStatuses: [worktree.status]
+            ) { currentWorktree in
+                await self.performHibernateReplacementLocked(
+                    terminal: terminal,
+                    worktree: currentWorktree,
+                    reason: reason,
+                    policy: policy)
+            }
+        } catch {
+            logger.warning("hibernate: failed to lock the current tmux server for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notFound
+        }
+    }
+
+    /// Runs only while the worktree tmux server resource lock is held. Every
+    /// in-place process replacement on that server participates in the same
+    /// lock, while the two database transitions additionally CAS the captured
+    /// process incarnation so a request that waited cannot act on stale state.
+    private func performHibernateReplacementLocked(
+        terminal: Terminal,
+        worktree: LocalWorktree,
+        reason: HibernateReason,
+        policy: HibernateEligibilityPolicy
+    ) async -> HibernateResult {
+        guard let currentTerminal = try? await db.terminals.get(id: terminal.id) else {
+            return .notFound
+        }
+        guard TerminalReplacementSnapshot(terminal: terminal).matches(currentTerminal) else {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Terminal process changed before hibernation")
+        }
+        if case .automatic = policy,
+           !TerminalHibernationSnapshot(terminal: terminal).matchesActivity(currentTerminal) {
+            // A full turn may start and finish while an automatic park waits
+            // for this server lock. The fresh row can be idle again, but its
+            // old idle timer no longer proves a full quiet window. Refuse this
+            // attempt and let the next sweep seed a new idle generation.
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Session activity changed before hibernation")
+        }
+        guard let sessionID = currentTerminal.claudeSessionID else {
+            return .notEligible(reason: "No session id to resume later")
+        }
+        if let refusal = hibernationRefusal(terminal: currentTerminal, policy: policy) {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return refusal
+        }
+
+        let server = worktree.tmuxServer
+        let paneID = currentTerminal.tmuxPaneID
+        let windowID = currentTerminal.tmuxWindowID
+
+        guard await tmux.windowExists(server: server, windowID: windowID) else {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Terminal window is no longer live")
+        }
+        if tmux.verifiesPaneCurrentCommand {
+            guard let command = try? await tmux.paneCurrentCommand(server: server, paneID: paneID),
+                  ClaudeStateDetector.isClaudeProcess(command) else {
+                idleSince[terminal.id] = nil
+                pendingKillSince[terminal.id] = nil
+                return .notEligible(reason: "Terminal session is no longer live")
+            }
+        }
+
+        // The checks above the server lock are only a fast refusal. This fresh
+        // capture and transcript read are authoritative: a queued hibernation
+        // must not act on input or transcript state observed before another
+        // replacement or hook had its turn under the same server lock.
+        let capturedSnapshot: String?
+        if let capture = try? await tmux.capturePaneWithAnsi(server: server, paneID: paneID) {
+            if HibernationSafetyChecks.hasPendingInput(paneCapture: capture) {
+                logger.debug("hibernate: skipping \(terminal.id, privacy: .public) — pending typed input in prompt")
+                return .notEligible(reason: "Terminal has unsent typed input")
+            }
+            capturedSnapshot = capture.isEmpty ? nil : capture
+        } else {
+            capturedSnapshot = nil
+        }
+
+        if let transcriptPath = currentTerminal.transcriptPath,
+           let body = try? String(contentsOfFile: transcriptPath, encoding: .utf8),
+           !HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: body) {
+            logger.warning("hibernate: skipping \(terminal.id, privacy: .public) — transcript tail not parseable, would be unresumable")
+            return .notEligible(reason: "Transcript is mid-write; try again shortly")
+        }
+
+        // Persist the park intent before touching the live process, without
+        // rotating its token. A crash or failure before tmux replaces Claude
+        // can therefore be reconciled by unparking the surviving process, whose
+        // hooks still match the row.
+        let expectedState = TerminalHibernationSnapshot(terminal: currentTerminal)
+        let inertIncarnation: TerminalSessionIncarnation
+        do {
+            guard let prepared = try await db.terminals.beginHibernatedShellRespawn(
+                id: terminal.id,
+                expectedState: expectedState,
+                snapshot: capturedSnapshot,
+                reason: reason,
+                at: now()) else {
+                idleSince[terminal.id] = nil
+                pendingKillSince[terminal.id] = nil
+                return .notEligible(reason: "Terminal process changed before hibernation")
+            }
+            inertIncarnation = prepared
+        } catch {
+            logger.warning("hibernate: failed to prepare parked state for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Failed to persist hibernation")
+        }
+
         // Polite park: try an in-band `/exit` first (ported from Suspend) so
         // Claude flushes its transcript, shuts down MCP children, and fires Stop
         // hooks, then poll up to ~3s for the process to actually leave. Only if
         // it's still a claude process after the poll window do we escalate to
         // the graceful-interrupt SIGTERM fallback. Either way, `respawn-window
         // -k` below guarantees termination.
-        let exited = await politeExitThenPoll(server: server, paneID: paneID, terminalID: terminal.id)
+        let exited = await politeExitThenPoll(
+            server: server, paneID: paneID, terminalID: terminal.id)
         if !exited {
             logger.debug("hibernate: /exit did not terminate \(terminal.id, privacy: .public) within poll window — falling back to graceful interrupt")
             await gracefullyInterruptPane(server: server, paneID: paneID)
         }
 
-        // Respawn the SAME window to a bare login shell: the claude process (and
-        // its RSS) is gone, but the tmux window/pane and its scrollback stay.
+        let baseEnvironment = [
+            "TBD_WORKTREE_ID": worktree.id.uuidString,
+            "TBD_TERMINAL_ID": terminal.id.uuidString,
+        ]
+
+        // First replace Claude with a controlled process that cannot emit agent
+        // hooks. Only after this succeeds is it safe to rotate the durable
+        // token and clear process-local lifecycle evidence.
         do {
             try await tmux.respawnWindow(
                 server: server,
                 windowID: windowID,
                 cwd: worktree.path,
-                shellCommand: defaultShell
+                shellCommand: "exec /usr/bin/tail -f /dev/null",
+                env: baseEnvironment
+            )
+        } catch {
+            logger.warning("hibernate: respawn-to-inert failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return .notEligible(reason: "Failed to replace agent")
+        }
+
+        let shellIncarnationID: UUID
+        do {
+            guard let finalized = try await db.terminals.finalizeHibernatedShellRespawn(
+                id: terminal.id,
+                expectedIncarnation: inertIncarnation,
+                at: now()) else {
+                idleSince[terminal.id] = nil
+                pendingKillSince[terminal.id] = nil
+                return .notEligible(reason: "Terminal process changed during hibernation")
+            }
+            shellIncarnationID = finalized
+        } catch {
+            logger.warning("hibernate: failed to fence replaced agent for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Failed to finalize hibernation")
+        }
+        let shellEnvironment = AgentProcessEnvironment.replacement(
+            base: baseEnvironment,
+            incarnationID: shellIncarnationID)
+
+        // Replace the inert process with the user-facing login shell carrying
+        // the exact token persisted by the finalization transaction. A failure
+        // leaves the inert pane parked and rejects hooks from the old agent.
+        do {
+            try await tmux.respawnWindow(
+                server: server,
+                windowID: windowID,
+                cwd: worktree.path,
+                shellCommand: defaultShell,
+                env: shellEnvironment
             )
         } catch {
             logger.warning("hibernate: respawn-to-shell failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -423,43 +606,67 @@ public actor HibernationCoordinator {
         }
 
         // Post-kill verification: the pane must now be running a shell, not
-        // claude. respawn-window -k replaces the pane's program, so this
-        // confirms the swap took and the shell (window) survived. Any leftover
-        // orphaned claude child processes (#43944, #25188) are logged but not
-        // killed in v1 — surfacing them is enough.
-        await verifyHibernationTookEffect(server: server, paneID: paneID, terminalID: terminal.id)
-
-        // Clear the recorded input timestamp for this pane. The paneID may be
-        // reused in a future respawn, so clearing prevents a stale veto from the
-        // old session's final keystrokes. (A paneID reused with residual input
-        // would only add a stale veto, never drop a real one — the safe direction
-        // — but clearing is cleaner.)
+        // claude. Any leftover orphaned descendants are logged but not killed.
+        await verifyHibernationTookEffect(
+            server: server, paneID: paneID, terminalID: terminal.id)
+        // The pane id may be reused later; do not carry an old input veto into
+        // the replacement process.
         inputActivity.forget(paneID: paneID)
 
-        do {
-            // setHibernated also cancels any scheduled auto-resume in the
-            // same write transaction (spec §Cancellation): parking kills the
-            // Claude process, so a pending "TBD types continue at ..." row
-            // must die with it. The actuator's fire-time `isParked` check is
-            // the backstop for a park that races an in-flight actuation.
-            try await db.terminals.setHibernated(
-                id: terminal.id, sessionID: sessionID, snapshot: capturedSnapshot,
-                reason: reason, at: now()
-            )
-        } catch {
-            logger.warning("hibernate: failed to mark hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        guard let persisted = try? await db.terminals.get(id: terminal.id),
+              persisted.sessionIncarnationID == shellIncarnationID else {
+            logger.warning("hibernate: prepared row disappeared or changed during shell launch for \(terminal.id, privacy: .public)")
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Failed to verify hibernation")
         }
         idleSince[terminal.id] = nil
         pendingKillSince[terminal.id] = nil
-        // The delta must carry the just-captured snapshot and the park reason:
-        // the app's parked view materializes on this flip reading its cached
-        // row, and wake-on-focus filters on the cached reason — the refetch
-        // that would eventually bring both lands after the view is built.
+        // The app materializes its parked view on this flip, so carry the
+        // snapshot and reason rather than waiting for a later row refresh.
         broadcastHibernation(
-            terminal: terminal, hibernated: true, keepWarm: terminal.keepWarm,
+            terminal: currentTerminal, hibernated: true, keepWarm: currentTerminal.keepWarm,
             suspendedSnapshot: capturedSnapshot, hibernateReason: reason)
         logger.info("hibernated terminal \(terminal.id, privacy: .public) (session \(sessionID, privacy: .public))")
         return .ok
+    }
+
+    private func hibernationRefusal(
+        terminal: Terminal,
+        policy: HibernateEligibilityPolicy
+    ) -> HibernateResult? {
+        switch policy {
+        case .manual:
+            guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
+            guard terminal.isManuallyHibernatable else {
+                return .notEligible(reason: manualBlockReason(terminal))
+            }
+            return nil
+
+        case let .merge(inputVetoEnabled):
+            let decision = HibernationGate.decideForMerge(
+                terminal: terminal,
+                inputVetoEnabled: inputVetoEnabled,
+                lastInputAt: inputActivity.lastInput(paneID: terminal.tmuxPaneID))
+            guard decision == .eligible else {
+                return .notEligible(reason: Self.mergeBlockReason(decision))
+            }
+            return nil
+
+        case let .automatic(enabled, inputVetoEnabled, idleTimeout, idleSince):
+            let decision = HibernationGate.decide(
+                terminal: terminal,
+                autoHibernateEnabled: enabled,
+                inputVetoEnabled: inputVetoEnabled,
+                idleTimeout: idleTimeout,
+                idleSince: idleSince,
+                lastInputAt: inputActivity.lastInput(paneID: terminal.tmuxPaneID),
+                now: now())
+            guard decision == .eligible else {
+                return .notEligible(reason: Self.mergeBlockReason(decision))
+            }
+            return nil
+        }
     }
 
     /// Confirm the respawn-to-shell actually replaced claude, and log any
@@ -602,6 +809,20 @@ public actor HibernationCoordinator {
     /// the parked check below. An UNPARKED row whose session died is reported
     /// (`.sessionGone`) but not repaired — see `classifyUnparkedWake`.
     public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, allowDefaultProfileFallback: Bool = false, initialPrompt: String? = nil) async -> WakeResult {
+        // Claim synchronously, before the first suspension. Otherwise two wake
+        // calls can both read the parked row, then each pass the in-flight check
+        // after actor reentrancy lets them interleave. Keep the claim across all
+        // early exits so the defer releases lookup failures and successful wakes
+        // alike.
+        // `performHibernate` is actor-reentrant while it waits for polite exit
+        // and tmux. Once its durable begin transition marks this row parked, a
+        // wake must not rotate/clear the row and let hibernation resume against
+        // the replacement process.
+        guard !hibernatesInFlight.contains(terminalID) else { return .inFlight }
+        guard !wakesInFlight.contains(terminalID) else { return .inFlight }
+        wakesInFlight.insert(terminalID)
+        defer { wakesInFlight.remove(terminalID) }
+
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
         }
@@ -610,7 +831,7 @@ public actor HibernationCoordinator {
         // `clearHibernated` nils both columns, so this fully un-parks either.
         guard terminal.isParked else { return await classifyUnparkedWake(terminal) }
         guard let sessionID = terminal.claudeSessionID else { return .noSessionID }
-        guard !wakesInFlight.contains(terminalID) else { return .inFlight }
+        let expectedReplacementState = TerminalReplacementSnapshot(terminal: terminal)
         guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return .notFound
         }
@@ -622,13 +843,8 @@ public actor HibernationCoordinator {
             logger.error("wake: worktree path missing on disk for terminal \(terminal.id, privacy: .public): \(worktree.path, privacy: .public) — refusing respawn (would fall back to $HOME)")
             return .worktreeMissing(path: worktree.path)
         }
-
-        wakesInFlight.insert(terminalID)
-        defer { wakesInFlight.remove(terminalID) }
-
         let server = worktree.tmuxServer
         let paneID = terminal.tmuxPaneID
-        let windowID = terminal.tmuxWindowID
 
         // `claude --resume` is cwd-scoped (session lookup is per-directory).
         // Respawning inside the existing window already runs in the worktree,
@@ -774,6 +990,7 @@ public actor HibernationCoordinator {
         let livePaneID: String
         let liveWindowID: String
         let liveServer: String
+        let liveIncarnationID: UUID
 
         // The whole decide-then-mutate tmux section (ownership check +
         // windowExists + respawn/create/kill/persist) runs under the
@@ -786,12 +1003,18 @@ public actor HibernationCoordinator {
             outcome = try await tmux.withWorktreeServerLock(
                 db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
             ) { currentWorktree in
-                await self.wakeTmuxSection(
-                    terminal: terminal,
+                guard let currentTerminal = try await self.db.terminals.get(
+                    id: terminal.id),
+                      expectedReplacementState.matches(currentTerminal) else {
+                    return .failed(.respawnFailed(
+                        reason: "terminal changed while wake was preparing; retry"))
+                }
+                return await self.wakeTmuxSection(
+                    terminal: currentTerminal,
                     worktree: currentWorktree.worktree,
                     server: currentWorktree.tmuxServer,
-                    windowID: windowID,
-                    paneID: paneID,
+                    windowID: currentTerminal.tmuxWindowID,
+                    paneID: currentTerminal.tmuxPaneID,
                     spawnCommand: spawn.command,
                     env: env,
                     sensitiveEnv: sensitiveEnv,
@@ -805,16 +1028,16 @@ public actor HibernationCoordinator {
         switch outcome {
         case .failed(let result):
             return result
-        case .respawned(let newPaneID, let newWindowID, let currentServer):
+        case .respawned(
+            let newPaneID,
+            let newWindowID,
+            let currentServer,
+            let incarnationID
+        ):
             livePaneID = newPaneID
             liveWindowID = newWindowID
             liveServer = currentServer
-        }
-
-        do {
-            try await db.terminals.clearHibernated(id: terminal.id)
-        } catch {
-            logger.warning("wake: failed to clear hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            liveIncarnationID = incarnationID
         }
         idleSince[terminal.id] = nil
         // Carry the LIVE window/pane ids on the un-park broadcast so the app
@@ -828,16 +1051,11 @@ public actor HibernationCoordinator {
 
         // `claude --resume <id>` forks into a NEW session file; re-capture the
         // fresh id so subsequent hibernate/wake reference the live session.
-        let termID = terminal.id
-        Task {
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-            try? await Task.sleep(for: .seconds(5))
-            if let newID = await self.detector.captureSessionID(
-                server: liveServer, paneID: livePaneID
-            ) {
-                try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
-            }
-        }
+        SessionRecaptureScheduler(db: db, tmux: tmux, clock: clock).schedule(
+            terminalID: terminal.id,
+            paneID: livePaneID,
+            server: liveServer,
+            expectedIncarnationID: liveIncarnationID)
         logger.info("woke terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public))")
         return .ok
     }
@@ -845,7 +1063,12 @@ public actor HibernationCoordinator {
     /// Outcome of `wakeTmuxSection`: the live pane/window ids the rest of
     /// `wake()` should reference, or the `WakeResult` to return verbatim.
     private enum WakeTmuxOutcome {
-        case respawned(paneID: String, windowID: String, server: String)
+        case respawned(
+            paneID: String,
+            windowID: String,
+            server: String,
+            incarnationID: UUID
+        )
         case failed(WakeResult)
     }
 
@@ -882,17 +1105,40 @@ public actor HibernationCoordinator {
 
         if !claimedByOther, await tmux.windowExists(server: server, windowID: windowID) {
             do {
+                guard let incarnationID = try await db.terminals.prepareHibernatedAgentRespawn(
+                    id: terminal.id,
+                    expectedState: TerminalReplacementSnapshot(terminal: terminal),
+                    at: now()) else {
+                    return .failed(.respawnFailed(
+                        reason: "terminal changed before wake could launch; retry"))
+                }
+                let replacementEnv = AgentProcessEnvironment.replacement(
+                    base: env, incarnationID: incarnationID)
                 try await tmux.respawnWindow(
                     server: server,
                     windowID: windowID,
                     cwd: worktree.localPath,
                     shellCommand: spawnCommand,
-                    env: env,
+                    env: replacementEnv,
                     sensitiveEnv: sensitiveEnv,
                     cols: cols,
                     rows: rows
                 )
-                return .respawned(paneID: paneID, windowID: windowID, server: server)
+                do {
+                    try await db.terminals.clearHibernated(id: terminal.id)
+                } catch {
+                    // Keep the live replacement parked. Startup reconciliation
+                    // detects parked+live-agent and clears this marker without
+                    // erasing a SessionStart that arrived during launch.
+                    logger.warning("wake: launched the replacement agent for terminal \(terminal.id, privacy: .public), but failed to clear its parked marker: \(error.localizedDescription, privacy: .public)")
+                    return .failed(.respawnFailed(
+                        reason: "replacement agent launched, but clearing the parked marker failed: \(error.localizedDescription)"))
+                }
+                return .respawned(
+                    paneID: paneID,
+                    windowID: windowID,
+                    server: server,
+                    incarnationID: incarnationID)
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
                 logger.warning("wake: respawn-to-claude failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -922,7 +1168,10 @@ public actor HibernationCoordinator {
                     server: server,
                     session: "main",
                     cwd: worktree.localPath,
-                    shellCommand: spawnCommand,
+                    // Stage an inert pane first. Launching Claude here would
+                    // let its SessionStart arrive before the replacement tmux
+                    // IDs and lifecycle fence commit below.
+                    shellCommand: "exec /usr/bin/tail -f /dev/null",
                     env: env,
                     sensitiveEnv: sensitiveEnv,
                     cols: resolvedCols,
@@ -947,10 +1196,21 @@ public actor HibernationCoordinator {
                 if let bootstrapWindowID, !bootstrapWindowID.isEmpty {
                     try? await tmux.killWindow(server: server, windowID: bootstrapWindowID)
                 }
+                let incarnationID: UUID
+                let replacementEnv: [String: String]
                 do {
-                    try await db.terminals.updateTmuxIDs(
-                        id: terminal.id, windowID: window.windowID, paneID: window.paneID
-                    )
+                    guard let preparedIncarnationID = try await db.terminals
+                        .prepareHibernatedAgentRespawn(
+                        id: terminal.id,
+                        expectedState: TerminalReplacementSnapshot(terminal: terminal),
+                        windowID: window.windowID,
+                        paneID: window.paneID,
+                        at: now()) else {
+                        throw StaleTerminalWakeError()
+                    }
+                    incarnationID = preparedIncarnationID
+                    replacementEnv = AgentProcessEnvironment.replacement(
+                        base: env, incarnationID: incarnationID)
                 } catch {
                     // Don't leave an orphaned claude the DB doesn't know
                     // about: best-effort kill of the just-created window,
@@ -960,9 +1220,39 @@ public actor HibernationCoordinator {
                     logger.warning("wake: created window \(window.windowID, privacy: .public) but failed to persist tmux ids for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
                     return .failed(.respawnFailed(reason: "recreated tmux window \(window.windowID), but persisting the new tmux ids failed: \(error.localizedDescription)"))
                 }
+                do {
+                    try await tmux.respawnWindow(
+                        server: server,
+                        windowID: window.windowID,
+                        cwd: worktree.localPath,
+                        shellCommand: spawnCommand,
+                        env: replacementEnv,
+                        sensitiveEnv: sensitiveEnv,
+                        cols: resolvedCols,
+                        rows: resolvedRows)
+                } catch {
+                    // The row already owns this inert replacement window and
+                    // remains parked, so startup reconciliation or a later wake
+                    // can safely recover it.
+                    logger.warning("wake: staged window \(window.windowID, privacy: .public) but failed to launch its agent for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    return .failed(.respawnFailed(
+                        reason: "recreated tmux window \(window.windowID), but launching the agent failed: \(error.localizedDescription)"))
+                }
+                do {
+                    try await db.terminals.clearHibernated(id: terminal.id)
+                } catch {
+                    // Keep the live replacement parked for startup
+                    // reconciliation; identity and process token stay intact.
+                    logger.warning("wake: launched a replacement agent in \(window.windowID, privacy: .public), but failed to clear the parked marker for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    return .failed(.respawnFailed(
+                        reason: "replacement agent launched in \(window.windowID), but clearing the parked marker failed: \(error.localizedDescription)"))
+                }
                 logger.info("wake: window \(windowID, privacy: .public) was gone for terminal \(terminal.id, privacy: .public); recreated as \(window.windowID, privacy: .public) (pane \(window.paneID, privacy: .public))")
                 return .respawned(
-                    paneID: window.paneID, windowID: window.windowID, server: server)
+                    paneID: window.paneID,
+                    windowID: window.windowID,
+                    server: server,
+                    incarnationID: incarnationID)
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
                 logger.warning("wake: recreate-window failed for terminal \(terminal.id, privacy: .public) (old window \(windowID, privacy: .public)): \(error.localizedDescription, privacy: .public)")
@@ -1039,7 +1329,14 @@ public actor HibernationCoordinator {
                         guard let actuationID = try? await actuationLog.appendRequest(row) else {
                             continue
                         }
-                        let result = await performHibernate(terminal: terminal, reason: .auto)
+                        let result = await performHibernate(
+                            terminal: terminal,
+                            reason: .auto,
+                            policy: .automatic(
+                                enabled: config.autoHibernateEnabled,
+                                inputVetoEnabled: config.hibernateInputVetoEnabled,
+                                idleTimeout: timeout,
+                                idleSince: idleSince[terminal.id]))
                         await actuationLog.appendOutcome(
                             confirms: actuationID,
                             result: ActuationOutcome.classify(result),

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1512,7 +1512,8 @@ extension WorktreeLifecycle {
             SessionRecaptureScheduler(db: db, tmux: tmux).schedule(
                 terminalID: plannedTerminalID1,
                 paneID: window1.paneID,
-                server: tmuxServer
+                server: tmuxServer,
+                expectedIncarnationID: nil
             )
         }
         var createdTerminals: [(id: UUID, label: String)] = [

--- a/Sources/TBDDaemon/Process/AgentProcessEnvironment.swift
+++ b/Sources/TBDDaemon/Process/AgentProcessEnvironment.swift
@@ -1,0 +1,33 @@
+import Foundation
+import TBDShared
+
+/// Environment carried by TBD-managed replacement agent processes. The
+/// incarnation identifies a process lifetime to SessionStart's transactional
+/// CAS; the CLI path keeps hooks on the daemon's matching wire version.
+enum AgentProcessEnvironment {
+    static let cliPath: String? = {
+        guard let argv0 = CommandLine.arguments.first, !argv0.isEmpty else { return nil }
+        let executable: URL
+        if argv0.hasPrefix("/") {
+            executable = URL(fileURLWithPath: argv0)
+        } else {
+            executable = URL(
+                fileURLWithPath: argv0,
+                relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+        }
+        let daemonPath = executable.resolvingSymlinksInPath().standardizedFileURL.path
+        return CLIInstaller.cliPath(forDaemonExecutable: daemonPath)
+    }()
+
+    static func replacement(
+        base: [String: String],
+        incarnationID: UUID
+    ) -> [String: String] {
+        var environment = base
+        environment["TBD_TERMINAL_INCARNATION_ID"] = incarnationID.uuidString
+        if let cliPath {
+            environment["TBD_CLI_PATH"] = cliPath
+        }
+        return environment
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3622,89 +3622,14 @@ extension RPCRouter {
         // Hook callers are bridged through `tbd terminal-activity`; the params
         // do not yet carry WHICH hook event fired, so the RPC surface stands in
         // as their source name. The app's explicit interrupt declares its
-        // origin separately and is persisted as a user action instead.
+        // origin separately, bypasses process identity, and uses user-action
+        // provenance for Codex; Claude retains its legacy hook provenance.
         // `observedAt` from the router's date seam, never the store's default
         // `Date()`. The resolver's rung-4 decision is an ordering comparison
         // between exactly this stamp and the one `recordAwaitingInputReason`
         // writes above, so a test that cannot pin both ends cannot pin the
         // decision at all.
-        guard terminal.isCodexTerminal else {
-            // Claude and shell hooks retain their established last-writer
-            // behavior. Their persisted activity is a hibernation input, not
-            // Codex transcript presentation, so this fix must not impose the
-            // new ordering and tie-precedence policy on them.
-            // UserPromptSubmit reaches the daemon as activity=working. If a
-            // session-limit auto-resume is pending, the user just continued
-            // manually — cancel it even when the legacy activity value is
-            // unchanged, preserving the established non-Codex behavior.
-            if params.activityState == .working, terminal.pendingResumeAt != nil {
-                if (try? await db.scheduledResumes.cancelPending(
-                    terminalID: terminal.id)) == true {
-                    await limitResumeScheduler?.wake()
-                }
-            }
-            // Marked BEFORE the unchanged-state guard below, deliberately. A
-            // background agent's completion wakes the parent, which runs a
-            // turn and ends it — a second `idle` with no `working` between.
-            // Marking below the guard would drop that boundary and latch the
-            // previous turn's count. Sampling itself is deferred to
-            // `terminal.list`: Claude Code writes the turn's `turn_duration`
-            // record a couple of milliseconds AFTER these hooks return, so a
-            // read here would observe the previous turn.
-            //
-            // An explicit interrupt CLEARS instead of marking. An interrupted
-            // turn frequently writes no `turn_duration`, so sampling after one
-            // would re-read the PRE-interrupt record and relight the indicator
-            // with nothing running — the false-thinking direction this rail is
-            // never allowed to fail toward.
-            if params.origin == .userInterrupt {
-                await claudeDelegationTracker.clear(terminalID: terminal.id)
-            } else if params.activityState == .idle {
-                await claudeDelegationTracker.mark(terminalID: terminal.id)
-            }
-            guard terminal.activityState != params.activityState else {
-                // Previously a pure no-op. A same-state observation still
-                // supersedes a not-newer wait reason: this is the only rail
-                // that speaks when an activity value repeats, and the reason
-                // column moves independently of the activity stamp.
-                //
-                // Deliberately NOT gated on `terminal`'s reason columns. That
-                // row was read before an unbounded stretch of async work (a
-                // counter actor hop, a worktree read, and on an idle event a
-                // transcript file copy), and `handleTerminalNotificationEvent`
-                // runs concurrently on its own connection — a prompt recorded
-                // inside that window is invisible here, and skipping the call
-                // would leave the database holding a reason older than the
-                // newest activity observation, which is the one state the
-                // ordering rule exists to prevent. The store re-reads inside
-                // its own transaction and returns false without writing when
-                // there is nothing to retract, and a repeated activity value
-                // is a rare event on this rail (a queued prompt mid-turn, a
-                // second Stop), so the saved write was worth little anyway.
-                if try await db.terminals.clearAwaitingInputReasonIfNotNewer(
-                    id: terminal.id, observedAt: observedAt) {
-                    broadcastAwaitingInputRetraction(terminal: terminal)
-                }
-                return .ok()
-            }
-            // `setActivityState` nils the reason columns unconditionally — it
-            // IS the superseding rail — and reports whether a standing reason
-            // went with them, so the retraction is announced from what the
-            // write actually did rather than from the row read before it.
-            let retracted = try await db.terminals.setActivityState(
-                id: terminal.id,
-                activityState: params.activityState,
-                source: .hookEvent(RPCMethod.terminalActivityEvent),
-                observedAt: observedAt)
-            subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
-                terminalID: terminal.id,
-                worktreeID: terminal.worktreeID,
-                activityState: params.activityState
-            )))
-            if retracted { broadcastAwaitingInputRetraction(terminal: terminal) }
-            return .ok()
-        }
-        let source: FactSource = params.origin == .userInterrupt
+        let source: FactSource = params.origin == .userInterrupt && terminal.isCodexTerminal
             ? .terminalInterrupt
             : .hookEvent(RPCMethod.terminalActivityEvent)
         let activityApplication = try await db.terminals.applyActivityObservation(
@@ -3714,8 +3639,19 @@ extension RPCRouter {
             observedAt: observedAt,
             sessionID: params.sessionID,
             sessionIncarnationID: params.sessionIncarnationID,
+            processBound: params.origin != .userInterrupt,
             replaceSameValue: params.origin == .userInterrupt)
         guard let activityApplication else { return .ok() }
+        if !terminal.isCodexTerminal {
+            // Keep Claude's delegation boundary bookkeeping behind the same
+            // atomic identity decision as its durable activity. A delayed
+            // outgoing-process hook must not advance this in-memory rail.
+            if params.origin == .userInterrupt {
+                await claudeDelegationTracker.clear(terminalID: terminal.id)
+            } else if params.activityState == .idle {
+                await claudeDelegationTracker.mark(terminalID: terminal.id)
+            }
+        }
         // The transactional identity check above must accept a Codex working
         // hook before it can cancel state belonging to the current session.
         // The actuator's own "continue" also lands here; by then verification
@@ -3726,14 +3662,24 @@ extension RPCRouter {
                 await limitResumeScheduler?.wake()
             }
         }
-        subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
-            terminalID: terminal.id,
-            worktreeID: terminal.worktreeID,
-            activityState: activityApplication.activityState,
-            activityStateSource: activityApplication.source,
-            activityStateObservedAt: activityApplication.observedAt,
-            activityStateOrderObservedAt: activityApplication.orderObservedAt
-        )))
+        if activityApplication.activityStateChanged {
+            if terminal.isCodexTerminal {
+                subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+                    terminalID: terminal.id,
+                    worktreeID: terminal.worktreeID,
+                    activityState: activityApplication.activityState,
+                    activityStateSource: activityApplication.source,
+                    activityStateObservedAt: activityApplication.observedAt,
+                    activityStateOrderObservedAt: activityApplication.orderObservedAt
+                )))
+            } else {
+                subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+                    terminalID: terminal.id,
+                    worktreeID: terminal.worktreeID,
+                    activityState: activityApplication.activityState
+                )))
+            }
+        }
         if activityApplication.clearedAwaitingInput {
             broadcastAwaitingInputRetraction(terminal: terminal)
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3713,6 +3713,7 @@ extension RPCRouter {
             source: source,
             observedAt: observedAt,
             sessionID: params.sessionID,
+            sessionIncarnationID: params.sessionIncarnationID,
             replaceSameValue: params.origin == .userInterrupt)
         guard let activityApplication else { return .ok() }
         // The transactional identity check above must accept a Codex working

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -5,6 +5,26 @@ import TBDShared
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "terminalHandlers")
 private let perfTranscriptLog = Logger(subsystem: "com.tbd.daemon", category: "perf-transcript")
 
+private struct StaleTerminalReplacementError: LocalizedError {
+    let errorDescription: String? = "Terminal changed while waiting for replacement"
+}
+
+/// Observe a rollout's byte boundary before SessionStart enters its database
+/// transaction. `seekToEnd` returns an unsigned size, so negative values cannot
+/// enter the model; values that cannot fit the durable signed column are
+/// rejected instead of narrowing or wrapping.
+private func observedTranscriptBoundary(atAbsolutePath path: String?) -> ObservedTranscriptBoundary? {
+    guard let path, path.hasPrefix("/") else { return nil }
+    guard let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: path)) else {
+        return nil
+    }
+    defer { try? handle.close() }
+    guard let size = try? handle.seekToEnd(), size <= UInt64(Int64.max) else {
+        return nil
+    }
+    return ObservedTranscriptBoundary(path: path, eof: Int64(size))
+}
+
 // MARK: - Transcript parse cache
 
 private struct TranscriptParseCacheEntry {
@@ -17,6 +37,7 @@ private struct CodexPresentationIdentity: Equatable {
     let sessionID: String?
     let transcriptPath: String?
     let sessionOrderObservedAt: Date?
+    let transcriptBoundaryOffset: Int64?
 }
 
 /// Caches the last `TranscriptParser.parse` result per session file path.
@@ -577,7 +598,8 @@ extension RPCRouter {
                 ($0.id, CodexPresentationIdentity(
                     sessionID: $0.claudeSessionID,
                     transcriptPath: $0.transcriptPath,
-                    sessionOrderObservedAt: $0.sessionOrderObservedAt))
+                    sessionOrderObservedAt: $0.sessionOrderObservedAt,
+                    transcriptBoundaryOffset: $0.codexTranscriptBoundaryOffset))
             })
 
         for index in terminals.indices where terminals[index].isCodexTerminal {
@@ -587,16 +609,15 @@ extension RPCRouter {
                 transcriptPath: transcriptPath,
                 worktreeID: terminals[index].worktreeID,
                 terminalID: terminals[index].id,
-                sessionGeneration: terminals[index].sessionOrderObservedAt)
+                sessionGeneration: terminals[index].sessionOrderObservedAt,
+                transcriptBoundaryOffset: terminals[index].codexTranscriptBoundaryOffset)
             codexTargets.append(target)
         }
 
-        // SessionStart's persisted session generation is the restart-safe boundary
-        // cue. On a fresh tracker, start at the path's current EOF rather than
-        // replaying an orphan task_started from before that lifecycle event. The
-        // tracker prepares or retries that boundary in the same actor turn as
-        // observation, so a temporarily missing file cannot bootstrap between
-        // the two operations.
+        // The persisted generation and transcript offset form the restart-safe
+        // recovery target. The tracker prepares or retries that boundary in the
+        // same actor turn as observation, so a temporarily missing file cannot
+        // bootstrap between the two operations.
         let codexObservation = await codexActivityTracker.observeStamped(
             transcripts: codexTargets,
             now: now)
@@ -617,7 +638,8 @@ extension RPCRouter {
             let currentIdentity = CodexPresentationIdentity(
                 sessionID: terminals[index].claudeSessionID,
                 transcriptPath: transcriptPath,
-                sessionOrderObservedAt: terminals[index].sessionOrderObservedAt)
+                sessionOrderObservedAt: terminals[index].sessionOrderObservedAt,
+                transcriptBoundaryOffset: terminals[index].codexTranscriptBoundaryOffset)
             guard observedIdentities[terminals[index].id] == currentIdentity else {
                 terminals[index].presentationActivityState = nil
                 terminals[index].presentationActivityObservedAt = codexObservation.observedAt
@@ -1185,6 +1207,7 @@ extension RPCRouter {
         guard let worktree = try await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
+        let expectedReplacementState = TerminalReplacementSnapshot(terminal: terminal)
 
         // A Claude-resumable terminal whose window died must NOT be recreated as a
         // plain shell — that silently turns the tab into a shell and discards the
@@ -1195,41 +1218,69 @@ extension RPCRouter {
         // ID on demand, so this is non-destructive even if the window were somehow
         // still alive.
         if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
-            // Stale-caller gate: if the row's CURRENT window is actually
-            // alive, the caller acted on stale state — e.g. the app's
-            // dead-window path racing a wake that just RECREATED the window
-            // and updated the row's ids. Killing it here would tear down the
-            // freshly-spawned claude and re-park the row (wake flap). Leave
-            // the row untouched.
-            if await tmux.windowExists(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID) {
-                logger.info("recreateWindow: window \(terminal.tmuxWindowID, privacy: .public) for claude terminal \(terminal.id, privacy: .public) is alive — ignoring stale recreate request")
-                return try RPCResponse(result: terminal)
-            }
-            // This branch actuates too, and differently: it kills a window the
-            // check above read as gone — a read that can be stale — and parks
-            // the session. That is the same act reconcile's recovery park
-            // performs, so it carries kind `hibernate` through this surface's
-            // own door (`ActuationBranch.recreateWindowRepark`). The row goes in
-            // ahead of the kill, fail-closed: an unrecordable park refuses the
-            // RPC with the window and the row untouched.
+            // Record the request before waiting on the shared server lock. The
+            // row is not mutated until the post-lock snapshot check below.
             let reparkID = try await beginActuation(
                 .recreateWindowRepark, actor: actor,
                 target: .local(worktree: worktree.id, terminal: terminal.id))
+            let repark = try await actuating(reparkID) {
+                try await tmux.withWorktreeServerLock(
+                    db: db, worktreeID: worktree.id,
+                    allowedStatuses: [worktree.status]
+                ) { currentWorktree -> (terminal: Terminal?, didPark: Bool) in
+                    guard let currentTerminal = try await self.db.terminals.get(
+                        id: terminal.id),
+                          expectedReplacementState.matches(currentTerminal),
+                          currentTerminal.isClaudeResumable,
+                          currentTerminal.claudeSessionID == sessionID else {
+                        throw StaleTerminalReplacementError()
+                    }
 
-            // Clean up any lingering (almost always already-dead) window to avoid orphans.
-            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
-            let parked = try await actuating(reparkID) { () -> Terminal? in
-                // Authoritative `hibernatedAt` column so the unified `wake()` can resume it.
-                try await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID)
-                // Drop any stale pending-question entry — the window the question
-                // belonged to is gone. Mirrors reconcile()/handleTerminalDelete.
-                await pendingQuestions.clear(terminalID: terminal.id)
-                return try await db.terminals.get(id: params.terminalID)
+                    // The liveness decision and every following process mutation
+                    // share the server lock with wake and profile replacement.
+                    // A queued stale re-park therefore cannot kill their new pane.
+                    if await self.tmux.windowExists(
+                        server: currentWorktree.tmuxServer,
+                        windowID: currentTerminal.tmuxWindowID
+                    ) {
+                        logger.info("recreateWindow: window \(currentTerminal.tmuxWindowID, privacy: .public) for claude terminal \(currentTerminal.id, privacy: .public) is alive — ignoring stale recreate request")
+                        return (currentTerminal, false)
+                    }
+
+                    let currentState = TerminalHibernationSnapshot(terminal: currentTerminal)
+                    guard let inertIncarnation = try await self.db.terminals
+                        .beginHibernatedShellRespawn(
+                            id: currentTerminal.id,
+                            expectedState: currentState,
+                            at: self.now()) else {
+                        throw StaleTerminalReplacementError()
+                    }
+
+                    // The durable park intent above preserves the old token.
+                    // Once the dead pane is eliminated, rotate the token and
+                    // clear its process-local facts before exposing the park.
+                    try? await self.tmux.killWindow(
+                        server: currentWorktree.tmuxServer,
+                        windowID: currentTerminal.tmuxWindowID)
+                    guard try await self.db.terminals.finalizeHibernatedShellRespawn(
+                        id: currentTerminal.id,
+                        expectedIncarnation: inertIncarnation,
+                        at: self.now()) != nil else {
+                        throw StaleTerminalReplacementError()
+                    }
+                    await self.pendingQuestions.clear(terminalID: currentTerminal.id)
+                    return (try await self.db.terminals.get(id: currentTerminal.id), true)
+                }
             }
-            guard let updated = parked else {
+            guard let updated = repark.terminal else {
                 await finishActuation(
                     reparkID, .refused(.notFound), error: "Terminal not found after suspend")
                 return RPCResponse(error: "Terminal not found after suspend")
+            }
+            guard repark.didPark else {
+                await finishActuation(
+                    reparkID, .refused(.notEligible), error: "Terminal window is alive")
+                return try RPCResponse(result: updated)
             }
             await finishActuation(reparkID, .dispatched)
             logger.info("recreateWindow: parked claude terminal \(terminal.id, privacy: .public) as suspended — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved")
@@ -1273,14 +1324,15 @@ extension RPCRouter {
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
-            var codexEnv: [String: String] = [:]
-            codexEnv["TBD_WORKTREE_ID"] = worktree.id.uuidString
-            codexEnv["TBD_TERMINAL_ID"] = terminal.id.uuidString
-            // Explicitly export the global Codex home. This is intentional —
-            // the design's allowed "set the global path" option — not leftover
-            // per-repo isolation: it pins deterministic behavior and lets the
-            // TBD_TEST_CODEX_HOME test-isolation override flow through.
-            codexEnv["CODEX_HOME"] = codexPreparation.codexHome.path
+            let codexEnv: [String: String] = [
+                "TBD_WORKTREE_ID": worktree.id.uuidString,
+                "TBD_TERMINAL_ID": terminal.id.uuidString,
+                // Explicitly export the global Codex home. This is intentional —
+                // the design's allowed "set the global path" option — not leftover
+                // per-repo isolation: it pins deterministic behavior and lets the
+                // TBD_TEST_CODEX_HOME test-isolation override flow through.
+                "CODEX_HOME": codexPreparation.codexHome.path,
+            ]
 
             // Codex: re-apply the merged free-form overrides (global < repo) so a
             // recreated Codex pane keeps them, plus omz-update suppression via
@@ -1299,17 +1351,27 @@ extension RPCRouter {
                 repo: recreateRepo?.envOverrides,
                 profile: nil
             ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
-            let codexRecreateEnv = codexEnv
             let updatedTerminal = try await actuating(actuationID) {
                 try await tmux.withWorktreeServerLock(
                     db: db, worktreeID: worktree.id,
                     allowedStatuses: [worktree.status]
                 ) { currentWorktree in
+                    guard let currentTerminal = try await self.db.terminals.get(
+                        id: terminal.id),
+                          expectedReplacementState.matches(currentTerminal),
+                          currentTerminal.kind == .codex
+                            || currentTerminal.label == TerminalLabel.codex,
+                          !currentTerminal.isParked else {
+                        throw StaleTerminalReplacementError()
+                    }
+                    let expectedIncarnation = TerminalSessionIncarnation(
+                        terminal: currentTerminal)
+                    var replacementEnv = codexEnv
                     // Kill the old window and rebuild the server while holding
                     // the same lock reconciliation uses for ownership reads.
                     try? await tmux.killWindow(
                         server: currentWorktree.tmuxServer,
-                        windowID: terminal.tmuxWindowID)
+                        windowID: currentTerminal.tmuxWindowID)
                     _ = try await tmux.ensureServer(
                         server: currentWorktree.tmuxServer,
                         session: "main",
@@ -1326,7 +1388,7 @@ extension RPCRouter {
                         session: "main",
                         cwd: currentWorktree.path,
                         shellCommand: "exec /usr/bin/tail -f /dev/null",
-                        env: codexRecreateEnv,
+                        env: replacementEnv,
                         cols: resolvedCols,
                         rows: resolvedRows
                     )
@@ -1334,11 +1396,16 @@ extension RPCRouter {
                     do {
                         // The new Codex process does not exist yet. Reset the
                         // dead process lifecycle before launching Codex.
-                        try await db.terminals.replaceRecreatedCodexWindow(
+                        guard let incarnationID = try await db.terminals.replaceRecreatedCodexWindow(
                             id: params.terminalID,
+                            expectedIncarnation: expectedIncarnation,
                             windowID: window.windowID,
                             paneID: window.paneID,
-                            at: now())
+                            at: now()) else {
+                            throw StaleTerminalReplacementError()
+                        }
+                        replacementEnv = AgentProcessEnvironment.replacement(
+                            base: replacementEnv, incarnationID: incarnationID)
                     } catch {
                         try? await tmux.killWindow(
                             server: currentWorktree.tmuxServer,
@@ -1353,7 +1420,7 @@ extension RPCRouter {
                             cwd: currentWorktree.path,
                             shellCommand: CodexSpawnCommandBuilder.command(
                                 executablePath: codexPreparation.executablePath),
-                            env: codexRecreateEnv,
+                            env: replacementEnv,
                             sensitiveEnv: codexEnvOverrides,
                             cols: resolvedCols,
                             rows: resolvedRows)
@@ -1402,9 +1469,21 @@ extension RPCRouter {
                     db: db, worktreeID: worktree.id,
                     allowedStatuses: [worktree.status]
                 ) { currentWorktree in
+                    guard let currentTerminal = try await self.db.terminals.get(
+                        id: terminal.id),
+                          expectedReplacementState.matches(currentTerminal),
+                          currentTerminal.kind != .codex,
+                          currentTerminal.label != TerminalLabel.codex,
+                          !currentTerminal.isClaudeResumable,
+                          !currentTerminal.isParked else {
+                        throw StaleTerminalReplacementError()
+                    }
+                    let expectedIncarnation = TerminalSessionIncarnation(
+                        terminal: currentTerminal)
+                    var replacementEnv = env
                     try? await tmux.killWindow(
                         server: currentWorktree.tmuxServer,
-                        windowID: terminal.tmuxWindowID)
+                        windowID: currentTerminal.tmuxWindowID)
                     _ = try await tmux.ensureServer(
                         server: currentWorktree.tmuxServer,
                         session: "main",
@@ -1417,28 +1496,48 @@ extension RPCRouter {
                         server: currentWorktree.tmuxServer,
                         session: "main",
                         cwd: currentWorktree.path,
-                        shellCommand: shell,
-                        env: env,
+                        shellCommand: "exec /usr/bin/tail -f /dev/null",
+                        env: replacementEnv,
                         cols: resolvedCols,
                         rows: resolvedRows
                     )
 
                     do {
-                        // Update the row while the window cannot be mistaken
-                        // for an orphan by reconciliation.
-                        try await db.terminals.updateTmuxIDs(
+                        // Bind the staged window and its process token before
+                        // the shell can launch a hook-emitting agent.
+                        guard let incarnationID = try await db.terminals.replaceRecreatedShellWindow(
                             id: params.terminalID,
+                            expectedIncarnation: expectedIncarnation,
                             windowID: window.windowID,
-                            paneID: window.paneID
-                        )
-                        try await db.terminals.clearRecreated(id: params.terminalID)
-                        return try await db.terminals.get(id: params.terminalID)
+                            paneID: window.paneID,
+                            at: now()) else {
+                            throw StaleTerminalReplacementError()
+                        }
+                        replacementEnv = AgentProcessEnvironment.replacement(
+                            base: replacementEnv, incarnationID: incarnationID)
                     } catch {
                         try? await tmux.killWindow(
                             server: currentWorktree.tmuxServer,
                             windowID: window.windowID)
                         throw error
                     }
+
+                    do {
+                        try await tmux.respawnWindow(
+                            server: currentWorktree.tmuxServer,
+                            windowID: window.windowID,
+                            cwd: currentWorktree.path,
+                            shellCommand: shell,
+                            env: replacementEnv,
+                            cols: resolvedCols,
+                            rows: resolvedRows)
+                    } catch {
+                        try? await tmux.killWindow(
+                            server: currentWorktree.tmuxServer,
+                            windowID: window.windowID)
+                        throw error
+                    }
+                    return try await db.terminals.get(id: params.terminalID)
                 }
             }
 
@@ -1697,6 +1796,7 @@ extension RPCRouter {
         guard let worktree = try await db.worktrees.getLocal(id: oldTerminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
+        let expectedReplacementState = TerminalReplacementSnapshot(terminal: oldTerminal)
 
         // Resolve the requested profile (nil = no override; keychain login).
         // We do NOT touch the old terminal — both tabs coexist after the swap.
@@ -1761,17 +1861,23 @@ extension RPCRouter {
             }
 
             let destProfileID: UUID? = resolved?.profileID
-            try await db.terminals.setProfileID(id: oldTerminal.id, profileID: destProfileID)
+            let updated = try await tmux.withWorktreeServerLock(
+                db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
+            ) { _ in
+                guard let updated = try await self.db.terminals.setParkedProfileID(
+                    id: oldTerminal.id,
+                    expectedState: expectedReplacementState,
+                    profileID: destProfileID) else {
+                    throw StaleTerminalReplacementError()
+                }
+                return updated
+            }
             subscriptions.broadcast(delta: .terminalProfileChanged(TerminalProfileDelta(
-                terminalID: oldTerminal.id,
-                worktreeID: worktree.id,
+                terminalID: updated.id,
+                worktreeID: updated.worktreeID,
                 newProfileID: destProfileID
             )))
             logger.info("cold swap: re-homed parked terminal \(oldTerminal.id, privacy: .public) to profile \(destProfileID?.uuidString ?? "ambient", privacy: .public) — not woken")
-
-            guard let updated = try await db.terminals.get(id: oldTerminal.id) else {
-                return RPCResponse(error: "Terminal vanished after cold swap")
-            }
             return try RPCResponse(result: updated)
         }
 
@@ -2010,18 +2116,33 @@ extension RPCRouter {
                 )
 
             case .inPlace:
-                let outcome = try await inPlaceSwapRespawn(
-                    oldTerminal: oldTerminal,
-                    worktree: worktree.worktree,
-                    spawnCommand: spawn.command,
-                    env: env,
-                    sensitiveEnv: sensitiveEnv,
-                    storedSessionID: storedSessionID,
-                    newProfileID: resolved?.profileID,
-                    scheduleRecapture: scheduleRecapture,
-                    cols: resolvedCols,
-                    rows: resolvedRows
-                )
+                let expectedIncarnation = TerminalSessionIncarnation(terminal: oldTerminal)
+                let replacementBaseEnv = env
+                let outcome = try await tmux.withWorktreeServerLock(
+                    db: db,
+                    worktreeID: worktree.id,
+                    allowedStatuses: [worktree.status]
+                ) { currentWorktree in
+                    guard let currentTerminal = try await self.db.terminals.get(id: oldTerminal.id),
+                          expectedIncarnation.matches(currentTerminal),
+                          currentTerminal.claudeSessionID == oldTerminal.claudeSessionID,
+                          currentTerminal.transcriptPath == oldTerminal.transcriptPath,
+                          !currentTerminal.isParked else {
+                        throw StaleTerminalReplacementError()
+                    }
+                    return try await self.inPlaceSwapRespawn(
+                        oldTerminal: currentTerminal,
+                        worktree: currentWorktree.worktree,
+                        spawnCommand: spawn.command,
+                        env: replacementBaseEnv,
+                        sensitiveEnv: sensitiveEnv,
+                        storedSessionID: storedSessionID,
+                        newProfileID: resolved?.profileID,
+                        scheduleRecapture: scheduleRecapture,
+                        cols: resolvedCols,
+                        rows: resolvedRows
+                    )
+                }
                 response = outcome.response
                 respawnFailure = outcome.respawnError
             }
@@ -2104,7 +2225,10 @@ extension RPCRouter {
 
         if scheduleRecapture {
             scheduleSessionRecapture(
-                terminalID: newTerminal.id, paneID: window.paneID, server: currentServer
+                terminalID: newTerminal.id,
+                paneID: window.paneID,
+                server: currentServer,
+                expectedIncarnationID: newTerminal.sessionIncarnationID
             )
         }
 
@@ -2127,7 +2251,8 @@ extension RPCRouter {
     /// A failed respawn is therefore invisible in the returned response — by
     /// design, and unchanged here. `respawnError` reports it out of band so the
     /// caller's actuation row can say `transport-failed` instead of inheriting
-    /// the response's success.
+    /// the response's success. Callers must hold the worktree tmux-server lock
+    /// across this whole helper.
     private func inPlaceSwapRespawn(
         oldTerminal: Terminal,
         worktree: Worktree,
@@ -2151,10 +2276,22 @@ extension RPCRouter {
         //    in-flight generation. Best-effort — never blocks the swap.
         await gracefullyInterruptPane(server: server, paneID: paneID)
 
-        // 2. Update the terminal row to the new profile + session up front, so a
-        //    later respawn failure still leaves the row on the new account.
-        try await db.terminals.setProfileID(id: oldTerminal.id, profileID: newProfileID)
-        try await db.terminals.updateSessionID(id: oldTerminal.id, sessionID: storedSessionID)
+        // 2. Commit the replacement identity and process token before launch,
+        //    so old-process hooks are stale and new-process hooks can attach
+        //    immediately without a launch gate.
+        let replacementObservedAt = now()
+        guard let incarnationID = try await db.terminals.prepareProfileAgentRespawn(
+            id: oldTerminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: oldTerminal),
+            sessionID: storedSessionID,
+            transcriptPath: oldTerminal.transcriptPath,
+            profileID: newProfileID,
+            at: replacementObservedAt) else {
+            throw StaleTerminalReplacementError()
+        }
+        guard let prepared = try await db.terminals.get(id: oldTerminal.id) else {
+            return (RPCResponse(error: "Terminal vanished before swap"), nil)
+        }
         // Step 1 killed the process any recorded prompt was raised on, and this
         // row survives the swap — so a `permission_prompt` standing here now
         // describes a dead pane. `SessionStateResolver`'s rung 4 would keep
@@ -2164,8 +2301,17 @@ extension RPCRouter {
         // from TBD's own act rather than waiting for the respawned session's
         // hooks to arrive — they may be seconds away, or lost to a stale `tbd`
         // on the pane's PATH.
-        try await db.terminals.clearAwaitingInputReason(id: oldTerminal.id)
         broadcastAwaitingInputRetraction(terminal: oldTerminal)
+        subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+            terminalID: prepared.id,
+            worktreeID: prepared.worktreeID,
+            activityState: prepared.activityState,
+            activityStateSource: prepared.activityStateSource,
+            activityStateObservedAt: prepared.activityStateObservedAt,
+            activityStateOrderObservedAt: prepared.activityStateOrderObservedAt
+        )))
+        let replacementEnv = AgentProcessEnvironment.replacement(
+            base: env, incarnationID: incarnationID)
 
         // 3. Respawn IN PLACE — same window id / pane id → the tab and terminal
         //    row survive.
@@ -2175,7 +2321,7 @@ extension RPCRouter {
                 windowID: windowID,
                 cwd: worktree.localPath,
                 shellCommand: spawnCommand,
-                env: env,
+                env: replacementEnv,
                 sensitiveEnv: sensitiveEnv,
                 cols: cols,
                 rows: rows
@@ -2185,32 +2331,38 @@ extension RPCRouter {
             // retried); the pane surfaces the error. Log clearly and still
             // return the updated row so the app reflects the new account — but
             // hand the failure back so the record classifies it truthfully.
-            logger.warning("inPlace swap: respawn failed for terminal \(oldTerminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.warning("inPlace swap: respawn or lifecycle finalization failed for terminal \(oldTerminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
             respawnError = "\(error)"
-        }
-
-        subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
-            terminalID: oldTerminal.id,
-            worktreeID: worktree.id,
-            sessionID: storedSessionID,
-            transcriptPath: oldTerminal.transcriptPath
-        )))
-        // Update the row's account chip in place — same terminal id, new profile.
-        subscriptions.broadcast(delta: .terminalProfileChanged(TerminalProfileDelta(
-            terminalID: oldTerminal.id,
-            worktreeID: worktree.id,
-            newProfileID: newProfileID
-        )))
-
-        if scheduleRecapture {
-            scheduleSessionRecapture(
-                terminalID: oldTerminal.id, paneID: paneID, server: server
-            )
         }
 
         guard let updated = try await db.terminals.get(id: oldTerminal.id) else {
             return (RPCResponse(error: "Terminal vanished after swap"), respawnError)
         }
+        if let currentSessionID = updated.claudeSessionID {
+            subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
+                terminalID: updated.id,
+                worktreeID: updated.worktreeID,
+                sessionID: currentSessionID,
+                transcriptPath: updated.transcriptPath,
+                sessionOrderObservedAt: updated.sessionOrderObservedAt
+            )))
+        }
+        // Update the row's account chip in place — same terminal id, new profile.
+        subscriptions.broadcast(delta: .terminalProfileChanged(TerminalProfileDelta(
+            terminalID: updated.id,
+            worktreeID: updated.worktreeID,
+            newProfileID: updated.profileID
+        )))
+
+        if scheduleRecapture, respawnError == nil {
+            scheduleSessionRecapture(
+                terminalID: oldTerminal.id,
+                paneID: paneID,
+                server: server,
+                expectedIncarnationID: incarnationID
+            )
+        }
+
         logger.info("inPlace swap: terminal \(oldTerminal.id, privacy: .public) switched to profile \(newProfileID?.uuidString ?? "ambient", privacy: .public) in window \(windowID, privacy: .public)")
         return (try RPCResponse(result: updated), respawnError)
     }
@@ -2254,11 +2406,17 @@ extension RPCRouter {
     /// for Claude to settle, then capture the new id from the pane and persist it
     /// against `terminalID`. (On the `.inPlace` path there is no `--fork-session`,
     /// so the id is unchanged and the recapture is a harmless no-op.)
-    private func scheduleSessionRecapture(terminalID: UUID, paneID: String, server: String) {
+    private func scheduleSessionRecapture(
+        terminalID: UUID,
+        paneID: String,
+        server: String,
+        expectedIncarnationID: UUID?
+    ) {
         SessionRecaptureScheduler(db: db, tmux: tmux).schedule(
             terminalID: terminalID,
             paneID: paneID,
-            server: server
+            server: server,
+            expectedIncarnationID: expectedIncarnationID
         )
     }
 
@@ -3154,6 +3312,7 @@ extension RPCRouter {
             logger.debug("sessionEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
             return .ok()
         }
+        let expectedIncarnation = TerminalSessionIncarnation(terminal: terminal)
         await sessionCounters.recordHookEvent(terminalID: terminal.id, at: observedAt)
 
         // `cwd` is optional for backward compatibility — when absent we cannot
@@ -3174,6 +3333,10 @@ extension RPCRouter {
             }
             return p
         }()
+        let effectiveTranscriptPath = cleanedPath ?? terminal.transcriptPath
+        let observedTranscriptBoundary = terminal.isCodexTerminal
+            ? observedTranscriptBoundary(atAbsolutePath: effectiveTranscriptPath)
+            : nil
 
         // Codex session identity, prompt retraction, and the idle fact are
         // reconciled atomically on independent ordering rails. Other agent
@@ -3181,8 +3344,11 @@ extension RPCRouter {
         // in the same transaction.
         guard let sessionApplication = try await db.terminals.applySessionStart(
             id: terminal.id,
+            expectedIncarnation: expectedIncarnation,
+            reportedIncarnationID: params.sessionIncarnationID,
             sessionID: params.sessionID,
             transcriptPath: cleanedPath,
+            observedTranscriptBoundary: observedTranscriptBoundary,
             observedAt: observedAt
         ) else { return .ok() }
 
@@ -3196,17 +3362,21 @@ extension RPCRouter {
            !transcriptPath.isEmpty,
            let sessionGeneration = sessionApplication.orderObservedAt {
             if sessionApplication.isInitialAttachment {
-                await codexActivityTracker.adoptInitialSession(
-                    transcriptPath: transcriptPath,
-                    worktreeID: terminal.worktreeID,
-                    terminalID: terminal.id,
-                    generation: sessionGeneration)
+                if let boundaryOffset = sessionApplication.transcriptBoundaryOffset {
+                    await codexActivityTracker.adoptInitialSession(
+                        transcriptPath: transcriptPath,
+                        worktreeID: terminal.worktreeID,
+                        terminalID: terminal.id,
+                        generation: sessionGeneration,
+                        boundaryOffset: boundaryOffset)
+                }
             } else {
                 await codexActivityTracker.establishSessionBoundary(
                     transcriptPath: transcriptPath,
                     worktreeID: terminal.worktreeID,
                     terminalID: terminal.id,
-                    generation: sessionGeneration)
+                    generation: sessionGeneration,
+                    boundaryOffset: sessionApplication.transcriptBoundaryOffset)
             }
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -662,7 +662,8 @@ extension RPCRouter {
             .filter { !terminals[$0].isCodexTerminal }
             .map { ClaudeDelegationTarget(
                 terminalID: terminals[$0].id,
-                transcriptPath: terminals[$0].transcriptPath) }
+                transcriptPath: terminals[$0].transcriptPath,
+                sessionIncarnationID: terminals[$0].sessionIncarnationID) }
         let delegationClaims = await claudeDelegationTracker.sample(
             targets: delegationTargets)
         for index in terminals.indices where !terminals[index].isCodexTerminal {
@@ -3562,7 +3563,9 @@ extension RPCRouter {
     /// arrives to retract it.
     func handleTerminalSessionEnded(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSessionEndedParams.self, from: paramsData)
-        await claudeDelegationTracker.clear(terminalID: params.terminalID)
+        await claudeDelegationTracker.clear(
+            terminalID: params.terminalID,
+            sessionIncarnationID: params.sessionIncarnationID)
         return .ok()
     }
 
@@ -3649,18 +3652,16 @@ extension RPCRouter {
             if params.origin == .userInterrupt {
                 await claudeDelegationTracker.clear(terminalID: terminal.id)
             } else if params.activityState == .idle {
-                await claudeDelegationTracker.mark(terminalID: terminal.id)
+                await claudeDelegationTracker.mark(
+                    terminalID: terminal.id,
+                    sessionIncarnationID: params.sessionIncarnationID)
             }
         }
-        // The transactional identity check above must accept a Codex working
-        // hook before it can cancel state belonging to the current session.
-        // The actuator's own "continue" also lands here; by then verification
-        // usually already moved the row out of pending, and a cancel-vs-sent
-        // race affects only audit status, never causes a second send.
-        if params.activityState == .working, terminal.pendingResumeAt != nil {
-            if (try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)) == true {
-                await limitResumeScheduler?.wake()
-            }
+        // Accepted working hooks cancel their pending resume in the same
+        // writer transaction as identity validation. Wake the scheduler only
+        // when that atomic transition actually cancelled a row.
+        if activityApplication.cancelledPendingResume {
+            await limitResumeScheduler?.wake()
         }
         if activityApplication.activityStateChanged {
             if terminal.isCodexTerminal {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -1093,7 +1093,9 @@ public struct TmuxManager: Sendable {
         )
         if dryRun {
             dryRunRecorder?(args)
-            if let error = dryRunRespawnWindowError?(windowID) { throw error }
+            if let error = dryRunRespawnWindowError?(windowID) {
+                throw error
+            }
             await stampTerminalID(
                 server: server, target: windowID, env: env, sensitiveEnv: sensitiveEnv)
             return

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -636,6 +636,13 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// Independent from activity and prompt timestamps because either hook
     /// can arrive late while describing the previous session.
     public var sessionOrderObservedAt: Date?
+    /// Safe byte offset from which Codex transcript lifecycle recovery may
+    /// begin. Nil means no durable boundary is known for this session.
+    public var codexTranscriptBoundaryOffset: Int64?
+    /// Durable process-incarnation nonce used to reject delayed SessionStart
+    /// hooks after a terminal is recreated. Nil identifies legacy and newly
+    /// created rows until their first process replacement.
+    public var sessionIncarnationID: UUID?
     public var kind: TerminalKind?
     public var activityState: TerminalActivityState
     /// Activity reconstructed for display from the current agent transcript.
@@ -731,6 +738,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 profileID: UUID? = nil,
                 transcriptPath: String? = nil,
                 sessionOrderObservedAt: Date? = nil,
+                codexTranscriptBoundaryOffset: Int64? = nil,
+                sessionIncarnationID: UUID? = nil,
                 kind: TerminalKind? = nil,
                 activityState: TerminalActivityState = .unknown,
                 presentationActivityState: TerminalActivityState? = nil,
@@ -758,6 +767,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.profileID = profileID
         self.transcriptPath = transcriptPath
         self.sessionOrderObservedAt = sessionOrderObservedAt
+        self.codexTranscriptBoundaryOffset = codexTranscriptBoundaryOffset
+        self.sessionIncarnationID = sessionIncarnationID
         self.kind = kind
         self.activityState = activityState
         self.presentationActivityState = presentationActivityState
@@ -777,7 +788,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath
-        case sessionOrderObservedAt, kind
+        case sessionOrderObservedAt, codexTranscriptBoundaryOffset, sessionIncarnationID, kind
         case activityState, presentationActivityState, presentationActivityObservedAt
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
         case activityStateSource, activityStateObservedAt, activityStateOrderObservedAt
@@ -799,6 +810,9 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         profileID = try c.decodeIfPresent(UUID.self, forKey: .profileID)
         transcriptPath = try c.decodeIfPresent(String.self, forKey: .transcriptPath)
         sessionOrderObservedAt = try c.decodeIfPresent(Date.self, forKey: .sessionOrderObservedAt)
+        codexTranscriptBoundaryOffset = try c.decodeIfPresent(
+            Int64.self, forKey: .codexTranscriptBoundaryOffset)
+        sessionIncarnationID = try c.decodeIfPresent(UUID.self, forKey: .sessionIncarnationID)
         kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
         presentationActivityState = try c.decodeIfPresent(

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -643,6 +643,10 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// hooks after a terminal is recreated. Nil identifies legacy and newly
     /// created rows until their first process replacement.
     public var sessionIncarnationID: UUID?
+    /// Replacement token staged while the current process is being made
+    /// inert. Process-bound hooks are rejected while this is non-nil; tmux
+    /// replacement confirmation promotes it to `sessionIncarnationID`.
+    public var pendingSessionIncarnationID: UUID?
     public var kind: TerminalKind?
     public var activityState: TerminalActivityState
     /// Activity reconstructed for display from the current agent transcript.
@@ -740,6 +744,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 sessionOrderObservedAt: Date? = nil,
                 codexTranscriptBoundaryOffset: Int64? = nil,
                 sessionIncarnationID: UUID? = nil,
+                pendingSessionIncarnationID: UUID? = nil,
                 kind: TerminalKind? = nil,
                 activityState: TerminalActivityState = .unknown,
                 presentationActivityState: TerminalActivityState? = nil,
@@ -769,6 +774,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.sessionOrderObservedAt = sessionOrderObservedAt
         self.codexTranscriptBoundaryOffset = codexTranscriptBoundaryOffset
         self.sessionIncarnationID = sessionIncarnationID
+        self.pendingSessionIncarnationID = pendingSessionIncarnationID
         self.kind = kind
         self.activityState = activityState
         self.presentationActivityState = presentationActivityState
@@ -788,7 +794,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath
-        case sessionOrderObservedAt, codexTranscriptBoundaryOffset, sessionIncarnationID, kind
+        case sessionOrderObservedAt, codexTranscriptBoundaryOffset, sessionIncarnationID
+        case pendingSessionIncarnationID, kind
         case activityState, presentationActivityState, presentationActivityObservedAt
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
         case activityStateSource, activityStateObservedAt, activityStateOrderObservedAt
@@ -813,6 +820,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         codexTranscriptBoundaryOffset = try c.decodeIfPresent(
             Int64.self, forKey: .codexTranscriptBoundaryOffset)
         sessionIncarnationID = try c.decodeIfPresent(UUID.self, forKey: .sessionIncarnationID)
+        pendingSessionIncarnationID = try c.decodeIfPresent(
+            UUID.self, forKey: .pendingSessionIncarnationID)
         kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
         presentationActivityState = try c.decodeIfPresent(

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3321,7 +3321,13 @@ public struct TerminalActivityEventParams: Codable, Sendable {
 /// to a running daemon, so that skew is real.
 public struct TerminalSessionEndedParams: Codable, Sendable, Equatable {
     public let terminalID: UUID
-    public init(terminalID: UUID) { self.terminalID = terminalID }
+    /// Process incarnation planted by TBD before a managed replacement starts.
+    /// Optional so older clients' payloads continue to decode unchanged.
+    public let sessionIncarnationID: UUID?
+    public init(terminalID: UUID, sessionIncarnationID: UUID? = nil) {
+        self.terminalID = terminalID
+        self.sessionIncarnationID = sessionIncarnationID
+    }
 }
 
 /// Params for `terminal.notificationEvent` — sent by `tbd hooks notification`

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3247,6 +3247,10 @@ public struct TerminalTranscriptItemFullBodyResult: Codable, Sendable {
 /// hook payload changes don't immediately break this bridge.
 public struct TerminalSessionEventParams: Codable, Sendable {
     public let terminalID: UUID
+    /// Process incarnation planted by TBD before a replacement agent starts.
+    /// Legacy, never-replaced terminals omit it and remain on the nil/nil
+    /// compatibility path until their first managed replacement.
+    public let sessionIncarnationID: UUID?
     public let sessionID: String
     public let transcriptPath: String?
     public let source: String?
@@ -3262,9 +3266,11 @@ public struct TerminalSessionEventParams: Codable, Sendable {
         sessionID: String,
         transcriptPath: String?,
         source: String?,
-        cwd: String? = nil
+        cwd: String? = nil,
+        sessionIncarnationID: UUID? = nil
     ) {
         self.terminalID = terminalID
+        self.sessionIncarnationID = sessionIncarnationID
         self.sessionID = sessionID
         self.transcriptPath = transcriptPath
         self.source = source

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3289,6 +3289,9 @@ public struct TerminalActivityEventParams: Codable, Sendable {
     /// Codex hook session identity when the caller consumed hook stdin.
     /// Optional for older hook overlays and non-hook callers.
     public let sessionID: String?
+    /// Process incarnation planted by TBD before a managed replacement starts.
+    /// Optional for older hook overlays and non-hook callers.
+    public let sessionIncarnationID: UUID?
     /// Absent for the existing agent-hook bridge. Optional so older clients'
     /// payloads continue to decode unchanged.
     public let origin: TerminalActivityEventOrigin?
@@ -3296,11 +3299,13 @@ public struct TerminalActivityEventParams: Codable, Sendable {
         terminalID: UUID,
         activityState: TerminalActivityState,
         sessionID: String? = nil,
+        sessionIncarnationID: UUID? = nil,
         origin: TerminalActivityEventOrigin? = nil
     ) {
         self.terminalID = terminalID
         self.activityState = activityState
         self.sessionID = sessionID
+        self.sessionIncarnationID = sessionIncarnationID
         self.origin = origin
     }
 }

--- a/Tests/TBDCLITests/SessionEventCommandTests.swift
+++ b/Tests/TBDCLITests/SessionEventCommandTests.swift
@@ -22,4 +22,17 @@ import Testing
             "TBD_TERMINAL_INCARNATION_ID": "not-a-uuid",
         ]) == nil)
     }
+
+    @Test("SessionEnd forwards the same process incarnation environment")
+    func sessionEndIncarnation() {
+        let incarnationID = UUID()
+
+        #expect(SessionEndCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": incarnationID.uuidString,
+        ]) == incarnationID)
+        #expect(SessionEndCommand.sessionIncarnationID(environment: [:]) == nil)
+        #expect(SessionEndCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": "not-a-uuid",
+        ]) == nil)
+    }
 }

--- a/Tests/TBDCLITests/SessionEventCommandTests.swift
+++ b/Tests/TBDCLITests/SessionEventCommandTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import TBDCLI
+
+@Suite struct SessionEventCommandTests {
+    @Test("valid terminal incarnation environment is forwarded")
+    func validIncarnation() {
+        let incarnationID = UUID()
+
+        #expect(SessionEventCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": incarnationID.uuidString,
+        ]) == incarnationID)
+    }
+
+    @Test("absent and invalid terminal incarnation environment remains legacy")
+    func legacyIncarnation() {
+        #expect(SessionEventCommand.sessionIncarnationID(environment: [:]) == nil)
+        #expect(SessionEventCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": "",
+        ]) == nil)
+        #expect(SessionEventCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": "not-a-uuid",
+        ]) == nil)
+    }
+}

--- a/Tests/TBDCLITests/TerminalActivityEventCommandTests.swift
+++ b/Tests/TBDCLITests/TerminalActivityEventCommandTests.swift
@@ -26,6 +26,22 @@ import Testing
         #expect(TerminalActivityEventCommand.sessionID(fromHookPayload: oversized) == nil)
     }
 
+    @Test("process incarnation parser accepts only a valid environment UUID")
+    func parsesProcessIncarnationIdentity() {
+        let incarnationID = UUID()
+
+        #expect(TerminalActivityEventCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": incarnationID.uuidString,
+        ]) == incarnationID)
+        #expect(TerminalActivityEventCommand.sessionIncarnationID(environment: [:]) == nil)
+        #expect(TerminalActivityEventCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": "",
+        ]) == nil)
+        #expect(TerminalActivityEventCommand.sessionIncarnationID(environment: [
+            "TBD_TERMINAL_INCARNATION_ID": "not-a-uuid",
+        ]) == nil)
+    }
+
     @Test("hook stdin parsing is explicit")
     func hookStdinParsingIsExplicit() throws {
         let command = try TerminalActivityEventCommand.parse([

--- a/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
+++ b/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
@@ -25,14 +25,16 @@ struct BoundedGateWaitTests {
         let gate = DispatchSemaphore(value: 0)
         let released = NSLock()
         nonisolated(unsafe) var didRelease = false
-        DispatchQueue.global().async {
+        let releaseThread = Thread {
             released.withLock { didRelease = true }
             gate.signal()
         }
+        releaseThread.name = "com.tbd.tests.gate-release"
+        releaseThread.start()
         // Default deadline, not a snappier number of its own: this is a
-        // hang-catcher on a `DispatchQueue.global()` hop, and 30 s was not
-        // enough for one on a saturated 3-core runner — it went red there
-        // while asserting nothing about time.
+        // hang-catcher on a dedicated thread hop. A dispatch queue is not a
+        // dedicated thread and cannot be the reference here: saturated gate
+        // work used to starve the queue for the entire deadline.
         #expect(gate.waitForGate("self-test: cross-thread"))
         #expect(released.withLock { didRelease }, "the wait must not return before the signal")
     }
@@ -86,6 +88,41 @@ struct BoundedGateWaitTests {
         for task in tasks where await task.value { released += 1 }
         #expect(released == holders, "every holder must be released, not expire")
         #expect(parked.value == holders, "every holder must have reached its gate")
+    }
+
+    @Test("gate holders leave the dispatch worker pool free")
+    func gateHoldersDoNotStarveDispatchWorkers() async throws {
+        // 64 is the smallest stress count that reproduced the old executor's
+        // dispatch-worker ceiling on the development host, and it exceeds the
+        // 25 gate holders added by this PR when the 3-core CI runner starved.
+        // The count is deliberately fixed: this stresses a shared worker limit,
+        // which is not the same as active CPU width.
+        let holders = 64
+        let gate = DispatchSemaphore(value: 0)
+        let parked = Counter()
+        let tasks = (0..<holders).map { index in
+            gateHoldingTask {
+                parked.increment()
+                return gate.waitForGate("self-test: dispatch-starvation holder \(index)")
+            }
+        }
+        defer { for _ in 0..<holders { gate.signal() } }
+
+        guard await waitUntil({ parked.value == holders }, timeout: ciSafeDeadline) else {
+            for _ in 0..<holders { gate.signal() }
+            for task in tasks { _ = await task.value }
+            Issue.record("every stress holder must reach its gate")
+            return
+        }
+
+        let dispatched = Counter()
+        DispatchQueue.global(qos: .userInitiated).async { dispatched.increment() }
+        let dispatchRan = await waitUntil(
+            { dispatched.value == 1 }, timeout: ciSafeDeadline)
+
+        for _ in 0..<holders { gate.signal() }
+        for task in tasks { _ = await task.value }
+        #expect(dispatchRan, "gate holders must not consume the workers needed by unrelated dispatch work")
     }
 
     @Test("the timeout diagnostic names the gate and the deadline")

--- a/Tests/TBDDaemonTests/ClaudeDelegationTrackerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeDelegationTrackerTests.swift
@@ -66,6 +66,33 @@ import Testing
             targets: [ClaudeDelegationTarget(terminalID: id, transcriptPath: new)])[id] == nil)
     }
 
+    @Test func anOldProcessMarkCannotSampleOrReplaceASuccessorClaim() async throws {
+        let tracker = ClaudeDelegationTracker()
+        let path = try write(record(pending: 2) + "\n")
+        let id = UUID()
+        let oldIncarnationID = UUID()
+        let replacementIncarnationID = UUID()
+        let replacementTarget = ClaudeDelegationTarget(
+            terminalID: id,
+            transcriptPath: path,
+            sessionIncarnationID: replacementIncarnationID)
+
+        await tracker.mark(
+            terminalID: id,
+            sessionIncarnationID: oldIncarnationID)
+        #expect(await tracker.sample(targets: [replacementTarget])[id] == nil)
+        #expect(await tracker.isMarked(terminalID: id) == false)
+
+        await tracker.mark(
+            terminalID: id,
+            sessionIncarnationID: replacementIncarnationID)
+        #expect(await tracker.sample(targets: [replacementTarget])[id] == 2)
+        await tracker.mark(
+            terminalID: id,
+            sessionIncarnationID: oldIncarnationID)
+        #expect(await tracker.sample(targets: [replacementTarget])[id] == 2)
+    }
+
     @Test func clearDropsALiveClaim() async throws {
         let tracker = ClaudeDelegationTracker()
         let path = try write(record(pending: 1) + "\n")

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -16,13 +16,15 @@ extension TBDHomeSerialized {
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let hooks = parsed?["hooks"] as? [String: Any]
         #expect(hooks != nil)
-        // SessionStart entry registers `tbd session-event` with a `*` matcher.
+        // SessionStart prefers the daemon-matched CLI and retains a PATH
+        // fallback, with a `*` matcher.
         let sessionStart = hooks?["SessionStart"] as? [[String: Any]]
         let matcher0 = sessionStart?.first?["matcher"] as? String
         #expect(matcher0 == "*")
         let inner = sessionStart?.first?["hooks"] as? [[String: Any]]
         let cmd0 = inner?.first?["command"] as? String
-        #expect(cmd0?.contains("tbd session-event") == true)
+        #expect(cmd0?.contains("TBD_CLI_PATH-tbd") == true)
+        #expect(cmd0?.contains("session-event") == true)
 
         // Stop entry registers `tbd notify` as the first matcher and
         // `tbd hooks stop-rename-check` as a sibling matcher.
@@ -36,6 +38,44 @@ extension TBDHomeSerialized {
             return inner.compactMap { $0["command"] as? String }
         }
         #expect(allStopCommands.contains(where: { $0.contains("stop-rename-check") }))
+    }
+
+    @Test func sessionStartUsesQuotedMatchedCLIAndFallsBackToPath() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-claude-session-hook-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let matched = directory.appendingPathComponent("matched tbd cli")
+        let fallback = directory.appendingPathComponent("tbd")
+        let marker = directory.appendingPathComponent("marker")
+        let matchedScript = "#!/bin/sh\nprintf 'matched:%s\\n' \"$1\" >> \"$TBD_CLI_MARKER\"\n"
+        let fallbackScript = "#!/bin/sh\nprintf 'fallback:%s\\n' \"$1\" >> \"$TBD_CLI_MARKER\"\n"
+        try matchedScript.write(to: matched, atomically: true, encoding: .utf8)
+        try fallbackScript.write(to: fallback, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: matched.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fallback.path)
+
+        func run(matchedPath: String?) throws -> String {
+            try? FileManager.default.removeItem(at: marker)
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/sh")
+            process.arguments = ["-c", ClaudeHookOverlay.sessionStartCommand]
+            var environment = ProcessInfo.processInfo.environment
+            environment["PATH"] = "\(directory.path):/usr/bin:/bin"
+            environment["TBD_CLI_MARKER"] = marker.path
+            environment["TBD_CLI_PATH"] = matchedPath
+            process.environment = environment
+            process.standardInput = Pipe()
+            process.standardOutput = Pipe()
+            process.standardError = Pipe()
+            try process.run()
+            process.waitUntilExit()
+            #expect(process.terminationStatus == 0)
+            return try String(contentsOf: marker, encoding: .utf8)
+        }
+
+        #expect(try run(matchedPath: matched.path) == "matched:session-event\nmatched:terminal-activity\n")
+        #expect(try run(matchedPath: nil) == "fallback:session-event\nfallback:terminal-activity\n")
     }
 
     @Test func postToolUseBashHookBindsPRsAndKeepsAskUserQuestion() throws {

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -896,6 +896,19 @@ struct CodexActivityReconciliationTests {
         #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == nil)
     }
 
+    @Test("suspending with an unordered session identity clears the Codex boundary")
+    func setSuspendedClearsBoundary() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "set-suspended")
+        try await seedBoundary(103, terminalID: terminal.id)
+
+        try await db.terminals.setSuspended(
+            id: terminal.id,
+            sessionID: "replacement",
+            at: presentationObservedAt)
+
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == nil)
+    }
+
     @Test("shell window recreation clears the Codex boundary")
     func clearRecreatedClearsBoundary() async throws {
         let terminal = try await makeBoundaryTerminal(tag: "clear-recreated")

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -45,6 +45,31 @@ struct CodexActivityReconciliationTests {
             actuationLog: makeTestActuationLog())
     }
 
+    private func makeBoundaryTerminal(
+        tag: String,
+        kind: TerminalKind = .codex
+    ) async throws -> Terminal {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-boundary-\(tag)-repo-\(UUID().uuidString)",
+            displayName: "car-boundary-\(tag)", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-boundary-\(tag)-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-boundary-\(tag)")
+        return try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: kind == .codex ? TerminalLabel.codex : kind.rawValue,
+            kind: kind)
+    }
+
+    private func seedBoundary(_ offset: Int64, terminalID: UUID) async throws {
+        try await db.writerForTests.write { database in
+            try database.execute(
+                sql: "UPDATE terminal SET codexTranscriptBoundaryOffset = ? WHERE id = ?",
+                arguments: [offset, terminalID.uuidString])
+        }
+    }
+
     private func makeCodexRecreateFixture(
         tag: String,
         tmux: TmuxManager,
@@ -112,11 +137,12 @@ struct CodexActivityReconciliationTests {
             label: "Codex",
             kind: .codex
         )
-        try await db.terminals.updateSession(
+        _ = try #require(try await db.terminals.applySessionStart(
             id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
             sessionID: "codex-session",
-            transcriptPath: transcriptPath.path
-        )
+            transcriptPath: transcriptPath.path,
+            observedAt: Date(timeIntervalSince1970: 1_779_999_999)))
         let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
         try await db.terminals.setActivityState(
             id: terminal.id, activityState: .idle,
@@ -167,10 +193,12 @@ struct CodexActivityReconciliationTests {
             tmuxPaneID: "%1",
             label: "Codex",
             kind: .codex)
-        try await db.terminals.updateSession(
+        _ = try #require(try await db.terminals.applySessionStart(
             id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
             sessionID: "current-session",
-            transcriptPath: transcript.path)
+            transcriptPath: transcript.path,
+            observedAt: Date(timeIntervalSince1970: 1_790_000_009)))
         let initialActivityAt = Date(timeIntervalSince1970: 1_790_000_010)
         try await db.terminals.setActivityState(
             id: terminal.id,
@@ -246,6 +274,15 @@ struct CodexActivityReconciliationTests {
         let before = await router.handle(list)
         #expect(before.success)
         #expect(try before.decodeResult([Terminal].self).first?
+            .presentationActivityState == nil)
+
+        try append(
+            Data((#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current"}}"#
+                + "\n").utf8),
+            to: transcript)
+        let current = await router.handle(list)
+        #expect(current.success)
+        #expect(try current.decodeResult([Terminal].self).first?
             .presentationActivityState == .working)
 
         let sessionStart = try RPCRequest(
@@ -346,8 +383,10 @@ struct CodexActivityReconciliationTests {
             tmuxServer: "tbd-codex-recreate")
         let terminal = try await db.terminals.create(
             worktreeID: wt.id,
-            tmuxWindowID: "@old",
-            tmuxPaneID: "%old",
+            // Dry-run window creation deliberately reuses these coordinates,
+            // proving the process token closes the tmux-ID/label ABA case.
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0",
             label: "Codex Recovery",
             kind: .codex)
         let oldSessionAt = Date(timeIntervalSince1970: 1_790_000_100)
@@ -401,9 +440,40 @@ struct CodexActivityReconciliationTests {
             return
         }
 
-        // Exercise the real race: the new process can report SessionStart as
-        // soon as tmux launches it. The handler must already have durably
-        // cleared the dead process before this hook is accepted.
+        // Exercise the real race: a delayed hook from the dead process reaches
+        // the handler after the prelaunch process token commits. Its legacy
+        // nil token must be rejected while the replacement launch is paused.
+        dates.advance(by: 1)
+        let gapSessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "old-session",
+                transcriptPath: oldTranscript.path,
+                source: "startup"))
+        #expect((await recreateRouter.handle(gapSessionStart)).success)
+        let staged = try #require(try await db.terminals.get(id: terminal.id))
+        let replacementToken = try #require(staged.sessionIncarnationID)
+        #expect(staged.tmuxWindowID == terminal.tmuxWindowID)
+        #expect(staged.tmuxPaneID == terminal.tmuxPaneID)
+        #expect(staged.label == terminal.label)
+        #expect(staged.claudeSessionID == nil)
+        #expect(launchRecorder.blockedCommand?.last?.contains(
+            "TBD_TERMINAL_INCARNATION_ID='\(replacementToken.uuidString)'") == true)
+        let matchedCLIPath = try #require(AgentProcessEnvironment.cliPath)
+        #expect(launchRecorder.blockedCommand?.last?.contains(
+            "TBD_CLI_PATH=\(SystemPromptBuilder.shellEscape(matchedCLIPath))") == true)
+        launchRecorder.releaseCodexLaunch()
+
+        let recreateResponse = await recreateTask.value
+        #expect(recreateResponse.success, "recreate failed: \(recreateResponse.error ?? "nil")")
+        let finalized = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(finalized.claudeSessionID == nil)
+        #expect(finalized.transcriptPath == nil)
+        #expect(finalized.sessionOrderObservedAt == nil)
+
+        // The replacement process echoes its environment token and can attach
+        // immediately; no post-launch writer can erase the accepted hook.
         dates.advance(by: 1)
         let sessionStart = try RPCRequest(
             method: RPCMethod.terminalSessionEvent,
@@ -411,12 +481,9 @@ struct CodexActivityReconciliationTests {
                 terminalID: terminal.id,
                 sessionID: "new-session",
                 transcriptPath: transcript.path,
-                source: "startup"))
+                source: "startup",
+                sessionIncarnationID: replacementToken))
         #expect((await recreateRouter.handle(sessionStart)).success)
-        launchRecorder.releaseCodexLaunch()
-
-        let recreateResponse = await recreateTask.value
-        #expect(recreateResponse.success, "recreate failed: \(recreateResponse.error ?? "nil")")
 
         let recreated = try #require(try await db.terminals.get(id: terminal.id))
         #expect(recreated.label == "Codex Recovery")
@@ -606,6 +673,8 @@ struct CodexActivityReconciliationTests {
         #expect(response.success)
         #expect(try response.decodeResult([Terminal].self).first?
             .presentationActivityState == nil)
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset
+            == Int64(try Data(contentsOf: transcript).count))
     }
 
     @Test("a stored session-order watermark makes a nil-identity SessionStart later")
@@ -644,6 +713,291 @@ struct CodexActivityReconciliationTests {
         #expect(response.success)
         #expect(try response.decodeResult([Terminal].self).first?
             .presentationActivityState == nil)
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset
+            == Int64(try Data(contentsOf: transcript).count))
+    }
+
+    @Test("a stored identity makes a SessionStart a later attachment")
+    func storedIdentityFencesNextSessionStart() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "partial-identity")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        try await db.writerForTests.write { database in
+            try database.execute(
+                sql: "UPDATE terminal SET claudeSessionID = ? WHERE id = ?",
+                arguments: ["prior-session", terminal.id.uuidString])
+        }
+
+        let application = try #require(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "next-session",
+            transcriptPath: transcript.path,
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: transcript.path,
+                eof: Int64(try Data(contentsOf: transcript).count)),
+            observedAt: presentationObservedAt))
+
+        #expect(!application.isInitialAttachment)
+        #expect(application.transcriptBoundaryOffset
+            == Int64(try Data(contentsOf: transcript).count))
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset
+            == application.transcriptBoundaryOffset)
+    }
+
+    @Test("a stored boundary makes an otherwise empty SessionStart a later attachment")
+    func storedBoundaryFencesNextSessionStart() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "partial-boundary")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        try await seedBoundary(7, terminalID: terminal.id)
+        let eof = Int64(try Data(contentsOf: transcript).count)
+
+        let application = try #require(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "next-session",
+            transcriptPath: transcript.path,
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: transcript.path,
+                eof: eof),
+            observedAt: presentationObservedAt))
+
+        #expect(!application.isInitialAttachment)
+        #expect(application.transcriptBoundaryOffset == eof)
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == eof)
+    }
+
+    @Test("an initial Codex attachment stores zero regardless of observed EOF")
+    func initialAttachmentStoresZeroBoundary() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "initial")
+
+        let application = try #require(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "initial-session",
+            transcriptPath: "/tmp/car-boundary-initial.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/car-boundary-initial.jsonl",
+                eof: 4_096),
+            observedAt: presentationObservedAt))
+
+        #expect(application.isInitialAttachment)
+        #expect(application.transcriptBoundaryOffset == 0)
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == 0)
+    }
+
+    @Test("stale and equal-stamped SessionStarts cannot move an accepted boundary")
+    func rejectedSessionStartsPreserveAcceptedBoundary() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "rejected")
+        _ = try #require(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "initial-session",
+            transcriptPath: "/tmp/car-boundary-rejected.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/car-boundary-rejected.jsonl",
+                eof: 10),
+            observedAt: presentationObservedAt))
+        let acceptedAt = presentationObservedAt.addingTimeInterval(1)
+        let accepted = try #require(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "accepted-session",
+            transcriptPath: "/tmp/car-boundary-rejected.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/car-boundary-rejected.jsonl",
+                eof: 111),
+            observedAt: acceptedAt))
+        #expect(accepted.transcriptBoundaryOffset == 111)
+
+        #expect(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "stale-session",
+            transcriptPath: "/tmp/car-boundary-stale.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/car-boundary-stale.jsonl",
+                eof: 222),
+            observedAt: presentationObservedAt) == nil)
+        #expect(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "accepted-session",
+            transcriptPath: "/tmp/car-boundary-rejected.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/car-boundary-rejected.jsonl",
+                eof: 333),
+            observedAt: acceptedAt) == nil)
+
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.claudeSessionID == "accepted-session")
+        #expect(stored.transcriptPath == "/tmp/car-boundary-rejected.jsonl")
+        #expect(stored.codexTranscriptBoundaryOffset == 111)
+    }
+
+    @Test("a retained path mismatch cannot persist an EOF observed for another transcript")
+    func retainedPathMismatchRejectsObservedEOF() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "retained-path-race")
+        let observedPath = "/tmp/car-boundary-observed.jsonl"
+        let transactionPath = "/tmp/car-boundary-transaction.jsonl"
+        try await db.writerForTests.write { database in
+            try database.execute(
+                sql: """
+                    UPDATE terminal
+                    SET claudeSessionID = ?, transcriptPath = ?
+                    WHERE id = ?
+                    """,
+                arguments: ["prior-session", transactionPath, terminal.id.uuidString])
+        }
+
+        let application = try #require(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "next-session",
+            transcriptPath: nil,
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: observedPath,
+                eof: 12_345),
+            observedAt: presentationObservedAt))
+
+        #expect(!application.isInitialAttachment)
+        #expect(application.transcriptPath == transactionPath)
+        #expect(application.transcriptBoundaryOffset == nil)
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.transcriptPath == transactionPath)
+        #expect(stored.codexTranscriptBoundaryOffset == nil)
+    }
+
+    @Test("unordered session replacement clears the Codex boundary")
+    func updateSessionClearsBoundary() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "update-session")
+        try await seedBoundary(101, terminalID: terminal.id)
+
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "replacement",
+            transcriptPath: "/tmp/car-boundary-replacement.jsonl")
+
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == nil)
+    }
+
+    @Test("in-place session identity replacement clears the Codex boundary")
+    func updateSessionIDClearsBoundary() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "update-session-id")
+        try await seedBoundary(102, terminalID: terminal.id)
+
+        try await db.terminals.updateSessionID(id: terminal.id, sessionID: "replacement")
+
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == nil)
+    }
+
+    @Test("shell window recreation clears the Codex boundary")
+    func clearRecreatedClearsBoundary() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "clear-recreated")
+        try await seedBoundary(103, terminalID: terminal.id)
+
+        try await db.terminals.clearRecreated(id: terminal.id)
+
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == nil)
+    }
+
+    @Test("in-place Codex window replacement clears the old process boundary")
+    func replaceRecreatedCodexWindowClearsBoundary() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "replace-recreated")
+        try await seedBoundary(104, terminalID: terminal.id)
+
+        _ = try await db.terminals.replaceRecreatedCodexWindow(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            windowID: "@new",
+            paneID: "%new",
+            at: presentationObservedAt)
+
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.tmuxWindowID == "@new")
+        #expect(stored.tmuxPaneID == "%new")
+        #expect(stored.codexTranscriptBoundaryOffset == nil)
+    }
+
+    @Test("a delayed SessionStart cannot repopulate a terminal cleared during recreation")
+    func clearRecreatedRejectsPriorIncarnationSessionStart() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "stale-clear-recreated")
+        let expectedIncarnation = TerminalSessionIncarnation(terminal: terminal)
+        try await seedSessionStateForRecreation(terminalID: terminal.id)
+
+        try await db.terminals.clearRecreated(
+            id: terminal.id,
+            at: presentationObservedAt.addingTimeInterval(1))
+        let application = try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: expectedIncarnation,
+            sessionID: "dead-session",
+            transcriptPath: "/tmp/car-dead-clear-recreated.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/car-dead-clear-recreated.jsonl",
+                eof: 999),
+            observedAt: presentationObservedAt.addingTimeInterval(2))
+
+        #expect(application == nil)
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.kind == .shell)
+        #expect(stored.claudeSessionID == nil)
+        #expect(stored.transcriptPath == nil)
+        #expect(stored.sessionOrderObservedAt == nil)
+        #expect(stored.codexTranscriptBoundaryOffset == nil)
+    }
+
+    @Test("a delayed SessionStart cannot repopulate a replacement Codex window")
+    func replaceRecreatedRejectsPriorIncarnationSessionStart() async throws {
+        let terminal = try await makeBoundaryTerminal(tag: "stale-replace-recreated")
+        let expectedIncarnation = TerminalSessionIncarnation(terminal: terminal)
+        try await seedSessionStateForRecreation(terminalID: terminal.id)
+
+        _ = try await db.terminals.replaceRecreatedCodexWindow(
+            id: terminal.id,
+            expectedIncarnation: expectedIncarnation,
+            windowID: "@replacement",
+            paneID: "%replacement",
+            at: presentationObservedAt.addingTimeInterval(1))
+        let application = try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: expectedIncarnation,
+            sessionID: "dead-session",
+            transcriptPath: "/tmp/car-dead-replace-recreated.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/car-dead-replace-recreated.jsonl",
+                eof: 999),
+            observedAt: presentationObservedAt.addingTimeInterval(2))
+
+        #expect(application == nil)
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.tmuxWindowID == "@replacement")
+        #expect(stored.tmuxPaneID == "%replacement")
+        #expect(stored.claudeSessionID == nil)
+        #expect(stored.transcriptPath == nil)
+        #expect(stored.sessionOrderObservedAt == nil)
+        #expect(stored.codexTranscriptBoundaryOffset == nil)
+    }
+
+    private func seedSessionStateForRecreation(terminalID: UUID) async throws {
+        try await db.writerForTests.write { database in
+            try database.execute(
+                sql: """
+                    UPDATE terminal
+                    SET claudeSessionID = ?, transcriptPath = ?,
+                        sessionOrderObservedAt = ?, codexTranscriptBoundaryOffset = ?
+                    WHERE id = ?
+                    """,
+                arguments: [
+                    "live-session", "/tmp/car-live-before-recreate.jsonl",
+                    presentationObservedAt, 123, terminalID.uuidString,
+                ])
+        }
     }
 
     @Test("concurrent SessionStarts classify exactly one accepted transaction as initial")
@@ -665,13 +1019,17 @@ struct CodexActivityReconciliationTests {
         let first = Task {
             await gate.waitForRelease()
             return try await db.terminals.applySessionStart(
-                id: terminal.id, sessionID: "first-session",
+                id: terminal.id,
+                expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+                sessionID: "first-session",
                 transcriptPath: "/tmp/car-atomic-first.jsonl", observedAt: firstAt)
         }
         let second = Task {
             await gate.waitForRelease()
             return try await db.terminals.applySessionStart(
-                id: terminal.id, sessionID: "second-session",
+                id: terminal.id,
+                expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+                sessionID: "second-session",
                 transcriptPath: "/tmp/car-atomic-second.jsonl", observedAt: secondAt)
         }
         await gate.releaseAll()
@@ -707,10 +1065,14 @@ struct CodexActivityReconciliationTests {
         let secondAt = Date(timeIntervalSince1970: 1_790_000_000.123_4)
 
         let first = try #require(try await db.terminals.applySessionStart(
-            id: terminal.id, sessionID: "first-session",
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "first-session",
             transcriptPath: transcript.path, observedAt: firstAt))
         let second = try #require(try await db.terminals.applySessionStart(
-            id: terminal.id, sessionID: "second-session",
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "second-session",
             transcriptPath: transcript.path, observedAt: secondAt))
         let firstGeneration = try #require(first.orderObservedAt)
         let secondGeneration = try #require(second.orderObservedAt)
@@ -729,7 +1091,8 @@ struct CodexActivityReconciliationTests {
             transcriptPath: transcript.path,
             worktreeID: wt.id,
             terminalID: terminal.id,
-            generation: secondGeneration)
+            generation: secondGeneration,
+            boundaryOffset: second.transcriptBoundaryOffset)
         #expect(await router.codexActivityTracker.observe(
             transcriptPath: transcript.path, worktreeID: wt.id) == nil)
     }
@@ -764,11 +1127,15 @@ struct CodexActivityReconciliationTests {
 
         #expect(try await db.terminals.get(id: terminal.id)?.sessionOrderObservedAt == legacyAt)
         #expect(try await db.terminals.applySessionStart(
-            id: terminal.id, sessionID: "stale-session", transcriptPath: nil,
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "stale-session", transcriptPath: nil,
             observedAt: legacyAt.addingTimeInterval(-0.000_1)) == nil)
         let laterAt = legacyAt.addingTimeInterval(0.000_1)
         let later = try #require(try await db.terminals.applySessionStart(
-            id: terminal.id, sessionID: "later-session", transcriptPath: nil,
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "later-session", transcriptPath: nil,
             observedAt: laterAt))
         let laterGeneration = try #require(later.orderObservedAt)
         #expect(laterGeneration > legacyAt)
@@ -777,8 +1144,8 @@ struct CodexActivityReconciliationTests {
             == laterGeneration)
     }
 
-    @Test("initial adoption supersedes same-generation list reconstruction")
-    func initialAdoptionWinsAfterPersistedSessionListRace() async throws {
+    @Test("initial durable boundary recovers during list reconstruction")
+    func initialBoundaryRecoversAcrossPersistedSessionListRace() async throws {
         let repo = try await db.repos.create(
             path: "/tmp/car-adoption-race-repo-\(UUID().uuidString)",
             displayName: "car-adoption-race-repo", defaultBranch: "main")
@@ -797,7 +1164,9 @@ struct CodexActivityReconciliationTests {
 
         let observedAt = Date(timeIntervalSince1970: 1_790_000_000.123_6)
         let application = try #require(try await db.terminals.applySessionStart(
-            id: terminal.id, sessionID: "initial-session",
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "initial-session",
             transcriptPath: transcript.path, observedAt: observedAt))
         #expect(application.isInitialAttachment)
         let stored = try #require(try await db.terminals.get(id: terminal.id))
@@ -810,7 +1179,7 @@ struct CodexActivityReconciliationTests {
         let racedList = await router.handle(list)
         #expect(racedList.success)
         #expect(try racedList.decodeResult([Terminal].self).first?
-            .presentationActivityState == nil)
+            .presentationActivityState == .working)
 
         await router.codexActivityTracker.adoptInitialSession(
             transcriptPath: transcript.path,
@@ -821,6 +1190,112 @@ struct CodexActivityReconciliationTests {
         #expect(afterAdoption.success)
         #expect(try afterAdoption.decodeResult([Terminal].self).first?
             .presentationActivityState == .working)
+    }
+
+    @Test("a fresh router progressively recovers activity older than the transcript tail")
+    func freshRouterRecoversInitialSessionBeyondOneMiB() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-cold-recovery-repo-\(UUID().uuidString)",
+            displayName: "car-cold-recovery-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-cold-recovery-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-cold-recovery")
+        let transcript = try makeTranscript(String(decoding: lifecycleEvent(
+            type: "task_started", turnID: "current"), as: UTF8.self))
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        for index in 0..<17 {
+            try append(lifecycleEvent(
+                type: "agent_message",
+                turnID: "padding-\(index)",
+                exactByteCount: 64 * 1024), to: transcript)
+        }
+        #expect(try Data(contentsOf: transcript).count > 1024 * 1024)
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "initial-session",
+                transcriptPath: transcript.path,
+                source: "SessionStart"))
+        #expect((await router.handle(sessionStart)).success)
+        #expect(try await db.terminals.get(id: terminal.id)?
+            .codexTranscriptBoundaryOffset == 0)
+
+        let restartedRouter = makeRouter(now: { presentationObservedAt })
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id))
+        let firstResponse = await restartedRouter.handle(list)
+        #expect(firstResponse.success)
+        #expect(try firstResponse.decodeResult([Terminal].self).first?
+            .presentationActivityState == nil)
+
+        var recoveredState: TerminalActivityState?
+        for _ in 0..<3 where recoveredState == nil {
+            let response = await restartedRouter.handle(list)
+            #expect(response.success)
+            recoveredState = try response.decodeResult([Terminal].self).first?
+                .presentationActivityState
+        }
+        #expect(recoveredState == .working)
+        #expect(try await db.terminals.get(id: terminal.id)?
+            .codexTranscriptBoundaryOffset == 0)
+
+        try append(lifecycleEvent(
+            type: "task_complete", turnID: "current"), to: transcript)
+        var completedState = recoveredState
+        for _ in 0..<2 where completedState != .idle {
+            let response = await restartedRouter.handle(list)
+            #expect(response.success)
+            completedState = try response.decodeResult([Terminal].self).first?
+                .presentationActivityState
+        }
+        #expect(completedState == .idle)
+    }
+
+    @Test("durable boundary supersedes same-generation provisional EOF but not newer state")
+    func durableBoundaryWinsAfterListReconstructionRace() async throws {
+        let tracker = CodexTranscriptActivityTracker()
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        let generation = Date(timeIntervalSince1970: 1_790_300_000)
+
+        let provisionalTarget = CodexTranscriptActivityTracker.Target(
+            transcriptPath: transcript.path,
+            worktreeID: worktreeID,
+            terminalID: terminalID,
+            sessionGeneration: generation)
+        await tracker.establishSessionBoundariesIfAbsent(
+            transcripts: [provisionalTarget])
+        #expect(await tracker.observe(
+            transcriptPath: transcript.path,
+            worktreeID: worktreeID) == nil)
+
+        await tracker.establishSessionBoundary(
+            transcriptPath: transcript.path,
+            worktreeID: worktreeID,
+            terminalID: terminalID,
+            generation: generation,
+            boundaryOffset: 0)
+        await tracker.establishSessionBoundary(
+            transcriptPath: transcript.path,
+            worktreeID: worktreeID,
+            terminalID: terminalID,
+            generation: generation.addingTimeInterval(-1),
+            boundaryOffset: Int64(try Data(contentsOf: transcript).count))
+
+        #expect(await tracker.observe(
+            transcriptPath: transcript.path,
+            worktreeID: worktreeID) == .working)
     }
 
     @Test("an unavailable initial rollout remains eligible for later bootstrap")
@@ -861,8 +1336,8 @@ struct CodexActivityReconciliationTests {
             .presentationActivityState == .working)
     }
 
-    @Test("a fresh tracker keeps an unavailable persisted generation conservative")
-    func unavailablePersistedSessionFencesWhenRolloutAppears() async throws {
+    @Test("a fresh tracker replays an unavailable initial rollout when it appears")
+    func unavailableInitialBoundaryReplaysWhenRolloutAppears() async throws {
         let repo = try await db.repos.create(
             path: "/tmp/car-unavailable-restart-repo-\(UUID().uuidString)",
             displayName: "car-unavailable-restart-repo", defaultBranch: "main")
@@ -879,7 +1354,9 @@ struct CodexActivityReconciliationTests {
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "Codex", kind: .codex)
         _ = try #require(try await db.terminals.applySessionStart(
-            id: terminal.id, sessionID: "persisted-session",
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "persisted-session",
             transcriptPath: transcript.path, observedAt: presentationObservedAt))
         let restartedRouter = makeRouter(now: { presentationObservedAt })
         let list = try RPCRequest(
@@ -896,7 +1373,7 @@ struct CodexActivityReconciliationTests {
         let afterFileAppears = await restartedRouter.handle(list)
         #expect(afterFileAppears.success)
         #expect(try afterFileAppears.decodeResult([Terminal].self).first?
-            .presentationActivityState == nil)
+            .presentationActivityState == .working)
     }
 
     @Test("sub-millisecond later boundary remains pending across database reload")
@@ -917,7 +1394,9 @@ struct CodexActivityReconciliationTests {
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "Codex", kind: .codex)
         _ = try #require(try await db.terminals.applySessionStart(
-            id: terminal.id, sessionID: "initial-session",
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "initial-session",
             transcriptPath: "/tmp/car-submillisecond-initial.jsonl",
             observedAt: Date(timeIntervalSince1970: 1_790_000_000)))
         let observedAt = Date(timeIntervalSince1970: 1_790_000_001.123_4)
@@ -976,7 +1455,8 @@ struct CodexActivityReconciliationTests {
             transcriptPath: laterTranscript.path,
             worktreeID: worktreeID,
             terminalID: terminalID,
-            generation: laterGeneration)
+            generation: laterGeneration,
+            boundaryOffset: nil)
         await router.codexActivityTracker.adoptInitialSession(
             transcriptPath: initialTranscript.path,
             worktreeID: worktreeID,
@@ -1001,7 +1481,8 @@ struct CodexActivityReconciliationTests {
             transcriptPath: transcript.path,
             worktreeID: worktreeID,
             terminalID: terminalID,
-            generation: laterGeneration)
+            generation: laterGeneration,
+            boundaryOffset: nil)
         await router.codexActivityTracker.retain(
             transcriptPaths: [], scope: worktreeID)
         await router.codexActivityTracker.adoptInitialSession(
@@ -1013,7 +1494,8 @@ struct CodexActivityReconciliationTests {
             transcriptPath: transcript.path,
             worktreeID: worktreeID,
             terminalID: terminalID,
-            generation: initialGeneration.addingTimeInterval(0.5))
+            generation: initialGeneration.addingTimeInterval(0.5),
+            boundaryOffset: nil)
 
         #expect(await router.codexActivityTracker.observe(
             transcriptPath: transcript.path, worktreeID: worktreeID) == nil)
@@ -1122,11 +1604,12 @@ struct CodexActivityReconciliationTests {
             label: "Codex",
             kind: .codex
         )
-        try await db.terminals.updateSession(
+        _ = try #require(try await db.terminals.applySessionStart(
             id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
             sessionID: "codex-session",
-            transcriptPath: transcriptPath.path
-        )
+            transcriptPath: transcriptPath.path,
+            observedAt: Date(timeIntervalSince1970: 1_779_999_999)))
         try await db.terminals.setActivityState(
             id: terminal.id, activityState: .working, source: .hookEvent("TurnStart"),
             observedAt: Date(timeIntervalSince1970: 1_780_000_000))
@@ -1229,10 +1712,12 @@ struct CodexActivityReconciliationTests {
         let terminal = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "Codex", kind: .codex)
-        try await db.terminals.updateSession(
+        _ = try #require(try await db.terminals.applySessionStart(
             id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
             sessionID: "old-session",
-            transcriptPath: oldTranscript.path)
+            transcriptPath: oldTranscript.path,
+            observedAt: Date(timeIntervalSince1970: 1_790_000_099)))
 
         let firstAt = Date(timeIntervalSince1970: 1_790_000_100)
         let currentAt = firstAt.addingTimeInterval(1)
@@ -1386,6 +1871,60 @@ struct CodexActivityReconciliationTests {
         #expect(staleTerminal.transcriptPath == transcript.path)
         #expect(staleTerminal.presentationActivityState == nil)
         #expect(staleTerminal.presentationActivityObservedAt == listAt)
+    }
+
+    @Test("terminal.list revalidates the durable transcript boundary")
+    func terminalListRejectsPresentationFromChangedBoundary() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-boundary-identity-repo-\(UUID().uuidString)",
+            displayName: "car-boundary-identity-repo", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/car-boundary-identity-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-boundary-identity")
+        let transcript = try makeTranscript(
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current"}}"#
+                + "\n")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        let generation = Date(timeIntervalSince1970: 1_790_400_600)
+        _ = try #require(try await db.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "current-session",
+            transcriptPath: transcript.path, observedAt: generation))
+        let dates = BlockingListDates(
+            first: presentationObservedAt,
+            subsequent: presentationObservedAt.addingTimeInterval(1))
+        let raceRouter = makeRouter(now: dates.provider)
+        let list = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id))
+
+        let inFlightList = gateHoldingTask { await raceRouter.handle(list) }
+        guard await waitUntil(
+            { dates.firstCallIsBlocked }, timeout: Self.raceRendezvousTimeout
+        ) else {
+            dates.releaseFirstCall()
+            _ = await inFlightList.value
+            Issue.record("terminal.list never reached its transcript stamp")
+            return
+        }
+        try await db.writerForTests.write { database in
+            try database.execute(
+                sql: "UPDATE terminal SET codexTranscriptBoundaryOffset = ? WHERE id = ?",
+                arguments: [Int64(1), terminal.id.uuidString])
+        }
+        dates.releaseFirstCall()
+
+        let response = await inFlightList.value
+        #expect(response.success)
+        let listed = try #require(
+            response.decodeResult([Terminal].self).first(where: { $0.id == terminal.id }))
+        #expect(listed.presentationActivityState == nil)
+        #expect(listed.presentationActivityObservedAt == presentationObservedAt)
     }
 
     @Test("terminal.list retention respects worktree and fleet scopes")
@@ -1732,6 +2271,10 @@ private final class BlockingCodexLaunchRecorder: @unchecked Sendable {
 
     var codexLaunchIsBlocked: Bool {
         lock.withLock { blocked }
+    }
+
+    var blockedCommand: [String]? {
+        lock.withLock { commands.last(where: { $0.last?.contains(" --profile") == true }) }
     }
 
     var recorder: @Sendable ([String]) -> Void {

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -138,7 +138,8 @@ import TBDShared
         #expect(sessionStart?.first?["matcher"] as? String == "startup|resume|clear")
         let sessionHooks = sessionStart?.first?["hooks"] as? [[String: Any]]
         let sessionCommand = sessionHooks?.first?["command"] as? String
-        #expect(sessionCommand?.contains("tbd session-event") == true)
+        #expect(sessionCommand?.contains("TBD_CLI_PATH-tbd") == true)
+        #expect(sessionCommand?.contains("session-event") == true)
 
         let stop = hooks?["Stop"] as? [[String: Any]]
         #expect(stop?.count == 1)
@@ -176,7 +177,8 @@ import TBDShared
             .appendingPathComponent("tbd-codex-session-hook-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
-        let tbdPath = directory.appendingPathComponent("tbd")
+        let tbdPath = directory.appendingPathComponent("matched tbd cli")
+        let fallbackPath = directory.appendingPathComponent("tbd")
         try """
         #!/bin/sh
         if [ "$1" = session-event ]; then
@@ -189,6 +191,10 @@ import TBDShared
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o755],
             ofItemAtPath: tbdPath.path)
+        try "#!/bin/sh\nexit 91\n".write(to: fallbackPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: fallbackPath.path)
         let sessionInput = directory.appendingPathComponent("session-input")
         let activityInput = directory.appendingPathComponent("activity-input")
         let activityArgs = directory.appendingPathComponent("activity-args")
@@ -200,6 +206,7 @@ import TBDShared
         process.currentDirectoryURL = directory
         var environment = ProcessInfo.processInfo.environment
         environment["PATH"] = "\(directory.path):/usr/bin:/bin"
+        environment["TBD_CLI_PATH"] = tbdPath.path
         environment["TBD_SESSION_STDIN"] = sessionInput.path
         environment["TBD_ACTIVITY_STDIN"] = activityInput.path
         environment["TBD_ACTIVITY_ARGS"] = activityArgs.path
@@ -220,6 +227,37 @@ import TBDShared
             == "terminal-activity idle --read-hook-payload\n")
         #expect(!FileManager.default.fileExists(
             atPath: directory.appendingPathComponent("should-not-run").path))
+    }
+
+    @Test func sessionStartFallsBackToPathWhenMatchedCLIIsAbsent() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-session-hook-fallback-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fallback = directory.appendingPathComponent("tbd")
+        try "#!/bin/sh\nprintf '%s' \"$1\" > \"$TBD_FALLBACK_MARKER\"\n"
+            .write(to: fallback, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fallback.path)
+        let marker = directory.appendingPathComponent("marker")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", CodexHookOverlay.sessionStartCommand]
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(directory.path):/usr/bin:/bin"
+        environment.removeValue(forKey: "TBD_CLI_PATH")
+        environment["TBD_FALLBACK_MARKER"] = marker.path
+        process.environment = environment
+        let input = Pipe()
+        process.standardInput = input
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "terminal-activity")
     }
 
     @Test func stopHookGatesIdleBehindRenameCheck() throws {

--- a/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptActivityTrackerTests.swift
@@ -5,7 +5,8 @@ import Testing
 
 @Suite("Codex transcript activity tracker")
 struct CodexTranscriptActivityTrackerTests {
-    private static let initialTailByteLimit = Int(CodexTranscriptActivityTracker.initialTailByteLimit)
+    private static let transcriptReadByteLimit =
+        Int(CodexTranscriptActivityTracker.transcriptReadByteLimit)
     private static let incrementalReadByteLimit =
         Int(CodexTranscriptActivityTracker.incrementalReadByteLimit)
     private static let maxBufferedRecordByteCount =
@@ -216,115 +217,43 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(reducer.activityState == nil)
     }
 
-    @Test func firstObservationRebuildsPreExistingOpenTurn() async throws {
+    @Test("generationless direct observation fences current EOF")
+    func generationlessDirectObservationFencesCurrentEOF() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
-        try fixture.write(event(type: "task_started", turnID: "a"))
-        let tracker = CodexTranscriptActivityTracker()
-
-        let state = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-
-        #expect(state == .working)
-    }
-
-    @Test func firstObservationDoesNotDecodeLifecycleOlderThanTailLimit() async throws {
-        let fixture = try TranscriptFixture()
-        defer { fixture.remove() }
-        let oldStart = event(type: "task_started", turnID: "old")
-        let tail = event(
-            type: "agent_message", turnID: "padding",
-            exactByteCount: Self.initialTailByteLimit)
-        try fixture.write(oldStart + tail)
-        let tracker = CodexTranscriptActivityTracker()
-
-        let state = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-
-        #expect(state == nil)
-    }
-
-    @Test func firstObservationReconstructsLifecycleInsideOversizedTranscriptTail() async throws {
-        let fixture = try TranscriptFixture()
-        defer { fixture.remove() }
-        let prefix = event(
-            type: "agent_message", turnID: "padding",
-            exactByteCount: Self.initialTailByteLimit + 128)
-        try fixture.write(prefix + event(type: "task_started", turnID: "latest"))
-        let tracker = CodexTranscriptActivityTracker()
-
-        let firstSlice = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-        let state = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-
-        #expect(firstSlice == nil)
-        #expect(state == .working)
-    }
-
-    @Test func tailStartingOnRecordBoundaryRetainsFirstRecord() async throws {
-        let fixture = try TranscriptFixture()
-        defer { fixture.remove() }
-        let prefix = event(type: "agent_message", turnID: "prefix")
-        let start = event(type: "task_started", turnID: "boundary")
-        let tailPadding = event(
-            type: "agent_message", turnID: "padding",
-            exactByteCount: Self.initialTailByteLimit - start.count)
-        try fixture.write(prefix + start + tailPadding)
-        let tracker = CodexTranscriptActivityTracker()
-
-        let firstSlice = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-        let state = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-
-        #expect(firstSlice == nil)
-        #expect(state == .working)
-    }
-
-    @Test func tailStartingMidRecordDiscardsOnlyLeadingPartialRecord() async throws {
-        let fixture = try TranscriptFixture()
-        defer { fixture.remove() }
-        let partialStart = event(
-            type: "task_started", turnID: "old",
-            exactByteCount: Self.initialTailByteLimit + 128)
-        try fixture.write(partialStart + event(type: "task_complete", turnID: "other"))
-        let tracker = CodexTranscriptActivityTracker()
-
-        let firstSlice = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-        let state = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
-
-        #expect(firstSlice == nil)
-        #expect(state == .idle)
-    }
-
-    @Test func appendedCompletionAfterTailBootstrapDoesNotRescanHistory() async throws {
-        let fixture = try TranscriptFixture()
-        defer { fixture.remove() }
-        let prefix = event(
-            type: "agent_message", turnID: "padding",
-            exactByteCount: Self.initialTailByteLimit + 128)
-        let initialStart = event(type: "task_started", turnID: "a")
-        let replacementStart = event(type: "task_started", turnID: "b")
-        #expect(initialStart.count == replacementStart.count)
-        try fixture.write(prefix + initialStart)
+        try fixture.write(event(type: "task_started", turnID: "historical"))
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
-        let initialSlice = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: worktreeID)
-        let initial = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: worktreeID)
 
-        try fixture.overwrite(at: UInt64(prefix.count), with: replacementStart)
-        try fixture.append(event(type: "task_complete", turnID: "a"))
-        let completed = await tracker.observe(
+        let cold = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
+        #expect(cold == nil)
 
-        #expect(initialSlice == nil)
-        #expect(initial == .working)
-        #expect(completed == .idle)
+        try fixture.append(event(type: "task_started", turnID: "current"))
+        let incremental = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        #expect(incremental == .working)
+    }
+
+    @Test("generationless cold targets fence current EOF before incremental observation")
+    func generationlessColdTargetFencesCurrentEOF() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "historical"))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: nil,
+            sessionGeneration: nil,
+            transcriptBoundaryOffset: nil)
+
+        let cold = await tracker.observe(transcripts: [target])
+        #expect(cold[target.transcriptPath] == nil)
+
+        try fixture.append(event(type: "task_started", turnID: "current"))
+        let incremental = await tracker.observe(transcripts: [target])
+        #expect(incremental[target.transcriptPath] == .working)
     }
 
     @Test func secondObservationReadsAppendedCompletion() async throws {
@@ -405,9 +334,12 @@ struct CodexTranscriptActivityTrackerTests {
         let initial = event(type: "task_started", turnID: "a")
         let replacement = event(type: "task_started", turnID: "b")
         #expect(initial.count == replacement.count)
-        try fixture.write(initial)
+        try fixture.write(Data())
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
+        _ = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(initial)
         let firstState = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
 
@@ -424,9 +356,12 @@ struct CodexTranscriptActivityTrackerTests {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
         let record = event(type: "task_started", turnID: "a", terminated: false)
-        try fixture.write(record)
+        try fixture.write(Data())
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
+        _ = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(record)
 
         let beforeNewline = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
@@ -441,9 +376,12 @@ struct CodexTranscriptActivityTrackerTests {
     @Test func partialLifecycleRecordAtEOFDoesNotRepublishCachedState() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
-        try fixture.write(event(type: "task_started", turnID: "a"))
+        try fixture.write(Data())
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
+        _ = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(event(type: "task_started", turnID: "a"))
         let working = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
 
@@ -529,59 +467,42 @@ struct CodexTranscriptActivityTrackerTests {
             type: "task_started", turnID: "a",
             padding: String(repeating: "x", count: 64 * 1024))
         #expect(record.count > 64 * 1024)
-        try fixture.write(record)
+        try fixture.write(Data())
         let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(record)
 
         let state = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: UUID())
+            transcriptPath: fixture.path, worktreeID: worktreeID)
 
         #expect(state == .working)
     }
 
-    @Test func truncationResetsAndRebuildsFromByteZero() async throws {
+    @Test func generationlessTruncationFencesReplacementEOF() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
-        try fixture.write(
+        try fixture.write(Data())
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        _ = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(
             event(type: "task_started", turnID: "a")
                 + event(type: "agent_message", turnID: "padding"))
-        let tracker = CodexTranscriptActivityTracker()
-        let worktreeID = UUID()
-        let initial = await tracker.observe(
+        #expect(await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID) == .working)
+
+        try fixture.write(event(type: "task_started", turnID: "replacement"))
+        let fenced = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
+        #expect(fenced == nil)
 
-        try fixture.write(event(type: "task_complete", turnID: "replacement"))
-        let rebuilt = await tracker.observe(
+        try fixture.append(event(type: "task_complete", turnID: "replacement"))
+        let incremental = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
-
-        #expect(initial == .working)
-        #expect(rebuilt == .idle)
-    }
-
-    @Test func truncationRebuildUsesBoundedTailPolicy() async throws {
-        let fixture = try TranscriptFixture()
-        defer { fixture.remove() }
-        let initialPrefix = event(
-            type: "agent_message", turnID: "initial-padding",
-            exactByteCount: Self.initialTailByteLimit + 512)
-        try fixture.write(
-            initialPrefix
-                + event(type: "task_started", turnID: "initial")
-                + event(
-                    type: "agent_message", turnID: "more-padding",
-                    exactByteCount: Self.initialTailByteLimit + 512))
-        let tracker = CodexTranscriptActivityTracker()
-        let worktreeID = UUID()
-        _ = await tracker.observe(transcriptPath: fixture.path, worktreeID: worktreeID)
-
-        let oldStart = event(type: "task_started", turnID: "old")
-        let replacementTail = event(
-            type: "agent_message", turnID: "replacement-padding",
-            exactByteCount: Self.initialTailByteLimit)
-        try fixture.write(oldStart + replacementTail)
-        let rebuilt = await tracker.observe(
-            transcriptPath: fixture.path, worktreeID: worktreeID)
-
-        #expect(rebuilt == nil)
+        #expect(incremental == .idle)
     }
 
     @Test func transcriptPathsHaveIndependentBaselines() async throws {
@@ -591,10 +512,16 @@ struct CodexTranscriptActivityTrackerTests {
             first.remove()
             second.remove()
         }
-        try first.write(event(type: "task_started", turnID: "a"))
-        try second.write(event(type: "task_complete", turnID: "b"))
+        try first.write(Data())
+        try second.write(Data())
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
+        _ = await tracker.observe(
+            transcriptPath: first.path, worktreeID: worktreeID)
+        _ = await tracker.observe(
+            transcriptPath: second.path, worktreeID: worktreeID)
+        try first.append(event(type: "task_started", turnID: "a"))
+        try second.append(event(type: "task_complete", turnID: "b"))
 
         let firstState = await tracker.observe(
             transcriptPath: first.path, worktreeID: worktreeID)
@@ -623,8 +550,13 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(noBudget.isEmpty)
         #expect(!(await tracker.hasBaseline(transcriptPath: fixture.path)))
 
-        let caughtUp = await tracker.observe(
+        let fenced = await tracker.observe(
             transcripts: [target], totalByteLimit: UInt64(record.count))
+        #expect(fenced[fixture.path] == nil)
+        #expect(await tracker.hasBaseline(transcriptPath: fixture.path))
+
+        try fixture.append(event(type: "task_started", turnID: "current"))
+        let caughtUp = await tracker.observe(transcripts: [target])
         #expect(caughtUp[fixture.path] == .working)
     }
 
@@ -644,9 +576,10 @@ struct CodexTranscriptActivityTrackerTests {
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
         for fixture in readable {
-            try fixture.write(event(type: "task_complete", turnID: fixture.path))
+            try fixture.write(Data())
             _ = await tracker.observe(
                 transcriptPath: fixture.path, worktreeID: worktreeID)
+            try fixture.append(event(type: "task_complete", turnID: fixture.path))
         }
         let targets = (unreadable + readable).map {
             CodexTranscriptActivityTracker.Target(
@@ -675,12 +608,15 @@ struct CodexTranscriptActivityTrackerTests {
                 transcriptPath: $0.path, worktreeID: worktreeID)
         }
         for fixture in [first, second] {
-            try fixture.write(
+            try fixture.write(Data())
+            _ = await tracker.observe(
+                transcriptPath: fixture.path, worktreeID: worktreeID)
+            try fixture.append(
                 event(type: "task_complete", turnID: fixture.path)
                     + event(
                         type: "agent_message", turnID: "backlog",
                         terminated: false,
-                        exactByteCount: Self.initialTailByteLimit))
+                        exactByteCount: Self.transcriptReadByteLimit))
         }
         let onePathBudget: UInt64 = 2
 
@@ -688,15 +624,15 @@ struct CodexTranscriptActivityTrackerTests {
         let firstAfterOne = await tracker.bufferedRecordState(transcriptPath: first.path)
         let secondAfterOne = await tracker.bufferedRecordState(transcriptPath: second.path)
         #expect([firstAfterOne?.byteCount, secondAfterOne?.byteCount].compactMap { $0 }
-            .sorted() == [Int(onePathBudget) - 1])
+            .sorted() == [0, Int(onePathBudget)])
 
         try first.append(event(type: "agent_message", turnID: "still-growing"))
         _ = await tracker.observe(transcripts: targets, totalByteLimit: onePathBudget)
         let firstAfterTwo = await tracker.bufferedRecordState(transcriptPath: first.path)
         let secondAfterTwo = await tracker.bufferedRecordState(transcriptPath: second.path)
 
-        #expect(firstAfterTwo?.byteCount == Int(onePathBudget) - 1)
-        #expect(secondAfterTwo?.byteCount == Int(onePathBudget) - 1)
+        #expect(firstAfterTwo?.byteCount == Int(onePathBudget))
+        #expect(secondAfterTwo?.byteCount == Int(onePathBudget))
     }
 
     @Test func batchCursorRecoversWhenItsSavedPathDisappearsAndInputsReorder() async throws {
@@ -715,32 +651,35 @@ struct CodexTranscriptActivityTrackerTests {
                 transcriptPath: $0.path, worktreeID: worktreeID)
         }
         for fixture in [first, removed, third] {
-            try fixture.write(
+            try fixture.write(Data())
+            _ = await tracker.observe(
+                transcriptPath: fixture.path, worktreeID: worktreeID)
+            try fixture.append(
                 event(type: "task_complete", turnID: fixture.path)
                     + event(
                         type: "agent_message", turnID: "backlog",
                         terminated: false,
-                        exactByteCount: Self.initialTailByteLimit))
+                        exactByteCount: Self.transcriptReadByteLimit))
         }
         let onePathBudget: UInt64 = 2
 
         _ = await tracker.observe(transcripts: targets, totalByteLimit: onePathBudget)
         #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
-            == Int(onePathBudget) - 1)
+            == Int(onePathBudget))
 
         let withoutSavedPath = [targets[0], targets[2]]
         _ = await tracker.observe(
             transcripts: withoutSavedPath, totalByteLimit: onePathBudget)
         #expect(await tracker.bufferedRecordState(transcriptPath: third.path)?.byteCount
-            == Int(onePathBudget) - 1)
+            == Int(onePathBudget))
         #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
-            == Int(onePathBudget) - 1)
+            == Int(onePathBudget))
 
         let reordered = [targets[2], targets[0]]
         _ = await tracker.observe(
             transcripts: reordered, totalByteLimit: onePathBudget)
         #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
-            == Int(onePathBudget) * 2 - 1)
+            == Int(onePathBudget) * 2)
     }
 
     @Test func scopedPollDoesNotResetFleetBatchCursor() async throws {
@@ -758,12 +697,16 @@ struct CodexTranscriptActivityTrackerTests {
         let secondTarget = CodexTranscriptActivityTracker.Target(
             transcriptPath: second.path, worktreeID: secondWorktreeID)
         for fixture in [first, second] {
-            try fixture.write(
+            try fixture.write(Data())
+            _ = await tracker.observe(
+                transcriptPath: fixture.path,
+                worktreeID: fixture.path == first.path ? firstWorktreeID : secondWorktreeID)
+            try fixture.append(
                 event(type: "task_complete", turnID: fixture.path)
                     + event(
                         type: "agent_message", turnID: "backlog",
                         terminated: false,
-                        exactByteCount: Self.initialTailByteLimit))
+                        exactByteCount: Self.transcriptReadByteLimit))
         }
         let onePathBudget: UInt64 = 2
 
@@ -782,32 +725,39 @@ struct CodexTranscriptActivityTrackerTests {
         _ = await tracker.observe(
             transcripts: [firstTarget, secondTarget], totalByteLimit: onePathBudget)
 
-        #expect(firstAfterScopedPoll == Int(onePathBudget) * 2 - 1)
+        #expect(firstAfterScopedPoll == Int(onePathBudget) * 2)
         #expect(await tracker.bufferedRecordState(transcriptPath: first.path)?.byteCount
             == firstAfterScopedPoll)
         #expect(await tracker.bufferedRecordState(transcriptPath: second.path)?.byteCount
-            == Int(onePathBudget) - 1)
+            == Int(onePathBudget))
     }
 
     @Test func unreadablePathReturnsNilInsteadOfCachedWorking() async throws {
         let fixture = try TranscriptFixture()
         defer { fixture.remove() }
-        try fixture.write(
-            event(type: "task_started", turnID: "a", padding: String(repeating: "x", count: 256)))
+        try fixture.write(Data())
         let tracker = CodexTranscriptActivityTracker()
         let worktreeID = UUID()
+        _ = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(
+            event(type: "task_started", turnID: "a", padding: String(repeating: "x", count: 256)))
         let initial = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
         try fixture.replaceFileWithDirectory()
 
         let unreadable = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
-        try fixture.replaceDirectoryWithFile(event(type: "task_complete", turnID: "replacement"))
+        try fixture.replaceDirectoryWithFile(Data())
+        let refenced = await tracker.observe(
+            transcriptPath: fixture.path, worktreeID: worktreeID)
+        try fixture.append(event(type: "task_complete", turnID: "replacement"))
         let recovered = await tracker.observe(
             transcriptPath: fixture.path, worktreeID: worktreeID)
 
         #expect(initial == .working)
         #expect(unreadable == nil)
+        #expect(refenced == nil)
         #expect(recovered == .idle)
     }
 
@@ -873,6 +823,519 @@ struct CodexTranscriptActivityTrackerTests {
         #expect(states[target.transcriptPath] == nil)
     }
 
+    @Test("known boundary recovery advances past the request window and resumes incremental reads")
+    func knownBoundaryRecoveryIsProgressive() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        var transcript = event(type: "task_started", turnID: "current")
+        for index in 0..<320 {
+            transcript += event(
+                type: "agent_message",
+                turnID: "padding-\(index)",
+                exactByteCount: 4 * 1024)
+        }
+        #expect(transcript.count > Self.transcriptReadByteLimit)
+        try fixture.write(transcript)
+        let tracker = CodexTranscriptActivityTracker()
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: UUID(),
+            sessionGeneration: Date(timeIntervalSince1970: 1_790_400_000),
+            transcriptBoundaryOffset: 0)
+        let pollBudget: UInt64 = 64 * 1024
+
+        let first = await tracker.observe(
+            transcripts: [target], totalByteLimit: pollBudget)
+        #expect(first[target.transcriptPath] == nil)
+        var recovered: TerminalActivityState?
+        for _ in 0..<48 where recovered == nil {
+            recovered = await tracker.observe(
+                transcripts: [target], totalByteLimit: pollBudget)[target.transcriptPath]
+        }
+        #expect(recovered == .working)
+
+        try fixture.append(event(type: "task_complete", turnID: "current"))
+        let completed = await tracker.observe(
+            transcripts: [target], totalByteLimit: pollBudget)
+        #expect(completed[target.transcriptPath] == .idle)
+    }
+
+    @Test("cold recovery scans backward to the newest start without reading older history")
+    func coldRecoveryStopsAtNewestStart() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        var transcript = Data()
+        for index in 0..<6 {
+            transcript += event(
+                type: "agent_message", turnID: "old-padding-\(index)",
+                exactByteCount: 512 * 1024)
+        }
+        transcript += event(type: "task_started", turnID: "current", startedAt: 200)
+        for index in 0..<3 {
+            transcript += event(
+                type: "agent_message", turnID: "new-padding-\(index)",
+                exactByteCount: 400 * 1024)
+        }
+        try fixture.write(transcript)
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_000)
+
+        var observations: [TerminalActivityState?] = []
+        for _ in 0..<4 where observations.last != .working {
+            observations.append(
+                await tracker.observe(transcripts: [target])[fixture.path])
+        }
+
+        #expect(observations.prefix(2).allSatisfy { $0 == nil })
+        #expect(observations.last == .working)
+    }
+
+    @Test("reverse recovery agrees with forward lifecycle reduction")
+    func reverseRecoveryMatchesForwardLifecycleSemantics() async throws {
+        let cases: [[Data]] = [
+            [event(type: "task_started", turnID: "current", startedAt: 200)],
+            [
+                event(type: "task_started", turnID: "current", startedAt: 200),
+                event(type: "task_complete", turnID: "current", startedAt: 200),
+            ],
+            [
+                event(type: "task_started", turnID: "current", startedAt: 200),
+                event(type: "task_complete", turnID: "older", startedAt: 100),
+            ],
+            [
+                event(type: "task_started", turnID: "current", startedAt: 200),
+                event(type: "turn_aborted", turnID: nil, startedAt: 100),
+            ],
+            [
+                event(type: "task_started", turnID: "current", startedAt: 200),
+                event(type: "task_complete", turnID: "rewritten", startedAt: nil),
+            ],
+            [event(type: "task_complete", turnID: "closed", startedAt: 100)],
+            [
+                Data("not json\n".utf8),
+                Data(#"{"type":"response_item","payload":{"type":"task_started","turn_id":"ignored"}}"#.utf8)
+                    + Data([0x0A]),
+            ],
+        ]
+
+        for (index, lines) in cases.enumerated() {
+            var reducer = CodexTurnLifecycleReducer()
+            lines.forEach { reducer.consume(line: $0) }
+            let fixture = try TranscriptFixture()
+            defer { fixture.remove() }
+            try fixture.write(lines.reduce(into: Data()) { $0 += $1 })
+            let tracker = CodexTranscriptActivityTracker()
+            let target = recoveryTarget(
+                fixture: fixture, boundary: 0,
+                generation: 1_790_401_010 + Double(index))
+
+            let recovered = await tracker.observe(transcripts: [target])[fixture.path]
+
+            #expect(recovered == reducer.activityState)
+        }
+    }
+
+    @Test("reliable closes encountered backward match the newest start by ID or time")
+    func coldRecoveryCorrelatesReliableCloses() async throws {
+        let matchingID = try TranscriptFixture()
+        let matchingTime = try TranscriptFixture()
+        let mismatching = try TranscriptFixture()
+        defer {
+            matchingID.remove()
+            matchingTime.remove()
+            mismatching.remove()
+        }
+        try matchingID.write(
+            event(type: "task_started", turnID: "current", startedAt: 200)
+                + event(type: "task_complete", turnID: "current", startedAt: 999))
+        try matchingTime.write(
+            event(type: "task_started", turnID: "current", startedAt: 200)
+                + event(type: "turn_aborted", turnID: "rewritten", startedAt: 200))
+        try mismatching.write(
+            event(type: "task_started", turnID: "current", startedAt: 200)
+                + event(type: "task_complete", turnID: "older", startedAt: 100))
+        let tracker = CodexTranscriptActivityTracker()
+        let targets = [matchingID, matchingTime, mismatching].enumerated().map { index, fixture in
+            recoveryTarget(
+                fixture: fixture, boundary: 0,
+                generation: 1_790_401_100 + Double(index))
+        }
+
+        let states = await tracker.observe(transcripts: targets)
+
+        #expect(states[matchingID.path] == .idle)
+        #expect(states[matchingTime.path] == .idle)
+        #expect(states[mismatching.path] == .working)
+    }
+
+    @Test("many reliable closes transition to bounded forward replay at the newest start")
+    func coldRecoveryDoesNotRetainReliableCloseKeys() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        var transcript = event(type: "task_started", turnID: "current", startedAt: 200)
+        for index in 0..<2_000 {
+            transcript += event(
+                type: "task_complete", turnID: "older-\(index)", startedAt: index + 1_000)
+        }
+        try fixture.write(transcript)
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_150)
+
+        var phase: CodexTranscriptActivityTracker.ColdRecoveryPhase?
+        for _ in 0..<16 where phase != .forwardReplay {
+            #expect(await tracker.observe(
+                transcripts: [target], totalByteLimit: 64 * 1024)[fixture.path] == nil)
+            phase = await tracker.coldRecoveryPhase(transcriptPath: fixture.path)
+        }
+
+        #expect(phase == .forwardReplay)
+        var state: TerminalActivityState?
+        for _ in 0..<16 where state == nil {
+            state = await tracker.observe(
+                transcripts: [target], totalByteLimit: 64 * 1024)[fixture.path]
+        }
+        #expect(state == .working)
+    }
+
+    @Test("an unreliable close synchronizes idle without scanning older history")
+    func coldRecoveryStopsAtUnconditionalClose() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        var transcript = Data()
+        for index in 0..<6 {
+            transcript += event(
+                type: "agent_message", turnID: "padding-\(index)",
+                exactByteCount: 512 * 1024)
+        }
+        transcript += event(type: "task_complete", turnID: "rewritten", startedAt: nil)
+        try fixture.write(transcript)
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_200)
+
+        let states = await tracker.observe(
+            transcripts: [target], totalByteLimit: 64 * 1024)
+
+        #expect(states[fixture.path] == .idle)
+    }
+
+    @Test("recovery reaches the boundary before publishing no lifecycle evidence")
+    func coldRecoveryWithNoAnchorScansToBoundary() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        var transcript = Data()
+        for index in 0..<3 {
+            transcript += event(
+                type: "agent_message", turnID: "padding-\(index)",
+                exactByteCount: 512 * 1024)
+        }
+        try fixture.write(transcript)
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_300)
+
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        try fixture.append(event(type: "task_started", turnID: "appended"))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .working)
+    }
+
+    @Test("a record crossing a positive recovery boundary is excluded")
+    func coldRecoveryExcludesRecordCrossingPositiveBoundary() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let crossing = event(
+            type: "task_started", turnID: "crossing", startedAt: 100,
+            exactByteCount: 128 * 1024)
+        let boundary = crossing.count / 2
+        try fixture.write(crossing + event(type: "agent_message", turnID: "after"))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(
+            fixture: fixture, boundary: Int64(boundary), generation: 1_790_401_400)
+
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        try fixture.append(event(type: "task_started", turnID: "current"))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .working)
+    }
+
+    @Test("a captured partial record remains unknown and recovery stops at its newline")
+    func coldRecoveryWaitsForCapturedPartialRecord() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(
+            type: "task_started", turnID: "current", startedAt: 200,
+            terminated: false))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_500)
+
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        try fixture.append(
+            Data([0x0A]) + event(type: "task_complete", turnID: "current", startedAt: 200))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .working)
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .idle)
+    }
+
+    @Test("partial completion charges bytes read beyond its first newline")
+    func capturedPartialCompletionExhaustsItsReadBudget() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(
+            type: "task_started", turnID: "current", startedAt: 200,
+            terminated: false))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_550)
+        let budget = 64 * 1024
+
+        #expect(await tracker.observe(
+            transcripts: [target], totalByteLimit: UInt64(budget))[fixture.path] == nil)
+        try fixture.append(
+            Data([0x0A])
+                + event(
+                    type: "agent_message", turnID: "later-padding",
+                    exactByteCount: budget))
+
+        #expect(await tracker.observe(
+            transcripts: [target], totalByteLimit: UInt64(budget))[fixture.path] == nil)
+        #expect(await tracker.coldRecoveryPhase(transcriptPath: fixture.path) == .reverseSearch)
+        #expect(await tracker.observe(
+            transcripts: [target], totalByteLimit: UInt64(budget))[fixture.path] == .working)
+    }
+
+    @Test("shrinking during reverse recovery restarts from the known boundary")
+    func shrinkDuringReverseRecoveryRestartsExactly() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        var transcript = event(type: "task_started", turnID: "old", startedAt: 100)
+        for index in 0..<4 {
+            transcript += event(
+                type: "agent_message", turnID: "padding-\(index)",
+                exactByteCount: 256 * 1024)
+        }
+        try fixture.write(transcript)
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_575)
+
+        #expect(await tracker.observe(
+            transcripts: [target], totalByteLimit: 64 * 1024)[fixture.path] == nil)
+        #expect(await tracker.coldRecoveryPhase(transcriptPath: fixture.path) == .reverseSearch)
+
+        try fixture.write(event(type: "task_started", turnID: "replacement", startedAt: 300))
+
+        #expect(await tracker.observe(
+            transcripts: [target], totalByteLimit: 64 * 1024)[fixture.path] == .working)
+        try fixture.append(event(
+            type: "task_complete", turnID: "replacement", startedAt: 300))
+        #expect(await tracker.observe(
+            transcripts: [target], totalByteLimit: 64 * 1024)[fixture.path] == .idle)
+    }
+
+    @Test("malformed and oversized reverse records do not become lifecycle evidence")
+    func coldRecoveryIgnoresMalformedAndOversizedRecords() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(
+            event(type: "task_complete", turnID: "seed", startedAt: nil)
+                + Data("not json\n".utf8)
+                + event(
+                    type: "task_started", turnID: "oversized",
+                    exactByteCount: Self.maxBufferedRecordByteCount + 128))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = recoveryTarget(fixture: fixture, boundary: 0, generation: 1_790_401_600)
+
+        var state: TerminalActivityState?
+        for _ in 0..<4 where state == nil {
+            state = await tracker.observe(transcripts: [target])[fixture.path]
+        }
+
+        #expect(state == .idle)
+    }
+
+    @Test("positive durable boundaries exclude prior lifecycle evidence after restart")
+    func positiveBoundaryExcludesPriorLifecycleEvidence() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let orphan = event(type: "task_started", turnID: "orphan")
+        try fixture.write(
+            orphan + event(type: "agent_message", turnID: "later-session"))
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: UUID(),
+            sessionGeneration: Date(timeIntervalSince1970: 1_790_400_100),
+            transcriptBoundaryOffset: Int64(orphan.count))
+
+        let tracker = CodexTranscriptActivityTracker()
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        let restartedTracker = CodexTranscriptActivityTracker()
+        #expect(await restartedTracker.observe(transcripts: [target])[fixture.path] == nil)
+
+        try fixture.append(event(type: "task_started", turnID: "current"))
+        #expect(await restartedTracker.observe(transcripts: [target])[fixture.path] == .working)
+    }
+
+    @Test("unknown durable boundary fences at current EOF")
+    func unknownBoundaryRetainsConservativeFence() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(type: "task_started", turnID: "historical"))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: UUID(),
+            sessionGeneration: Date(timeIntervalSince1970: 1_790_400_200),
+            transcriptBoundaryOffset: nil)
+
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        try fixture.append(event(type: "task_complete", turnID: "later"))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .idle)
+    }
+
+    @Test("recovery finishes its captured record without chasing later records")
+    func recoveryExtendsOnlyThroughCapturedRecord() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(event(
+            type: "task_started", turnID: "current", terminated: false))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: UUID(),
+            sessionGeneration: Date(timeIntervalSince1970: 1_790_400_300),
+            transcriptBoundaryOffset: 0)
+
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        try fixture.append(
+            Data([0x0A]) + event(type: "task_complete", turnID: "current"))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .working)
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .idle)
+    }
+
+    @Test("initial durable boundary replays a truncated replacement from zero")
+    func initialBoundaryReplaysAfterTruncation() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        try fixture.write(
+            event(type: "task_started", turnID: "initial")
+                + event(type: "agent_message", turnID: "padding"))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: UUID(),
+            sessionGeneration: Date(timeIntervalSince1970: 1_790_400_400),
+            transcriptBoundaryOffset: 0)
+
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .working)
+        try fixture.write(event(type: "task_complete", turnID: "replacement"))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .idle)
+    }
+
+    @Test("positive durable boundary fences when the transcript shrinks below it")
+    func positiveBoundaryFencesAfterShrink() async throws {
+        let fixture = try TranscriptFixture()
+        defer { fixture.remove() }
+        let prefix = event(
+            type: "agent_message", turnID: "prefix", exactByteCount: 4 * 1024)
+        try fixture.write(prefix + event(type: "task_started", turnID: "current"))
+        let tracker = CodexTranscriptActivityTracker()
+        let target = CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: UUID(),
+            sessionGeneration: Date(timeIntervalSince1970: 1_790_400_500),
+            transcriptBoundaryOffset: Int64(prefix.count))
+
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .working)
+        try fixture.write(event(type: "task_started", turnID: "pre-fence"))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == nil)
+        try fixture.append(event(type: "task_started", turnID: "post-fence"))
+        #expect(await tracker.observe(transcripts: [target])[fixture.path] == .working)
+    }
+
+    @Test("cold boundary preparation obeys the shared filesystem step limit")
+    func coldBoundaryPreparationIsStepBounded() async throws {
+        let fixtures = try (0...16).map { _ in try TranscriptFixture() }
+        defer { fixtures.forEach { $0.remove() } }
+        for fixture in fixtures {
+            try fixture.write(Data())
+        }
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let generation = Date(timeIntervalSince1970: 1_790_400_700)
+        let targets = fixtures.map {
+            CodexTranscriptActivityTracker.Target(
+                transcriptPath: $0.path,
+                worktreeID: worktreeID,
+                terminalID: UUID(),
+                sessionGeneration: generation,
+                transcriptBoundaryOffset: 0)
+        }
+
+        _ = await tracker.observe(transcripts: targets)
+        #expect(await tracker.baselineCount == 16)
+
+        _ = await tracker.observe(transcripts: targets)
+        #expect(await tracker.baselineCount == 17)
+    }
+
+    @Test("progressive recoveries share request bytes in round-robin order")
+    func progressiveRecoveriesRemainFair() async throws {
+        let first = try TranscriptFixture()
+        let second = try TranscriptFixture()
+        defer {
+            first.remove()
+            second.remove()
+        }
+        let recoveryBytes = 2 * 64 * 1024
+        for (index, fixture) in [first, second].enumerated() {
+            try fixture.write(
+                event(type: "task_started", turnID: "turn-\(index)")
+                    + event(
+                        type: "agent_message",
+                        turnID: "padding-\(index)",
+                        exactByteCount: recoveryBytes))
+        }
+        let tracker = CodexTranscriptActivityTracker()
+        let worktreeID = UUID()
+        let generation = Date(timeIntervalSince1970: 1_790_400_800)
+        let targets = [first, second].map {
+            CodexTranscriptActivityTracker.Target(
+                transcriptPath: $0.path,
+                worktreeID: worktreeID,
+                terminalID: UUID(),
+                sessionGeneration: generation,
+                transcriptBoundaryOffset: 0)
+        }
+        let oneQuantum: UInt64 = 64 * 1024
+
+        var completionPoll: [String: Int] = [:]
+        for poll in 1...16 where completionPoll.count < targets.count {
+            let states = await tracker.observe(
+                transcripts: targets, totalByteLimit: oneQuantum)
+            #expect(states.isEmpty || Set(states.keys) == Set(targets.map(\.transcriptPath)))
+            for (path, state) in states {
+                #expect(state == .working)
+                completionPoll[path] = poll
+            }
+
+            if poll.isMultiple(of: 2) {
+                let firstPhase = await tracker.coldRecoveryPhase(
+                    transcriptPath: first.path)
+                let secondPhase = await tracker.coldRecoveryPhase(
+                    transcriptPath: second.path)
+                #expect(firstPhase == secondPhase)
+            }
+        }
+
+        #expect(Set(completionPoll.keys) == Set(targets.map(\.transcriptPath)))
+        if let firstPoll = completionPoll[first.path],
+           let secondPoll = completionPoll[second.path]
+        {
+            #expect(firstPoll == secondPoll)
+        }
+    }
+
     private func event(
         type: String,
         turnID: String?,
@@ -900,6 +1363,19 @@ struct CodexTranscriptActivityTrackerTests {
         precondition(exactByteCount >= emptyPadded.count)
         let exactPadding = String(repeating: "x", count: exactByteCount - emptyPadded.count)
         return encoded(padding: exactPadding)
+    }
+
+    private func recoveryTarget(
+        fixture: TranscriptFixture,
+        boundary: Int64,
+        generation: Double
+    ) -> CodexTranscriptActivityTracker.Target {
+        CodexTranscriptActivityTracker.Target(
+            transcriptPath: fixture.path,
+            worktreeID: UUID(),
+            terminalID: UUID(),
+            sessionGeneration: Date(timeIntervalSince1970: generation),
+            transcriptBoundaryOffset: boundary)
     }
 }
 

--- a/Tests/TBDDaemonTests/CodexTranscriptBoundaryMigrationTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptBoundaryMigrationTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct CodexTranscriptBoundaryMigrationTests {
+    @Test func forwardMigrationAddsNullableBoundaryToExistingTerminal() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "20260824214437_auto_create_notes_setting")
+
+        let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+        let repoID = UUID().uuidString
+        let worktreeID = UUID().uuidString
+        let terminalID = UUID().uuidString
+        try queue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                    VALUES (?, '/tmp/codex-boundary-repo', 'Boundary', 'main', ?)
+                    """,
+                arguments: [repoID, epoch]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO worktree
+                        (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                    VALUES (?, ?, 'w', 'w', 'main', '/tmp/codex-boundary-wt',
+                            'active', ?, 'tbd-boundary')
+                    """,
+                arguments: [worktreeID, repoID, epoch]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO terminal
+                        (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt)
+                    VALUES (?, ?, '@1', '%1', ?)
+                    """,
+                arguments: [terminalID, worktreeID, epoch]
+            )
+        }
+
+        let columnsBefore = try queue.read { db in
+            try Row.fetchAll(db, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+        }
+        #expect(!columnsBefore.contains("codexTranscriptBoundaryOffset"))
+
+        try migrator.migrate(queue, upTo: "20260825024814_codex_transcript_boundary")
+
+        let result = try queue.read { db in
+            let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+            let row = try Row.fetchOne(
+                db,
+                sql: "SELECT codexTranscriptBoundaryOffset FROM terminal WHERE id = ?",
+                arguments: [terminalID]
+            )
+            return (columns, row)
+        }
+        #expect(result.0.contains("codexTranscriptBoundaryOffset"))
+        let row = try #require(result.1)
+        #expect((row["codexTranscriptBoundaryOffset"] as Int64?) == nil)
+    }
+
+    @Test(arguments: [Int64?.none, Int64?.some(0), Int64?.some(4_294_967_296)])
+    func terminalRecordRoundTripsBoundary(_ boundary: Int64?) async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/codex-boundary-record-repo-\(UUID().uuidString)",
+            displayName: "Boundary",
+            defaultBranch: "main"
+        )
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "boundary",
+            branch: "boundary",
+            path: "/tmp/codex-boundary-record-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-boundary-record"
+        )
+        let terminal = Terminal(
+            worktreeID: worktree.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            codexTranscriptBoundaryOffset: boundary
+        )
+
+        try await db.writerForTests.write { dbConnection in
+            try TerminalRecord(from: terminal).insert(dbConnection)
+        }
+
+        let rawRow = try db.writerForTests.read { dbConnection in
+            return try Row.fetchOne(
+                dbConnection,
+                sql: "SELECT codexTranscriptBoundaryOffset FROM terminal WHERE id = ?",
+                arguments: [terminal.id.uuidString]
+            )
+        }
+        let row = try #require(rawRow)
+        #expect((row["codexTranscriptBoundaryOffset"] as Int64?) == boundary)
+
+        let fetched = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(fetched.codexTranscriptBoundaryOffset == boundary)
+    }
+}

--- a/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
+++ b/Tests/TBDDaemonTests/CodexTranscriptPresentationObservationTests.swift
@@ -14,9 +14,7 @@ struct CodexPresentationObservationTests {
             at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
         let transcript = directory.appendingPathComponent("rollout.jsonl")
-        try Data(
-            (#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}"# + "\n").utf8
-        ).write(to: transcript)
+        try Data().write(to: transcript)
 
         let firstAt = Date(timeIntervalSince1970: 1_700_000_000)
         let secondAt = firstAt.addingTimeInterval(1)
@@ -26,6 +24,13 @@ struct CodexPresentationObservationTests {
             transcriptPath: transcript.path,
             worktreeID: UUID()
         )]
+        #expect(await tracker.observe(transcripts: targets).isEmpty)
+        let initialHandle = try FileHandle(forWritingTo: transcript)
+        try initialHandle.seekToEnd()
+        try initialHandle.write(contentsOf: Data(
+            (#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}"# + "\n").utf8
+        ))
+        try initialHandle.close()
 
         // `observeStamped` is a synchronous actor method, so the gate below
         // holds the tracker actor itself. Off the cooperative pool, that costs

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -77,6 +77,389 @@ struct HibernationCoordinatorTests {
         #expect(after?.isHibernated == true)
     }
 
+    @Test func hibernateRespawnRejectsPreReplacementSessionStart() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: recorded.append)
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "sess-1",
+            transcriptPath: "/tmp/hibernation-old-session.jsonl")
+        let before = try #require(try await db.terminals.get(id: terminalID))
+
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.manualHibernate(terminalID: terminalID) == .ok)
+        let parked = try #require(try await db.terminals.get(id: terminalID))
+        #expect(parked.sessionIncarnationID != before.sessionIncarnationID)
+        #expect(parked.tmuxWindowID == before.tmuxWindowID)
+        #expect(parked.tmuxPaneID == before.tmuxPaneID)
+        #expect(parked.label == before.label)
+        #expect(parked.claudeSessionID == "sess-1")
+        #expect(parked.transcriptPath == "/tmp/hibernation-old-session.jsonl")
+        #expect(parked.sessionOrderObservedAt == nil)
+        #expect(parked.codexTranscriptBoundaryOffset == nil)
+        let parkedToken = try #require(parked.sessionIncarnationID)
+        let matchedCLIPath = try #require(AgentProcessEnvironment.cliPath)
+        let shellRespawn = try #require(recorded.snapshot().last { call in
+            call.contains("respawn-window")
+        }?.last)
+        #expect(shellRespawn.contains(
+            "TBD_TERMINAL_INCARNATION_ID='\(parkedToken.uuidString)'"))
+        #expect(shellRespawn.contains(
+            "TBD_CLI_PATH=\(SystemPromptBuilder.shellEscape(matchedCLIPath))"))
+
+        let staleApplication = try await db.terminals.applySessionStart(
+            id: terminalID,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: before),
+            sessionID: "stale-session",
+            transcriptPath: "/tmp/stale-hibernation-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 20))
+        #expect(staleApplication == nil)
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged.claudeSessionID == parked.claudeSessionID)
+        #expect(unchanged.transcriptPath == parked.transcriptPath)
+        #expect(unchanged.sessionIncarnationID == parked.sessionIncarnationID)
+        #expect(unchanged.isHibernated)
+    }
+
+    @Test func staleHibernateCannotParkAProfileReplacement() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "profile-source-session",
+            transcriptPath: "/tmp/profile-source-session.jsonl")
+        let replacementProfile = try await db.modelProfiles.create(
+            name: "Replacement", kind: .oauth)
+        let captureGate = BlockingCapturePane()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: commands.append,
+            dryRunCapturePane: captureGate.capture)
+        let deltas = RecordedHibernationDeltas()
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        let hibernate = gateHoldingTask {
+            await coordinator.manualHibernate(terminalID: terminalID)
+        }
+        guard await waitUntil({ captureGate.isBlocked }) else {
+            captureGate.release()
+            _ = await hibernate.value
+            Issue.record("hibernate never reached its pre-lock capture")
+            return
+        }
+
+        let profileResponse = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: terminalID,
+                newProfileID: replacementProfile.id,
+                mode: .inPlace)))
+        #expect(profileResponse.success)
+        let replacement = try #require(try await db.terminals.get(id: terminalID))
+        let respawnsAfterProfile = commands.snapshot().filter { $0.contains("respawn-window") }.count
+        #expect(respawnsAfterProfile == 1)
+
+        captureGate.release()
+        #expect(await hibernate.value != .ok)
+
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged.sessionIncarnationID == replacement.sessionIncarnationID)
+        #expect(unchanged.tmuxWindowID == replacement.tmuxWindowID)
+        #expect(unchanged.tmuxPaneID == replacement.tmuxPaneID)
+        #expect(unchanged.profileID == replacement.profileID)
+        #expect(unchanged.claudeSessionID == replacement.claudeSessionID)
+        #expect(unchanged.transcriptPath == replacement.transcriptPath)
+        #expect(unchanged.activityState == replacement.activityState)
+        #expect(unchanged.activityStateSource == replacement.activityStateSource)
+        #expect(unchanged.activityStateObservedAt == replacement.activityStateObservedAt)
+        #expect(unchanged.activityStateOrderObservedAt
+                == replacement.activityStateOrderObservedAt)
+        #expect(!unchanged.isParked)
+        #expect(commands.snapshot().filter { $0.contains("respawn-window") }.count
+                == respawnsAfterProfile)
+        #expect(deltas.snapshot().isEmpty)
+    }
+
+    @Test func profileReplacementRevalidatesAfterHibernationWinsServerLock() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "profile-source-session",
+            transcriptPath: "/tmp/profile-source-session.jsonl")
+        let replacementProfile = try await db.modelProfiles.create(
+            name: "Replacement", kind: .apiKey)
+        let keychainGate = BlockingKeychainLookup()
+        let resolver = ModelProfileResolver(
+            profiles: db.modelProfiles,
+            repos: db.repos,
+            config: db.config,
+            keychain: keychainGate.load)
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: commands.append)
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            modelProfileResolver: resolver,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        let swapRequest = try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: terminalID,
+                newProfileID: replacementProfile.id,
+                mode: .inPlace))
+        let swap = gateHoldingTask { await router.handle(swapRequest) }
+        guard await waitUntil({ keychainGate.isBlocked }) else {
+            keychainGate.release()
+            _ = await swap.value
+            Issue.record("profile replacement never reached credential resolution")
+            return
+        }
+
+        #expect(await coordinator.manualHibernate(terminalID: terminalID) == .ok)
+        let hibernated = try #require(try await db.terminals.get(id: terminalID))
+        let respawnsAfterHibernate = commands.snapshot()
+            .filter { $0.contains("respawn-window") }.count
+        #expect(respawnsAfterHibernate == 2)
+
+        keychainGate.release()
+        #expect(!(await swap.value).success)
+
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged.sessionIncarnationID == hibernated.sessionIncarnationID)
+        #expect(unchanged.tmuxWindowID == hibernated.tmuxWindowID)
+        #expect(unchanged.tmuxPaneID == hibernated.tmuxPaneID)
+        #expect(unchanged.profileID == hibernated.profileID)
+        #expect(unchanged.claudeSessionID == hibernated.claudeSessionID)
+        #expect(unchanged.transcriptPath == hibernated.transcriptPath)
+        #expect(unchanged.activityState == hibernated.activityState)
+        #expect(unchanged.activityStateSource == hibernated.activityStateSource)
+        #expect(unchanged.isParked)
+        #expect(commands.snapshot().filter { $0.contains("respawn-window") }.count
+                == respawnsAfterHibernate)
+    }
+
+    @Test func hibernateDoesNotReportSuccessWhenPostShellCommitFails() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let recorder = BlockingRespawnRecorder()
+        let deltas = RecordedHibernationDeltas()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: recorder.record)
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        recorder.arm()
+        let hibernate = gateHoldingTask {
+            await coord.manualHibernate(terminalID: terminalID)
+        }
+        guard await waitUntil({ recorder.isBlocked }) else {
+            recorder.release()
+            _ = await hibernate.value
+            Issue.record("hibernate never reached the shell respawn")
+            return
+        }
+        try await db.terminals.delete(id: terminalID)
+        recorder.release()
+
+        let result = await hibernate.value
+        #expect(result != .ok)
+        #expect(deltas.snapshot().isEmpty,
+                "a failed durable park must not broadcast hibernated=true")
+    }
+
+    @Test func firstHibernateRespawnFailureKeepsOldTokenForStartupRecovery() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "sess-1",
+            transcriptPath: "/tmp/hibernate-first-respawn.jsonl")
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let parkedForToken = try #require(try await db.terminals.get(id: terminalID))
+        let oldToken = try #require(try await db.terminals.prepareHibernatedAgentRespawn(
+            id: terminalID,
+            expectedState: TerminalReplacementSnapshot(terminal: parkedForToken),
+            at: Date(timeIntervalSinceReferenceDate: 1)))
+        try await db.terminals.clearHibernated(id: terminalID)
+        try await db.terminals.setActivityState(
+            id: terminalID, activityState: .idle, source: .derived)
+        let oldProcess = try #require(try await db.terminals.get(id: terminalID))
+        let failures = FailRespawnOnAttempt(1)
+        let deltas = RecordedHibernationDeltas()
+        let failingTmux = TmuxManager(
+            dryRun: true,
+            dryRunRespawnWindowError: failures.error)
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: failingTmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        #expect(await coordinator.manualHibernate(terminalID: terminalID) != .ok)
+        let failed = try #require(try await db.terminals.get(id: terminalID))
+        #expect(failed.isParked)
+        #expect(failed.sessionIncarnationID == oldToken)
+        #expect(failed.claudeSessionID == "sess-1")
+        #expect(failed.transcriptPath == "/tmp/hibernate-first-respawn.jsonl")
+        #expect(failed.activityState == oldProcess.activityState)
+        #expect(failed.activityStateSource == oldProcess.activityStateSource)
+        #expect(failed.activityStateObservedAt == oldProcess.activityStateObservedAt)
+        #expect(failed.activityStateOrderObservedAt == oldProcess.activityStateOrderObservedAt)
+        #expect(deltas.snapshot().isEmpty)
+
+        let liveTmux = TmuxManager(
+            dryRun: true,
+            dryRunPaneCurrentCommand: { _, _ in "1.2.3" })
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: liveTmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: liveTmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        await router.hibernationCoordinator.reconcileOnStartup()
+        #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
+
+        let oldProcessHook = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID,
+                sessionID: "still-live-session",
+                transcriptPath: "/tmp/still-live-session.jsonl",
+                source: "startup",
+                sessionIncarnationID: oldToken))
+        #expect((await router.handle(oldProcessHook)).success)
+        let recovered = try #require(try await db.terminals.get(id: terminalID))
+        #expect(recovered.claudeSessionID == "still-live-session")
+        #expect(recovered.transcriptPath == "/tmp/still-live-session.jsonl")
+        #expect(recovered.sessionIncarnationID == oldToken)
+    }
+
+    @Test func secondHibernateRespawnFailureLeavesInertPaneWithNewToken() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let parkedForToken = try #require(try await db.terminals.get(id: terminalID))
+        let oldToken = try #require(try await db.terminals.prepareHibernatedAgentRespawn(
+            id: terminalID,
+            expectedState: TerminalReplacementSnapshot(terminal: parkedForToken),
+            at: Date(timeIntervalSinceReferenceDate: 1)))
+        try await db.terminals.clearHibernated(id: terminalID)
+        try await db.terminals.setActivityState(
+            id: terminalID, activityState: .idle, source: .derived)
+        let oldProcess = try #require(try await db.terminals.get(id: terminalID))
+        let failures = FailRespawnOnAttempt(2)
+        let recorded = RecordedTmuxCommands()
+        let deltas = RecordedHibernationDeltas()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunRespawnWindowError: failures.error)
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        #expect(await coordinator.manualHibernate(terminalID: terminalID) != .ok)
+        let failed = try #require(try await db.terminals.get(id: terminalID))
+        let newToken = try #require(failed.sessionIncarnationID)
+        #expect(failed.isParked)
+        #expect(newToken != oldToken)
+        #expect(deltas.snapshot().isEmpty)
+        let respawns = recorded.snapshot()
+            .filter { $0.contains("respawn-window") }
+            .compactMap(\.last)
+        #expect(respawns.count == 2)
+        #expect(respawns.first?.contains("exec /usr/bin/tail -f /dev/null") == true)
+        #expect(respawns.last?.contains(
+            "TBD_TERMINAL_INCARNATION_ID='\(newToken.uuidString)'") == true)
+
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let staleHook = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID,
+                sessionID: "stale-session",
+                transcriptPath: "/tmp/stale-session.jsonl",
+                source: "startup",
+                sessionIncarnationID: oldProcess.sessionIncarnationID))
+        #expect((await router.handle(staleHook)).success)
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged.sessionIncarnationID == newToken)
+        #expect(unchanged.claudeSessionID == failed.claudeSessionID)
+        #expect(unchanged.transcriptPath == failed.transcriptPath)
+    }
+
+    @Test func wakeCannotOvertakeStagedHibernation() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let recorded = RecordedTmuxCommands()
+        let clock = TestClock<Duration>()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunPaneCurrentCommand: { _, _ in "1.2.3" })
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            exitPollAttempts: 1,
+            exitPollInterval: .milliseconds(200),
+            clock: clock,
+            actuationLog: makeTestActuationLog())
+
+        let hibernate = Task {
+            await coordinator.manualHibernate(terminalID: terminalID)
+        }
+        await clock.waitForSuspension()
+        #expect(try await db.terminals.get(id: terminalID)?.isParked == true)
+
+        #expect(await coordinator.wake(terminalID: terminalID) == .inFlight)
+        await clock.advanceWhenSuspended(by: .milliseconds(200))
+        #expect(await hibernate.value == .ok)
+        #expect(try await db.terminals.get(id: terminalID)?.isParked == true)
+        let respawns = recorded.snapshot().filter { $0.contains("respawn-window") }
+        #expect(respawns.count == 2)
+    }
+
     @Test func manualHibernateRefusesRunningTurn() async throws {
         let (db, _, terminalID) = try await setup(activityState: .working)
         let result = await coordinator(db).manualHibernate(terminalID: terminalID)
@@ -95,6 +478,240 @@ struct HibernationCoordinatorTests {
             return
         }
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func queuedHibernateRefusesActivityThatStartsWhileWaitingForServerLock() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let capture = MutableHibernationCapture()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: commands.append,
+            dryRunCapturePane: capture.capture)
+        let deltas = RecordedHibernationDeltas()
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let serverLock = HibernationServerLockGate()
+        let holder = serverLock.hold(tmux, server: "tbd-hib")
+        await serverLock.waitUntilHeld()
+        defer { serverLock.release() }
+
+        let hibernate = gateHoldingTask {
+            await coord.manualHibernate(terminalID: terminalID)
+        }
+        await capture.waitForFirstCapture()
+        await Task.megaYield()
+        let workingAt = Date(timeIntervalSinceReferenceDate: 50)
+        try await db.terminals.setActivityState(
+            id: terminalID,
+            activityState: .working,
+            source: .hookEvent("task_started"),
+            observedAt: workingAt)
+        let working = try #require(try await db.terminals.get(id: terminalID))
+        let commandCount = commands.snapshot().count
+        serverLock.release()
+        _ = await holder.value
+
+        #expect(await hibernate.value != .ok)
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged == working)
+        #expect(commands.snapshot().count == commandCount)
+        #expect(deltas.snapshot().isEmpty)
+    }
+
+    @Test func queuedAutomaticHibernateRestartsIdleWindowAfterCompletedTurn() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let capture = MutableHibernationCapture()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: commands.append,
+            dryRunCapturePane: capture.capture)
+        let deltas = RecordedHibernationDeltas()
+        let dates = TestDateSource()
+        let originallyIdle = try #require(try await db.terminals.get(id: terminalID))
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            now: dates.provider,
+            exitPollAttempts: 1,
+            exitPollInterval: .milliseconds(1),
+            actuationLog: ActuationLog(path: try sweepLogPath()))
+
+        await coord.sweep()
+        dates.advance(by: 61)
+        await coord.sweep()
+        dates.advance(by: HibernationCoordinator.killDebounce + 1)
+
+        let serverLock = HibernationServerLockGate()
+        let holder = serverLock.hold(tmux, server: "tbd-hib")
+        await serverLock.waitUntilHeld()
+        defer { serverLock.release() }
+        let sweep = gateHoldingTask { await coord.sweep() }
+        await capture.waitForFirstCapture()
+        await Task.megaYield()
+
+        dates.advance(by: 1)
+        try await db.terminals.setActivityState(
+            id: terminalID,
+            activityState: .working,
+            source: .hookEvent("task_started"),
+            observedAt: dates.now)
+        dates.advance(by: 1)
+        try await db.terminals.setActivityState(
+            id: terminalID,
+            activityState: .idle,
+            source: .hookEvent("stop"),
+            observedAt: dates.now)
+        let newlyIdle = try #require(try await db.terminals.get(id: terminalID))
+        #expect(TerminalReplacementSnapshot(terminal: originallyIdle).matches(newlyIdle))
+        let commandCount = commands.snapshot().count
+        serverLock.release()
+        _ = await holder.value
+        _ = await sweep.value
+
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged == newlyIdle)
+        #expect(!unchanged.isParked)
+        #expect(commands.snapshot().count == commandCount)
+        #expect(deltas.snapshot().isEmpty)
+    }
+
+    @Test func queuedHibernateRecapturesPendingInputAfterServerLock() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let capture = MutableHibernationCapture()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: commands.append,
+            dryRunCapturePane: capture.capture)
+        let deltas = RecordedHibernationDeltas()
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let serverLock = HibernationServerLockGate()
+        let holder = serverLock.hold(tmux, server: "tbd-hib")
+        await serverLock.waitUntilHeld()
+        defer { serverLock.release() }
+
+        let before = try #require(try await db.terminals.get(id: terminalID))
+        let hibernate = gateHoldingTask {
+            await coord.manualHibernate(terminalID: terminalID)
+        }
+        await capture.waitForFirstCapture()
+        capture.setPendingInput()
+        await Task.megaYield()
+        let commandCount = commands.snapshot().count
+        serverLock.release()
+        _ = await holder.value
+
+        #expect(await hibernate.value == .notEligible(
+            reason: "Terminal has unsent typed input"))
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged == before)
+        #expect(capture.count >= 2)
+        #expect(commands.snapshot().count == commandCount)
+        #expect(deltas.snapshot().isEmpty)
+    }
+
+    @Test func queuedMergeHibernateRechecksInputTrackerAfterServerLock() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let capture = MutableHibernationCapture()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: commands.append,
+            dryRunCapturePane: capture.capture)
+        let deltas = RecordedHibernationDeltas()
+        let inputActivity = InputActivityTracker()
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        await coord.setInputActivity(inputActivity)
+        let serverLock = HibernationServerLockGate()
+        let holder = serverLock.hold(tmux, server: "tbd-hib")
+        await serverLock.waitUntilHeld()
+        defer { serverLock.release() }
+
+        let before = try #require(try await db.terminals.get(id: terminalID))
+        let hibernate = gateHoldingTask {
+            await coord.hibernateForMerge(
+                terminalID: terminalID,
+                inputVetoEnabled: true)
+        }
+        await capture.waitForFirstCapture()
+        inputActivity.recordInput(paneID: before.tmuxPaneID)
+        await Task.megaYield()
+        let commandCount = commands.snapshot().count
+        serverLock.release()
+        _ = await holder.value
+
+        #expect(await hibernate.value == .notEligible(
+            reason: "Terminal has unsent typed input"))
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged == before)
+        #expect(commands.snapshot().count == commandCount)
+        #expect(deltas.snapshot().isEmpty)
+    }
+
+    @Test func queuedHibernateRevalidatesTranscriptTailAfterServerLock() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let transcript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-hibernate-tail-\(UUID().uuidString).jsonl")
+        try Data("{\"type\":\"result\"}\n".utf8).write(to: transcript)
+        defer { try? FileManager.default.removeItem(at: transcript) }
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "sess-1",
+            transcriptPath: transcript.path)
+        let capture = MutableHibernationCapture()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: commands.append,
+            dryRunCapturePane: capture.capture)
+        let deltas = RecordedHibernationDeltas()
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let serverLock = HibernationServerLockGate()
+        let holder = serverLock.hold(tmux, server: "tbd-hib")
+        await serverLock.waitUntilHeld()
+        defer { serverLock.release() }
+
+        let before = try #require(try await db.terminals.get(id: terminalID))
+        let hibernate = gateHoldingTask {
+            await coord.manualHibernate(terminalID: terminalID)
+        }
+        await capture.waitForFirstCapture()
+        await Task.megaYield()
+        try Data("{\"type\":\"assistant\"".utf8).write(to: transcript)
+        let commandCount = commands.snapshot().count
+        serverLock.release()
+        _ = await holder.value
+
+        #expect(await hibernate.value == .notEligible(
+            reason: "Transcript is mid-write; try again shortly"))
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged == before)
+        #expect(commands.snapshot().count == commandCount)
+        #expect(deltas.snapshot().isEmpty)
     }
 
     @Test func manualHibernateIgnoresKeepWarm() async throws {
@@ -368,6 +985,43 @@ struct HibernationCoordinatorTests {
                 "expected a respawn-window carrying claude --resume; got: \(joined)")
     }
 
+    @Test func wakeRespawnPreservesRetryIdentityAndRejectsParkedIncarnation() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "sess-1",
+            transcriptPath: "/tmp/hibernation-wake-old-session.jsonl")
+        let coord = coordinator(db)
+        #expect(await coord.manualHibernate(terminalID: terminalID) == .ok)
+        let parked = try #require(try await db.terminals.get(id: terminalID))
+
+        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        let awake = try #require(try await db.terminals.get(id: terminalID))
+        #expect(awake.sessionIncarnationID != parked.sessionIncarnationID)
+        #expect(awake.tmuxWindowID == parked.tmuxWindowID)
+        #expect(awake.tmuxPaneID == parked.tmuxPaneID)
+        #expect(awake.label == parked.label)
+        #expect(awake.claudeSessionID == "sess-1")
+        #expect(awake.transcriptPath == "/tmp/hibernation-wake-old-session.jsonl")
+        #expect(awake.sessionOrderObservedAt == nil)
+        #expect(awake.codexTranscriptBoundaryOffset == nil)
+        #expect(awake.activityState == .unknown)
+        #expect(!awake.isParked)
+
+        let staleApplication = try await db.terminals.applySessionStart(
+            id: terminalID,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: parked),
+            sessionID: "stale-parked-session",
+            transcriptPath: "/tmp/stale-parked-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 30))
+        #expect(staleApplication == nil)
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged.claudeSessionID == "sess-1")
+        #expect(unchanged.transcriptPath == "/tmp/hibernation-wake-old-session.jsonl")
+        #expect(unchanged.sessionIncarnationID == awake.sessionIncarnationID)
+        #expect(!unchanged.isParked)
+    }
+
     @Test func wakeOnNonHibernatedIsIdempotentNoOp() async throws {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
@@ -590,10 +1244,9 @@ struct HibernationCoordinatorTests {
     }
 
     /// Window DEAD (post-reboot / killed): wake recreates the server + window,
-    /// persists the NEW window/pane ids, un-parks the row, and spawns the same
-    /// `claude --resume` via `new-window -c <worktree path>` — no
-    /// `respawn-window` into the dead window. The server hook fires so a
-    /// recreated server gets its gated control-mode connection.
+    /// persists the NEW window/pane ids, stages an inert `new-window`, then
+    /// respawns the same `claude --resume` into that replacement. The
+    /// server hook fires so a recreated server gets its control-mode connection.
     @Test func wakeRecreatesDeadWindowAndPersistsNewIDs() async throws {
         let (db, _, terminalID) = try await setup()
         try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
@@ -615,9 +1268,11 @@ struct HibernationCoordinatorTests {
         #expect(after?.tmuxPaneID == "%mock-0", "recreate must persist the new pane id")
 
         let joined = recorded.snapshot().map { $0.joined(separator: " ") }
-        #expect(joined.contains { $0.contains("new-window") && $0.contains("-c /tmp/hib-repo") && $0.contains("--resume sess-1") },
-                "expected new-window in the worktree cwd carrying claude --resume; got: \(joined)")
-        #expect(!joined.contains { $0.contains("respawn-window") },
+        #expect(joined.contains { $0.contains("new-window") && $0.contains("-c /tmp/hib-repo") && $0.contains("tail -f /dev/null") },
+                "expected an inert staged new-window in the worktree cwd; got: \(joined)")
+        #expect(joined.contains { $0.contains("respawn-window") && $0.contains("@mock-0") && $0.contains("--resume sess-1") },
+                "expected a respawn into the replacement window; got: \(joined)")
+        #expect(!joined.contains { $0.contains("respawn-window") && $0.contains("-t @0") },
                 "a dead window must NOT be respawned into; got: \(joined)")
         // Old-window cleanup: a transient windowExists misclassification must
         // not leak a live old window (usually already dead — kill no-ops).
@@ -625,6 +1280,172 @@ struct HibernationCoordinatorTests {
                 "expected a best-effort kill of the old window; got: \(joined)")
         #expect(serverHookCalls.snapshot() == [["tbd-hib"]],
                 "onServerCreated must fire once with the recreated server name")
+    }
+
+    @Test func deadWindowWakePersistsReplacementTokenBeforeAgentLaunch() async throws {
+        let (db, _, terminalID) = try await setup()
+        // Dry-run recreation returns these same coordinates, exercising the
+        // ABA shape where tmux IDs and the label cannot distinguish processes.
+        try await db.terminals.updateTmuxIDs(
+            id: terminalID, windowID: "@mock-0", paneID: "%mock-0")
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let recorder = BlockingRespawnRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.record,
+            dryRunWindowIsDead: { $0 == "@mock-0" })
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        recorder.arm(matching: "claude --resume sess-1")
+        let wake = gateHoldingTask {
+            await router.hibernationCoordinator.wake(terminalID: terminalID)
+        }
+        guard await waitUntil({ recorder.isBlocked }) else {
+            recorder.release()
+            _ = await wake.value
+            Issue.record("wake never reached the replacement agent launch")
+            return
+        }
+
+        let staged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(staged.tmuxWindowID == "@mock-0")
+        #expect(staged.tmuxPaneID == "%mock-0")
+        #expect(staged.label == "claude")
+        #expect(staged.isParked)
+        let replacementToken = try #require(staged.sessionIncarnationID)
+        #expect(recorder.blockedCommand?.last?.contains(
+            "TBD_TERMINAL_INCARNATION_ID='\(replacementToken.uuidString)'") == true)
+        let matchedCLIPath = try #require(AgentProcessEnvironment.cliPath)
+        #expect(recorder.blockedCommand?.last?.contains(
+            "TBD_CLI_PATH=\(SystemPromptBuilder.shellEscape(matchedCLIPath))") == true)
+
+        let staleHook = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID,
+                sessionID: "stale-session",
+                transcriptPath: "/tmp/stale-session.jsonl",
+                source: "startup"))
+        #expect((await router.handle(staleHook)).success)
+        #expect(try await db.terminals.get(id: terminalID)?.claudeSessionID == "sess-1")
+        recorder.release()
+        #expect(await wake.value == .ok)
+
+        let replacementHook = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID,
+                sessionID: "replacement-session",
+                transcriptPath: "/tmp/replacement-session.jsonl",
+                source: "startup",
+                sessionIncarnationID: replacementToken))
+        #expect((await router.handle(replacementHook)).success)
+        let attached = try #require(try await db.terminals.get(id: terminalID))
+        #expect(attached.claudeSessionID == "replacement-session")
+        #expect(attached.transcriptPath == "/tmp/replacement-session.jsonl")
+    }
+
+    @Test func liveWindowWakeFencesSessionStartHandledDuringRespawnGap() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let recorder = BlockingRespawnRecorder()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: recorder.record)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        recorder.arm(matching: "claude --resume sess-1")
+        let wake = gateHoldingTask {
+            await router.hibernationCoordinator.wake(terminalID: terminalID)
+        }
+        guard await waitUntil({ recorder.isBlocked }) else {
+            recorder.release()
+            _ = await wake.value
+            Issue.record("wake never reached the in-place respawn")
+            return
+        }
+        let staged = try #require(try await db.terminals.get(id: terminalID))
+        let replacementToken = try #require(staged.sessionIncarnationID)
+        #expect(recorder.blockedCommand?.last?.contains(
+            "TBD_TERMINAL_INCARNATION_ID='\(replacementToken.uuidString)'") == true)
+        let matchedCLIPath = try #require(AgentProcessEnvironment.cliPath)
+        #expect(recorder.blockedCommand?.last?.contains(
+            "TBD_CLI_PATH=\(SystemPromptBuilder.shellEscape(matchedCLIPath))") == true)
+
+        let gapEvent = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID,
+                sessionID: "old-process-gap-session",
+                transcriptPath: "/tmp/old-process-gap-session.jsonl",
+                source: "startup"))
+        #expect((await router.handle(gapEvent)).success)
+        #expect(try await db.terminals.get(id: terminalID)?.claudeSessionID == "sess-1")
+
+        recorder.release()
+        #expect(await wake.value == .ok)
+        let finalized = try #require(try await db.terminals.get(id: terminalID))
+        #expect(!finalized.isParked)
+        #expect(finalized.claudeSessionID == "sess-1")
+        #expect(finalized.transcriptPath == nil)
+
+        let replacementEvent = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID,
+                sessionID: "replacement-session",
+                transcriptPath: "/tmp/replacement-session.jsonl",
+                source: "startup",
+                sessionIncarnationID: replacementToken))
+        #expect((await router.handle(replacementEvent)).success)
+        #expect(try await db.terminals.get(id: terminalID)?.claudeSessionID
+                == "replacement-session")
+    }
+
+    @Test func wakeDoesNotReportSuccessWhenPostLaunchMarkerClearFails() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let recorder = BlockingRespawnRecorder()
+        let deltas = RecordedHibernationDeltas()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: recorder.record)
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        recorder.arm(matching: "claude --resume sess-1")
+        let wake = gateHoldingTask {
+            await coord.wake(terminalID: terminalID)
+        }
+        guard await waitUntil({ recorder.isBlocked }) else {
+            recorder.release()
+            _ = await wake.value
+            Issue.record("wake never reached the replacement launch")
+            return
+        }
+        try await db.terminals.delete(id: terminalID)
+        recorder.release()
+
+        #expect(await wake.value != .ok)
+        #expect(deltas.snapshot().isEmpty,
+                "a wake whose final durable marker clear failed must not broadcast success")
+        let joined = recorder.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.filter { $0.contains("respawn-window") }.count == 1,
+                "marker failure must not erase an already-running replacement")
     }
 
     // MARK: - Wake: window-id ownership (post-reboot id recycling)
@@ -662,7 +1483,9 @@ struct HibernationCoordinatorTests {
         let joined = recorded.snapshot().map { $0.joined(separator: " ") }
         #expect(joined.contains { $0.contains("new-window") },
                 "expected the recreate branch (new-window); got: \(joined)")
-        #expect(!joined.contains { $0.contains("respawn-window") },
+        #expect(joined.contains { $0.contains("respawn-window") && $0.contains("@mock-0") },
+                "the replacement window must receive the agent; got: \(joined)")
+        #expect(!joined.contains { $0.contains("respawn-window") && $0.contains("-t @0") },
                 "must never respawn into a window another terminal owns; got: \(joined)")
         #expect(!joined.contains { $0.contains("kill-window") && $0.contains("@0") },
                 "must never kill the other terminal's live window; got: \(joined)")
@@ -702,6 +1525,86 @@ struct HibernationCoordinatorTests {
     // the same terminal. Both branches of the lock gate are covered: same
     // server serializes (and loses no wake), different servers don't.
 
+    @Test func concurrentWakesForSameTerminalClaimBeforeDatabaseLookup() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let parked = try #require(try await db.terminals.get(id: terminalID))
+        let recorded = RecordedTmuxCommands()
+        let deltas = RecordedHibernationDeltas()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: recorded.append)
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            subscriptions: deltas.subscriptions(),
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let databaseGate = BlockingDatabaseWriter()
+        let heldWriter = databaseGate.hold(db)
+        guard await waitUntil({ databaseGate.isHolding }) else {
+            databaseGate.release()
+            await heldWriter.value
+            Issue.record("database writer gate was never acquired")
+            return
+        }
+
+        let earlyResults = RecordedWakeResults()
+        let first = Task {
+            let result = await coordinator.wake(
+                terminalID: terminalID,
+                initialPrompt: "deliver exactly once")
+            earlyResults.append(result)
+            return result
+        }
+        let second = Task {
+            let result = await coordinator.wake(
+                terminalID: terminalID,
+                initialPrompt: "deliver exactly once")
+            earlyResults.append(result)
+            return result
+        }
+        let duplicateWasRejectedBeforeDatabaseRelease = await waitUntil {
+            earlyResults.snapshot().contains(.inFlight)
+        }
+        databaseGate.release()
+        await heldWriter.value
+
+        let results = await [first.value, second.value]
+        #expect(duplicateWasRejectedBeforeDatabaseRelease)
+        #expect(results.filter { $0 == .ok }.count == 1)
+        #expect(results.filter { $0 == .inFlight }.count == 1)
+        let after = try #require(try await db.terminals.get(id: terminalID))
+        #expect(after.sessionIncarnationID != parked.sessionIncarnationID)
+        #expect(!after.isParked)
+        let replacementCommands = recorded.snapshot().filter { command in
+            let body = command.joined(separator: " ")
+            return body.contains("respawn-window")
+                && body.contains("claude --resume sess-1")
+                && body.contains("deliver exactly once")
+        }
+        #expect(replacementCommands.count == 1)
+        #expect(deltas.snapshot().filter { !$0.hibernated }.count == 1)
+    }
+
+    @Test func terminalLookupFailureReleasesSameTerminalClaim() async throws {
+        let (db, worktreeID, _) = try await setup()
+        let terminalID = UUID()
+        let subject = coordinator(db)
+
+        #expect(await subject.wake(terminalID: terminalID) == .notFound)
+
+        _ = try await db.terminals.create(
+            id: terminalID,
+            worktreeID: worktreeID,
+            tmuxWindowID: "@retry",
+            tmuxPaneID: "%retry",
+            label: "claude",
+            claudeSessionID: "sess-retry",
+            kind: .claude)
+        try await db.terminals.setHibernated(
+            id: terminalID, sessionID: "sess-retry")
+        #expect(await subject.wake(terminalID: terminalID) == .ok)
+    }
+
     /// Two concurrent wakes, two parked terminals, SAME server, both windows
     /// dead: both must succeed with DISTINCT fresh window ids and exactly two
     /// new-window commands — no lost wake, no hijack, no deadlock.
@@ -740,8 +1643,12 @@ struct HibernationCoordinatorTests {
         let newWindowCount = joined.filter { $0.contains("new-window") }.count
         #expect(newWindowCount == 2,
                 "expected exactly two new-window commands (one per wake); got \(newWindowCount) in: \(joined)")
-        #expect(!joined.contains { $0.contains("respawn-window") },
-                "dead windows must never be respawned into; got: \(joined)")
+        #expect(joined.filter { $0.contains("respawn-window") && $0.contains("@mock-") }.count == 2,
+                "each replacement must receive one respawn; got: \(joined)")
+        #expect(!joined.contains { command in
+            command.contains("respawn-window")
+                && (command.contains("-t @0") || command.contains("-t @1"))
+        }, "dead windows must never be respawned into; got: \(joined)")
     }
 
     /// Two concurrent wakes on DIFFERENT servers: the per-server lock must
@@ -901,6 +1808,84 @@ struct HibernationCoordinatorTests {
         #expect(after?.isParked == true, "a failed wake must leave the row parked for retry")
     }
 
+    @Test func liveWindowLaunchFailurePreservesResumeIdentityForRetry() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "sess-1",
+            transcriptPath: "/tmp/live-wake-retry.jsonl")
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let failures = FailFirstRespawn()
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunRespawnWindowError: failures.error)
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        guard case .respawnFailed = await coord.wake(terminalID: terminalID) else {
+            Issue.record("first live-window wake must expose the launch failure")
+            return
+        }
+        let failed = try #require(try await db.terminals.get(id: terminalID))
+        #expect(failed.isParked)
+        #expect(failed.claudeSessionID == "sess-1")
+        #expect(failed.transcriptPath == "/tmp/live-wake-retry.jsonl")
+
+        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        let retried = try #require(try await db.terminals.get(id: terminalID))
+        #expect(!retried.isParked)
+        #expect(retried.claudeSessionID == "sess-1")
+        #expect(retried.transcriptPath == "/tmp/live-wake-retry.jsonl")
+        #expect(recorded.snapshot().filter {
+            $0.contains("respawn-window") && $0.last?.contains("--resume sess-1") == true
+        }.count == 2)
+    }
+
+    @Test func deadWindowLaunchFailurePreservesResumeIdentityForRetry() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.updateSession(
+            id: terminalID,
+            sessionID: "sess-1",
+            transcriptPath: "/tmp/dead-wake-retry.jsonl")
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let failures = FailFirstRespawn()
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunWindowIsDead: { $0 == "@0" },
+            dryRunRespawnWindowError: failures.error)
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        guard case .respawnFailed = await coord.wake(terminalID: terminalID) else {
+            Issue.record("first dead-window wake must expose the launch failure")
+            return
+        }
+        let failed = try #require(try await db.terminals.get(id: terminalID))
+        #expect(failed.isParked)
+        #expect(failed.tmuxWindowID == "@mock-0")
+        #expect(failed.claudeSessionID == "sess-1")
+        #expect(failed.transcriptPath == "/tmp/dead-wake-retry.jsonl")
+
+        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        let retried = try #require(try await db.terminals.get(id: terminalID))
+        #expect(!retried.isParked)
+        #expect(retried.claudeSessionID == "sess-1")
+        #expect(retried.transcriptPath == "/tmp/dead-wake-retry.jsonl")
+        #expect(recorded.snapshot().filter {
+            $0.contains("respawn-window") && $0.last?.contains("--resume sess-1") == true
+        }.count == 2)
+    }
+
     /// The wake transcript sync must resolve the ambient (nil-profile)
     /// projects root through the INJECTED `configDirManager` — the seam this
     /// suite relies on to stay out of the real `~/.claude`. A transcript
@@ -1007,6 +1992,138 @@ struct HibernationCoordinatorTests {
         #expect(after?.hibernatedAt == nil, "row must be un-parked")
     }
 
+    @Test func coldProfileSwapWinsBeforeWakeLaunch() async throws {
+        let (db, _, terminalID) = try await setup()
+        let oldProfile = try await db.modelProfiles.create(name: "Old", kind: .apiKey)
+        let newProfile = try await db.modelProfiles.create(name: "New", kind: .oauth)
+        try await db.terminals.setProfileID(id: terminalID, profileID: oldProfile.id)
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let keychainGate = BlockingKeychainLookup()
+        let wakeResolver = ModelProfileResolver(
+            profiles: db.modelProfiles,
+            repos: db.repos,
+            config: db.config,
+            keychain: keychainGate.load)
+        let configDirs = isolatedConfigDirManager()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: commands.append)
+        let deltas = RecordedStateDeltas()
+        let subscriptions = deltas.subscriptions()
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            modelProfileResolver: wakeResolver,
+            subscriptions: subscriptions,
+            configDirManager: configDirs,
+            actuationLog: makeTestActuationLog())
+        let swapRouter = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: configDirs),
+            tmux: tmux,
+            subscriptions: subscriptions,
+            configDirManager: configDirs,
+            actuationLog: makeTestActuationLog())
+
+        let wake = gateHoldingTask { await coordinator.wake(terminalID: terminalID) }
+        guard await waitUntil({ keychainGate.isBlocked }) else {
+            keychainGate.release()
+            _ = await wake.value
+            Issue.record("wake never reached old-profile resolution")
+            return
+        }
+        let swapResponse = await swapRouter.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: terminalID, newProfileID: newProfile.id, mode: .inPlace)))
+        #expect(swapResponse.success)
+        let swapped = try #require(try await db.terminals.get(id: terminalID))
+        #expect(swapped.isParked)
+        #expect(swapped.profileID == newProfile.id)
+        let commandCount = commands.snapshot().count
+        keychainGate.release()
+
+        #expect(await wake.value != .ok)
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged == swapped)
+        #expect(commands.snapshot().count == commandCount,
+                "a wake prepared for the old profile must not launch")
+        #expect(deltas.snapshot().filter { delta in
+            if case .terminalHibernationChanged = delta { return true }
+            return false
+        }.isEmpty, "the rejected wake must not broadcast an unpark")
+    }
+
+    @Test func wakeWinsBeforeColdProfileSwapCommit() async throws {
+        let (db, _, terminalID) = try await setup()
+        let oldProfile = try await db.modelProfiles.create(name: "Old", kind: .oauth)
+        let newProfile = try await db.modelProfiles.create(name: "New", kind: .apiKey)
+        try await db.terminals.setProfileID(id: terminalID, profileID: oldProfile.id)
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let keychainGate = BlockingKeychainLookup()
+        let swapResolver = ModelProfileResolver(
+            profiles: db.modelProfiles,
+            repos: db.repos,
+            config: db.config,
+            keychain: keychainGate.load)
+        let wakeResolver = ModelProfileResolver(
+            profiles: db.modelProfiles,
+            repos: db.repos,
+            config: db.config,
+            keychain: { _ in nil })
+        let configDirs = isolatedConfigDirManager()
+        let commands = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: commands.append)
+        let deltas = RecordedStateDeltas()
+        let subscriptions = deltas.subscriptions()
+        let coordinator = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            modelProfileResolver: wakeResolver,
+            subscriptions: subscriptions,
+            configDirManager: configDirs,
+            actuationLog: makeTestActuationLog())
+        let swapRouter = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: configDirs),
+            tmux: tmux,
+            subscriptions: subscriptions,
+            modelProfileResolver: swapResolver,
+            configDirManager: configDirs,
+            actuationLog: makeTestActuationLog())
+
+        let swapRequest = try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: terminalID, newProfileID: newProfile.id, mode: .inPlace))
+        let swap = gateHoldingTask { await swapRouter.handle(swapRequest) }
+        guard await waitUntil({ keychainGate.isBlocked }) else {
+            keychainGate.release()
+            _ = await swap.value
+            Issue.record("cold swap never reached new-profile resolution")
+            return
+        }
+
+        #expect(await coordinator.wake(terminalID: terminalID) == .ok)
+        let woken = try #require(try await db.terminals.get(id: terminalID))
+        #expect(!woken.isParked)
+        #expect(woken.profileID == oldProfile.id)
+        let commandCount = commands.snapshot().count
+        keychainGate.release()
+
+        #expect(!(await swap.value).success)
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged == woken)
+        #expect(commands.snapshot().count == commandCount)
+        #expect(deltas.snapshot().filter { delta in
+            if case .terminalProfileChanged = delta { return true }
+            return false
+        }.isEmpty, "the rejected cold swap must not broadcast a profile change")
+    }
+
     /// When no resolver is injected, the profile check doesn't fire — even if a
     /// profileID is pinned. This pins that the plain `coordinator(db)` (used by
     /// other tests) is unaffected.
@@ -1035,7 +2152,8 @@ struct HibernationCoordinatorTests {
     @Test func reconcileOnStartupClearsStaleParkedForLiveClaude() async throws {
         let (db, _, terminalID) = try await setup()
         try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
-        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt != nil)
+        let parked = try #require(try await db.terminals.get(id: terminalID))
+        #expect(parked.hibernatedAt != nil)
 
         // Pane still runs claude (reported as its version string) → the parked
         // state is stale and must be cleared.
@@ -1043,8 +2161,58 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
         await coord.reconcileOnStartup()
 
-        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
+        let reconciled = try #require(try await db.terminals.get(id: terminalID))
+        #expect(reconciled.hibernatedAt == nil,
                 "a still-running claude must have its stale parked timestamp cleared")
+        #expect(reconciled.claudeSessionID == parked.claudeSessionID)
+        #expect(reconciled.transcriptPath == parked.transcriptPath)
+        #expect(reconciled.sessionIncarnationID == parked.sessionIncarnationID)
+    }
+
+    @Test func reconcileOnStartupPreservesSessionStartAcceptedWhileReplacementStayedParked() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let parkedBeforeReplacement = try #require(
+            try await db.terminals.get(id: terminalID))
+        let replacementToken = try #require(
+            try await db.terminals.prepareHibernatedAgentRespawn(
+                id: terminalID,
+                expectedState: TerminalReplacementSnapshot(
+                    terminal: parkedBeforeReplacement),
+                at: Date(timeIntervalSinceReferenceDate: 10)))
+        let staged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(staged.isParked)
+        #expect(staged.sessionIncarnationID == replacementToken)
+
+        let tmux = TmuxManager(dryRun: true, dryRunPaneCurrentCommand: { _, _ in "1.2.3" })
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        let replacementHook = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID,
+                sessionID: "replacement-session",
+                transcriptPath: "/tmp/replacement-session.jsonl",
+                source: "startup",
+                sessionIncarnationID: replacementToken))
+        #expect((await router.handle(replacementHook)).success)
+
+        let attachedWhileParked = try #require(try await db.terminals.get(id: terminalID))
+        #expect(attachedWhileParked.isParked)
+        #expect(attachedWhileParked.claudeSessionID == "replacement-session")
+        await router.hibernationCoordinator.reconcileOnStartup()
+
+        let reconciled = try #require(try await db.terminals.get(id: terminalID))
+        #expect(!reconciled.isParked)
+        #expect(reconciled.claudeSessionID == "replacement-session")
+        #expect(reconciled.transcriptPath == "/tmp/replacement-session.jsonl")
+        #expect(reconciled.sessionIncarnationID == replacementToken)
     }
 
     /// The inverse: a genuinely parked terminal (pane running a bare shell, not
@@ -1461,6 +2629,93 @@ private final class RecordedHibernationDeltas: @unchecked Sendable {
     }
 }
 
+private final class HibernationServerLockGate: @unchecked Sendable {
+    private let entered: AsyncStream<Void>
+    private let enteredContinuation: AsyncStream<Void>.Continuation
+    private let releaseStream: AsyncStream<Void>
+    private let releaseContinuation: AsyncStream<Void>.Continuation
+
+    init() {
+        (entered, enteredContinuation) = AsyncStream.makeStream(of: Void.self)
+        (releaseStream, releaseContinuation) = AsyncStream.makeStream(of: Void.self)
+    }
+
+    func hold(_ tmux: TmuxManager, server: String) -> Task<Void, Never> {
+        Task {
+            await tmux.withServerResourceLock(server: server) { [self] in
+                enteredContinuation.yield()
+                var iterator = releaseStream.makeAsyncIterator()
+                _ = await iterator.next()
+            }
+        }
+    }
+
+    func waitUntilHeld() async {
+        var iterator = entered.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func release() {
+        releaseContinuation.yield()
+    }
+}
+
+private final class MutableHibernationCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private let firstCapture: AsyncStream<Void>
+    private let firstCaptureContinuation: AsyncStream<Void>.Continuation
+    private var captures = 0
+    private var pendingInput = false
+
+    init() {
+        (firstCapture, firstCaptureContinuation) = AsyncStream.makeStream(of: Void.self)
+    }
+
+    var count: Int { lock.withLock { captures } }
+
+    var capture: @Sendable (String, String) -> String {
+        { [self] _, _ in
+            lock.withLock {
+                captures += 1
+                if captures == 1 {
+                    firstCaptureContinuation.yield()
+                }
+                return pendingInput ? "> preserve this typed prompt" : ""
+            }
+        }
+    }
+
+    func waitForFirstCapture() async {
+        var iterator = firstCapture.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func setPendingInput() {
+        lock.withLock { pendingInput = true }
+    }
+}
+
+private final class RecordedStateDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func subscriptions() -> StateSubscriptionManager {
+        let manager = StateSubscriptionManager()
+        manager.addSubscriber { [weak self] data in
+            guard let delta = try? JSONDecoder().decode(StateDelta.self, from: data) else {
+                return true
+            }
+            self?.lock.withLock { self?.deltas.append(delta) }
+            return true
+        }
+        return manager
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.withLock { deltas }
+    }
+}
+
 /// Thread-safe collector for TmuxManager dryRun recorded args.
 private final class RecordedTmuxCommands: @unchecked Sendable {
     private let lock = NSLock()
@@ -1472,5 +2727,164 @@ private final class RecordedTmuxCommands: @unchecked Sendable {
     func snapshot() -> [[String]] {
         lock.lock(); defer { lock.unlock() }
         return commands
+    }
+}
+
+private final class FailFirstRespawn: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasFailed = false
+
+    var error: @Sendable (String) -> Error? {
+        { [self] _ in
+            lock.withLock {
+                guard !hasFailed else { return nil }
+                hasFailed = true
+                return TmuxError.unexpectedOutput("first replacement launch failed")
+            }
+        }
+    }
+}
+
+private final class FailRespawnOnAttempt: @unchecked Sendable {
+    private let lock = NSLock()
+    private let failingAttempt: Int
+    private var attempt = 0
+
+    init(_ failingAttempt: Int) {
+        self.failingAttempt = failingAttempt
+    }
+
+    var error: @Sendable (String) -> Error? {
+        { [self] _ in
+            lock.withLock {
+                attempt += 1
+                guard attempt == failingAttempt else { return nil }
+                return TmuxError.unexpectedOutput(
+                    "replacement attempt \(failingAttempt) failed")
+            }
+        }
+    }
+}
+
+private final class BlockingDatabaseWriter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private var holding = false
+
+    var isHolding: Bool { lock.withLock { holding } }
+
+    func hold(_ db: TBDDatabase) -> Task<Void, Never> {
+        gateHoldingTask { [self] in
+            try? await db.writerForTests.writeWithoutTransaction { _ in
+                lock.withLock { holding = true }
+                releaseGate.waitForGate("same-terminal wake database writer")
+            }
+        }
+    }
+
+    func release() {
+        releaseGate.signal()
+    }
+}
+
+private final class RecordedWakeResults: @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [WakeResult] = []
+
+    func append(_ result: WakeResult) {
+        lock.withLock { results.append(result) }
+    }
+
+    func snapshot() -> [WakeResult] {
+        lock.withLock { results }
+    }
+}
+
+private final class BlockingCapturePane: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private var blocked = false
+
+    var isBlocked: Bool { lock.withLock { blocked } }
+
+    var capture: @Sendable (String, String) -> String {
+        { [self] _, _ in
+            lock.withLock { blocked = true }
+            releaseGate.waitForGate("pre-hibernation capture")
+            return ""
+        }
+    }
+
+    func release() {
+        releaseGate.signal()
+    }
+}
+
+private final class BlockingKeychainLookup: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private var blocked = false
+
+    var isBlocked: Bool { lock.withLock { blocked } }
+
+    var load: @Sendable (String) throws -> String? {
+        { [self] _ in
+            lock.withLock { blocked = true }
+            releaseGate.waitForGate("profile credential lookup")
+            return "replacement-secret"
+        }
+    }
+
+    func release() {
+        releaseGate.signal()
+    }
+}
+
+private final class BlockingRespawnRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private var armed = false
+    private var blocked = false
+    private var match = "respawn-window"
+    private var blockedValue: [String]?
+    private var commands: [[String]] = []
+
+    var isBlocked: Bool { lock.withLock { blocked } }
+    var blockedCommand: [String]? { lock.withLock { blockedValue } }
+
+    var record: @Sendable ([String]) -> Void {
+        { [self] command in
+            let shouldBlock = lock.withLock { () -> Bool in
+                commands.append(command)
+                guard armed,
+                      !blocked,
+                      command.joined(separator: " ").contains(match) else {
+                    return false
+                }
+                blocked = true
+                blockedValue = command
+                return true
+            }
+            if shouldBlock {
+                releaseGate.waitForGate("hibernation respawn")
+            }
+        }
+    }
+
+    func arm(matching match: String = "respawn-window") {
+        lock.withLock {
+            armed = true
+            blocked = false
+            self.match = match
+            blockedValue = nil
+        }
+    }
+
+    func release() {
+        releaseGate.signal()
+    }
+
+    func snapshot() -> [[String]] {
+        lock.withLock { commands }
     }
 }

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -314,7 +314,6 @@ struct HibernationCoordinatorTests {
         try await db.terminals.clearHibernated(id: terminalID)
         try await db.terminals.setActivityState(
             id: terminalID, activityState: .idle, source: .derived)
-        let oldProcess = try #require(try await db.terminals.get(id: terminalID))
         let failures = FailRespawnOnAttempt(1)
         let deltas = RecordedHibernationDeltas()
         let failingTmux = TmuxManager(
@@ -331,12 +330,13 @@ struct HibernationCoordinatorTests {
         let failed = try #require(try await db.terminals.get(id: terminalID))
         #expect(failed.isParked)
         #expect(failed.sessionIncarnationID == oldToken)
+        #expect(failed.pendingSessionIncarnationID != nil)
         #expect(failed.claudeSessionID == "sess-1")
         #expect(failed.transcriptPath == "/tmp/hibernate-first-respawn.jsonl")
-        #expect(failed.activityState == oldProcess.activityState)
-        #expect(failed.activityStateSource == oldProcess.activityStateSource)
-        #expect(failed.activityStateObservedAt == oldProcess.activityStateObservedAt)
-        #expect(failed.activityStateOrderObservedAt == oldProcess.activityStateOrderObservedAt)
+        #expect(failed.activityState == .idle)
+        #expect(failed.activityStateSource == .database)
+        #expect(failed.activityStateObservedAt != nil)
+        #expect(failed.activityStateOrderObservedAt == failed.activityStateObservedAt)
         #expect(deltas.snapshot().isEmpty)
 
         let liveTmux = TmuxManager(
@@ -351,7 +351,10 @@ struct HibernationCoordinatorTests {
             configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
         await router.hibernationCoordinator.reconcileOnStartup()
-        #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
+        let unparked = try #require(try await db.terminals.get(id: terminalID))
+        #expect(!unparked.isParked)
+        #expect(unparked.sessionIncarnationID == oldToken)
+        #expect(unparked.pendingSessionIncarnationID == nil)
 
         let oldProcessHook = try RPCRequest(
             method: RPCMethod.terminalSessionEvent,

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1312,7 +1312,7 @@ struct HibernationCoordinatorTests {
         let wake = gateHoldingTask {
             await router.hibernationCoordinator.wake(terminalID: terminalID)
         }
-        guard await waitUntil({ recorder.isBlocked }) else {
+        guard await waitUntil({ recorder.isBlocked }, timeout: ciSafeDeadline) else {
             recorder.release()
             _ = await wake.value
             Issue.record("wake never reached the replacement agent launch")

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1375,7 +1375,7 @@ struct HibernationCoordinatorTests {
         let wake = gateHoldingTask {
             await router.hibernationCoordinator.wake(terminalID: terminalID)
         }
-        guard await waitUntil({ recorder.isBlocked }) else {
+        guard await waitUntil({ recorder.isBlocked }, timeout: ciSafeDeadline) else {
             recorder.release()
             _ = await wake.value
             Issue.record("wake never reached the in-place respawn")
@@ -1436,7 +1436,7 @@ struct HibernationCoordinatorTests {
         let wake = gateHoldingTask {
             await coord.wake(terminalID: terminalID)
         }
-        guard await waitUntil({ recorder.isBlocked }) else {
+        guard await waitUntil({ recorder.isBlocked }, timeout: ciSafeDeadline) else {
             recorder.release()
             _ = await wake.value
             Issue.record("wake never reached the replacement launch")
@@ -1807,7 +1807,7 @@ struct HibernationCoordinatorTests {
 
         recorder.arm(matching: "new-window")
         let wake = gateHoldingTask { await coord.wake(terminalID: terminalID) }
-        guard await waitUntil({ recorder.isBlocked }) else {
+        guard await waitUntil({ recorder.isBlocked }, timeout: ciSafeDeadline) else {
             recorder.release()
             _ = await wake.value
             Issue.record("wake never reached replacement window creation")

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -278,7 +278,8 @@ struct HibernationCoordinatorTests {
             configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
 
-        recorder.arm()
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        recorder.arm(matching: "; \(shell)")
         let hibernate = gateHoldingTask {
             await coord.manualHibernate(terminalID: terminalID)
         }
@@ -288,6 +289,7 @@ struct HibernationCoordinatorTests {
             Issue.record("hibernate never reached the shell respawn")
             return
         }
+        #expect(recorder.blockedCommand?.last?.hasSuffix(shell) == true)
         try await db.terminals.delete(id: terminalID)
         recorder.release()
 
@@ -1784,6 +1786,40 @@ struct HibernationCoordinatorTests {
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == true, "a failed wake must leave the row parked for retry")
         #expect(after?.tmuxWindowID == "@0", "tmux ids must be unchanged on failure")
+    }
+
+    @Test func deadWindowWakeReportsStaleStateAsRetryable() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let recorder = BlockingRespawnRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorder.record,
+            dryRunWindowIsDead: { $0 == "@0" })
+        let coord = HibernationCoordinator(
+            db: db,
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        recorder.arm(matching: "new-window")
+        let wake = gateHoldingTask { await coord.wake(terminalID: terminalID) }
+        guard await waitUntil({ recorder.isBlocked }) else {
+            recorder.release()
+            _ = await wake.value
+            Issue.record("wake never reached replacement window creation")
+            return
+        }
+        try await db.terminals.updateSessionID(
+            id: terminalID, sessionID: "replacement-session")
+        recorder.release()
+
+        #expect(await wake.value == .respawnFailed(
+            reason: "terminal changed before wake could launch; retry"))
+        let unchanged = try #require(try await db.terminals.get(id: terminalID))
+        #expect(unchanged.tmuxWindowID == "@0")
+        #expect(unchanged.tmuxPaneID == "%0")
+        #expect(unchanged.isParked)
     }
 
     /// Respawn FAILS (window alive but respawn-window errors): result is

--- a/Tests/TBDDaemonTests/MigrationV75StateProvenanceTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV75StateProvenanceTests.swift
@@ -234,6 +234,7 @@ import Testing
             source: .hookEvent("UserPromptSubmit"), observedAt: epoch)
         _ = try await db.terminals.applySessionStart(
             id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
             sessionID: "session-before-recreation",
             transcriptPath: "/tmp/session-before-recreation.jsonl",
             observedAt: epoch.addingTimeInterval(10))

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -33,6 +33,7 @@ struct ModelProfileSpawnTests {
         private var _calls: [[String]] = []
         private var blockMatch: String?
         private var _isBlocked = false
+        private var _blockedCommand: [String]?
         var calls: [[String]] {
             lock.lock(); defer { lock.unlock() }
             return _calls
@@ -46,6 +47,7 @@ struct ModelProfileSpawnTests {
                     return false
                 }
                 _isBlocked = true
+                _blockedCommand = args
                 return true
             }
             if shouldBlock {
@@ -56,15 +58,11 @@ struct ModelProfileSpawnTests {
             lock.withLock {
                 blockMatch = value
                 _isBlocked = false
+                _blockedCommand = nil
             }
         }
         var isBlocked: Bool { lock.withLock { _isBlocked } }
-        var blockedCommand: [String]? {
-            lock.withLock {
-                guard let blockMatch else { return nil }
-                return _calls.last { $0.joined(separator: " ").contains(blockMatch) }
-            }
-        }
+        var blockedCommand: [String]? { lock.withLock { _blockedCommand } }
         func release() {
             releaseGate.signal()
         }

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -29,14 +29,44 @@ struct ModelProfileSpawnTests {
     /// Recorder for tmux argv lists invoked during dryRun.
     final class TmuxRecorder: @unchecked Sendable {
         private let lock = NSLock()
+        private let releaseGate = DispatchSemaphore(value: 0)
         private var _calls: [[String]] = []
+        private var blockMatch: String?
+        private var _isBlocked = false
         var calls: [[String]] {
             lock.lock(); defer { lock.unlock() }
             return _calls
         }
         func record(_ args: [String]) {
-            lock.lock(); defer { lock.unlock() }
-            _calls.append(args)
+            let shouldBlock = lock.withLock { () -> Bool in
+                _calls.append(args)
+                guard let blockMatch,
+                      !_isBlocked,
+                      args.joined(separator: " ").contains(blockMatch) else {
+                    return false
+                }
+                _isBlocked = true
+                return true
+            }
+            if shouldBlock {
+                releaseGate.waitForGate("profile respawn")
+            }
+        }
+        func arm(matching value: String) {
+            lock.withLock {
+                blockMatch = value
+                _isBlocked = false
+            }
+        }
+        var isBlocked: Bool { lock.withLock { _isBlocked } }
+        var blockedCommand: [String]? {
+            lock.withLock {
+                guard let blockMatch else { return nil }
+                return _calls.last { $0.joined(separator: " ").contains(blockMatch) }
+            }
+        }
+        func release() {
+            releaseGate.signal()
         }
         var joinedAll: String { calls.map { $0.joined(separator: " ") }.joined(separator: "\n") }
         /// Concatenation of just the shell-command bodies (last argv element of
@@ -47,9 +77,34 @@ struct ModelProfileSpawnTests {
         }
     }
 
-    private func makeFixture() -> (RPCRouter, TBDDatabase, TmuxRecorder) {
+    final class StateDeltaRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [StateDelta] = []
+
+        func subscribe(to router: RPCRouter) {
+            router.subscriptions.addSubscriber { [weak self] data in
+                guard let delta = try? JSONDecoder().decode(StateDelta.self, from: data) else {
+                    return true
+                }
+                guard let self else { return false }
+                self.lock.withLock { self.values.append(delta) }
+                return true
+            }
+        }
+
+        func snapshot() -> [StateDelta] {
+            lock.withLock { values }
+        }
+    }
+
+    private func makeFixture(
+        respawnWindowError: (@Sendable (String) -> Error?)? = nil
+    ) -> (RPCRouter, TBDDatabase, TmuxRecorder) {
         let recorder = TmuxRecorder()
-        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { args in recorder.record(args) },
+            dryRunRespawnWindowError: respawnWindowError)
         let db = try! TBDDatabase(inMemory: true)
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
@@ -741,17 +796,136 @@ struct ModelProfileSpawnTests {
         #expect(joined.contains("CLAUDE_CONFIG_DIR="))
     }
 
+    @Test("in-place swap: handler event from the respawn gap is fenced")
+    func inPlaceSwapFencesSessionStartHandledDuringRespawnGap() async throws {
+        let (router, db, recorder) = makeFixture()
+        let deltas = StateDeltaRecorder()
+        deltas.subscribe(to: router)
+        defer { Task { await cleanup(db) } }
+        let (_, worktree) = try await seedRepoAndWorktree(db)
+        let profileA = try await seedOAuthProfile(db, name: "A")
+        let profileB = try await seedOAuthProfile(db, name: "B")
+        try await db.config.setDefaultProfileID(profileA.id)
+
+        let createResponse = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: worktree.id, type: .claude)))
+        let terminal = try createResponse.decodeResult(Terminal.self)
+
+        let swapRequest = try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: terminal.id,
+                newProfileID: profileB.id,
+                mode: .inPlace))
+        recorder.arm(matching: "respawn-window")
+        let swap = gateHoldingTask {
+            await router.handle(swapRequest)
+        }
+        guard await waitUntil({ recorder.isBlocked }) else {
+            recorder.release()
+            _ = await swap.value
+            Issue.record("profile swap never reached the respawn")
+            return
+        }
+        let staged = try #require(try await db.terminals.get(id: terminal.id))
+        let intendedSessionID = try #require(staged.claudeSessionID)
+        let replacementToken = try #require(staged.sessionIncarnationID)
+        #expect(recorder.blockedCommand?.last?.contains(
+            "TBD_TERMINAL_INCARNATION_ID='\(replacementToken.uuidString)'") == true)
+        let matchedCLIPath = try #require(AgentProcessEnvironment.cliPath)
+        #expect(recorder.blockedCommand?.last?.contains(
+            "TBD_CLI_PATH=\(SystemPromptBuilder.shellEscape(matchedCLIPath))") == true)
+
+        let gapEvent = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "old-process-gap-session",
+                transcriptPath: "/tmp/old-process-gap-session.jsonl",
+                source: "startup"))
+        #expect((await router.handle(gapEvent)).success)
+        #expect(try await db.terminals.get(id: terminal.id)?.claudeSessionID
+                == intendedSessionID)
+
+        let replacementEvent = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "replacement-session",
+                transcriptPath: "/tmp/replacement-session.jsonl",
+                source: "startup",
+                sessionIncarnationID: replacementToken))
+        #expect((await router.handle(replacementEvent)).success)
+        #expect(try await db.terminals.get(id: terminal.id)?.claudeSessionID
+                == "replacement-session")
+
+        recorder.release()
+        #expect((await swap.value).success)
+        let finalized = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(finalized.profileID == profileB.id)
+        #expect(finalized.claudeSessionID == "replacement-session")
+        #expect(finalized.transcriptPath == "/tmp/replacement-session.jsonl")
+
+        let sessionDeltas = deltas.snapshot().compactMap { delta -> TerminalSessionDelta? in
+            guard case .terminalSessionUpdated(let session) = delta else { return nil }
+            return session
+        }
+        #expect(sessionDeltas.last?.sessionID == "replacement-session")
+        #expect(sessionDeltas.last?.transcriptPath == "/tmp/replacement-session.jsonl")
+    }
+
+    @Test("in-place swap: launch failure broadcasts the derived unknown reset")
+    func inPlaceSwapLaunchFailureBroadcastsActivityReset() async throws {
+        let (router, db, _) = makeFixture(respawnWindowError: { _ in
+            TmuxError.unexpectedOutput("replacement launch failed")
+        })
+        defer { Task { await cleanup(db) } }
+        let (_, worktree) = try await seedRepoAndWorktree(db)
+        let profileA = try await seedOAuthProfile(db, name: "A")
+        let profileB = try await seedOAuthProfile(db, name: "B")
+        try await db.config.setDefaultProfileID(profileA.id)
+        let createResponse = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: worktree.id, type: .claude)))
+        let terminal = try createResponse.decodeResult(Terminal.self)
+        try await db.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: Date(timeIntervalSinceReferenceDate: 5))
+        let deltas = StateDeltaRecorder()
+        deltas.subscribe(to: router)
+
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: terminal.id,
+                newProfileID: profileB.id,
+                mode: .inPlace)))
+
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.activityState == .unknown)
+        #expect(stored.activityStateSource == .derived)
+        let activityDeltas = deltas.snapshot().compactMap { delta -> TerminalActivityDelta? in
+            guard case .terminalActivityUpdated(let activity) = delta else { return nil }
+            return activity
+        }
+        let reset = try #require(activityDeltas.last)
+        #expect(reset.activityState == stored.activityState)
+        #expect(reset.activityStateSource == stored.activityStateSource)
+        #expect(reset.activityStateObservedAt == stored.activityStateObservedAt)
+        #expect(reset.activityStateOrderObservedAt == stored.activityStateOrderObservedAt)
+    }
+
     /// An in-place swap kills the pane's Claude and respawns it, keeping the
     /// SAME terminal row — so a permission prompt that was on screen when the
     /// user switched account died with the old process while its recorded
     /// reason stayed on the row.
     ///
-    /// Nothing on the row's own rails retracts it: the swap writes only
-    /// `profile_id` and the session id, `transcriptPath` is unchanged so the
-    /// resolver's growth comparison still says "no growth since the prompt",
-    /// and the respawned session's `tbd terminal-activity idle` is a separate
-    /// best-effort CLI invocation seconds away at best. So the swap retracts it
-    /// itself, from its own act.
+    /// The post-respawn lifecycle transition retracts the prompt and replaces
+    /// old-process activity with derived unknown. The resumed process's hooks
+    /// establish its new activity after that durable fence.
     @Test("in-place swap: retracts a prompt recorded against the process it killed")
     func inPlaceSwapRetractsAStandingWaitReason() async throws {
         let (router, db, _) = makeFixture()
@@ -791,14 +965,13 @@ struct ModelProfileSpawnTests {
         #expect(after.profileID == b.id)
         #expect(after.awaitingInputReason == nil)
         #expect(after.awaitingInputObservedAt == nil)
-        // The dead prompt is gone from the composed answer — and with no
-        // growth fact at all, which is the shape that used to pin it.
+        // The dead prompt and activity are gone from the composed answer.
         let state = SessionStateResolver().resolve(SessionStateFacts(terminal: after))
-        #expect(state.value == .working)
-        // The activity columns are untouched: the swap knows the old prompt is
-        // gone, not what the respawned session is doing.
-        #expect(after.activityState == .working)
-        #expect(after.activityStateObservedAt == workingAt)
+        #expect(state.value == .unknown(
+            why: "the activity rail recorded state 'unknown' for this session"))
+        #expect(after.activityState == .unknown)
+        #expect(after.activityStateSource == .derived)
+        #expect(after.activityStateObservedAt != workingAt)
     }
 
     // MARK: - Swap over a NON-BLANK session: resume + --fork-session flag

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -488,6 +488,8 @@ import Testing
             "20260816122608_worktree_remote_parent_assigned",
             "20260816181509_remote_create_defaults",
             "20260824214437_auto_create_notes_setting",
+            "20260825024814_codex_transcript_boundary",
+            "20260825060216_terminal_session_incarnation",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -490,6 +490,7 @@ import Testing
             "20260824214437_auto_create_notes_setting",
             "20260825024814_codex_transcript_boundary",
             "20260825060216_terminal_session_incarnation",
+            "20260829210843_pending_terminal_incarnation",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)

--- a/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
@@ -22,7 +22,7 @@ struct SessionRecaptureSchedulerTests {
             clock: clock
         )
 
-        scheduler.schedule(
+        let recapture = scheduler.schedule(
             terminalID: fixture.terminal.id,
             paneID: "%7",
             server: "tbd-recapture",
@@ -30,7 +30,7 @@ struct SessionRecaptureSchedulerTests {
         )
 
         await clock.advanceWhenSuspended(by: .seconds(5))
-        await Task.megaYield()
+        await recapture.value
         let updated = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
         #expect(updated.claudeSessionID == detectedSessionID)
     }
@@ -45,7 +45,7 @@ struct SessionRecaptureSchedulerTests {
             clock: clock
         )
 
-        scheduler.schedule(
+        let recapture = scheduler.schedule(
             terminalID: fixture.terminal.id,
             paneID: "%7",
             server: "tbd-recapture",
@@ -53,7 +53,7 @@ struct SessionRecaptureSchedulerTests {
         )
 
         await clock.advanceWhenSuspended(by: .seconds(5))
-        await Task.megaYield()
+        await recapture.value
         let unchanged = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
         #expect(unchanged.claudeSessionID == fixture.sourceSessionID)
     }
@@ -68,7 +68,7 @@ struct SessionRecaptureSchedulerTests {
             captureSessionID: { _, _ in capture.capture() },
             clock: clock)
 
-        scheduler.schedule(
+        let recapture = scheduler.schedule(
             terminalID: fixture.terminal.id,
             paneID: "%7",
             server: "tbd-recapture",
@@ -88,7 +88,7 @@ struct SessionRecaptureSchedulerTests {
             profileID: nil,
             at: Date(timeIntervalSinceReferenceDate: 20)))
         capture.release()
-        await Task.megaYield()
+        await recapture.value
 
         let stored = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
         #expect(stored.sessionIncarnationID == replacementToken)

--- a/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
@@ -96,6 +96,44 @@ struct SessionRecaptureSchedulerTests {
         #expect(stored.transcriptPath == "/tmp/replacement-session.jsonl")
     }
 
+    @Test func ignoresCaptureWhileHibernationReplacementIsPending() async throws {
+        let fixture = try await makeFixture()
+        let clock = TestClock<Duration>()
+        let capture = BlockingSessionCapture(result: "stale-captured-session")
+        let scheduler = SessionRecaptureScheduler(
+            db: fixture.db,
+            tmux: TmuxManager(dryRun: true),
+            captureSessionID: { _, _ in capture.capture() },
+            clock: clock)
+
+        let recapture = scheduler.schedule(
+            terminalID: fixture.terminal.id,
+            paneID: "%7",
+            server: "tbd-recapture",
+            expectedIncarnationID: fixture.terminal.sessionIncarnationID)
+
+        await clock.advanceWhenSuspended(by: .seconds(5))
+        guard await waitUntil({ capture.isBlocked }) else {
+            capture.release()
+            await recapture.value
+            Issue.record("recapture did not reach the detector")
+            return
+        }
+        let current = try #require(try await fixture.db.terminals.get(
+            id: fixture.terminal.id))
+        _ = try #require(try await fixture.db.terminals.beginHibernatedShellRespawn(
+            id: fixture.terminal.id,
+            expectedState: TerminalHibernationSnapshot(terminal: current),
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 20)))
+        capture.release()
+        await recapture.value
+
+        let stored = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
+        #expect(stored.pendingSessionIncarnationID != nil)
+        #expect(stored.claudeSessionID == fixture.sourceSessionID)
+    }
+
     private func makeFixture() async throws -> (
         db: TBDDatabase,
         terminal: Terminal,

--- a/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
@@ -25,7 +25,8 @@ struct SessionRecaptureSchedulerTests {
         scheduler.schedule(
             terminalID: fixture.terminal.id,
             paneID: "%7",
-            server: "tbd-recapture"
+            server: "tbd-recapture",
+            expectedIncarnationID: fixture.terminal.sessionIncarnationID
         )
 
         await clock.advanceWhenSuspended(by: .seconds(5))
@@ -47,13 +48,52 @@ struct SessionRecaptureSchedulerTests {
         scheduler.schedule(
             terminalID: fixture.terminal.id,
             paneID: "%7",
-            server: "tbd-recapture"
+            server: "tbd-recapture",
+            expectedIncarnationID: fixture.terminal.sessionIncarnationID
         )
 
         await clock.advanceWhenSuspended(by: .seconds(5))
         await Task.megaYield()
         let unchanged = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
         #expect(unchanged.claudeSessionID == fixture.sourceSessionID)
+    }
+
+    @Test func ignoresCaptureFromAProcessReplacedBeforePersistence() async throws {
+        let fixture = try await makeFixture()
+        let clock = TestClock<Duration>()
+        let capture = BlockingSessionCapture(result: "stale-captured-session")
+        let scheduler = SessionRecaptureScheduler(
+            db: fixture.db,
+            tmux: TmuxManager(dryRun: true),
+            captureSessionID: { _, _ in capture.capture() },
+            clock: clock)
+
+        scheduler.schedule(
+            terminalID: fixture.terminal.id,
+            paneID: "%7",
+            server: "tbd-recapture",
+            expectedIncarnationID: fixture.terminal.sessionIncarnationID)
+
+        await clock.advanceWhenSuspended(by: .seconds(5))
+        guard await waitUntil({ capture.isBlocked }) else {
+            capture.release()
+            Issue.record("recapture did not reach the detector")
+            return
+        }
+        let replacementToken = try #require(try await fixture.db.terminals.prepareProfileAgentRespawn(
+            id: fixture.terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: fixture.terminal),
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            profileID: nil,
+            at: Date(timeIntervalSinceReferenceDate: 20)))
+        capture.release()
+        await Task.megaYield()
+
+        let stored = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
+        #expect(stored.sessionIncarnationID == replacementToken)
+        #expect(stored.claudeSessionID == "replacement-session")
+        #expect(stored.transcriptPath == "/tmp/replacement-session.jsonl")
     }
 
     private func makeFixture() async throws -> (
@@ -84,5 +124,30 @@ struct SessionRecaptureSchedulerTests {
             kind: .claude
         )
         return (db, terminal, sourceSessionID)
+    }
+}
+
+private final class BlockingSessionCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private let result: String
+    private var blocked = false
+
+    init(result: String) {
+        self.result = result
+    }
+
+    var isBlocked: Bool {
+        lock.withLock { blocked }
+    }
+
+    func capture() -> String {
+        lock.withLock { blocked = true }
+        releaseGate.waitForGate("session recapture")
+        return result
+    }
+
+    func release() {
+        releaseGate.signal()
     }
 }

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -711,7 +711,7 @@ func delayedClaudeReparkRejectsProfileReplacement() async throws {
         params: TerminalSwapProfileParams(
             terminalID: terminal.id, newProfileID: profile.id, mode: .inPlace))
     let profileTask = gateHoldingTask { await router.handle(profileRequest) }
-    guard await waitUntil({ profileInterrupt.isBlocked }) else {
+    guard await waitUntil({ profileInterrupt.isBlocked }, timeout: ciSafeDeadline) else {
         profileInterrupt.release()
         _ = await profileTask.value
         Issue.record("profile replacement never reached the respawn")
@@ -726,7 +726,7 @@ func delayedClaudeReparkRejectsProfileReplacement() async throws {
         (try? actuationRows(at: actuationLogPath).contains {
             $0["method"] as? String == RPCMethod.terminalRecreateWindow
         }) == true
-    }) else {
+    }, timeout: ciSafeDeadline) else {
         profileInterrupt.release()
         _ = await profileTask.value
         _ = await repark.value

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -32,6 +32,61 @@ private final class RecordedCommands: @unchecked Sendable {
     }
 }
 
+private final class ServerLockGate: @unchecked Sendable {
+    private let entered: AsyncStream<Void>
+    private let enteredContinuation: AsyncStream<Void>.Continuation
+    private let release: AsyncStream<Void>
+    private let releaseContinuation: AsyncStream<Void>.Continuation
+
+    init() {
+        (entered, enteredContinuation) = AsyncStream.makeStream(of: Void.self)
+        (release, releaseContinuation) = AsyncStream.makeStream(of: Void.self)
+    }
+
+    func hold(_ tmux: TmuxManager, server: String) -> Task<Void, Never> {
+        Task {
+            await tmux.withServerResourceLock(server: server) { [self] in
+                enteredContinuation.yield()
+                var iterator = release.makeAsyncIterator()
+                _ = await iterator.next()
+            }
+        }
+    }
+
+    func waitUntilHeld() async {
+        var iterator = entered.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func unlock() {
+        releaseContinuation.yield()
+    }
+}
+
+private final class BlockingProfileInterruptProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private var blocked = false
+
+    var isBlocked: Bool { lock.withLock { blocked } }
+
+    func record(_ args: [String]) {
+        guard args.contains("send-keys") else { return }
+        let shouldBlock = lock.withLock { () -> Bool in
+            guard !blocked else { return false }
+            blocked = true
+            return true
+        }
+        if shouldBlock {
+            releaseGate.waitForGate("profile replacement interrupt")
+        }
+    }
+
+    func release() {
+        releaseGate.signal()
+    }
+}
+
 /// Returns the shell command body (last argument of `new-window`) for any
 /// recorded `new-window` invocation. tmux argv ends with
 /// `<shell> -i -l -c <body>` (separate flag elements, see
@@ -186,6 +241,31 @@ func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
         call.contains("set-option") && call.contains(TmuxManager.terminalIDPaneOption)
             && call.contains(terminal.id.uuidString)
     }, "the recreated pane must be stamped with its terminal id")
+
+    let updated = try response.decodeResult(Terminal.self)
+    let incarnationID = try #require(updated.sessionIncarnationID)
+    let matchedCLIPath = try #require(AgentProcessEnvironment.cliPath)
+    let replacementCommand = try #require(recorded.snapshot().last { call in
+        call.contains("respawn-window")
+    }?.last)
+    #expect(replacementCommand.contains(
+        "TBD_TERMINAL_INCARNATION_ID='\(incarnationID.uuidString)'"))
+    #expect(replacementCommand.contains(
+        "TBD_CLI_PATH=\(SystemPromptBuilder.shellEscape(matchedCLIPath))"))
+    #expect(bodies.contains { $0.contains("tail -f /dev/null") },
+            "the replacement window must stay inert until its token commits")
+
+    let manualAgentHook = try RPCRequest(
+        method: RPCMethod.terminalSessionEvent,
+        params: TerminalSessionEventParams(
+            terminalID: terminal.id,
+            sessionID: "manual-agent-session",
+            transcriptPath: "/tmp/manual-agent-session.jsonl",
+            source: "startup",
+            sessionIncarnationID: incarnationID))
+    #expect((await router.handle(manualAgentHook)).success)
+    #expect(try await db.terminals.get(id: terminal.id)?.claudeSessionID
+            == "manual-agent-session")
 }
 
 
@@ -408,6 +488,7 @@ func testRecreateWindowReparkRefusedWhenRecordUnwritable() async throws {
 func testHandleTerminalRecreateWindowIgnoresStaleRequestWhenWindowAlive() async throws {
     let db = try TBDDatabase(inMemory: true)
     let recorded = RecordedCommands()
+    let (actuationLog, actuationLogPath) = try makeReadableActuationLog()
     // dryRun default: every window reports ALIVE.
     let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
     let router = RPCRouter(
@@ -419,7 +500,7 @@ func testHandleTerminalRecreateWindowIgnoresStaleRequestWhenWindowAlive() async 
             hooks: HookResolver()
         ),
         tmux: tmux,
-        actuationLog: makeTestActuationLog()
+        actuationLog: actuationLog
     )
 
     let repo = try await db.repos.create(
@@ -461,6 +542,16 @@ func testHandleTerminalRecreateWindowIgnoresStaleRequestWhenWindowAlive() async 
     let returned = try response.decodeResult(Terminal.self)
     #expect(returned.id == terminal.id)
     #expect(!returned.isParked, "the returned row must be the current, un-parked one")
+
+    let written = try actuationRows(at: actuationLogPath)
+    #expect(written.count == 2, "the declined re-park must close its request; got \(written)")
+    let requestRow = try #require(written.first)
+    let outcome = try #require(written.last)
+    #expect(requestRow["kind"] as? String == "hibernate")
+    #expect(outcome["kind"] as? String == "outcome")
+    #expect(outcome["confirms"] as? String == requestRow["id"] as? String)
+    #expect(outcome["result"] as? String == "refused")
+    #expect(outcome["reason"] as? String == "not-eligible")
 }
 
 /// Regression guard for the OTHER branch: a plain shell terminal whose window
@@ -511,6 +602,150 @@ func testHandleTerminalRecreateWindowRebuildsShellAsShell() async throws {
     #expect(updated.suspendedAt == nil, "shell terminal must not be parked as suspended")
     #expect(updated.kind == .shell, "shell terminal must remain a shell")
     #expect(updated.claudeSessionID == nil, "shell terminal has no session to preserve")
+}
+
+@Test("a queued shell recreation cannot overwrite a newer replacement")
+func queuedShellRecreationRejectsNewerReplacement() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: recorded.append)
+    let (log, logPath) = try makeReadableActuationLog()
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+        tmux: tmux,
+        actuationLog: log)
+    let repoPath = "/tmp/fake-repo-recreate-shell-race"
+    let worktreePath = "\(repoPath)/wt"
+    try ensureWorktreeDir(worktreePath)
+    let repo = try await db.repos.create(
+        path: repoPath, displayName: "test", defaultBranch: "main")
+    let worktree = try await db.worktrees.create(
+        repoID: repo.id, name: "wt", branch: "main", path: worktreePath,
+        tmuxServer: "tbd-shell-recreate-race")
+    let terminal = try await db.terminals.create(
+        worktreeID: worktree.id,
+        tmuxWindowID: "@old", tmuxPaneID: "%old",
+        label: TerminalLabel.shell, kind: .shell)
+
+    let lockGate = ServerLockGate()
+    let holder = lockGate.hold(tmux, server: worktree.tmuxServer)
+    await lockGate.waitUntilHeld()
+    defer { lockGate.unlock() }
+    let request = try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id))
+    let recreation = gateHoldingTask { await router.handle(request) }
+    guard await waitUntil({
+        (try? actuationRows(at: logPath).contains {
+            $0["method"] as? String == RPCMethod.terminalRecreateWindow
+        }) == true
+    }) else {
+        lockGate.unlock()
+        _ = await holder.value
+        _ = await recreation.value
+        Issue.record("recreation never reached the held server lock")
+        return
+    }
+
+    _ = try await db.terminals.replaceRecreatedShellWindow(
+        id: terminal.id,
+        expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+        windowID: "@replacement", paneID: "%replacement",
+        at: Date(timeIntervalSinceReferenceDate: 10))
+    let replacement = try #require(try await db.terminals.get(id: terminal.id))
+    let commandCount = recorded.snapshot().count
+    lockGate.unlock()
+    _ = await holder.value
+
+    #expect(!(await recreation.value).success)
+    let unchanged = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(unchanged == replacement)
+    #expect(recorded.snapshot().count == commandCount,
+            "a stale recreation must issue no kill, create, or respawn")
+}
+
+@Test("a delayed Claude re-park cannot kill a completed profile replacement")
+func delayedClaudeReparkRejectsProfileReplacement() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let profileInterrupt = BlockingProfileInterruptProbe()
+    let tmux = TmuxManager(
+        dryRun: true,
+        dryRunRecorder: { args in
+            recorded.append(args)
+            profileInterrupt.record(args)
+        })
+    let configDirs = ClaudeProfileConfigDirManager(
+        baseDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-repark-profiles-\(UUID().uuidString)"),
+        hostBaseDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-repark-host-\(UUID().uuidString)"))
+    let (actuationLog, actuationLogPath) = try makeReadableActuationLog()
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+            configDirManager: configDirs),
+        tmux: tmux,
+        configDirManager: configDirs,
+        actuationLog: actuationLog)
+    let repoPath = "/tmp/fake-repo-repark-profile-race"
+    let worktreePath = "\(repoPath)/wt"
+    try ensureWorktreeDir(worktreePath)
+    let repo = try await db.repos.create(
+        path: repoPath, displayName: "test", defaultBranch: "main")
+    let worktree = try await db.worktrees.create(
+        repoID: repo.id, name: "wt", branch: "main", path: worktreePath,
+        tmuxServer: "tbd-repark-profile-race")
+    let terminal = try await db.terminals.create(
+        worktreeID: worktree.id,
+        tmuxWindowID: "@claude", tmuxPaneID: "%claude",
+        label: TerminalLabel.claudeCode,
+        claudeSessionID: "source-session", kind: .claude)
+    let profile = try await db.modelProfiles.create(name: "Replacement", kind: .oauth)
+
+    let profileRequest = try RPCRequest(
+        method: RPCMethod.terminalSwapProfile,
+        params: TerminalSwapProfileParams(
+            terminalID: terminal.id, newProfileID: profile.id, mode: .inPlace))
+    let profileTask = gateHoldingTask { await router.handle(profileRequest) }
+    guard await waitUntil({ profileInterrupt.isBlocked }) else {
+        profileInterrupt.release()
+        _ = await profileTask.value
+        Issue.record("profile replacement never reached the respawn")
+        return
+    }
+
+    let recreateRequest = try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id))
+    let repark = gateHoldingTask { await router.handle(recreateRequest) }
+    guard await waitUntil({
+        (try? actuationRows(at: actuationLogPath).contains {
+            $0["method"] as? String == RPCMethod.terminalRecreateWindow
+        }) == true
+    }) else {
+        profileInterrupt.release()
+        _ = await profileTask.value
+        _ = await repark.value
+        Issue.record("re-park never reached the held server lock")
+        return
+    }
+    profileInterrupt.release()
+
+    let profileResponse = await profileTask.value
+    #expect(profileResponse.success)
+    let replacement = try #require(try await db.terminals.get(id: terminal.id))
+    let commandCount = recorded.snapshot().count
+
+    #expect(!(await repark.value).success)
+    let unchanged = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(unchanged == replacement)
+    #expect(!unchanged.isParked)
+    #expect(recorded.snapshot().count == commandCount,
+            "the stale re-park must not kill the replacement pane")
 }
 
 // MARK: - Fix 3: setupTerminals injects TBD_TERMINAL_ID + TBD_WORKTREE_ID on the setup tab
@@ -710,6 +945,69 @@ struct CodexLaunchCommandTests {
         }, "recreated codex tab must respawn codex with the TBD profile; got bodies: \(respawnBodies)")
         #expect(!respawnBodies.contains { $0.contains("codex --full-auto") },
                 "recreated codex tab must not use removed --full-auto flag; got bodies: \(respawnBodies)")
+    }
+
+    @Test("a queued Codex recreation cannot overwrite a newer replacement")
+    func queuedCodexRecreationRejectsNewerReplacement() async throws {
+        let codex = isolateCodexHome(); defer { codex.cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: recorded.append)
+        let (log, logPath) = try makeReadableActuationLog()
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            actuationLog: log)
+        let repoPath = "/tmp/fake-repo-recreate-codex-race"
+        let worktreePath = "\(repoPath)/wt"
+        try ensureWorktreeDir(worktreePath)
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "test", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main", path: worktreePath,
+            tmuxServer: "tbd-codex-recreate-race")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id,
+            tmuxWindowID: "@old", tmuxPaneID: "%old",
+            label: TerminalLabel.codex, kind: .codex)
+
+        let lockGate = ServerLockGate()
+        let holder = lockGate.hold(tmux, server: worktree.tmuxServer)
+        await lockGate.waitUntilHeld()
+        defer { lockGate.unlock() }
+        let request = try RPCRequest(
+            method: RPCMethod.terminalRecreateWindow,
+            params: TerminalRecreateWindowParams(terminalID: terminal.id))
+        let recreation = gateHoldingTask { await router.handle(request) }
+        guard await waitUntil({
+            (try? actuationRows(at: logPath).contains {
+                $0["method"] as? String == RPCMethod.terminalRecreateWindow
+            }) == true
+        }) else {
+            lockGate.unlock()
+            _ = await holder.value
+            _ = await recreation.value
+            Issue.record("Codex recreation never reached the held server lock")
+            return
+        }
+
+        _ = try await db.terminals.replaceRecreatedCodexWindow(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            windowID: "@replacement", paneID: "%replacement",
+            at: Date(timeIntervalSinceReferenceDate: 10))
+        let replacement = try #require(try await db.terminals.get(id: terminal.id))
+        let commandCount = recorded.snapshot().count
+        lockGate.unlock()
+        _ = await holder.value
+
+        #expect(!(await recreation.value).success)
+        let unchanged = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(unchanged == replacement)
+        #expect(recorded.snapshot().count == commandCount,
+                "a stale recreation must issue no kill, create, or respawn")
     }
 
     @Test("handleTerminalCreate uses current Codex launch command")

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -738,14 +738,16 @@ func delayedClaudeReparkRejectsProfileReplacement() async throws {
     let profileResponse = await profileTask.value
     #expect(profileResponse.success)
     let replacement = try #require(try await db.terminals.get(id: terminal.id))
-    let commandCount = recorded.snapshot().count
 
     #expect(!(await repark.value).success)
     let unchanged = try #require(try await db.terminals.get(id: terminal.id))
     #expect(unchanged == replacement)
     #expect(!unchanged.isParked)
-    #expect(recorded.snapshot().count == commandCount,
-            "the stale re-park must not kill the replacement pane")
+    let commands = recorded.snapshot().map { $0.joined(separator: " ") }
+    #expect(!commands.contains { $0.contains("kill-window") },
+            "the stale re-park must not kill the replacement pane; got: \(commands)")
+    #expect(!commands.contains { $0.contains("new-window") },
+            "the stale re-park must not recreate a window; got: \(commands)")
 }
 
 // MARK: - Fix 3: setupTerminals injects TBD_TERMINAL_ID + TBD_WORKTREE_ID on the setup tab

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -780,7 +780,7 @@ struct TerminalActivityEventHandlerTests {
         )
 
         let earlier = gateHoldingTask { await router.handle(idle) }
-        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+        guard await waitUntil({ dates.firstCallIsBlocked }, timeout: ciSafeDeadline) else {
             dates.releaseFirstCall()
             _ = await earlier.value
             Issue.record("earlier idle event never reached the date seam")

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -159,6 +159,78 @@ struct TerminalActivityEventHandlerTests {
         #expect(try await db.scheduledResumes.pending(terminalID: terminal.id) != nil)
     }
 
+    @Test("old-process Codex activity cannot mutate a replacement with the same session ID")
+    func oldProcessActivityCannotMutateSameSessionReplacement() async throws {
+        let terminal = try await makeTerminal()
+        let sessionID = "session-reused"
+        let oldIncarnationID = UUID()
+        try await db.writerForTests.write { database in
+            try database.execute(
+                sql: """
+                    UPDATE terminal
+                    SET sessionIncarnationID = ?, claudeSessionID = ?
+                    WHERE id = ?
+                    """,
+                arguments: [
+                    oldIncarnationID.uuidString,
+                    sessionID,
+                    terminal.id.uuidString,
+                ])
+        }
+        try await db.terminals.updateTmuxIDs(
+            id: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement")
+        let replacement = try #require(await db.terminals.get(id: terminal.id))
+        let replacementIncarnationID = try #require(replacement.sessionIncarnationID)
+        #expect(replacementIncarnationID != oldIncarnationID)
+
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: sessionID,
+                transcriptPath: nil,
+                source: "resume",
+                sessionIncarnationID: replacementIncarnationID))
+        #expect((await router.handle(sessionStart)).success)
+
+        let currentPrompt = AwaitingInputReason(
+            message: "Replacement needs permission",
+            hookEventName: "Notification",
+            notificationType: "permission_prompt")
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: currentPrompt,
+            observedAt: Date())
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            resetsAt: Date().addingTimeInterval(3_600),
+            fireAt: Date().addingTimeInterval(3_660),
+            limitType: "session",
+            rawMessage: "rate limit"))
+
+        // Raw JSON makes the wire-level regression fail before the shared
+        // params type knows about the process-incarnation field.
+        let delayedOldProcessActivity = RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: """
+                {"terminalID":"\(terminal.id.uuidString)","activityState":"working",\
+                "sessionID":"\(sessionID)",\
+                "sessionIncarnationID":"\(oldIncarnationID.uuidString)"}
+                """)
+        #expect((await router.handle(delayedOldProcessActivity)).success)
+
+        let unchanged = try #require(await db.terminals.get(id: terminal.id))
+        #expect(unchanged.sessionIncarnationID == replacementIncarnationID)
+        #expect(unchanged.claudeSessionID == sessionID)
+        #expect(unchanged.activityState == .idle)
+        #expect(unchanged.activityStateSource == .hookEvent("SessionStart"))
+        #expect(unchanged.awaitingInputReason == currentPrompt)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminal.id) != nil)
+    }
+
     @Test(
         "same-session Codex activity supersedes SessionStart",
         arguments: [TerminalActivityState.working, .waitingForUser]
@@ -210,6 +282,38 @@ struct TerminalActivityEventHandlerTests {
 
         let updated = try #require(await db.terminals.get(id: terminal.id))
         #expect(updated.activityState == .waitingForUser)
+    }
+
+    @Test("identity-free Codex activity is rejected after managed replacement")
+    func identityFreeActivityIsRejectedAfterManagedReplacement() async throws {
+        let terminal = try await makeTerminal()
+        try await db.terminals.updateTmuxIDs(
+            id: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement")
+        let replacement = try #require(await db.terminals.get(id: terminal.id))
+        let replacementIncarnationID = try #require(replacement.sessionIncarnationID)
+        let sessionStart = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "session-current",
+                transcriptPath: nil,
+                source: "resume",
+                sessionIncarnationID: replacementIncarnationID))
+        #expect((await router.handle(sessionStart)).success)
+
+        let identityFreeActivity = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .working,
+                sessionID: "session-current"))
+        #expect((await router.handle(identityFreeActivity)).success)
+
+        let unchanged = try #require(await db.terminals.get(id: terminal.id))
+        #expect(unchanged.activityState == .idle)
+        #expect(unchanged.activityStateSource == .hookEvent("SessionStart"))
     }
 
     @Test("Claude activity hooks retain legacy unordered replacement semantics")
@@ -371,9 +475,13 @@ struct TerminalActivityEventHandlerTests {
         #expect(response.error == nil)
     }
 
-    @Test("user interrupt persists distinct provenance from working state")
+    @Test("user interrupt remains accepted without hook identity after managed replacement")
     func userInterruptPersistsProvenanceFromWorking() async throws {
         let terminal = try await makeTerminal()
+        try await db.terminals.updateTmuxIDs(
+            id: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement")
         try await db.terminals.setActivityState(
             id: terminal.id,
             activityState: .working,

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -813,7 +813,7 @@ struct TerminalActivityEventHandlerTests {
         )
 
         let earlier = gateHoldingTask { await router.handle(interrupt) }
-        guard await waitUntil({ dates.firstCallIsBlocked }) else {
+        guard await waitUntil({ dates.firstCallIsBlocked }, timeout: ciSafeDeadline) else {
             dates.releaseFirstCall()
             _ = await earlier.value
             Issue.record("earlier interrupt never reached the date seam")

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -350,6 +350,54 @@ struct TerminalActivityEventHandlerTests {
         #expect(updated.awaitingInputObservedAt == nil)
     }
 
+    @Test("outgoing Claude activity is inert during hibernation replacement")
+    func outgoingClaudeActivityIsInertDuringHibernationReplacement() async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        let oldToken = try #require(try await db.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: terminal),
+            sessionID: "current-session",
+            transcriptPath: nil,
+            profileID: nil,
+            at: Date(timeIntervalSinceReferenceDate: 10)))
+        let current = try #require(await db.terminals.get(id: terminal.id))
+        _ = try #require(try await db.terminals.beginHibernatedShellRespawn(
+            id: terminal.id,
+            expectedState: TerminalHibernationSnapshot(terminal: current),
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 20)))
+        let prompt = AwaitingInputReason(
+            message: "Keep current attention",
+            hookEventName: "Notification",
+            notificationType: "permission_prompt")
+        try await db.terminals.recordAwaitingInputReason(
+            id: terminal.id,
+            reason: prompt,
+            observedAt: Date(timeIntervalSinceReferenceDate: 30))
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            resetsAt: Date(timeIntervalSinceReferenceDate: 100),
+            fireAt: Date(timeIntervalSinceReferenceDate: 110),
+            limitType: "session",
+            rawMessage: "limit"))
+
+        let stale = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .working,
+                sessionID: "current-session",
+                sessionIncarnationID: oldToken))
+        #expect((await router.handle(stale)).success)
+
+        let stored = try #require(await db.terminals.get(id: terminal.id))
+        #expect(stored.activityState == .idle)
+        #expect(stored.activityStateSource == .database)
+        #expect(stored.awaitingInputReason == prompt)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminal.id) != nil)
+    }
+
     @Test("Claude user-interrupt origin retains legacy unordered persistence")
     func claudeUserInterruptRetainsLegacyUnorderedPersistence() async throws {
         let terminal = try await makeTerminal(kind: .claude, label: "Claude")

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -159,6 +159,51 @@ struct TerminalActivityEventHandlerTests {
         #expect(try await db.scheduledResumes.pending(terminalID: terminal.id) != nil)
     }
 
+    @Test("replacement after accepted working activity keeps its own pending resume")
+    func replacementAfterAcceptedWorkingKeepsItsPendingResume() async throws {
+        let terminal = try await makeTerminal()
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            resetsAt: Date().addingTimeInterval(3_600),
+            fireAt: Date().addingTimeInterval(3_660),
+            limitType: "session",
+            rawMessage: "rate limit"))
+
+        let application = try #require(try await db.terminals.applyActivityObservation(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent(RPCMethod.terminalActivityEvent),
+            observedAt: Date()))
+
+        #expect(application.cancelledPendingResume)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminal.id) == nil)
+        #expect(try await db.terminals.get(id: terminal.id)?.pendingResumeAt == nil)
+
+        // A replacement can begin immediately after the accepted activity
+        // transaction returns. There must be no deferred router-side cancel
+        // left that could consume this successor-owned schedule.
+        try await db.terminals.updateTmuxIDs(
+            id: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement")
+        let replacementResume = ScheduledResume(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            resetsAt: Date().addingTimeInterval(7_200),
+            fireAt: Date().addingTimeInterval(7_260),
+            limitType: "session",
+            rawMessage: "replacement rate limit")
+        let inserted = try await db.scheduledResumes.insertPending(replacementResume)
+
+        #expect(inserted?.id == replacementResume.id)
+        let persistedResume = try #require(
+            try await db.scheduledResumes.pending(terminalID: terminal.id))
+        #expect(persistedResume.id == replacementResume.id)
+        #expect(try await db.terminals.get(id: terminal.id)?.pendingResumeAt
+            == persistedResume.fireAt)
+    }
+
     @Test("old-process Codex activity cannot mutate a replacement with the same session ID")
     func oldProcessActivityCannotMutateSameSessionReplacement() async throws {
         let terminal = try await makeTerminal()
@@ -454,6 +499,43 @@ struct TerminalActivityEventHandlerTests {
         #expect((await router.handle(request)).success)
 
         #expect(await router.claudeDelegationTracker.isMarked(terminalID: terminal.id))
+    }
+
+    @Test("an old-process SessionEnd cannot clear a replacement's Claude delegation mark")
+    func oldProcessSessionEndCannotClearReplacementDelegation() async throws {
+        let terminal = try await makeTerminal(kind: .claude, label: "Claude")
+        try await db.terminals.updateTmuxIDs(
+            id: terminal.id,
+            windowID: "@old",
+            paneID: "%old")
+        let oldIncarnationID = try #require(
+            try await db.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        try await db.terminals.updateTmuxIDs(
+            id: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement")
+        let replacementIncarnationID = try #require(
+            try await db.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        #expect(replacementIncarnationID != oldIncarnationID)
+        await router.claudeDelegationTracker.mark(
+            terminalID: terminal.id,
+            sessionIncarnationID: replacementIncarnationID)
+
+        let staleEnd = try RPCRequest(
+            method: RPCMethod.terminalSessionEnded,
+            params: TerminalSessionEndedParams(
+                terminalID: terminal.id,
+                sessionIncarnationID: oldIncarnationID))
+        #expect((await router.handle(staleEnd)).success)
+        #expect(await router.claudeDelegationTracker.isMarked(terminalID: terminal.id))
+
+        let currentEnd = try RPCRequest(
+            method: RPCMethod.terminalSessionEnded,
+            params: TerminalSessionEndedParams(
+                terminalID: terminal.id,
+                sessionIncarnationID: replacementIncarnationID))
+        #expect((await router.handle(currentEnd)).success)
+        #expect(await router.claudeDelegationTracker.isMarked(terminalID: terminal.id) == false)
     }
 
     /// The interrupt leg of the delegation rail, driven through the handler

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -68,6 +69,16 @@ struct TerminalSessionEventHandlerTests {
             kind: kind
         )
         return (terminal, wt)
+    }
+
+    private func makeTranscript(_ contents: String, tag: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-session-boundary-\(tag)-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let transcript = directory.appendingPathComponent("rollout.jsonl")
+        try Data(contents.utf8).write(to: transcript)
+        return transcript
     }
 
     /// Creates a second, independent worktree (different path) so we can
@@ -156,6 +167,112 @@ struct TerminalSessionEventHandlerTests {
         let updated = try await db.terminals.get(id: terminal.id)
         #expect(updated?.claudeSessionID == "s")
         #expect(updated?.transcriptPath == nil)
+    }
+
+    @Test("initial Codex SessionStart persists a zero boundary")
+    func initialCodexSessionPersistsZeroBoundary() async throws {
+        let transcript = try makeTranscript("already written\n", tag: "initial")
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let (terminal, _) = try await makeTerminal(label: TerminalLabel.codex, kind: .codex)
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "initial-session",
+                transcriptPath: transcript.path,
+                source: "startup"))
+
+        #expect((await router.handle(request)).success)
+
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.codexTranscriptBoundaryOffset == 0)
+    }
+
+    @Test("later Codex SessionStarts persist EOF for supplied and retained paths")
+    func laterCodexSessionsPersistEffectivePathEOF() async throws {
+        let initial = try makeTranscript("initial\n", tag: "later-initial")
+        let later = try makeTranscript("later transcript bytes\n", tag: "later-effective")
+        defer {
+            try? FileManager.default.removeItem(at: initial.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: later.deletingLastPathComponent())
+        }
+        let (terminal, _) = try await makeTerminal(label: TerminalLabel.codex, kind: .codex)
+        let baseline = Date(timeIntervalSince1970: 1_790_100_000)
+        let initialRouter = makeRouter(now: { baseline })
+        let suppliedRouter = makeRouter(now: { baseline.addingTimeInterval(1) })
+        let retainedRouter = makeRouter(now: { baseline.addingTimeInterval(2) })
+
+        #expect((await initialRouter.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "initial-session",
+                transcriptPath: initial.path, source: "startup")))).success)
+        #expect((await suppliedRouter.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "supplied-session",
+                transcriptPath: later.path, source: "resume")))).success)
+        let suppliedEOF = Int64(try Data(contentsOf: later).count)
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset
+            == suppliedEOF)
+
+        let handle = try FileHandle(forWritingTo: later)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("appended\n".utf8))
+        try handle.close()
+        #expect((await retainedRouter.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "retained-session",
+                transcriptPath: nil, source: "resume")))).success)
+
+        let retainedEOF = Int64(try Data(contentsOf: later).count)
+        let stored = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(stored.transcriptPath == later.path)
+        #expect(stored.codexTranscriptBoundaryOffset == retainedEOF)
+    }
+
+    @Test("later Codex SessionStart persists nil when its effective transcript is unavailable")
+    func laterCodexSessionPersistsNilForUnavailableEOF() async throws {
+        let transcript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-session-boundary-missing-\(UUID().uuidString).jsonl")
+        let (terminal, _) = try await makeTerminal(label: TerminalLabel.codex, kind: .codex)
+        let baseline = Date(timeIntervalSince1970: 1_790_200_000)
+
+        #expect((await makeRouter(now: { baseline }).handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "initial-session",
+                transcriptPath: transcript.path, source: "startup")))).success)
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == 0)
+
+        #expect((await makeRouter(now: { baseline.addingTimeInterval(1) }).handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id, sessionID: "later-session",
+                transcriptPath: nil, source: "resume")))).success)
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == nil)
+    }
+
+    @Test(
+        "non-Codex SessionStart does not acquire a transcript boundary",
+        arguments: [TerminalKind.claude, .shell]
+    )
+    func nonCodexSessionDoesNotAcquireBoundary(kind: TerminalKind) async throws {
+        let transcript = try makeTranscript("available\n", tag: kind.rawValue)
+        defer { try? FileManager.default.removeItem(at: transcript.deletingLastPathComponent()) }
+        let (terminal, _) = try await makeTerminal(label: kind.rawValue, kind: kind)
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "session",
+                transcriptPath: transcript.path,
+                source: "startup"))
+
+        #expect((await router.handle(request)).success)
+
+        #expect(try await db.terminals.get(id: terminal.id)?.codexTranscriptBoundaryOffset == nil)
     }
 
     @Test("nil/rejected transcriptPath preserves a previously-stored path")
@@ -257,6 +374,7 @@ struct TerminalSessionEventHandlerTests {
         let newerSessionAt = olderSessionAt.addingTimeInterval(1)
         _ = try await db.terminals.applySessionStart(
             id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
             sessionID: "newer-session",
             transcriptPath: "/tmp/newer-session.jsonl",
             observedAt: newerSessionAt)
@@ -345,8 +463,7 @@ struct TerminalSessionEventHandlerTests {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
         let transcript = directory.appendingPathComponent("current.jsonl")
-        try (#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current"}}"#
-            + "\n").write(to: transcript, atomically: true, encoding: .utf8)
+        try Data().write(to: transcript)
         try await db.terminals.updateSession(
             id: terminal.id,
             sessionID: "initial-session",
@@ -362,6 +479,14 @@ struct TerminalSessionEventHandlerTests {
             observedAt: baseline)
         let dates = BlockingSessionDates(first: earlierSessionAt, subsequent: laterPromptAt)
         let raceRouter = makeRouter(now: dates.provider)
+        #expect(await raceRouter.codexActivityTracker.observe(
+            transcriptPath: transcript.path,
+            worktreeID: worktree.id) == nil)
+        let initialHandle = try FileHandle(forWritingTo: transcript)
+        try initialHandle.write(contentsOf: Data(
+            (#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current"}}"#
+                + "\n").utf8))
+        try initialHandle.close()
         #expect(await raceRouter.codexActivityTracker.observe(
             transcriptPath: transcript.path,
             worktreeID: worktree.id) == .working)
@@ -625,6 +750,200 @@ struct TerminalSessionEventHandlerTests {
         let result = try resp.decodeResult(TerminalTranscriptResult.self)
         #expect(result.sessionID == "logical-session-id")
         #expect(!result.messages.isEmpty)
+    }
+
+    @Test(
+        "an in-flight SessionStart cannot attach after terminal recreation",
+        arguments: SessionEventRecreationShape.allCases)
+    func inFlightSessionStartRejectsRecreatedTerminal(
+        shape: SessionEventRecreationShape
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-session-incarnation-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let isolatedDB = try TBDDatabase(path: directory.appendingPathComponent("state.db").path)
+        let isolatedRouter = RPCRouter(
+            db: isolatedDB,
+            lifecycle: WorktreeLifecycle(
+                db: isolatedDB,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: makeTestActuationLog())
+        let repo = try await isolatedDB.repos.create(
+            path: directory.appendingPathComponent("repo").path,
+            displayName: "session-incarnation",
+            defaultBranch: "main")
+        let worktree = try await isolatedDB.worktrees.create(
+            repoID: repo.id,
+            name: "worktree",
+            branch: "main",
+            path: directory.appendingPathComponent("worktree").path,
+            tmuxServer: "tbd-session-incarnation")
+        let terminal = try await isolatedDB.terminals.create(
+            worktreeID: worktree.id,
+            tmuxWindowID: "@old",
+            tmuxPaneID: "%old",
+            label: "Codex",
+            kind: .codex)
+        let transcript = directory.appendingPathComponent("rollout.jsonl")
+        try Data(#"{"type":"event_msg","payload":{"type":"task_started"}}"#.utf8)
+            .write(to: transcript)
+        _ = try #require(try await isolatedDB.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            sessionID: "live-session",
+            transcriptPath: transcript.path,
+            observedAt: Date(timeIntervalSinceReferenceDate: 10)))
+        _ = await isolatedRouter.sessionCounters.sample(
+            terminalID: terminal.id,
+            worktreeID: worktree.id,
+            transcriptPath: transcript.path,
+            commitsUnchangedSince: nil,
+            at: Date(timeIntervalSinceReferenceDate: 11))
+
+        let updateGate = BlockingTerminalUpdateTrigger()
+        let pauseUpdate = DatabaseFunction(
+            "tbd_test_pause_terminal_update", argumentCount: 0
+        ) { _ in
+            updateGate.pauseFirstCall()
+            return nil
+        }
+        try await isolatedDB.writerForTests.write { database in
+            database.add(function: pauseUpdate)
+            try database.execute(sql: """
+                CREATE TEMP TRIGGER pause_terminal_recreation
+                AFTER UPDATE ON terminal
+                WHEN NEW.id = '\(terminal.id.uuidString)'
+                BEGIN
+                    SELECT tbd_test_pause_terminal_update();
+                END
+                """)
+        }
+
+        let resetTask = Task(executorPreference: GateExecutor.shared) {
+            switch shape {
+            case .clearRecreated:
+                try await isolatedDB.terminals.clearRecreated(
+                    id: terminal.id, at: Date(timeIntervalSinceReferenceDate: 20))
+            case .replaceCodexWindow:
+                _ = try await isolatedDB.terminals.replaceRecreatedCodexWindow(
+                    id: terminal.id,
+                    expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+                    windowID: "@old",
+                    paneID: "%old",
+                    at: Date(timeIntervalSinceReferenceDate: 20))
+            }
+        }
+        defer { updateGate.release() }
+        let entered = gateHoldingTask { updateGate.waitUntilPaused() }
+        #expect(await entered.value)
+
+        let captured = SessionDeltaCapture()
+        isolatedRouter.subscriptions.addSubscriber { data in
+            captured.append(data)
+            return true
+        }
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "dead-session",
+                transcriptPath: transcript.path,
+                source: "resume"))
+        let handlerTask = Task { await isolatedRouter.handle(request) }
+        let passedTerminalFetch = await waitForHookEvent(
+            router: isolatedRouter,
+            terminal: terminal,
+            transcriptPath: transcript.path)
+        #expect(passedTerminalFetch,
+                "SessionStart never passed its terminal fetch while recreation was paused")
+
+        updateGate.release()
+        try await resetTask.value
+        #expect((await handlerTask.value).success)
+
+        let stored = try #require(try await isolatedDB.terminals.get(id: terminal.id))
+        #expect(stored.claudeSessionID == nil)
+        #expect(stored.transcriptPath == nil)
+        #expect(stored.sessionOrderObservedAt == nil)
+        #expect(stored.codexTranscriptBoundaryOffset == nil)
+        #expect(stored.sessionIncarnationID != terminal.sessionIncarnationID)
+        #expect(stored.activityState == .unknown)
+        switch shape {
+        case .clearRecreated:
+            #expect(stored.tmuxWindowID == "@old")
+            #expect(stored.tmuxPaneID == "%old")
+            #expect(stored.kind == .shell)
+        case .replaceCodexWindow:
+            #expect(stored.tmuxWindowID == "@old")
+            #expect(stored.tmuxPaneID == "%old")
+            #expect(stored.kind == .codex)
+        }
+        #expect(captured.values.isEmpty)
+        #expect(!(await isolatedRouter.codexActivityTracker.hasBaseline(
+            transcriptPath: transcript.path)))
+    }
+
+    private func waitForHookEvent(
+        router: RPCRouter,
+        terminal: Terminal,
+        transcriptPath: String
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+        while clock.now < deadline {
+            let counters = await router.sessionCounters.sample(
+                terminalID: terminal.id,
+                worktreeID: terminal.worktreeID,
+                transcriptPath: transcriptPath,
+                commitsUnchangedSince: nil)
+            if counters?.hookEventsInWindow == 1 { return true }
+            await Task.yield()
+        }
+        return false
+    }
+}
+
+enum SessionEventRecreationShape: CaseIterable, Sendable,
+    CustomTestStringConvertible {
+    case clearRecreated
+    case replaceCodexWindow
+
+    var testDescription: String {
+        switch self {
+        case .clearRecreated: "clearRecreated"
+        case .replaceCodexWindow: "replaceRecreatedCodexWindow"
+        }
+    }
+}
+
+private final class BlockingTerminalUpdateTrigger: @unchecked Sendable {
+    private let lock = NSLock()
+    private let entered = DispatchSemaphore(value: 0)
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private var callCount = 0
+
+    func pauseFirstCall() {
+        let shouldPause = lock.withLock { () -> Bool in
+            defer { callCount += 1 }
+            return callCount == 0
+        }
+        guard shouldPause else { return }
+        entered.signal()
+        releaseGate.waitForGate("terminal recreation transaction")
+    }
+
+    func waitUntilPaused() -> Bool {
+        entered.waitForGate("terminal recreation trigger entry")
+    }
+
+    func release() {
+        releaseGate.signal()
     }
 }
 

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -855,7 +855,10 @@ struct TerminalSessionEventHandlerTests {
                 sessionID: "dead-session",
                 transcriptPath: transcript.path,
                 source: "resume"))
-        let handlerTask = Task { await isolatedRouter.handle(request) }
+        // The handler blocks behind the writer transaction held by
+        // `resetTask`; keep both sides off Swift's cooperative pool so a
+        // heavily parallel test run cannot starve this rendezvous.
+        let handlerTask = gateHoldingTask { await isolatedRouter.handle(request) }
         let passedTerminalFetch = await waitForHookEvent(
             router: isolatedRouter,
             terminal: terminal,
@@ -895,17 +898,17 @@ struct TerminalSessionEventHandlerTests {
         transcriptPath: String
     ) async -> Bool {
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(5))
-        while clock.now < deadline {
+        let deadline = clock.now.advanced(by: ciSafeDeadline)
+        while true {
             let counters = await router.sessionCounters.sample(
                 terminalID: terminal.id,
                 worktreeID: terminal.worktreeID,
                 transcriptPath: transcriptPath,
                 commitsUnchangedSince: nil)
             if counters?.hookEventsInWindow == 1 { return true }
+            guard clock.now < deadline else { return false }
             await Task.yield()
         }
-        return false
     }
 }
 

--- a/Tests/TBDDaemonTests/TerminalSessionIncarnationMigrationTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionIncarnationMigrationTests.swift
@@ -6,6 +6,7 @@ import Testing
 
 @Suite struct TerminalSessionIncarnationMigrationTests {
     private static let migrationID = "20260825060216_terminal_session_incarnation"
+    private static let pendingMigrationID = "20260829210843_pending_terminal_incarnation"
 
     @Test func forwardMigrationLeavesExistingIncarnationNil() throws {
         let queue = try DatabaseQueue()
@@ -65,21 +66,72 @@ import Testing
             path: "/tmp/session-incarnation-record-wt-\(UUID().uuidString)",
             tmuxServer: "tbd-incarnation-record")
         let incarnationID = UUID()
+        let pendingIncarnationID = UUID()
         let terminal = Terminal(
             worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
-            sessionIncarnationID: incarnationID)
+            sessionIncarnationID: incarnationID,
+            pendingSessionIncarnationID: pendingIncarnationID)
         try await database.writerForTests.write { connection in
             try TerminalRecord(from: terminal).insert(connection)
         }
-        let raw = try await database.writerForTests.read { connection in
-            try String.fetchOne(
+        let raw = try database.writerForTests.read { connection in
+            return try Row.fetchOne(
                 connection,
-                sql: "SELECT sessionIncarnationID FROM terminal WHERE id = ?",
+                sql: """
+                    SELECT sessionIncarnationID, pendingSessionIncarnationID
+                    FROM terminal WHERE id = ?
+                    """,
                 arguments: [terminal.id.uuidString])
         }
-        #expect(raw == incarnationID.uuidString)
-        #expect(try await database.terminals.get(id: terminal.id)?.sessionIncarnationID
-                == incarnationID)
+        #expect(raw?["sessionIncarnationID"] as String? == incarnationID.uuidString)
+        #expect(raw?["pendingSessionIncarnationID"] as String? == pendingIncarnationID.uuidString)
+        let decoded = try await database.terminals.get(id: terminal.id)
+        #expect(decoded?.sessionIncarnationID == incarnationID)
+        #expect(decoded?.pendingSessionIncarnationID == pendingIncarnationID)
+    }
+
+    @Test func forwardMigrationLeavesExistingPendingIncarnationNil() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.migrationID)
+        let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+        let repoID = UUID().uuidString
+        let worktreeID = UUID().uuidString
+        let terminalID = UUID().uuidString
+        try queue.write { database in
+            try database.execute(
+                sql: """
+                    INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                    VALUES (?, '/tmp/pending-incarnation-repo', 'Incarnation', 'main', ?)
+                    """, arguments: [repoID, epoch])
+            try database.execute(
+                sql: """
+                    INSERT INTO worktree
+                        (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                    VALUES (?, ?, 'w', 'w', 'main', '/tmp/pending-incarnation-wt',
+                            'active', ?, 'tbd-pending-incarnation')
+                    """, arguments: [worktreeID, repoID, epoch])
+            try database.execute(
+                sql: """
+                    INSERT INTO terminal
+                        (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt,
+                         sessionIncarnationID)
+                    VALUES (?, ?, '@1', '%1', ?, ?)
+                    """, arguments: [terminalID, worktreeID, epoch, UUID().uuidString])
+        }
+
+        try migrator.migrate(queue, upTo: Self.pendingMigrationID)
+        let result = try queue.read { database in
+            let columns = try Row.fetchAll(database, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+            let value = try String.fetchOne(
+                database,
+                sql: "SELECT pendingSessionIncarnationID FROM terminal WHERE id = ?",
+                arguments: [terminalID])
+            return (columns, value)
+        }
+        #expect(result.0.contains("pendingSessionIncarnationID"))
+        #expect(result.1 == nil)
     }
 
     @Test func legacyNilSessionStartStillAttachesToLegacyRow() async throws {
@@ -421,6 +473,13 @@ import Testing
             sessionID: "replacement-session",
             transcriptPath: "/tmp/replacement-session.jsonl",
             observedAt: Date(timeIntervalSinceReferenceDate: 30)))
+        _ = try #require(try await database.terminals.applyActivityObservation(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: Date(timeIntervalSinceReferenceDate: 31),
+            sessionID: "replacement-session",
+            sessionIncarnationID: token))
         try await database.terminals.clearHibernated(id: terminal.id)
 
         let released = try #require(try await database.terminals.get(id: terminal.id))
@@ -428,6 +487,7 @@ import Testing
         #expect(released.sessionIncarnationID == prepared.sessionIncarnationID)
         #expect(released.claudeSessionID == "replacement-session")
         #expect(released.transcriptPath == "/tmp/replacement-session.jsonl")
+        #expect(released.activityState == .working)
     }
 
     @Test func hibernationBeginRejectsAReplacedProcessWithoutMutation() async throws {
@@ -489,6 +549,125 @@ import Testing
         #expect(preparation == nil)
         let unchanged = try #require(try await database.terminals.get(id: terminal.id))
         assertReplacementState(unchanged, equals: working)
+    }
+
+    @Test func hibernationBeginMakesOutgoingActivityInertBeforeProcessReplacement() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        let oldToken = try #require(try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: terminal),
+            sessionID: "resume-session",
+            transcriptPath: "/tmp/resume-session.jsonl",
+            profileID: nil,
+            at: Date(timeIntervalSinceReferenceDate: 10)))
+        try await database.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: Date(timeIntervalSinceReferenceDate: 20))
+        let working = try #require(try await database.terminals.get(id: terminal.id))
+
+        let inertStage = try #require(
+            try await database.terminals.beginHibernatedShellRespawn(
+                id: terminal.id,
+                expectedState: TerminalHibernationSnapshot(terminal: working),
+                reason: .manual,
+                at: Date(timeIntervalSinceReferenceDate: 30)))
+
+        let prepared = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(prepared.isParked)
+        #expect(prepared.sessionIncarnationID == oldToken)
+        let pendingToken = try #require(prepared.pendingSessionIncarnationID)
+        #expect(pendingToken != oldToken)
+        #expect(prepared.activityState == .idle)
+        #expect(prepared.activityStateSource == .database)
+
+        let staleActivity = try await database.terminals.applyActivityObservation(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: Date(timeIntervalSinceReferenceDate: 40),
+            sessionID: "resume-session",
+            sessionIncarnationID: oldToken)
+        #expect(staleActivity == nil)
+        #expect(try await database.terminals.get(id: terminal.id)?.activityState == .idle)
+        let staleStart = try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: prepared),
+            reportedIncarnationID: oldToken,
+            sessionID: "stale-session",
+            transcriptPath: "/tmp/stale-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 41))
+        #expect(staleStart == nil)
+        #expect(try await database.terminals.get(id: terminal.id)?.claudeSessionID
+            == "resume-session")
+
+        let shellToken = try #require(
+            try await database.terminals.finalizeHibernatedShellRespawn(
+                id: terminal.id,
+                expectedIncarnation: inertStage,
+                at: Date(timeIntervalSinceReferenceDate: 50)))
+        #expect(shellToken == pendingToken)
+        let finalized = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(finalized.sessionIncarnationID == pendingToken)
+        #expect(finalized.pendingSessionIncarnationID == nil)
+    }
+
+    @Test func clearingInterruptedHibernationPreparationRestoresCurrentProcess() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        let oldToken = try #require(try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: terminal),
+            sessionID: "current-session",
+            transcriptPath: "/tmp/current-session.jsonl",
+            profileID: nil,
+            at: Date(timeIntervalSinceReferenceDate: 10)))
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+        _ = try #require(try await database.terminals.beginHibernatedShellRespawn(
+            id: terminal.id,
+            expectedState: TerminalHibernationSnapshot(terminal: current),
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 20)))
+        #expect(try await database.terminals.get(id: terminal.id)?
+            .pendingSessionIncarnationID != nil)
+
+        try await database.terminals.clearHibernated(id: terminal.id)
+
+        let restored = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(!restored.isParked)
+        #expect(restored.sessionIncarnationID == oldToken)
+        #expect(restored.pendingSessionIncarnationID == nil)
+    }
+
+    @Test func wakePreparationReplacesAnInterruptedHibernationStage() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        let oldToken = try #require(try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: terminal),
+            sessionID: "resume-session",
+            transcriptPath: "/tmp/resume-session.jsonl",
+            profileID: nil,
+            at: Date(timeIntervalSinceReferenceDate: 10)))
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+        _ = try #require(try await database.terminals.beginHibernatedShellRespawn(
+            id: terminal.id,
+            expectedState: TerminalHibernationSnapshot(terminal: current),
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 20)))
+        let interrupted = try #require(try await database.terminals.get(id: terminal.id))
+        let stagedToken = try #require(interrupted.pendingSessionIncarnationID)
+
+        let wakeToken = try #require(try await database.terminals.prepareHibernatedAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: interrupted),
+            at: Date(timeIntervalSinceReferenceDate: 30)))
+
+        let prepared = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(prepared.isParked)
+        #expect(wakeToken != oldToken)
+        #expect(wakeToken != stagedToken)
+        #expect(prepared.sessionIncarnationID == wakeToken)
+        #expect(prepared.pendingSessionIncarnationID == nil)
     }
 
     @Test func hibernationFinalizeRejectsAReplacedInertStageWithoutMutation() async throws {
@@ -628,6 +807,7 @@ import Testing
 
     private func assertReplacementState(_ actual: Terminal, equals expected: Terminal) {
         #expect(actual.sessionIncarnationID == expected.sessionIncarnationID)
+        #expect(actual.pendingSessionIncarnationID == expected.pendingSessionIncarnationID)
         #expect(actual.tmuxWindowID == expected.tmuxWindowID)
         #expect(actual.tmuxPaneID == expected.tmuxPaneID)
         #expect(actual.label == expected.label)

--- a/Tests/TBDDaemonTests/TerminalSessionIncarnationMigrationTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionIncarnationMigrationTests.swift
@@ -1,0 +1,695 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct TerminalSessionIncarnationMigrationTests {
+    private static let migrationID = "20260825060216_terminal_session_incarnation"
+
+    @Test func forwardMigrationLeavesExistingIncarnationNil() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "20260825024814_codex_transcript_boundary")
+        let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+        let repoID = UUID().uuidString
+        let worktreeID = UUID().uuidString
+        let terminalID = UUID().uuidString
+        try queue.write { database in
+            try database.execute(
+                sql: """
+                    INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                    VALUES (?, '/tmp/session-incarnation-repo', 'Incarnation', 'main', ?)
+                    """, arguments: [repoID, epoch])
+            try database.execute(
+                sql: """
+                    INSERT INTO worktree
+                        (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                    VALUES (?, ?, 'w', 'w', 'main', '/tmp/session-incarnation-wt',
+                            'active', ?, 'tbd-incarnation')
+                    """, arguments: [worktreeID, repoID, epoch])
+            try database.execute(
+                sql: """
+                    INSERT INTO terminal
+                        (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt)
+                    VALUES (?, ?, '@1', '%1', ?)
+                    """, arguments: [terminalID, worktreeID, epoch])
+        }
+        let columnsBefore = try queue.read { database in
+            try Row.fetchAll(database, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+        }
+        #expect(!columnsBefore.contains("sessionIncarnationID"))
+
+        try migrator.migrate(queue, upTo: Self.migrationID)
+        let result = try queue.read { database in
+            let columns = try Row.fetchAll(database, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+            let value = try String.fetchOne(
+                database,
+                sql: "SELECT sessionIncarnationID FROM terminal WHERE id = ?",
+                arguments: [terminalID])
+            return (columns, value)
+        }
+        #expect(result.0.contains("sessionIncarnationID"))
+        #expect(result.1 == nil)
+    }
+
+    @Test func terminalRecordRoundTripsIncarnation() async throws {
+        let database = try TBDDatabase(inMemory: true)
+        let repo = try await database.repos.create(
+            path: "/tmp/session-incarnation-record-repo-\(UUID().uuidString)",
+            displayName: "Incarnation", defaultBranch: "main")
+        let worktree = try await database.worktrees.create(
+            repoID: repo.id, name: "incarnation", branch: "incarnation",
+            path: "/tmp/session-incarnation-record-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-incarnation-record")
+        let incarnationID = UUID()
+        let terminal = Terminal(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            sessionIncarnationID: incarnationID)
+        try await database.writerForTests.write { connection in
+            try TerminalRecord(from: terminal).insert(connection)
+        }
+        let raw = try await database.writerForTests.read { connection in
+            try String.fetchOne(
+                connection,
+                sql: "SELECT sessionIncarnationID FROM terminal WHERE id = ?",
+                arguments: [terminal.id.uuidString])
+        }
+        #expect(raw == incarnationID.uuidString)
+        #expect(try await database.terminals.get(id: terminal.id)?.sessionIncarnationID
+                == incarnationID)
+    }
+
+    @Test func legacyNilSessionStartStillAttachesToLegacyRow() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .codex, label: "Codex")
+
+        let application = try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            reportedIncarnationID: nil,
+            sessionID: "legacy-session",
+            transcriptPath: "/tmp/legacy-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 10))
+
+        #expect(application?.sessionID == "legacy-session")
+        #expect(try await database.terminals.get(id: terminal.id)?.sessionIncarnationID == nil)
+    }
+
+    @Test func nonnilProcessIncarnationRejectsLegacyRowWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .codex, label: "Codex")
+        let sessionOrderAt = Date(timeIntervalSinceReferenceDate: 5)
+        let activityObservedAt = Date(timeIntervalSinceReferenceDate: 6)
+        let activityOrderAt = Date(timeIntervalSinceReferenceDate: 7)
+        let activitySource = FactSource.hookEvent("kept")
+        try await database.writerForTests.write { connection in
+            try connection.execute(
+                sql: """
+                    UPDATE terminal
+                    SET claudeSessionID = ?, transcriptPath = ?,
+                        sessionOrderObservedAt = ?, codexTranscriptBoundaryOffset = ?,
+                        activityState = ?, activityStateSource = ?, activityStateObservedAt = ?,
+                        activityStateOrderObservedAt = ?
+                    WHERE id = ?
+                    """,
+                arguments: [
+                    "kept-session", "/tmp/kept-session.jsonl", sessionOrderAt, 77,
+                    TerminalActivityState.working.rawValue,
+                    FactColumnJSON.encode(activitySource), activityObservedAt, activityOrderAt,
+                    terminal.id.uuidString,
+                ])
+        }
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(current.sessionIncarnationID == nil)
+
+        let application = try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: current),
+            reportedIncarnationID: UUID(),
+            sessionID: "foreign-session",
+            transcriptPath: "/tmp/foreign-session.jsonl",
+            observedTranscriptBoundary: ObservedTranscriptBoundary(
+                path: "/tmp/foreign-session.jsonl", eof: 999),
+            observedAt: Date(timeIntervalSinceReferenceDate: 10))
+
+        #expect(application == nil)
+        let stored = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(stored.sessionIncarnationID == nil)
+        #expect(stored.claudeSessionID == "kept-session")
+        #expect(stored.transcriptPath == "/tmp/kept-session.jsonl")
+        #expect(stored.sessionOrderObservedAt == sessionOrderAt)
+        #expect(stored.codexTranscriptBoundaryOffset == 77)
+        #expect(stored.activityState == .working)
+        #expect(stored.activityStateSource == activitySource)
+        #expect(stored.activityStateObservedAt == activityObservedAt)
+        #expect(stored.activityStateOrderObservedAt == activityOrderAt)
+    }
+
+    @Test func exactProcessIncarnationAcceptsSessionStart() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .codex, label: "Codex")
+        let incarnationID = UUID()
+        try await setIncarnation(incarnationID, terminalID: terminal.id, in: database)
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+
+        let application = try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: current),
+            reportedIncarnationID: incarnationID,
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 10))
+
+        #expect(application?.sessionID == "replacement-session")
+        #expect(try await database.terminals.get(id: terminal.id)?.sessionIncarnationID
+                == incarnationID)
+    }
+
+    @Test func missingAndMismatchedProcessIncarnationRejectWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .codex, label: "Codex")
+        let incarnationID = UUID()
+        let seededAt = Date(timeIntervalSinceReferenceDate: 5)
+        try await database.writerForTests.write { connection in
+            try connection.execute(
+                sql: """
+                    UPDATE terminal
+                    SET sessionIncarnationID = ?, claudeSessionID = ?, transcriptPath = ?,
+                        sessionOrderObservedAt = ?, codexTranscriptBoundaryOffset = ?,
+                        activityState = ?, activityStateSource = ?, activityStateObservedAt = ?,
+                        activityStateOrderObservedAt = ?
+                    WHERE id = ?
+                    """,
+                arguments: [
+                    incarnationID.uuidString, "kept-session", "/tmp/kept-session.jsonl",
+                    seededAt, 77, TerminalActivityState.working.rawValue,
+                    FactColumnJSON.encode(FactSource.hookEvent("kept")), seededAt, seededAt,
+                    terminal.id.uuidString,
+                ])
+        }
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+
+        for reported in [nil, UUID()] as [UUID?] {
+            let application = try await database.terminals.applySessionStart(
+                id: terminal.id,
+                expectedIncarnation: TerminalSessionIncarnation(terminal: current),
+                reportedIncarnationID: reported,
+                sessionID: "stale-session",
+                transcriptPath: "/tmp/stale-session.jsonl",
+                observedTranscriptBoundary: ObservedTranscriptBoundary(
+                    path: "/tmp/stale-session.jsonl", eof: 999),
+                observedAt: Date(timeIntervalSinceReferenceDate: 10))
+            #expect(application == nil)
+        }
+
+        let stored = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(stored.sessionIncarnationID == incarnationID)
+        #expect(stored.claudeSessionID == "kept-session")
+        #expect(stored.transcriptPath == "/tmp/kept-session.jsonl")
+        #expect(stored.sessionOrderObservedAt == seededAt)
+        #expect(stored.codexTranscriptBoundaryOffset == 77)
+        #expect(stored.activityState == .working)
+        #expect(stored.activityStateObservedAt == seededAt)
+        #expect(stored.activityStateOrderObservedAt == seededAt)
+    }
+
+    @Test func trueProcessReplacementsMintButSessionRecapturePreservesIncarnation() async throws {
+        let database = try TBDDatabase(inMemory: true)
+        let repo = try await database.repos.create(
+            path: "/tmp/session-incarnation-reset-repo-\(UUID().uuidString)",
+            displayName: "Incarnation", defaultBranch: "main")
+        let worktree = try await database.worktrees.create(
+            repoID: repo.id, name: "incarnation", branch: "incarnation",
+            path: "/tmp/session-incarnation-reset-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-incarnation-reset")
+        let terminal = try await database.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Codex", kind: .codex)
+        #expect(terminal.sessionIncarnationID == nil)
+
+        _ = try await database.terminals.replaceRecreatedCodexWindow(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+            windowID: "@1", paneID: "%1", at: Date())
+        let replacement = try #require(
+            try await database.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        try await database.terminals.updateTmuxIDs(
+            id: terminal.id, windowID: "@1", paneID: "%1")
+        let moved = try #require(
+            try await database.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        #expect(moved != replacement)
+        try await database.terminals.clearRecreated(id: terminal.id)
+        let cleared = try #require(
+            try await database.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        #expect(cleared != moved)
+        try await database.terminals.updateSessionID(id: terminal.id, sessionID: "replacement")
+        let recaptured = try #require(
+            try await database.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        #expect(recaptured == cleared)
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "next-replacement",
+            transcriptPath: "/tmp/next-replacement.jsonl")
+        let updated = try #require(
+            try await database.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        #expect(updated == recaptured)
+    }
+
+    @Test func codexPrelaunchTransitionReturnsTokenAndAcceptsImmediateMatchingHook() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .codex, label: "Codex")
+        let token = try #require(
+            try await database.terminals.replaceRecreatedCodexWindow(
+                id: terminal.id,
+                expectedIncarnation: TerminalSessionIncarnation(terminal: terminal),
+                windowID: "@1", paneID: "%1", at: Date()))
+        let prepared = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(prepared.sessionIncarnationID == token)
+        #expect(try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: prepared),
+            reportedIncarnationID: nil,
+            sessionID: "stale-session",
+            transcriptPath: "/tmp/stale-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 9)) == nil)
+        _ = try #require(try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: prepared),
+            reportedIncarnationID: token,
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 10)))
+
+        let accepted = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(accepted.sessionIncarnationID == token)
+        #expect(accepted.claudeSessionID == "replacement-session")
+        #expect(accepted.transcriptPath == "/tmp/replacement-session.jsonl")
+    }
+
+    @Test func codexWindowReplacementRejectsStaleIncarnationWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .codex, label: "Codex")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "current-session",
+            transcriptPath: "/tmp/current-codex-session.jsonl")
+        let staleIncarnation = TerminalSessionIncarnation(terminal: terminal)
+        try await database.terminals.updateTmuxIDs(
+            id: terminal.id, windowID: "@current", paneID: "%current")
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+
+        let replacement = try await database.terminals.replaceRecreatedCodexWindow(
+            id: terminal.id,
+            expectedIncarnation: staleIncarnation,
+            windowID: "@stale",
+            paneID: "%stale",
+            at: Date(timeIntervalSinceReferenceDate: 20))
+
+        #expect(replacement == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: current)
+    }
+
+    @Test func shellWindowReplacementRejectsStaleIncarnationWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .shell, label: "shell")
+        let staleIncarnation = TerminalSessionIncarnation(terminal: terminal)
+        try await database.terminals.updateTmuxIDs(
+            id: terminal.id, windowID: "@current", paneID: "%current")
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+
+        let replacement = try await database.terminals.replaceRecreatedShellWindow(
+            id: terminal.id,
+            expectedIncarnation: staleIncarnation,
+            windowID: "@stale",
+            paneID: "%stale",
+            at: Date(timeIntervalSinceReferenceDate: 20))
+
+        #expect(replacement == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: current)
+    }
+
+    @Test func profilePrelaunchTransitionAtomicallySetsIntentAndReturnsToken() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "stored-session",
+            transcriptPath: "/tmp/stored-session.jsonl")
+        let expectedState = try #require(try await database.terminals.get(id: terminal.id))
+        let profileID = UUID()
+        let token = try #require(try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: expectedState),
+            sessionID: "stored-session",
+            transcriptPath: "/tmp/stored-session.jsonl",
+            profileID: profileID,
+            at: Date(timeIntervalSinceReferenceDate: 20)))
+        let prepared = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(prepared.profileID == profileID)
+        #expect(prepared.sessionIncarnationID == token)
+        #expect(prepared.claudeSessionID == "stored-session")
+        #expect(prepared.transcriptPath == "/tmp/stored-session.jsonl")
+        #expect(prepared.activityState == .unknown)
+
+        _ = try #require(try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: prepared),
+            reportedIncarnationID: token,
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 30)))
+        let accepted = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(accepted.sessionIncarnationID == token)
+        #expect(accepted.claudeSessionID == "replacement-session")
+        #expect(accepted.transcriptPath == "/tmp/replacement-session.jsonl")
+    }
+
+    @Test func profilePrelaunchTransitionRejectsChangedStateWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "old-session",
+            transcriptPath: "/tmp/old-session.jsonl")
+        let stale = try #require(try await database.terminals.get(id: terminal.id))
+        try await database.terminals.updateTmuxIDs(
+            id: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement")
+        let replacement = try #require(try await database.terminals.get(id: terminal.id))
+
+        let token = try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: stale),
+            sessionID: "stale-session",
+            transcriptPath: "/tmp/stale-session.jsonl",
+            profileID: UUID(),
+            at: Date(timeIntervalSinceReferenceDate: 20))
+
+        #expect(token == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: replacement)
+    }
+
+    @Test func wakePreparationKeepsTerminalParkedUntilLaunchIsConfirmed() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "parked-session",
+            transcriptPath: "/tmp/parked-session.jsonl")
+        try await database.terminals.setHibernated(
+            id: terminal.id,
+            sessionID: "parked-session",
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 10))
+        let parked = try #require(try await database.terminals.get(id: terminal.id))
+
+        let token = try #require(try await database.terminals.prepareHibernatedAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: parked),
+            at: Date(timeIntervalSinceReferenceDate: 20)))
+        let prepared = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(prepared.isParked)
+        #expect(prepared.sessionIncarnationID == token)
+        #expect(token != parked.sessionIncarnationID)
+        #expect(prepared.claudeSessionID == "parked-session")
+        #expect(prepared.transcriptPath == "/tmp/parked-session.jsonl")
+        #expect(prepared.sessionOrderObservedAt == nil)
+        #expect(prepared.codexTranscriptBoundaryOffset == nil)
+        #expect(prepared.activityState == .unknown)
+
+        _ = try #require(try await database.terminals.applySessionStart(
+            id: terminal.id,
+            expectedIncarnation: TerminalSessionIncarnation(terminal: prepared),
+            reportedIncarnationID: token,
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            observedAt: Date(timeIntervalSinceReferenceDate: 30)))
+        try await database.terminals.clearHibernated(id: terminal.id)
+
+        let released = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(!released.isParked)
+        #expect(released.sessionIncarnationID == prepared.sessionIncarnationID)
+        #expect(released.claudeSessionID == "replacement-session")
+        #expect(released.transcriptPath == "/tmp/replacement-session.jsonl")
+    }
+
+    @Test func hibernationBeginRejectsAReplacedProcessWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "old-session",
+            transcriptPath: "/tmp/old-session.jsonl")
+        let oldProcess = try #require(try await database.terminals.get(id: terminal.id))
+        let replacementProfile = UUID()
+        _ = try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: oldProcess),
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            profileID: replacementProfile,
+            at: Date(timeIntervalSinceReferenceDate: 20))
+        let replacement = try #require(try await database.terminals.get(id: terminal.id))
+
+        let preparation = try await database.terminals.beginHibernatedShellRespawn(
+            id: terminal.id,
+            expectedState: TerminalHibernationSnapshot(terminal: oldProcess),
+            snapshot: "stale snapshot",
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 30))
+
+        #expect(preparation == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: replacement)
+    }
+
+    @Test func hibernationBeginRejectsChangedActivityWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "old-session",
+            transcriptPath: "/tmp/old-session.jsonl")
+        try await database.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .idle,
+            source: .derived,
+            observedAt: Date(timeIntervalSinceReferenceDate: 10))
+        let idle = try #require(try await database.terminals.get(id: terminal.id))
+        let expected = TerminalHibernationSnapshot(terminal: idle)
+        try await database.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("task_started"),
+            observedAt: Date(timeIntervalSinceReferenceDate: 20))
+        let working = try #require(try await database.terminals.get(id: terminal.id))
+
+        let preparation = try await database.terminals.beginHibernatedShellRespawn(
+            id: terminal.id,
+            expectedState: expected,
+            snapshot: "stale snapshot",
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 30))
+
+        #expect(preparation == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: working)
+    }
+
+    @Test func hibernationFinalizeRejectsAReplacedInertStageWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "old-session",
+            transcriptPath: "/tmp/old-session.jsonl")
+        let oldProcess = try #require(try await database.terminals.get(id: terminal.id))
+        let inertStage = try #require(
+            try await database.terminals.beginHibernatedShellRespawn(
+                id: terminal.id,
+                expectedState: TerminalHibernationSnapshot(terminal: oldProcess),
+                snapshot: "parked snapshot",
+                reason: .manual,
+                at: Date(timeIntervalSinceReferenceDate: 20)))
+        let replacementProfile = UUID()
+        let inert = try #require(try await database.terminals.get(id: terminal.id))
+        _ = try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: inert),
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            profileID: replacementProfile,
+            at: Date(timeIntervalSinceReferenceDate: 30))
+        let replacement = try #require(try await database.terminals.get(id: terminal.id))
+
+        let shellToken = try await database.terminals.finalizeHibernatedShellRespawn(
+            id: terminal.id,
+            expectedIncarnation: inertStage,
+            at: Date(timeIntervalSinceReferenceDate: 40))
+
+        #expect(shellToken == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: replacement)
+    }
+
+    @Test func hibernationBeginRejectsChangedCoordinatesWithMatchingToken() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        let token = try #require(try await database.terminals.prepareProfileAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: terminal),
+            sessionID: "replacement-session",
+            transcriptPath: "/tmp/replacement-session.jsonl",
+            profileID: UUID(),
+            at: Date(timeIntervalSinceReferenceDate: 10)))
+        let expected = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(expected.sessionIncarnationID == token)
+        try await setCoordinatesWithoutRotating(
+            terminalID: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement",
+            in: database)
+        let replacement = try #require(try await database.terminals.get(id: terminal.id))
+
+        let preparation = try await database.terminals.beginHibernatedShellRespawn(
+            id: terminal.id,
+            expectedState: TerminalHibernationSnapshot(terminal: expected),
+            snapshot: "stale snapshot",
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 20))
+
+        #expect(preparation == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: replacement)
+    }
+
+    @Test func hibernationFinalizeRejectsChangedCoordinatesWithMatchingToken() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+        let inertStage = try #require(
+            try await database.terminals.beginHibernatedShellRespawn(
+                id: terminal.id,
+                expectedState: TerminalHibernationSnapshot(terminal: current),
+                reason: .manual,
+                at: Date(timeIntervalSinceReferenceDate: 10)))
+        try await setCoordinatesWithoutRotating(
+            terminalID: terminal.id,
+            windowID: "@replacement",
+            paneID: "%replacement",
+            in: database)
+        let replacement = try #require(try await database.terminals.get(id: terminal.id))
+
+        let shellToken = try await database.terminals.finalizeHibernatedShellRespawn(
+            id: terminal.id,
+            expectedIncarnation: inertStage,
+            at: Date(timeIntervalSinceReferenceDate: 20))
+
+        #expect(shellToken == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: replacement)
+    }
+
+    @Test func wakePreparationRejectsAChangedParkedProfileWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "resume-session",
+            transcriptPath: "/tmp/resume-session.jsonl")
+        try await database.terminals.setHibernated(
+            id: terminal.id, sessionID: "resume-session")
+        let expected = try #require(try await database.terminals.get(id: terminal.id))
+        try await database.terminals.setProfileID(id: terminal.id, profileID: UUID())
+        let changed = try #require(try await database.terminals.get(id: terminal.id))
+
+        let token = try await database.terminals.prepareHibernatedAgentRespawn(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: expected),
+            at: Date(timeIntervalSinceReferenceDate: 30))
+
+        #expect(token == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: changed)
+    }
+
+    @Test func parkedProfileSwapRejectsACompletedWakeWithoutMutation() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        try await database.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "resume-session",
+            transcriptPath: "/tmp/resume-session.jsonl")
+        try await database.terminals.setHibernated(
+            id: terminal.id, sessionID: "resume-session")
+        let expected = try #require(try await database.terminals.get(id: terminal.id))
+        try await database.terminals.clearHibernated(id: terminal.id)
+        let woken = try #require(try await database.terminals.get(id: terminal.id))
+
+        let swapped = try await database.terminals.setParkedProfileID(
+            id: terminal.id,
+            expectedState: TerminalReplacementSnapshot(terminal: expected),
+            profileID: UUID())
+
+        #expect(swapped == nil)
+        let unchanged = try #require(try await database.terminals.get(id: terminal.id))
+        assertReplacementState(unchanged, equals: woken)
+    }
+
+    private func assertReplacementState(_ actual: Terminal, equals expected: Terminal) {
+        #expect(actual.sessionIncarnationID == expected.sessionIncarnationID)
+        #expect(actual.tmuxWindowID == expected.tmuxWindowID)
+        #expect(actual.tmuxPaneID == expected.tmuxPaneID)
+        #expect(actual.label == expected.label)
+        #expect(actual.profileID == expected.profileID)
+        #expect(actual.claudeSessionID == expected.claudeSessionID)
+        #expect(actual.transcriptPath == expected.transcriptPath)
+        #expect(actual.sessionOrderObservedAt == expected.sessionOrderObservedAt)
+        #expect(actual.codexTranscriptBoundaryOffset
+                == expected.codexTranscriptBoundaryOffset)
+        #expect(actual.activityState == expected.activityState)
+        #expect(actual.activityStateSource == expected.activityStateSource)
+        #expect(actual.activityStateObservedAt == expected.activityStateObservedAt)
+        #expect(actual.activityStateOrderObservedAt
+                == expected.activityStateOrderObservedAt)
+        #expect(actual.hibernatedAt == expected.hibernatedAt)
+        #expect(actual.hibernateReason == expected.hibernateReason)
+        #expect(actual.suspendedSnapshot == expected.suspendedSnapshot)
+    }
+
+    private func makeTerminal(
+        kind: TerminalKind,
+        label: String
+    ) async throws -> (TBDDatabase, Terminal) {
+        let database = try TBDDatabase(inMemory: true)
+        let repo = try await database.repos.create(
+            path: "/tmp/session-respawn-repo-\(UUID().uuidString)",
+            displayName: "Respawn", defaultBranch: "main")
+        let worktree = try await database.worktrees.create(
+            repoID: repo.id, name: "respawn", branch: "respawn",
+            path: "/tmp/session-respawn-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-session-respawn")
+        let terminal = try await database.terminals.create(
+            worktreeID: worktree.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: label,
+            kind: kind)
+        return (database, terminal)
+    }
+
+    private func setIncarnation(
+        _ incarnationID: UUID,
+        terminalID: UUID,
+        in database: TBDDatabase
+    ) async throws {
+        try await database.writerForTests.write { connection in
+            try connection.execute(
+                sql: "UPDATE terminal SET sessionIncarnationID = ? WHERE id = ?",
+                arguments: [incarnationID.uuidString, terminalID.uuidString])
+        }
+    }
+
+    private func setCoordinatesWithoutRotating(
+        terminalID: UUID,
+        windowID: String,
+        paneID: String,
+        in database: TBDDatabase
+    ) async throws {
+        try await database.writerForTests.write { connection in
+            try connection.execute(
+                sql: "UPDATE terminal SET tmuxWindowID = ?, tmuxPaneID = ? WHERE id = ?",
+                arguments: [windowID, paneID, terminalID.uuidString])
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSessionIncarnationMigrationTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionIncarnationMigrationTests.swift
@@ -8,6 +8,68 @@ import Testing
     private static let migrationID = "20260825060216_terminal_session_incarnation"
     private static let pendingMigrationID = "20260829210843_pending_terminal_incarnation"
 
+    @Test func factSourcePersistenceMatchUsesDecodedValue() {
+        let source = FactSource.hookEvent("UserPromptSubmit")
+
+        #expect(FactColumnJSON.matches(
+            source,
+            encoded: #"{"detail":"UserPromptSubmit","kind":"hook"}"#))
+        #expect(FactColumnJSON.matches(Optional<FactSource>.none, encoded: nil))
+        #expect(!FactColumnJSON.matches(source, encoded: "not-json"))
+        #expect(!FactColumnJSON.matches(Optional<FactSource>.none, encoded: "not-json"))
+    }
+
+    @Test func awaitingInputPersistenceMatchUsesDecodedValue() {
+        let reason = AwaitingInputReason(
+            message: "Approve?",
+            hookEventName: "Notification")
+
+        #expect(FactColumnJSON.matches(
+            reason,
+            encoded: #"{"hookEventName":"Notification","message":"Approve?"}"#))
+        #expect(FactColumnJSON.matches(Optional<AwaitingInputReason>.none, encoded: nil))
+        #expect(!FactColumnJSON.matches(reason, encoded: "not-json"))
+        #expect(!FactColumnJSON.matches(Optional<AwaitingInputReason>.none, encoded: "not-json"))
+    }
+
+    @Test func hibernationBeginMatchesPersistedFactSemantics() async throws {
+        let (database, terminal) = try await makeTerminal(kind: .claude, label: "claude")
+        let observedAt = Date(timeIntervalSinceReferenceDate: 20)
+        let reason = AwaitingInputReason(
+            message: "Approve?",
+            hookEventName: "Notification")
+        try await database.terminals.setActivityState(
+            id: terminal.id,
+            activityState: .working,
+            source: .hookEvent("UserPromptSubmit"),
+            observedAt: observedAt,
+            awaitingInputReason: reason)
+        try await database.writerForTests.write { connection in
+            try connection.execute(
+                sql: """
+                    UPDATE terminal
+                    SET activityStateSource = ?, awaitingInputReason = ?
+                    WHERE id = ?
+                    """,
+                arguments: [
+                    #"{ "detail": "UserPromptSubmit", "kind": "hook" }"#,
+                    #"{ "hookEventName": "Notification", "message": "Approve?" }"#,
+                    terminal.id.uuidString,
+                ])
+        }
+        let current = try #require(try await database.terminals.get(id: terminal.id))
+        #expect(current.activityStateSource == .hookEvent("UserPromptSubmit"))
+        #expect(current.awaitingInputReason == reason)
+
+        let preparation = try await database.terminals.beginHibernatedShellRespawn(
+            id: terminal.id,
+            expectedState: TerminalHibernationSnapshot(terminal: current),
+            reason: .manual,
+            at: Date(timeIntervalSinceReferenceDate: 30))
+
+        #expect(preparation != nil)
+    }
+
     @Test func forwardMigrationLeavesExistingIncarnationNil() throws {
         let queue = try DatabaseQueue()
         let migrator = TBDDatabase.buildMigratorForTests()

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -53,6 +53,7 @@ import Testing
 
 @Test func testTerminalRoundTrip() throws {
     let sessionOrderObservedAt = Date(timeIntervalSinceReferenceDate: 30)
+    let sessionIncarnationID = UUID()
     let terminal = Terminal(
         id: UUID(),
         worktreeID: UUID(),
@@ -61,6 +62,7 @@ import Testing
         label: "editor",
         createdAt: Date(),
         sessionOrderObservedAt: sessionOrderObservedAt,
+        sessionIncarnationID: sessionIncarnationID,
         activityState: .working,
         presentationActivityState: .idle
     )
@@ -70,8 +72,24 @@ import Testing
     #expect(decoded.tmuxWindowID == "@1")
     #expect(decoded.label == "editor")
     #expect(decoded.sessionOrderObservedAt == sessionOrderObservedAt)
+    #expect(decoded.sessionIncarnationID == sessionIncarnationID)
     #expect(decoded.activityState == .working)
     #expect(decoded.presentationActivityState == .idle)
+}
+
+@Test(arguments: [Int64?.none, Int64?.some(0), Int64?.some(4_294_967_296)])
+func testTerminalCodexTranscriptBoundaryRoundTrip(_ boundary: Int64?) throws {
+    let terminal = Terminal(
+        worktreeID: UUID(),
+        tmuxWindowID: "@1",
+        tmuxPaneID: "%3",
+        codexTranscriptBoundaryOffset: boundary
+    )
+
+    let data = try JSONEncoder().encode(terminal)
+    let decoded = try JSONDecoder().decode(Terminal.self, from: data)
+
+    #expect(decoded.codexTranscriptBoundaryOffset == boundary)
 }
 
 @Test func testNotificationRoundTrip() throws {
@@ -254,6 +272,8 @@ import Testing
     #expect(decoded.activityState == .unknown)
     #expect(decoded.presentationActivityState == nil)
     #expect(decoded.sessionOrderObservedAt == nil)
+    #expect(decoded.codexTranscriptBoundaryOffset == nil)
+    #expect(decoded.sessionIncarnationID == nil)
 }
 
 // MARK: - Hibernation fields + gating helpers

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -54,6 +54,7 @@ import Testing
 @Test func testTerminalRoundTrip() throws {
     let sessionOrderObservedAt = Date(timeIntervalSinceReferenceDate: 30)
     let sessionIncarnationID = UUID()
+    let pendingSessionIncarnationID = UUID()
     let terminal = Terminal(
         id: UUID(),
         worktreeID: UUID(),
@@ -63,6 +64,7 @@ import Testing
         createdAt: Date(),
         sessionOrderObservedAt: sessionOrderObservedAt,
         sessionIncarnationID: sessionIncarnationID,
+        pendingSessionIncarnationID: pendingSessionIncarnationID,
         activityState: .working,
         presentationActivityState: .idle
     )
@@ -73,6 +75,7 @@ import Testing
     #expect(decoded.label == "editor")
     #expect(decoded.sessionOrderObservedAt == sessionOrderObservedAt)
     #expect(decoded.sessionIncarnationID == sessionIncarnationID)
+    #expect(decoded.pendingSessionIncarnationID == pendingSessionIncarnationID)
     #expect(decoded.activityState == .working)
     #expect(decoded.presentationActivityState == .idle)
 }
@@ -274,6 +277,7 @@ func testTerminalCodexTranscriptBoundaryRoundTrip(_ boundary: Int64?) throws {
     #expect(decoded.sessionOrderObservedAt == nil)
     #expect(decoded.codexTranscriptBoundaryOffset == nil)
     #expect(decoded.sessionIncarnationID == nil)
+    #expect(decoded.pendingSessionIncarnationID == nil)
 }
 
 // MARK: - Hibernation fields + gating helpers

--- a/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
+++ b/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
@@ -14,20 +14,24 @@ import Testing
         #expect(decoded.terminalID == terminalID)
         #expect(decoded.activityState == .working)
         #expect(decoded.sessionID == nil)
+        #expect(decoded.sessionIncarnationID == nil)
     }
 
-    @Test("activity payload carries optional Codex session identity")
-    func sessionIdentityRoundTrips() throws {
+    @Test("activity payload carries optional Codex session and process identity")
+    func sessionAndProcessIdentityRoundTrips() throws {
+        let incarnationID = UUID()
         let params = TerminalActivityEventParams(
             terminalID: UUID(),
             activityState: .waitingForUser,
-            sessionID: "session-current")
+            sessionID: "session-current",
+            sessionIncarnationID: incarnationID)
 
         let decoded = try JSONDecoder().decode(
             TerminalActivityEventParams.self,
             from: JSONEncoder().encode(params))
 
         #expect(decoded.sessionID == "session-current")
+        #expect(decoded.sessionIncarnationID == incarnationID)
     }
 }
 

--- a/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
+++ b/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
@@ -30,3 +30,35 @@ import Testing
         #expect(decoded.sessionID == "session-current")
     }
 }
+
+@Suite struct TerminalSessionEventParamsCodingTests {
+    @Test("legacy session payload without process incarnation still decodes")
+    func legacyPayloadStillDecodes() throws {
+        let terminalID = UUID()
+        let data = Data(
+            #"{"terminalID":"\#(terminalID.uuidString)","sessionID":"session-current","transcriptPath":null,"source":"startup"}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(TerminalSessionEventParams.self, from: data)
+
+        #expect(decoded.terminalID == terminalID)
+        #expect(decoded.sessionID == "session-current")
+        #expect(decoded.sessionIncarnationID == nil)
+    }
+
+    @Test("session payload carries optional process incarnation")
+    func processIncarnationRoundTrips() throws {
+        let incarnationID = UUID()
+        let params = TerminalSessionEventParams(
+            terminalID: UUID(),
+            sessionID: "session-current",
+            transcriptPath: "/tmp/session-current.jsonl",
+            source: "startup",
+            sessionIncarnationID: incarnationID)
+
+        let decoded = try JSONDecoder().decode(
+            TerminalSessionEventParams.self,
+            from: JSONEncoder().encode(params))
+
+        #expect(decoded.sessionIncarnationID == incarnationID)
+    }
+}

--- a/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
+++ b/Tests/TBDSharedTests/TerminalActivityEventParamsCodingTests.swift
@@ -66,3 +66,30 @@ import Testing
         #expect(decoded.sessionIncarnationID == incarnationID)
     }
 }
+
+@Suite struct TerminalSessionEndedParamsCodingTests {
+    @Test("legacy SessionEnd payload without process incarnation still decodes")
+    func legacyPayloadStillDecodes() throws {
+        let terminalID = UUID()
+        let data = Data(#"{"terminalID":"\#(terminalID.uuidString)"}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(TerminalSessionEndedParams.self, from: data)
+
+        #expect(decoded.terminalID == terminalID)
+        #expect(decoded.sessionIncarnationID == nil)
+    }
+
+    @Test("SessionEnd payload carries optional process incarnation")
+    func processIncarnationRoundTrips() throws {
+        let incarnationID = UUID()
+        let params = TerminalSessionEndedParams(
+            terminalID: UUID(),
+            sessionIncarnationID: incarnationID)
+
+        let decoded = try JSONDecoder().decode(
+            TerminalSessionEndedParams.self,
+            from: JSONEncoder().encode(params))
+
+        #expect(decoded.sessionIncarnationID == incarnationID)
+    }
+}

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -39,12 +39,13 @@ import Testing
 // gate with `gateHoldingTask`, which pins it (and every default-actor hop it
 // makes) to threads these tests own.
 //
-// Gates reached from a dedicated `Thread` or a `DispatchQueue` never had the
-// problem and need nothing: `FDVendingServer` delivers to its sinks from a
-// dedicated receive `Thread`, `WorktreeDeletionQueue`'s gate sits on its own
-// `drainQueue`, and `TmuxControlSupervisor` runs `stopConnection` on
-// `DispatchQueue.global(qos:.utility)` precisely so a blocking stop stays off
-// the actor. Those three keep a plain bounded `waitForGate` and no executor.
+// Gates reached from a dedicated `Thread` never had the problem and need
+// nothing: `FDVendingServer` delivers to its sinks from a dedicated receive
+// thread. `WorktreeDeletionQueue` and `TmuxControlSupervisor` reach their gates
+// from dispatch queues, which keeps them off the cooperative pool but does NOT
+// give them dedicated threads. Their small fixed counts keep a plain bounded
+// `waitForGate`; the executor below cannot share libdispatch workers with them,
+// because many simultaneous gate tasks can consume every such worker.
 //
 // ## 2. Bound every wait anyway — `waitForGate`
 //
@@ -66,24 +67,29 @@ import Testing
 /// anywhere in `Sources/`, so there is no actor along these paths that would
 /// pull the job back onto the pool.
 ///
-/// The queue is concurrent: gates are held one per task, and a blocked worker
-/// must not stall an unrelated job that happens to be queued behind it.
+/// Every enqueued task job gets a real `Thread`, not a concurrent dispatch
+/// queue. Dispatch queues do not own threads; enough blocking jobs on one can
+/// consume libdispatch's workers and starve unrelated queue work. A task job is
+/// one synchronous continuation: its thread exits when that continuation
+/// completes or suspends, and the next continuation gets another thread. Gate
+/// tasks follow finite test-only RPC paths, so this bounded resumption churn is
+/// preferable to sharing either of the process-wide worker pools they test.
 public final class GateExecutor: TaskExecutor, @unchecked Sendable {
     /// One per process. The executor holds no state; the shared instance
     /// exists so `gateHoldingTask` does not mint a queue per call site.
     public static let shared = GateExecutor()
-
-    private let queue = DispatchQueue(
-        label: "com.tbd.tests.gate-executor",
-        qos: .userInitiated,
-        attributes: .concurrent)
 
     private init() {}
 
     public func enqueue(_ job: consuming ExecutorJob) {
         let job = UnownedJob(job)
         let executor = asUnownedTaskExecutor()
-        queue.async { job.runSynchronously(on: executor) }
+        let thread = Thread {
+            job.runSynchronously(on: executor)
+        }
+        thread.name = "com.tbd.tests.gate-executor"
+        thread.qualityOfService = .userInitiated
+        thread.start()
     }
 }
 

--- a/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
+++ b/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
@@ -16,7 +16,7 @@ The central safety policy is that false thinking is worse than false idle. Ambig
 - Clear stale working indicators after interruption, restart, resumed sessions, and rewritten lifecycle identifiers.
 - Recover an open Codex turn after daemon state loss even when its start lies outside the transcript tail.
 - Preserve explicit user-attention states and immediate Ctrl+C feedback.
-- Reject delayed activity hooks from an older Codex session.
+- Reject delayed activity hooks from an older Codex process, including when a replacement reuses the same session ID.
 - Handle root sessions and spawned subagents without treating copied parent history as nested active work.
 - Keep terminal-list polling bounded and fair across a fleet.
 - Preserve wire and database compatibility during upgrades.
@@ -46,7 +46,7 @@ This path is the shipped default for every Codex terminal and has no feature fla
 
 - A Codex terminal presents working only from complete lifecycle evidence associated with its current transcript identity and session generation.
 - Unknown transcript evidence never reuses cached working evidence.
-- A session-bound hook from an older Codex session changes no terminal fact and does not cancel current-session scheduled work.
+- A session-bound hook from an older Codex process changes no terminal fact and does not cancel current-process scheduled work, even when the replacement reuses the same session ID.
 - Ctrl+C clears working immediately and remains authoritative until a valid later current-session event supersedes it.
 - A current permission wait defeats transcript working.
 - SessionStart applies identity and its eligible prompt/activity effects atomically; an event rejected by one ordering rail cannot partially roll identity backward.
@@ -69,9 +69,9 @@ Rendered terminal content is not an input. TBD does not parse prompts, status te
 
 The generated Codex hook overlay forwards hook JSON from standard input to TBD. `SessionStart`, `UserPromptSubmit`, `PermissionRequest`, and `Stop` payloads include the Codex `session_id`; their `transcript_path` may be absent.
 
-The CLI accepts a dedicated hook-payload mode rather than consuming standard input for ordinary commands. Input is bounded to 1 MiB and decoded into an optional, backward-compatible session identity on the terminal activity RPC. Payload reuse must preserve the same JSON for commands that perform more than one actuation.
+The CLI accepts a dedicated hook-payload mode rather than consuming standard input for ordinary commands. Input is bounded to 1 MiB and decoded into an optional, backward-compatible session identity on the terminal activity RPC. The CLI also forwards the process-incarnation token that TBD plants in the spawned process environment. Payload reuse must preserve the same JSON for commands that perform more than one actuation.
 
-Already-running installations may still send activity events without a session identity until their generated overlay is refreshed. Identity-free events remain accepted during this upgrade window. Events that do carry an identity are validated transactionally against the terminal's current Codex session before they mutate activity, attention state, ordering watermarks, or scheduled-resume state.
+Legacy terminals whose durable process-incarnation token is `NULL` accept activity events without a token, preserving compatibility with processes launched before TBD managed replacements. Once a row carries a managed token, every process-bound activity event must report that exact token; a missing or mismatched token is stale even when its session ID matches the current Codex session. The daemon validates both identities transactionally before mutating activity, attention state, ordering watermarks, or scheduled-resume state. Explicit app-originated interrupts are user actions rather than process-bound hook observations and remain accepted without either identity.
 
 ### SessionStart and durable boundaries
 
@@ -187,8 +187,8 @@ Field measurements found lifecycle lines near 3 KiB at the 99th percentile and a
 - **Initial rollout is temporarily unavailable** — retain boundary `0` without positive evidence, then recover from zero when the file appears.
 - **Daemon restart with a known boundary** — capture a fixed EOF, search backward for an anchor, replay only an anchored forward suffix when needed, and publish unknown until exact.
 - **Daemon restart with a `NULL` boundary** — fence at the current EOF in memory and wait for new evidence rather than guessing at historical eligibility.
-- **Delayed old-session hook with identity** — reject it before any mutation.
-- **Legacy hook without identity** — accept it for upgrade compatibility; subsequent session-bound hooks restore full protection.
+- **Delayed old-process hook with identity** — reject it before any mutation, including when its session ID matches a replacement process.
+- **Legacy hook without process identity** — accept it only while the durable row also has no process-incarnation token; a managed row requires an exact token match.
 
 These cases intentionally favor temporary idle over stale working.
 
@@ -212,7 +212,7 @@ The migration file, GRDB record, and shared model change together. The Swift mig
 
 Session identity order and the transcript boundary are persisted independently from activity order but atomically with each other. Presentation order, recovery cursors, captured recovery EOFs, and reducer state remain transient because they describe observations produced by the live transcript tracker rather than durable user or hook facts.
 
-Generated hook configuration is refreshed through the existing plugin installation path. Mixed-version clients remain usable because identity-free activity events are accepted and new wire fields are optional.
+Generated hook configuration is refreshed through the existing plugin installation path. The new wire field is optional, so mixed-version payloads still decode. Identity-free activity remains usable for legacy nil-token rows, while managed replacement rows reject clients that cannot prove the current process incarnation.
 
 ## Testing strategy
 
@@ -252,8 +252,8 @@ Daemon and wire tests cover:
 - atomic first-attachment classification, including partial-history rows, concurrent starts, sub-millisecond ordering, and legacy datetime rows;
 - stale and retried SessionStart events leaving the accepted boundary unchanged;
 - identity-clearing and identity-replacement paths clearing the boundary;
-- current-session hook acceptance and stale-session rejection;
-- legacy identity-free hook compatibility;
+- current-process hook acceptance and stale-process rejection when session IDs differ or are reused;
+- legacy identity-free hook compatibility on nil-token rows and rejection on managed-token rows;
 - atomic ordering of session, activity, and attention facts;
 - equal-time precedence;
 - Ctrl+C persistence and later supersession;

--- a/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
+++ b/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
@@ -26,7 +26,10 @@ The central safety policy is that false thinking is worse than false idle. Ambig
 
 - Inferring state from rendered terminal text or TUI glyphs.
 - Reporting the internal progress of every nested tool or process inside a turn.
-- Changing Claude hooks, shell activity, hibernation policy, or notification policy.
+- Changing Claude or shell activity interpretation, user-visible hibernation
+  policy, or notification policy. The shared replacement fence used by their
+  existing process lifecycle is specified in
+  [Terminal Process Incarnation Design](2026-08-29-terminal-process-incarnation-design.md).
 - Introducing a general event-sourcing framework for terminal state.
 
 ## Product semantics
@@ -71,7 +74,7 @@ The generated Codex hook overlay forwards hook JSON from standard input to TBD. 
 
 The CLI accepts a dedicated hook-payload mode rather than consuming standard input for ordinary commands. Input is bounded to 1 MiB and decoded into an optional, backward-compatible session identity on the terminal activity RPC. The CLI also forwards the process-incarnation token that TBD plants in the spawned process environment. Payload reuse must preserve the same JSON for commands that perform more than one actuation.
 
-Legacy terminals whose durable process-incarnation token is `NULL` accept activity events without a token, preserving compatibility with processes launched before TBD managed replacements. Once a row carries a managed token, every process-bound activity event must report that exact token; a missing or mismatched token is stale even when its session ID matches the current Codex session. The daemon validates both identities transactionally before mutating activity, attention state, ordering watermarks, or scheduled-resume state. Explicit app-originated interrupts are user actions rather than process-bound hook observations and remain accepted without either identity.
+Legacy terminals whose durable process-incarnation token is `NULL` accept activity events without a token, preserving compatibility with processes launched before TBD managed replacements. Once a row carries a managed token, every process-bound activity event must report that exact token; a missing or mismatched token is stale even when its session ID matches the current Codex session. A staged replacement token temporarily makes both the outgoing and not-yet-launched processes ineligible to write hook facts. The daemon validates these identities transactionally before mutating activity, attention state, ordering watermarks, or scheduled-resume state. Explicit app-originated interrupts are user actions rather than process-bound hook observations and remain accepted without either identity. The shared token lifecycle, including hibernate and wake recovery, is defined in [Terminal Process Incarnation Design](2026-08-29-terminal-process-incarnation-design.md).
 
 ### SessionStart and durable boundaries
 
@@ -286,4 +289,9 @@ Verification includes focused suites for each layer, `scripts/swift-safe build`,
 
 The design adds no new durable external resource and requires no new reconciler. It reads existing rollout files, persists ordering metadata and the transcript boundary in the existing terminal record, and uses existing RPC and hook installation paths.
 
-No automatic process control, input injection, deletion, or background actuation is introduced. The change affects only Codex activity observation and presentation.
+Codex reconciliation introduces no automatic process control, input injection,
+deletion, or background actuation. It changes only Codex activity observation
+and presentation. The shared incarnation fence hardens the existing terminal
+replacement, hibernate, and wake paths described in
+[Terminal Process Incarnation Design](2026-08-29-terminal-process-incarnation-design.md);
+it does not expand when those paths actuate.

--- a/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
+++ b/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
@@ -95,11 +95,15 @@ A `NULL` boundary means TBD cannot identify a safe historical starting point. Th
 
 A daemon actor owns transcript targets, recovery cursors, incremental offsets, partial records, reducer state, and presentation observation ordering. Serial actor access gives observations a stable order without blocking on unrelated database state.
 
-Each target includes the terminal's current session identity, effective transcript path, session generation, and durable boundary. A cold tracker starts at a known boundary and captures the transcript's current EOF as a fixed recovery target. It replays forward in the existing fixed-size chunks and under the shared request budget, preserving its cursor and reducer between polls. It publishes authoritative unknown, which presents as idle, until the cursor reaches the captured EOF with no incomplete or discarding record. It then publishes the exact reconstructed working or idle state and resumes ordinary incremental reads from the same cursor.
+Each target includes the terminal's current session identity, effective transcript path, session generation, and durable boundary. For a known-boundary cold recovery, the tracker captures the transcript's current EOF as a fixed target, then searches complete eligible JSONL records backward from that target under the shared byte, step, and round-robin budgets. It publishes authoritative unknown, which presents as idle, throughout recovery.
 
-The fixed recovery EOF prevents a continuously growing transcript from keeping recovery perpetually behind. Bytes appended after capture wait for ordinary incremental polls once recovery reaches the fixed target.
+The reverse search stops at the first of three exact anchors. A close that omits either `turn_id` or `started_at` is an unconditional idle synchronizer and seeds idle immediately. The newest valid `task_started` supplies a byte offset; from that offset, the tracker replays only the start-to-frozen-EOF suffix forward through the ordinary lifecycle reducer. If the durable boundary is reached without a valid start, any close evidence seeds idle and no lifecycle evidence yields `nil`. A start-anchored recovery remains unknown until the bounded forward suffix replay reaches the target with no incomplete or discarding record. Ordinary incremental reads then resume at the effective recovery EOF.
 
-The tracker preserves an unterminated fragment across reads, discards a record that grows beyond the record cap, and resumes at the next newline. An initial attachment whose file truncates may reset to boundary `0` and replay the replacement file from its beginning. If a later attachment's file shrinks below its boundary, the tracker fences at the new EOF in memory and waits for new lifecycle evidence; it does not reinterpret pre-boundary history or replace the durable boundary.
+The two phases keep recovery memory bounded without weakening close correlation. Reverse search retains framing for at most one capped record and a `sawClose` bit; it does not retain a set of identifiers or timestamps from fully identified closes. Exact correlation of those closes against the newest start happens during the forward suffix replay through the existing reducer. The fixed target also prevents a continuously growing transcript from keeping recovery perpetually behind. Bytes appended after capture wait for ordinary incremental polls once recovery reaches that target.
+
+If the captured EOF falls inside a JSONL record, cold recovery remains unknown until the first later newline completes that record. That newline becomes the effective recovery EOF; later records returned in the same filesystem read are not included and are read again by ordinary incremental processing. Recovery does not chase later appends while waiting for the captured record to finish.
+
+The tracker preserves an unterminated fragment across incremental reads, discards a record that grows beyond the record cap, and resumes at the next newline. An initial attachment whose file truncates restarts exact recovery from boundary `0` against the replacement file's frozen EOF. If a later attachment's file shrinks below its boundary, the tracker fences at the new EOF in memory and waits for new lifecycle evidence; it does not reinterpret pre-boundary history or replace the durable boundary.
 
 Fleet and worktree-scoped observations share a fair cyclic path order. Scoped polling cannot reset fleet progress or starve a deferred transcript. A terminal-list response revalidates terminal identity, transcript path, session generation, and durable boundary after the actor observation. If any target fact changed during the scan, the response returns the current identity with a newly ordered unknown presentation rather than stale activity from the old file.
 
@@ -155,30 +159,33 @@ Raw generic idle hooks do not defeat a valid open transcript. Raw generic workin
 
 Terminal-list polling must not decode unbounded transcript history or perform unbounded zero-byte filesystem work.
 
-- Recovery reads fixed-size chunks and retains its cursor across requests; no request scans the whole backlog.
+- Reverse search and forward suffix replay read fixed-size chunks and retain their phase and cursor across requests; no request scans the whole backlog.
 - A terminal-list observation has a shared 1 MiB byte budget across Codex transcripts.
 - Pending transcripts receive 64 KiB round-robin quanta.
 - One observation performs at most 16 filesystem steps, including caught-up and unreadable paths that consume no content bytes.
 - A single JSONL record is capped at 1 MiB. Oversized records are discarded through their newline.
-- Partial, discarding, untouched, and not-yet-caught-up paths publish unknown rather than cached working.
+- Bytes returned while completing a captured partial record count against the request budget even when bytes after its first newline are deferred to incremental processing.
+- Reverse-searching, suffix-replaying, partial, discarding, untouched, and not-yet-caught-up paths publish unknown rather than cached working.
 
-Large backlogs converge over multiple polls, regardless of how far the relevant lifecycle event lies from EOF. A continuously growing early path cannot consume every request because the cyclic cursor advances across requests and survives scoped polling and path removal.
+Large backlogs converge over multiple polls, regardless of how far the relevant lifecycle event lies from EOF or how large its forward suffix is. Reverse recovery stores no per-close collection, so the number of fully identified closes does not increase retained correlation state. A continuously growing early path cannot consume every request because the cyclic cursor advances across requests and survives scoped polling and path removal.
 
 Field measurements found lifecycle lines near 3 KiB at the 99th percentile and about 21 KiB at the observed maximum. The 1 MiB record cap leaves substantial margin while bounding memory and scan cost.
 
 ## Failure handling
 
-- **Incomplete final record** — retain the bounded fragment, publish unknown, and retry after more bytes arrive.
+- **Incomplete incremental final record** — retain the bounded fragment, publish unknown, and retry after more bytes arrive.
+- **Captured partial EOF record** — publish unknown until its first later newline, make only that completed record part of recovery, charge every byte returned by the read, and leave later records for incremental processing.
 - **Oversized record** — discard through the next newline, publish unknown while discarding, then resume normal parsing.
 - **Unreadable file** — publish unknown and retry on a later observation.
-- **Initial-attachment truncation or replacement** — discard incompatible reducer evidence and replay from boundary `0`.
+- **Initial-attachment truncation or replacement** — discard incompatible reducer evidence and restart reverse recovery from boundary `0` against the replacement's frozen EOF.
 - **Later-attachment shrink below the boundary** — fence at the new EOF in memory, publish unknown, and wait for later lifecycle evidence.
-- **Backlog beyond the request budget** — preserve incremental progress and publish unknown until caught up.
+- **Shrink during cold recovery** — discard both recovery phases and restart under the target's original known-boundary policy against the replacement file.
+- **Backlog beyond the request budget** — preserve reverse-search or forward-suffix progress and publish unknown until exact.
 - **Target changes during a scan** — discard the old result when identity, path, generation, or boundary revalidation fails, then publish an ordered unknown for the current target.
-- **Initial task precedes SessionStart** — replay from durable boundary `0`, so already-written lifecycle evidence remains eligible.
+- **Initial task precedes SessionStart** — recover from durable boundary `0`, so already-written lifecycle evidence remains eligible.
 - **Terminal list races tracker attachment** — bind both operations to the complete persisted target; same-generation work with a different boundary cannot publish.
-- **Initial rollout is temporarily unavailable** — retain boundary `0` without positive evidence, then replay from zero when the file appears.
-- **Daemon restart with a known boundary** — capture a fixed EOF, replay progressively from the durable boundary, and publish unknown until caught up.
+- **Initial rollout is temporarily unavailable** — retain boundary `0` without positive evidence, then recover from zero when the file appears.
+- **Daemon restart with a known boundary** — capture a fixed EOF, search backward for an anchor, replay only an anchored forward suffix when needed, and publish unknown until exact.
 - **Daemon restart with a `NULL` boundary** — fence at the current EOF in memory and wait for new evidence rather than guessing at historical eligibility.
 - **Delayed old-session hook with identity** — reject it before any mutation.
 - **Legacy hook without identity** — accept it for upgrade compatibility; subsequent session-bound hooks restore full protection.
@@ -221,17 +228,19 @@ Reducer tests cover:
 
 Tracker tests cover:
 
-- a fresh tracker replaying from boundary `0` when `task_started` lies more than 1 MiB before EOF;
-- early bounded observations publishing unknown, then converging to working after reaching the fixed recovery EOF;
-- completion or abort after an old start converging to idle;
-- a later-session boundary excluding an unmatched start before the boundary;
-- fixed-EOF recovery when the transcript grows during catch-up, followed by ordinary incremental reads;
-- initial-attachment replay from zero after truncation and later-attachment in-memory fencing after shrink below the boundary;
-- 64 KiB boundaries and unterminated fragments;
-- oversized-record discard and recovery;
+- a fresh tracker finding a valid start more than one request budget from EOF while every intermediate reverse-search and forward-replay observation remains unknown;
+- exact agreement between reverse-anchored recovery and ordinary forward reducer semantics for working starts, matching closes, reliable mismatches, unconditional closes, malformed records, and missing lifecycle evidence;
+- stopping reverse search at an unconditional close, at the newest valid start, or at the durable boundary without scanning ineligible older history;
+- exact reliable-close correlation during bounded forward suffix replay without retaining per-close keys during reverse search;
+- positive-boundary and crossing-record exclusion;
+- a captured partial EOF record waiting for its first later newline without chasing later records, including full filesystem-read budget accounting;
+- fixed-EOF recovery when the transcript grows during either phase, followed by ordinary incremental reads;
+- initial-attachment recovery from zero after truncation, shrink during reverse recovery, and later-attachment in-memory fencing after shrink below the boundary;
+- 64 KiB boundaries, malformed records, and unterminated fragments;
+- oversized-record discard in both reverse and forward processing;
 - unreadable-file recovery;
 - per-request byte and step limits;
-- fleet fairness, scoped polling, path removal, and reordering;
+- round-robin fairness across simultaneous reverse searches and forward suffix replays, scoped polling, path removal, and reordering;
 - target changes during suspended observation, including identity, path, generation, and boundary changes.
 
 Daemon and wire tests cover:
@@ -268,7 +277,7 @@ Verification includes focused suites for each layer, `scripts/swift-safe build`,
 - **Transcript alone** — it cannot provide immediate Ctrl+C feedback or preserve a permission prompt over an open task.
 - **Bounded tail recovery** — an open turn whose start lies before the tail window remains falsely idle after tracker state is lost.
 - **Persisting the reducer checkpoint** — storing the cursor and open-task state would require frequent database writes and crash-consistency rules, and a stale checkpoint could restore false working.
-- **Searching backward from EOF** — reverse lifecycle correlation is more complex, and a long-running open turn still requires scanning nearly the entire transcript.
+- **One-pass backward close correlation** — exact membership checks for arbitrary fully identified close records require retaining an unbounded set of identifiers or timestamps. The bounded two-phase scan instead uses constant reverse-search state and delegates exact correlation to a forward replay of only the anchored suffix.
 - **A task stack** — copied parent history and orphaned starts would be restored after the current subagent task closes, creating false working.
 - **A default-off flag** — the legacy path is the known failure and parallel modes would preserve conflicting interpretations. Conservative idle fallback bounds the replacement's risk.
 - **Terminal screen scraping** — rendered TUI text is not a stable machine interface.

--- a/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
+++ b/docs/specs/2026-08-19-codex-activity-reconciliation-design.md
@@ -14,6 +14,7 @@ The central safety policy is that false thinking is worse than false idle. Ambig
 
 - Derive Codex working and idle presentation from rollout lifecycle events.
 - Clear stale working indicators after interruption, restart, resumed sessions, and rewritten lifecycle identifiers.
+- Recover an open Codex turn after daemon state loss even when its start lies outside the transcript tail.
 - Preserve explicit user-attention states and immediate Ctrl+C feedback.
 - Reject delayed activity hooks from an older Codex session.
 - Handle root sessions and spawned subagents without treating copied parent history as nested active work.
@@ -25,7 +26,6 @@ The central safety policy is that false thinking is worse than false idle. Ambig
 
 - Inferring state from rendered terminal text or TUI glyphs.
 - Reporting the internal progress of every nested tool or process inside a turn.
-- Reconstructing lifecycle history older than the bounded transcript window when no current evidence exists.
 - Changing Claude hooks, shell activity, hibernation policy, or notification policy.
 - Introducing a general event-sourcing framework for terminal state.
 
@@ -50,6 +50,7 @@ This path is the shipped default for every Codex terminal and has no feature fla
 - Ctrl+C clears working immediately and remains authoritative until a valid later current-session event supersedes it.
 - A current permission wait defeats transcript working.
 - SessionStart applies identity and its eligible prompt/activity effects atomically; an event rejected by one ordering rail cannot partially roll identity backward.
+- Session identity, ordering watermark, transcript path, and transcript boundary describe one accepted SessionStart and change atomically.
 - Session identity, raw activity, attention state, and transcript presentation are ordered by the timestamps that describe those specific facts.
 - Claude and shell terminals do not enter Codex reconciliation or acquire its ordering behavior.
 
@@ -74,29 +75,33 @@ Already-running installations may still send activity events without a session i
 
 ### SessionStart and durable boundaries
 
-An accepted `SessionStart` establishes the current session identity and transcript path. Session identity has its own persisted observation order, separate from activity and attention timestamps. This prevents a delayed event from one rail from incorrectly ordering another rail.
+An accepted `SessionStart` establishes the current session identity, transcript path, session-order watermark, and durable transcript boundary. The boundary is a byte offset: lifecycle records before it belong to an earlier process or session, and records at or after it are eligible evidence for the accepted session. Session identity has its own persisted observation order, separate from activity and attention timestamps. This prevents a delayed event from one rail from incorrectly ordering another rail.
 
-The first accepted Codex start attaches the terminal to its initial rollout; there is no earlier terminal session to fence. The database classifies that attachment inside the same transaction that accepts the start. It is initial only when the stored row has no session identity, transcript path, or session-order watermark. A partial legacy or damaged row with any of those history fields is a later attachment and fences conservatively.
+The first accepted Codex start attaches the terminal to its initial rollout; there is no earlier terminal session to fence. The database classifies that attachment inside the same transaction that accepts the start. It is initial only when the stored row has no session identity, transcript path, session-order watermark, or transcript boundary. An initial attachment stores boundary `0`, even when the transcript does not exist yet, so lifecycle records written before the hook arrived remain eligible. A partial legacy or damaged row with any history field is a later attachment and fences conservatively.
 
-A recreated Codex window is a deliberate fresh-process boundary, not a partial-history row. TBD first creates an inert replacement pane, then atomically stores its new tmux coordinates, clears the dead process's session identity, transcript path, session-order watermark, attention, and activity facts, and retains the tab's Codex label and kind. Only after that write commits does TBD respawn the pane with Codex, so the replacement process cannot send SessionStart against the dead process's history. Its first SessionStart is an initial attachment and may adopt lifecycle records it wrote before its hook arrived. Until that start arrives, session-bound activity hooks from the dead process mismatch the cleared identity and change nothing.
+Every later accepted Codex start, including a same-path resume, records the effective transcript's current EOF as its boundary. If the effective path is absent or unreadable, the start records `NULL`. The database persists this choice atomically with the accepted identity, path, and session-order watermark. Rejected or stale starts change none of those facts. Equal-time competing starts are first-wins so completion order cannot roll identity backward.
+
+Any path that clears or replaces Codex session identity without accepting an ordered `SessionStart` also clears the durable boundary. This rule prevents a new process from inheriting an offset chosen for a dead identity. A permission fact observed at the same time as, or after, SessionStart survives it; only a strictly older permission fact is retracted.
+
+A recreated Codex window is a deliberate fresh-process boundary, not a partial-history row. TBD first creates an inert replacement pane, then atomically stores its new tmux coordinates, clears the dead process's session identity, transcript path, session-order watermark, transcript boundary, attention, and activity facts, and retains the tab's Codex label and kind. Only after that write commits does TBD respawn the pane with Codex, so the replacement process cannot send SessionStart against the dead process's history. Its first SessionStart is an initial attachment and may adopt lifecycle records it wrote before its hook arrived. Until that start arrives, session-bound activity hooks from the dead process mismatch the cleared identity and change nothing.
 
 Failure before the durable reset leaves the old row unchanged and removes any inert replacement pane on a best-effort basis; the normal worktree and tmux reconciler reclaims the unmatched pane if cleanup fails. Failure while launching Codex after the reset leaves the row cleared and retryable and also removes the inert pane on a best-effort basis. If that cleanup fails, the row still names the replacement window, so the same reconciler continues to own it rather than leaving an untracked resource.
 
-Codex can write `session_meta` and `task_started` before the first SessionStart hook reaches TBD, so the tracker retains an existing baseline or performs its ordinary bounded tail bootstrap. Those already-written lifecycle records are eligible to present the initial prompt as working, and a later matching close advances that baseline to idle. If the rollout is temporarily unavailable, the tracker remembers that the live generation is initial and a later poll bootstraps when the file appears.
+Session-order watermarks use numeric epoch storage so distinct starts within one millisecond remain distinct; the decoder also accepts legacy datetime text rows. Tracker targets carry the identity, effective path, watermark, and boundary read back from the updated database row, so the live handler and later terminal-list reload identify the same durable generation. A later generation defeats an older delayed tracker operation.
 
-Every later accepted Codex start establishes a lifecycle boundary at the transcript's current end, including a same-path resume. Events before that boundary do not become current work in the new session. Session-order watermarks use numeric epoch storage so distinct starts within one millisecond remain distinct; the decoder also accepts legacy datetime text rows. Tracker session operations carry the watermark read back from the updated database row, so the live handler and later terminal-list reload use the same durable generation. A later generation defeats an older delayed tracker operation. Within the same generation, live initial-attachment knowledge defeats a conservative boundary reconstructed by a terminal-list call that raced ahead after database persistence.
-
-The persisted SessionStart fact lets a tracker with no in-memory generation state, such as after daemon restart, reconstruct the boundary conservatively at the current end. Boundary preparation or retry and stamped transcript observation happen in one tracker actor operation. If the file is unavailable, that reconstructed boundary remains pending and makes the transcript ineligible for ordinary bootstrap until a later poll captures its EOF. In-memory generation state is transient, terminal-keyed, and pruned with transcript baselines during worktree- or fleet-scoped retention.
-
-Rejected or stale SessionStart events do not change identity, transcript path, attention state, activity, or tracker boundaries. Equal-time competing starts are first-wins so completion order cannot roll identity backward. A permission fact observed at the same time as, or after, SessionStart survives it; only a strictly older permission fact is retracted.
+A `NULL` boundary means TBD cannot identify a safe historical starting point. The tracker captures the transcript's current EOF once for that target, uses it as an in-memory fence, and waits for later lifecycle evidence. This applies to pre-migration terminals and later attachments whose transcript was unavailable when SessionStart arrived. The database retains `NULL` until a later accepted SessionStart supplies a new boundary; tracker recovery never guesses or backfills one.
 
 ### Transcript tracker
 
-A daemon actor owns transcript baselines, incremental offsets, partial records, reducer state, and presentation observation ordering. Serial actor access gives observations a stable order without blocking on unrelated database state.
+A daemon actor owns transcript targets, recovery cursors, incremental offsets, partial records, reducer state, and presentation observation ordering. Serial actor access gives observations a stable order without blocking on unrelated database state.
 
-The tracker reads appended JSONL incrementally. Initial observation and truncation recovery inspect only a bounded tail. It preserves an unterminated fragment across reads, discards a record that grows beyond the record cap, and resumes at the next newline.
+Each target includes the terminal's current session identity, effective transcript path, session generation, and durable boundary. A cold tracker starts at a known boundary and captures the transcript's current EOF as a fixed recovery target. It replays forward in the existing fixed-size chunks and under the shared request budget, preserving its cursor and reducer between polls. It publishes authoritative unknown, which presents as idle, until the cursor reaches the captured EOF with no incomplete or discarding record. It then publishes the exact reconstructed working or idle state and resumes ordinary incremental reads from the same cursor.
 
-Fleet and worktree-scoped observations share a fair cyclic path order. Scoped polling cannot reset fleet progress or starve a deferred transcript. A terminal-list response revalidates terminal identity, transcript path, and session generation after the actor observation. If the transcript changed during the scan, the response returns the current identity with a newly ordered unknown presentation rather than stale activity from the old file.
+The fixed recovery EOF prevents a continuously growing transcript from keeping recovery perpetually behind. Bytes appended after capture wait for ordinary incremental polls once recovery reaches the fixed target.
+
+The tracker preserves an unterminated fragment across reads, discards a record that grows beyond the record cap, and resumes at the next newline. An initial attachment whose file truncates may reset to boundary `0` and replay the replacement file from its beginning. If a later attachment's file shrinks below its boundary, the tracker fences at the new EOF in memory and waits for new lifecycle evidence; it does not reinterpret pre-boundary history or replace the durable boundary.
+
+Fleet and worktree-scoped observations share a fair cyclic path order. Scoped polling cannot reset fleet progress or starve a deferred transcript. A terminal-list response revalidates terminal identity, transcript path, session generation, and durable boundary after the actor observation. If any target fact changed during the scan, the response returns the current identity with a newly ordered unknown presentation rather than stale activity from the old file.
 
 ### Lifecycle reducer
 
@@ -150,14 +155,14 @@ Raw generic idle hooks do not defeat a valid open transcript. Raw generic workin
 
 Terminal-list polling must not decode unbounded transcript history or perform unbounded zero-byte filesystem work.
 
-- An initial or truncation bootstrap reads at most 1 MiB of transcript content, plus the bounded boundary check.
+- Recovery reads fixed-size chunks and retains its cursor across requests; no request scans the whole backlog.
 - A terminal-list observation has a shared 1 MiB byte budget across Codex transcripts.
 - Pending transcripts receive 64 KiB round-robin quanta.
 - One observation performs at most 16 filesystem steps, including caught-up and unreadable paths that consume no content bytes.
 - A single JSONL record is capped at 1 MiB. Oversized records are discarded through their newline.
 - Partial, discarding, untouched, and not-yet-caught-up paths publish unknown rather than cached working.
 
-Large backlogs converge over multiple polls. A continuously growing early path cannot consume every request because the cyclic cursor advances across requests and survives scoped polling and path removal.
+Large backlogs converge over multiple polls, regardless of how far the relevant lifecycle event lies from EOF. A continuously growing early path cannot consume every request because the cyclic cursor advances across requests and survives scoped polling and path removal.
 
 Field measurements found lifecycle lines near 3 KiB at the 99th percentile and about 21 KiB at the observed maximum. The 1 MiB record cap leaves substantial margin while bounding memory and scan cost.
 
@@ -166,13 +171,15 @@ Field measurements found lifecycle lines near 3 KiB at the 99th percentile and a
 - **Incomplete final record** — retain the bounded fragment, publish unknown, and retry after more bytes arrive.
 - **Oversized record** — discard through the next newline, publish unknown while discarding, then resume normal parsing.
 - **Unreadable file** — publish unknown and retry on a later observation.
-- **Truncation or replacement** — rebuild from the bounded tail and do not reuse incompatible reducer evidence.
+- **Initial-attachment truncation or replacement** — discard incompatible reducer evidence and replay from boundary `0`.
+- **Later-attachment shrink below the boundary** — fence at the new EOF in memory, publish unknown, and wait for later lifecycle evidence.
 - **Backlog beyond the request budget** — preserve incremental progress and publish unknown until caught up.
-- **Transcript identity changes during a scan** — discard the old-path result and publish an ordered unknown for the current identity.
-- **Initial task precedes SessionStart** — bootstrap or retain the first session's bounded baseline so already-written lifecycle evidence remains eligible.
-- **Terminal list races initial tracker attachment** — order both operations by the persisted session generation; same-generation initial knowledge replaces the speculative restart boundary.
-- **Initial rollout is temporarily unavailable** — retain the initial-generation mode without positive evidence, then use the ordinary bounded bootstrap when the file appears.
-- **Daemon restart after SessionStart** — reconstruct the boundary conservatively at the current end so an orphaned historical start cannot restore working.
+- **Target changes during a scan** — discard the old result when identity, path, generation, or boundary revalidation fails, then publish an ordered unknown for the current target.
+- **Initial task precedes SessionStart** — replay from durable boundary `0`, so already-written lifecycle evidence remains eligible.
+- **Terminal list races tracker attachment** — bind both operations to the complete persisted target; same-generation work with a different boundary cannot publish.
+- **Initial rollout is temporarily unavailable** — retain boundary `0` without positive evidence, then replay from zero when the file appears.
+- **Daemon restart with a known boundary** — capture a fixed EOF, replay progressively from the durable boundary, and publish unknown until caught up.
+- **Daemon restart with a `NULL` boundary** — fence at the current EOF in memory and wait for new evidence rather than guessing at historical eligibility.
 - **Delayed old-session hook with identity** — reject it before any mutation.
 - **Legacy hook without identity** — accept it for upgrade compatibility; subsequent session-bound hooks restore full protection.
 
@@ -192,9 +199,11 @@ The design uses aggregate counts and schema behavior only. No rollout content or
 
 ## Persistence and compatibility
 
-New shared-model and RPC fields are optional so older JSON continues to decode. Database ordering fields are nullable so pre-migration rows retain an explicit unknown state and fall back to their existing semantic timestamps where required.
+The `terminal` table gains `codexTranscriptBoundaryOffset INTEGER` with no SQL default. Its GRDB record and shared `Terminal` model expose the value as `Int64?`. The shared model decodes the field with `decodeIfPresent`, so older JSON remains valid. Pre-migration rows read `NULL`, not `0`; `NULL` preserves the distinction between a known initial boundary and an unknown safe boundary.
 
-Session identity order is persisted independently from activity order. Presentation order is transient because it describes observations produced by the live transcript tracker rather than a durable user or hook fact.
+The migration file, GRDB record, and shared model change together. The Swift migration escape hatch also omits a default if it must add the missing column. Existing RPC payloads remain compatible because the new field is optional.
+
+Session identity order and the transcript boundary are persisted independently from activity order but atomically with each other. Presentation order, recovery cursors, captured recovery EOFs, and reducer state remain transient because they describe observations produced by the live transcript tracker rather than durable user or hook facts.
 
 Generated hook configuration is refreshed through the existing plugin installation path. Mixed-version clients remain usable because identity-free activity events are accepted and new wire fields are optional.
 
@@ -212,26 +221,35 @@ Reducer tests cover:
 
 Tracker tests cover:
 
-- initial tail bootstrap, truncation, and incremental reads;
+- a fresh tracker replaying from boundary `0` when `task_started` lies more than 1 MiB before EOF;
+- early bounded observations publishing unknown, then converging to working after reaching the fixed recovery EOF;
+- completion or abort after an old start converging to idle;
+- a later-session boundary excluding an unmatched start before the boundary;
+- fixed-EOF recovery when the transcript grows during catch-up, followed by ordinary incremental reads;
+- initial-attachment replay from zero after truncation and later-attachment in-memory fencing after shrink below the boundary;
 - 64 KiB boundaries and unterminated fragments;
 - oversized-record discard and recovery;
 - unreadable-file recovery;
 - per-request byte and step limits;
 - fleet fairness, scoped polling, path removal, and reordering;
-- atomic first-attachment classification, including partial-history rows, concurrent starts, sub-millisecond ordering, and legacy datetime rows;
-- same-generation list/adoption races, pending-boundary observation, unavailable initial rollouts, later-generation precedence, and generation-state retention;
-- later SessionStart boundaries, daemon reconstruction, and same-path invalidation;
-- transcript identity rollover during concurrent list calls.
+- target changes during suspended observation, including identity, path, generation, and boundary changes.
 
 Daemon and wire tests cover:
 
+- migration of pre-existing rows to a `NULL` boundary and model round trips for `0`, positive offsets, and `NULL`;
+- backward-compatible shared-model decoding when the boundary field is absent;
+- initial attachment storing `0`, including when the transcript is not yet readable;
+- later attachment storing the effective transcript EOF or `NULL` when the file is unavailable;
+- atomic first-attachment classification, including partial-history rows, concurrent starts, sub-millisecond ordering, and legacy datetime rows;
+- stale and retried SessionStart events leaving the accepted boundary unchanged;
+- identity-clearing and identity-replacement paths clearing the boundary;
 - current-session hook acceptance and stale-session rejection;
 - legacy identity-free hook compatibility;
 - atomic ordering of session, activity, and attention facts;
 - equal-time precedence;
 - Ctrl+C persistence and later supersession;
 - bounded hook-payload parsing and JSON round trips;
-- migration of nullable ordering fields.
+- a terminal-list integration path that loads a database-backed terminal into a fresh tracker and recovers activity after daemon-state loss.
 
 App and sidebar tests cover:
 
@@ -248,12 +266,15 @@ Verification includes focused suites for each layer, `scripts/swift-safe build`,
 
 - **Hooks alone** — hooks do not reliably close every interrupted or resumed turn and can arrive after session rollover.
 - **Transcript alone** — it cannot provide immediate Ctrl+C feedback or preserve a permission prompt over an open task.
+- **Bounded tail recovery** — an open turn whose start lies before the tail window remains falsely idle after tracker state is lost.
+- **Persisting the reducer checkpoint** — storing the cursor and open-task state would require frequent database writes and crash-consistency rules, and a stale checkpoint could restore false working.
+- **Searching backward from EOF** — reverse lifecycle correlation is more complex, and a long-running open turn still requires scanning nearly the entire transcript.
 - **A task stack** — copied parent history and orphaned starts would be restored after the current subagent task closes, creating false working.
 - **A default-off flag** — the legacy path is the known failure and parallel modes would preserve conflicting interpretations. Conservative idle fallback bounds the replacement's risk.
 - **Terminal screen scraping** — rendered TUI text is not a stable machine interface.
 
 ## Operational impact
 
-The design adds no new durable external resource and requires no new reconciler. It reads existing rollout files, persists ordering metadata in the existing terminal record, and uses existing RPC and hook installation paths.
+The design adds no new durable external resource and requires no new reconciler. It reads existing rollout files, persists ordering metadata and the transcript boundary in the existing terminal record, and uses existing RPC and hook installation paths.
 
 No automatic process control, input injection, deletion, or background actuation is introduced. The change affects only Codex activity observation and presentation.

--- a/docs/specs/2026-08-29-terminal-process-incarnation-design.md
+++ b/docs/specs/2026-08-29-terminal-process-incarnation-design.md
@@ -1,0 +1,183 @@
+# Terminal Process Incarnation Design
+
+## Purpose
+
+A terminal row outlives the process running in its tmux pane. TBD may replace
+that process when a terminal is recreated, a model profile changes, or a
+session hibernates and wakes. Process hooks can arrive after the originating
+process has exited, and tmux coordinates and agent session IDs can both be
+reused. Neither value alone proves that a hook belongs to the process the row
+currently represents.
+
+TBD assigns each managed terminal process a durable incarnation token. The
+token travels in the process environment and returns through process-bound
+hook RPCs. The daemon validates it in the same database transaction that
+applies the hook. This design defines that shared lifecycle for Claude, Codex,
+and replacement shells.
+
+## Goals
+
+- Reject SessionStart and activity hooks from replaced processes.
+- Make replacement safe when tmux coordinates or agent session IDs are reused.
+- Represent the prepare interval of a two-step hibernation replacement without
+  claiming either the outgoing or future process owns the row.
+- Accept hooks from a newly launched wake process while the parked marker
+  remains until tmux confirms launch.
+- Recover safely after a crash or failed replacement.
+- Preserve compatibility for terminals launched before incarnation tokens.
+
+## Non-goals
+
+- Changing activity interpretation for any terminal kind.
+- Changing when terminals hibernate, wake, or recreate.
+- Making notification hooks or arbitrary agent protocols incarnation-aware.
+- Making tmux process replacement transactional with the database.
+- Introducing a general event-sourcing or process-leasing framework.
+
+## Durable state
+
+Each terminal row has two optional UUIDs:
+
+- **Current incarnation** — `sessionIncarnationID` names the process that owns
+  the row. TBD exports it as `TBD_TERMINAL_INCARNATION_ID` when launching that
+  process.
+- **Pending incarnation** — `pendingSessionIncarnationID` names a replacement
+  being prepared but not yet confirmed. It is normally `NULL`.
+
+Both fields are optional for database and JSON compatibility. A row with both
+fields `NULL` is a legacy row. A non-null pending token is a durable replacement
+phase, not the identity of a running process.
+
+The terminal replacement snapshots used for compare-and-swap operations carry
+both tokens. Any competing replacement, rollback, or wake therefore makes a
+stale operation fail rather than overwrite the winner.
+
+## Core invariants
+
+- A process-bound SessionStart or activity event is accepted only when the
+  pending token is `NULL` and the reported optional token exactly equals the
+  current optional token.
+- Exact optional equality preserves legacy behavior: a missing token matches
+  only a legacy row whose current token is also `NULL`.
+- Once a row has a managed current token, a missing or different token is
+  stale.
+- While a pending token exists, no process-bound SessionStart or activity event
+  is accepted. The current token is retained only as rollback identity, and the
+  pending token does not belong to a launched process yet.
+- App-originated user interrupts are actions against the selected terminal, not
+  process hooks. They bypass process identity validation and remain accepted.
+- Token validation and the resulting terminal mutation happen in one database
+  writer transaction.
+- Every one-step process reset clears any pending token as it installs its new
+  current token.
+
+## One-step replacement
+
+Most replacement paths can establish their complete launch intent before they
+start a new process. Recreated Claude, Codex, and shell windows, profile swaps,
+and wake preparation atomically:
+
+1. Compare the caller's replacement snapshot with the durable row.
+2. Set any new tmux coordinates and process-owned session fields.
+3. Mint and store a new current token.
+4. Clear the pending token and process-local activity, prompt, ordering, and
+   transcript-boundary facts as appropriate for that path.
+5. Commit before launching the process with the returned token.
+
+A hook can race the launch, but it cannot arrive before the durable identity it
+must report exists. A delayed outgoing hook reports the former token and loses
+the atomic comparison.
+
+## Two-step hibernation replacement
+
+Hibernation is different because TBD first records park intent and then asks
+tmux to replace a live agent with an inert shell. The outgoing agent may remain
+alive if tmux replacement fails, so changing the current token at prepare time
+would prevent startup recovery from recognizing and restoring that still-live
+process.
+
+The prepare transaction therefore:
+
+1. Verifies the complete hibernation snapshot.
+2. Retains the outgoing process's current token.
+3. Mints a pending token.
+4. Records the parked marker and cancels scheduled resume.
+5. Stores idle activity with database provenance and clears prompt state.
+
+The non-null pending token makes subsequent process-bound hooks inert. This
+prevents a delayed or still-exiting agent from restoring working activity after
+the row is parked, while retaining its current token for rollback.
+
+TBD then asks tmux to replace the agent with an inert process. Only after tmux
+confirms that replacement does the finalize transaction promote the exact
+pending token to current, clear pending, and reset process-local ordering and
+attention facts. The promoted token is injected into the replacement shell.
+Promotion cannot happen earlier: before tmux confirmation the outgoing process
+may still be the real pane occupant, and a crash must remain recoverable.
+
+## Wake while parked
+
+The parked marker describes user-visible lifecycle state; it is not an
+incarnation gate. It deliberately remains set from wake preparation until tmux
+confirms that the new agent launched.
+
+Wake preparation is a one-step process reset. It replaces any abandoned
+pending token, installs a fresh current token, clears pending, and commits
+before launch. SessionStart and activity from the new process can therefore be
+accepted by exact current-token equality even while the row is still marked
+parked. Launch confirmation clears only the parked fields and preserves session
+and activity facts already accepted from the new process.
+
+Using `isParked` as the hook gate would reject these legitimate wake events.
+Inferring the replacement phase from activity provenance or terminal kind would
+also conflate observable state with process ownership. The explicit pending
+token is the smallest durable state that distinguishes prepare from wake.
+
+## Failure and recovery
+
+- **Failure before prepare commits** — the row and running process are
+  unchanged.
+- **Failure after prepare while the old agent is still alive** — startup
+  reconciliation proves the agent is live and clears the parked and pending
+  fields. The retained current token continues to identify that process.
+- **Failure after the pane becomes inert but before finalize** — the row remains
+  parked with a pending token, so no old hook can mutate it. A later wake
+  preparation replaces the pending token with a fresh current token before
+  launching an agent.
+- **Failure after finalize** — the inert replacement owns the promoted current
+  token and the row remains parked. Wake follows the normal one-step reset.
+- **Failure after wake preparation but before launch confirmation** — the row
+  remains parked with the new current token and no pending token. A matching
+  early hook is valid; a retry compares the full replacement snapshot and
+  rotates the token again if it wins.
+- **Startup finds a live replacement agent while parked** — reconciliation
+  clears the parked and pending fields without replacing the current token, so
+  any already accepted SessionStart or activity remains attached.
+
+The existing hibernation startup reconciler owns these crash states. Existing
+worktree and tmux reconciliation owns unmatched windows and panes. This design
+creates no new external durable resource.
+
+## Terminal-kind behavior
+
+- **Claude** — SessionStart and activity hooks report and validate the process
+  token. Activity keeps its existing last-writer and same-value behavior after
+  identity acceptance.
+- **Codex** — SessionStart and activity hooks use the same process fence before
+  Codex-specific ordering, transcript boundary, and presentation reconciliation.
+- **Shell** — replacement shells receive tokens so a later transition can
+  compare process generations. Shell activity, where present, keeps legacy
+  semantics after identity acceptance.
+
+## Compatibility and observability
+
+The pending database column has no SQL default. Existing rows migrate to
+`NULL`, and older encoded `Terminal` values decode it as `nil`. The hook RPC
+token remains optional, allowing mixed-version clients to decode while exact
+optional equality prevents an old client from mutating a managed row.
+
+Rejected hook events are idempotent no-ops. They do not change session,
+activity, prompt, ordering, or scheduled-resume state and do not broadcast a
+terminal activity transition. No new autonomous actuation, timer, or feature
+flag is introduced; this fence hardens process replacements TBD already
+performs.

--- a/docs/specs/2026-08-29-terminal-process-incarnation-design.md
+++ b/docs/specs/2026-08-29-terminal-process-incarnation-design.md
@@ -17,7 +17,8 @@ and replacement shells.
 
 ## Goals
 
-- Reject SessionStart and activity hooks from replaced processes.
+- Reject SessionStart, activity, SessionEnd delegation changes, and delayed
+  session recapture from replaced processes.
 - Make replacement safe when tmux coordinates or agent session IDs are reused.
 - Represent the prepare interval of a two-step hibernation replacement without
   claiming either the outgoing or future process owns the row.
@@ -31,6 +32,8 @@ and replacement shells.
 - Changing activity interpretation for any terminal kind.
 - Changing when terminals hibernate, wake, or recreate.
 - Making notification hooks or arbitrary agent protocols incarnation-aware.
+- Ordering client delta delivery for an observation that committed before a
+  later replacement.
 - Making tmux process replacement transactional with the database.
 - Introducing a general event-sourcing or process-leasing framework.
 
@@ -54,20 +57,28 @@ stale operation fail rather than overwrite the winner.
 
 ## Core invariants
 
-- A process-bound SessionStart or activity event is accepted only when the
-  pending token is `NULL` and the reported optional token exactly equals the
-  current optional token.
+- A process-bound SessionStart, activity event, or session recapture is accepted
+  only when the pending token is `NULL` and its expected optional token exactly
+  equals the current optional token.
 - Exact optional equality preserves legacy behavior: a missing token matches
   only a legacy row whose current token is also `NULL`.
 - Once a row has a managed current token, a missing or different token is
   stale.
-- While a pending token exists, no process-bound SessionStart or activity event
-  is accepted. The current token is retained only as rollback identity, and the
-  pending token does not belong to a launched process yet.
+- While a pending token exists, no process-bound SessionStart, activity event,
+  or session recapture is accepted. The current token is retained only as
+  rollback identity, and the pending token does not belong to a launched
+  process yet.
 - App-originated user interrupts are actions against the selected terminal, not
   process hooks. They bypass process identity validation and remain accepted.
 - Token validation and the resulting terminal mutation happen in one database
   writer transaction.
+- An accepted working hook cancels its scheduled resume in that same writer
+  transaction, so a replacement cannot interleave and lose its own later
+  schedule.
+- Deferred Claude delegation marks, claims, and SessionEnd clears carry their
+  process token. Sampling and process-derived clearing discard mismatched
+  tokens, while an app-originated user interrupt still clears the selected
+  terminal across incarnations.
 - Every one-step process reset clears any pending token as it installs its new
   current token.
 
@@ -144,8 +155,9 @@ token is the smallest durable state that distinguishes prepare from wake.
   parked with a pending token, so no old hook can mutate it. A later wake
   preparation replaces the pending token with a fresh current token before
   launching an agent.
-- **Failure after finalize** — the inert replacement owns the promoted current
-  token and the row remains parked. Wake follows the normal one-step reset.
+- **Failure after finalize** — the row holds the token intended for the
+  replacement shell, while the hook-silent inert process remains in the pane
+  and the row stays parked. Wake follows the normal one-step reset.
 - **Failure after wake preparation but before launch confirmation** — the row
   remains parked with the new current token and no pending token. A matching
   early hook is valid; a retry compares the full replacement snapshot and
@@ -160,8 +172,10 @@ creates no new external durable resource.
 
 ## Terminal-kind behavior
 
-- **Claude** — SessionStart and activity hooks report and validate the process
-  token. Activity keeps its existing last-writer and same-value behavior after
+- **Claude** — SessionStart, activity, and SessionEnd hooks report the process
+  token. SessionStart and activity validate it transactionally; deferred
+  delegation marks, claims, and clears retain it through their actor hops.
+  Activity keeps its existing last-writer and same-value behavior after
   identity acceptance.
 - **Codex** — SessionStart and activity hooks use the same process fence before
   Codex-specific ordering, transcript boundary, and presentation reconciliation.
@@ -173,11 +187,11 @@ creates no new external durable resource.
 
 The pending database column has no SQL default. Existing rows migrate to
 `NULL`, and older encoded `Terminal` values decode it as `nil`. The hook RPC
-token remains optional, allowing mixed-version clients to decode while exact
+tokens remain optional, allowing mixed-version clients to decode while exact
 optional equality prevents an old client from mutating a managed row.
 
-Rejected hook events are idempotent no-ops. They do not change session,
-activity, prompt, ordering, or scheduled-resume state and do not broadcast a
-terminal activity transition. No new autonomous actuation, timer, or feature
-flag is introduced; this fence hardens process replacements TBD already
-performs.
+Rejected hook events and session recaptures are idempotent no-ops. They do not
+change session, activity, prompt, ordering, or scheduled-resume state and do
+not broadcast a terminal activity transition. No new autonomous actuation,
+timer, or feature flag is introduced; this fence hardens process replacements
+TBD already performs.


### PR DESCRIPTION
## What's broken

After the daemon restarts or a managed terminal process is replaced, the terminal can lose its working indicator or accept delayed state from the process that no longer owns the pane. Large Codex transcripts make recovery especially visible: if the open turn began outside a bounded tail, rebuilding from the full transcript can take minutes while the sidebar remains unknown or idle. Hibernation, wake, recreation, and profile replacement also have intervals where tmux has changed process state but delayed hooks are still arriving.

## Why it happens

Activity recovery previously depended on transient tracker state and a bounded transcript tail. Process replacement also treated tmux coordinates and agent session IDs as sufficient identity, even though both can be reused. Hook handling, deferred delegation work, session recapture, and scheduled resume cancellation could therefore observe one process and mutate the row after a replacement won. The hibernation compare-and-swap also compared re-encoded JSON text, so equivalent fact objects with a different key order could be rejected intermittently.

## What this PR does

- Persists Codex transcript boundaries and reconstructs cold activity with a bounded reverse anchor search followed by forward replay of only the necessary suffix. Presentation remains unknown until recovery is definitive.
- Gives every managed terminal process a durable incarnation token and validates process-bound SessionStart, activity, SessionEnd delegation work, and delayed session recapture against it.
- Adds a nullable pending incarnation for the two-step hibernation replacement interval. Outgoing hooks become inert before tmux replacement, the current token remains available for rollback, and the pending token is promoted only after replacement succeeds.
- Makes accepted working activity cancel its scheduled resume in the same transaction, and carries incarnation identity through deferred Claude delegation actor hops.
- Compares persisted activity facts by their decoded values rather than JSON object key order, while keeping SQL NULL distinct from malformed non-null data.
- Runs blocking test-gate continuations on real owned threads rather than a private dispatch queue, so gate-heavy regression coverage cannot exhaust libdispatch workers and starve unrelated test work.
- Documents the shared Claude, Codex, and shell replacement lifecycle in `docs/specs/2026-08-29-terminal-process-incarnation-design.md` and reconciles the Codex activity design with it.

## Evidence & verification

- Regressions cover reverse recovery outside the active transcript window, stale hooks across replacement, staged hibernation, wake-time SessionStart, session recapture, SessionEnd delegation clearing, scheduled-resume races, JSON key-order independence, and malformed persisted facts.
- A 100-case concurrent stress run reproduced the pre-fix JSON comparison failure and passed after semantic comparison.
- The final focused incarnation, activity, and hibernation matrix passed 138 tests in 5 suites.
- A 64-holder gate stress reproduced dispatch-worker exhaustion before the test-infrastructure fix. The gate suite then passed 10 consecutive runs, and the relevant 244-test matrix passed.
- `scripts/swift-safe build`, strict SwiftLint, migration lint, and diff checks pass.
- The complete fenced suite was run on the final commit. All changed daemon/shared areas pass under full parallel load. The run remains red only in unchanged baseline areas: the three `ScratchpadCollectorTests` base-directory assertions, four `MarkdownWebViewConfigurationTests` URL-policy assertions, and one transcript row-height estimator assertion.
- Live restart verification recovered the current Codex presentation state from a large transcript and resumed incremental observation.

[🧠 Fix Codex Thinking Recovery](https://cheapsteak.github.io/tbd/open/?worktree=79A0DA6B-0F6D-4AD5-A8BF-88570E840ECD)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable Codex activity recovery across restarts, transcript truncation, incomplete records, and sessions beginning outside the transcript tail.
  * Added configurable CLI executable paths and terminal session identity tracking.
  * Added durable recovery state for Codex transcript boundaries.

* **Bug Fixes**
  * Prevented stale session and activity events from overwriting newer terminal state.
  * Improved hibernation, wake, profile switching, and terminal recreation reliability.
  * Preserved recoverable state when replacement launches fail.
  * Added backward-compatible handling for older session event data.
  * Improved delegation tracking across terminal session replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->