### PR TITLE
Feat: measure what the daemon pushes at the app, and what decoding it costs

### DIFF
--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -149,7 +149,7 @@ actor DaemonClient {
     /// Try a single connection attempt (non-async).
     private func tryConnect() -> Bool {
         do {
-            _ = try sendRaw(RPCRequest(method: RPCMethod.daemonStatus))
+            try sendRaw(RPCRequest(method: RPCMethod.daemonStatus)).finish()
             connected = true
             return true
         } catch {
@@ -246,11 +246,34 @@ actor DaemonClient {
         return fd
     }
 
+    /// An `RPCResponse` paired with the still-open `RPCVolumeProbe`
+    /// measurement of the frame that carried it.
+    ///
+    /// The envelope decode in `sendRaw` is only the first half of a response's
+    /// cost: `RPCResponse.result` is a JSON *string*, so `decodeResult` runs a
+    /// SECOND full decode over the whole payload, and that second decode is
+    /// the expensive one this diagnostic exists to rank. Closing the
+    /// measurement in `sendRaw` would report the string unescape and miss the
+    /// structured parse entirely. So the measurement rides out to the caller
+    /// and `finish()` closes it — after the typed decode where there is one,
+    /// immediately where there is not (an error response, or a void call).
+    private struct MeasuredResponse: Sendable {
+        let response: RPCResponse
+        let method: String
+        let bytes: Int
+        let start: UInt64?
+
+        func finish() {
+            RPCVolumeProbe.shared.record(
+                start: start, kind: .response, type: method, bytes: bytes)
+        }
+    }
+
     /// Send an RPCRequest over a fresh POSIX Unix socket and return the RPCResponse.
     /// Wrapped in autoreleasepool to ensure ObjC-bridged objects (from JSON coding,
     /// FileManager, etc.) are freed immediately — prevents accumulation across
     /// the 2-second polling cycle.
-    private nonisolated func sendRaw(_ request: RPCRequest) throws -> RPCResponse {
+    private nonisolated func sendRaw(_ request: RPCRequest) throws -> MeasuredResponse {
         // The app is the operator's hand: every request it makes is declared
         // `{"kind":"app"}` at this one encode chokepoint rather than at each
         // of the ~200 call sites.
@@ -322,18 +345,17 @@ actor DaemonClient {
             }
 
             // Probe is default-off; when off `startMeasurement()` reads no
-            // clock and `record` returns on the nil start.
-            let probe = RPCVolumeProbe.shared
-            let started = probe.startMeasurement()
+            // clock and `record` returns on the nil start. The measurement is
+            // NOT closed here — see `MeasuredResponse`.
+            let started = RPCVolumeProbe.shared.startMeasurement()
             let decoder = JSONDecoder()
             let response = try decoder.decode(RPCResponse.self, from: responseData)
-            probe.record(
-                start: started,
-                kind: .response,
-                type: request.method,
-                bytes: responseData.count
+            return MeasuredResponse(
+                response: response,
+                method: request.method,
+                bytes: responseData.count,
+                start: started
             )
-            return response
         }
     }
 
@@ -342,36 +364,44 @@ actor DaemonClient {
         method: String, params: P, resultType: R.Type
     ) throws -> R {
         let request = try RPCRequest(method: method, params: params)
-        let response = try sendRaw(request)
+        let measured = try sendRaw(request)
+        let response = measured.response
         guard response.success else {
+            measured.finish()
             throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
+        defer { measured.finish() }
         return try response.decodeResult(resultType)
     }
 
     /// Send an RPC request with typed params that returns no meaningful result.
     private func callVoid<P: Encodable>(method: String, params: P) throws {
         let request = try RPCRequest(method: method, params: params)
-        let response = try sendRaw(request)
-        guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
+        let measured = try sendRaw(request)
+        measured.finish()   // no typed result to wait for
+        guard measured.response.success else {
+            throw DaemonClientError.rpcError(
+                measured.response.error ?? "Unknown error", code: measured.response.errorCode)
         }
     }
 
     /// Send an RPC request with no params and decode a typed result.
     private func callNoParams<R: Decodable>(method: String, resultType: R.Type) throws -> R {
         let request = RPCRequest(method: method)
-        let response = try sendRaw(request)
+        let measured = try sendRaw(request)
+        let response = measured.response
         guard response.success else {
+            measured.finish()
             throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
+        defer { measured.finish() }
         return try response.decodeResult(resultType)
     }
 
     // MARK: - Async RPC helpers (dispatch blocking recv off the cooperative thread pool)
 
     /// Wraps the blocking `sendRaw` in a detached task so it runs on a background thread.
-    private func sendRawAsync(_ request: RPCRequest) async throws -> RPCResponse {
+    private func sendRawAsync(_ request: RPCRequest) async throws -> MeasuredResponse {
         try await Task.detached(priority: .userInitiated) { [self] in
             try self.sendRaw(request)
         }.value
@@ -379,9 +409,11 @@ actor DaemonClient {
 
     private func callVoidAsync<P: Encodable>(method: String, params: P) async throws {
         let request = try RPCRequest(method: method, params: params)
-        let response = try await sendRawAsync(request)
-        guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
+        let measured = try await sendRawAsync(request)
+        measured.finish()   // no typed result to wait for
+        guard measured.response.success else {
+            throw DaemonClientError.rpcError(
+                measured.response.error ?? "Unknown error", code: measured.response.errorCode)
         }
     }
 
@@ -389,19 +421,25 @@ actor DaemonClient {
         method: String, params: P, resultType: R.Type
     ) async throws -> R {
         let request = try RPCRequest(method: method, params: params)
-        let response = try await sendRawAsync(request)
+        let measured = try await sendRawAsync(request)
+        let response = measured.response
         guard response.success else {
+            measured.finish()
             throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
+        defer { measured.finish() }
         return try response.decodeResult(resultType)
     }
 
     private func callNoParamsAsync<R: Decodable>(method: String, resultType: R.Type) async throws -> R {
         let request = RPCRequest(method: method)
-        let response = try await sendRawAsync(request)
+        let measured = try await sendRawAsync(request)
+        let response = measured.response
         guard response.success else {
+            measured.finish()
             throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
+        defer { measured.finish() }
         return try response.decodeResult(resultType)
     }
 
@@ -1842,10 +1880,13 @@ actor DaemonClient {
             method: RPCMethod.sessionMessages,
             params: SessionMessagesParams(filePath: filePath)
         )
-        let response = try await sendRawAsync(request)
+        let measured = try await sendRawAsync(request)
+        let response = measured.response
         guard response.success else {
+            measured.finish()
             throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
+        defer { measured.finish() }
         let bytes = response.result?.utf8.count ?? 0
         let decodeStart = ContinuousClock.now
         let result = try response.decodeResult([TranscriptItem].self)
@@ -1867,10 +1908,13 @@ actor DaemonClient {
             method: RPCMethod.terminalTranscript,
             params: TerminalTranscriptParams(terminalID: terminalID, tailLimit: tailLimit)
         )
-        let response = try await sendRawAsync(request)
+        let measured = try await sendRawAsync(request)
+        let response = measured.response
         guard response.success else {
+            measured.finish()
             throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
+        defer { measured.finish() }
         let bytes = response.result?.utf8.count ?? 0
         let decodeStart = ContinuousClock.now
         let result = try response.decodeResult(TerminalTranscriptResult.self)
@@ -1918,10 +1962,13 @@ actor DaemonClient {
     /// roundtrip-validated). Repo-level files are NEVER auto-modified.
     func removeLegacyGlobalHooks() async throws -> RemoveLegacyGlobalHooksResult {
         let request = RPCRequest(method: RPCMethod.daemonRemoveLegacyGlobalHooks)
-        let response = try await sendRawAsync(request)
+        let measured = try await sendRawAsync(request)
+        let response = measured.response
         guard response.success else {
+            measured.finish()
             throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
+        defer { measured.finish() }
         return try response.decodeResult(RemoveLegacyGlobalHooksResult.self)
     }
 }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -321,8 +321,19 @@ actor DaemonClient {
                 throw DaemonClientError.invalidResponse
             }
 
+            // Probe is default-off; when off `startMeasurement()` reads no
+            // clock and `record` returns on the nil start.
+            let probe = RPCVolumeProbe.shared
+            let started = probe.startMeasurement()
             let decoder = JSONDecoder()
-            return try decoder.decode(RPCResponse.self, from: responseData)
+            let response = try decoder.decode(RPCResponse.self, from: responseData)
+            probe.record(
+                start: started,
+                kind: .response,
+                type: request.method,
+                bytes: responseData.count
+            )
+            return response
         }
     }
 
@@ -1493,6 +1504,7 @@ actor DaemonClient {
 
         var accumulated = Data()
         let decoder = JSONDecoder()
+        let probe = RPCVolumeProbe.shared
 
         while !Task.isCancelled {
             let bytesRead = recv(fd, buffer, bufferSize, 0)
@@ -1514,16 +1526,35 @@ actor DaemonClient {
                 let lineData = accumulated[accumulated.startIndex..<newlineIndex]
                 accumulated = accumulated[accumulated.index(after: newlineIndex)...]
 
+                // Measured from here so the recorded cost is the WHOLE frame's
+                // decode, including the ack probe below that fails on every
+                // real delta. That failed attempt is a genuine per-delta cost
+                // of this path and hiding it would understate the total.
+                let started = probe.startMeasurement()
+
                 // Skip the initial ack from SocketServer's subscription handler.
                 // This is the only RPC that sends an RPCResponse with success=true
                 // and no result — all other RPCs include a result payload.
                 if let response = try? decoder.decode(RPCResponse.self, from: Data(lineData)),
                    response.success && response.result == nil {
+                    probe.record(start: started, kind: .delta, type: "(ack)", bytes: lineData.count)
                     continue
                 }
 
                 if let delta = try? decoder.decode(StateDelta.self, from: Data(lineData)) {
+                    probe.record(
+                        start: started,
+                        kind: .delta,
+                        type: delta.rpcVolumeTypeName,
+                        bytes: lineData.count
+                    )
                     onDelta(delta)
+                } else {
+                    // Bytes that cost two failed decodes and are then dropped:
+                    // a delta case this app build does not know, or a response
+                    // that carries a result. Counting them keeps the probe's
+                    // byte total equal to what the socket actually delivered.
+                    probe.record(start: started, kind: .delta, type: "(undecodable)", bytes: lineData.count)
                 }
             }
         }

--- a/Sources/TBDApp/Diagnostics/RPCVolumeProbe.swift
+++ b/Sources/TBDApp/Diagnostics/RPCVolumeProbe.swift
@@ -54,12 +54,13 @@ enum RPCVolumeDiagnosticPreferences {
 /// be safe would discard exactly the messages under suspicion, and the
 /// denominators (total bytes, total decode ms, messages/second) would be lost.
 ///
-/// The window is closed **lazily, by the next record that finds it expired** —
-/// there is no timer, no `Task`, and therefore no sleeping and no `Clock`
-/// seam. The cost is that a window whose traffic stops is not emitted until
-/// traffic resumes, and the final partial window at app exit is dropped; for a
-/// diagnostic that only runs while traffic is flowing, that is the right
-/// trade against putting a scheduled wake-up inside the thing being measured.
+/// The window is closed **lazily, by the next record that finds it expired**
+/// (whose own message then opens the new window) — there is no timer, no
+/// `Task`, and therefore no sleeping and no `Clock` seam. The cost is that a
+/// window whose traffic stops is not emitted until traffic resumes, and the
+/// final partial window at app exit is dropped; for a diagnostic that only
+/// runs while traffic is flowing, that is the right trade against putting a
+/// scheduled wake-up inside the thing being measured.
 ///
 /// ## What is logged
 ///
@@ -74,6 +75,14 @@ enum RPCVolumeDiagnosticPreferences {
 /// work and never reach a log line. The `type` values are compile-time
 /// constants: an `RPCMethod` string for a response, a `StateDelta` case name
 /// for a delta.
+///
+/// ## What it does NOT see
+///
+/// `DaemonClient`'s two receive paths, and nothing else.
+/// `FDSidecarClient.handleFDVend` also decodes daemon-pushed JSON — a small
+/// `FDVendHeader` per control-mode attach, not a hot path — and is deliberately
+/// left uninstrumented, so the totals here are the app's RPC traffic rather
+/// than every byte the daemon sends it.
 final class RPCVolumeProbe: Sendable {
     /// Which receive path the message arrived on. The two have different
     /// fixes — a response is one call the app chose to make, a delta is
@@ -148,14 +157,33 @@ final class RPCVolumeProbe: Sendable {
     func record(start: UInt64?, kind: Kind, type: String, bytes: Int) {
         guard let start else { return }
         let end = now()
-        let decodeNanos = end >= start ? end - start : 0
+        let decodeNanos = Self.elapsed(from: start, to: end)
         let key = TypeKey(kind: kind.rawValue, type: type)
 
-        let closed: Window? = window.withLock { current in
+        let closed: Window? = window.withLock { current -> Window? in
+            // Roll BEFORE adding: this message arrived after the old window's
+            // span ended, so its bytes belong to the new one. Attributing them
+            // to a window whose `secs` does not cover them inflates that
+            // window's byte rate by exactly one message.
+            //
+            // The elapsed subtraction saturates rather than wrapping. `end` is
+            // read before the lock, so a thread descheduled between its clock
+            // read and its turn at the lock can arrive with a reading OLDER
+            // than a window another thread has already opened — and `sendRaw`
+            // on arbitrary detached threads runs concurrently with the
+            // long-lived `subscribe(onDelta:)` receive loop, which is exactly
+            // the contention this probe exists to observe. Unsigned wrapping
+            // would turn that into a near-`UInt64.max` elapsed, a spurious
+            // roll, and an astronomical `secs=` that drags the reader's rate
+            // denominators toward zero.
+            var finished: Window?
+            if Self.elapsed(from: current.startedAt, to: end) >= windowNanos {
+                // An expired window with nothing in it is a quiet stretch, not
+                // a measurement; replace it rather than logging an empty line.
+                if current.messages > 0 { finished = current }
+                current = Window(startedAt: end)
+            }
             current.add(key: key, bytes: bytes, decodeNanos: decodeNanos, latencySampleCap: latencySampleCap)
-            guard end &- current.startedAt >= windowNanos else { return nil }
-            let finished = current
-            current = Window(startedAt: end)
             return finished
         }
         if let closed { report(closed, endedAt: end) }
@@ -178,8 +206,13 @@ final class RPCVolumeProbe: Sendable {
 
     // MARK: - Reporting
 
+    /// Saturating monotonic difference. See the note in `record`.
+    private static func elapsed(from start: UInt64, to end: UInt64) -> UInt64 {
+        end >= start ? end - start : 0
+    }
+
     private func report(_ closed: Window, endedAt: UInt64) {
-        let seconds = Double(endedAt &- closed.startedAt) / 1e9
+        let seconds = Double(Self.elapsed(from: closed.startedAt, to: endedAt)) / 1e9
         let latencies = closed.latencies.sorted()
         emit(
             "rpc kind=window secs=\(fmt(seconds, 3)) msgs=\(closed.messages) bytes=\(closed.bytes) "

--- a/Sources/TBDApp/Diagnostics/RPCVolumeProbe.swift
+++ b/Sources/TBDApp/Diagnostics/RPCVolumeProbe.swift
@@ -1,0 +1,325 @@
+import Foundation
+import TBDShared
+import os
+
+/// Default-off gate for the RPC volume probe.
+///
+/// App-only behaviour, so `UserDefaults` is the right home per CLAUDE.md —
+/// precedent is `enableTranscript`. There is deliberately no Settings toggle:
+/// this is a measurement instrument, not a feature, and the flag is read once
+/// per process (see `RPCVolumeProbe.init`) so the receive path costs one
+/// already-loaded `Bool` when it is off.
+///
+/// Enable for a measurement session with
+/// `defaults write TBDApp enableRPCVolumeDiagnostic -bool true`, then relaunch
+/// the app. `defaults delete TBDApp enableRPCVolumeDiagnostic` returns to unset.
+enum RPCVolumeDiagnosticPreferences {
+    static let enabledKey = "enableRPCVolumeDiagnostic"
+
+    /// The one default for `enabledKey`. Every read site must spell the
+    /// default with this constant rather than a bare literal.
+    ///
+    /// Off, because the probe is not free: enabled, it takes two monotonic
+    /// clock reads and one uncontended lock acquisition per message received
+    /// from the daemon, and keeps a per-second window of per-type totals.
+    static let enabledDefault = false
+
+    static func isEnabled(_ defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enabledKey) as? Bool ?? enabledDefault
+    }
+}
+
+/// Measures how much data the daemon pushes at the app and what decoding it
+/// costs, per message, on both receive paths in `DaemonClient`.
+///
+/// ## Why this exists
+///
+/// A `sample` of TBDApp taken during a confirmed terminal-lag episode found
+/// 1,265 samples inside `JSONDecoder` internals against 81 blocked in
+/// `read`/`recv`/`poll`/`cond_wait`, spread over six cooperative-pool threads.
+/// Those threads were not waiting on the socket; they were burning CPU
+/// decoding. Nothing logged payload sizes, so there was no way to tell whether
+/// that is a meaningful load or a sampling artifact. This closes that gap.
+///
+/// ## Rate limiting: a periodic summary, flushed lazily
+///
+/// The measurement's whole premise is that messages may arrive hundreds of
+/// times a second. One log line each would cost more than the decode it
+/// measures and would corrupt the reading, so records aggregate into a window
+/// (1 s by default) and only the window is logged.
+///
+/// The alternative — logging individual lines above a byte or duration
+/// threshold — was rejected because it cannot answer the question asked. The
+/// suspicion is death by a thousand small deltas; a threshold high enough to
+/// be safe would discard exactly the messages under suspicion, and the
+/// denominators (total bytes, total decode ms, messages/second) would be lost.
+///
+/// The window is closed **lazily, by the next record that finds it expired** —
+/// there is no timer, no `Task`, and therefore no sleeping and no `Clock`
+/// seam. The cost is that a window whose traffic stops is not emitted until
+/// traffic resumes, and the final partial window at app exit is dropped; for a
+/// diagnostic that only runs while traffic is flowing, that is the right
+/// trade against putting a scheduled wake-up inside the thing being measured.
+///
+/// ## What is logged
+///
+/// One `kind=window` line with the totals, then one line per (kind, type)
+/// pair — capped at the union of the top eight by bytes and the top eight by
+/// decode time, with the remainder rolled into a `type=(other)` line so the
+/// per-type totals still sum to the window's. Both rankings the reader needs —
+/// which messages dominate *bytes* and which dominate *decode time* — survive
+/// that cap, and they are not the same ranking.
+///
+/// **Sizes, type names and timings only.** Payloads carry the user's real
+/// work and never reach a log line. The `type` values are compile-time
+/// constants: an `RPCMethod` string for a response, a `StateDelta` case name
+/// for a delta.
+final class RPCVolumeProbe: Sendable {
+    /// Which receive path the message arrived on. The two have different
+    /// fixes — a response is one call the app chose to make, a delta is
+    /// pushed traffic the app cannot decline — so they are never merged.
+    enum Kind: String, Sendable {
+        case delta
+        case response
+    }
+
+    /// The process-wide probe used by `DaemonClient`.
+    static let shared = RPCVolumeProbe()
+
+    /// Read once at construction. A per-message `UserDefaults` lookup would
+    /// itself be overhead on the path being measured, so toggling the flag
+    /// takes effect at the next app launch.
+    let isEnabled: Bool
+
+    private let windowNanos: UInt64
+    private let latencySampleCap: Int
+    private let now: @Sendable () -> UInt64
+    private let emit: @Sendable (String) -> Void
+    private let window: OSAllocatedUnfairLock<Window>
+
+    private static let logger = Logger(subsystem: "com.tbd.app", category: "rpcvolume")
+
+    /// - Parameters:
+    ///   - defaults: the domain the gate is read from.
+    ///   - windowSeconds: how much traffic one summary line covers.
+    ///   - latencySampleCap: upper bound on decode durations retained per
+    ///     window for percentiles. Counts, byte totals and decode-time totals
+    ///     stay exact past the cap; only the percentiles are drawn from the
+    ///     first `latencySampleCap` messages. Bounds the probe's own
+    ///     allocation under exactly the flood it is there to catch.
+    ///   - now: monotonic nanosecond source. A closure seam, not a `Clock`:
+    ///     nothing here sleeps or schedules, and these readings are compared,
+    ///     never persisted.
+    ///   - emit: one formatted line. Defaults to the `rpcvolume` logger.
+    init(
+        defaults: UserDefaults = .standard,
+        windowSeconds: Double = 1.0,
+        latencySampleCap: Int = 8192,
+        now: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
+        emit: (@Sendable (String) -> Void)? = nil
+    ) {
+        self.isEnabled = RPCVolumeDiagnosticPreferences.isEnabled(defaults)
+        self.windowNanos = UInt64(max(0, windowSeconds) * 1_000_000_000)
+        self.latencySampleCap = latencySampleCap
+        self.now = now
+        // `.info` so the lines persist for a `log show` after an episode, and
+        // `.public` because every interpolated value is a size, a count, a
+        // duration, or a compile-time type name.
+        self.emit = emit ?? { line in Self.logger.info("\(line, privacy: .public)") }
+        self.window = OSAllocatedUnfairLock(initialState: Window(startedAt: now()))
+    }
+
+    // MARK: - Recording
+
+    /// Timestamp to hand back to `record`, or nil when the probe is off — in
+    /// which case no clock is read and no measurement overhead is taken.
+    func startMeasurement() -> UInt64? {
+        isEnabled ? now() : nil
+    }
+
+    /// Record one received message. A nil `start` (probe off) returns
+    /// immediately.
+    ///
+    /// - Parameters:
+    ///   - start: the value `startMeasurement()` returned before decoding began.
+    ///   - bytes: length of the framed message, excluding the newline delimiter.
+    ///   - type: the RPC method name for a response, the `StateDelta` case
+    ///     name for a delta.
+    func record(start: UInt64?, kind: Kind, type: String, bytes: Int) {
+        guard let start else { return }
+        let end = now()
+        let decodeNanos = end >= start ? end - start : 0
+        let key = TypeKey(kind: kind.rawValue, type: type)
+
+        let closed: Window? = window.withLock { current in
+            current.add(key: key, bytes: bytes, decodeNanos: decodeNanos, latencySampleCap: latencySampleCap)
+            guard end &- current.startedAt >= windowNanos else { return nil }
+            let finished = current
+            current = Window(startedAt: end)
+            return finished
+        }
+        if let closed { report(closed, endedAt: end) }
+    }
+
+    /// Close and emit the current window even though it has not expired.
+    /// Production never calls this — the next record rolls the window — but it
+    /// lets a test close a partial window without waiting on wall time.
+    func flush() {
+        guard isEnabled else { return }
+        let end = now()
+        let closed: Window? = window.withLock { current in
+            guard current.messages > 0 else { return nil }
+            let finished = current
+            current = Window(startedAt: end)
+            return finished
+        }
+        if let closed { report(closed, endedAt: end) }
+    }
+
+    // MARK: - Reporting
+
+    private func report(_ closed: Window, endedAt: UInt64) {
+        let seconds = Double(endedAt &- closed.startedAt) / 1e9
+        let latencies = closed.latencies.sorted()
+        emit(
+            "rpc kind=window secs=\(fmt(seconds, 3)) msgs=\(closed.messages) bytes=\(closed.bytes) "
+            + "decodems=\(millis(closed.decodeNanos)) p50ms=\(millis(percentile(latencies, 0.5))) "
+            + "p90ms=\(millis(percentile(latencies, 0.9))) maxms=\(millis(closed.maxDecodeNanos)) "
+            + "types=\(closed.byType.count) sampled=\(latencies.count)"
+        )
+        // Both rankings are kept whole — a type that dominates bytes and one
+        // that dominates decode time are frequently different types, and that
+        // difference is the actionable part — but the line count per window
+        // stays bounded, so a window with pathologically many distinct types
+        // cannot turn the summary back into per-message logging.
+        let byBytes = closed.byType.sorted { $0.value.bytes > $1.value.bytes }
+        let byTime = closed.byType.sorted { $0.value.decodeNanos > $1.value.decodeNanos }
+        var kept = Set(byBytes.prefix(Self.typeLinesPerRanking).map(\.key))
+        kept.formUnion(byTime.prefix(Self.typeLinesPerRanking).map(\.key))
+
+        var other = TypeTotals()
+        for (key, totals) in byBytes {
+            guard kept.contains(key) else {
+                other.count += totals.count
+                other.bytes += totals.bytes
+                other.decodeNanos += totals.decodeNanos
+                other.maxDecodeNanos = max(other.maxDecodeNanos, totals.maxDecodeNanos)
+                continue
+            }
+            emit(typeLine(kind: key.kind, type: key.type, totals: totals))
+        }
+        if other.count > 0 {
+            emit(typeLine(kind: "mixed", type: "(other)", totals: other))
+        }
+    }
+
+    /// How many types each ranking contributes to a window's per-type lines.
+    /// The union of the two rankings plus the `(other)` rollup caps a window
+    /// at `2 * typeLinesPerRanking + 2` lines.
+    private static let typeLinesPerRanking = 8
+
+    private func typeLine(kind: String, type: String, totals: TypeTotals) -> String {
+        "rpc kind=\(kind) type=\(type) n=\(totals.count) bytes=\(totals.bytes) "
+        + "decodems=\(millis(totals.decodeNanos)) maxms=\(millis(totals.maxDecodeNanos))"
+    }
+
+    private func millis(_ nanos: UInt64) -> String {
+        fmt(Double(nanos) / 1_000_000, 3)
+    }
+
+    private func fmt(_ value: Double, _ places: Int) -> String {
+        String(format: "%.\(places)f", value)
+    }
+
+    private func percentile(_ sorted: [UInt64], _ quantile: Double) -> UInt64 {
+        guard !sorted.isEmpty else { return 0 }
+        return sorted[min(sorted.count - 1, Int(Double(sorted.count) * quantile))]
+    }
+
+    // MARK: - Window
+
+    private struct TypeKey: Hashable, Sendable {
+        let kind: String
+        let type: String
+    }
+
+    private struct TypeTotals: Sendable {
+        var count = 0
+        var bytes = 0
+        var decodeNanos: UInt64 = 0
+        var maxDecodeNanos: UInt64 = 0
+    }
+
+    private struct Window: Sendable {
+        let startedAt: UInt64
+        var messages = 0
+        var bytes = 0
+        var decodeNanos: UInt64 = 0
+        var maxDecodeNanos: UInt64 = 0
+        var latencies: [UInt64] = []
+        var byType: [TypeKey: TypeTotals] = [:]
+
+        init(startedAt: UInt64) {
+            self.startedAt = startedAt
+        }
+
+        mutating func add(key: TypeKey, bytes: Int, decodeNanos: UInt64, latencySampleCap: Int) {
+            messages += 1
+            self.bytes += bytes
+            self.decodeNanos += decodeNanos
+            maxDecodeNanos = max(maxDecodeNanos, decodeNanos)
+            if latencies.count < latencySampleCap { latencies.append(decodeNanos) }
+            var totals = byType[key] ?? TypeTotals()
+            totals.count += 1
+            totals.bytes += bytes
+            totals.decodeNanos += decodeNanos
+            totals.maxDecodeNanos = max(totals.maxDecodeNanos, decodeNanos)
+            byType[key] = totals
+        }
+    }
+}
+
+// MARK: - Delta naming
+
+extension StateDelta {
+    /// The case name alone, for the probe's `type=` field.
+    ///
+    /// An exhaustive switch on purpose: it is allocation-free on the path
+    /// being measured (a `Mirror` is not), and a new `StateDelta` case breaks
+    /// the build rather than silently going unlabelled. `String(describing:)`
+    /// is not an option — for a case with a payload it would interpolate the
+    /// payload, which is the user's real work.
+    var rpcVolumeTypeName: String {
+        switch self {
+        case .worktreeCreated: return "worktreeCreated"
+        case .worktreeArchived: return "worktreeArchived"
+        case .worktreeRevived: return "worktreeRevived"
+        case .worktreeRenamed: return "worktreeRenamed"
+        case .notificationReceived: return "notificationReceived"
+        case .repoAdded: return "repoAdded"
+        case .repoRemoved: return "repoRemoved"
+        case .repoRenamed: return "repoRenamed"
+        case .repoHiddenChanged: return "repoHiddenChanged"
+        case .repoExpandedChanged: return "repoExpandedChanged"
+        case .terminalCreated: return "terminalCreated"
+        case .terminalRemoved: return "terminalRemoved"
+        case .worktreeConflictsChanged: return "worktreeConflictsChanged"
+        case .terminalPinChanged: return "terminalPinChanged"
+        case .worktreeReordered: return "worktreeReordered"
+        case .modelProfileUsageUpdated: return "modelProfileUsageUpdated"
+        case .modelProfilesChanged: return "modelProfilesChanged"
+        case .terminalSessionUpdated: return "terminalSessionUpdated"
+        case .terminalActivityUpdated: return "terminalActivityUpdated"
+        case .terminalAwaitingInputChanged: return "terminalAwaitingInputChanged"
+        case .terminalProfileChanged: return "terminalProfileChanged"
+        case .watchDeskRolesChanged: return "watchDeskRolesChanged"
+        case .worktreeMoved: return "worktreeMoved"
+        case .terminalHibernationChanged: return "terminalHibernationChanged"
+        case .controlModeInputHealthChanged: return "controlModeInputHealthChanged"
+        case .reapRecordsChanged: return "reapRecordsChanged"
+        case .panelSurfaceChanged: return "panelSurfaceChanged"
+        case .remoteSessionsChanged: return "remoteSessionsChanged"
+        case .remoteSessionAttention: return "remoteSessionAttention"
+        }
+    }
+}

--- a/Tests/TBDAppTests/RPCVolumeProbeTests.swift
+++ b/Tests/TBDAppTests/RPCVolumeProbeTests.swift
@@ -181,10 +181,13 @@ struct RPCVolumeProbeTests {
             #expect(lines[2] == "rpc kind=delta type=terminalActivityUpdated n=3 bytes=3000 "
                                 + "decodems=6.000 maxms=2.000")
 
-            // The message that rolled the window belongs to the NEW one.
+            // The message that rolled the window belongs to the NEW one: its
+            // bytes arrived after the old window's span ended, so counting
+            // them there would inflate that window's byte rate.
             sink.append("--")
             probe.flush()
-            #expect(sink.all.last!.contains("n=1"))
+            #expect(sink.all.last! == "rpc kind=delta type=terminalActivityUpdated n=1 bytes=10 "
+                                     + "decodems=0.000 maxms=0.000")
         }
     }
 
@@ -272,6 +275,46 @@ struct RPCVolumeProbeTests {
             }
             #expect(sum("n") == 30)
             #expect(sum("bytes") == (1...30).reduce(0) { $0 + $1 * 1000 })
+        }
+    }
+
+    @Test("on: a clock reading older than the open window cannot wrap the elapsed time")
+    func onBranchSaturatesNonMonotonicReadings() {
+        withIsolatedDefaults(seed: true) { defaults in
+            let sink = Sink()
+            // Two records race: the first reads late and rolls the window to
+            // t=2000ms, the second was descheduled holding an OLDER reading and
+            // reaches the lock afterwards. Unsigned wrapping would make its
+            // elapsed ~UInt64.max, roll a second time, and emit an astronomical
+            // `secs=` that drags the reader's rate denominators toward zero.
+            let readings: [UInt64] = [
+                0,                    // init seeds the window
+                0, 2_000_000_000,     // first record: start, end -> rolls
+                0, 1_000_000_000      // second record: an older end than the new window
+            ]
+            let cursor = Counter()
+            let probe = RPCVolumeProbe(
+                defaults: defaults,
+                windowSeconds: 1.0,
+                now: {
+                    let i = cursor.value
+                    cursor.bump()
+                    return readings[min(i, readings.count - 1)]
+                },
+                emit: { sink.append($0) }
+            )
+
+            probe.record(start: probe.startMeasurement(), kind: .delta, type: "a", bytes: 1)
+            probe.record(start: probe.startMeasurement(), kind: .delta, type: "b", bytes: 1)
+            probe.flush()
+
+            let windows = sink.all.filter { $0.hasPrefix("rpc kind=window ") }
+            #expect(windows.count == 1, "the stale reading must not roll its own window")
+            // Sanity: no window may claim a span longer than the test itself.
+            for line in windows {
+                let secs = line.split(separator: " ").first { $0.hasPrefix("secs=") }!.dropFirst(5)
+                #expect(Double(secs)! < 60, "secs=\(secs) — the elapsed subtraction wrapped")
+            }
         }
     }
 

--- a/Tests/TBDAppTests/RPCVolumeProbeTests.swift
+++ b/Tests/TBDAppTests/RPCVolumeProbeTests.swift
@@ -1,0 +1,302 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// Tests for the default-off RPC volume probe, covering both branches of the
+/// gate per the repo rule for gating conditionals.
+///
+/// Isolation matters: TBDApp ships as an unbundled SPM executable, so its
+/// `UserDefaults.standard` domain is `TBDApp.plist` in the developer's home —
+/// the SAME domain a running production TBDApp reads. Every test below builds
+/// a per-test `UserDefaults(suiteName:)` and tears the domain down, so
+/// `.standard` is never touched.
+@Suite("RPC volume probe")
+struct RPCVolumeProbeTests {
+    /// Collects emitted lines from any thread the probe reports on.
+    private final class Sink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lines: [String] = []
+        func append(_ line: String) {
+            lock.lock(); defer { lock.unlock() }
+            lines.append(line)
+        }
+        var all: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return lines
+        }
+    }
+
+    /// A monotonic clock the test drives by hand, so window rollover is
+    /// deterministic rather than a race against wall time.
+    private final class FakeClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var nanos: UInt64 = 0
+        func read() -> UInt64 {
+            lock.lock(); defer { lock.unlock() }
+            return nanos
+        }
+        func advance(ms: Double) {
+            lock.lock(); defer { lock.unlock() }
+            nanos += UInt64(ms * 1_000_000)
+        }
+    }
+
+    private func withIsolatedDefaults(seed: Bool?, _ body: (UserDefaults) -> Void) {
+        let suiteName = "TBDAppTests.RPCVolume.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        if let seed { defaults.set(seed, forKey: RPCVolumeDiagnosticPreferences.enabledKey) }
+        body(defaults)
+    }
+
+    // MARK: - The gate
+
+    @Test("defaults to off when the user has never touched the key")
+    func defaultsOff() {
+        withIsolatedDefaults(seed: nil) { defaults in
+            #expect(RPCVolumeDiagnosticPreferences.isEnabled(defaults) == false)
+            #expect(RPCVolumeDiagnosticPreferences.enabledDefault == false)
+        }
+    }
+
+    @Test("reads an explicit true and an explicit false")
+    func readsExplicitValues() {
+        withIsolatedDefaults(seed: true) { defaults in
+            #expect(RPCVolumeDiagnosticPreferences.isEnabled(defaults) == true)
+        }
+        withIsolatedDefaults(seed: false) { defaults in
+            #expect(RPCVolumeDiagnosticPreferences.isEnabled(defaults) == false)
+        }
+    }
+
+    // MARK: - Flag OFF branch
+
+    @Test("off: nothing is logged and no clock is read")
+    func offBranchIsInert() {
+        withIsolatedDefaults(seed: false) { defaults in
+            let sink = Sink()
+            let reads = Counter()
+            let probe = RPCVolumeProbe(
+                defaults: defaults,
+                windowSeconds: 0,
+                now: { reads.bump(); return 0 },
+                emit: { sink.append($0) }
+            )
+            #expect(probe.isEnabled == false)
+
+            // Init seeds the window with one read; everything after must add none.
+            let baseline = reads.value
+            #expect(probe.startMeasurement() == nil)
+            probe.record(
+                start: probe.startMeasurement(),
+                kind: .delta, type: "terminalActivityUpdated", bytes: 4096
+            )
+            probe.flush()
+
+            #expect(sink.all.isEmpty)
+            #expect(reads.value == baseline, "off path must not read the clock")
+        }
+    }
+
+    @Test("off: a nil start is ignored even if record is called anyway")
+    func offBranchIgnoresNilStart() {
+        withIsolatedDefaults(seed: false) { defaults in
+            let sink = Sink()
+            let probe = RPCVolumeProbe(defaults: defaults, windowSeconds: 0, emit: { sink.append($0) })
+            probe.record(start: nil, kind: .response, type: "worktree.list", bytes: 1)
+            #expect(sink.all.isEmpty)
+        }
+    }
+
+    // MARK: - Flag ON branch
+
+    @Test("on: records a message and emits a window plus a per-type line")
+    func onBranchRecords() {
+        withIsolatedDefaults(seed: true) { defaults in
+            let sink = Sink()
+            let clock = FakeClock()
+            let probe = RPCVolumeProbe(
+                defaults: defaults, windowSeconds: 1.0, now: { clock.read() }, emit: { sink.append($0) }
+            )
+            #expect(probe.isEnabled == true)
+
+            let start = probe.startMeasurement()
+            #expect(start != nil)
+            clock.advance(ms: 7)
+            probe.record(start: start, kind: .delta, type: "terminalActivityUpdated", bytes: 4096)
+            #expect(sink.all.isEmpty, "window has not expired yet")
+
+            probe.flush()
+            let lines = sink.all
+            #expect(lines.count == 2)
+            #expect(lines[0].hasPrefix("rpc kind=window "))
+            #expect(lines[0].contains("msgs=1"))
+            #expect(lines[0].contains("bytes=4096"))
+            #expect(lines[0].contains("decodems=7.000"))
+            #expect(lines[0].contains("maxms=7.000"))
+            #expect(lines[1] == "rpc kind=delta type=terminalActivityUpdated n=1 bytes=4096 "
+                                + "decodems=7.000 maxms=7.000")
+        }
+    }
+
+    @Test("on: aggregates a window and rolls it over only when it expires")
+    func onBranchAggregatesAndRolls() {
+        withIsolatedDefaults(seed: true) { defaults in
+            let sink = Sink()
+            let clock = FakeClock()
+            let probe = RPCVolumeProbe(
+                defaults: defaults, windowSeconds: 1.0, now: { clock.read() }, emit: { sink.append($0) }
+            )
+
+            // Three cheap deltas and one expensive response, all inside 1s.
+            for _ in 0..<3 {
+                let start = probe.startMeasurement()
+                clock.advance(ms: 2)
+                probe.record(start: start, kind: .delta, type: "terminalActivityUpdated", bytes: 1000)
+            }
+            let start = probe.startMeasurement()
+            clock.advance(ms: 50)
+            probe.record(start: start, kind: .response, type: "worktree.list", bytes: 200_000)
+            #expect(sink.all.isEmpty, "still inside the window")
+
+            // Cross the boundary: the next record closes the window.
+            clock.advance(ms: 1000)
+            let last = probe.startMeasurement()
+            probe.record(start: last, kind: .delta, type: "terminalActivityUpdated", bytes: 10)
+
+            let lines = sink.all
+            #expect(lines.count == 3, "one window line plus one line per (kind,type)")
+            let window = lines[0]
+            #expect(window.contains("msgs=4"))
+            #expect(window.contains("bytes=203000"))
+            #expect(window.contains("decodems=56.000"))
+            #expect(window.contains("maxms=50.000"))
+            #expect(window.contains("types=2"))
+
+            // Bytes-descending, so the response leads even though the deltas
+            // are more numerous.
+            #expect(lines[1] == "rpc kind=response type=worktree.list n=1 bytes=200000 "
+                                + "decodems=50.000 maxms=50.000")
+            #expect(lines[2] == "rpc kind=delta type=terminalActivityUpdated n=3 bytes=3000 "
+                                + "decodems=6.000 maxms=2.000")
+
+            // The message that rolled the window belongs to the NEW one.
+            sink.append("--")
+            probe.flush()
+            #expect(sink.all.last!.contains("n=1"))
+        }
+    }
+
+    @Test("on: the byte ranking and the decode ranking can disagree")
+    func onBranchSeparatesTheTwoRankings() {
+        withIsolatedDefaults(seed: true) { defaults in
+            let sink = Sink()
+            let clock = FakeClock()
+            let probe = RPCVolumeProbe(
+                defaults: defaults, windowSeconds: 1.0, now: { clock.read() }, emit: { sink.append($0) }
+            )
+            // Big and cheap.
+            var start = probe.startMeasurement()
+            clock.advance(ms: 1)
+            probe.record(start: start, kind: .response, type: "blob", bytes: 1_000_000)
+            // Small and expensive.
+            start = probe.startMeasurement()
+            clock.advance(ms: 100)
+            probe.record(start: start, kind: .delta, type: "nested", bytes: 500)
+            probe.flush()
+
+            let perType = sink.all.dropFirst()
+            #expect(perType.first!.contains("type=blob"), "bytes-descending puts blob first")
+            let nested = perType.first { $0.contains("type=nested") }
+            #expect(nested?.contains("decodems=100.000") == true)
+        }
+    }
+
+    @Test("on: percentile sampling is capped but counts and totals stay exact")
+    func onBranchCapsLatencySamples() {
+        withIsolatedDefaults(seed: true) { defaults in
+            let sink = Sink()
+            let clock = FakeClock()
+            let probe = RPCVolumeProbe(
+                defaults: defaults, windowSeconds: 1.0, latencySampleCap: 4,
+                now: { clock.read() }, emit: { sink.append($0) }
+            )
+            for _ in 0..<10 {
+                let start = probe.startMeasurement()
+                clock.advance(ms: 1)
+                probe.record(start: start, kind: .delta, type: "reapRecordsChanged", bytes: 10)
+            }
+            probe.flush()
+            let window = sink.all[0]
+            #expect(window.contains("msgs=10"))
+            #expect(window.contains("bytes=100"))
+            #expect(window.contains("decodems=10.000"))
+            #expect(window.contains("sampled=4"))
+        }
+    }
+
+    @Test("on: per-type lines are capped, and the (other) rollup keeps the totals whole")
+    func onBranchCapsTypeLines() {
+        withIsolatedDefaults(seed: true) { defaults in
+            let sink = Sink()
+            let clock = FakeClock()
+            let probe = RPCVolumeProbe(
+                defaults: defaults, windowSeconds: 1.0, now: { clock.read() }, emit: { sink.append($0) }
+            )
+            // 30 distinct types. Byte size and decode cost are deliberately
+            // anti-correlated, so the top-by-bytes and top-by-decode sets are
+            // disjoint and the union is exactly 16 types.
+            for i in 0..<30 {
+                let start = probe.startMeasurement()
+                clock.advance(ms: Double(i + 1))
+                probe.record(start: start, kind: .delta, type: "t\(i)", bytes: (30 - i) * 1000)
+            }
+            probe.flush()
+
+            let lines = sink.all
+            #expect(lines[0].contains("types=30"))
+            // 1 window + 8 + 8 distinct + 1 rollup.
+            #expect(lines.count == 18)
+            let rollup = lines.last!
+            #expect(rollup.hasPrefix("rpc kind=mixed type=(other) "))
+            #expect(rollup.contains("n=14"))
+
+            // The per-type lines plus the rollup must still sum to the window.
+            func sum(_ key: String) -> Int {
+                lines.dropFirst().reduce(0) { total, line in
+                    guard let field = line.split(separator: " ").first(where: { $0.hasPrefix(key + "=") }),
+                          let value = Int(field.dropFirst(key.count + 1)) else { return total }
+                    return total + value
+                }
+            }
+            #expect(sum("n") == 30)
+            #expect(sum("bytes") == (1...30).reduce(0) { $0 + $1 * 1000 })
+        }
+    }
+
+    // MARK: - Naming
+
+    @Test("delta type names are the case name and carry no payload")
+    func deltaTypeNames() {
+        #expect(StateDelta.reapRecordsChanged.rpcVolumeTypeName == "reapRecordsChanged")
+        #expect(StateDelta.modelProfilesChanged.rpcVolumeTypeName == "modelProfilesChanged")
+        let delta = StateDelta.worktreeArchived(WorktreeIDDelta(worktreeID: UUID()))
+        #expect(delta.rpcVolumeTypeName == "worktreeArchived")
+        #expect(!delta.rpcVolumeTypeName.contains("-"), "a UUID must never leak into the label")
+    }
+}
+
+/// Thread-safe read counter for the "off path takes no clock read" assertion.
+private final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    func bump() {
+        lock.lock(); defer { lock.unlock() }
+        count += 1
+    }
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return count
+    }
+}

--- a/scripts/diag/rpc-volume-report.py
+++ b/scripts/diag/rpc-volume-report.py
@@ -66,6 +66,16 @@ def parse(line):
     return dict(PAIR.findall(body))
 
 
+def positive_int(raw):
+    # argparse happily accepts `--top -1`, and a negative slice silently DROPS
+    # the last ranking entry instead of erroring -- a quiet wrong answer from a
+    # tool whose whole job is to be trusted about rankings.
+    value = int(raw)
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be 1 or more")
+    return value
+
+
 def human_bytes(n):
     for unit in ("B", "KB", "MB", "GB"):
         if abs(n) < 1024 or unit == "GB":
@@ -76,17 +86,29 @@ def human_bytes(n):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--last", default="30m")
-    ap.add_argument("--top", type=int, default=12,
+    ap.add_argument("--top", type=positive_int, default=12,
                     help="how many message types to list in each ranking")
     args = ap.parse_args()
 
-    out = subprocess.run(
+    proc = subprocess.run(
         ["/usr/bin/log", "show", "--last", args.last, "--info", "--style", "compact",
          "--predicate", 'subsystem == "com.tbd.app" AND category == "rpcvolume"'],
-        capture_output=True, text=True).stdout
+        capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        # Without this, a rejected `--last` or a denied predicate produces empty
+        # stdout and the "probe is off" guidance below -- sending the reader to
+        # check a flag that was never the problem.
+        print(f"`log show` failed (exit {proc.returncode}):", file=sys.stderr)
+        print(proc.stderr.strip(), file=sys.stderr)
+        return 2
+    out = proc.stdout
+
+    def totals():
+        return {"n": 0, "bytes": 0, "decodems": 0.0, "maxms": 0.0}
 
     windows = []
-    types = defaultdict(lambda: {"n": 0, "bytes": 0, "decodems": 0.0, "maxms": 0.0})
+    types = defaultdict(totals)
+    rollup = totals()
 
     for ln in out.splitlines():
         kv = parse(ln)
@@ -96,7 +118,10 @@ def main():
             windows.append(kv)
             continue
         key = (kv.get("kind", "?"), kv.get("type", "?"))
-        t = types[key]
+        # The probe's own rollup is not a message type and must never win a
+        # ranking of message types. It is reported on its own below, where a
+        # large share means the traffic is spread thin rather than concentrated.
+        t = rollup if key == ("mixed", "(other)") else types[key]
         t["n"] += int(kv.get("n", 0))
         t["bytes"] += int(kv.get("bytes", 0))
         t["decodems"] += float(kv.get("decodems", 0.0))
@@ -158,7 +183,23 @@ def main():
           lambda t: f"{t['decodems'] / 1000:8.1f}s "
                     f"({100 * t['decodems'] / decode_ms:4.1f}%)" if decode_ms else "n/a")
 
+    if rollup["n"]:
+        byte_pct = 100 * rollup["bytes"] / total_bytes if total_bytes else 0.0
+        time_pct = 100 * rollup["decodems"] / decode_ms if decode_ms else 0.0
+        print(f"\nspread thin, outside both per-window rankings "
+              f"(the probe's `(other)` rollup):")
+        print(f"  {rollup['n']:,} messages, {human_bytes(rollup['bytes'])} "
+              f"({byte_pct:.1f}% of bytes), {rollup['decodems'] / 1000:.1f}s decode "
+              f"({time_pct:.1f}%)")
+        if byte_pct > 50 or time_pct > 50:
+            print("  -> most of the traffic is NOT concentrated in a few types.")
+            print("     Look at message rate and the daemon's broadcast policy,")
+            print("     not at any one payload's shape.")
+
     print()
+    if not types:
+        print("  -> only the probe's (other) rollup was logged; no type dominates.")
+        return 0
     by_bytes = sorted(types, key=lambda k: types[k]["bytes"], reverse=True)
     by_time = sorted(types, key=lambda k: types[k]["decodems"], reverse=True)
     if by_bytes[:3] != by_time[:3]:
@@ -171,9 +212,14 @@ def main():
     if share < 0.05:
         print(f"  -> decode share {share:.3f} is negligible. The `sample` frames were")
         print("     an artifact of short bursts; look elsewhere for the lag.")
-    elif share >= 0.5:
-        print(f"  -> decode share {share:.3f} is a standing multi-core load. The fix is")
-        print("     upstream of the decoder, in what the daemon chooses to send.")
+    elif share >= 1.0:
+        print(f"  -> decode share {share:.3f} is a standing multi-core load: more than")
+        print("     one core-second of decode per wall second. The fix is upstream of")
+        print("     the decoder, in what the daemon chooses to send.")
+    else:
+        print(f"  -> decode share {share:.3f} is a real but sub-core load. It competes")
+        print("     with the render path on a loaded box without being the whole story;")
+        print("     weigh it against what else is running before acting.")
     return 0
 
 

--- a/scripts/diag/rpc-volume-report.py
+++ b/scripts/diag/rpc-volume-report.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""How much does the daemon push at the app, and what does decoding it cost?
+
+    rpc-volume-report.py [--last 30m] [--top 12]
+
+A `sample` of TBDApp during a confirmed terminal-lag episode (load 154, swap
+97% full) found 1,265 samples inside `JSONDecoder` internals against only 81
+blocked in `read`/`recv`/`poll`/`cond_wait`, spread across six
+`user-initiated-qos.cooperative` threads. Those threads were not waiting on the
+socket -- they were burning CPU decoding JSON. The work is off the main thread
+(72 `JSONDecoder` mentions on main against 1,717 overall), so it does not block
+drawing directly; the question is whether it is a load worth caring about at
+all. On a 12-core box already at load 150 six CPU-burning threads compete with
+the render path, and on a swap-thrashing machine the allocation churn of a
+decode is page faults.
+
+Nothing logged payload sizes, so that question had no answer. `RPCVolumeProbe`
+(default off, `defaults write TBDApp enableRPCVolumeDiagnostic -bool true`)
+supplies one, and this reads it back.
+
+The headline number is DECODE SHARE: total decode milliseconds divided by the
+wall time they were spread over. It is a thread-seconds ratio, not a duty
+cycle -- decoding runs on several threads at once, so a share above 1.0 is not
+a bug, it means more than one core-second of decode per wall second. Below
+about 0.05 the sample's `JSONDecoder` frames are a sampling artifact of threads
+that decode in short bursts and the lag is somewhere else. Around 1.0 or above,
+JSON decoding is a standing multi-core load and the fix is upstream of the
+decoder: send less, send it less often, or stop re-sending state that did not
+change.
+
+The two rankings at the bottom are the actionable part, and they are usually
+NOT the same ranking. A message type can dominate bytes without dominating
+decode time (a big flat blob, cheap per byte) or dominate decode time without
+dominating bytes (a small deeply-nested payload, or one arriving thousands of
+times a second). Bytes-heavy points at the daemon's payload shape; decode-heavy
+points at frequency and nesting. Fixing the wrong one moves nothing.
+
+`kind` separates the two receive paths because they have different fixes.
+`response` is a reply to a call the app chose to make: the fix is to call less
+often, or to ask for less. `delta` is pushed subscription traffic the app
+cannot decline: the fix has to happen in the daemon's broadcast. `(ack)` is the
+subscription handshake and should appear once per connection -- more than that
+means the subscription is reconnecting.
+
+`kind=mixed type=(other)` is the probe's own rollup of everything outside the
+top eight by bytes and the top eight by decode time within a single window. It
+exists so the per-type rows still sum to the window totals; a large `(other)`
+share means the traffic is spread thin across many types rather than
+concentrated in a few, which is itself the answer.
+"""
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# Every probe line is a flat key=value bag; one regex reads both shapes.
+PAIR = re.compile(r"(\w+)=([^\s]+)")
+LINE = re.compile(r"\brpc kind=")
+
+
+def parse(line):
+    if not LINE.search(line):
+        return None
+    body = line[LINE.search(line).start():]
+    return dict(PAIR.findall(body))
+
+
+def human_bytes(n):
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(n) < 1024 or unit == "GB":
+            return f"{n:,.1f} {unit}" if unit != "B" else f"{n:,.0f} B"
+        n /= 1024.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--last", default="30m")
+    ap.add_argument("--top", type=int, default=12,
+                    help="how many message types to list in each ranking")
+    args = ap.parse_args()
+
+    out = subprocess.run(
+        ["/usr/bin/log", "show", "--last", args.last, "--info", "--style", "compact",
+         "--predicate", 'subsystem == "com.tbd.app" AND category == "rpcvolume"'],
+        capture_output=True, text=True).stdout
+
+    windows = []
+    types = defaultdict(lambda: {"n": 0, "bytes": 0, "decodems": 0.0, "maxms": 0.0})
+
+    for ln in out.splitlines():
+        kv = parse(ln)
+        if not kv:
+            continue
+        if kv.get("kind") == "window":
+            windows.append(kv)
+            continue
+        key = (kv.get("kind", "?"), kv.get("type", "?"))
+        t = types[key]
+        t["n"] += int(kv.get("n", 0))
+        t["bytes"] += int(kv.get("bytes", 0))
+        t["decodems"] += float(kv.get("decodems", 0.0))
+        t["maxms"] = max(t["maxms"], float(kv.get("maxms", 0.0)))
+
+    if not windows:
+        print(f"No rpcvolume lines in the last {args.last}.")
+        print("The probe is default-OFF. To enable it for a measurement session:")
+        print("  defaults write TBDApp enableRPCVolumeDiagnostic -bool true")
+        print("  # then relaunch TBDApp -- the flag is read once per process")
+        return 1
+
+    secs = sum(float(w.get("secs", 0.0)) for w in windows)
+    msgs = sum(int(w.get("msgs", 0)) for w in windows)
+    total_bytes = sum(int(w.get("bytes", 0)) for w in windows)
+    decode_ms = sum(float(w.get("decodems", 0.0)) for w in windows)
+    max_ms = max(float(w.get("maxms", 0.0)) for w in windows)
+    # Windows close lazily, on the next message after they expire. A quiet
+    # stretch is therefore ONE long window, not a gap -- so summing the
+    # windows' own spans is the honest denominator, not the clock elapsed.
+    if secs <= 0:
+        print("Windows carry no elapsed time; nothing to divide by.")
+        return 1
+
+    print(f"over {secs:.0f}s of measured traffic ({len(windows)} windows)")
+    print(f"  received     = {human_bytes(total_bytes)} in {msgs:,} messages")
+    print(f"  message rate = {msgs / secs:10.1f}/s")
+    print(f"  byte rate    = {total_bytes / secs / 1e6:10.3f} MB/s")
+    print(f"  mean message = {human_bytes(total_bytes / msgs) if msgs else 'n/a'}")
+
+    share = decode_ms / (secs * 1000.0)
+    print(f"\ndecode cost:")
+    print(f"  total        = {decode_ms / 1000:10.1f} thread-seconds")
+    print(f"  share        = {share:10.3f} x wall time  "
+          f"({share * 100:.1f}% of one core)")
+    print(f"  slowest one  = {max_ms:10.1f} ms")
+
+    # Percentiles come from the windows, which already reduced them; averaging
+    # per-window p50s is a stand-in for a true global p50 and is labelled so.
+    p50s = sorted(float(w.get("p50ms", 0.0)) for w in windows)
+    p90s = sorted(float(w.get("p90ms", 0.0)) for w in windows)
+    if p50s:
+        print(f"  per-window p50 median = {p50s[len(p50s) // 2]:.3f} ms, "
+              f"p90 median = {p90s[len(p90s) // 2]:.3f} ms")
+
+    def table(title, keyfn, fmt):
+        print(f"\n{title}")
+        ranked = sorted(types.items(), key=lambda kv: keyfn(kv[1]), reverse=True)
+        for (kind, name), t in ranked[:args.top]:
+            print(f"  {fmt(t):>22}  {t['n']:>9,} msgs  {kind:<8} {name}")
+
+    table("by BYTES -- what the daemon is sending too much of:",
+          lambda t: t["bytes"],
+          lambda t: f"{human_bytes(t['bytes'])} "
+                    f"({100 * t['bytes'] / total_bytes:4.1f}%)")
+
+    table("by DECODE TIME -- what is actually costing CPU:",
+          lambda t: t["decodems"],
+          lambda t: f"{t['decodems'] / 1000:8.1f}s "
+                    f"({100 * t['decodems'] / decode_ms:4.1f}%)" if decode_ms else "n/a")
+
+    print()
+    by_bytes = sorted(types, key=lambda k: types[k]["bytes"], reverse=True)
+    by_time = sorted(types, key=lambda k: types[k]["decodems"], reverse=True)
+    if by_bytes[:3] != by_time[:3]:
+        print("  -> the two rankings disagree. The bytes leader is a payload-shape")
+        print(f"     problem ({by_bytes[0][1]}); the decode leader is a frequency or")
+        print(f"     nesting problem ({by_time[0][1]}). They need different fixes.")
+    else:
+        print(f"  -> both rankings agree on {by_time[0][1]}: fix that one first.")
+
+    if share < 0.05:
+        print(f"  -> decode share {share:.3f} is negligible. The `sample` frames were")
+        print("     an artifact of short bursts; look elsewhere for the lag.")
+    elif share >= 0.5:
+        print(f"  -> decode share {share:.3f} is a standing multi-core load. The fix is")
+        print("     upstream of the decoder, in what the daemon chooses to send.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

When the app feels laggy, we can now find out whether JSON decoding of daemon
traffic is part of the reason, and which messages are responsible.

A `sample` of TBDApp taken during a user-confirmed terminal-lag episode (load
154, swap 97% full, while actively scrolling) found **1,265 samples inside
`JSONDecoder` internals** against only **81** blocked in
`read`/`recv`/`poll`/`cond_wait`, spread across **six**
`user-initiated-qos.cooperative` threads. Those threads were not waiting on the
socket — they were burning CPU decoding. The work is off the main thread (72
`JSONDecoder` mentions on main against 1,717 overall), so it does not block
drawing directly, but on a 12-core box already at load 150 six CPU-burning
threads compete with the render path, and on a swap-thrashing machine the
allocation churn of a decode means page faults.

Whether that is a meaningful load or a sampling artifact was unanswerable:
nothing logged payload sizes anywhere in `DaemonClient`. This adds the
instrument and the reader for it.

## Why this shape

No spec: this is a measurement instrument that is off by default and changes no
product behavior. It revises no theory of the system — it exists to produce the
evidence a theory would need.

**Rate limiting: a periodic summary, not a per-message line.** The
measurement's own premise is that messages may arrive hundreds of times a
second; one log line each would cost more than the decode it measures and
corrupt the reading. Records aggregate into a one-second window and only the
window is logged. The alternative — logging individual lines above a byte or
duration threshold — was rejected because it cannot answer the question asked:
the suspicion is death by a thousand small deltas, so a threshold high enough
to be safe would discard exactly the messages under suspicion, and the
denominators (total bytes, total decode ms, messages/second) would be lost.

**The window closes lazily, on the next record that finds it expired.** No
timer, no `Task`, therefore no sleeping and no `Clock` seam. The cost is that a
window whose traffic stops is not emitted until traffic resumes, and the final
partial window at app exit is dropped — the right trade against putting a
scheduled wake-up inside the thing being measured.

**Per-type lines are capped** at the union of the top eight by bytes and the
top eight by decode time, with the remainder rolled into a `type=(other)` line
so the rows still sum to the window totals. Without the cap, a window with
pathologically many distinct types would turn the summary back into
per-message logging.

**The `StateDelta` case name comes from an exhaustive switch**, not a `Mirror`
and not `String(describing:)`. A `Mirror` allocates on the path being measured;
`String(describing:)` would interpolate the payload, which is the user's real
work. The switch is allocation-free and a new delta case breaks the build
rather than going silently unlabelled.

## What this PR does

- `Sources/TBDApp/Diagnostics/RPCVolumeProbe.swift` — the probe and its
  `UserDefaults` gate. Records `(kind, type, bytes, decode duration)` per
  message under an `OSAllocatedUnfairLock`, emits one `kind=window` summary
  line plus the capped per-type lines to `com.tbd.app` / `rpcvolume` at
  `.info`, so the lines persist for `log show` after an episode. Timing is
  `DispatchTime.uptimeNanoseconds` throughout — a monotonic counter that is
  compared, never persisted.
- `Sources/TBDApp/DaemonClient.swift` — both receive paths call it.
  `RPCResponse.result` is a JSON *string*, so the envelope decode is only the
  first half of a response's cost and the structured parse happens later in
  `decodeResult`. `sendRaw` therefore returns a `MeasuredResponse` carrying a
  still-open measurement, which the `call*` helpers close after the typed
  decode — measuring at the envelope would have missed most of what this tool
  is for. Responses are recorded as `kind=response` with the RPC method name;
  `subscribe(onDelta:)` records `kind=delta` with the delta case name. The two
  are never merged because they have different fixes: a response is a call the
  app chose to make, a delta is pushed traffic it cannot decline.
  The subscription measurement starts *before* the ack probe that fails on
  every real delta, so the recorded cost is the whole frame's decode — that
  failed attempt is a genuine per-delta cost of this path. Frames that decode
  as neither are counted as `(undecodable)` so the byte total still equals what
  the socket delivered.
- `scripts/diag/rpc-volume-report.py` — reads the lines back over a window and
  reports total MB, messages/second, MB/second, decode ms as a share of wall
  time, and **two separate rankings**: which types dominate bytes and which
  dominate decode time. They are usually not the same ranking, and the
  difference is the actionable part — bytes-heavy points at the daemon's
  payload shape, decode-heavy points at frequency and nesting. Fixing the wrong
  one moves nothing.

Never logs message contents or field values. Sizes, counts, durations, and
type names only — every type name is a compile-time constant (`RPCMethod`
strings and `StateDelta` case names).

## Flag & rollout

- **Flag:** `enableRPCVolumeDiagnostic` (`UserDefaults`, app-only behaviour, so
  `UserDefaults` per CLAUDE.md — precedent `enableTranscript`). Default **OFF**,
  spelled once on `RPCVolumeDiagnosticPreferences.enabledDefault`.
- **Enable for a measurement session:**
  `defaults write TBDApp enableRPCVolumeDiagnostic -bool true`, then relaunch
  TBDApp. `defaults delete TBDApp enableRPCVolumeDiagnostic` returns to unset.
- The flag is read **once per process**, deliberately: a per-message
  `UserDefaults` lookup would itself be overhead on the path being measured.
  That is why enabling requires a relaunch.
- No Settings toggle, and no graduation plan — this is an instrument, not a
  feature. It stays default-off; when the terminal-lag question is settled it
  should be deleted rather than flipped on.

## Assumptions

- The probe covers `DaemonClient`'s two receive paths and **not** every byte
  the daemon sends. `FDSidecarClient.handleFDVend` already decodes a
  daemon-pushed `FDVendHeader` per control-mode attach — small, not a hot
  path — and is deliberately left uninstrumented. The totals are the app's RPC
  traffic; read them as that, not as exhaustive. A fourth receive path added
  later would be invisible the same way.
- Assumes a window's distinct-type count stays small. It does not enforce that;
  the `(other)` rollup is what keeps the line count bounded when it doesn't,
  and a large `(other)` share is itself a finding.

## Evidence & verification

- **Both branches of the gate are tested** (`Tests/TBDAppTests/RPCVolumeProbeTests.swift`),
  per the repo rule for gating conditionals. Flag **off**: nothing is emitted
  *and* no clock is read — asserted by counting reads through an injected
  monotonic source, so the test fails if the off path takes measurement
  overhead rather than merely staying quiet. Flag **on**: the window and
  per-type lines are emitted with exact byte, count and duration values.
  Unset defaults to off, and explicit `true`/`false` both read back.
- Further tests cover window rollover on an injected clock (deterministic, not
  a race against wall time), aggregation across a window, the per-type line cap
  and that the `(other)` rollup keeps the per-type totals summing to the
  window's, the latency-sample cap leaving counts and totals exact, and that a
  delta with a UUID payload yields a label containing no UUID.
- All tests use a per-test `UserDefaults(suiteName:)` torn down with
  `removePersistentDomain(forName:)` — `.standard` on this unbundled executable
  is the developer's real `TBDApp.plist`, which a running production TBDApp
  reads.
- `scripts/swift-safe build` is clean (only the pre-existing SwiftTerm
  `Color: Sendable` warnings); `swiftlint --strict` passes.
- The reader was exercised end-to-end against synthetic `log show` output: it
  computes the rates, the decode share, and correctly reports the two rankings
  disagreeing (a large infrequent response leading on bytes, a small frequent
  delta leading on decode time).
- **Not verified in the running app**, deliberately: installing this build
  would swap the machine-wide binaries and disturb a live measurement in
  progress. Nothing is user-visible, and with the flag off the change is inert.
- The full local suite was not run to completion here — the machine's shared
  build slot is contended by ~40 sibling worktrees and CI is the verdict.
  `scripts/swift-safe build --build-tests` is clean, so the test target
  compiles; the run itself is CI's.

### Review round 2

Four review findings were real and are fixed in the three follow-up commits:

- **The probe measured the wrong half of a response.** `RPCResponse.result` is
  a JSON string, so `sendRaw`'s envelope decode only unescapes it — the
  structured parse the `sample` caught happens later in `decodeResult`. The
  measurement now rides out to the `call*` helpers and closes after the typed
  decode. Without this the tool under-reported response decode cost by most of
  it.
- **The rollover-triggering message landed in the old window**, inflating that
  window's byte rate by one message. It now opens the new window instead, and
  an expired window with nothing in it is replaced rather than logged.
- **A stale clock read could wrap the window elapsed.** `record` reads the
  clock before taking the lock, and detached `sendRaw` threads race the
  `subscribe(onDelta:)` receive loop, so a descheduled thread could arrive
  holding a reading older than a window another thread had already opened. The
  unsigned subtraction wrapped to near `UInt64.max` — a spurious roll and an
  astronomical `secs=` that the reader sums into its rate denominators, driving
  reported rates toward zero under exactly the concurrency being measured. It
  saturates at zero now, and a regression test drives a non-monotonic clock.
- **The reader could answer confidently when it couldn't answer at all**: a
  failing `log show` read as "the probe is off", `--top -1` silently dropped a
  ranking entry, the probe's own `(other)` rollup could be ranked as a message
  type, and the multi-core verdict fired at half a core. All four fixed, and
  each verified against synthetic `log show` output.

Still open for a maintainer: the review flagged as MINOR that a new flag ships
without a `docs/specs/` entry, noting the no-spec reasoning above is
substantive but is not something the author can self-certify. That call is
yours.

[20260829-rpc-volume-probe](https://cheapsteak.github.io/tbd/open/?worktree=EA96CE49-18DA-4DF3-B905-47B53B5F4F80)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in diagnostics for measuring RPC message volume, decode latency, and traffic by message type.
  * Added a command-line report for analyzing RPC traffic, throughput, latency, and decoding costs.

* **Bug Fixes**
  * Improved measurement coverage for responses, acknowledgments, state updates, and undecodable messages.

* **Tests**
  * Added comprehensive coverage for diagnostic preferences, aggregation, ranking, sampling limits, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
