### PR TITLE
Diagnostic: measure the app-side commit latency of terminal frames (default-off)

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -3536,6 +3536,26 @@ final class AppState {
         defaults.object(forKey: enableTranscriptKey) as? Bool ?? enableTranscriptDefault
     }
 
+    /// UserDefaults key gating the terminal commit-latency diagnostic
+    /// (`TerminalCommitLatencyProbe`), a temporary instrument that measures
+    /// app-draw → render-server-commit. There is deliberately no Settings
+    /// toggle: it logs at `.info` once per display cycle, so it is turned on
+    /// for a measurement session and off again —
+    /// `defaults write TBDApp enableCommitLatencyDiagnostic -bool true`,
+    /// then relaunch.
+    nonisolated static let enableCommitLatencyDiagnosticKey = "enableCommitLatencyDiagnostic"
+
+    /// The one default for `enableCommitLatencyDiagnosticKey`. OFF: per-frame
+    /// `.info` logging is far too heavy to ship on.
+    nonisolated static let enableCommitLatencyDiagnosticDefault = false
+
+    /// Read of the commit-latency diagnostic gate. Defaults to off when the
+    /// user has never set the key.
+    nonisolated static func commitLatencyDiagnosticEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enableCommitLatencyDiagnosticKey) as? Bool
+            ?? enableCommitLatencyDiagnosticDefault
+    }
+
     /// UserDefaults key for a Claude spawn-env setting, by registry ID.
     nonisolated static func claudeEnvKey(_ settingID: String) -> String {
         "claudeEnvSetting.\(settingID)"

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -141,6 +141,23 @@ class TBDTerminalView: TerminalView {
         return .passthrough
     }
 
+    /// Instrumented only while the commit-latency diagnostic is on. With the
+    /// flag off `shared` is nil and this is `super.viewWillDraw()` plus one
+    /// branch: no timestamps, no completion block, no logging.
+    ///
+    /// `viewWillDraw` rather than `draw(_:)` because SwiftTerm's `draw(_:)` is
+    /// `public`, not `open`, and so cannot be overridden from this module. See
+    /// `TerminalCommitLatencyProbe` for how the far end of the draw is stamped
+    /// and for what the numbers do and do not cover.
+    override func viewWillDraw() {
+        super.viewWillDraw()
+        guard let probe = TerminalCommitLatencyProbe.shared else { return }
+        probe.recordDrawWillBegin(
+            at: probe.timestamp(),
+            isOnScreen: TerminalCommitLatencyProbe.isOnScreen(self)
+        )
+    }
+
     override func layout() {
         super.layout()
         if !didFireReady && bounds.width > 0 && bounds.height > 0 {

--- a/Sources/TBDApp/Terminal/TerminalCommitLatencyProbe.swift
+++ b/Sources/TBDApp/Terminal/TerminalCommitLatencyProbe.swift
@@ -1,0 +1,301 @@
+import AppKit
+import Foundation
+import QuartzCore
+import SwiftTerm
+import os
+
+/// Measures the one leg of the terminal render path nothing else instruments:
+/// **app finishes drawing → the render server has committed that frame.**
+///
+/// ## What this is a lower bound on
+///
+/// This is NOT time-to-glass. `CATransaction`'s completion block fires once
+/// the render server has committed the transaction; everything after that —
+/// `WindowServer` compositing the layer tree, the display's own scanout — is
+/// invisible here. Every number this probe emits is therefore a **lower
+/// bound** on what a user perceives, and a future reader must not quote it as
+/// a keystroke-to-pixel figure.
+///
+/// ## Why this leg
+///
+/// The lag investigation closed off everything upstream with numbers: TBD's
+/// client parity with other emulators (#750), a main thread measured 83% idle
+/// during a confirmed lag episode, idle SwiftTerm IO threads, and tmux at
+/// 0.1–0.4% CPU. `sample` could follow the trail as far as
+/// `CA::Transaction::commit` and then lost it at the process boundary, with
+/// `WindowServer` at 57–66% CPU. The remaining hypothesis is that TBD's deep
+/// SwiftUI-hosted layer tree degrades under a loaded compositor where
+/// iTerm2's single flat layer does not. This probe puts a number on the first
+/// half of that gap.
+///
+/// ## The two seams
+///
+/// SwiftTerm's `TerminalView.draw(_:)` is `public`, not `open`, so a subclass
+/// outside that module cannot override it and bracket the draw directly. The
+/// two ends are therefore stamped from the two hooks that ARE reachable:
+///
+/// - **`viewWillDraw()`** (`open` on `NSView`, `open override` on
+///   `TerminalView`) — the start. AppKit sends it to each view it is about to
+///   draw, on the main thread, inside the display cycle's transaction, which
+///   is what makes the completion-block registration land on the right
+///   transaction.
+/// - **`TerminalView.onFramePresented`** — the end of the app's drawing.
+///   SwiftTerm's fork provides it as a diagnostics hook and calls it at the
+///   end of `draw` on the main thread (the Core Graphics path; TBD does not
+///   use the Metal renderer). TBD uses it nowhere else, so the probe takes
+///   sole ownership of it while the diagnostic is on.
+///
+/// AppKit sends `viewWillDraw` to a whole subtree before drawing any of it, so
+/// the two hooks cannot be paired per view. `drawms` is therefore the *span* —
+/// first terminal view about to draw → last terminal draw returned — not a sum
+/// of per-view draw bodies. The span is the more useful of the two anyway: it
+/// includes whatever AppKit does between the terminal draws.
+///
+/// ## Per-transaction, not per-view
+///
+/// Several terminal views can draw in one display cycle, and they all land in
+/// the same `CATransaction`. The probe therefore keys its state on the
+/// *cycle*, not the view: `t0` is stamped at the first terminal draw of a
+/// cycle, later draws only add to the count, and exactly one line is logged
+/// when the completion block fires. Registering a block per view would
+/// overwrite the previous one (see `defaultRegisterCommitCompletion`) and
+/// measure nonsense.
+///
+/// ## Reading the output
+///
+/// One `.info` line per instrumented display cycle, on subsystem
+/// `com.tbd.app`, category `commitlatency`:
+///
+///     commit draws=<n> drawms=<f> commitms=<f> vis=<0|1>
+///
+/// - `draws` — terminal views that drew in this transaction
+/// - `drawms` — first terminal view about to draw → last terminal draw
+///   returned (the app-side paint span)
+/// - `commitms` — first draw's start → render server committed (the missing leg)
+/// - `vis` — 1 if at least one of those views was genuinely on screen
+///
+/// Plus, when a cycle is abandoned (see `staleCycleSeconds`):
+///
+///     commitdrop cycles=<cumulative count>
+///
+/// `scripts/diag/commit-latency-report.py` parses both.
+///
+/// ## Gating
+///
+/// Default OFF behind `AppState.enableCommitLatencyDiagnosticKey`. Per-frame
+/// `.info` logging is far too heavy to ship on, and this registers a
+/// completion block on a transaction it does not own — neither is acceptable
+/// outside a measurement session.
+@MainActor
+final class TerminalCommitLatencyProbe {
+    /// Where a finished line goes. Injected so tests can capture without a
+    /// log-store round trip.
+    typealias Emit = @MainActor (String) -> Void
+
+    /// Registers a block to run once the render server has committed the
+    /// transaction currently in flight.
+    typealias RegisterCommitCompletion = @MainActor (@escaping @Sendable () -> Void) -> Void
+
+    nonisolated static let logger = Logger(subsystem: "com.tbd.app", category: "commitlatency")
+
+    /// A cycle whose completion block has not fired this long after its first
+    /// draw is assumed lost and abandoned, so one swallowed block cannot wedge
+    /// the instrument for the rest of the session. A block is lost whenever
+    /// AppKit or SwiftUI sets its own completion block on the same transaction
+    /// after we set ours — `setCompletionBlock` replaces, it does not chain.
+    nonisolated static let staleCycleSeconds: Double = 0.5
+
+    /// Monotonic seconds. `Duration` is behaviour, `Date` is data, and this is
+    /// behaviour — so uptime, not wall clock, and never a `Date` difference.
+    private let now: @MainActor () -> Double
+    private let registerCommitCompletion: RegisterCommitCompletion
+    private let emit: Emit
+
+    private struct Cycle {
+        let id: UInt64
+        let startedAt: Double
+        var draws: Int
+        /// When the last terminal draw in this cycle returned. Nil until the
+        /// first `onFramePresented`; a cycle can in principle be invalidated
+        /// without any view actually drawing, and then `drawms` is 0.
+        var lastPresentedAt: Double?
+        var anyOnScreen: Bool
+    }
+
+    private var cycle: Cycle?
+    private var nextCycleID: UInt64 = 0
+    private var droppedCycles = 0
+
+    init(
+        now: @escaping @MainActor () -> Double = { ProcessInfo.processInfo.systemUptime },
+        registerCommitCompletion: @escaping RegisterCommitCompletion
+            = TerminalCommitLatencyProbe.defaultRegisterCommitCompletion,
+        emit: @escaping Emit = { line in
+            TerminalCommitLatencyProbe.logger.info("\(line, privacy: .public)")
+        }
+    ) {
+        self.now = now
+        self.registerCommitCompletion = registerCommitCompletion
+        self.emit = emit
+    }
+
+    /// The probe's own clock, so the call site stamps both ends of a draw off
+    /// the same source the completion block will use.
+    func timestamp() -> Double { now() }
+
+    // MARK: - Recording
+
+    /// Called from `TBDTerminalView.viewWillDraw()`, which AppKit sends on the
+    /// main thread inside the transaction it is building for this display
+    /// cycle — that is what makes the completion-block registration land on
+    /// the right transaction.
+    func recordDrawWillBegin(at startedAt: Double, isOnScreen: Bool) {
+        if var open = cycle {
+            if startedAt - open.startedAt > Self.staleCycleSeconds {
+                // The completion block for that cycle never arrived. Drop it
+                // and start fresh rather than counting draws into a cycle that
+                // will never be reported.
+                droppedCycles += 1
+                emit("commitdrop cycles=\(droppedCycles)")
+                cycle = nil
+            } else {
+                open.draws += 1
+                open.anyOnScreen = open.anyOnScreen || isOnScreen
+                cycle = open
+                return
+            }
+        }
+
+        nextCycleID += 1
+        let id = nextCycleID
+        cycle = Cycle(
+            id: id,
+            startedAt: startedAt,
+            draws: 1,
+            lastPresentedAt: nil,
+            anyOnScreen: isOnScreen
+        )
+        registerCommitCompletion { [weak self] in
+            // CoreAnimation runs the completion block on the thread that
+            // committed the transaction, which for an AppKit display cycle is
+            // the main thread. Hopping via `DispatchQueue.main.async` instead
+            // would fold an unrelated dispatch latency into `commitms`.
+            MainActor.assumeIsolated {
+                self?.completeCycle(id: id)
+            }
+        }
+    }
+
+    /// Called from `TerminalView.onFramePresented` at the end of a terminal
+    /// draw. Only moves the end of the app-side paint span; a frame presented
+    /// with no cycle open (nothing of ours drew) is ignored.
+    func recordFramePresented(at presentedAt: Double) {
+        guard cycle != nil else { return }
+        cycle?.lastPresentedAt = presentedAt
+    }
+
+    private func completeCycle(id: UInt64) {
+        // A block from an already-abandoned cycle must not close the current
+        // one; the id makes stale blocks inert.
+        guard let open = cycle, open.id == id else { return }
+        let committedAt = now()
+        cycle = nil
+        let drawSeconds = (open.lastPresentedAt ?? open.startedAt) - open.startedAt
+        emit(
+            "commit draws=\(open.draws)"
+                + " drawms=\(Self.millis(drawSeconds))"
+                + " commitms=\(Self.millis(committedAt - open.startedAt))"
+                + " vis=\(open.anyOnScreen ? 1 : 0)"
+        )
+    }
+
+    nonisolated private static func millis(_ seconds: Double) -> String {
+        String(format: "%.3f", seconds * 1000)
+    }
+
+    // MARK: - CoreAnimation seam
+
+    /// Registers `block` on the `CATransaction` currently in flight.
+    ///
+    /// **`CATransaction.setCompletionBlock` has no getter and unconditionally
+    /// replaces any block already set on this transaction.** There is no way
+    /// to read the incumbent and chain to it. Two consequences we accept
+    /// because this is a default-off diagnostic and for no other reason:
+    /// a block someone else set earlier in this cycle is discarded by us, and
+    /// a block someone else sets later discards ours (that cycle then reports
+    /// nothing and is eventually counted by the stale-cycle drop). Setting one
+    /// per view instead of one per cycle would make the second case the common
+    /// case.
+    static func defaultRegisterCommitCompletion(_ block: @escaping @Sendable () -> Void) {
+        CATransaction.setCompletionBlock(block)
+    }
+
+    /// Points SwiftTerm's frame-presented diagnostics hook at this probe.
+    ///
+    /// The hook is a process-wide static with a single slot, so installing
+    /// takes sole ownership of it. That is safe here only because TBD uses it
+    /// nowhere else; a second user would need a real fan-out in the fork. Only
+    /// `shared` installs, so a probe built by `make(defaults:)` in a test
+    /// never touches process-global state.
+    func installFramePresentedHook() {
+        TerminalView.onFramePresented = { [weak self] in
+            // SwiftTerm calls this on the main thread from the Core Graphics
+            // `draw` path, and off-main only from the Metal renderer — which
+            // TBD does not use. Ignoring a non-main call keeps that assumption
+            // from turning into a crash if it ever stops holding, and hopping
+            // to main instead would fold dispatch latency into the span.
+            guard Thread.isMainThread else { return }
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.recordFramePresented(at: self.now())
+            }
+        }
+    }
+
+    // MARK: - Visibility
+
+    /// Whether AppKit would actually put this view's pixels on screen.
+    ///
+    /// TBD keeps terminals for unselected worktrees alive and fed inside a
+    /// visible window, so the window-level checks alone are not enough:
+    /// `window.occlusionState` reports the *window*, and admits views that
+    /// AppKit correctly never draws because they are clipped entirely out of
+    /// their scroll/pager container. The non-empty `visibleRect` is what
+    /// separates those.
+    static func isOnScreen(_ view: NSView) -> Bool {
+        guard let window = view.window, window.isVisible else { return false }
+        guard window.occlusionState.contains(.visible) else { return false }
+        return !view.visibleRect.isEmpty
+    }
+
+    // MARK: - Gate
+
+    private static var didResolveShared = false
+    private static var sharedStorage: TerminalCommitLatencyProbe?
+
+    /// The process-wide probe, or `nil` when the diagnostic is off — which is
+    /// the default. `nil` is the whole gate: the draw call site's `guard let`
+    /// falls straight through to `super.draw`, so nothing is timed, nothing is
+    /// logged, and no completion block is registered.
+    ///
+    /// Resolved once, on the first terminal draw. Flipping the flag takes
+    /// effect on the next launch; a measurement session starts with a relaunch
+    /// anyway.
+    static var shared: TerminalCommitLatencyProbe? {
+        if !didResolveShared {
+            didResolveShared = true
+            sharedStorage = make(defaults: .standard)
+            sharedStorage?.installFramePresentedHook()
+        }
+        return sharedStorage
+    }
+
+    /// Builds a probe if the flag in `defaults` is on, `nil` otherwise. The
+    /// injectable half of `shared`, so both branches of the gate are testable
+    /// without touching `UserDefaults.standard` — which on this unbundled
+    /// executable is the developer's live `TBDApp.plist`.
+    static func make(defaults: UserDefaults) -> TerminalCommitLatencyProbe? {
+        guard AppState.commitLatencyDiagnosticEnabled(defaults: defaults) else { return nil }
+        return TerminalCommitLatencyProbe()
+    }
+}

--- a/Sources/TBDApp/Terminal/TerminalCommitLatencyProbe.swift
+++ b/Sources/TBDApp/Terminal/TerminalCommitLatencyProbe.swift
@@ -4,17 +4,61 @@ import QuartzCore
 import SwiftTerm
 import os
 
-/// Measures the one leg of the terminal render path nothing else instruments:
-/// **app finishes drawing → the render server has committed that frame.**
+/// Measures a leg of the terminal render path nothing else instruments:
+/// **app starts drawing → the app has finished committing that frame.**
 ///
-/// ## What this is a lower bound on
+/// ## What it actually measures — read this before quoting a number
 ///
-/// This is NOT time-to-glass. `CATransaction`'s completion block fires once
-/// the render server has committed the transaction; everything after that —
-/// `WindowServer` compositing the layer tree, the display's own scanout — is
-/// invisible here. Every number this probe emits is therefore a **lower
-/// bound** on what a user perceives, and a future reader must not quote it as
-/// a keystroke-to-pixel figure.
+/// `commitms` is: first terminal `viewWillDraw` of a transaction → the
+/// `CATransaction` completion block for that transaction runs.
+///
+/// **That is app-side only. It does NOT cross into the render server, and it
+/// is nowhere near time-to-glass.** Measured on this machine with a real
+/// on-screen window and real committed layer changes, the completion block
+/// runs **12–99 microseconds after `CATransaction.commit()` returns**, on the
+/// same runloop turn. Nothing makes a round trip to `WindowServer` in 20µs.
+/// Apple's contract for `setCompletionBlock` says only that the block runs
+/// "as soon as all animations subsequent to this transaction group have
+/// completed", and that with no animations it "will be invoked immediately" —
+/// the render server is not mentioned, because it is not involved.
+///
+/// So this instrument covers the app's own cost of assembling and committing
+/// the frame — `CA::Transaction::commit` on the main thread, the last thing
+/// `sample` could see before the trail left the process. **The render-server
+/// leg remains uninstrumented.** No public API exposes it for a
+/// CoreGraphics-drawn `NSView`; `CAMetalDrawable.addPresentedHandler` would,
+/// but TBD does not use the Metal renderer.
+///
+/// A small `commitms` therefore licenses NO conclusion about the compositor.
+/// It says the app hands the frame over quickly, which was already the
+/// direction the evidence pointed. Do not read it as "the render server is
+/// fine".
+///
+/// ## The distortion that will bite you: animations
+///
+/// Because the block waits for *animations*, not for a commit, any animation
+/// added inside a transaction the probe marked redefines `commitms` for that
+/// cycle. Measured here:
+///
+/// - A finite 0.6s animation → the block fired **675ms** after commit. That
+///   sample reports the animation's duration and lands straight in p90/p99,
+///   looking exactly like the compositor stall this instrument was built to
+///   look for.
+/// - An infinite animation → the block **never fired**. The cycle is lost and
+///   surfaces as a `commitdrop`.
+///
+/// TBD's terminal has both shapes in it: SwiftTerm's caret blink is
+/// `repeatCount = .infinity` (`MacCaretView`), and the overlay scroller fades
+/// over 0.25s — during scrolling, which is the lag repro. These are added on
+/// state changes rather than per frame, so the effect is episodic, not
+/// constant.
+///
+/// **`sync` is the discriminator.** The probe schedules a marker for the end
+/// of the current runloop turn. `sync=1` means the completion block beat it —
+/// same turn, no animation wait, the number means what it says. `sync=0` means
+/// the block arrived later, so the sample is an animation wait, a commit that
+/// spanned turns, or both, and the two cannot be told apart from inside the
+/// process. Report `sync=1` and `sync=0` separately; never pool them.
 ///
 /// ## Why this leg
 ///
@@ -74,6 +118,16 @@ import os
 /// stopwatch.** `CATransaction.setValue(_:forKey:)` is a per-transaction store
 /// with a getter, so the probe stamps its cycle id there and reads it back on
 /// the next draw: same mark means same transaction, no mark means a new one.
+/// One edge the mark does not cover: a nested transaction inherits its
+/// parent's mark on read and discards its own writes at its commit (measured),
+/// so a terminal draw *joining* an existing cycle is safe. But a cycle's
+/// FIRST draw landing while a nested transaction is current would mark and
+/// register on the nested one, which commits early — `commitms` would measure
+/// that nested commit and later draws in the display cycle would read no mark
+/// and emit a spurious drop. TBD has one nested transaction, in
+/// `TypingDotsView.layout()`; interleaving it with a terminal draw is
+/// unlikely, and this is recorded rather than defended against.
+///
 /// An elapsed-time heuristic cannot do this job — AppKit's cadence is ~16.67ms,
 /// so any window wide enough to tolerate a slow commit is also wide enough to
 /// swallow the following cycle whole. That failure would grow with exactly the
@@ -85,7 +139,7 @@ import os
 /// One `.info` line per instrumented display cycle, on subsystem
 /// `com.tbd.app`, category `commitlatency`:
 ///
-///     commit draws=<n> paints=<n> drawms=<f> commitms=<f> vis=<0|1>
+///     commit draws=<n> paints=<n> drawms=<f> commitms=<f> vis=<0|1> sync=<0|1>
 ///
 /// - `draws` — terminal views that drew in this transaction
 /// - `paints` — terminal draws that actually reached the end of `draw`. Less
@@ -94,12 +148,14 @@ import os
 ///   "nothing painted" distinguishable from one that means "painted instantly".
 /// - `drawms` — first terminal view about to draw → last terminal draw
 ///   returned (the app-side paint span)
-/// - `commitms` — first draw's start → render server committed (the missing leg)
+/// - `commitms` — first draw's start → the transaction's completion block ran
 /// - `vis` — 1 if at least one of those views was genuinely on screen
+/// - `sync` — 1 if the completion block ran in the same runloop turn as the
+///   draw. Only `sync=1` samples are comparable; see above.
 ///
 /// Plus, one line per cycle whose completion block never fired:
 ///
-///     commitdrop draws=<n>
+///     commitdrop draws=<n> vis=<0|1>
 ///
 /// One line per lost cycle rather than a running total, so a reader working
 /// over a time window counts the drops in that window rather than inheriting a
@@ -133,8 +189,9 @@ final class TerminalCommitLatencyProbe {
         var mark: @MainActor () -> UInt64?
 
         /// Stamps `cycleID` on the transaction currently in flight and
-        /// registers `onCommitted` to run once the render server has committed
-        /// it.
+        /// registers `onCommitted` to run when CoreAnimation completes it —
+        /// which, absent animations, is microseconds later on the same
+        /// runloop turn. See the type header: this is not a render-server ack.
         var begin: @MainActor (_ cycleID: UInt64, _ onCommitted: @escaping @Sendable () -> Void) -> Void
 
         /// Key for the probe's per-transaction mark. Namespaced because the
@@ -163,12 +220,18 @@ final class TerminalCommitLatencyProbe {
         )
     }
 
+    /// Runs `body` once the current runloop turn's work has drained. Used
+    /// only to date-stamp the turn boundary for `sync`; injected so tests can
+    /// fire it deterministically.
+    typealias AfterCurrentTurn = @MainActor (@escaping @MainActor () -> Void) -> Void
+
     nonisolated static let logger = Logger(subsystem: "com.tbd.app", category: "commitlatency")
 
     /// Monotonic seconds. `Duration` is behaviour, `Date` is data, and this is
     /// behaviour — so uptime, not wall clock, and never a `Date` difference.
     private let now: @MainActor () -> Double
     private let transaction: TransactionSeam
+    private let afterCurrentTurn: AfterCurrentTurn
     private let emit: Emit
 
     private struct Cycle {
@@ -183,6 +246,11 @@ final class TerminalCommitLatencyProbe {
         /// nothing.
         var lastPresentedAt: Double?
         var anyOnScreen: Bool
+        /// False once the current runloop turn has drained with this cycle
+        /// still open — i.e. the completion block did not run in the same
+        /// turn as the draw, so an animation (or a commit spanning turns)
+        /// is folded into `commitms`.
+        var sameTurn: Bool
     }
 
     private var cycle: Cycle?
@@ -191,12 +259,16 @@ final class TerminalCommitLatencyProbe {
     init(
         now: @escaping @MainActor () -> Double = { ProcessInfo.processInfo.systemUptime },
         transaction: TransactionSeam = .coreAnimation,
+        afterCurrentTurn: @escaping AfterCurrentTurn = { body in
+            DispatchQueue.main.async { body() }
+        },
         emit: @escaping Emit = { line in
             TerminalCommitLatencyProbe.logger.info("\(line, privacy: .public)")
         }
     ) {
         self.now = now
         self.transaction = transaction
+        self.afterCurrentTurn = afterCurrentTurn
         self.emit = emit
     }
 
@@ -221,11 +293,15 @@ final class TerminalCommitLatencyProbe {
                 return
             }
             // A different transaction is in flight while our cycle is still
-            // open, so that cycle's completion block never fired — somebody
-            // replaced it. Report it lost, with the draws that went with it,
-            // instead of folding this transaction's draws into a frame that
-            // will never be reported.
-            emit("commitdrop draws=\(open.draws)")
+            // open, so that cycle's completion block has not run. Two causes,
+            // and from inside the process they are indistinguishable: somebody
+            // replaced our block on that transaction, or an animation in it is
+            // still running and CoreAnimation is still holding the block. Do
+            // not claim which. Report the cycle lost, with the draws and the
+            // visibility that went with it — drops cluster on animated frames
+            // rather than falling randomly, so a reader needs to know whether
+            // the lost ones were on screen.
+            emit("commitdrop draws=\(open.draws) vis=\(open.anyOnScreen ? 1 : 0)")
             cycle = nil
         }
 
@@ -237,13 +313,21 @@ final class TerminalCommitLatencyProbe {
             draws: 1,
             paints: 0,
             lastPresentedAt: nil,
-            anyOnScreen: isOnScreen
+            anyOnScreen: isOnScreen,
+            sameTurn: true
         )
+        afterCurrentTurn { [weak self] in
+            self?.markTurnEnded(id: id)
+        }
         transaction.begin(id) { [weak self] in
             // CoreAnimation runs the completion block on the thread that
             // committed the transaction, which for an AppKit display cycle is
             // the main thread. Hopping via `DispatchQueue.main.async` instead
-            // would fold an unrelated dispatch latency into `commitms`.
+            // would fold an unrelated dispatch latency into `commitms`. The
+            // guard matches `installFramePresentedHook`: if that assumption
+            // ever stops holding, this diagnostic goes quiet rather than
+            // crashing the app.
+            guard Thread.isMainThread else { return }
             MainActor.assumeIsolated {
                 self?.completeCycle(id: id)
             }
@@ -260,6 +344,15 @@ final class TerminalCommitLatencyProbe {
         cycle = open
     }
 
+    /// The current runloop turn has drained. If the cycle is still open its
+    /// completion block did not run in the same turn as the draw, so whatever
+    /// `commitms` ends up being is not a clean app-side commit.
+    private func markTurnEnded(id: UInt64) {
+        guard var open = cycle, open.id == id else { return }
+        open.sameTurn = false
+        cycle = open
+    }
+
     private func completeCycle(id: UInt64) {
         // A block from an already-abandoned cycle must not close the current
         // one; the id makes stale blocks inert.
@@ -273,6 +366,7 @@ final class TerminalCommitLatencyProbe {
                 + " drawms=\(Self.millis(drawSeconds))"
                 + " commitms=\(Self.millis(committedAt - open.startedAt))"
                 + " vis=\(open.anyOnScreen ? 1 : 0)"
+                + " sync=\(open.sameTurn ? 1 : 0)"
         )
     }
 

--- a/Sources/TBDApp/Terminal/TerminalCommitLatencyProbe.swift
+++ b/Sources/TBDApp/Terminal/TerminalCommitLatencyProbe.swift
@@ -39,6 +39,15 @@ import os
 ///   draw, on the main thread, inside the display cycle's transaction, which
 ///   is what makes the completion-block registration land on the right
 ///   transaction.
+///   `Package.swift` carries a standing warning from the #750 bump that a frame
+///   loop not running on the main thread may never call `viewWillDraw()`, so
+///   TBD's terminal diagnostics can go quiet. It does not bite here: SwiftTerm
+///   takes the render-loop path only when the Metal layer surface is enabled,
+///   TBD never enables it, and `frameTick` therefore falls through to
+///   `setNeedsDisplay` and an ordinary AppKit display pass. **If this
+///   instrument ever logs nothing at all, suspect that assumption before
+///   concluding there is no lag** — silence here is indistinguishable from a
+///   fast frame.
 /// - **`TerminalView.onFramePresented`** — the end of the app's drawing.
 ///   SwiftTerm's fork provides it as a diagnostics hook and calls it at the
 ///   end of `draw` on the main thread (the Core Graphics path; TBD does not
@@ -51,32 +60,53 @@ import os
 /// of per-view draw bodies. The span is the more useful of the two anyway: it
 /// includes whatever AppKit does between the terminal draws.
 ///
-/// ## Per-transaction, not per-view
+/// ## Per-transaction, not per-view — and the boundary is exact
 ///
-/// Several terminal views can draw in one display cycle, and they all land in
+/// Several terminal views can draw in one display cycle and they all land in
 /// the same `CATransaction`. The probe therefore keys its state on the
-/// *cycle*, not the view: `t0` is stamped at the first terminal draw of a
-/// cycle, later draws only add to the count, and exactly one line is logged
-/// when the completion block fires. Registering a block per view would
-/// overwrite the previous one (see `defaultRegisterCommitCompletion`) and
-/// measure nonsense.
+/// *transaction*: `t0` is stamped at the first terminal draw in a transaction,
+/// later draws in the same one fold into it — raising `draws`, and `vis` if
+/// any of them was on screen — and exactly one line is
+/// logged when the completion block fires. Registering a block per view would
+/// overwrite the previous one (see `TransactionSeam`) and measure nonsense.
+///
+/// **Transaction identity comes from the transaction itself, not from a
+/// stopwatch.** `CATransaction.setValue(_:forKey:)` is a per-transaction store
+/// with a getter, so the probe stamps its cycle id there and reads it back on
+/// the next draw: same mark means same transaction, no mark means a new one.
+/// An elapsed-time heuristic cannot do this job — AppKit's cadence is ~16.67ms,
+/// so any window wide enough to tolerate a slow commit is also wide enough to
+/// swallow the following cycle whole. That failure would grow with exactly the
+/// latency this instrument exists to characterize, silently merging frames and
+/// leaving later transactions with no completion block at all.
 ///
 /// ## Reading the output
 ///
 /// One `.info` line per instrumented display cycle, on subsystem
 /// `com.tbd.app`, category `commitlatency`:
 ///
-///     commit draws=<n> drawms=<f> commitms=<f> vis=<0|1>
+///     commit draws=<n> paints=<n> drawms=<f> commitms=<f> vis=<0|1>
 ///
 /// - `draws` — terminal views that drew in this transaction
+/// - `paints` — terminal draws that actually reached the end of `draw`. Less
+///   than `draws` means a view bailed before painting, and `drawms` is
+///   meaningless for that cycle; `paints=0` makes a `drawms=0.000` that means
+///   "nothing painted" distinguishable from one that means "painted instantly".
 /// - `drawms` — first terminal view about to draw → last terminal draw
 ///   returned (the app-side paint span)
 /// - `commitms` — first draw's start → render server committed (the missing leg)
 /// - `vis` — 1 if at least one of those views was genuinely on screen
 ///
-/// Plus, when a cycle is abandoned (see `staleCycleSeconds`):
+/// Plus, one line per cycle whose completion block never fired:
 ///
-///     commitdrop cycles=<cumulative count>
+///     commitdrop draws=<n>
+///
+/// One line per lost cycle rather than a running total, so a reader working
+/// over a time window counts the drops in that window rather than inheriting a
+/// process-lifetime counter. A cycle is declared lost the moment a draw arrives
+/// in a different transaction — promptly and exactly, not on a timer. The one
+/// loss that goes uncounted is a final cycle at the end of a session with no
+/// draw after it.
 ///
 /// `scripts/diag/commit-latency-report.py` parses both.
 ///
@@ -92,50 +122,81 @@ final class TerminalCommitLatencyProbe {
     /// log-store round trip.
     typealias Emit = @MainActor (String) -> Void
 
-    /// Registers a block to run once the render server has committed the
-    /// transaction currently in flight.
-    typealias RegisterCommitCompletion = @MainActor (@escaping @Sendable () -> Void) -> Void
+    /// The per-transaction seam: reads back the mark the probe left on the
+    /// `CATransaction` currently in flight, and stamps a new one together with
+    /// the completion block that closes it. Injected so tests can open and
+    /// commit transactions by hand.
+    struct TransactionSeam {
+        /// The cycle id the probe stamped on the transaction currently in
+        /// flight, or nil if it has not marked this one — which is exactly how
+        /// "a new transaction has begun" is detected.
+        var mark: @MainActor () -> UInt64?
+
+        /// Stamps `cycleID` on the transaction currently in flight and
+        /// registers `onCommitted` to run once the render server has committed
+        /// it.
+        var begin: @MainActor (_ cycleID: UInt64, _ onCommitted: @escaping @Sendable () -> Void) -> Void
+
+        /// Key for the probe's per-transaction mark. Namespaced because the
+        /// transaction's value store is shared with everything else drawing
+        /// in this process.
+        static let markKey = "com.tbd.app.commitLatency.cycle"
+
+        /// The real seam.
+        ///
+        /// **`CATransaction.setCompletionBlock` has no getter and
+        /// unconditionally replaces any block already set on this
+        /// transaction.** There is no way to read the incumbent and chain to
+        /// it. Two consequences we accept because this is a default-off
+        /// diagnostic and for no other reason: a block someone else set
+        /// earlier in this cycle is discarded by us, and a block someone else
+        /// sets later discards ours — that cycle then reports nothing and is
+        /// counted by the drop line at the next transaction. Setting one per
+        /// view instead of one per transaction would make the second case the
+        /// common case.
+        static let coreAnimation = TransactionSeam(
+            mark: { (CATransaction.value(forKey: markKey) as? NSNumber)?.uint64Value },
+            begin: { cycleID, onCommitted in
+                CATransaction.setValue(NSNumber(value: cycleID), forKey: markKey)
+                CATransaction.setCompletionBlock(onCommitted)
+            }
+        )
+    }
 
     nonisolated static let logger = Logger(subsystem: "com.tbd.app", category: "commitlatency")
-
-    /// A cycle whose completion block has not fired this long after its first
-    /// draw is assumed lost and abandoned, so one swallowed block cannot wedge
-    /// the instrument for the rest of the session. A block is lost whenever
-    /// AppKit or SwiftUI sets its own completion block on the same transaction
-    /// after we set ours — `setCompletionBlock` replaces, it does not chain.
-    nonisolated static let staleCycleSeconds: Double = 0.5
 
     /// Monotonic seconds. `Duration` is behaviour, `Date` is data, and this is
     /// behaviour — so uptime, not wall clock, and never a `Date` difference.
     private let now: @MainActor () -> Double
-    private let registerCommitCompletion: RegisterCommitCompletion
+    private let transaction: TransactionSeam
     private let emit: Emit
 
     private struct Cycle {
         let id: UInt64
         let startedAt: Double
         var draws: Int
-        /// When the last terminal draw in this cycle returned. Nil until the
-        /// first `onFramePresented`; a cycle can in principle be invalidated
-        /// without any view actually drawing, and then `drawms` is 0.
+        /// Terminal draws in this cycle that reached the end of `draw`.
+        var paints: Int
+        /// When the last terminal draw in this cycle returned. Nil while
+        /// `paints` is 0 — SwiftTerm's `draw` has early returns before its
+        /// frame-presented hook, so a view can be asked to draw and paint
+        /// nothing.
         var lastPresentedAt: Double?
         var anyOnScreen: Bool
     }
 
     private var cycle: Cycle?
     private var nextCycleID: UInt64 = 0
-    private var droppedCycles = 0
 
     init(
         now: @escaping @MainActor () -> Double = { ProcessInfo.processInfo.systemUptime },
-        registerCommitCompletion: @escaping RegisterCommitCompletion
-            = TerminalCommitLatencyProbe.defaultRegisterCommitCompletion,
+        transaction: TransactionSeam = .coreAnimation,
         emit: @escaping Emit = { line in
             TerminalCommitLatencyProbe.logger.info("\(line, privacy: .public)")
         }
     ) {
         self.now = now
-        self.registerCommitCompletion = registerCommitCompletion
+        self.transaction = transaction
         self.emit = emit
     }
 
@@ -147,23 +208,25 @@ final class TerminalCommitLatencyProbe {
 
     /// Called from `TBDTerminalView.viewWillDraw()`, which AppKit sends on the
     /// main thread inside the transaction it is building for this display
-    /// cycle — that is what makes the completion-block registration land on
+    /// cycle — that is what makes the mark and the completion block land on
     /// the right transaction.
     func recordDrawWillBegin(at startedAt: Double, isOnScreen: Bool) {
+        let mark = transaction.mark()
+
         if var open = cycle {
-            if startedAt - open.startedAt > Self.staleCycleSeconds {
-                // The completion block for that cycle never arrived. Drop it
-                // and start fresh rather than counting draws into a cycle that
-                // will never be reported.
-                droppedCycles += 1
-                emit("commitdrop cycles=\(droppedCycles)")
-                cycle = nil
-            } else {
+            if mark == open.id {
                 open.draws += 1
                 open.anyOnScreen = open.anyOnScreen || isOnScreen
                 cycle = open
                 return
             }
+            // A different transaction is in flight while our cycle is still
+            // open, so that cycle's completion block never fired — somebody
+            // replaced it. Report it lost, with the draws that went with it,
+            // instead of folding this transaction's draws into a frame that
+            // will never be reported.
+            emit("commitdrop draws=\(open.draws)")
+            cycle = nil
         }
 
         nextCycleID += 1
@@ -172,10 +235,11 @@ final class TerminalCommitLatencyProbe {
             id: id,
             startedAt: startedAt,
             draws: 1,
+            paints: 0,
             lastPresentedAt: nil,
             anyOnScreen: isOnScreen
         )
-        registerCommitCompletion { [weak self] in
+        transaction.begin(id) { [weak self] in
             // CoreAnimation runs the completion block on the thread that
             // committed the transaction, which for an AppKit display cycle is
             // the main thread. Hopping via `DispatchQueue.main.async` instead
@@ -190,8 +254,10 @@ final class TerminalCommitLatencyProbe {
     /// draw. Only moves the end of the app-side paint span; a frame presented
     /// with no cycle open (nothing of ours drew) is ignored.
     func recordFramePresented(at presentedAt: Double) {
-        guard cycle != nil else { return }
-        cycle?.lastPresentedAt = presentedAt
+        guard var open = cycle else { return }
+        open.paints += 1
+        open.lastPresentedAt = presentedAt
+        cycle = open
     }
 
     private func completeCycle(id: UInt64) {
@@ -203,6 +269,7 @@ final class TerminalCommitLatencyProbe {
         let drawSeconds = (open.lastPresentedAt ?? open.startedAt) - open.startedAt
         emit(
             "commit draws=\(open.draws)"
+                + " paints=\(open.paints)"
                 + " drawms=\(Self.millis(drawSeconds))"
                 + " commitms=\(Self.millis(committedAt - open.startedAt))"
                 + " vis=\(open.anyOnScreen ? 1 : 0)"
@@ -211,23 +278,6 @@ final class TerminalCommitLatencyProbe {
 
     nonisolated private static func millis(_ seconds: Double) -> String {
         String(format: "%.3f", seconds * 1000)
-    }
-
-    // MARK: - CoreAnimation seam
-
-    /// Registers `block` on the `CATransaction` currently in flight.
-    ///
-    /// **`CATransaction.setCompletionBlock` has no getter and unconditionally
-    /// replaces any block already set on this transaction.** There is no way
-    /// to read the incumbent and chain to it. Two consequences we accept
-    /// because this is a default-off diagnostic and for no other reason:
-    /// a block someone else set earlier in this cycle is discarded by us, and
-    /// a block someone else sets later discards ours (that cycle then reports
-    /// nothing and is eventually counted by the stale-cycle drop). Setting one
-    /// per view instead of one per cycle would make the second case the common
-    /// case.
-    static func defaultRegisterCommitCompletion(_ block: @escaping @Sendable () -> Void) {
-        CATransaction.setCompletionBlock(block)
     }
 
     /// Points SwiftTerm's frame-presented diagnostics hook at this probe.
@@ -274,9 +324,10 @@ final class TerminalCommitLatencyProbe {
     private static var sharedStorage: TerminalCommitLatencyProbe?
 
     /// The process-wide probe, or `nil` when the diagnostic is off — which is
-    /// the default. `nil` is the whole gate: the draw call site's `guard let`
-    /// falls straight through to `super.draw`, so nothing is timed, nothing is
-    /// logged, and no completion block is registered.
+    /// the default. `nil` is the whole gate: `TBDTerminalView.viewWillDraw()`
+    /// returns right after its `super.viewWillDraw()` call, so nothing is
+    /// timed, nothing is logged, no transaction is marked, and no completion
+    /// block is registered.
     ///
     /// Resolved once, on the first terminal draw. Flipping the flag takes
     /// effect on the next launch; a measurement session starts with a relaunch

--- a/Tests/TBDAppTests/TerminalCommitLatencyProbeTests.swift
+++ b/Tests/TBDAppTests/TerminalCommitLatencyProbeTests.swift
@@ -16,22 +16,41 @@ import Testing
 struct TerminalCommitLatencyProbeTests {
     // MARK: - Harness
 
-    /// Drives the probe with a hand-cranked clock and a captured completion
-    /// block, so a display cycle can be replayed deterministically.
+    /// Drives the probe with a hand-cranked clock and a fake transaction, so a
+    /// display cycle can be replayed deterministically — including the cases
+    /// real CoreAnimation will not stage on demand: a transaction whose
+    /// completion block someone else replaced, and two transactions arriving
+    /// closer together than any timer could separate.
     @MainActor
     private final class Harness {
         var now: Double = 0
         var lines: [String] = []
-        /// Blocks handed to `registerCommitCompletion`, in registration order.
+        /// Completion blocks, in registration order.
         var registered: [@Sendable () -> Void] = []
+
+        /// The mark on the transaction currently in flight, standing in for
+        /// `CATransaction`'s per-transaction value store.
+        private var mark: UInt64?
         private(set) var probe: TerminalCommitLatencyProbe!
 
         init() {
             probe = TerminalCommitLatencyProbe(
                 now: { [unowned self] in self.now },
-                registerCommitCompletion: { [unowned self] block in self.registered.append(block) },
+                transaction: TerminalCommitLatencyProbe.TransactionSeam(
+                    mark: { [unowned self] in self.mark },
+                    begin: { [unowned self] id, onCommitted in
+                        self.mark = id
+                        self.registered.append(onCommitted)
+                    }
+                ),
                 emit: { [unowned self] line in self.lines.append(line) }
             )
+        }
+
+        /// End the transaction currently in flight without committing it —
+        /// the next draw will find no mark and so belongs to a new one.
+        func beginNewTransaction() {
+            mark = nil
         }
 
         /// One terminal view about to draw, then that draw finishing `costMs`
@@ -42,11 +61,19 @@ struct TerminalCommitLatencyProbeTests {
             probe.recordFramePresented(at: now)
         }
 
+        /// A view asked to draw that bails before painting — SwiftTerm's
+        /// `draw` has early returns before its frame-presented hook.
+        func drawWithoutPainting(isOnScreen: Bool = true) {
+            probe.recordDrawWillBegin(at: now, isOnScreen: isOnScreen)
+        }
+
         /// Fire the most recently registered completion block, as CoreAnimation
-        /// would once the render server has committed.
+        /// would once the render server has committed, and end the transaction.
         func commit(afterMs: Double) {
             now += afterMs / 1000
-            registered.last?()
+            let block = registered.last
+            mark = nil
+            block?()
         }
     }
 
@@ -97,7 +124,7 @@ struct TerminalCommitLatencyProbeTests {
         harness.draw(costMs: 2)
         #expect(harness.lines.isEmpty, "nothing is reported until the render server commits")
         harness.commit(afterMs: 8)
-        #expect(harness.lines == ["commit draws=1 drawms=2.000 commitms=10.000 vis=1"])
+        #expect(harness.lines == ["commit draws=1 paints=1 drawms=2.000 commitms=10.000 vis=1"])
     }
 
     @Test("several views drawing in one cycle produce ONE line, not one per view")
@@ -108,7 +135,7 @@ struct TerminalCommitLatencyProbeTests {
         harness.draw(costMs: 3)
         #expect(harness.registered.count == 1, "exactly one completion block per transaction")
         harness.commit(afterMs: 4)
-        #expect(harness.lines == ["commit draws=3 drawms=6.000 commitms=10.000 vis=1"])
+        #expect(harness.lines == ["commit draws=3 paints=3 drawms=6.000 commitms=10.000 vis=1"])
     }
 
     @Test("vis=0 only when every view in the cycle was off screen")
@@ -134,8 +161,8 @@ struct TerminalCommitLatencyProbeTests {
         harness.commit(afterMs: 20)
         #expect(harness.registered.count == 2)
         #expect(harness.lines == [
-            "commit draws=1 drawms=1.000 commitms=5.000 vis=1",
-            "commit draws=1 drawms=2.000 commitms=22.000 vis=1",
+            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1",
+            "commit draws=1 paints=1 drawms=2.000 commitms=22.000 vis=1",
         ])
     }
 
@@ -149,23 +176,57 @@ struct TerminalCommitLatencyProbeTests {
         harness.now = 10
         harness.draw(costMs: 1)
         harness.commit(afterMs: 1)
-        #expect(harness.lines == ["commit draws=1 drawms=1.000 commitms=2.000 vis=1"])
+        #expect(harness.lines == ["commit draws=1 paints=1 drawms=1.000 commitms=2.000 vis=1"])
     }
 
-    @Test("a swallowed completion block is dropped, not wedged forever")
-    func staleCycleIsAbandoned() {
+    @Test("a new transaction one frame later is a NEW cycle, not more draws on the old one")
+    func backToBackTransactionsDoNotMerge() {
         let harness = Harness()
         harness.draw(costMs: 1)
-        // Someone else set their own completion block on that transaction, so
-        // ours never fires. The next draw arrives well past the stale window.
-        harness.now += TerminalCommitLatencyProbe.staleCycleSeconds + 0.1
+        harness.commit(afterMs: 4)
+
+        // 16.67ms later — inside any plausible time window, and a different
+        // transaction. An elapsed-time boundary would fold this into the
+        // previous cycle; the transaction mark does not.
+        harness.now += 0.01667
         harness.draw(costMs: 1)
-        #expect(harness.lines == ["commitdrop cycles=1"])
+        harness.commit(afterMs: 4)
+
+        #expect(harness.registered.count == 2, "each transaction gets its own completion block")
+        #expect(harness.lines == [
+            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1",
+            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1",
+        ])
+    }
+
+    @Test("a swallowed completion block is reported lost at the next transaction")
+    func lostCycleIsReportedPromptly() {
+        let harness = Harness()
+        harness.draw(costMs: 1)
+        harness.draw(costMs: 1)
+        // Someone else replaced our completion block on that transaction, so
+        // it never fires. The transaction ends anyway.
+        harness.beginNewTransaction()
+
+        harness.draw(costMs: 1)
+        #expect(harness.lines == ["commitdrop draws=2"], "the lost cycle's draw count is reported")
+
         harness.commit(afterMs: 3)
         #expect(harness.lines == [
-            "commitdrop cycles=1",
-            "commit draws=1 drawms=1.000 commitms=4.000 vis=1",
+            "commitdrop draws=2",
+            "commit draws=1 paints=1 drawms=1.000 commitms=4.000 vis=1",
         ])
+    }
+
+    @Test("each lost cycle gets its own line, so a windowed reader counts only its window")
+    func eachLostCycleIsItsOwnLine() {
+        let harness = Harness()
+        for _ in 0..<3 {
+            harness.draw(costMs: 1)
+            harness.beginNewTransaction()
+        }
+        harness.draw(costMs: 1)
+        #expect(harness.lines == ["commitdrop draws=1", "commitdrop draws=1", "commitdrop draws=1"])
     }
 
     @Test("a late block from an abandoned cycle cannot close the current one")
@@ -173,7 +234,7 @@ struct TerminalCommitLatencyProbeTests {
         let harness = Harness()
         harness.draw(costMs: 1)
         let abandoned = harness.registered[0]
-        harness.now += TerminalCommitLatencyProbe.staleCycleSeconds + 0.1
+        harness.beginNewTransaction()
         harness.draw(costMs: 1)
         harness.lines.removeAll()
 
@@ -181,6 +242,14 @@ struct TerminalCommitLatencyProbeTests {
         #expect(harness.lines.isEmpty, "the stale block must not report the new cycle")
 
         harness.commit(afterMs: 2)
-        #expect(harness.lines == ["commit draws=1 drawms=1.000 commitms=3.000 vis=1"])
+        #expect(harness.lines == ["commit draws=1 paints=1 drawms=1.000 commitms=3.000 vis=1"])
+    }
+
+    @Test("paints=0 distinguishes a draw that painted nothing from an instant paint")
+    func drawWithoutPaintIsDistinguishable() {
+        let harness = Harness()
+        harness.drawWithoutPainting()
+        harness.commit(afterMs: 7)
+        #expect(harness.lines == ["commit draws=1 paints=0 drawms=0.000 commitms=7.000 vis=1"])
     }
 }

--- a/Tests/TBDAppTests/TerminalCommitLatencyProbeTests.swift
+++ b/Tests/TBDAppTests/TerminalCommitLatencyProbeTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QuartzCore
 import Testing
 @testable import TBDApp
 
@@ -31,6 +32,8 @@ struct TerminalCommitLatencyProbeTests {
         /// The mark on the transaction currently in flight, standing in for
         /// `CATransaction`'s per-transaction value store.
         private var mark: UInt64?
+        /// Turn-boundary markers, in registration order. Fired by `endTurn()`.
+        private var turnEndMarkers: [@MainActor () -> Void] = []
         private(set) var probe: TerminalCommitLatencyProbe!
 
         init() {
@@ -43,8 +46,25 @@ struct TerminalCommitLatencyProbeTests {
                         self.registered.append(onCommitted)
                     }
                 ),
+                afterCurrentTurn: { [unowned self] body in self.turnEndMarkers.append(body) },
                 emit: { [unowned self] line in self.lines.append(line) }
             )
+        }
+
+        /// Drain the runloop turn without the completion block having fired —
+        /// what CoreAnimation does when an animation in the transaction is
+        /// still running.
+        func endTurn() {
+            let markers = turnEndMarkers
+            turnEndMarkers.removeAll()
+            for marker in markers { marker() }
+        }
+
+        /// Fire only the OLDEST pending turn marker, leaving later ones armed:
+        /// an earlier turn's marker draining after a new cycle has begun.
+        func fireOldestTurnMarker() {
+            guard !turnEndMarkers.isEmpty else { return }
+            turnEndMarkers.removeFirst()()
         }
 
         /// End the transaction currently in flight without committing it —
@@ -124,7 +144,7 @@ struct TerminalCommitLatencyProbeTests {
         harness.draw(costMs: 2)
         #expect(harness.lines.isEmpty, "nothing is reported until the render server commits")
         harness.commit(afterMs: 8)
-        #expect(harness.lines == ["commit draws=1 paints=1 drawms=2.000 commitms=10.000 vis=1"])
+        #expect(harness.lines == ["commit draws=1 paints=1 drawms=2.000 commitms=10.000 vis=1 sync=1"])
     }
 
     @Test("several views drawing in one cycle produce ONE line, not one per view")
@@ -135,7 +155,7 @@ struct TerminalCommitLatencyProbeTests {
         harness.draw(costMs: 3)
         #expect(harness.registered.count == 1, "exactly one completion block per transaction")
         harness.commit(afterMs: 4)
-        #expect(harness.lines == ["commit draws=3 paints=3 drawms=6.000 commitms=10.000 vis=1"])
+        #expect(harness.lines == ["commit draws=3 paints=3 drawms=6.000 commitms=10.000 vis=1 sync=1"])
     }
 
     @Test("vis=0 only when every view in the cycle was off screen")
@@ -143,13 +163,13 @@ struct TerminalCommitLatencyProbeTests {
         let offscreen = Harness()
         offscreen.draw(costMs: 1, isOnScreen: false)
         offscreen.commit(afterMs: 1)
-        #expect(offscreen.lines.first?.hasSuffix("vis=0") == true)
+        #expect(offscreen.lines.first?.contains(" vis=0 ") == true)
 
         let mixed = Harness()
         mixed.draw(costMs: 1, isOnScreen: false)
         mixed.draw(costMs: 1, isOnScreen: true)
         mixed.commit(afterMs: 1)
-        #expect(mixed.lines.first?.hasSuffix("vis=1") == true)
+        #expect(mixed.lines.first?.contains(" vis=1 ") == true)
     }
 
     @Test("consecutive cycles are measured independently")
@@ -161,8 +181,8 @@ struct TerminalCommitLatencyProbeTests {
         harness.commit(afterMs: 20)
         #expect(harness.registered.count == 2)
         #expect(harness.lines == [
-            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1",
-            "commit draws=1 paints=1 drawms=2.000 commitms=22.000 vis=1",
+            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1 sync=1",
+            "commit draws=1 paints=1 drawms=2.000 commitms=22.000 vis=1 sync=1",
         ])
     }
 
@@ -176,26 +196,30 @@ struct TerminalCommitLatencyProbeTests {
         harness.now = 10
         harness.draw(costMs: 1)
         harness.commit(afterMs: 1)
-        #expect(harness.lines == ["commit draws=1 paints=1 drawms=1.000 commitms=2.000 vis=1"])
+        #expect(harness.lines == ["commit draws=1 paints=1 drawms=1.000 commitms=2.000 vis=1 sync=1"])
     }
 
-    @Test("a new transaction one frame later is a NEW cycle, not more draws on the old one")
-    func backToBackTransactionsDoNotMerge() {
+    /// Back-to-back committed cycles stay separate. This does NOT discriminate
+    /// the transaction mark from the elapsed-time boundary it replaced — the
+    /// first cycle is already closed by its commit, so both designs agree. The
+    /// tests that actually fail under the old design are
+    /// `lostCycleIsReportedPromptly`, `eachLostCycleIsItsOwnLine` and
+    /// `staleBlockIsInert`, which all leave a cycle open across a transaction
+    /// boundary.
+    @Test("back-to-back committed cycles are reported separately")
+    func backToBackCyclesStaySeparate() {
         let harness = Harness()
         harness.draw(costMs: 1)
         harness.commit(afterMs: 4)
 
-        // 16.67ms later — inside any plausible time window, and a different
-        // transaction. An elapsed-time boundary would fold this into the
-        // previous cycle; the transaction mark does not.
         harness.now += 0.01667
         harness.draw(costMs: 1)
         harness.commit(afterMs: 4)
 
         #expect(harness.registered.count == 2, "each transaction gets its own completion block")
         #expect(harness.lines == [
-            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1",
-            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1",
+            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1 sync=1",
+            "commit draws=1 paints=1 drawms=1.000 commitms=5.000 vis=1 sync=1",
         ])
     }
 
@@ -209,12 +233,12 @@ struct TerminalCommitLatencyProbeTests {
         harness.beginNewTransaction()
 
         harness.draw(costMs: 1)
-        #expect(harness.lines == ["commitdrop draws=2"], "the lost cycle's draw count is reported")
+        #expect(harness.lines == ["commitdrop draws=2 vis=1"], "the lost cycle's draw count is reported")
 
         harness.commit(afterMs: 3)
         #expect(harness.lines == [
-            "commitdrop draws=2",
-            "commit draws=1 paints=1 drawms=1.000 commitms=4.000 vis=1",
+            "commitdrop draws=2 vis=1",
+            "commit draws=1 paints=1 drawms=1.000 commitms=4.000 vis=1 sync=1",
         ])
     }
 
@@ -226,7 +250,7 @@ struct TerminalCommitLatencyProbeTests {
             harness.beginNewTransaction()
         }
         harness.draw(costMs: 1)
-        #expect(harness.lines == ["commitdrop draws=1", "commitdrop draws=1", "commitdrop draws=1"])
+        #expect(harness.lines == ["commitdrop draws=1 vis=1", "commitdrop draws=1 vis=1", "commitdrop draws=1 vis=1"])
     }
 
     @Test("a late block from an abandoned cycle cannot close the current one")
@@ -242,7 +266,58 @@ struct TerminalCommitLatencyProbeTests {
         #expect(harness.lines.isEmpty, "the stale block must not report the new cycle")
 
         harness.commit(afterMs: 2)
-        #expect(harness.lines == ["commit draws=1 paints=1 drawms=1.000 commitms=3.000 vis=1"])
+        #expect(harness.lines == ["commit draws=1 paints=1 drawms=1.000 commitms=3.000 vis=1 sync=1"])
+    }
+
+    @Test("sync=0 when the completion block missed its runloop turn — the animation case")
+    func deferredCompletionIsMarkedUnsynchronized() {
+        let harness = Harness()
+        harness.draw(costMs: 1)
+        // CoreAnimation holds the block while an animation in the transaction
+        // runs, so the turn drains first.
+        harness.endTurn()
+        harness.commit(afterMs: 674)
+        #expect(harness.lines == ["commit draws=1 paints=1 drawms=1.000 commitms=675.000 vis=1 sync=0"])
+    }
+
+    @Test("a turn-end marker from an already-closed cycle cannot mark a later one")
+    func turnEndMarkerIsScopedToItsCycle() {
+        let harness = Harness()
+        harness.draw(costMs: 1)
+        harness.commit(afterMs: 1)
+        harness.draw(costMs: 1)
+        // The first cycle's marker drains now; it must not touch cycle two.
+        harness.fireOldestTurnMarker()
+        harness.commit(afterMs: 1)
+        #expect(harness.lines.allSatisfy { $0.hasSuffix("sync=1") })
+    }
+
+    // MARK: - The real CoreAnimation seam
+    //
+    // Every other test drives the injected fake, so without these the whole
+    // point of the mark/getter mechanism is unpinned: a typo in `markKey` or a
+    // change to the NSNumber cast would stay green.
+
+    @Test("the real transaction seam round-trips its mark")
+    func coreAnimationSeamRoundTrips() {
+        let seam = TerminalCommitLatencyProbe.TransactionSeam.coreAnimation
+        CATransaction.begin()
+        defer { CATransaction.commit() }
+        #expect(seam.mark() == nil, "a fresh transaction carries no mark")
+        seam.begin(4242) {}
+        #expect(seam.mark() == 4242)
+    }
+
+    @Test("the real transaction seam's mark does not survive its transaction")
+    func coreAnimationSeamMarkDiesWithTheTransaction() {
+        CATransaction.begin()
+        TerminalCommitLatencyProbe.TransactionSeam.coreAnimation.begin(7) {}
+        CATransaction.commit()
+        CATransaction.flush()
+        #expect(
+            TerminalCommitLatencyProbe.TransactionSeam.coreAnimation.mark() == nil,
+            "no mark is exactly how a new transaction is detected"
+        )
     }
 
     @Test("paints=0 distinguishes a draw that painted nothing from an instant paint")
@@ -250,6 +325,6 @@ struct TerminalCommitLatencyProbeTests {
         let harness = Harness()
         harness.drawWithoutPainting()
         harness.commit(afterMs: 7)
-        #expect(harness.lines == ["commit draws=1 paints=0 drawms=0.000 commitms=7.000 vis=1"])
+        #expect(harness.lines == ["commit draws=1 paints=0 drawms=0.000 commitms=7.000 vis=1 sync=1"])
     }
 }

--- a/Tests/TBDAppTests/TerminalCommitLatencyProbeTests.swift
+++ b/Tests/TBDAppTests/TerminalCommitLatencyProbeTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tests for `TerminalCommitLatencyProbe` — the app-draw → render-server-commit
+/// instrument — and for the `enableCommitLatencyDiagnostic` gate that keeps it
+/// off by default.
+///
+/// Isolation matters: TBDApp ships as an unbundled SPM executable, so its
+/// `UserDefaults.standard` domain is `TBDApp.plist` in the developer's home —
+/// the same domain a running production TBDApp reads. Every test below drives
+/// the gate through a per-test `UserDefaults(suiteName:)` and tears the domain
+/// down afterwards, so `.standard` is never touched.
+@MainActor
+@Suite("Terminal commit-latency probe")
+struct TerminalCommitLatencyProbeTests {
+    // MARK: - Harness
+
+    /// Drives the probe with a hand-cranked clock and a captured completion
+    /// block, so a display cycle can be replayed deterministically.
+    @MainActor
+    private final class Harness {
+        var now: Double = 0
+        var lines: [String] = []
+        /// Blocks handed to `registerCommitCompletion`, in registration order.
+        var registered: [@Sendable () -> Void] = []
+        private(set) var probe: TerminalCommitLatencyProbe!
+
+        init() {
+            probe = TerminalCommitLatencyProbe(
+                now: { [unowned self] in self.now },
+                registerCommitCompletion: { [unowned self] block in self.registered.append(block) },
+                emit: { [unowned self] line in self.lines.append(line) }
+            )
+        }
+
+        /// One terminal view about to draw, then that draw finishing `costMs`
+        /// later — the `viewWillDraw` / `onFramePresented` pair.
+        func draw(costMs: Double, isOnScreen: Bool = true) {
+            probe.recordDrawWillBegin(at: now, isOnScreen: isOnScreen)
+            now += costMs / 1000
+            probe.recordFramePresented(at: now)
+        }
+
+        /// Fire the most recently registered completion block, as CoreAnimation
+        /// would once the render server has committed.
+        func commit(afterMs: Double) {
+            now += afterMs / 1000
+            registered.last?()
+        }
+    }
+
+    private func withIsolatedDefaults(
+        seed: Bool?,
+        _ body: (UserDefaults) -> Void
+    ) {
+        let suiteName = "TBDAppTests.CommitLatency.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        if let seed {
+            defaults.set(seed, forKey: AppState.enableCommitLatencyDiagnosticKey)
+        }
+        body(defaults)
+    }
+
+    // MARK: - The gate, both branches
+
+    @Test("flag off: no probe exists, so the draw path registers and logs nothing")
+    func gateOffYieldsNoProbe() {
+        withIsolatedDefaults(seed: false) { defaults in
+            #expect(AppState.commitLatencyDiagnosticEnabled(defaults: defaults) == false)
+            #expect(TerminalCommitLatencyProbe.make(defaults: defaults) == nil)
+        }
+    }
+
+    @Test("unset defaults to off — a diagnostic nobody asked for stays silent")
+    func gateDefaultsOff() {
+        withIsolatedDefaults(seed: nil) { defaults in
+            #expect(AppState.commitLatencyDiagnosticEnabled(defaults: defaults) == false)
+            #expect(TerminalCommitLatencyProbe.make(defaults: defaults) == nil)
+        }
+    }
+
+    @Test("flag on: a probe is built")
+    func gateOnYieldsProbe() {
+        withIsolatedDefaults(seed: true) { defaults in
+            #expect(AppState.commitLatencyDiagnosticEnabled(defaults: defaults) == true)
+            #expect(TerminalCommitLatencyProbe.make(defaults: defaults) != nil)
+        }
+    }
+
+    // MARK: - The instrument
+
+    @Test("one draw, one commit: logs draw cost and draw→commit latency")
+    func singleDrawCycle() {
+        let harness = Harness()
+        harness.draw(costMs: 2)
+        #expect(harness.lines.isEmpty, "nothing is reported until the render server commits")
+        harness.commit(afterMs: 8)
+        #expect(harness.lines == ["commit draws=1 drawms=2.000 commitms=10.000 vis=1"])
+    }
+
+    @Test("several views drawing in one cycle produce ONE line, not one per view")
+    func multipleDrawsInOneCycle() {
+        let harness = Harness()
+        harness.draw(costMs: 1)
+        harness.draw(costMs: 2)
+        harness.draw(costMs: 3)
+        #expect(harness.registered.count == 1, "exactly one completion block per transaction")
+        harness.commit(afterMs: 4)
+        #expect(harness.lines == ["commit draws=3 drawms=6.000 commitms=10.000 vis=1"])
+    }
+
+    @Test("vis=0 only when every view in the cycle was off screen")
+    func visibilityIsPerCycle() {
+        let offscreen = Harness()
+        offscreen.draw(costMs: 1, isOnScreen: false)
+        offscreen.commit(afterMs: 1)
+        #expect(offscreen.lines.first?.hasSuffix("vis=0") == true)
+
+        let mixed = Harness()
+        mixed.draw(costMs: 1, isOnScreen: false)
+        mixed.draw(costMs: 1, isOnScreen: true)
+        mixed.commit(afterMs: 1)
+        #expect(mixed.lines.first?.hasSuffix("vis=1") == true)
+    }
+
+    @Test("consecutive cycles are measured independently")
+    func consecutiveCycles() {
+        let harness = Harness()
+        harness.draw(costMs: 1)
+        harness.commit(afterMs: 4)
+        harness.draw(costMs: 2)
+        harness.commit(afterMs: 20)
+        #expect(harness.registered.count == 2)
+        #expect(harness.lines == [
+            "commit draws=1 drawms=1.000 commitms=5.000 vis=1",
+            "commit draws=1 drawms=2.000 commitms=22.000 vis=1",
+        ])
+    }
+
+    @Test("a frame presented with no terminal draw of ours open is ignored")
+    func framePresentedOutsideACycle() {
+        let harness = Harness()
+        harness.probe.recordFramePresented(at: 5)
+        #expect(harness.registered.isEmpty)
+        #expect(harness.lines.isEmpty)
+
+        harness.now = 10
+        harness.draw(costMs: 1)
+        harness.commit(afterMs: 1)
+        #expect(harness.lines == ["commit draws=1 drawms=1.000 commitms=2.000 vis=1"])
+    }
+
+    @Test("a swallowed completion block is dropped, not wedged forever")
+    func staleCycleIsAbandoned() {
+        let harness = Harness()
+        harness.draw(costMs: 1)
+        // Someone else set their own completion block on that transaction, so
+        // ours never fires. The next draw arrives well past the stale window.
+        harness.now += TerminalCommitLatencyProbe.staleCycleSeconds + 0.1
+        harness.draw(costMs: 1)
+        #expect(harness.lines == ["commitdrop cycles=1"])
+        harness.commit(afterMs: 3)
+        #expect(harness.lines == [
+            "commitdrop cycles=1",
+            "commit draws=1 drawms=1.000 commitms=4.000 vis=1",
+        ])
+    }
+
+    @Test("a late block from an abandoned cycle cannot close the current one")
+    func staleBlockIsInert() {
+        let harness = Harness()
+        harness.draw(costMs: 1)
+        let abandoned = harness.registered[0]
+        harness.now += TerminalCommitLatencyProbe.staleCycleSeconds + 0.1
+        harness.draw(costMs: 1)
+        harness.lines.removeAll()
+
+        abandoned()
+        #expect(harness.lines.isEmpty, "the stale block must not report the new cycle")
+
+        harness.commit(afterMs: 2)
+        #expect(harness.lines == ["commit draws=1 drawms=1.000 commitms=3.000 vis=1"])
+    }
+}

--- a/docs/specs/2026-08-29-commit-latency-diagnostic-design.md
+++ b/docs/specs/2026-08-29-commit-latency-diagnostic-design.md
@@ -1,0 +1,186 @@
+# Commit-latency diagnostic: app draw → render-server commit
+
+## The gap this closes
+
+The terminal-lag investigation has settled everything upstream of the process
+boundary with numbers:
+
+- **TBD's client was slower than other emulators on the identical tmux window.**
+  PR #750 fixed it; TBD now measures at parity with an attached iTerm2 or
+  Ghostty on the same window.
+- **Residual lag is still worse in TBD than in iTerm2 at the same machine
+  load.** That is the live problem, and it is ours.
+- **The main thread is not the bottleneck.** `sample` during a
+  user-confirmed lag episode (load 154) put the main thread 83% idle — 46,475
+  of 55,761 samples in `mach_msg` — with terminal drawing ~4.6% of its busy
+  time.
+- **The SwiftTerm IO threads are idle** (`_pthread_cond_wait`, `poll`): #750's
+  off-main parse works as designed.
+- **tmux is not involved** (0.1–0.4% CPU, and an external client attached to
+  the same window is smooth).
+
+What `sample` could see ended at `CA::Transaction::commit` and
+`UC::DriverCore::continueProcessing`, and then the trail left the process.
+`WindowServer` was measured at 57–66% CPU during episodes. The standing
+hypothesis is **compositing**: TBD presents a deep SwiftUI-hosted layer tree
+with many panels where iTerm2 presents one flat layer, and under a loaded
+compositor an expensive tree degrades where a cheap one does not.
+
+Nothing has ever instrumented the leg between the app finishing a draw and the
+frame being committed. This diagnostic does.
+
+## What it measures, and what it does not
+
+`CATransaction.setCompletionBlock` fires after the **render server** has
+committed the transaction currently in flight. Stamping a timestamp when a
+terminal view begins drawing and again when that block fires yields exactly the
+missing leg.
+
+**This is not time-to-glass.** Nothing after the render-server commit is
+covered: not `WindowServer` compositing the layer tree, not the display's
+scanout. Every figure the instrument produces is a **lower bound** on what a
+user perceives. Measuring the second half needs a WindowServer-side instrument
+we do not have and this design does not attempt.
+
+## Design
+
+`TerminalCommitLatencyProbe` (`Sources/TBDApp/Terminal/`) is a `@MainActor`
+object owned by a lazily-resolved static.
+
+**The two ends are stamped from two different seams, because the obvious one is
+closed.** SwiftTerm's `TerminalView.draw(_:)` is `public`, not `open`, so a
+subclass outside that module cannot override it and bracket the draw. What is
+reachable:
+
+- **`viewWillDraw()`** — the start. `open` on `NSView` and `open override` on
+  `TerminalView`. AppKit sends it to each view it is about to draw, on the main
+  thread, inside the display cycle's transaction, which is what makes the
+  completion-block registration land on the right transaction.
+- **`TerminalView.onFramePresented`** — the end of the app's drawing. TBD's
+  SwiftTerm fork provides it as a diagnostics hook and calls it at the end of
+  `draw` on the main thread on the Core Graphics path. TBD does not use the
+  Metal renderer, so that path is the live one; TBD uses the hook nowhere else,
+  so the probe takes sole ownership of its single slot while the diagnostic is
+  on, and only the production `shared` accessor installs it.
+
+AppKit sends `viewWillDraw` to a whole subtree before drawing any of it, so the
+two hooks cannot be paired per view. `drawms` is therefore the **span** — first
+terminal view about to draw → last terminal draw returned — not a sum of
+per-view draw bodies. The span is the more useful of the two anyway: it includes
+whatever AppKit does between the terminal draws. `commitms` is unaffected; it
+was always measured from the first draw of the cycle.
+
+**Per-transaction, not per-view.** Several terminal views can draw in one
+display cycle and they all land in the same `CATransaction`. The probe stamps
+`t0` at the *first* terminal draw of a cycle, counts later draws into that same
+cycle, and logs exactly one line when the completion block fires. Registering a
+block per view would overwrite the previous one and measure nonsense.
+
+**`setCompletionBlock` has no getter and replaces any incumbent block.** There
+is no way to read what is already set and chain to it. Two consequences are
+accepted, and are the reason this cannot ship on: a block someone else set
+earlier in the cycle is discarded by us, and a block someone else sets later
+discards ours. The second case is why a cycle can go unreported.
+
+**A lost block must not wedge the instrument.** If a draw arrives more than
+`staleCycleSeconds` (0.5s) after an open cycle's `t0` with no completion having
+fired, that cycle is abandoned and a running `commitdrop cycles=<n>` counter is
+logged. Each cycle also carries an id, so a completion block from an abandoned
+cycle arriving late cannot close the current one. The reader reports the drop
+rate and warns above 20%, because a high rate means the percentiles describe a
+biased sample.
+
+**Clock.** `ProcessInfo.processInfo.systemUptime`, injected as a closure.
+`Duration` is behaviour, `Date` is data, and this is behaviour — so monotonic
+uptime, never a wall-clock difference. No `Clock<Duration>` is involved because
+nothing here sleeps, debounces, polls, or times out.
+
+**Visibility.** TBD keeps terminals for unselected worktrees alive and fed
+inside a visible window, so `window.occlusionState` alone admits views AppKit
+correctly never draws — it reports the *window*. The probe additionally
+requires a non-empty `visibleRect`, which is what excludes a view clipped
+entirely out of its pager or scroll container. `vis=1` on a line means at least
+one of that cycle's drawing views was genuinely on screen; the reader reports
+off-screen cycles as their own bucket rather than folding them into the
+headline percentiles.
+
+## Output
+
+One `.info` line per instrumented display cycle, subsystem `com.tbd.app`,
+category `commitlatency`:
+
+```
+commit draws=<n> drawms=<f> commitms=<f> vis=<0|1>
+```
+
+- `draws` — terminal views that drew in this transaction
+- `drawms` — first terminal view about to draw → last terminal draw returned
+  (the app-side paint span)
+- `commitms` — first draw's start → render server committed
+- `vis` — 1 if at least one of those views was genuinely on screen
+
+`.info` rather than `.debug` so the lines persist and can be read back after an
+episode with `log show`. The key=value shape matches the other diagnostics'
+convention. `scripts/diag/commit-latency-report.py` reports p50/p90/p99/max for
+`commitms`, split by `draws=1` versus `draws>1` and by on-screen versus not,
+plus an optional split by machine load when a sidecar load log is supplied.
+Load is not in the log line because reading it once per frame would be its own
+overhead; the reader joins on the `log show` timestamp instead.
+
+## Gating
+
+Default OFF behind the UserDefaults key `enableCommitLatencyDiagnostic`
+(`AppState.enableCommitLatencyDiagnosticKey`, default
+`enableCommitLatencyDiagnosticDefault = false`). App-only behaviour, so a
+UserDefaults key is the right seam — precedent `enableTranscript`. Per-frame
+`.info` logging is far too heavy to ship on, and registering a completion block
+on a transaction the app does not own is not acceptable outside a measurement
+session.
+
+`nil` is the whole gate: with the flag off the static resolves to no probe,
+`viewWillDraw()`'s `guard let` returns straight after `super.viewWillDraw()`,
+and the frame-presented hook is never installed — nothing timed, nothing
+logged, no completion block registered. Both branches are
+covered by `TerminalCommitLatencyProbeTests`, driven through a per-test
+`UserDefaults(suiteName:)` because `UserDefaults.standard` on this unbundled
+executable is the developer's live `TBDApp.plist`.
+
+There is deliberately no Settings toggle. This is an instrument turned on for a
+measurement session and off again, not a preference:
+
+```
+defaults write TBDApp enableCommitLatencyDiagnostic -bool true    # then relaunch
+defaults write TBDApp enableCommitLatencyDiagnostic -bool false
+```
+
+The gate is resolved once, on the first terminal draw, so flipping the key
+takes effect at the next launch — which a measurement session begins with
+anyway.
+
+## Lifetime
+
+Temporary. It exists to answer one question: how much of the residual lag lives
+between the app's draw and the render server's commit. Once that is answered —
+either the leg is fat, and the compositing hypothesis becomes a fix, or it is
+thin, and attention moves past the render server — the probe, its flag, its
+tests, and its reader come out. It is deliberately cheap to delete: one new
+file, one `viewWillDraw()` override, one key on `AppState`, one script.
+
+## Rejected alternatives
+
+- **`TerminalView.onFramePresented` alone.** It is process-wide with no view
+  identity, so on its own it cannot report draws-per-cycle or visibility — the
+  two dimensions the compositing hypothesis actually turns on. It is used here
+  only for the end of the paint span, where identity does not matter.
+- **A `Duration`-based clock seam.** The repo requires an injected
+  `Clock<Duration>` for anything that sleeps, debounces, polls, or times out.
+  This does none of those; it reads a monotonic instant twice. Adding a clock
+  would be ceremony that measures nothing.
+- **`CADisplayLink` frame callbacks.** They report when a frame was scheduled,
+  not when the render server accepted it, which is the boundary in question.
+- **Sampling load per frame into the log line.** `getloadavg` per frame is
+  measurable overhead inside the very path being measured. A sidecar load log
+  joined on timestamp costs the measurement nothing.
+- **A Settings toggle.** A per-frame `.info` logger that also mutates a shared
+  `CATransaction` should not be one click away from a user who is not running a
+  measurement.

--- a/docs/specs/2026-08-29-commit-latency-diagnostic-design.md
+++ b/docs/specs/2026-08-29-commit-latency-diagnostic-design.md
@@ -1,4 +1,4 @@
-# Commit-latency diagnostic: app draw → render-server commit
+# Commit-latency diagnostic: the app-side commit of a terminal frame
 
 ## The gap this closes
 
@@ -30,21 +30,69 @@ hypothesis is **compositing**: TBD presents a deep SwiftUI-hosted layer tree
 with many panels where iTerm2 presents one flat layer, and under a loaded
 compositor an expensive tree degrades where a cheap one does not.
 
-Nothing has ever instrumented the leg between the app finishing a draw and the
-frame being committed. This diagnostic does.
+Nothing has ever instrumented what the app itself spends committing a terminal
+frame. This diagnostic does — and, as the next section explains, that turns out
+to be less than the work set out to measure. The design brief assumed
+`CATransaction`'s completion block signals the render server; measurement says
+otherwise, and the rest of this document is written to what was measured.
 
 ## What it measures, and what it does not
 
-`CATransaction.setCompletionBlock` fires after the **render server** has
-committed the transaction currently in flight. Stamping a timestamp when a
-terminal view begins drawing and again when that block fires yields exactly the
-missing leg.
+`commitms` is: first terminal `viewWillDraw` of a transaction → the
+`CATransaction` completion block for that transaction runs.
 
-**This is not time-to-glass.** Nothing after the render-server commit is
-covered: not `WindowServer` compositing the layer tree, not the display's
-scanout. Every figure the instrument produces is a **lower bound** on what a
-user perceives. Measuring the second half needs a WindowServer-side instrument
-we do not have and this design does not attempt.
+**That is app-side only. It does not cross into the render server, and it is
+nowhere near time-to-glass.** This correction matters enough to lead with,
+because the instrument was designed on the opposite premise. Measured on this
+machine with a real on-screen window and real committed layer changes, the
+completion block runs **12–99 microseconds after `CATransaction.commit()`
+returns**, on the same runloop turn. Nothing makes a round trip to
+`WindowServer` in 20µs. Apple's contract for `setCompletionBlock` says only
+that the block runs "as soon as all animations subsequent to this transaction
+group have completed", and that with no animations it "will be invoked
+immediately" — the render server is not mentioned, because it is not involved.
+
+What the instrument does cover is the app's own cost of assembling and
+committing the frame: `CA::Transaction::commit` on the main thread, the last
+thing `sample` could see before the trail left the process. That is a per-frame
+number nobody had, and it is worth having. It is not the leg this work set out
+to measure.
+
+**The render-server leg remains uninstrumented.** No public API exposes it for
+a CoreGraphics-drawn `NSView`. `CAMetalDrawable.addPresentedHandler` does, but
+TBD does not use SwiftTerm's Metal renderer; adopting it would be a much larger
+change and is not proposed here.
+
+The consequence for how results get read: **a small `commitms` licenses no
+conclusion about the compositor.** It says the app hands the frame over
+quickly, which is the direction the evidence already pointed. Anyone reading a
+capture must not conclude "attention moves past the render server" from an
+instrument that never observed the render server.
+
+### The animation distortion, and the `sync` bit
+
+The completion block waits for *animations*, not for a commit. Any animation
+added inside a transaction the probe marked therefore redefines `commitms` for
+that cycle. Measured here:
+
+- A finite 0.6s animation → the block fired **675ms** after commit. That sample
+  reports the animation's duration, lands straight in p90/p99, and looks
+  exactly like the compositor stall this instrument was built to look for.
+- An infinite animation → the block **never fired**, and the cycle surfaces as
+  a drop.
+
+TBD's terminal contains both shapes. SwiftTerm's caret blink is
+`repeatCount = .infinity` (`MacCaretView`), and the overlay scroller fades over
+0.25s — during scrolling, which is the lag repro itself. They are added on
+state changes rather than per frame, so the effect is episodic, not constant.
+
+`sync` is the discriminator. The probe schedules a marker for the end of the
+current runloop turn: `sync=1` means the completion block beat it — same turn,
+no animation wait, the number means what it says. `sync=0` means the block
+arrived later, so the sample folds in an animation wait, a commit spanning
+turns, or both, and the two cannot be separated from inside the process. The
+reader reports the two populations separately and never pools them; `sync=1` is
+the measurement, `sync=0` is a count of cycles that cannot be used.
 
 ## Design
 
@@ -104,16 +152,21 @@ accepted, and are the reason this cannot ship on: a block someone else set
 earlier in the cycle is discarded by us, and a block someone else sets later
 discards ours. The second case is why a cycle can go unreported.
 
-**A lost cycle is reported, promptly and exactly.** When a draw arrives in a
-different transaction while a cycle is still open, that cycle's completion
-block demonstrably never fired, so it is emitted as `commitdrop draws=<n>` —
+**A lost cycle is reported promptly.** When a draw arrives in a different
+transaction while a cycle is still open, that cycle's completion block has not
+run. Two causes produce that observable and they are indistinguishable from
+inside the process: somebody replaced our block on that transaction, or an
+animation in it is still running and CoreAnimation is still holding the block.
+The probe does not claim which. It emits `commitdrop draws=<n> vis=<0|1>` —
 one line per lost cycle, carrying the draws that went with it. One line rather
 than a running total, so a reader working over a `log show` window counts the
 drops inside its window instead of inheriting a process-lifetime counter. Each
 cycle also carries an id, so a completion block from an abandoned cycle
-arriving late cannot close the current one. The reader reports the drop rate
-and warns at 20% or above, because a high rate means the percentiles describe a
-biased sample. The one loss that goes uncounted is a final open cycle at the
+arriving late cannot close the current one. The line carries `vis` because
+drops cluster on animated frames rather than falling randomly, so a reader
+needs to know whether the lost cycles were on screen — that is what makes the
+bias characterizable rather than merely flagged. The reader warns at 20% or
+above. The one loss that goes uncounted is a final open cycle at the
 end of a session with no draw after it.
 
 **A draw that paints nothing is distinguishable.** SwiftTerm's `draw` has early
@@ -143,15 +196,17 @@ One `.info` line per instrumented display cycle, subsystem `com.tbd.app`,
 category `commitlatency`:
 
 ```
-commit draws=<n> paints=<n> drawms=<f> commitms=<f> vis=<0|1>
+commit draws=<n> paints=<n> drawms=<f> commitms=<f> vis=<0|1> sync=<0|1>
 ```
 
 - `draws` — terminal views that drew in this transaction
 - `paints` — how many of those reached the end of `draw`
 - `drawms` — first terminal view about to draw → last terminal draw returned
   (the app-side paint span)
-- `commitms` — first draw's start → render server committed
+- `commitms` — first draw's start → the transaction's completion block ran
 - `vis` — 1 if at least one of those views was genuinely on screen
+- `sync` — 1 if that block ran in the same runloop turn as the draw; only
+  `sync=1` samples are comparable
 
 `.info` rather than `.debug` because of how the two are retained.
 [`docs/diagnostics-strategy.md`](../diagnostics-strategy.md) assigns per-event
@@ -225,11 +280,12 @@ about latency.
 
 ## Lifetime
 
-Temporary. It exists to answer one question: how much of the residual lag lives
-between the app's draw and the render server's commit. Once that is answered —
-either the leg is fat, and the compositing hypothesis becomes a fix, or it is
-thin, and attention moves past the render server — the probe, its flag, its
-tests, and its reader come out. It is deliberately cheap to delete: one new
+Temporary. It answers a narrower question than the one that motivated it: how
+much per-frame time the app spends assembling and committing terminal frames.
+A fat `commitms` at `sync=1` would be a finding. A thin one closes off the
+app-side commit and says nothing about the compositor, which stays open and
+needs an instrument this design does not provide. Either way the probe, its
+flag, its tests, and its reader come out afterwards. It is deliberately cheap to delete: one new
 file, one `viewWillDraw()` override, one key on `AppState`, one script.
 
 ## Rejected alternatives

--- a/docs/specs/2026-08-29-commit-latency-diagnostic-design.md
+++ b/docs/specs/2026-08-29-commit-latency-diagnostic-design.md
@@ -3,7 +3,11 @@
 ## The gap this closes
 
 The terminal-lag investigation has settled everything upstream of the process
-boundary with numbers:
+boundary with numbers. They were measured during that investigation against a
+running fleet and are recorded here because they are the reason this instrument
+exists; the raw sample output is not in this tree, so treat the figures as the
+investigation's findings rather than as something a reader can re-derive from
+the repository:
 
 - **TBD's client was slower than other emulators on the identical tmux window.**
   PR #750 fixed it; TBD now measures at parity with an attached iTerm2 or
@@ -72,9 +76,27 @@ was always measured from the first draw of the cycle.
 
 **Per-transaction, not per-view.** Several terminal views can draw in one
 display cycle and they all land in the same `CATransaction`. The probe stamps
-`t0` at the *first* terminal draw of a cycle, counts later draws into that same
-cycle, and logs exactly one line when the completion block fires. Registering a
-block per view would overwrite the previous one and measure nonsense.
+`t0` at the *first* terminal draw of a transaction, folds later draws in the
+same transaction into that cycle, and logs exactly one line when the completion
+block fires. Registering a block per view would overwrite the previous one and
+measure nonsense.
+
+**Transaction identity comes from the transaction, not from a stopwatch.** This
+is the load-bearing decision. `CATransaction.setValue(_:forKey:)` is a
+per-transaction store *with a getter* — unlike `setCompletionBlock` — so the
+probe stamps its cycle id there and reads it back on the next draw: the same
+mark means the same transaction, no mark means a new one.
+
+An elapsed-time boundary cannot do this job, and its failure is not a rounding
+error. AppKit's cadence is ~16.67ms, so any window wide enough to tolerate a
+slow commit is also wide enough to swallow the entire next cycle. Draws from
+the following transaction would be counted into a frame that had already been
+committed, that transaction would get no completion block of its own, and the
+frame would vanish from the output — counted neither as a sample nor as a
+drop. The bias would grow precisely with the latency the instrument exists to
+characterize, and the `draws=1` versus `draws>1` split would partition on
+"draws within the window" rather than "draws in one transaction". A diagnostic
+that degrades in the presence of the phenomenon it measures is worse than none.
 
 **`setCompletionBlock` has no getter and replaces any incumbent block.** There
 is no way to read what is already set and chain to it. Two consequences are
@@ -82,13 +104,24 @@ accepted, and are the reason this cannot ship on: a block someone else set
 earlier in the cycle is discarded by us, and a block someone else sets later
 discards ours. The second case is why a cycle can go unreported.
 
-**A lost block must not wedge the instrument.** If a draw arrives more than
-`staleCycleSeconds` (0.5s) after an open cycle's `t0` with no completion having
-fired, that cycle is abandoned and a running `commitdrop cycles=<n>` counter is
-logged. Each cycle also carries an id, so a completion block from an abandoned
-cycle arriving late cannot close the current one. The reader reports the drop
-rate and warns above 20%, because a high rate means the percentiles describe a
-biased sample.
+**A lost cycle is reported, promptly and exactly.** When a draw arrives in a
+different transaction while a cycle is still open, that cycle's completion
+block demonstrably never fired, so it is emitted as `commitdrop draws=<n>` —
+one line per lost cycle, carrying the draws that went with it. One line rather
+than a running total, so a reader working over a `log show` window counts the
+drops inside its window instead of inheriting a process-lifetime counter. Each
+cycle also carries an id, so a completion block from an abandoned cycle
+arriving late cannot close the current one. The reader reports the drop rate
+and warns at 20% or above, because a high rate means the percentiles describe a
+biased sample. The one loss that goes uncounted is a final open cycle at the
+end of a session with no draw after it.
+
+**A draw that paints nothing is distinguishable.** SwiftTerm's `draw` has early
+returns before its frame-presented hook, so a view can be asked to draw and
+paint nothing; `drawms` is then 0.000 for a reason that has nothing to do with
+paint speed. The line carries `paints=<n>` alongside `draws=<n>` so the two
+cases are separable, and the reader excludes unpainted cycles from the paint
+percentiles rather than dragging them toward zero.
 
 **Clock.** `ProcessInfo.processInfo.systemUptime`, injected as a closure.
 `Duration` is behaviour, `Date` is data, and this is behaviour — so monotonic
@@ -110,17 +143,27 @@ One `.info` line per instrumented display cycle, subsystem `com.tbd.app`,
 category `commitlatency`:
 
 ```
-commit draws=<n> drawms=<f> commitms=<f> vis=<0|1>
+commit draws=<n> paints=<n> drawms=<f> commitms=<f> vis=<0|1>
 ```
 
 - `draws` — terminal views that drew in this transaction
+- `paints` — how many of those reached the end of `draw`
 - `drawms` — first terminal view about to draw → last terminal draw returned
   (the app-side paint span)
 - `commitms` — first draw's start → render server committed
 - `vis` — 1 if at least one of those views was genuinely on screen
 
-`.info` rather than `.debug` so the lines persist and can be read back after an
-episode with `log show`. The key=value shape matches the other diagnostics'
+`.info` rather than `.debug` because of how the two are retained.
+[`docs/diagnostics-strategy.md`](../diagnostics-strategy.md) assigns per-event
+traces to `.debug`, which this is, and this deviates deliberately: `.debug`
+lives in an in-memory ring buffer that `log show` does not return for past
+events unless someone raised the subsystem's persistence with `sudo log config`
+*before* the episode. The whole workflow here is "reproduce, then ask the system
+for the recent past", which only `.info` and above satisfy without that
+prior step. The cost is real and worth knowing when reading a capture: `.info`
+is retained briefly rather than persisted, and at roughly a line per frame a
+long session can lose its earlier minutes, biasing a capture toward its end.
+Take short captures. The key=value shape matches the other diagnostics'
 convention. `scripts/diag/commit-latency-report.py` reports p50/p90/p99/max for
 `commitms`, split by `draws=1` versus `draws>1` and by on-screen versus not,
 plus an optional split by machine load when a sidecar load log is supplied.
@@ -132,15 +175,25 @@ overhead; the reader joins on the `log show` timestamp instead.
 Default OFF behind the UserDefaults key `enableCommitLatencyDiagnostic`
 (`AppState.enableCommitLatencyDiagnosticKey`, default
 `enableCommitLatencyDiagnosticDefault = false`). App-only behaviour, so a
-UserDefaults key is the right seam — precedent `enableTranscript`. Per-frame
-`.info` logging is far too heavy to ship on, and registering a completion block
-on a transaction the app does not own is not acceptable outside a measurement
-session.
+UserDefaults key is the right seam — precedent `enableTranscript`.
+
+**This departs from the diagnostics doctrine, and the departure is the point.**
+[`docs/diagnostics-strategy.md`](../diagnostics-strategy.md) says a diagnostic
+should need "no env var, no defaults key, no debug build … the activation
+mechanism is the OS, not the app", and sibling instruments in this same
+investigation ship with no flag at all. That rule is about *verbosity*: where
+the only thing a flag would control is whether a line is emitted, os_log's
+level filter already does the job better. This instrument is not only verbosity.
+Turning it on **changes behaviour**: it stamps a value on, and claims the single
+completion-block slot of, a `CATransaction` the whole app shares, discarding
+whatever block was there. No subscriber-side level filter can express that, so
+the activation mechanism has to be in the app. Per-frame `.info` logging being
+too heavy to ship on is the lesser half of the argument.
 
 `nil` is the whole gate: with the flag off the static resolves to no probe,
 `viewWillDraw()`'s `guard let` returns straight after `super.viewWillDraw()`,
 and the frame-presented hook is never installed — nothing timed, nothing
-logged, no completion block registered. Both branches are
+logged, no transaction marked, no completion block registered. Both branches are
 covered by `TerminalCommitLatencyProbeTests`, driven through a per-test
 `UserDefaults(suiteName:)` because `UserDefaults.standard` on this unbundled
 executable is the developer's live `TBDApp.plist`.
@@ -156,6 +209,19 @@ defaults write TBDApp enableCommitLatencyDiagnostic -bool false
 The gate is resolved once, on the first terminal draw, so flipping the key
 takes effect at the next launch — which a measurement session begins with
 anyway.
+
+## The assumption that would make it lie
+
+`Package.swift` carries a standing warning from the #750 SwiftTerm bump: a
+frame loop that does not run on the main thread may never call
+`viewWillDraw()`, and TBD's terminal diagnostics hook it. It does not bite
+today — SwiftTerm takes its render-loop path only when the Metal layer surface
+is enabled, TBD enables it nowhere in `Sources/`, and `frameTick` therefore
+falls through to `setNeedsDisplay` and an ordinary AppKit display pass. It is
+written down because the failure is silent and reads as good news: **an
+instrument that logs nothing looks exactly like a machine with no lag.** If a
+capture comes back empty, check that assumption before concluding anything
+about latency.
 
 ## Lifetime
 

--- a/scripts/diag/commit-latency-report.py
+++ b/scripts/diag/commit-latency-report.py
@@ -1,22 +1,49 @@
 #!/usr/bin/env python3
-"""Report the distribution of app-draw -> render-server-commit latency.
+"""Report the distribution of the app-side commit latency of terminal frames.
 
 WHAT THE METRIC IS
 ------------------
 `TerminalCommitLatencyProbe` (Sources/TBDApp/Terminal) stamps `t0` at the first
-terminal view's `viewWillDraw` in a display cycle, registers a `CATransaction`
-completion block on the transaction AppKit is building around that cycle, and
-stamps `t1` when CoreAnimation fires it. `commitms = t1 - t0` is the leg between
-"the app started painting its terminal content" and "the render server has
-committed that frame". `drawms` is the app-side paint span within it: `t0` to
-the last terminal draw returning.
+terminal view's `viewWillDraw` in a display cycle, marks the `CATransaction`
+AppKit is building around that cycle, registers a completion block on it, and
+stamps `t1` when CoreAnimation runs that block. `commitms = t1 - t0`.
 
-WHAT IT IS NOT
---------------
-It is NOT time-to-glass. Nothing after the render server's commit is covered:
-not WindowServer compositing the layer tree, not the display's scanout. Every
-number below is therefore a LOWER BOUND on what a user perceives. If you are
-tempted to quote a p99 here as "keystroke latency", don't.
+WHAT IT IS NOT -- AND THIS IS NOT A QUIBBLE
+-------------------------------------------
+`commitms` is APP-SIDE ONLY. It does not cross into the render server, and it
+is nowhere near time-to-glass.
+
+Measured with a real on-screen window and real committed layer changes, the
+completion block runs 12-99 MICROSECONDS after `CATransaction.commit()`
+returns, on the same runloop turn. Nothing round-trips to WindowServer in 20us.
+Apple's contract for `setCompletionBlock` says the block runs "as soon as all
+animations subsequent to this transaction group have completed", and with no
+animations "will be invoked immediately" -- the render server is not mentioned
+because it is not involved.
+
+So a small `commitms` licenses NO conclusion about the compositor. It says the
+app hands the frame over quickly, which is where the evidence already pointed.
+Do not read it as "the render server is fine". The render-server leg remains
+uninstrumented: no public API exposes it for a CoreGraphics-drawn NSView
+(CAMetalDrawable.addPresentedHandler would, but TBD does not use Metal).
+
+THE ANIMATION DISTORTION, AND WHY `sync` EXISTS
+-----------------------------------------------
+Because the block waits for ANIMATIONS rather than for a commit, any animation
+inside a marked transaction redefines `commitms`. Measured: a finite 0.6s
+animation deferred the block by 675ms -- a sample that reports an animation
+duration and lands in p90/p99 looking exactly like a compositor stall. An
+infinite animation meant the block never fired at all, and the cycle surfaces
+as a drop. TBD's terminal has both: SwiftTerm's caret blink repeats forever,
+and the overlay scroller fades over 0.25s -- during scrolling, which is the lag
+repro.
+
+`sync` separates them. `sync=1` means the completion block ran in the same
+runloop turn as the draw: no animation wait, the number means what it says.
+`sync=0` means it arrived later -- an animation wait, a commit spanning turns,
+or both, indistinguishable from inside the process. This script reports the two
+populations separately and never pools them. Read `sync=1` as the measurement
+and `sync=0` as a count of cycles you cannot use.
 
 WHY THIS LEG
 ------------
@@ -27,9 +54,12 @@ IO threads were idle, and tmux sat at 0.1-0.4% CPU. `sample` followed the trail
 to `CA::Transaction::commit` and lost it at the process boundary while
 WindowServer ran at 57-66% CPU. The live hypothesis is that TBD presents a deep
 SwiftUI-hosted layer tree where iTerm2 presents one flat layer, and that a
-loaded compositor degrades the expensive tree. This script measures the first
-half of that gap; the second half needs a WindowServer-side instrument we do
-not have.
+loaded compositor degrades the expensive tree.
+
+This script puts a per-frame number on `CA::Transaction::commit` itself -- the
+last thing `sample` could see. It stops there. Confirming or refuting the
+compositing hypothesis needs a WindowServer-side instrument that does not
+exist here.
 
 WHY THE SPLIT BY draws-per-cycle
 --------------------------------
@@ -44,14 +74,20 @@ WHY vis MATTERS
 `vis=0` means no view in that cycle was genuinely on screen (a non-empty
 `visibleRect` inside a visible, unoccluded window). Off-screen cycles are work
 the user never sees; they belong in a separate bucket, not in the headline
-percentiles.
+percentiles. Drop lines carry `vis` too, because drops cluster on animated
+frames rather than falling randomly -- knowing whether the lost ones were on
+screen is what makes the bias characterizable rather than merely flagged.
 
 DROPPED CYCLES
 --------------
 `CATransaction.setCompletionBlock` has no getter and replaces any incumbent
 block. When AppKit or SwiftUI sets its own block on a transaction after the
-probe set one, the probe's block never fires and that cycle is lost. The probe
-emits one `commitdrop draws=<n>` line per lost cycle -- one line each, not a
+probe set one, the probe's block never fires and that cycle is lost. An
+animation still running in the transaction produces the same observable, and
+the two causes cannot be told apart from inside the process -- so a high drop
+rate may mean "our block was replaced" OR "animations were running", not
+necessarily a biased sample. The probe emits one `commitdrop draws=<n> vis=<0|1>`
+line per lost cycle -- one line each, not a
 running total, so a windowed read of the log counts the drops in its own window
 instead of inheriting a process-lifetime counter. A high drop rate means the
 percentiles describe a biased sample, so it is reported alongside them.
@@ -92,11 +128,12 @@ from datetime import datetime
 # `log show` prefixes each line with e.g. "2026-08-29 10:11:12.345678-0400".
 TIMESTAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+[+-]\d{4})")
 COMMIT_RE = re.compile(
-    r"\bcommit draws=(\d+) paints=(\d+) drawms=([\d.]+) commitms=([\d.]+) vis=([01])\b"
+    r"\bcommit draws=(\d+) paints=(\d+) drawms=([\d.]+) commitms=([\d.]+)"
+    r" vis=([01]) sync=([01])\b"
 )
 # One line per lost cycle, so drops are counted within the window being read
 # rather than inherited from a process-lifetime counter.
-DROP_RE = re.compile(r"\bcommitdrop draws=(\d+)\b")
+DROP_RE = re.compile(r"\bcommitdrop draws=(\d+) vis=([01])\b")
 
 # Load bands, as (label, upper bound exclusive). The last band is open-ended.
 LOAD_BANDS = [("load<2", 2.0), ("load 2-8", 8.0), ("load 8-32", 32.0), ("load>=32", None)]
@@ -112,6 +149,7 @@ class Sample:
     drawms: float
     commitms: float
     visible: bool
+    synchronous: bool
 
 
 def parse_epoch(line: str) -> float | None:
@@ -124,9 +162,10 @@ def parse_epoch(line: str) -> float | None:
         return None
 
 
-def parse(stream) -> tuple[list[Sample], int]:
+def parse(stream) -> tuple[list[Sample], int, int]:
     samples: list[Sample] = []
     drops = 0
+    drops_onscreen = 0
     for line in stream:
         commit = COMMIT_RE.search(line)
         if commit:
@@ -138,12 +177,16 @@ def parse(stream) -> tuple[list[Sample], int]:
                     drawms=float(commit.group(3)),
                     commitms=float(commit.group(4)),
                     visible=commit.group(5) == "1",
+                    synchronous=commit.group(6) == "1",
                 )
             )
             continue
-        if DROP_RE.search(line):
+        drop = DROP_RE.search(line)
+        if drop:
             drops += 1
-    return samples, drops
+            if drop.group(2) == "1":
+                drops_onscreen += 1
+    return samples, drops, drops_onscreen
 
 
 def load_series(path: str) -> list[tuple[float, float]]:
@@ -199,10 +242,11 @@ def report_group(label: str, samples: list[Sample]) -> None:
         print(f"  {label:<16} (no samples)")
         return
     commit = sorted(s.commitms for s in samples)
-    # A cycle with paints=0 was asked to draw and painted nothing, so its
-    # drawms is 0.000 for a reason that has nothing to do with paint speed.
-    # Folding those in would drag the paint figures toward zero.
-    draw = sorted(s.drawms for s in samples if s.paints > 0)
+    # `drawms` spans the first draw to the last paint, so it only describes
+    # paint cost when every draw in the cycle actually painted. Any shortfall
+    # (SwiftTerm's `draw` has early returns before its frame-presented hook)
+    # truncates the span for a reason unrelated to paint speed.
+    draw = sorted(s.drawms for s in samples if s.paints == s.draws)
     unpainted = len(samples) - len(draw)
     paint = (
         f"   (drawms p50={percentile(draw, 0.50):.2f} max={draw[-1]:.2f})"
@@ -210,7 +254,7 @@ def report_group(label: str, samples: list[Sample]) -> None:
         else "   (no painted cycles)"
     )
     if unpainted:
-        paint += f" [{unpainted} painted nothing]"
+        paint += f" [{unpainted} incompletely painted]"
     print(
         f"  {label:<16} n={len(commit):<7}"
         f" p50={percentile(commit, 0.50):8.2f}"
@@ -244,7 +288,7 @@ def main() -> int:
 
     stream = open(args.logfile, encoding="utf-8") if args.logfile else sys.stdin
     try:
-        samples, drops = parse(stream)
+        samples, drops, drops_onscreen = parse(stream)
     finally:
         if args.logfile:
             stream.close()
@@ -260,25 +304,41 @@ def main() -> int:
 
     offscreen = [s for s in samples if not s.visible]
     onscreen = samples if args.include_offscreen else [s for s in samples if s.visible]
+    # Never pool these two. See the docstring: a sync=0 sample may be reporting
+    # an animation's duration rather than a commit's cost.
+    deferred = [s for s in onscreen if not s.synchronous]
+    clean = [s for s in onscreen if s.synchronous]
 
     total = len(samples) + drops
     drop_pct = (100.0 * drops / total) if total else 0.0
 
-    print("app-draw -> render-server-commit latency, milliseconds")
-    print("NOT time-to-glass: WindowServer composite and scanout are not covered.")
+    print("app-side commit latency of terminal frames, milliseconds")
+    print("NOT time-to-glass, and NOT a render-server round trip: the CATransaction")
+    print("completion block runs on the same runloop turn, ~12-99us after commit.")
     print()
-    print(f"cycles reported: {len(samples)}   dropped (completion block lost): {drops}"
-          f" ({drop_pct:.1f}%)")
+    print(f"cycles reported: {len(samples)}   never completed: {drops}"
+          f" ({drop_pct:.1f}%, {drops_onscreen} of them on screen)")
     if drop_pct >= 20:
-        print("  WARNING: a fifth or more of cycles were dropped; this sample is biased.")
+        print("  WARNING: a fifth or more of cycles never completed. That is either our")
+        print("  completion block being replaced, or animations still running in those")
+        print("  transactions -- indistinguishable from here. Treat the rest as partial.")
     print(f"on screen: {len(samples) - len(offscreen)}   off screen: {len(offscreen)}")
+    print(f"of the on-screen cycles: {len(clean)} sync=1 (usable), "
+          f"{len(deferred)} sync=0 (animation wait or multi-turn commit)")
     print()
 
-    print("by draws-per-cycle" + ("" if args.include_offscreen else " (on-screen cycles only)"))
-    report_group("all", onscreen)
-    report_group("draws=1", [s for s in onscreen if s.draws == 1])
-    report_group("draws>1", [s for s in onscreen if s.draws > 1])
+    scope = "" if args.include_offscreen else ", on screen"
+    print(f"by draws-per-cycle (sync=1 only{scope}) -- THE measurement")
+    report_group("all", clean)
+    report_group("draws=1", [s for s in clean if s.draws == 1])
+    report_group("draws>1", [s for s in clean if s.draws > 1])
     print()
+
+    if deferred:
+        print("sync=0 cycles -- NOT comparable; commitms here may be an animation's")
+        print("duration rather than a commit's cost. Shown to be accounted for, not read.")
+        report_group("deferred", deferred)
+        print()
 
     if not args.include_offscreen and offscreen:
         print("off-screen cycles (work the user never sees)")
@@ -287,9 +347,9 @@ def main() -> int:
 
     if args.load_log:
         series = load_series(args.load_log)
-        print("by machine load (1-minute average, nearest sample within 30s)")
+        print("by machine load (1-minute average, nearest sample within 30s; sync=1 only)")
         banded: dict[str, list[Sample]] = {}
-        for sample in onscreen:
+        for sample in clean:
             banded.setdefault(band_for(load_at(series, sample.epoch)), []).append(sample)
         for label, _ in LOAD_BANDS:
             if label in banded:

--- a/scripts/diag/commit-latency-report.py
+++ b/scripts/diag/commit-latency-report.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Report the distribution of app-draw -> render-server-commit latency.
+
+WHAT THE METRIC IS
+------------------
+`TerminalCommitLatencyProbe` (Sources/TBDApp/Terminal) stamps `t0` at the first
+terminal view's `viewWillDraw` in a display cycle, registers a `CATransaction`
+completion block on the transaction AppKit is building around that cycle, and
+stamps `t1` when CoreAnimation fires it. `commitms = t1 - t0` is the leg between
+"the app started painting its terminal content" and "the render server has
+committed that frame". `drawms` is the app-side paint span within it: `t0` to
+the last terminal draw returning.
+
+WHAT IT IS NOT
+--------------
+It is NOT time-to-glass. Nothing after the render server's commit is covered:
+not WindowServer compositing the layer tree, not the display's scanout. Every
+number below is therefore a LOWER BOUND on what a user perceives. If you are
+tempted to quote a p99 here as "keystroke latency", don't.
+
+WHY THIS LEG
+------------
+The terminal-lag investigation ruled out everything upstream with numbers: TBD
+reached client parity with other emulators on the same tmux window (PR #750),
+the main thread measured 83% idle during a confirmed lag episode, the SwiftTerm
+IO threads were idle, and tmux sat at 0.1-0.4% CPU. `sample` followed the trail
+to `CA::Transaction::commit` and lost it at the process boundary while
+WindowServer ran at 57-66% CPU. The live hypothesis is that TBD presents a deep
+SwiftUI-hosted layer tree where iTerm2 presents one flat layer, and that a
+loaded compositor degrades the expensive tree. This script measures the first
+half of that gap; the second half needs a WindowServer-side instrument we do
+not have.
+
+WHY THE SPLIT BY draws-per-cycle
+--------------------------------
+Several terminal views can draw in one transaction (TBD keeps terminals for
+unselected worktrees alive and fed). A cycle with several drawing views is
+doing more app-side work AND presenting more dirty layers, so mixing the two
+populations hides which one moves. `draws=1` is the shape a single focused
+terminal produces; `draws>1` is the fleet-of-panels shape.
+
+WHY vis MATTERS
+---------------
+`vis=0` means no view in that cycle was genuinely on screen (a non-empty
+`visibleRect` inside a visible, unoccluded window). Off-screen cycles are work
+the user never sees; they belong in a separate bucket, not in the headline
+percentiles.
+
+DROPPED CYCLES
+--------------
+`CATransaction.setCompletionBlock` has no getter and replaces any incumbent
+block. When AppKit or SwiftUI sets its own block on a transaction after the
+probe set one, the probe's block never fires and that cycle is abandoned. The
+probe emits a running `commitdrop cycles=<n>` counter; this script reports it,
+because a high drop rate means the percentiles describe a biased sample.
+
+USAGE
+-----
+Turn the diagnostic on, relaunch the app, reproduce a lag episode, then:
+
+    defaults write TBDApp enableCommitLatencyDiagnostic -bool true
+    # relaunch TBDApp, reproduce, then:
+    log show --last 5m --info \
+      --predicate 'subsystem == "com.tbd.app" AND category == "commitlatency"' \
+      | scripts/diag/commit-latency-report.py
+    defaults write TBDApp enableCommitLatencyDiagnostic -bool false
+
+Optionally correlate with machine load. The log lines carry no load figure --
+reading `getloadavg` once per frame would be its own overhead -- so sample it
+alongside in a second shell and join on time:
+
+    while :; do
+      printf '%s %s\n' "$(date +%s)" "$(sysctl -n vm.loadavg | awk '{print $2}')"
+      sleep 5
+    done > /tmp/load.log
+
+    ... | scripts/diag/commit-latency-report.py --load-log /tmp/load.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+
+# `log show` prefixes each line with e.g. "2026-08-29 10:11:12.345678-0400".
+TIMESTAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+[+-]\d{4})")
+COMMIT_RE = re.compile(
+    r"\bcommit draws=(\d+) drawms=([\d.]+) commitms=([\d.]+) vis=([01])\b"
+)
+DROP_RE = re.compile(r"\bcommitdrop cycles=(\d+)\b")
+
+# Load bands, as (label, upper bound exclusive). The last band is open-ended.
+LOAD_BANDS = [("load<2", 2.0), ("load 2-8", 8.0), ("load 8-32", 32.0), ("load>=32", None)]
+
+
+@dataclass(slots=True)
+class Sample:
+    """One display cycle in which at least one terminal view drew."""
+
+    epoch: float | None
+    draws: int
+    drawms: float
+    commitms: float
+    visible: bool
+
+
+def parse_epoch(line: str) -> float | None:
+    match = TIMESTAMP_RE.match(line)
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S.%f%z").timestamp()
+    except ValueError:
+        return None
+
+
+def parse(stream) -> tuple[list[Sample], int]:
+    samples: list[Sample] = []
+    drops = 0
+    for line in stream:
+        commit = COMMIT_RE.search(line)
+        if commit:
+            samples.append(
+                Sample(
+                    epoch=parse_epoch(line),
+                    draws=int(commit.group(1)),
+                    drawms=float(commit.group(2)),
+                    commitms=float(commit.group(3)),
+                    visible=commit.group(4) == "1",
+                )
+            )
+            continue
+        drop = DROP_RE.search(line)
+        if drop:
+            # The counter is cumulative, so the largest value seen is the total.
+            drops = max(drops, int(drop.group(1)))
+    return samples, drops
+
+
+def load_series(path: str) -> list[tuple[float, float]]:
+    series: list[tuple[float, float]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            try:
+                series.append((float(parts[0]), float(parts[1])))
+            except ValueError:
+                continue
+    series.sort()
+    return series
+
+
+def load_at(series: list[tuple[float, float]], epoch: float | None) -> float | None:
+    """Nearest load sample at or before `epoch`, within 30s."""
+    if not series or epoch is None:
+        return None
+    index = bisect.bisect_right(series, (epoch, float("inf"))) - 1
+    if index < 0:
+        return None
+    when, value = series[index]
+    return value if epoch - when <= 30 else None
+
+
+def band_for(load: float | None) -> str:
+    if load is None:
+        return "load unknown"
+    for label, upper in LOAD_BANDS:
+        if upper is None or load < upper:
+            return label
+    return LOAD_BANDS[-1][0]
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    """Nearest-rank percentile. `values` must be sorted."""
+    if not values:
+        return float("nan")
+    rank = max(1, min(len(values), int(round(fraction * len(values) + 0.5))))
+    return values[rank - 1]
+
+
+def report_group(label: str, samples: list[Sample]) -> None:
+    if not samples:
+        print(f"  {label:<16} (no samples)")
+        return
+    commit = sorted(s.commitms for s in samples)
+    draw = sorted(s.drawms for s in samples)
+    print(
+        f"  {label:<16} n={len(commit):<7}"
+        f" p50={percentile(commit, 0.50):8.2f}"
+        f" p90={percentile(commit, 0.90):8.2f}"
+        f" p99={percentile(commit, 0.99):8.2f}"
+        f" max={commit[-1]:8.2f}"
+        f"   (drawms p50={percentile(draw, 0.50):.2f} max={draw[-1]:.2f})"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="p50/p90/p99/max of app-draw -> render-server-commit latency.",
+        epilog="All figures are milliseconds, and are a LOWER BOUND on time-to-glass.",
+    )
+    parser.add_argument(
+        "logfile",
+        nargs="?",
+        help="`log show` output to read; defaults to stdin.",
+    )
+    parser.add_argument(
+        "--load-log",
+        help="Sidecar file of '<epoch> <load1>' lines, to split figures by machine load.",
+    )
+    parser.add_argument(
+        "--include-offscreen",
+        action="store_true",
+        help="Fold vis=0 cycles into the headline figures instead of reporting them apart.",
+    )
+    args = parser.parse_args()
+
+    stream = open(args.logfile, encoding="utf-8") if args.logfile else sys.stdin
+    try:
+        samples, drops = parse(stream)
+    finally:
+        if args.logfile:
+            stream.close()
+
+    if not samples:
+        print("No `commit draws=...` lines found.", file=sys.stderr)
+        print(
+            "Is `defaults write TBDApp enableCommitLatencyDiagnostic -bool true` set,"
+            " and did the app relaunch after? `log show` also needs --info.",
+            file=sys.stderr,
+        )
+        return 1
+
+    offscreen = [s for s in samples if not s.visible]
+    onscreen = samples if args.include_offscreen else [s for s in samples if s.visible]
+
+    total = len(samples) + drops
+    drop_pct = (100.0 * drops / total) if total else 0.0
+
+    print("app-draw -> render-server-commit latency, milliseconds")
+    print("NOT time-to-glass: WindowServer composite and scanout are not covered.")
+    print()
+    print(f"cycles reported: {len(samples)}   dropped (completion block lost): {drops}"
+          f" ({drop_pct:.1f}%)")
+    if drop_pct > 20:
+        print("  WARNING: a fifth or more of cycles were dropped; this sample is biased.")
+    print(f"on screen: {len(samples) - len(offscreen)}   off screen: {len(offscreen)}")
+    print()
+
+    print("by draws-per-cycle" + ("" if args.include_offscreen else " (on-screen cycles only)"))
+    report_group("all", onscreen)
+    report_group("draws=1", [s for s in onscreen if s.draws == 1])
+    report_group("draws>1", [s for s in onscreen if s.draws > 1])
+    print()
+
+    if not args.include_offscreen and offscreen:
+        print("off-screen cycles (work the user never sees)")
+        report_group("vis=0", offscreen)
+        print()
+
+    if args.load_log:
+        series = load_series(args.load_log)
+        print("by machine load (1-minute average, nearest sample within 30s)")
+        banded: dict[str, list[Sample]] = {}
+        for sample in onscreen:
+            banded.setdefault(band_for(load_at(series, sample.epoch)), []).append(sample)
+        for label, _ in LOAD_BANDS:
+            if label in banded:
+                report_group(label, banded[label])
+        if "load unknown" in banded:
+            report_group("load unknown", banded["load unknown"])
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/diag/commit-latency-report.py
+++ b/scripts/diag/commit-latency-report.py
@@ -50,9 +50,11 @@ DROPPED CYCLES
 --------------
 `CATransaction.setCompletionBlock` has no getter and replaces any incumbent
 block. When AppKit or SwiftUI sets its own block on a transaction after the
-probe set one, the probe's block never fires and that cycle is abandoned. The
-probe emits a running `commitdrop cycles=<n>` counter; this script reports it,
-because a high drop rate means the percentiles describe a biased sample.
+probe set one, the probe's block never fires and that cycle is lost. The probe
+emits one `commitdrop draws=<n>` line per lost cycle -- one line each, not a
+running total, so a windowed read of the log counts the drops in its own window
+instead of inheriting a process-lifetime counter. A high drop rate means the
+percentiles describe a biased sample, so it is reported alongside them.
 
 USAGE
 -----
@@ -81,6 +83,7 @@ from __future__ import annotations
 
 import argparse
 import bisect
+import math
 import re
 import sys
 from dataclasses import dataclass
@@ -89,9 +92,11 @@ from datetime import datetime
 # `log show` prefixes each line with e.g. "2026-08-29 10:11:12.345678-0400".
 TIMESTAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+[+-]\d{4})")
 COMMIT_RE = re.compile(
-    r"\bcommit draws=(\d+) drawms=([\d.]+) commitms=([\d.]+) vis=([01])\b"
+    r"\bcommit draws=(\d+) paints=(\d+) drawms=([\d.]+) commitms=([\d.]+) vis=([01])\b"
 )
-DROP_RE = re.compile(r"\bcommitdrop cycles=(\d+)\b")
+# One line per lost cycle, so drops are counted within the window being read
+# rather than inherited from a process-lifetime counter.
+DROP_RE = re.compile(r"\bcommitdrop draws=(\d+)\b")
 
 # Load bands, as (label, upper bound exclusive). The last band is open-ended.
 LOAD_BANDS = [("load<2", 2.0), ("load 2-8", 8.0), ("load 8-32", 32.0), ("load>=32", None)]
@@ -103,6 +108,7 @@ class Sample:
 
     epoch: float | None
     draws: int
+    paints: int
     drawms: float
     commitms: float
     visible: bool
@@ -128,16 +134,15 @@ def parse(stream) -> tuple[list[Sample], int]:
                 Sample(
                     epoch=parse_epoch(line),
                     draws=int(commit.group(1)),
-                    drawms=float(commit.group(2)),
-                    commitms=float(commit.group(3)),
-                    visible=commit.group(4) == "1",
+                    paints=int(commit.group(2)),
+                    drawms=float(commit.group(3)),
+                    commitms=float(commit.group(4)),
+                    visible=commit.group(5) == "1",
                 )
             )
             continue
-        drop = DROP_RE.search(line)
-        if drop:
-            # The counter is cumulative, so the largest value seen is the total.
-            drops = max(drops, int(drop.group(1)))
+        if DROP_RE.search(line):
+            drops += 1
     return samples, drops
 
 
@@ -177,10 +182,15 @@ def band_for(load: float | None) -> str:
 
 
 def percentile(values: list[float], fraction: float) -> float:
-    """Nearest-rank percentile. `values` must be sorted."""
+    """Nearest-rank percentile, rank = ceil(p*n), clamped. `values` must be sorted.
+
+    `ceil`, not `round(p*n + 0.5)`: Python rounds half to even, so that form
+    overshoots — at n=100 it puts p99 on rank 100, reporting the maximum. This
+    matches InputLatencyRecorder.percentile in the daemon.
+    """
     if not values:
         return float("nan")
-    rank = max(1, min(len(values), int(round(fraction * len(values) + 0.5))))
+    rank = max(1, min(len(values), math.ceil(fraction * len(values))))
     return values[rank - 1]
 
 
@@ -189,14 +199,25 @@ def report_group(label: str, samples: list[Sample]) -> None:
         print(f"  {label:<16} (no samples)")
         return
     commit = sorted(s.commitms for s in samples)
-    draw = sorted(s.drawms for s in samples)
+    # A cycle with paints=0 was asked to draw and painted nothing, so its
+    # drawms is 0.000 for a reason that has nothing to do with paint speed.
+    # Folding those in would drag the paint figures toward zero.
+    draw = sorted(s.drawms for s in samples if s.paints > 0)
+    unpainted = len(samples) - len(draw)
+    paint = (
+        f"   (drawms p50={percentile(draw, 0.50):.2f} max={draw[-1]:.2f})"
+        if draw
+        else "   (no painted cycles)"
+    )
+    if unpainted:
+        paint += f" [{unpainted} painted nothing]"
     print(
         f"  {label:<16} n={len(commit):<7}"
         f" p50={percentile(commit, 0.50):8.2f}"
         f" p90={percentile(commit, 0.90):8.2f}"
         f" p99={percentile(commit, 0.99):8.2f}"
         f" max={commit[-1]:8.2f}"
-        f"   (drawms p50={percentile(draw, 0.50):.2f} max={draw[-1]:.2f})"
+        f"{paint}"
     )
 
 
@@ -248,7 +269,7 @@ def main() -> int:
     print()
     print(f"cycles reported: {len(samples)}   dropped (completion block lost): {drops}"
           f" ({drop_pct:.1f}%)")
-    if drop_pct > 20:
+    if drop_pct >= 20:
         print("  WARNING: a fifth or more of cycles were dropped; this sample is biased.")
     print(f"on screen: {len(samples) - len(offscreen)}   off screen: {len(offscreen)}")
     print()


### PR DESCRIPTION
## Summary

The terminal-lag investigation ruled out everything upstream of the process boundary with numbers — client parity after #750, a main thread measured 83% idle during a confirmed lag episode, idle SwiftTerm IO threads, tmux at 0.1–0.4% CPU. `sample` followed the trail to `CA::Transaction::commit` and lost it there.

This adds a temporary, default-off instrument that puts a per-frame number on that last visible step: **how long the app itself spends between starting to draw a terminal frame and finishing its CoreAnimation commit.** Turn it on for a measurement session, reproduce a lag episode, read the log back with `scripts/diag/commit-latency-report.py`.

## ⚠️ This is NOT time-to-glass, and NOT a render-server round trip

The brief this was built from assumed `CATransaction.setCompletionBlock` fires once the render server has committed the transaction. **It does not, and that was measured, not reasoned about.** With a real on-screen window and real committed layer changes:

```
iter 0: commit returned 0.209 ms, completion at 0.269 ms
iter 3: commit returned 0.065 ms, completion at 0.077 ms
```

The block runs **12–99 microseconds after `CATransaction.commit()` returns**, on the same runloop turn. Nothing round-trips to `WindowServer` in 20µs. Apple's contract agrees: the block runs "as soon as all animations subsequent to this transaction group have completed", and with no animations "will be invoked immediately" — the render server is not mentioned because it is not involved.

So every figure this produces is **app-side only**. A small `commitms` licenses **no** conclusion about the compositor; it says the app hands the frame over quickly, which is where the evidence already pointed. **The render-server leg remains uninstrumented** — no public API exposes it for a CoreGraphics-drawn `NSView`. `CAMetalDrawable.addPresentedHandler` would, but that means adopting SwiftTerm's Metal renderer, which is a much larger change and is not proposed here.

All three claim sites — probe header, spec, reader docstring — state what was measured rather than what was assumed.

## Why this shape

Spec: [`docs/specs/2026-08-29-commit-latency-diagnostic-design.md`](docs/specs/2026-08-29-commit-latency-diagnostic-design.md).

**Two seams, because the obvious one is closed.** SwiftTerm's `TerminalView.draw(_:)` is `public`, not `open`, so it cannot be overridden from `TBDApp` (verified by compile failure). The start is stamped in `viewWillDraw()`; the end of the paint span comes from `TerminalView.onFramePresented`, the fork's own diagnostics hook. AppKit sends `viewWillDraw` to a whole subtree before drawing any of it, so the two cannot be paired per view — `drawms` is the span, not a sum of per-view bodies.

**Transaction identity comes from the transaction, not a stopwatch.** `CATransaction.setValue(_:forKey:)` is a per-transaction store *with* a getter, unlike `setCompletionBlock`. The probe stamps its cycle id there and reads it back: same mark = same transaction, no mark = a new one. An elapsed-time boundary cannot do this job — AppKit's cadence is ~16.67ms, so any window wide enough to tolerate a slow commit also swallows the next cycle whole, and that bias would grow with exactly the latency the instrument exists to characterize. This also makes the probe agnostic to the open question of whether per-view `FrameDriver`s share one display pass: it no longer guesses.

**`sync` exists because animations silently redefine the metric.** The block waits for *animations*, not for a commit. Measured: a finite 0.6s animation deferred it by **675ms** — a sample that lands in p99 looking exactly like the compositor stall we are hunting; an infinite one meant it never fired. TBD's terminal has both — SwiftTerm's caret blink is `repeatCount = .infinity`, and the overlay scroller fades over 0.25s during scrolling, which *is* the lag repro. The probe schedules a runloop-turn marker: `sync=1` means the completion beat it (no animation wait, the number means what it says), `sync=0` means it did not. The reader reports the two populations separately and never pools them.

Rejected alternatives (in the spec): `onFramePresented` alone (no view identity), a `Clock<Duration>` seam (nothing here sleeps or polls), `CADisplayLink` (reports scheduling, not acceptance), per-frame `getloadavg` (overhead inside the path being measured), a Settings toggle.

## What this PR does

- `Sources/TBDApp/Terminal/TerminalCommitLatencyProbe.swift` — the probe. Per-transaction state, injected seams for the clock, the transaction, the runloop-turn marker, and the log sink.
- `Sources/TBDApp/Terminal/TBDTerminalView.swift` — a `viewWillDraw()` override; the `guard let` on the probe is the entire gate.
- `Sources/TBDApp/AppState.swift` — the flag key, default, and a `nonisolated` read helper.
- `Tests/TBDAppTests/TerminalCommitLatencyProbeTests.swift` — 17 tests, including the real `TransactionSeam.coreAnimation` rather than only the injected fake.
- `scripts/diag/commit-latency-report.py` — p50/p90/p99/max for `commitms`, split by `sync`, by `draws=1` vs `draws>1`, by on-screen, and optionally by machine load via a sidecar log joined on timestamp.

Output, one `.info` line per instrumented display cycle on `com.tbd.app` / `commitlatency`:

```
commit draws=<n> paints=<n> drawms=<f> commitms=<f> vis=<0|1> sync=<0|1>
commitdrop draws=<n> vis=<0|1>
```

`.info` rather than `.debug` deliberately, against [`docs/diagnostics-strategy.md`](docs/diagnostics-strategy.md)'s per-event-trace rule: that doc also says `log show` returns only `.info`+ for past events without a prior `sudo log config`, and "reproduce, then ask for the recent past" is the whole workflow. The cost is real — `.info` is retained briefly, so take short captures.

## Flag & rollout

- **Flag:** `enableCommitLatencyDiagnostic` (UserDefaults, app-only behaviour; precedent `enableTranscript`). **Default OFF.**
- **Enable for a measurement session:**
  ```
  defaults write TBDApp enableCommitLatencyDiagnostic -bool true   # then relaunch TBDApp
  # reproduce the lag, then:
  log show --last 5m --info \
    --predicate 'subsystem == "com.tbd.app" AND category == "commitlatency"' \
    | scripts/diag/commit-latency-report.py
  defaults write TBDApp enableCommitLatencyDiagnostic -bool false
  ```
- **Graduation plan: none — this is meant to be deleted.** It does not graduate. Once the app-side commit question is answered, the probe, its flag, its tests, and its reader come out. It is deliberately cheap to remove: one new file, one `viewWillDraw()` override, one key on `AppState`, one script.

This departs from that same diagnostics doc's "no defaults key" rule, and the spec argues why: that rule is about *verbosity*, where os_log's level filter is the better activation mechanism. This flag gates a **behaviour change** — the probe stamps a value on, and claims the single completion-block slot of, a `CATransaction` the whole app shares, discarding whatever block was there. No subscriber-side filter can express that.

## Assumptions

- **`viewWillDraw()` is called at all.** `Package.swift` carries a standing warning from #750 that a frame loop not on the main thread may never call it. It does not bite today: SwiftTerm takes its render-loop path only when the Metal layer surface is enabled, and TBD enables it nowhere in `Sources/`. Recorded because the failure is silent and reads as good news — **an instrument that logs nothing looks exactly like a machine with no lag.**
- **A cycle's first draw is not inside a nested transaction.** Nested transactions inherit the parent's mark on read and discard their own writes (measured), so *joining* is safe; a first draw landing inside one would measure the nested commit. TBD has one nested transaction, in `TypingDotsView.layout()`. Recorded, not defended against.
- **`commitdrop` has two indistinguishable causes** — our block replaced, or an animation still holding it. The probe no longer claims which.

## Evidence & verification

- **The mechanism claim was falsified by measurement, not review opinion.** Standalone AppKit binaries with a real on-screen window produced the timing table above, the 675ms finite-animation deferral, and the never-firing infinite-animation case. That is what drove the rewrite of what this instrument claims.
- **Both flag branches tested**, per the repo rule, through a per-test `UserDefaults(suiteName:)` torn down with `removePersistentDomain` — never `.standard`, which on this unbundled executable is the developer's live `TBDApp.plist`.
- **The transaction mechanism is discriminated, and the tests say which ones do it.** `lostCycleIsReportedPromptly`, `eachLostCycleIsItsOwnLine` and `staleBlockIsInert` all fail under the elapsed-time boundary this replaced. `backToBackCyclesStaySeparate` does **not** discriminate it, and its docstring says so rather than implying otherwise.
- **The real `CATransaction` seam is tested**, not only the injected fake — mark round-trip and mark-dies-with-the-transaction.
- **Not live-verified in the running app.** Per the task's constraints I did not run `scripts/restart.sh` or start/stop the daemon or app — a live measurement was in progress on this machine. **This needs installing before it can produce a reading**, and the first thing to check is that a capture is non-empty (see the `viewWillDraw` assumption above).
- Local runs on this shared box kept getting killed mid-suite, so CI is the authority for this branch. `swiftlint --strict` clean locally (0 violations, 844 files).

[CA commit latency probe](https://cheapsteak.github.io/tbd/open/?worktree=653193B8-D2C5-49F5-AC4C-43D195954F14)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in diagnostic for measuring terminal drawing and commit latency.
  * Added command-line reporting for latency percentiles, dropped cycles, visibility, and load conditions.
* **Documentation**
  * Added a design specification describing measurement behavior, reporting, and known limitations.
* **Tests**
  * Added comprehensive coverage for diagnostic gating, timing, rendering, transaction handling, and dropped samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->